### PR TITLE
Change peer dependencies to be regular dependencies #576

### DIFF
--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -12,6 +12,7 @@
     "clean": "backstage-cli clean"
   },
   "devDependencies": {
+    "@backstage/cli": "^{{version}}",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -8,11 +8,10 @@
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
-    "test": "backstage-cli test", 
+    "test": "backstage-cli test",
     "clean": "backstage-cli clean"
   },
   "devDependencies": {
-    "@backstage/cli": "^{{version}}",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
@@ -21,7 +20,7 @@
     "@types/testing-library__jest-dom": "5.0.2",
     "jest-fetch-mock": "^3.0.3"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@backstage/core": "^{{version}}",
     "@backstage/theme": "^{{version}}",
     "@material-ui/core": "^4.9.1",


### PR DESCRIPTION
Removed explicit dependency on backstage cli to inherit from root.

## Hey, I just made a Pull Request!

Fix for #576

After creating a new app and then adding a new plugin following along with the getting started guide it came up that peerDependencies weren't available in the newly created app using `npx @backstage/cli create-app` the same as they are in the main backstage app. The peer dependencies have been converted to regular dependencies in the plugin template. 

One thing that may need to change: We mentioned possibly removing duplication so I removed `@backstage/cli` allowing it to be resolved from the root. I am not sure if this is the right solution here. If this might get used to create a standalone plugin down then this wouldn't work but if the intention is to keep the plugins being generated into a mono repo for now it could be OK. 


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
