### PR TITLE
Fix build error on Safari | MediaQueryList.addEventListener not supported

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -24,8 +24,8 @@ describe('App', () => {
       value: jest.fn(() => {
         return {
           matches: true,
-          addEventListener: jest.fn(),
-          removeEventListener: jest.fn(),
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
         };
       }),
     });

--- a/packages/app/src/ThemeContext.tsx
+++ b/packages/app/src/ThemeContext.tsx
@@ -41,9 +41,9 @@ export function useThemeType(themeId: string): [string, () => void] {
         setTheme('auto');
       }
     };
-    mql.addEventListener('change', darkListener);
+    mql.addListener(darkListener);
     return () => {
-      mql.removeEventListener('change', darkListener);
+      mql.removeListener(darkListener);
     };
   });
   function toggleTheme() {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Closes #531 

`MediaQueryList.addEventListener` is not supported on Safari and hence the build fails.
Reference: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList

Using [`MediaQueryList.addListener`](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener) instead to support Safari.

App now working on Safari - <img width="1365" alt="Screen Shot 2020-04-12 at 15 28 15" src="https://user-images.githubusercontent.com/8065913/79062111-3d33c200-7cd2-11ea-9cb5-215eeff08d01.png">


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
