### PR TITLE
Rewrite layout/Header/Waves to use TypeScript

### DIFF
--- a/packages/core/src/layout/Header/Waves.test.tsx
+++ b/packages/core/src/layout/Header/Waves.test.tsx
@@ -16,8 +16,8 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import Waves from './Waves';
 import { pageTheme } from '../Page/PageThemeProvider';
+import Waves from './Waves';
 
 describe('<Waves/>', () => {
   it('should render svg', () => {

--- a/packages/core/src/layout/Header/Waves.test.tsx
+++ b/packages/core/src/layout/Header/Waves.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import Waves from './Waves';
+import { pageTheme } from '../Page/PageThemeProvider';
+
+describe('<Waves/>', () => {
+  it('should render svg', () => {
+    const rendered = render(<Waves theme={pageTheme.home} />);
+    rendered.getByTestId('wave-svg');
+  });
+});

--- a/packages/core/src/layout/Header/Waves.tsx
+++ b/packages/core/src/layout/Header/Waves.tsx
@@ -16,7 +16,7 @@
 
 import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core';
-import { PageTheme } from '@backstage/core';
+import { PageTheme } from '../Page';
 
 const useStyles = makeStyles<PageTheme>({
   wave: {

--- a/packages/core/src/layout/Header/Waves.tsx
+++ b/packages/core/src/layout/Header/Waves.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core';
+import { PageTheme } from '@backstage/core';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles<PageTheme>({
   wave: {
     position: 'absolute',
     height: '100%',
@@ -26,11 +27,15 @@ const useStyles = makeStyles({
     bottom: 0,
     left: 0,
     right: 0,
-    'z-index': -1,
+    zIndex: -1,
   },
 });
 
-const Waves = ({ theme }) => {
+type Props = {
+  theme: PageTheme;
+};
+
+const Waves: FC<Props> = ({ theme }) => {
   const classes = useStyles();
   const [color1, color2] = theme.gradient.colors;
 
@@ -41,6 +46,7 @@ const Waves = ({ theme }) => {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={classes.wave}
+      data-testid="wave-svg"
     >
       <rect width="1440" height="94" fill="url(#paint0_linear)" />
       <g opacity="0.8">


### PR DESCRIPTION
* Add simple test looking for svg node
## Hey, I just made a Pull Request!

#### :heavy_check_mark: Checklist
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] [CODEOWNERS](./CODEOWNERS) updated (for new stuff)
- [ ] Regression tests added for bug fixes

#### Description
Simple rewrite of Waves componet. New things include:
* type `Props` using `PageTheme`
* test looking for svg