### PR TITLE
packages/cli: avoid clearing screen in app-serve

### DIFF
--- a/packages/cli/src/commands/app/serve.ts
+++ b/packages/cli/src/commands/app/serve.ts
@@ -14,18 +14,29 @@
  * limitations under the License.
  */
 
-import { run } from 'helpers/run';
+import { spawn } from 'child_process';
+import { waitForExit } from 'helpers/run';
 import { watchDeps } from 'commands/watch-deps';
+import { createLogger } from 'commands/watch-deps/logger';
 
 export default async () => {
-  const args = ['start'];
-
   // Start dynamic watch and build of dependencies, then serve the app
   await watchDeps({ build: true });
-  await run('react-scripts', args, {
+
+  const child = spawn('react-scripts', ['start'], {
     env: {
+      FORCE_COLOR: 'true',
       EXTEND_ESLINT: 'true',
       SKIP_PREFLIGHT_CHECK: 'true',
+      ...process.env,
     },
+    stdio: ['inherit', 'pipe', 'inherit'],
+    shell: true,
   });
+
+  // We need to avoid clearing the terminal, or the build feedback of dependencies will be lost
+  const log = createLogger();
+  child.stdout.setEncoding('utf8');
+  child.stdout!.on('data', log.out);
+  await waitForExit(child);
 };


### PR DESCRIPTION
Avoids the screen being cleared when running app serve, so that build output from the deps doesn't get removed.

Needs #491