### PR TITLE
packages/core: fix watch mode

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",
   "scripts": {
+    "build:watch": "tsc --outDir dist/cjs --noEmit false --module CommonJS --watch",
     "build": "backstage-cli build-cache -- tsc --outDir dist/cjs --noEmit false --module CommonJS",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"


### PR DESCRIPTION
Until we can build the build-cache command into the build command we'll need a separate `build:watch` command.

Not fixing this for the plugins as that'll be fixed in #387
