### PR TITLE
packages: fix typescript import autocompletion

### DIFF
--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -1,7 +1,8 @@
 {
   "name": "@spotify-backstage/plugin-{{id}}",
   "version": "0.0.0",
-  "main": "dist/cjs",
+  "main": "dist/cjs/index.js",
+  "types": "dist/cjs/index.d.ts",
   "license": "Apache-2.0",
   "private": false,
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "license": "Apache-2.0",
   "private": false,
-  "main": "dist/cjs",
+  "main": "dist/cjs/index.js",
+  "types": "dist/cjs/index.d.ts",
   "scripts": {
     "build": "tsc --outDir dist/cjs --noEmit false --module CommonJS",
     "lint": "web-scripts lint",

--- a/plugins/hello-world/package.json
+++ b/plugins/hello-world/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@spotify-backstage/plugin-hello-world",
   "version": "0.0.0",
-  "main": "dist/cjs",
+  "main": "dist/cjs/index.js",
+  "types": "dist/cjs/index.d.ts",
   "devDependencies": {
     "@spotify-backstage/cli": "^1.2.0",
     "@spotify-backstage/core": "1.0.0",

--- a/plugins/home-page/package.json
+++ b/plugins/home-page/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@spotify-backstage/plugin-home-page",
   "version": "0.0.0",
-  "main": "dist/cjs",
+  "main": "dist/cjs/index.js",
+  "types": "dist/cjs/index.d.ts",
   "devDependencies": {
     "@spotify-backstage/cli": "^1.2.0",
     "@spotify-backstage/core": "1.0.0",


### PR DESCRIPTION
Without pointing directly to the type definitions file in package.json you end up with autocompleted imports like ´@spotify-backstage/core/dist/cjs´