### PR TITLE
packages/cli: default to mocking style imports in tests

### DIFF
--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -26,6 +26,9 @@ if (fs.existsSync('jest.config.js')) {
 } else {
   const extraOptions = {
     modulePaths: ['<rootDir>'],
+    moduleNameMapper: {
+      '\\.(css|less|scss|sss|styl)$': require.resolve('jest-css-modules'),
+    },
   };
 
   // Use src/setupTests.ts as the default location for configuring test env

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,7 @@
     "html-webpack-plugin": "^3.2.0",
     "inquirer": "^7.0.4",
     "jest": "^25.1.0",
+    "jest-css-modules": "^2.1.0",
     "ora": "^4.0.3",
     "react": "^16.0.0",
     "react-dev-utils": "^10.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11535,6 +11535,13 @@ jest-config@^25.1.0:
     pretty-format "^25.1.0"
     realpath-native "^1.1.0"
 
+jest-css-modules@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/jest-css-modules/-/jest-css-modules-2.1.0.tgz#9c25ebe9d0214d8f55861a442268fdd4b01b4781"
+  integrity sha512-my3Scnt6l2tOll/eGwNZeh1KLAFkNzdl4MyZRdpl46GO6/93JcKKdTjNqK6Nokg8A8rT84MFLOpY1pzqKBEqMw==
+  dependencies:
+    identity-obj-proxy "3.0.0"
+
 jest-diff@^24.0.0, jest-diff@^24.3.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"


### PR DESCRIPTION
Otherwise including any modules that import css files will break tests