### PR TITLE
packages/cli: fix and document watch mode

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,8 @@ $ yarn add @backstage/cli
 
 For local development the cli can be used directly, even from other packages in this repo. The `bin/backstage-cli` entrypoint contains a switch that will load the implementation from the `src` directory when executed inside this repo.
 
+To run the cli in watch mode, use `yarn start <args>`. For example `yarn start create-app --help`.
+
 To try out the `create-app` command locally, you can execute the following from the parent directory of this repo:
 
 ```bash

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,13 +18,12 @@
   "license": "Apache-2.0",
   "main": "dist",
   "scripts": {
-    "exec": "npx ts-node ./src",
     "build": "backstage-cli build-cache -- tsc",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "test:e2e": "node e2e-test/cli-e2e-test.js",
     "clean": "backstage-cli clean",
-    "start": "nodemon ."
+    "start": "nodemon --"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
@@ -92,7 +91,7 @@
   ],
   "nodemonConfig": {
     "watch": "./src",
-    "exec": "ts-node ./src",
+    "exec": "bin/backstage-cli",
     "ext": "ts"
   }
 }


### PR DESCRIPTION
Watch mode is pretty useful for developing the cli, so let's have it working :grin:. This also removes the need for the ugly hacks we were using before to pass args in `index.ts`, now you just pass them to `yarn start` instead.