### PR TITLE
github/pr-template: remove codeowners checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,4 @@
 - [ ] Relevant documentation updated
 - [ ] Prettier run on changed files
 - [ ] Tests added for new functionality
-- [ ] [CODEOWNERS](./CODEOWNERS) updated (for new stuff)
 - [ ] Regression tests added for bug fixes


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We're not using codeowners atm, let's get rid of it

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [x] [CODEOWNERS](./CODEOWNERS) updated (for new stuff)
- [ ] Regression tests added for bug fixes
