### PR TITLE
package: update storybook command and remove build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "test": "cross-env CI=true lerna run test --since origin/master -- --coverage",
     "create-plugin": "backstage-cli create-plugin",
     "lint": "lerna run lint",
-    "storybook": "yarn workspace @spotify-backstage/core storybook",
-    "build-storybook": "yarn workspace @spotify-backstage/core build-storybook"
+    "storybook": "yarn workspace storybook start"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
Didn't see the top-level storybook command so I didn't update it in #371, this fixes that.

Also figured we could remove the top-level build command? Don't see to much value in having it as building the storybook I expect is something that's mostly done by CI, and the build output lives in the package anyway. The way to build from now would be to go into the storybook package itself and build it.