### PR TITLE
Disable Verbose logging when building Storybook

### DIFF
--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -39,6 +39,10 @@ module.exports = {
       },
     );
     config.resolve.extensions.push('.ts', '.tsx');
+
+    // Disable ProgressPlugin which logs verbose webpack build progress. Warnings and Errors are still logged.
+    config.plugins = config.plugins.filter(({ constructor }) => constructor.name !== "ProgressPlugin")
+
     return config;
   },
 };


### PR DESCRIPTION
As of now, building Storybook logs thousands of lines of build progress. This makes it hard to spot warnings and other crucial information in the log. The progress log is not very helpful either.

<img width="2048" alt="Screen Shot 2020-04-20 at 21 04 16" src="https://user-images.githubusercontent.com/8065913/79749641-86c38300-834a-11ea-9cb6-82f0dd54623e.png">

This PR disables the Webpack plugin `ProgressPlugin` for Storybook. The errors and warnings would still be logged.

Source of information: https://github.com/storybookjs/storybook/issues/1872

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
