### PR TITLE
Configure rollup resolve plugin

### DIFF
--- a/packages/cli/src/commands/plugin/rollup.config.ts
+++ b/packages/cli/src/commands/plugin/rollup.config.ts
@@ -31,7 +31,9 @@ export default {
   },
   plugins: [
     peerDepsExternal(),
-    resolve(),
+    resolve({
+      mainFields: ['browser', 'module', 'main'],
+    }),
     commonjs({
       include: ['node_modules/**', '../../node_modules/**'],
       exclude: ['**/*.stories.js'],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Tried using a library in an example plugin, in this case `axios` which failed. Looked like it was trying to call `node` APIs. Adding this config to `@rollup/plugin-node-resolve` fixed it...
