### PR TITLE
fix: circular dependency came back (test-utils => core => test-utils)

### DIFF
--- a/packages/testUtils/package.json
+++ b/packages/testUtils/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.2",
-    "@backstage/core": "^0.1.1-alpha.2",
     "@backstage/theme": "^0.1.1-alpha.2",
     "@material-ui/core": "^4.9.1",
     "@testing-library/jest-dom": "^4.2.4",
@@ -40,7 +39,6 @@
     "react-router-dom": "^5.1.2"
   },
   "peerDependencies": {
-    "@backstage/core": "^0.1.1-alpha.2",
     "@backstage/theme": "^0.1.1-alpha.2",
     "@material-ui/core": "^4.9.1",
     "@testing-library/jest-dom": "^4.2.4",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In the rebasing of #487, the circular dependency came back! The build passed that time but it will likely become flaky without landing this.

Basically, the dependency on core is unused by the package that it's deleted from here, but should be removed to avoid issues in the future.
