### PR TITLE
packages/cli: forward all args to jest and run in watch mode by default

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,6 +65,7 @@
     "handlebars": "^4.7.3",
     "html-webpack-plugin": "^3.2.0",
     "inquirer": "^7.0.4",
+    "jest": "^25.1.0",
     "ora": "^4.0.3",
     "react": "^16.0.0",
     "react-dev-utils": "^10.2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -70,9 +70,9 @@ const main = (argv: string[]) => {
 
   program
     .command('test')
-    .option('--watch', 'Enable watch mode')
-    .option('--coverage', 'Report test coverage')
-    .description('Run all tests for package')
+    .allowUnknownOption(true) // Allows the command to run, but we still need to parse raw args
+    .helpOption(', --backstage-cli-help') // Let Jest handle help
+    .description('Run tests, forwarding args to Jest, defaulting to watch mode')
     .action(actionHandler(() => require('commands/testCommand')));
 
   program


### PR DESCRIPTION
We're not likely to switch away from jest, so let's just forward all args directly.

You can now do things like `yarn test src/components/HorizontalScrollGrid`

It also behaves similar to react-scripts and what we use internally, where it runs in watch mode by default.

Fixes #488