### PR TITLE
packages/cli: add build option to watchDeps and use for app serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=12.0.0"
   },
   "scripts": {
-    "start": "yarn build && yarn workspace example-app start",
+    "start": "yarn workspace example-app start",
     "bundle": "yarn build && yarn workspace example-app bundle",
     "build": "lerna run build",
     "test": "yarn build && lerna run test --since origin/master -- --coverage",

--- a/packages/cli/src/commands/app/serve.ts
+++ b/packages/cli/src/commands/app/serve.ts
@@ -21,7 +21,7 @@ export default async () => {
   const args = ['start'];
 
   // Start dynamic watch and build of dependencies, then serve the app
-  await watchDeps();
+  await watchDeps({ build: true });
   await run('react-scripts', args, {
     env: {
       EXTEND_ESLINT: 'true',

--- a/packages/cli/src/commands/watch-deps/packages.ts
+++ b/packages/cli/src/commands/watch-deps/packages.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
-import { promisify } from 'util';
 import { paths } from 'helpers/paths';
-
-const readFile = promisify(fs.readFile);
 
 const LernaProject = require('@lerna/project');
 const PackageGraph = require('@lerna/package-graph');
@@ -63,11 +59,4 @@ export async function findAllDeps(
   }
 
   return [...deps.values()];
-}
-
-export async function getPackageDeps(packagePath: string, blacklist: string[]) {
-  const packageData = await readFile(packagePath, 'utf8');
-  const packageJson = JSON.parse(packageData);
-
-  return await findAllDeps(packageJson.name, blacklist);
 }


### PR DESCRIPTION
This bakes the build step into the app:serve task, so that only dependencies are built instead of all packages. Will be more useful for plugin serve :grin:

Needs #484 