### PR TITLE
Fix actions/setup-node to not use working-directory

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,7 +29,6 @@ jobs:
     - name: use node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        working-directory: ./frontend
         node-version: ${{ matrix.node-version }}
     - name: yarn install, build, and test
       working-directory: ./frontend


### PR DESCRIPTION
Seems like `working-directory:` is not working well with `uses` and is causing CI to fail: #8  