### PR TITLE
Use GHA checkout v2 for faster fetch

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Let's use checkout@v2 on GitHub Actions because it is faster at the initial fetch :)
Ref. https://github.com/actions/checkout/releases/tag/v2.0.0

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR won't make any changes for the code so I don't think the checklist is necessary, but tell me if I'm wrong!

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] [CODEOWNERS](./CODEOWNERS) updated (for new stuff)
- [ ] Regression tests added for bug fixes
