### PR TITLE
Fix error when using yarn lint

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",
+    "@backstage/test-utils": "0.1.1-alpha.4",
     "@backstage/test-utils-core": "^0.1.1-alpha.4",
     "@backstage/theme": "^0.1.1-alpha.4",
     "@storybook/addon-storysource": "^5.3.18",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed lint errors related to
 ```
error: '@backstage/test-utils' should be listed in the project's dependencies. Run 'npm i -S @backstage/test-utils' to add it (import/no-extraneous-dependencies) at src/components/CircleProgress.test.js:19:1:
  17 | import React from 'react';
  18 | import { render } from '@testing-library/react';
> 19 | import { wrapInThemedTestApp } from '@backstage/test-utils';
     | ^
  20 | import CircleProgress, { getProgressColor } from './CircleProgress';
  21 | 
  22 | describe('<CircleProgress />', () => {
```

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
