### PR TITLE
WIP: ErrorBoundary rewrite to TS

### DIFF
--- a/packages/core/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/core/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -18,12 +18,12 @@ import React, { ComponentClass, Component, SFC } from 'react';
 
 type Props = {
   slackChannel: string;
+  onError?: (error: Error, errorInfo: string) => null;
 };
 
 type State = {
   error?: Error;
   errorInfo?: string;
-  onError?: (error: Error, errorInfo: string) => null;
 };
 
 const ErrorBoundary: ComponentClass<
@@ -36,7 +36,6 @@ const ErrorBoundary: ComponentClass<
     this.state = {
       error: undefined,
       errorInfo: undefined,
-      onError: props.onError,
     };
   }
 
@@ -46,8 +45,8 @@ const ErrorBoundary: ComponentClass<
     this.setState({ error, errorInfo });
 
     // Exposed for testing
-    if (this.state.onError) {
-      this.state.onError(error, errorInfo);
+    if (this.props.onError) {
+      this.props.onError(error, errorInfo);
     }
   }
 

--- a/packages/core/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/core/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -14,17 +14,28 @@
  * limitations under the License.
  */
 
-import React, { Component } from 'react';
+import React, { ComponentClass, Component, SFC } from 'react';
 
-export default class ErrorBoundary extends Component {
+
+type Props = {
+  slackChannel: string;
+};
+
+type State = {
+  error?: Error;
+  errorInfo?: string;
+  onError?: (error: Error, errorInfo: string) => null;
+}
+
+const ErrorBoundary: ComponentClass<Props, State> = class ErrorBoundary extends Component<Props, State> {
   constructor(props) {
     super(props);
 
     this.state = {
-      error: null,
-      errorInfo: null,
+      error: undefined,
+      errorInfo: undefined,
       onError: props.onError,
-    };
+    }
   }
 
   componentDidCatch(error, errorInfo) {
@@ -33,8 +44,8 @@ export default class ErrorBoundary extends Component {
     this.setState({ error, errorInfo });
 
     // Exposed for testing
-    if (ErrorBoundary.onError) {
-      ErrorBoundary.onError(error, errorInfo);
+    if (this.state.onError) {
+      this.state.onError(error, errorInfo);
     }
   }
 
@@ -52,9 +63,15 @@ export default class ErrorBoundary extends Component {
   }
 }
 
-// Importing Error would mean importing a lot of stuff
-// will take it up in a separate PR
-const Error = ({ slackChannel }) => {
+export default ErrorBoundary;
+
+type EProps = {
+  error?: Error;
+  errorInfo?: string;
+  slackChannel: string;
+}
+
+const Error: SFC<EProps> = ({ slackChannel }) => {
   return (
     <div>
       Something went wrong here. Please contact {slackChannel} for help.

--- a/packages/core/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/core/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -16,7 +16,6 @@
 
 import React, { ComponentClass, Component, SFC } from 'react';
 
-
 type Props = {
   slackChannel: string;
 };
@@ -25,9 +24,12 @@ type State = {
   error?: Error;
   errorInfo?: string;
   onError?: (error: Error, errorInfo: string) => null;
-}
+};
 
-const ErrorBoundary: ComponentClass<Props, State> = class ErrorBoundary extends Component<Props, State> {
+const ErrorBoundary: ComponentClass<
+  Props,
+  State
+> = class ErrorBoundary extends Component<Props, State> {
   constructor(props) {
     super(props);
 
@@ -35,7 +37,7 @@ const ErrorBoundary: ComponentClass<Props, State> = class ErrorBoundary extends 
       error: undefined,
       errorInfo: undefined,
       onError: props.onError,
-    }
+    };
   }
 
   componentDidCatch(error, errorInfo) {
@@ -61,7 +63,7 @@ const ErrorBoundary: ComponentClass<Props, State> = class ErrorBoundary extends 
       <Error error={error} errorInfo={errorInfo} slackChannel={slackChannel} />
     );
   }
-}
+};
 
 export default ErrorBoundary;
 
@@ -69,7 +71,7 @@ type EProps = {
   error?: Error;
   errorInfo?: string;
   slackChannel: string;
-}
+};
 
 const Error: SFC<EProps> = ({ slackChannel }) => {
   return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a rewrite of the ErrorBoundary to typescript

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] [CODEOWNERS](./CODEOWNERS) updated (for new stuff)
- [ ] Regression tests added for bug fixes
