### PR TITLE
Add alert api

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -25,9 +25,9 @@ import { createApp } from '@backstage/core';
 import React, { FC } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import Root from './components/Root';
-import ErrorDisplay from './components/ErrorDisplay';
+import AlertDisplay from './components/AlertDisplay';
 import * as plugins from './plugins';
-import apis, { errorDialogForwarder } from './apis';
+import apis, { alertApiForwarder } from './apis';
 import { ThemeContextType, ThemeContext, useThemeType } from './ThemeContext';
 
 const useStyles = makeStyles(theme => ({
@@ -86,7 +86,7 @@ const App: FC<{}> = () => {
     <ThemeContext.Provider value={themeContext}>
       <ThemeProvider theme={backstageTheme as Theme}>
         <CssBaseline>
-          <ErrorDisplay forwarder={errorDialogForwarder} />
+          <AlertDisplay forwarder={alertApiForwarder} />
           <Router>
             <Root>
               <AppComponent />

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -17,7 +17,10 @@
 import {
   ApiHolder,
   ApiRegistry,
+  alertApiRef,
   errorApiRef,
+  AlertApiForwarder,
+  ErrorApiForwarder,
   featureFlagsApiRef,
   FeatureFlags,
 } from '@backstage/core';
@@ -26,13 +29,13 @@ import {
   LighthouseRestApi,
 } from '@backstage/plugin-lighthouse';
 
-import { ErrorDisplayForwarder } from './components/ErrorDisplay/ErrorDisplay';
-
 const builder = ApiRegistry.builder();
 
-export const errorDialogForwarder = new ErrorDisplayForwarder();
+export const alertApiForwarder = new AlertApiForwarder();
+builder.add(alertApiRef, alertApiForwarder);
 
-builder.add(errorApiRef, errorDialogForwarder);
+export const errorApiForwarder = new ErrorApiForwarder(alertApiForwarder);
+builder.add(errorApiRef, errorApiForwarder);
 
 builder.add(featureFlagsApiRef, new FeatureFlags());
 

--- a/packages/app/src/components/AlertDisplay/index.ts
+++ b/packages/app/src/components/AlertDisplay/index.ts
@@ -14,10 +14,4 @@
  * limitations under the License.
  */
 
-export { default as ApiProvider, useApi } from './ApiProvider';
-export { default as ApiRegistry } from './ApiRegistry';
-export { default as ApiTestRegistry } from './ApiTestRegistry';
-export { default as ApiRef } from './ApiRef';
-export * from './types';
-export * from './definitions';
-export * from './implementations';
+export { default } from './AlertDisplay';

--- a/packages/core/src/api/apis/definitions/alert.ts
+++ b/packages/core/src/api/apis/definitions/alert.ts
@@ -13,11 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import ApiRef from '../ApiRef';
 
-export { default as ApiProvider, useApi } from './ApiProvider';
-export { default as ApiRegistry } from './ApiRegistry';
-export { default as ApiTestRegistry } from './ApiTestRegistry';
-export { default as ApiRef } from './ApiRef';
-export * from './types';
-export * from './definitions';
-export * from './implementations';
+export type AlertMessage = {
+  message: string;
+  // Severity will default to success since that is what material ui defaults the value to.
+  severity?: 'success' | 'info' | 'warning' | 'error';
+};
+
+/**
+ * The alert API is used to report alerts to the app, and display them to the user.
+ */
+
+export type AlertApi = {
+  /**
+   * Post an alert for handling by the application.
+   */
+  post(alert: AlertMessage);
+};
+
+export const alertApiRef = new ApiRef<AlertApi>({
+  id: 'core.alert',
+  description: 'Used to report alerts and forward them to the app',
+});

--- a/packages/core/src/api/apis/definitions/index.ts
+++ b/packages/core/src/api/apis/definitions/index.ts
@@ -20,5 +20,6 @@
 //
 // If you think some API definition is missing, please open an Issue or send a PR!
 
+export * from './alert';
 export * from './error';
 export * from './featureFlags';

--- a/packages/core/src/api/apis/implementations/AlertApiForwarder.ts
+++ b/packages/core/src/api/apis/implementations/AlertApiForwarder.ts
@@ -13,5 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { AlertApi, AlertMessage } from '../../../';
 
-export { default } from './ErrorDisplay';
+type SubscriberFunc = (message: AlertMessage) => void;
+type Unsubscribe = () => void;
+
+export class AlertApiForwarder implements AlertApi {
+  private readonly subscribers = new Set<SubscriberFunc>();
+
+  post(alert: AlertMessage) {
+    this.subscribers.forEach(subscriber => subscriber(alert));
+  }
+
+  subscribe(func: SubscriberFunc): Unsubscribe {
+    this.subscribers.add(func);
+
+    return () => {
+      this.subscribers.delete(func);
+    };
+  }
+}

--- a/packages/core/src/api/apis/implementations/ErrorApiForwarder.ts
+++ b/packages/core/src/api/apis/implementations/ErrorApiForwarder.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ErrorApi, ErrorContext, AlertApi } from '../../../';
+
+type SubscriberFunc = (error: Error) => void;
+type Unsubscribe = () => void;
+
+export class ErrorApiForwarder implements ErrorApi {
+  private readonly subscribers = new Set<SubscriberFunc>();
+  private alertApi: AlertApi;
+
+  constructor(alertApi: AlertApi) {
+    this.alertApi = alertApi;
+  }
+
+  post(error: Error, context?: ErrorContext) {
+    if (context?.hidden) {
+      return;
+    }
+
+    this.alertApi.post({ message: error.message, severity: 'error' });
+    this.subscribers.forEach(subscriber => subscriber(error));
+  }
+
+  subscribe(func: SubscriberFunc): Unsubscribe {
+    this.subscribers.add(func);
+
+    return () => {
+      this.subscribers.delete(func);
+    };
+  }
+}

--- a/packages/core/src/api/apis/implementations/index.ts
+++ b/packages/core/src/api/apis/implementations/index.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-export { default as ApiProvider, useApi } from './ApiProvider';
-export { default as ApiRegistry } from './ApiRegistry';
-export { default as ApiTestRegistry } from './ApiTestRegistry';
-export { default as ApiRef } from './ApiRef';
-export * from './types';
-export * from './definitions';
-export * from './implementations';
+// This folder contains implementations for all core APIs.
+//
+// Plugins should rely on these APIs for functionality as much as possible.
+
+export * from './AlertApiForwarder';
+export * from './ErrorApiForwarder';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7226,7 +7226,7 @@ cyclist@^1.0.1:
   resolved "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@*, cypress@^4.2.0:
+cypress@*, cypress@4.2.0, cypress@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/cypress/-/cypress-4.2.0.tgz#45673fb648b1a77b9a78d73e58b89ed05212d243"
   integrity sha512-8LdreL91S/QiTCLYLNbIjLL8Ht4fJmu/4HGLxUI20Tc7JSfqEfCmXELrRfuPT0kjosJwJJZacdSji9XSRkPKUw==
@@ -17222,7 +17222,7 @@ request@^2.85.0, request@^2.87.0, request@^2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-request@cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16:
+"request@github:cypress-io/request#b5af0d1fa47eec97ba980cde90a13e69a2afcd16":
   version "2.88.1"
   resolved "https://codeload.github.com/cypress-io/request/tar.gz/b5af0d1fa47eec97ba980cde90a13e69a2afcd16"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Addresses https://github.com/spotify/backstage/issues/405

Alert api (formerly the Error api) now takes an optional severity argument that allows you to specify what type of alert you wish

<img width="479" alt="Screen Shot 2020-04-20 at 10 54 38 AM" src="https://user-images.githubusercontent.com/3150067/79765986-62898700-82f5-11ea-873a-0140e807e27d.png">


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes