### PR TITLE
packages: no need to wrap plugin builds with build-cache

### DIFF
--- a/packages/testUtils/package.json
+++ b/packages/testUtils/package.json
@@ -19,8 +19,7 @@
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build:watch": "backstage-cli plugin:build --watch",
-    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
+    "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -19,8 +19,7 @@
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build:watch": "backstage-cli plugin:build --watch",
-    "build": "backstage-cli build-cache -- backstage-cli plugin:build",
+    "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint"
   },
   "devDependencies": {


### PR DESCRIPTION
Not needed since cli update