### PR TITLE
packages/cli: exclude tests from build

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src"],
+  "exclude": ["**/*.test.*"],
   "compilerOptions": {
     "outFile": "dist/index.js",
     "module": "amd",


### PR DESCRIPTION
Tests are being included in the build output atm, which is a bug.

Was a bit worried this would break type checking in tests, but errors are picked up fine by jest, and also vscode.

Fixes #525