### PR TITLE
fix(storybook): theme doesn't import properly

### DIFF
--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -7,6 +7,10 @@ module.exports = {
   ],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],
   webpackFinal: async config => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@backstage/theme': path.resolve(__dirname, '../../theme/src'),
+    };
     config.resolve.modules.push(path.resolve(__dirname, '../../core/src'));
     config.module.rules.push(
       {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this PR fixed theme import https://github.com/spotify/backstage/issues/530.

Previously i can't run storybook in my local and got error like this.
![image](https://user-images.githubusercontent.com/4416419/79101913-d4ad1980-7d93-11ea-91b6-637ec3e25359.png)

And i add aliases for theme, and it can run normal again.


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
