### PR TITLE
cli: add experimental build-cache command and make sure things are only built on change in CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,11 +29,11 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: cache node_modules
+      - name: cache node_modules/.cache
         uses: actions/cache@v1
         with:
-          path: node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+          path: node_modules/.cache
+          key: node_modules-cache
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,6 +30,11 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: cache node_modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: cache build cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       CI: true
+      BACKSTAGE_CACHE_DIR: <repoRoot>/.backstage-build-cache
 
     steps:
       - uses: actions/checkout@v2
@@ -29,11 +30,13 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: cache node_modules/.cache
+      - name: cache build cache
         uses: actions/cache@v1
         with:
-          path: node_modules/.cache
-          key: node_modules-cache
+          path: .backstage-build-cache
+          key: build-cache-${{ github.sha }}
+          restore-keys: |
+            build-cache-
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       CI: true
       BACKSTAGE_CACHE_DIR: <repoRoot>/.backstage-build-cache
+      BACKSTAGE_CACHE_MAX_ENTRIES: 2
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -53,6 +53,6 @@ jobs:
       - run: yarn build
       - run: yarn test
       - name: yarn bundle, if app was changed
-        run: git diff --quiet origin/master HEAD -- packages/app || yarn bundle
+        run: git diff --quiet origin/master HEAD -- packages/app packages/core || yarn bundle
       - name: verify storybook
         run: yarn workspace storybook build-storybook

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -43,5 +43,7 @@ jobs:
       - run: yarn lint
       - run: yarn build
       - run: yarn test
+      - name: yarn bundle, if app was changed
+        run: git diff --quiet origin/master HEAD -- packages/app || yarn bundle
       - name: verify storybook
         run: yarn workspace storybook build-storybook

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       CI: true
+      BACKSTAGE_CACHE_DIR: <repoRoot>/.backstage-build-cache
 
     steps:
       - uses: actions/checkout@v2
@@ -27,11 +28,13 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: cache node_modules/.cache
+      - name: cache build cache
         uses: actions/cache@v1
         with:
-          path: node_modules/.cache
-          key: node_modules-cache
+          path: .backstage-build-cache
+          key: build-cache-${{ github.sha }}
+          restore-keys: |
+            build-cache-
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,6 +28,11 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: cache node_modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: cache build cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       CI: true
       BACKSTAGE_CACHE_DIR: <repoRoot>/.backstage-build-cache
+      BACKSTAGE_CACHE_MAX_ENTRIES: 2
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,11 +27,11 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: cache node_modules
+      - name: cache node_modules/.cache
         uses: actions/cache@v1
         with:
-          path: node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+          path: node_modules/.cache
+          key: node_modules-cache
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "cross-env CI=true lerna run test --since origin/master -- --coverage",
     "create-plugin": "backstage-cli create-plugin",
     "release": "if [ \"$(git symbolic-ref --short HEAD)\" = master ]; then echo \"don't try to release master\"; exit 1; else lerna version --no-push; fi",
-    "lint": "lerna run lint",
+    "lint": "cross-env CI=true lerna run lint --since origin/master --",
     "storybook": "yarn workspace storybook start"
   },
   "workspaces": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "start": "yarn build && yarn workspace example-app start",
+    "bundle": "yarn build && yarn workspace example-app bundle",
     "build": "lerna run build",
     "test": "cross-env CI=true lerna run test --since origin/master -- --coverage",
     "create-plugin": "backstage-cli create-plugin",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "start": "backstage-cli app:serve",
-    "build": "backstage-cli app:build",
+    "bundle": "backstage-cli app:build",
     "test": "backstage-cli test",
     "test:e2e": "start-server-and-test start http://localhost:3000 cy:dev",
     "test:e2e:ci": "start-server-and-test start http://localhost:3000 cy:run",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,10 +32,12 @@
     "@types/ora": "^3.2.0",
     "@types/react-dev-utils": "^9.0.4",
     "@types/recursive-readdir": "^2.2.0",
+    "@types/tar": "^4.0.3",
     "@types/webpack": "^4.41.7",
     "@types/webpack-dev-server": "^3.10.0",
     "del": "^5.1.0",
     "nodemon": "^2.0.2",
