### PR TITLE
fix: install @backstage/core when scaffolding a plugin

### DIFF
--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -16,6 +16,7 @@
     "jest-fetch-mock": "^3.0.3"
   },
   "dependencies": {
+    "@backstage/core": "^{{version}}",
     "@material-ui/lab": "4.0.0-alpha.45"
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It turned out that the plugin scaffolding tool was not adding a dependency on `@backstage/core` to the new plugins, which leads to this error on `yarn build`:

```sh
$ backstage-cli plugin:build
src/components/ExampleComponent/ExampleComponent.tsx:28:8 - error TS2307: Cannot find module '@backstage/core'.

28 } from '@backstage/core';
          ~~~~~~~~~~~~~~~~~

src/components/ExampleFetchComponent/ExampleFetchComponent.tsx:28:26 - error TS2307: Cannot find module '@backstage/core'.

28 import { Progress } from '@backstage/core';
                            ~~~~~~~~~~~~~~~~~

src/plugin.ts:17:30 - error TS2307: Cannot find module '@backstage/core'.

17 import { createPlugin } from '@backstage/core';
                                ~~~~~~~~~~~~~~~~~

src/plugin.ts:22:14 - error TS7031: Binding element 'router' implicitly has an 'any' type.

22   register({ router }) {
```

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] [CODEOWNERS](./CODEOWNERS) updated (for new stuff)
- [ ] Regression tests added for bug fixes
