### PR TITLE
Remove the default export from plugins

### DIFF
--- a/packages/app/src/plugins.ts
+++ b/packages/app/src/plugins.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-import { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-import { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { HomePagePlugin, WelcomePlugin, LighthousePlugin };
+export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
+export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
+export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';

--- a/packages/app/src/plugins.ts
+++ b/packages/app/src/plugins.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { default as HomePagePlugin } from '@backstage/plugin-home-page';
-import { default as WelcomePlugin } from '@backstage/plugin-welcome';
-import { default as LighthousePlugin } from '@backstage/plugin-lighthouse';
+import { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
+import { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
+import { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
 export { HomePagePlugin, WelcomePlugin, LighthousePlugin };

--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -122,7 +122,7 @@ export async function addPluginToApp(rootDir: string, pluginName: string) {
     .split('-')
     .map(name => capitalize(name))
     .join('');
-  const pluginImport = `import { default as ${pluginNameCapitalized} } from '${pluginPackage}';`;
+  const pluginImport = `import { plugin as ${pluginNameCapitalized} } from '${pluginPackage}';`;
   const pluginExport = `export { ${pluginNameCapitalized} };`;
   const pluginsFilePath = 'packages/app/src/plugins.ts';
   const pluginsFile = resolvePath(rootDir, pluginsFilePath);

--- a/packages/cli/templates/default-app/packages/app/src/plugins.ts
+++ b/packages/cli/templates/default-app/packages/app/src/plugins.ts
@@ -1,1 +1,1 @@
-export { default as WelcomePlugin } from 'plugin-welcome';
+export { plugin as WelcomePlugin } from 'plugin-welcome';

--- a/packages/cli/templates/default-app/plugins/welcome/src/index.ts
+++ b/packages/cli/templates/default-app/plugins/welcome/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from './plugin';
+export { plugin } from './plugin';

--- a/packages/cli/templates/default-app/plugins/welcome/src/plugin.test.ts
+++ b/packages/cli/templates/default-app/plugins/welcome/src/plugin.test.ts
@@ -1,4 +1,4 @@
-import plugin from './plugin';
+import { plugin } from './plugin';
 
 describe('welcome', () => {
   it('should export plugin', () => {

--- a/packages/cli/templates/default-app/plugins/welcome/src/plugin.ts
+++ b/packages/cli/templates/default-app/plugins/welcome/src/plugin.ts
@@ -1,7 +1,7 @@
 import { createPlugin } from '@backstage/core';
 import WelcomePage from './components/WelcomePage';
 
-export default createPlugin({
+export const plugin = createPlugin({
   id: 'welcome',
   register({ router }) {
     router.registerRoute('/', WelcomePage);

--- a/packages/cli/templates/default-plugin/src/index.ts
+++ b/packages/cli/templates/default-plugin/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { default } from './plugin';
+export { plugin } from './plugin';

--- a/packages/cli/templates/default-plugin/src/plugin.test.ts.hbs
+++ b/packages/cli/templates/default-plugin/src/plugin.test.ts.hbs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import plugin from './plugin';
+import { plugin } from './plugin';
 
 describe('{{ id }}', () => {
   it('should export plugin', () => {

--- a/packages/cli/templates/default-plugin/src/plugin.ts.hbs
+++ b/packages/cli/templates/default-plugin/src/plugin.ts.hbs
@@ -17,7 +17,7 @@
 import { createPlugin } from '@backstage/core';
 import ExampleComponent from './components/ExampleComponent';
 
-export default createPlugin({
+export const plugin = createPlugin({
   id: '{{ id }}',
   register({ router }) {
     router.registerRoute('/{{ id }}', ExampleComponent);

--- a/plugins/home-page/src/index.ts
+++ b/plugins/home-page/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { default } from './plugin';
+export { plugin } from './plugin';

--- a/plugins/home-page/src/plugin.test.ts
+++ b/plugins/home-page/src/plugin.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import plugin from './plugin';
+import { plugin } from './plugin';
 
 describe('home-page', () => {
   it('should export plugin', () => {

--- a/plugins/home-page/src/plugin.ts
+++ b/plugins/home-page/src/plugin.ts
@@ -17,7 +17,7 @@
 import { createPlugin } from '@backstage/core';
 import HomePage from 'components/HomePage';
 
-export default createPlugin({
+export const plugin = createPlugin({
   id: 'home-page',
   register({ router }) {
     router.registerRoute('/home', HomePage);

--- a/plugins/lighthouse/src/index.ts
+++ b/plugins/lighthouse/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export { default } from './plugin';
+export { plugin } from './plugin';
 export * from './api';

--- a/plugins/lighthouse/src/plugin.test.ts
+++ b/plugins/lighthouse/src/plugin.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import plugin from './plugin';
+import { plugin } from './plugin';
 
 describe('lighthouse', () => {
   it('should export plugin', () => {

--- a/plugins/lighthouse/src/plugin.ts
+++ b/plugins/lighthouse/src/plugin.ts
@@ -19,7 +19,7 @@ import AuditList from './components/AuditList';
 import AuditView from './components/AuditView';
 import CreateAudit from './components/CreateAudit';
 
-export default createPlugin({
+export const plugin = createPlugin({
   id: 'lighthouse',
   register({ router }) {
     router.registerRoute('/lighthouse', AuditList);

--- a/plugins/welcome/src/index.ts
+++ b/plugins/welcome/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { default } from './plugin';
+export { plugin } from './plugin';

--- a/plugins/welcome/src/plugin.test.ts
+++ b/plugins/welcome/src/plugin.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import plugin from './plugin';
+import { plugin } from './plugin';
 
 describe('welcome', () => {
   it('should export plugin', () => {

--- a/plugins/welcome/src/plugin.ts
+++ b/plugins/welcome/src/plugin.ts
@@ -17,7 +17,7 @@
 import { createPlugin } from '@backstage/core';
 import WelcomePage from 'components/WelcomePage';
 
-export default createPlugin({
+export const plugin = createPlugin({
   id: 'welcome',
   register({ router, featureFlags }) {
     router.registerRoute('/', WelcomePage);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Move plugins to a named export instead of default.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

fixes #523 