### PR TITLE
github/workflows: trigger on default pull_request event types

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,7 +6,6 @@ on:
       - '.github/workflows/cli.yml'
       - 'packages/cli/**'
       - 'packages/core/**'
-    types: [opened, reopened, edited, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,7 +2,6 @@ name: Frontend CI
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
Avoids PRs being built when editing the text content.

Fixes #469
