### PR TITLE
packages/cli: use separate tsconfig for builds to get currect config in tests

### DIFF
--- a/packages/cli/bin/backstage-cli
+++ b/packages/cli/bin/backstage-cli
@@ -75,7 +75,7 @@ if (!isLocal || process.env.BACKSTAGE_E2E_CLI_TEST) {
   const cleanupPaths = require('tsconfig-paths').register({ baseUrl, paths });
 
   require('ts-node').register({
-    project: path.resolve(__dirname, '../tsconfig.json'),
+    project: path.resolve(__dirname, '../tsconfig.build.json'),
     compilerOptions: {
       module: 'CommonJS',
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "main": "dist",
   "scripts": {
-    "build": "backstage-cli build-cache -- tsc",
+    "build": "backstage-cli build-cache -- tsc --project tsconfig.build.json",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "test:e2e": "node e2e-test/cli-e2e-test.js",

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.*"],
+  "compilerOptions": {
+    "outFile": "dist/index.js",
+    "module": "amd"
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src"],
-  "exclude": ["**/*.test.*"],
   "compilerOptions": {
-    "outFile": "dist/index.js",
-    "module": "amd",
     "baseUrl": "src"
   }
 }


### PR DESCRIPTION
Fix for tests not being able to use src-relative imports. They actually work since it's up to jest to do the import, but editors will complain since tests are excluded from the default `tsconfig.json`.