### PR TITLE
Update default theme for headings

### DIFF
--- a/packages/core/src/theme/BackstageTheme.js
+++ b/packages/core/src/theme/BackstageTheme.js
@@ -73,6 +73,29 @@ const extendedThemeConfig = {
   },
   typography: {
     fontFamily: '"Helvetica Neue", Helvetica, Roboto, Arial, sans-serif',
+    h5: {
+      fontWeight: 700,
+    },
+    h4: {
+      fontWeight: 700,
+      fontSize: 28,
+      marginBottom: 6,
+    },
+    h3: {
+      fontSize: 32,
+      fontWeight: 700,
+      marginBottom: 6,
+    },
+    h2: {
+      fontSize: 40,
+      fontWeight: 700,
+      marginBottom: 8,
+    },
+    h1: {
+      fontSize: 54,
+      fontWeight: 700,
+      marginBottom: 10,
+    },
   },
 };
 

--- a/plugins/home-page/src/components/HomePage/HomePage.tsx
+++ b/plugins/home-page/src/components/HomePage/HomePage.tsx
@@ -60,9 +60,7 @@ const HomePage: FC<{}> = () => {
         <Content>
           <Grid container direction="row" spacing={3}>
             <Grid item xs={6}>
-              <Typography variant="h3" style={{ padding: '8px 0 16px 0' }}>
-                Things you own
-              </Typography>
+              <Typography variant="h3">Things you own</Typography>
               <InfoCard maxWidth>
                 <SortableTable data={data} columns={columns} orderBy="id" />
               </InfoCard>

--- a/plugins/home-page/src/components/HomePage/SquadTechHealth.tsx
+++ b/plugins/home-page/src/components/HomePage/SquadTechHealth.tsx
@@ -6,9 +6,7 @@ import { HorizontalScrollGrid, ProgressCard } from '@spotify-backstage/core';
 const SquadTechHealth: FC<{}> = () => {
   return (
     <>
-      <Typography variant="h3" style={{ padding: '8px 0 16px 0' }}>
-        Team Metrics
-      </Typography>
+      <Typography variant="h3">Team Metrics</Typography>
       <HorizontalScrollGrid scrollStep={400} scrollSpeed={100}>
         <Grid item>
           <ProgressCard


### PR DESCRIPTION
@freben I opted for not using the MUI default font sizes, since they are too big and doesn't have the correct weights.

MUI default:
<img width="1552" alt="Screenshot 2020-03-07 at 13 43 11" src="https://user-images.githubusercontent.com/190856/76143859-19e67900-607b-11ea-9171-399df33511f7.png">
This PR:
<img width="1552" alt="Screenshot 2020-03-07 at 13 51 07" src="https://user-images.githubusercontent.com/190856/76143862-1eab2d00-607b-11ea-9d52-1582114e6c43.png">
