### PR TITLE
[cli] CODEOWNERS: catch-all goes first, and paths are absolute

### DIFF
--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -405,7 +405,7 @@ const createPlugin = async () => {
     if (ownerIds && ownerIds.length) {
       await addCodeownersEntry(
         codeownersPath!,
-        path.join('plugins', answers.id),
+        `/plugins/${answers.id}`,
         ownerIds,
       );
     }

--- a/packages/cli/src/commands/create-plugin/lib/codeowners.ts
+++ b/packages/cli/src/commands/create-plugin/lib/codeowners.ts
@@ -20,6 +20,7 @@ import path from 'path';
 const TEAM_ID_RE = /^@[-\w]+\/[-\w]+$/;
 const USER_ID_RE = /^@[-\w]+$/;
 const EMAIL_RE = /^[^@]+@[-.\w]+\.[-\w]+$/i;
+const DEFAULT_OWNER = '@spotify/backstage-core';
 
 type CodeownersEntry = {
   ownedPath: string;
@@ -96,8 +97,11 @@ export async function addCodeownersEntry(
   const newDeclarationEntries = oldDeclarationEntries
     .filter(entry => entry.ownedPath !== '*')
     .concat([{ ownedPath, ownerIds }])
-    .sort((l1, l2) => l1.ownedPath.localeCompare(l2.ownedPath))
-    .concat([{ ownedPath: '*', ownerIds: ['@spotify/backstage-core'] }]);
+    .sort((l1, l2) => l1.ownedPath.localeCompare(l2.ownedPath));
+  newDeclarationEntries.unshift({
+    ownedPath: '*',
+    ownerIds: [DEFAULT_OWNER],
+  });
 
   // Calculate longest path to be able to align entries nicely
   const longestOwnedPath = newDeclarationEntries.reduce(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] [CODEOWNERS](./CODEOWNERS) updated (for new stuff)
- [ ] Regression tests added for bug fixes
