### PR TITLE
Updated purpleBlue in PageThemeProvider

### DIFF
--- a/packages/core/src/layout/Page/PageThemeProvider.ts
+++ b/packages/core/src/layout/Page/PageThemeProvider.ts
@@ -45,7 +45,7 @@ export const gradients: Record<string, Gradient> = {
     colors: ['#F13DA2', '#FF8A48'],
   },
   purpleBlue: {
-    colors: ['#4100F4', '#AF2996'],
+    colors: ['#2D00AA', '#C769B5'],
   },
   tealGreen: {
     colors: ['#19E68C', '#1D7F6E'],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changed the purpleBlue gradient setting in PageThemeProvider from '#4100F4', '#AF2996', to '#2D00AA', '#C769B5.

![purpleBlue](https://user-images.githubusercontent.com/62359443/77103838-0cb97a80-69e9-11ea-817e-6f7df8b4fc10.png)


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] [CODEOWNERS](./CODEOWNERS) updated (for new stuff)
- [ ] Regression tests added for bug fixes
