### PR TITLE
Updating README to use yarn start rather than serve

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,7 +5,7 @@
 Serve app:
 
 ```bash
-yarn serve
+yarn start
 ```
 
 Build app:


### PR DESCRIPTION
Looks like `yarn serve` is not working. `yarn workspace @backstage/app start` is the correct command, but `yarn start` also suffice.