### PR TITLE
Fix Sequence component not switching background on dark mode

### DIFF
--- a/packages/core/src/components/Sequence/Sequence.tsx
+++ b/packages/core/src/components/Sequence/Sequence.tsx
@@ -27,7 +27,6 @@ import SequenceFooter from './SequenceFooter';
 const useStyles = makeStyles((theme: any) => ({
   content: {
     padding: theme.spacing(0, 4, 4, 4),
-    backgroundColor: 'white',
   },
   completionBox: {
     padding: theme.spacing(3),

--- a/packages/core/src/components/Sequence/Sequence.tsx
+++ b/packages/core/src/components/Sequence/Sequence.tsx
@@ -26,7 +26,7 @@ import SequenceFooter from './SequenceFooter';
 
 const useStyles = makeStyles((theme: any) => ({
   content: {
-    padding: theme.spacing(0, 4, 4, 4),
+    padding: theme.spacing(4, 4, 4, 4),
   },
   completionBox: {
     padding: theme.spacing(3),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes sequence dark mode having a white background. I also took the liberty to add some vertical padding to the content. I think it looks a bit less crowded.

Fixes #650 :D
#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] All tests are passing `yarn test`
- [X] Screenshots attached (for UI changes)

![Screenshot from 2020-04-26 00-40-16](https://user-images.githubusercontent.com/62359443/80299087-4d7a8100-8757-11ea-904a-8edf8f0e13e6.png)

![Screenshot from 2020-04-26 00-41-03](https://user-images.githubusercontent.com/62359443/80299094-58351600-8757-11ea-946e-00a7c68c5421.png)

- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
