### PR TITLE
packages/cli: add cli version to build-cache key

### DIFF
--- a/packages/cli/src/commands/create-app/createApp.ts
+++ b/packages/cli/src/commands/create-app/createApp.ts
@@ -23,6 +23,7 @@ import { resolve as resolvePath } from 'path';
 import os from 'os';
 import { Task, templatingTask } from 'helpers/tasks';
 import { paths } from 'helpers/paths';
+import { version } from 'helpers/version';
 const exec = promisify(execCb);
 
 async function checkExists(rootDir: string, name: string) {
@@ -108,7 +109,6 @@ export default async () => {
   const templateDir = paths.resolveOwn('templates/default-app');
   const tempDir = resolvePath(os.tmpdir(), answers.name);
   const appDir = resolvePath(paths.targetDir, answers.name);
-  const version = require(paths.resolveOwn('package.json')).version;
 
   Task.log();
   Task.log('Creating the app...');

--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -27,6 +27,7 @@ import {
   getCodeownersFilePath,
 } from './lib/codeowners';
 import { paths } from 'helpers/paths';
+import { version } from 'helpers/version';
 import { Task, templatingTask } from 'helpers/tasks';
 const exec = promisify(execCb);
 
@@ -86,7 +87,7 @@ const addExportStatement = async (
 export async function addPluginDependencyToApp(
   rootDir: string,
   pluginName: string,
-  version: string,
+  versionStr: string,
 ) {
   const pluginPackage = `@backstage/plugin-${pluginName}`;
   const packageFilePath = 'packages/app/package.json';
@@ -103,7 +104,7 @@ export async function addPluginDependencyToApp(
       );
     }
 
-    dependencies[pluginPackage] = `^${version}`;
+    dependencies[pluginPackage] = `^${versionStr}`;
     packageFileJson.dependencies = sortObjectByKeys(dependencies);
     const newContents = `${JSON.stringify(packageFileJson, null, 2)}\n`;
 
@@ -223,7 +224,6 @@ export default async () => {
   const templateDir = paths.resolveOwn('templates/default-plugin');
   const tempDir = resolvePath(os.tmpdir(), answers.id);
   const pluginDir = paths.resolveTargetRoot('plugins', answers.id);
-  const version = require(paths.resolveOwn('package.json')).version;
   const ownerIds = parseOwnerIds(answers.owner);
 
   Task.log();

--- a/packages/cli/src/helpers/version.ts
+++ b/packages/cli/src/helpers/version.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import { paths } from './paths';
+
+export function findVersion() {
+  const pkgContent = fs.readFileSync(paths.resolveOwn('package.json'), 'utf8');
+  return JSON.parse(pkgContent).version;
+}
+
+export const version = findVersion();
+export const isDev = fs.pathExistsSync(paths.resolveOwn('src'));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,12 +16,10 @@
 
 import program from 'commander';
 import chalk from 'chalk';
-import { exitWithError } from './helpers/errors';
-import { paths } from './helpers/paths';
+import { exitWithError } from 'helpers/errors';
+import { version } from 'helpers/version';
 
 const main = (argv: string[]) => {
-  const version = require(paths.resolveOwn('package.json')).version;
-
   program.name('backstage-cli').version(version);
 
   program


### PR DESCRIPTION
This adds the cli package version to the cache key. For local development it adds the git tree of the cli packages instead.

This should avoid issues where the cli is updated but cache archives built with the old version are restored.

Needs #485 to be merged first