### PR TITLE
cli: add helpers for running child processes and error handling in commands

### DIFF
--- a/packages/cli/src/commands/plugin/build.ts
+++ b/packages/cli/src/commands/plugin/build.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import chalk from 'chalk';
 import { Command } from 'commander';
-import { spawnSync } from 'child_process';
 import fs from 'fs-extra';
 import recursive from 'recursive-readdir';
 import path from 'path';
+import { run } from '../../helpers/run';
 
 export default async (cmd: Command) => {
   const args = [
@@ -35,17 +34,8 @@ export default async (cmd: Command) => {
     args.push('--watch');
   }
 
-  try {
-    await copyStaticAssets();
-    const result = spawnSync('tsc', args, { stdio: 'inherit', shell: true });
-    if (result.error) {
-      throw result.error;
-    }
-    process.exit(result.status ?? 0);
-  } catch (error) {
-    process.stderr.write(`${chalk.red(error.message)}\n`);
-    process.exit(1);
-  }
+  await copyStaticAssets();
+  await run('tsc', args);
 };
 
 const copyStaticAssets = async () => {

--- a/packages/cli/src/commands/plugin/lint.ts
+++ b/packages/cli/src/commands/plugin/lint.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import chalk from 'chalk';
 import { Command } from 'commander';
-import { spawnSync } from 'child_process';
+import { run } from '../../helpers/run';
 
 export default async (cmd: Command) => {
   const args = ['lint'];
@@ -24,14 +23,5 @@ export default async (cmd: Command) => {
     args.push('--fix');
   }
 
-  try {
-    const result = spawnSync('web-scripts', args, { stdio: 'inherit', shell: true });
-    if (result.error) {
-      throw result.error;
-    }
-    process.exit(result.status ?? 0);
-  } catch (error) {
-    process.stderr.write(`${chalk.red(error.message)}\n`);
-    process.exit(1);
-  }
+  await run('web-scripts', args);
 };

--- a/packages/cli/src/commands/plugin/serve/index.ts
+++ b/packages/cli/src/commands/plugin/serve/index.ts
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-import chalk from 'chalk';
 import { startDevServer } from './server';
 
 export default async () => {
-  try {
-    await startDevServer();
-  } catch (error) {
-    process.stderr.write(`${chalk.red(error.message)}\n`);
-    process.exit(1);
-  }
+  await startDevServer();
 };

--- a/packages/cli/src/commands/plugin/testCommand.ts
+++ b/packages/cli/src/commands/plugin/testCommand.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import chalk from 'chalk';
 import { Command } from 'commander';
-import { spawnSync } from 'child_process';
+import { run } from '../../helpers/run';
 
 export default async (cmd: Command) => {
   const args = ['test'];
@@ -28,14 +27,5 @@ export default async (cmd: Command) => {
     args.push('--coverage');
   }
 
-  try {
-    const result = spawnSync('web-scripts', args, { stdio: 'inherit', shell: true });
-    if (result.error) {
-      throw result.error;
-    }
-    process.exit(result.status ?? 0);
-  } catch (error) {
-    process.stderr.write(`${chalk.red(error.message)}\n`);
-    process.exit(1);
-  }
+  await run('web-scripts', args);
 };

--- a/packages/cli/src/commands/watch-deps/child.ts
+++ b/packages/cli/src/commands/watch-deps/child.ts
@@ -34,4 +34,5 @@ export function startChild(args: string[]) {
   child.stderr!.on('data', data => {
     log.err(data.toString('utf8'));
   });
+  return child;
 }

--- a/packages/cli/src/commands/watch-deps/index.ts
+++ b/packages/cli/src/commands/watch-deps/index.ts
@@ -22,6 +22,7 @@ import { getPackageDeps } from './packages';
 import { startWatcher, startPackageWatcher } from './watcher';
 import { startCompiler } from './compiler';
 import { startChild } from './child';
+import { waitForExit } from '../../helpers/run';
 
 const PACKAGE_BLACKLIST = [
   // We never want to watch for changes in the cli, but all packages will depend on it.
@@ -67,6 +68,6 @@ export default async (_command: any, args: string[]) => {
   });
 
   if (args?.length) {
-    startChild(args);
+    await waitForExit(startChild(args));
   }
 };

--- a/packages/cli/src/helpers/errors.ts
+++ b/packages/cli/src/helpers/errors.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import chalk from 'chalk';
+
+export class CustomError extends Error {
+  get name(): string {
+    return this.constructor.name;
+  }
+}
+
+export class ExitCodeError extends CustomError {
+  readonly code: number;
+
+  constructor(code: number, command?: string) {
+    if (command) {
+      super(`Command '${command}' exited with code ${code}`);
+    } else {
+      super(`Child exited with code ${code}`);
+    }
+    this.code = code;
+  }
+}
+
+export function exitWithError(error: Error): never {
+  if (error instanceof ExitCodeError) {
+    process.stderr.write(`${chalk.red(error.message)}\n`);
+    process.exit(error.code);
+  } else {
+    process.stderr.write(`${chalk.red(`${error}`)}\n`);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/helpers/run.ts
+++ b/packages/cli/src/helpers/run.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SpawnSyncOptions, spawn } from 'child_process';
+import { ExitCodeError } from './errors';
+
+// Runs a child command, returning a promise that is only resolved if the child exits with code 0.
+export async function run(
+  name: string,
+  args: string[] = [],
+  options: SpawnSyncOptions = {},
+) {
+  return new Promise((resolve, reject) => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      FORCE_COLOR: 'true',
+      ...(options.env ?? {}),
+    };
+
+    const child = spawn(name, args, {
+      stdio: 'inherit',
+      shell: true,
+      ...options,
+      env,
+    });
+
+    child.once('error', error => reject(error));
+    child.once('exit', code => {
+      if (code) {
+        reject(new ExitCodeError(code, name));
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/scripts/cli-e2e-test.js
+++ b/scripts/cli-e2e-test.js
@@ -46,6 +46,9 @@ function print(msg) {
 }
 
 async function waitForExit(child) {
+  if (child.exitCode !== null) {
+    throw new Error(`Child already exited with code ${child.exitCode}`);
+  }
   await new Promise((resolve, reject) =>
     child.once('exit', code => {
       if (code) {


### PR DESCRIPTION
This reduces the amount of boilerplate in cli commands by a fair bit, also an example of custom error handling.

Editor isn't happy with src-relative imports, even though the build should work, so skipping those for now.