### PR TITLE
set up package publishing

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,10 +17,11 @@ jobs:
     name: Node ${{ matrix.node-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: find location of yarn cache
+      - name: find location of global yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - name: cache global yarn cache
+        uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,10 +14,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: find location of yarn cache
+      - name: find location of global yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - name: cache global yarn cache
+        uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,10 +14,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: find location of yarn cache
+      - name: find location of global yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - name: cache global yarn cache
+        uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,55 @@
+name: Master Build
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: find location of yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: cache node_modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: use node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+      - name: yarn install, build, and test
+        run: |
+          yarn install
+          yarn lint
+          yarn build
+          yarn test
+        env:
+          CI: true
+      # Publishes current version of packages that are not already present in the registry
+      - name: publish
+        run: npx --no-install lerna publish from-package --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          CI: true
+      # Tags the commit with the version in the core package if the tag doesn't exist
+      - uses: Klemensas/action-autotag@1.2.3
+        with:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          package_root: "packages/core"
+          tag_prefix: "v"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         node-version: [12.x]
 
+    env:
+      CI: true
+
     steps:
       - uses: actions/checkout@v2
       - name: find location of global yarn cache
@@ -34,20 +37,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/ # Needed for auth
-      - name: yarn install, build, and test
-        run: |
-          yarn install
-          yarn lint
-          yarn build
-          yarn test
-        env:
-          CI: true
+      - run: yarn install
+      - run: yarn lint
+      - run: yarn build
+      - run: yarn test
       # Publishes current version of packages that are not already present in the registry
       - name: publish
         run: npx --no-install lerna publish from-package --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          CI: true
       # Tags the commit with the version in the core package if the tag doesn't exist
       - uses: Klemensas/action-autotag@1.2.3
         with:

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@ Check out [https://backstage.io]() or see the table of content below.
 - [Architecture and terminology](architecture-terminology.md)
 - [Getting started](getting-started/README.md)
 - [References](reference/README.md)
+- [Publishing](publishing.md)

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,37 @@
+# Publishing
+
+## NPM
+
+NPM packages are published through CI/CD in the
+[.github/workflows/master.yml](../.github/workflows/master.yml) workflow. Every
+commit that is merged to master will be checked for new versions of all public
+packages, and any new versions will automatically be published to NPM.
+
+### Creating a new release
+
+Version bumps are made through release PRs. To create a new release, checkout out
+a new branch that you will use for the release, e.g.
+
+```sh
+$ git checkout -b new-release
+```
+
+Then, from the root of the repo, run
+
+```sh
+$ yarn release
+```
+
+This will bring up the lerna release CLI where you choose what type of version bump
+you want to make, (major/minor/patch/prerelease). The CLI will take you through choosing
+a version, previewing all changes, and then approving the release. Once the release
+is approved, a new commit is created that you can submit as a PR. Push the branch to GitHub:
+
+```sh
+$ git push origin -u new-release
+```
+
+And then create a PR. Once the PR is approved and merged into master, the master build
+will publish new versions of all bumped packages.
+
+[Back to Docs](README.md)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "lerna run build",
     "test": "cross-env CI=true lerna run test -- --coverage",
     "create-plugin": "backstage-cli create-plugin",
+    "release": "if [ \"$(git symbolic-ref --short HEAD)\" = master ]; then echo \"don't try to release master\"; exit 1; else lerna version --no-push; fi",
     "lint": "lerna run lint",
     "storybook": "yarn workspace @spotify-backstage/core storybook",
     "build-storybook": "yarn workspace @spotify-backstage/core build-storybook"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,9 @@
     "test": "backstage-cli test",
     "start": "nodemon ."
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
     "@types/html-webpack-plugin": "^3.2.2",

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -4,7 +4,7 @@
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",
   "license": "Apache-2.0",
-  "private": false,
+  "private": true,
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,9 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",

--- a/plugins/home-page/package.json
+++ b/plugins/home-page/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",
+  "private": true,
   "devDependencies": {
     "@spotify-backstage/cli": "^0.1.0",
     "@spotify-backstage/core": "^0.1.0",

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -4,7 +4,7 @@
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",
   "license": "Apache-2.0",
-  "private": false,
+  "private": true,
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",


### PR DESCRIPTION
Based on https://github.com/Rugvip/lerna-publish-experiment.

Version bumps happen through PRs with commits created via local `yarn release`. Once merged into master, the workflows published all public packages to npm, and tags the commit with the version number.

Fixes #363