### PR TITLE
github/workflows: cache node_modules

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -24,6 +24,11 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: cache node_modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Not sure whether this is a good idea or not tbh, but want to see how the workflows execute :grin:

Most of the deps are cached through the workspace-external yarn cache anyway, but this could potentially make the `yarn install` a no-op if yarn.lock isn't changed.

Only including the top-level node_modules and the ones inside the packages contain cache dirs with a different scope than the yarn.lock hash