### PR TITLE
packages/cli: fix usage of exec

### DIFF
--- a/packages/cli/src/commands/testCommand.ts
+++ b/packages/cli/src/commands/testCommand.ts
@@ -46,8 +46,9 @@ export default async (cmd: Command) => {
     // already watching
     !includesAnyOf(args, '--watch', '--watchAll')
   ) {
-    const isGitRepo = () => runCheck('git rev-parse --is-inside-work-tree');
-    const isMercurialRepo = () => runCheck('hg --cwd . root');
+    const isGitRepo = () =>
+      runCheck('git', 'rev-parse', '--is-inside-work-tree');
+    const isMercurialRepo = () => runCheck('hg', '--cwd', '.', 'root');
 
     if ((await isGitRepo()) || (await isMercurialRepo())) {
       args.push('--watch');

--- a/packages/cli/src/lib/buildCache/cache.ts
+++ b/packages/cli/src/lib/buildCache/cache.ts
@@ -82,19 +82,22 @@ export class Cache {
       allInputPaths.unshift(paths.ownDir);
     }
 
-    const quotedInputPaths = allInputPaths.map(input => `'${input}'`);
-
     // Make sure we don't have any uncommitted changes to the input, in that case we skip caching.
     const noChanges = await runCheck(
-      `git diff --quiet HEAD -- ${quotedInputPaths.join(' ')}`,
+      'git',
+      'diff',
+      '--quiet',
+      'HEAD',
+      '--',
+      ...allInputPaths,
     );
     if (!noChanges) {
       return undefined;
     }
 
     const trees = [];
-    for (const quotedInputPath of quotedInputPaths) {
-      const output = await runPlain(`git ls-tree HEAD ${quotedInputPath}`);
+    for (const inputPath of allInputPaths) {
+      const output = await runPlain('git', 'ls-tree', 'HEAD', inputPath);
       const [, , sha] = output.split(/\s+/, 3);
       // If we can't get a tree sha it means we're outside of tracked files, so treat as dirty
       if (!sha) {

--- a/packages/cli/src/lib/buildCache/options.ts
+++ b/packages/cli/src/lib/buildCache/options.ts
@@ -29,9 +29,7 @@ export type Options = {
 };
 
 function transformPath(path: string): string {
-  return resolvePath(
-    path.replace(/<repoRoot>/g, paths.targetRoot).replace(/'/g, ''),
-  );
+  return resolvePath(path.replace(/<repoRoot>/g, paths.targetRoot));
 }
 
 export async function parseOptions(cmd: Command): Promise<Options> {

--- a/packages/cli/src/lib/run.ts
+++ b/packages/cli/src/lib/run.ts
@@ -18,12 +18,12 @@ import {
   SpawnOptions,
   spawn,
   ChildProcess,
-  exec as execCb,
+  execFile as execFileCb,
 } from 'child_process';
 import { ExitCodeError } from './errors';
 import { promisify } from 'util';
 import { LogFunc } from './logging';
-const exec = promisify(execCb);
+const execFile = promisify(execFileCb);
 
 type SpawnOptionsPartialEnv = Omit<SpawnOptions, 'env'> & {
   env?: Partial<NodeJS.ProcessEnv>;
@@ -69,21 +69,21 @@ export async function run(
   await waitForExit(child, name);
 }
 
-export async function runPlain(cmd: string) {
+export async function runPlain(cmd: string, ...args: string[]) {
   try {
-    const { stdout } = await exec(cmd);
+    const { stdout } = await execFile(cmd, args, { shell: true });
     return stdout.trim();
   } catch (error) {
     if (error.stderr) {
       process.stderr.write(error.stderr);
     }
-    throw new ExitCodeError(error.code, cmd);
+    throw new ExitCodeError(error.code, [cmd, ...args].join(' '));
   }
 }
 
-export async function runCheck(cmd: string): Promise<boolean> {
+export async function runCheck(cmd: string, ...args: string[]) {
   try {
-    await exec(cmd);
+    await execFile(cmd, args, { shell: true });
     return true;
   } catch (error) {
     return false;


### PR DESCRIPTION
Gets rid of the ugly arg escaping.

I believe this will fix #618, did some testing and it looks like it being caused by cmd not being happy about single quotes.