### PR TITLE
packages/cli: make plugin:build have built-in caching

### DIFF
--- a/packages/cli/src/commands/build-cache/index.ts
+++ b/packages/cli/src/commands/build-cache/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import fs from 'fs-extra';
 import { Command } from 'commander';
 import { run } from 'helpers/run';
 import { Cache } from './cache';
@@ -31,6 +32,7 @@ export async function withCache(
   const key = await Cache.readInputKey(options.inputs);
   if (!key) {
     print('input directory is dirty, skipping cache');
+    await fs.remove(options.output);
     await buildFunc();
     return;
   }
@@ -49,6 +51,7 @@ export async function withCache(
   }
 
   print('cache miss, need to build');
+  await fs.remove(options.output);
   await buildFunc();
 
   await cacheResult.archive(options.output, options.maxCacheEntries);

--- a/packages/cli/src/commands/build-cache/options.ts
+++ b/packages/cli/src/commands/build-cache/options.ts
@@ -18,6 +18,7 @@ import { resolve as resolvePath } from 'path';
 import { Command } from 'commander';
 import { paths } from 'helpers/paths';
 
+const DEFAULT_CACHE_DIR = '<repoRoot>/node_modules/.cache/backstage-builds';
 const DEFAULT_MAX_ENTRIES = 10;
 
 export type Options = {
@@ -27,19 +28,34 @@ export type Options = {
   maxCacheEntries: number;
 };
 
-export async function parseOptions(cmd: Command): Promise<Options> {
-  const argTransformer = (arg: string) =>
-    resolvePath(arg.replace(/<repoRoot>/g, paths.targetRoot).replace(/'/g, ''));
+function transformPath(path: string): string {
+  return resolvePath(
+    path.replace(/<repoRoot>/g, paths.targetRoot).replace(/'/g, ''),
+  );
+}
 
-  const inputs = cmd.input.map(argTransformer) as string[];
+export async function parseOptions(cmd: Command): Promise<Options> {
+  const inputs = cmd.input.map(transformPath) as string[];
   if (inputs.length === 0) {
-    inputs.push(argTransformer('.'));
+    inputs.push(transformPath('.'));
   }
-  const output = argTransformer(cmd.output);
-  const cacheDir = argTransformer(
+  const output = transformPath(cmd.output);
+  const cacheDir = transformPath(
     process.env.BACKSTAGE_CACHE_DIR || cmd.cacheDir,
   );
   const maxCacheEntries =
     Number(process.env.BACKSTAGE_CACHE_MAX_ENTRIES) || DEFAULT_MAX_ENTRIES;
   return { inputs, output, cacheDir, maxCacheEntries };
+}
+
+export function getDefaultCacheOptions(): Options {
+  return {
+    inputs: [transformPath('.')],
+    output: transformPath('dist'),
+    cacheDir: transformPath(
+      process.env.BACKSTAGE_CACHE_DIR || DEFAULT_CACHE_DIR,
+    ),
+    maxCacheEntries:
+      Number(process.env.BACKSTAGE_CACHE_MAX_ENTRIES) || DEFAULT_MAX_ENTRIES,
+  };
 }

--- a/packages/cli/src/commands/plugin/build.ts
+++ b/packages/cli/src/commands/plugin/build.ts
@@ -17,6 +17,7 @@
 import { rollup, watch, OutputOptions } from 'rollup';
 import conf from './rollup.config';
 import { Command } from 'commander';
+import { withCache, getDefaultCacheOptions } from 'commands/build-cache';
 
 export default async (cmd: Command) => {
   if (cmd.watch) {
@@ -40,10 +41,12 @@ export default async (cmd: Command) => {
     });
   }
 
-  const bundle = await rollup({
-    input: conf.input,
-    plugins: conf.plugins,
+  await withCache(getDefaultCacheOptions(), async () => {
+    const bundle = await rollup({
+      input: conf.input,
+      plugins: conf.plugins,
+    });
+    await bundle.generate(conf.output as OutputOptions);
+    await bundle.write(conf.output as OutputOptions);
   });
-  await bundle.generate(conf.output as OutputOptions);
-  await bundle.write(conf.output as OutputOptions);
 };

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "build:watch": "backstage-cli plugin:build --watch",
-    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
+    "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -6,7 +6,6 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "build:watch": "backstage-cli plugin:build --watch",
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build:watch": "backstage-cli plugin:build --watch",
-    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
+    "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,6 @@
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build:watch": "backstage-cli plugin:build --watch",
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"

--- a/plugins/home-page/package.json
+++ b/plugins/home-page/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "build:watch": "backstage-cli plugin:build --watch",
-    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
+    "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },

--- a/plugins/home-page/package.json
+++ b/plugins/home-page/package.json
@@ -6,7 +6,6 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "build:watch": "backstage-cli plugin:build --watch",
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -6,7 +6,6 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "build:watch": "backstage-cli plugin:build --watch",
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build:watch": "backstage-cli plugin:build --watch",
-    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
+    "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },


### PR DESCRIPTION
This embeds the build-cache functionality in the `plugin:build` command, which makes the plugin code more portable and speeds up builds.

Needs #486 