+    "tar": "^6.0.1",
     "ts-node": "^8.6.2"
   },
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
   "main": "dist",
   "scripts": {
     "exec": "npx ts-node ./src",
-    "build": "tsc --outDir dist --noEmit false --module CommonJS",
+    "build": "backstage-cli build-cache -- tsc --outDir dist --noEmit false --module CommonJS",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "start": "nodemon ."

--- a/packages/cli/src/commands/build-cache/archive.ts
+++ b/packages/cli/src/commands/build-cache/archive.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import tar from 'tar';
+import { dirname } from 'path';
+
+export async function readFileFromArchive(
+  archivePath: string,
+  filePath: string,
+): Promise<Buffer> {
+  const reader = fs.createReadStream(archivePath);
+  const parser = new ((tar.Parse as unknown) as { new (): tar.ParseStream })();
+
+  const fileEntry = await new Promise<tar.ReadEntry>((resolve, reject) => {
+    parser.on('entry', entry => {
+      if (entry.path === `./${filePath}`) {
+        resolve(entry);
+        reader.close();
+      } else {
+        entry.resume();
+      }
+    });
+    parser.on('end', () => {
+      reject(new Error('cache archive did not contain build info'));
+    });
+    parser.on('error', error => reject(error));
+    reader.on('error', error => reject(error));
+
+    reader.pipe(parser);
+  });
+
+  const data = await new Promise<Buffer>((resolve, reject) => {
+    const chunks = new Array<Buffer>();
+    fileEntry.on('data', chunk => chunks.push(chunk));
+    fileEntry.on('end', () => resolve(Buffer.concat(chunks)));
+    fileEntry.on('error', error => reject(error));
+  });
+
+  return data;
+}
+
+// packages all files in inputDir into an archive at archivePath, deleting any existing archive
+export async function createArchive(
+  archivePath: string,
+  inputDir: string,
+): Promise<void> {
+  await fs.remove(archivePath);
+  await fs.ensureDir(dirname(archivePath));
+  await tar.create({ gzip: true, file: archivePath, cwd: inputDir }, ['.']);
+}
+
+// extracts archive at archive path into outputDir, deleting any existing files at outputDir
+export async function extractArchive(
+  archivePath: string,
+  outputDir: string,
+): Promise<void> {
+  await fs.remove(outputDir);
+  await fs.ensureDir(outputDir);
+  await tar.extract({ file: archivePath, cwd: outputDir });
+}

--- a/packages/cli/src/commands/build-cache/cache.ts
+++ b/packages/cli/src/commands/build-cache/cache.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import { resolve as resolvePath, relative as relativePath } from 'path';
+import { runPlain } from '../../helpers/run';
+import { readFileFromArchive } from './archive';
+import { Options } from './options';
+
+export type Cache = {
+  // External location of the cache outside the output folder
+  archivePath: string;
+  readable?: boolean;
+  writable?: boolean;
+  needsCopy?: boolean;
+  trees?: string[];
+};
+
+const CACHE_ARCHIVE = 'cache.tgz';
+const INFO_FILE = '.backstage-build-cache';
+
+export async function readCache(options: Options): Promise<Cache> {
+  const repoPath = relativePath(options.repoRoot, process.cwd());
+  const location = resolvePath(options.cacheDir, repoPath);
+  const archivePath = resolvePath(location, CACHE_ARCHIVE);
+
+  // Make sure we don't have any uncommitted changes to the input, in that case we consider the cache to be missing
+  try {
+    // await exec(`git diff --quiet HEAD -- ${options.inputs.join(' ')}`);
+  } catch (error) {
+    return { archivePath };
+  }
+
+  const infoFilePath = resolvePath(options.output, INFO_FILE);
+  const outputCacheExists = await fs.pathExists(infoFilePath);
+  if (outputCacheExists) {
+    const infoData = await fs.readFile(infoFilePath);
+    const { trees } = JSON.parse(infoData.toString('utf8'));
+    if (trees) {
+      return {
+        archivePath,
+        trees,
+        readable: true,
+        writable: true,
+      };
+    }
+  }
+
+  try {
+    const externalCacheExists = await fs.pathExists(location);
+    if (externalCacheExists) {
+      const infoData = await readFileFromArchive(archivePath, INFO_FILE);
+      const { trees } = JSON.parse(infoData.toString('utf8'));
+      if (trees) {
+        return {
+          archivePath,
+          trees,
+          readable: true,
+          writable: true,
+          needsCopy: true,
+        };
+      }
+    }
+  } catch (error) {
+    throw new Error(`failed to read external cache archive, ${error}`);
+  }
+  return { archivePath, writable: true };
+}
+
+export async function writeCacheInfo(
+  trees: string[],
+  options: Options,
+): Promise<void> {
+  const infoData = Buffer.from(JSON.stringify({ trees }, null, 2), 'utf8');
+  await fs.writeFile(resolvePath(options.output, INFO_FILE), infoData);
+}
+
+export async function readInputHashes(options: Options): Promise<string[]> {
+  const trees = [];
+  for (const input of options.inputs) {
+    const output = await runPlain(`git ls-tree HEAD '${input}'`);
+    const [, , sha] = output.split(/\s+/, 3);
+    trees.push(sha);
+  }
+  return trees;
+}

--- a/packages/cli/src/commands/build-cache/cache.ts
+++ b/packages/cli/src/commands/build-cache/cache.ts
@@ -20,13 +20,12 @@ import { runPlain, runCheck } from '../../helpers/run';
 import { Options } from './options';
 import { extractArchive, createArchive } from './archive';
 
-const MAX_ENTRIES = 10;
 const INFO_FILE = '.backstage-build-cache';
 
 export type CacheQueryResult = {
   hit: boolean;
   copy?: (outputDir: string) => Promise<void>;
-  archive?: (outputDir: string) => Promise<void>;
+  archive?: (outputDir: string, maxEntries: number) => Promise<void>;
 };
 
 export type CacheKey = string[];
@@ -83,7 +82,7 @@ export class Cache {
       return { hit: false };
     }
 
-    const archive = async (outputDir: string) => {
+    const archive = async (outputDir: string, maxEntries: number) => {
       await writeCacheInfo(outputDir, { key });
 
       const timestamp = new Date().toISOString().replace(/-|:|\..*/g, '');
@@ -111,7 +110,7 @@ export class Cache {
       entries.unshift({ key, path: archiveName });
 
       // Remove old cache entries
-      const removedEntries = entries.splice(MAX_ENTRIES);
+      const removedEntries = entries.splice(maxEntries);
       for (const entry of removedEntries) {
         try {
           await fs.remove(resolvePath(location, entry.path));

--- a/packages/cli/src/commands/build-cache/cache.ts
+++ b/packages/cli/src/commands/build-cache/cache.ts
@@ -16,7 +16,7 @@
 
 import fs from 'fs-extra';
 import { resolve as resolvePath, relative as relativePath } from 'path';
-import { runPlain } from '../../helpers/run';
+import { runPlain, runCheck } from '../../helpers/run';
 import { Options } from './options';
 import { extractArchive, createArchive } from './archive';
 
@@ -47,9 +47,10 @@ export class Cache {
     const location = resolvePath(options.cacheDir, repoPath);
 
     // Make sure we don't have any uncommitted changes to the input, in that case we consider the cache to be missing
-    try {
-      // await exec(`git diff --quiet HEAD -- ${options.inputs.join(' ')}`);
-    } catch (error) {
+    const noChanges = await runCheck(
+      `git diff --quiet HEAD -- ${options.inputs.join(' ')}`,
+    );
+    if (!noChanges) {
       return new Cache();
     }
 

--- a/packages/cli/src/commands/build-cache/cache.ts
+++ b/packages/cli/src/commands/build-cache/cache.ts
@@ -17,27 +17,29 @@
 import fs from 'fs-extra';
 import { resolve as resolvePath, relative as relativePath } from 'path';
 import { runPlain } from '../../helpers/run';
-import { readFileFromArchive } from './archive';
 import { Options } from './options';
+import { extractArchive, createArchive } from './archive';
 
-export type CacheHit = {
-  // External location of the cache outside the output folder
-  archivePath: string;
-  readable?: boolean;
-  writable?: boolean;
-  needsCopy?: boolean;
-  trees?: string[];
+const MAX_ENTRIES = 10;
+const INFO_FILE = '.backstage-build-cache';
+
+export type CacheQueryResult = {
+  hit: boolean;
+  copy?: (outputDir: string) => Promise<void>;
+  archive?: (outputDir: string) => Promise<void>;
 };
 
 export type CacheKey = string[];
 
 type CacheEntry = {
   key: CacheKey;
-  archivePath: string;
+  path: string;
 };
 
-const CACHE_ARCHIVE = 'cache.tgz';
-const INFO_FILE = '.backstage-build-cache';
+type CacheInfo = {
+  key?: CacheKey;
+  entries?: CacheEntry[];
+};
 
 export class Cache {
   static async read(options: Options) {
@@ -51,31 +53,11 @@ export class Cache {
       return new Cache();
     }
 
-    let localKey: CacheKey = [];
+    const outputInfo = await readCacheInfo(options.output);
+    const localKey = outputInfo?.key;
 
-    const localInfoFile = resolvePath(options.output, INFO_FILE);
-    const outputCacheExists = await fs.pathExists(localInfoFile);
-    if (outputCacheExists) {
-      const infoData = await fs.readFile(localInfoFile);
-      const { trees } = JSON.parse(infoData.toString('utf8'));
-      localKey = trees;
-    }
-
-    try {
-      const externalCacheExists = await fs.pathExists(location);
-      if (externalCacheExists) {
-        const archivePath = resolvePath(location, CACHE_ARCHIVE);
-        const infoData = await readFileFromArchive(archivePath, INFO_FILE);
-        const { trees } = JSON.parse(infoData.toString('utf8'));
-        if (trees) {
-          return new Cache([{ archivePath, key: trees }], location, localKey);
-        }
-      }
-    } catch (error) {
-      throw new Error(`failed to read external cache archive, ${error}`);
-    }
-
-    return new Cache([], location, localKey);
+    const { entries = [] } = (await readCacheInfo(location)) ?? {};
+    return new Cache(entries, location, localKey);
   }
 
   static async readInputKey(inputPaths: string[]): Promise<CacheKey> {
@@ -94,40 +76,97 @@ export class Cache {
     private readonly localKey?: CacheKey,
   ) {}
 
-  find(key: CacheKey): CacheHit | undefined {
-    if (!this.location) {
-      return undefined;
+  query(key: CacheKey): CacheQueryResult {
+    const { location } = this;
+    if (!location) {
+      return { hit: false };
     }
-    if (this.localKey?.join(',') === key.join(',')) {
-      return {
-        needsCopy: false,
-        archivePath: resolvePath(this.location, CACHE_ARCHIVE),
-      };
+
+    const archive = async (outputDir: string) => {
+      await writeCacheInfo(outputDir, { key });
+
+      const timestamp = new Date().toISOString().replace(/-|:|\..*/g, '');
+      const rand = Math.random()
+        .toString(36)
+        .slice(2, 6);
+      const archiveName = `cache-${timestamp}-${rand}.tgz`;
+      const archivePath = resolvePath(location, archiveName);
+
+      // Read existing entries and prepend the new one
+      const { entries = [] } = (await readCacheInfo(location)) ?? {};
+
+      // Check if there's already aan entry for this key, in that case we just wanna bump it
+      const entryIndex = entries.findIndex(e => compareKeys(e.key, key));
+      if (entryIndex !== -1) {
+        const [existingEntry] = entries.splice(entryIndex, 1);
+        entries.unshift(existingEntry);
+
+        await writeCacheInfo(location, { entries });
+        return;
+      }
+
+      // Create and add new archive to entries
+      await createArchive(archivePath, outputDir);
+      entries.unshift({ key, path: archiveName });
+
+      // Remove old cache entries
+      const removedEntries = entries.splice(MAX_ENTRIES);
+      for (const entry of removedEntries) {
+        try {
+          await fs.remove(resolvePath(location, entry.path));
+        } catch (error) {
+          process.stderr.write(`failed to remove old cache entry, ${error}\n`);
+        }
+      }
+
+      await writeCacheInfo(location, { entries });
+    };
+
+    if (compareKeys(this.localKey, key)) {
+      return { hit: true, archive };
     }
-    const matchingEntry = this.entries.find(entry => entry.key === key);
+
+    const matchingEntry = this.entries.find(e => compareKeys(e.key, key));
     if (!matchingEntry) {
-      return undefined;
+      return { hit: false, archive };
     }
+
     return {
-      needsCopy: true,
-      archivePath: matchingEntry.archivePath,
+      hit: true,
+      archive,
+      copy: async (outputDir: string) => {
+        const archivePath = resolvePath(location, matchingEntry.path);
+        await extractArchive(archivePath, outputDir);
+      },
     };
   }
+}
 
-  get shouldCacheOutput() {
-    return Boolean(this.location);
+function compareKeys(a?: CacheKey, b?: CacheKey): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  return a.join(',') === b.join(',');
+}
+
+async function readCacheInfo(
+  parentDir: string,
+): Promise<CacheInfo | undefined> {
+  const infoFile = resolvePath(parentDir, INFO_FILE);
+  const exists = await fs.pathExists(infoFile);
+  if (!exists) {
+    return undefined;
   }
 
-  async prepareOutput(key: CacheKey, outputDir: string): Promise<string> {
-    if (!this.location) {
-      throw new Error("can't write cache output, no location set");
-    }
-    const infoData = Buffer.from(
-      JSON.stringify({ trees: key }, null, 2),
-      'utf8',
-    );
-    await fs.writeFile(resolvePath(outputDir, INFO_FILE), infoData);
-    const archivePath = resolvePath(this.location, CACHE_ARCHIVE);
-    return archivePath;
-  }
+  const infoData = await fs.readFile(infoFile);
+  const cacheInfo = JSON.parse(infoData.toString('utf8')) as CacheInfo;
+  return cacheInfo;
+}
+
+async function writeCacheInfo(
+  parentDir: string,
+  cacheInfo: CacheInfo,
+): Promise<void> {
+  const infoData = Buffer.from(JSON.stringify(cacheInfo, null, 2), 'utf8');
+  await fs.writeFile(resolvePath(parentDir, INFO_FILE), infoData);
 }

--- a/packages/cli/src/commands/build-cache/index.ts
+++ b/packages/cli/src/commands/build-cache/index.ts
@@ -199,6 +199,7 @@ async function readInfoFileFromArchive(
       reject(new Error('cache archive did not contain build info'));
     });
     parser.on('error', error => reject(error));
+    reader.on('error', error => reject(error));
 
     reader.pipe(parser);
   });

--- a/packages/cli/src/commands/build-cache/index.ts
+++ b/packages/cli/src/commands/build-cache/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * The build-cache command is used to make builds a no-op if there are no changes to the package.
+ * It supports both local development where the output directory remains intact, as well as CI
+ * where the output directory is stored in a separate cache dir.
+ */
+export default async () => {};

--- a/packages/cli/src/commands/build-cache/index.ts
+++ b/packages/cli/src/commands/build-cache/index.ts
@@ -14,9 +14,162 @@
  * limitations under the License.
  */
 
+import fs from 'fs-extra';
+import { resolve as resolvePath, relative as relativePath } from 'path';
+import { promisify } from 'util';
+import { exec as execCb } from 'child_process';
+import { Command } from 'commander';
+import { ExitCodeError } from '../../helpers/errors';
+const exec = promisify(execCb);
+
+const INFO_FILE = '.backstage-build-cache';
+
+type Options = {
+  inputs: string[];
+  output: string;
+  cacheDir: string;
+  repoRoot: string;
+};
+
+async function parseOptions(cmd: Command): Promise<Options> {
+  const repoRoot = await run('git rev-parse --show-toplevel');
+  const argTransformer = (arg: string) =>
+    resolvePath(arg.replace(/<repoRoot>/g, repoRoot).replace(/'/g, ''));
+
+  const inputs = cmd.input.map(argTransformer) as string[];
+  if (inputs.length === 0) {
+    inputs.push(argTransformer('.'));
+  }
+  const output = argTransformer(cmd.output);
+  const cacheDir = argTransformer(cmd.cacheDir);
+  return { inputs, output, cacheDir, repoRoot };
+}
+
 /*
  * The build-cache command is used to make builds a no-op if there are no changes to the package.
  * It supports both local development where the output directory remains intact, as well as CI
  * where the output directory is stored in a separate cache dir.
  */
-export default async () => {};
+export default async (cmd: Command, args: string[]) => {
+  const options = await parseOptions(cmd);
+  console.log('DEBUG: options =', options);
+  console.log('DEBUG: args =', args);
+
+  const cache = await readCache(options);
+  console.log('DEBUG: cache =', cache);
+
+  const trees = await getInputHashes(options);
+  console.log('DEBUG: trees =', trees);
+
+  const cacheHit = cache.readable && cache.trees?.join(',') === trees.join(',');
+  if (!cacheHit) {
+    await build(options);
+
+    await fs.writeFile(
+      resolvePath(options.output, INFO_FILE),
+      JSON.stringify({ trees }, null, 2),
+      'utf-8',
+    );
+    if (cache.writable) {
+      console.log(`DEBUG: write cache`);
+      console.log('DEBUG: cache.location =', cache.location);
+      await fs.remove(cache.location);
+      console.log('DEBUG: options.output =', options.output);
+      await fs.copy(options.output, cache.location);
+    }
+  } else if (cache.needsCopy) {
+    console.log(`DEBUG: would copy cache`);
+    await fs.remove(options.output);
+    await fs.copy(cache.location, options.output);
+  }
+
+  const ls = await run('ls derp');
+  console.log('DEBUG: ls =', ls);
+};
+
+async function build(options: Options): Promise<void> {
+  console.log(`Imma build ${options.output}`);
+}
+
+async function run(cmd: string) {
+  try {
+    const { stdout } = await exec(cmd);
+    return stdout.trim();
+  } catch (error) {
+    if (error.stderr) {
+      process.stderr.write(error.stderr);
+    }
+    throw new ExitCodeError(error.code, cmd);
+  }
+}
+
+type Cache = {
+  // External location of the cache outside the output folder
+  location: string;
+  readable?: boolean;
+  writable?: boolean;
+  needsCopy?: boolean;
+  trees?: string[];
+};
+
+async function readCache(options: Options): Promise<Cache> {
+  const repoPath = relativePath(options.repoRoot, process.cwd());
+  const location = resolvePath(options.cacheDir, repoPath);
+
+  // Make sure we don't have any uncommitted changes to the input, in that case we consider the cache to be missing
+  try {
+    await exec(`git diff --quiet HEAD -- ${options.inputs.join(' ')}`);
+  } catch (error) {
+    return { location };
+  }
+
+  try {
+    const outputCacheExists = await fs.pathExists(
+      resolvePath(options.output, INFO_FILE),
+    );
+    if (outputCacheExists) {
+      const trees = await readInfoFile(options.output);
+      if (trees) {
+        return {
+          location,
+          trees,
+          readable: true,
+          writable: true,
+        };
+      }
+    }
+
+    const externalCacheExists = await fs.pathExists(location);
+    if (externalCacheExists) {
+      const trees = await readInfoFile(location);
+      if (trees) {
+        return {
+          location,
+          trees,
+          readable: true,
+          writable: true,
+          needsCopy: true,
+        };
+      }
+    }
+  } catch (error) {
+    console.log(`Cache not found, ${error}`);
+  }
+  return { location, writable: true };
+}
+
+async function readInfoFile(dir: string): Promise<string[] | undefined> {
+  const infoContents = await fs.readFile(resolvePath(dir, INFO_FILE), 'utf-8');
+  const { trees } = JSON.parse(infoContents);
+  return trees;
+}
+
+async function getInputHashes(options: Options): Promise<string[]> {
+  const trees = [];
+  for (const input of options.inputs) {
+    const output = await run(`git ls-tree HEAD '${input}'`);
+    const [, , sha] = output.split(/\s+/, 3);
+    trees.push(sha);
+  }
+  return trees;
+}

--- a/packages/cli/src/commands/build-cache/index.ts
+++ b/packages/cli/src/commands/build-cache/index.ts
@@ -48,7 +48,7 @@ export default async (cmd: Command, args: string[]) => {
 
     if (cacheResult.archive) {
       print('caching build output');
-      await cacheResult.archive(options.output);
+      await cacheResult.archive(options.output, options.maxCacheEntries);
     }
   }
 };

--- a/packages/cli/src/commands/build-cache/options.ts
+++ b/packages/cli/src/commands/build-cache/options.ts
@@ -35,6 +35,8 @@ export async function parseOptions(cmd: Command): Promise<Options> {
     inputs.push(argTransformer('.'));
   }
   const output = argTransformer(cmd.output);
-  const cacheDir = argTransformer(cmd.cacheDir);
+  const cacheDir = argTransformer(
+    process.env.BACKSTAGE_CACHE_DIR || cmd.cacheDir,
+  );
   return { inputs, output, cacheDir, repoRoot };
 }

--- a/packages/cli/src/commands/build-cache/options.ts
+++ b/packages/cli/src/commands/build-cache/options.ts
@@ -18,10 +18,13 @@ import { resolve as resolvePath } from 'path';
 import { Command } from 'commander';
 import { runPlain } from '../../helpers/run';
 
+const DEFAULT_MAX_ENTRIES = 10;
+
 export type Options = {
   inputs: string[];
   output: string;
   cacheDir: string;
+  maxCacheEntries: number;
   repoRoot: string;
 };
 
@@ -38,5 +41,7 @@ export async function parseOptions(cmd: Command): Promise<Options> {
   const cacheDir = argTransformer(
     process.env.BACKSTAGE_CACHE_DIR || cmd.cacheDir,
   );
-  return { inputs, output, cacheDir, repoRoot };
+  const maxCacheEntries =
+    Number(process.env.BACKSTAGE_CACHE_MAX_ENTRIES) || DEFAULT_MAX_ENTRIES;
+  return { inputs, output, cacheDir, repoRoot, maxCacheEntries };
 }

--- a/packages/cli/src/commands/build-cache/options.ts
+++ b/packages/cli/src/commands/build-cache/options.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolve as resolvePath } from 'path';
+import { Command } from 'commander';
+import { runPlain } from '../../helpers/run';
+
+export type Options = {
+  inputs: string[];
+  output: string;
+  cacheDir: string;
+  repoRoot: string;
+};
+
+export async function parseOptions(cmd: Command): Promise<Options> {
+  const repoRoot = await runPlain('git rev-parse --show-toplevel');
+  const argTransformer = (arg: string) =>
+    resolvePath(arg.replace(/<repoRoot>/g, repoRoot).replace(/'/g, ''));
+
+  const inputs = cmd.input.map(argTransformer) as string[];
+  if (inputs.length === 0) {
+    inputs.push(argTransformer('.'));
+  }
+  const output = argTransformer(cmd.output);
+  const cacheDir = argTransformer(cmd.cacheDir);
+  return { inputs, output, cacheDir, repoRoot };
+}

--- a/packages/cli/src/helpers/run.ts
+++ b/packages/cli/src/helpers/run.ts
@@ -62,6 +62,15 @@ export async function runPlain(cmd: string) {
   }
 }
 
+export async function runCheck(cmd: string): Promise<boolean> {
+  try {
+    await exec(cmd);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 export async function waitForExit(
   child: ChildProcess & { exitCode?: number },
   name?: string,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import createPluginCommand from './commands/create-plugin/createPlugin';
 import watch from './commands/watch-deps';
+import buildCache from './commands/build-cache';
 import lintCommand from './commands/lint';
 import testCommand from './commands/testCommand';
 import appBuild from './commands/app/build';
@@ -75,6 +76,23 @@ const main = (argv: string[]) => {
     .command('watch-deps')
     .description('Watch all dependencies while running another command')
     .action(actionHandler(watch));
+
+  program
+    .command('build-cache')
+    .description('Wrap build command with a cache')
+    .option(
+      '--input <dirs>',
+      'List of input directories that invalidate the cache [.]',
+      (value, acc) => acc.concat(value),
+      [],
+    )
+    .option('--output <dir>', 'Output directory to cache', 'dist')
+    .option(
+      '--cache-dir <dir>',
+      'Cache dir',
+      '<repoRoot>/node_modules/.cache/backstage-builds',
+    )
+    .action(actionHandler(buildCache));
 
   program.on('command:*', () => {
     console.log();

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",
   "scripts": {
-    "build": "tsc --outDir dist/cjs --noEmit false --module CommonJS",
+    "build": "backstage-cli build-cache -- tsc --outDir dist/cjs --noEmit false --module CommonJS",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },

--- a/plugins/home-page/package.json
+++ b/plugins/home-page/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^16.12.0"
   },
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3612,6 +3612,13 @@
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/minipass@*":
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/@types/minipass/-/minipass-2.2.0.tgz#51ad404e8eb1fa961f75ec61205796807b6f9651"
+  integrity sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@>= 8", "@types/node@^13.7.2":
   version "13.9.2"
   resolved "https://registry.npmjs.org/@types/node/-/node-13.9.2.tgz#ace1880c03594cc3e80206d96847157d8e7fa349"
@@ -3775,6 +3782,14 @@
   version "1.0.5"
   resolved "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
   integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/tar@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/@types/tar/-/tar-4.0.3.tgz#e2cce0b8ff4f285293243f5971bd7199176ac489"
+  integrity sha512-Z7AVMMlkI8NTWF0qGhC4QIX0zkV/+y0J8x7b/RsHrN0310+YNjoJd8UrApCiGBCWtKjxS9QhNqLi2UJNToh5hA==
+  dependencies:
+    "@types/minipass" "*"
+    "@types/node" "*"
 
 "@types/testing-library__cypress@^5.0.3":
   version "5.0.3"
@@ -5795,7 +5810,7 @@ chokidar@^3.2.2, chokidar@^3.3.0, chokidar@^3.3.1:
   optionalDependencies:
     fsevents "~2.1.2"
 
-chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.4:
+chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.3, chownr@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
@@ -13039,6 +13054,14 @@ minizlib@^1.2.1:
   dependencies:
     minipass "^2.9.0"
 
+minizlib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz#fd52c645301ef09a63a2c209697c294c6ce02cf3"
+  integrity sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mississippi@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
@@ -13078,7 +13101,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*:
+mkdirp@*, mkdirp@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
   integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
@@ -18082,6 +18105,18 @@ tar@^4.4.10, tar@^4.4.12, tar@^4.4.13, tar@^4.4.8:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
+
+tar@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/tar/-/tar-6.0.1.tgz#7b3bd6c313cb6e0153770108f8d70ac298607efa"
+  integrity sha512-bKhKrrz2FJJj5s7wynxy/fyxpE0CmCjmOQ1KV4KkgXFWOgoIT/NbTMnB1n+LFNrNk0SSBVGGxcK5AGsyC+pW5Q==
+  dependencies:
+    chownr "^1.1.3"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.0"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 telejson@^3.2.0:
   version "3.3.0"


### PR DESCRIPTION
Trying out some changes to the build process, with the goal to build/test/lint the least amount of code that's necessary. The `backstage-cli build-cache` command that is added in this PR caches the `dist/` folder in the `node_modules/.cache folder`, which should work both for CI and local development.

Another goal is to be able to jump between different commits during local development without having to rebuild packages all the time. The cache therefore stores up to 10 entries that can be restored to avoid a build.

The key used for the cache is the tree sha of the package in git, so it's very quick, but if there are any local changes caching is disabled.

I also snuck in a couple of changes for the workflows. The node_modules cache was removed, since that didn't work. I also enabled `--since` flag for tests, and made the app build a separate `bundle` script that's only run if the app is changed.

Hoping to get most PR checks down below 2 minutes, even for a large number of plugins.