### PR TITLE
feat(yarn): remove yarn as a global dependency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 
 #### :heavy_check_mark: Checklist
 <!--- Put an `x` in all the boxes that apply: -->
-- [ ] All tests are passing `yarn test`
+- [ ] All tests are passing `npm test`
 - [ ] Screenshots attached (for UI changes)
 - [ ] Relevant documentation updated
 - [ ] Prettier run on changed files

--- a/README.md
+++ b/README.md
@@ -57,17 +57,56 @@ To run the Backstage frontend, you will need to have the following installed:
 
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [NodeJS](https://nodejs.org/en/download/) - Active LTS Release, currently v12
-- [yarn](https://classic.yarnpkg.com/en/docs/install)
 
-Open a terminal window and start the web app using the following commands from the project root:
+Open a terminal window and run the following commands from the project root:
+
+First, install the project's dependencies with yarn:
 
 ```bash
-$ yarn install # may take a while
-
-$ yarn start
+$ npx yarn install # may take a while
+npx: installed 1 in ...
+yarn install v<project yarn version>
+[1/5] Validating package.json...
+[2/5] Resolving packages...
+[3/5] Fetching packages...
+[4/5] Linking dependencies...
+[5/5] Building fresh packages...
 ```
 
-The final `yarn start` command should open a local instance of Backstage in your browser, otherwise open one of the URLs printed in the terminal.
+Next, start the web app:
+
+```bash
+$ npm start
+
+> root@1.0.0 start C:\src\github\spotify\me\backstage
+> yarn build && yarn workspace example-app start
+
+yarn run v<project yarn version>
+$ lerna run build
+lerna notice cli v<project lerna version>
+lerna info Executing command in 4 packages: "yarn run build"
+lerna info run Ran npm script 'build' in '@backstage/cli' in ...:
+$ backstage-cli build-cache -- tsc --outDir dist --noEmit false --module CommonJS
+[build-cache] cache miss, need to build
+[build-cache] caching build output
+lerna info run Ran npm script 'build' in '@backstage/core' in ...:
+$ backstage-cli build-cache -- tsc --outDir dist/cjs --noEmit false --module CommonJS
+[build-cache] cache miss, need to build
+[build-cache] caching build output
+lerna info run Ran npm script 'build' in '@backstage/plugin-home-page' in ...:
+$ backstage-cli build-cache -- backstage-cli plugin:build
+Compiled successfully!
+
+You can now view example-app in the browser.
+
+  Local:            http://localhost:3000
+  ...
+
+Note that the development build is not optimized.
+To create a production build, use npm run build.
+```
+
+The final `npm start` command should open a local instance of Backstage in your browser, otherwise open one of the URLs printed in the terminal.
 
 For more complex development environment configuration, see the
 [Development Environment](docs/getting-started/development-environment.md) section of the Getting Started docs.

--- a/docs/getting-started/Plugin development.md
+++ b/docs/getting-started/Plugin development.md
@@ -18,7 +18,7 @@ yarn create-plugin
 This will create a new Backstage Plugin based on the ID that was provided. It will be built and
 added to the Backstage App automatically.
 
-*If `yarn start` is already running you should be able to see the default page for your new
+*If `npm start` is already running you should be able to see the default page for your new
 plugin directly by navigating to `http://localhost:3000/my-plugin`.*
 
 ![](my-plugin_screenshot.png) -->

--- a/docs/getting-started/create-a-plugin.md
+++ b/docs/getting-started/create-a-plugin.md
@@ -1,9 +1,9 @@
 # Create a plugin
 
-To create a new plugin, make sure you've run `yarn` and installed dependencies, then run the following on your command line (invoking the `backstage-cli`).
+To create a new plugin, make sure you've run `npx yarn` and installed dependencies, then run the following on your command line (invoking the `backstage-cli`).
 
 ```bash
-yarn create-plugin
+npx yarn create-plugin
 ```
 
 ![](create-plugin_output.png)
@@ -11,7 +11,7 @@ yarn create-plugin
 This will create a new Backstage Plugin based on the ID that was provided. It will be built and
 added to the Backstage App automatically.
 
-_If `yarn start` is already running you should be able to see the default page for your new
+_If `npm start` is already running you should be able to see the default page for your new
 plugin directly by navigating to `http://localhost:3000/my-plugin`._
 
 ![](my-plugin_screenshot.png)

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -3,14 +3,14 @@
 Open a terminal window and start the web app using the following commands from the project root:
 
 ```bash
-$ yarn install # may take a while
+$ npx yarn install # may take a while
 
-$ yarn start
+$ npm start
 ```
 
-The final `yarn start` command should open a local instance of Backstage in your browser, otherwise open one of the URLs printed in the terminal.
+The final `npm start` command should open a local instance of Backstage in your browser, otherwise open one of the URLs printed in the terminal.
 
-By default, backstage will start on port 3000, however you can override this by setting an environment variable `PORT` on your local machine. e.g. `export PORT=8080` then running `yarn start`. Or `PORT=8080 yarn start`.
+By default, backstage will start on port 3000, however you can override this by setting an environment variable `PORT` on your local machine. e.g. `export PORT=8080` then running `npm start`. Or `PORT=8080 npm start`.
 
 Once successfully started, you should see the following message in your terminal window:
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint-staged": "^10.1.0",
     "prettier": "^1.19.1",
     "typescript": "^3.7.5",
+    "yarn": "^1.22.1",
     "zombie": "^6.1.4"
   },
   "dependencies": {

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -86,8 +86,8 @@
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
 
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
+      To begin the development, run `npm start` or `npm start`.
+      To create a production bundle, use `npm run build` or `npm build`.
     -->
   </body>
 </html>

--- a/packages/cli/templates/default-app/packages/app/public/index.html
+++ b/packages/cli/templates/default-app/packages/app/public/index.html
@@ -86,8 +86,8 @@
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
 
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
+      To begin the development, run `npm start` or `npm start`.
+      To create a production bundle, use `npm run build` or `npm build`.
     -->
   </body>
 </html>

--- a/packages/cli/templates/serve_index.html
+++ b/packages/cli/templates/serve_index.html
@@ -20,8 +20,8 @@
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
 
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
+      To begin the development, run `npm start` or `npm start`.
+      To create a production bundle, use `npm run build` or `npm run build`.
     -->
   </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6676,14 +6676,6 @@ cross-env@^7.0.0:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-fetch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
-  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
-  dependencies:
-    node-fetch "2.6.0"
-    whatwg-fetch "3.0.0"
-
 cross-spawn-promise@^0.10.1:
   version "0.10.2"
   resolved "https://registry.npmjs.org/cross-spawn-promise/-/cross-spawn-promise-0.10.2.tgz#0e6338149caf53a6d557ac5c65efb3086d8704ac"
@@ -11207,14 +11199,6 @@ jest-environment-node@^25.1.0:
     jest-mock "^25.1.0"
     jest-util "^25.1.0"
 
-jest-fetch-mock@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
-  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
-  dependencies:
-    cross-fetch "^3.0.4"
-    promise-polyfill "^8.1.3"
-
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -13520,11 +13504,6 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.0, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -13532,6 +13511,11 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -15688,11 +15672,6 @@ promise-inflight@^1.0.1, promise-inflight@~1.0.1:
   resolved "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise-polyfill@^8.1.3:
-  version "8.1.3"
-  resolved "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
-  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
-
 promise-retry@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
@@ -16861,7 +16840,7 @@ request@^2.85.0, request@^2.87.0, request@^2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-"request@github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16":
+request@cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16:
   version "2.88.1"
   resolved "https://codeload.github.com/cypress-io/request/tar.gz/b5af0d1fa47eec97ba980cde90a13e69a2afcd16"
   dependencies:
@@ -19639,7 +19618,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
@@ -20232,6 +20211,11 @@ yargs@^8.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
+
+yarn@^1.22.1:
+  version "1.22.4"
+  resolved "https://registry.npmjs.org/yarn/-/yarn-1.22.4.tgz#01c1197ca5b27f21edc8bc472cd4c8ce0e5a470e"
+  integrity sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA==
 
 yauzl@2.10.0:
   version "2.10.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

These changes make yarn a development dependency, rather than a global dependency; allowing engineers to use standard commands like `npm` and `npx` and to defer to yarn where needed.

If engineers still have yarn installed globally, they may still use the yarn commands that they prefer. This simply makes the global yarn commands optional, not required.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- **n/a** Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- **n/a** Tests added for new functionality
- **n/a** Regression tests added for bug fixes
