### PR TITLE
fix(docs): bad backstage hyperlink

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Check out [https://backstage.io]() or see the table of content below.
+Check out <https://backstage.io> or see the table of content below.
 
 - [Architecture and terminology](architecture-terminology.md)
 - [Getting started](getting-started/README.md)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

All it does currently is link to the current page due to it having the equivalent of `<a href="">https://backstage.io</a>`

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
