### PR TITLE
packages/storybook: depend on dist version of local packages and make sure they are built

### DIFF
--- a/packages/cli/src/commands/watch-deps/index.ts
+++ b/packages/cli/src/commands/watch-deps/index.ts
@@ -23,6 +23,7 @@ import { startCompiler } from './compiler';
 import { startChild } from './child';
 import { waitForExit, run } from 'helpers/run';
 import { paths } from 'helpers/paths';
+import { Command } from 'commander';
 
 const PACKAGE_BLACKLIST = [
   // We never want to watch for changes in the cli, but all packages will depend on it.
@@ -88,8 +89,14 @@ export async function watchDeps(options: Options = {}) {
  * and instead start up watch mode for that package. Starting watch mode means running the first
  * available yarn script out of "build:watch", "watch", or "build" --watch.
  */
-export default async (_command: any, args: string[]) => {
-  await watchDeps();
+export default async (cmd: Command, args: string[]) => {
+  const options: Options = {};
+
+  if (cmd.build) {
+    options.build = true;
+  }
+
+  await watchDeps(options);
 
   if (args?.length) {
     await waitForExit(startChild(args));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -70,6 +70,7 @@ const main = (argv: string[]) => {
 
   program
     .command('watch-deps')
+    .option('--build', 'Build all dependencies on startup')
     .description('Watch all dependencies while running another command')
     .action(actionHandler(() => require('commands/watch-deps')));
 

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -13,7 +13,7 @@ module.exports = {
   webpackFinal: async config => {
     config.resolve.alias = {
       ...config.resolve.alias,
-      '@backstage/theme': path.resolve(__dirname, '../../theme/src'),
+      '@backstage/theme': path.resolve(__dirname, '../../theme'),
     };
     config.resolve.modules.push(path.resolve(__dirname, '../../core/src'));
     config.module.rules.push(

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -4,13 +4,16 @@
   "description": "Storybook build for core package",
   "private": true,
   "scripts": {
-    "start": "start-storybook -p 6006",
-    "build-storybook": "build-storybook --output-dir dist"
+    "start": "backstage-cli watch-deps --build -- start-storybook -p 6006",
+    "build-storybook": "backstage-cli watch-deps --build -- build-storybook --output-dir dist"
   },
   "workspaces": {
     "nohoist": [
       "@storybook/**"
     ]
+  },
+  "dependencies": {
+    "@backstage/theme": "0.1.1-alpha.4"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^5.3.17",


### PR DESCRIPTION
Fixes the issue in the CI build of #563

Depending on the src version of the packages is gonna be a bit of a nightmare because we'd need to add all src dirs to the modules path and then end up with a bunch of conflicts.