### PR TITLE
packages/cli: update plugin:build make deps external and work with .js + use to build core

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
   "main": "dist",
   "scripts": {
     "exec": "npx ts-node ./src",
-    "build": "backstage-cli build-cache -- tsc --outDir dist --noEmit false --module CommonJS",
+    "build": "backstage-cli build-cache -- tsc",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "start": "nodemon ."

--- a/packages/cli/src/commands/plugin/rollup.config.ts
+++ b/packages/cli/src/commands/plugin/rollup.config.ts
@@ -30,7 +30,9 @@ export default {
     format: 'cjs',
   },
   plugins: [
-    peerDepsExternal(),
+    peerDepsExternal({
+      includeDependencies: true,
+    }),
     resolve({
       mainFields: ['browser', 'module', 'main'],
     }),

--- a/packages/cli/src/commands/plugin/rollup.config.ts
+++ b/packages/cli/src/commands/plugin/rollup.config.ts
@@ -22,6 +22,7 @@ import postcss from 'rollup-plugin-postcss';
 import imageFiles from 'rollup-plugin-image-files';
 import json from '@rollup/plugin-json';
 import { RollupWatchOptions } from 'rollup';
+import { paths } from '../../helpers/paths';
 
 export default {
   input: 'src/index.ts',
@@ -43,6 +44,9 @@ export default {
     postcss(),
     imageFiles(),
     json(),
-    typescript(),
+    typescript({
+      include: `${paths.resolveTarget('src')}/**/*.{js,jsx,ts,tsx}`,
+      exclude: [paths.resolveTarget('src/testUtils/**')],
+    }),
   ],
 } as RollupWatchOptions;

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,9 @@
 {
-  "extends": "@spotify/web-scripts/config/tsconfig.json",
+  "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
+    "outDir": "dist",
+    "module": "CommonJS",
     "baseUrl": "src",
     "paths": {
       "*": ["src/*"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,11 +16,11 @@
     "backstage"
   ],
   "license": "Apache-2.0",
-  "main": "dist/cjs/index.js",
-  "types": "dist/cjs/index.d.ts",
+  "main": "dist/index.cjs.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "build:watch": "tsc --outDir dist/cjs --noEmit false --module CommonJS --watch",
-    "build": "backstage-cli build-cache -- tsc --outDir dist/cjs --noEmit false --module CommonJS",
+    "build:watch": "backstage-cli plugin:build --watch",
+    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },

--- a/packages/core/src/icons/icons.tsx
+++ b/packages/core/src/icons/icons.tsx
@@ -18,7 +18,7 @@ import { SvgIconProps } from '@material-ui/core';
 import PeopleIcon from '@material-ui/icons/People';
 import PersonIcon from '@material-ui/icons/Person';
 import React, { FC } from 'react';
-import { useApp } from '../api';
+import { useApp } from '../api/app/AppContext';
 import { IconComponent, SystemIconKey, SystemIcons } from './types';
 
 export const defaultSystemIcons: SystemIcons = {


### PR DESCRIPTION
This makes all imports be transpiled to imports instead of bringing in the code into the output. Atm it's only done for peer dependencies, but thinking we should do it for dependencies as well.

It would be nice if we could use the peerDependencies as external dependencies that will be linked to by the build output, and dependencies would be inlined. That way you can put small deps in the dependencies to avoid conflicts.

However, I don't think using peerDependencies at all is gonna be a good idea, except for maybe dependencies that are already present in @backstage/core. Peer dependencies don't work too well with yarn workspaces, see https://github.com/yarnpkg/yarn/issues/5810. But I'm also worried it would shift the burden of resolving dependency issues towards apps as opposed to plugin authors, which I don't think we want.

On top of that this PR also makes it possible to use `plugin:build` for the core package. It should also resolve issues with named exports that we're seeing in the rollup builds.