### PR TITLE
cli: don't enforce prop-types for plugins

### DIFF
--- a/packages/app/.eslintrc.js
+++ b/packages/app/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      rules: {
+        'react/prop-types': 1,
+      },
+    },
+  ],
+};

--- a/packages/cli/config/eslint.js
+++ b/packages/cli/config/eslint.js
@@ -39,4 +39,13 @@ module.exports = {
     },
   },
   ignorePatterns: ['**/dist/**', '**/build/**'],
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      rules: {
+        // Default to not enforcing prop-types in typescript
+        'react/prop-types': 0,
+      },
+    },
+  ],
 };

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -1,6 +1,14 @@
 module.exports = {
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      rules: {
+        // TODO: add prop types and set to 1
+        'react/prop-types': 0,
+      },
+    },
+  ],
   rules: {
-    'react/prop-types': 0,
     'jest/expect-expect': 0,
   },
 };


### PR DESCRIPTION
Thinking it doesn't make that much sense to enforce prop-types in TS for all plugins out of the box.

Plugins are still free to override the lint config, but I think runtime prop-types should mostly be enforced in `packages/*`, as we already have typescript to avoid compile-time issues.