### PR TITLE
Added global decorator for storybook wrapping stories with the MUI theme

### DIFF
--- a/packages/storybook/.storybook/config.js
+++ b/packages/storybook/.storybook/config.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { addDecorator } from '@storybook/react';
+import { BackstageTheme } from '@backstage/theme';
+import { CssBaseline, ThemeProvider } from '@material-ui/core';
+
+addDecorator(story => (
+  <ThemeProvider theme={BackstageTheme}>
+    <CssBaseline>{story()}</CssBaseline>
+  </ThemeProvider>
+));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a global decorator for stories that wraps them in a ThemeProvider.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
