### PR TITLE
#332 add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,11 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 
-[*.{ts,json,js}]
+[*.html]
+indent_style = space
+indent_size = 2
+
+[*.{ts,json,js,tsx,jsx}]
 indent_style = space
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+
+[*.{ts,json,js}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_size = 2
+indent_style = space
+
+[Dockerfile]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
Just added the `.editorconfig`.
The configuration is set like the current file types have their style.

No code changes or addition.