### PR TITLE
packages: rename @backstage/app to example-app

### DIFF
--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -15,7 +15,7 @@ By default, backstage will start on port 3000, however you can override this by 
 Once successfully started, you should see the following message in your terminal window:
 
 ```
-You can now view @backstage/app in the browser.
+You can now view example-app in the browser.
 
   Local:            http://localhost:8080
   On Your Network:  http://192.168.1.224:8080

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "start": "yarn build && yarn workspace @backstage/app start",
+    "start": "yarn build && yarn workspace example-app start",
     "build": "lerna run build",
     "test": "cross-env CI=true lerna run test --since origin/master -- --coverage",
     "create-plugin": "backstage-cli create-plugin",

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -1,3 +1,3 @@
-# @backstage/app
+# example-app
 
 This package is an example of a Backstage application.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@backstage/app",
+  "name": "example-app",
   "version": "0.1.1-alpha.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Making it a bit more clear that it's just an example and not a published package