### PR TITLE
packages/cli: fix app template referencing example-app

### DIFF
--- a/packages/cli/templates/default-app/package.json.hbs
+++ b/packages/cli/templates/default-app/package.json.hbs
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "start": "yarn workspace app start",
-    "bundle": "yarn build && yarn workspace example-app bundle",
+    "bundle": "yarn build && yarn workspace app bundle",
     "build": "lerna run build",
     "test": "yarn build && lerna run test --since origin/master -- --coverage",
     "test:all": "yarn build && lerna run test -- --coverage",


### PR DESCRIPTION
Should be the final fix before we can release a new version with a working `create-app`. Been testing the process manually and this was the only issue I found. Then future releases will be verified by #550.