### PR TITLE
[plugin] Google Analytics Dashboard

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",
     "@backstage/core": "^0.1.1-alpha.4",
+    "@backstage/plugin-google-analytics-dashboard": "^0.1.1-alpha.4",
     "@backstage/plugin-home-page": "^0.1.1-alpha.4",
     "@backstage/plugin-inventory": "^0.1.1-alpha.4",
     "@backstage/plugin-lighthouse": "^0.1.1-alpha.4",

--- a/plugins/google-analytics-dashboard/.eslintrc.js
+++ b/plugins/google-analytics-dashboard/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint.js')],
+};

--- a/plugins/google-analytics-dashboard/.npmrc
+++ b/plugins/google-analytics-dashboard/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+engine-strict=true

--- a/plugins/google-analytics-dashboard/.npmrc
+++ b/plugins/google-analytics-dashboard/.npmrc
@@ -1,2 +1,0 @@
-registry=https://registry.npmjs.org/
-engine-strict=true

--- a/plugins/google-analytics-dashboard/README.md
+++ b/plugins/google-analytics-dashboard/README.md
@@ -1,0 +1,6 @@
+# Title
+Welcome to the google-analytics-dashboard plugin!
+
+## Sub-section 1
+
+## Sub-section 2

--- a/plugins/google-analytics-dashboard/package.json
+++ b/plugins/google-analytics-dashboard/package.json
@@ -16,7 +16,6 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "@types/gapi.client.analytics": "v3",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
     "@types/testing-library__jest-dom": "5.0.2",

--- a/plugins/google-analytics-dashboard/package.json
+++ b/plugins/google-analytics-dashboard/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@backstage/plugin-google-analytics-dashboard",
+  "version": "0.1.1-alpha.4",
+  "main": "dist/index.cjs.js",
+  "types": "dist/index.d.ts",
+  "license": "Apache-2.0",
+  "private": true,
+  "scripts": {
+    "build": "backstage-cli plugin:build",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test",
+    "clean": "backstage-cli clean"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.1.1-alpha.4",
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/user-event": "^7.1.2",
+    "@types/gapi.client.analytics": "v3",
+    "@types/jest": "^24.0.0",
+    "@types/node": "^12.0.0",
+    "@types/testing-library__jest-dom": "5.0.2",
+    "jest-fetch-mock": "^3.0.3"
+  },
+  "dependencies": {
+    "@backstage/core": "^0.1.1-alpha.4",
+    "@backstage/theme": "^0.1.1-alpha.4",
+    "@material-ui/core": "^4.9.1",
+    "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "4.0.0-alpha.45",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "react-markdown": "^4.3.1",
+    "react-sparklines": "^1.7.0",
+    "react-syntax-highlighter": "^12.2.1",
+    "react-use": "^13.0.0"
+  }
+}

--- a/plugins/google-analytics-dashboard/src/api/api.js
+++ b/plugins/google-analytics-dashboard/src/api/api.js
@@ -22,12 +22,12 @@ import { API_KEY, CLIENT_ID } from './config';
 export const api = {
   init() {
     return new Promise((resolve, reject) => {
-      try {
-        const script = document.createElement('script');
-        script.src = 'https://apis.google.com/js/api.js';
-        document.body.appendChild(script);
+      const script = document.createElement('script');
+      script.src = 'https://apis.google.com/js/api.js';
+      document.body.appendChild(script);
 
-        const initClient = async () => {
+      const initClient = async () => {
+        try {
           await window.gapi.client.init({
             apiKey: API_KEY,
             clientId: CLIENT_ID,
@@ -43,20 +43,19 @@ export const api = {
           });
           const loginButton = document.getElementById('loginButton');
           loginButton.style.display = 'block';
-
           resolve();
-        };
+        } catch (e) {
+          reject(new Error(e.error.message));
+        }
+      };
 
-        const handleClientLoad = () => {
-          window.gapi.load('client:auth2:signin2', initClient);
-        };
+      const handleClientLoad = () => {
+        window.gapi.load('client:auth2:signin2', initClient);
+      };
 
-        script.onload = () => {
-          handleClientLoad();
-        };
-      } catch (e) {
-        reject(e);
-      }
+      script.onload = () => {
+        handleClientLoad();
+      };
     });
   },
   getGaData(query) {
@@ -65,12 +64,9 @@ export const api = {
         const data = await window.gapi.client.analytics.data.ga.get(query);
         resolve(data);
       } catch (e) {
-        reject(e);
+        reject(new Error(e.message));
       }
     });
-  },
-  isSignedIn() {
-    return window.gapi.auth2.getAuthInstance().isSignedIn.get();
   },
   listAccounts() {
     return new Promise(async (resolve, reject) => {
@@ -88,7 +84,7 @@ export const api = {
         });
         resolve(data);
       } catch (e) {
-        reject(e);
+        reject(new Error(e.message));
       }
     });
   },
@@ -111,9 +107,15 @@ export const api = {
         });
         resolve(data);
       } catch (e) {
-        reject(e);
+        reject(new Error(e.message));
       }
     });
+  },
+  isSignedIn() {
+    return window.gapi.auth2.getAuthInstance().isSignedIn.get();
+  },
+  signOut() {
+    return window.gapi.auth2.getAuthInstance().signOut();
   },
 };
 

--- a/plugins/google-analytics-dashboard/src/api/api.js
+++ b/plugins/google-analytics-dashboard/src/api/api.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { API_KEY, CLIENT_ID } from './config';
+
+// Using the Google API Client Library for JavaScript
+//  https://github.com/google/google-api-javascript-client
+
+export const api = {
+  init() {
+    return new Promise((resolve, reject) => {
+      try {
+        const script = document.createElement('script');
+        script.src = 'https://apis.google.com/js/api.js';
+        document.body.appendChild(script);
+
+        const initClient = async () => {
+          await window.gapi.client.init({
+            apiKey: API_KEY,
+            clientId: CLIENT_ID,
+            scope: 'profile',
+            discoveryDocs: [
+              'https://analytics.googleapis.com/$discovery/rest?version=v3',
+              'https://people.googleapis.com/$discovery/rest?version=v1',
+            ],
+          });
+          await window.gapi.signin2.render('loginButton', {
+            longtitle: true,
+            theme: 'dark',
+          });
+          const loginButton = document.getElementById('loginButton');
+          loginButton.style.display = 'block';
+
+          resolve();
+        };
+
+        const handleClientLoad = () => {
+          window.gapi.load('client:auth2:signin2', initClient);
+        };
+
+        script.onload = () => {
+          handleClientLoad();
+        };
+      } catch (e) {
+        reject(e);
+      }
+    });
+  },
+  getGaData(query) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const data = await window.gapi.client.analytics.data.ga.get(query);
+        resolve(data);
+      } catch (e) {
+        reject(e);
+      }
+    });
+  },
+  isSignedIn() {
+    return window.gapi.auth2.getAuthInstance().isSignedIn.get();
+  },
+  listAccounts() {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const request = window.gapi.client.analytics.management.accounts.list();
+        const data = new Promise((res, rej) => {
+          request.execute(results => {
+            if (results && !results.error) {
+              res(results);
+            }
+            if (results.error) {
+              rej(results.error);
+            }
+          });
+        });
+        resolve(data);
+      } catch (e) {
+        reject(e);
+      }
+    });
+  },
+  listViews(accountId) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const request = window.gapi.client.analytics.management.profiles.list({
+          accountId: accountId,
+          webPropertyId: '~all',
+        });
+        const data = new Promise((res, rej) => {
+          request.execute(results => {
+            if (results && !results.error) {
+              res(results);
+            }
+            if (results.error) {
+              rej(results.error);
+            }
+          });
+        });
+        resolve(data);
+      } catch (e) {
+        reject(e);
+      }
+    });
+  },
+};
+
+export default api;

--- a/plugins/google-analytics-dashboard/src/api/api.js
+++ b/plugins/google-analytics-dashboard/src/api/api.js
@@ -37,12 +37,18 @@ export const api = {
               'https://people.googleapis.com/$discovery/rest?version=v1',
             ],
           });
+
+          window.gapi.auth2
+            .getAuthInstance()
+            .isSignedIn.listen(() => window.location.reload());
+
           await window.gapi.signin2.render('loginButton', {
             longtitle: true,
             theme: 'dark',
           });
           const loginButton = document.getElementById('loginButton');
           loginButton.style.display = 'block';
+
           resolve();
         } catch (e) {
           reject(new Error(e.error.message));

--- a/plugins/google-analytics-dashboard/src/api/config.ts
+++ b/plugins/google-analytics-dashboard/src/api/config.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const API_KEY = '';
+export const CLIENT_ID = '';

--- a/plugins/google-analytics-dashboard/src/api/index.js
+++ b/plugins/google-analytics-dashboard/src/api/index.js
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './api';

--- a/plugins/google-analytics-dashboard/src/assets/ga_icon.svg
+++ b/plugins/google-analytics-dashboard/src/assets/ga_icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     width="192px" height="192px" viewBox="0 0 192 192" enable-background="new 0 0 192 192" xml:space="preserve">
+<rect x="0" y="0" fill="none" width="192" height="192"/>
+  <g>
+	<g>
+		<path fill="#F9AB00" d="M130,29v132c0,14.77,10.19,23,21,23c10,0,21-7,21-23V30c0-13.54-10-22-21-22S130,17.33,130,29z"/>
+	</g>
+    <g>
+		<path fill="#E37400" d="M75,96v65c0,14.77,10.19,23,21,23c10,0,21-7,21-23V97c0-13.54-10-22-21-22S75,84.33,75,96z"/>
+	</g>
+    <g>
+		<circle fill="#E37400" cx="41" cy="163" r="21"/>
+	</g>
+</g>
+</svg>

--- a/plugins/google-analytics-dashboard/src/components/Accounts/Accounts.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Accounts/Accounts.tsx
@@ -22,6 +22,11 @@ import { Progress } from '@backstage/core';
 import { Alert } from '@material-ui/lab';
 import Select from 'components/Select';
 
+export type Account = {
+  id: string;
+  name: string | undefined;
+};
+
 const Accounts: FC<{}> = () => {
   const { account, setCurrentAccount } = useContext(Context);
 

--- a/plugins/google-analytics-dashboard/src/components/Accounts/Accounts.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Accounts/Accounts.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, useContext } from 'react';
+import { Context } from 'contexts/Context';
+import { useAsync } from 'react-use';
+import api from 'api';
+import { Progress } from '@backstage/core';
+import { Alert } from '@material-ui/lab';
+import Select from 'components/Select';
+
+const Accounts: FC<{}> = () => {
+  const { account, setCurrentAccount } = useContext(Context);
+
+  const { value, loading, error } = useAsync(async () => {
+    const results = await api.listAccounts();
+    return results;
+  }, []);
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return <Alert severity="error">{error.message}</Alert>;
+  }
+
+  const accounts =
+    value.items?.map((item: any) => ({
+      value: item.id,
+      label: item.name,
+    })) ?? [];
+
+  const handleAccount = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentAccount({
+      name: accounts.filter((v: any) => v.value === event.target.value)[0]
+        .label,
+      id: event.target.value,
+    });
+  };
+
+  return <Select value={account.id} handler={handleAccount} items={accounts} />;
+};
+
+export default Accounts;

--- a/plugins/google-analytics-dashboard/src/components/Accounts/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Accounts/index.tsx
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './Accounts';

--- a/plugins/google-analytics-dashboard/src/components/BlueCard/BlueCard.tsx
+++ b/plugins/google-analytics-dashboard/src/components/BlueCard/BlueCard.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC } from 'react';
+import { Typography, makeStyles, Card, Divider } from '@material-ui/core';
+
+const useStyles = makeStyles({
+  card: {
+    color: 'white',
+    backgroundColor: '#4285f4',
+  },
+  heading: {
+    fontWeight: 700,
+    padding: '16px 16px 16px 20px',
+  },
+});
+
+const BlueCard: FC<{ title: string }> = ({ title, children }) => {
+  const classes = useStyles();
+
+  return (
+    <Card className={classes.card}>
+      <Typography variant="h5" className={classes.heading}>
+        {title}
+      </Typography>
+      <Divider />
+      {children}
+    </Card>
+  );
+};
+
+export default BlueCard;

--- a/plugins/google-analytics-dashboard/src/components/BlueCard/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/BlueCard/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from './BlueCard';

--- a/plugins/google-analytics-dashboard/src/components/Dashboard/Dashboard.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Dashboard/Dashboard.tsx
@@ -19,20 +19,24 @@ import { Grid } from '@material-ui/core';
 import { InfoCard, Progress } from '@backstage/core';
 import { Alert } from '@material-ui/lab';
 import { useAsync } from 'react-use';
-import UserTrend from 'components/UserTrend';
-import PageLoad from 'components/PageLoad';
-import SingleValueItem from 'components/SingleValueItem';
-import Settings from 'components/Settings';
-import { Context } from 'contexts/Context';
 import api from 'api';
 import { API_KEY, CLIENT_ID } from 'api/config';
+import { Context } from 'contexts/Context';
+import UserTrend from 'components/UserTrend';
+import PageLoad from 'components/PageLoad';
+import Settings from 'components/Settings';
 import Intro from 'components/Intro';
+import SingleValues from 'components/SingleValues';
+import BlueCard from 'components/BlueCard';
 
 const Dashboard: FC<{}> = () => {
   const { view } = useContext(Context);
   const [isSignedIn, setIsSignedIn] = useState(false);
 
   const { loading, error } = useAsync(async () => {
+    if (!API_KEY || !CLIENT_ID) {
+      return;
+    }
     await api.init();
     setIsSignedIn(api.isSignedIn());
   }, []);
@@ -65,23 +69,17 @@ const Dashboard: FC<{}> = () => {
     );
   }
 
-  const items = [
-    { title: 'Total Users', metric: 'ga:users' },
-    { title: 'New Users', metric: 'ga:newUsers' },
-    { title: 'Session per User', metric: 'ga:sessionsPerUser' },
-  ];
-
   return (
     <Grid item container spacing={3}>
       <Grid item>
-        <PageLoad />
+        <BlueCard title="Load">
+          <PageLoad />
+        </BlueCard>
       </Grid>
       <Grid item>
         <InfoCard title="Users">
           <Grid item container spacing={8}>
-            {items.map(item => (
-              <SingleValueItem key={item.title} item={item} />
-            ))}
+            <SingleValues />
           </Grid>
         </InfoCard>
       </Grid>

--- a/plugins/google-analytics-dashboard/src/components/Dashboard/Dashboard.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Dashboard/Dashboard.tsx
@@ -53,7 +53,7 @@ const Dashboard: FC<{}> = () => {
     return (
       <Grid container>
         <Grid item>
-          <Intro isSignedIn={isSignedIn} />
+          <Intro />
         </Grid>
       </Grid>
     );

--- a/plugins/google-analytics-dashboard/src/components/Dashboard/Dashboard.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Dashboard/Dashboard.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, useState, useContext } from 'react';
+import { Typography, Grid } from '@material-ui/core';
+import { InfoCard, Progress } from '@backstage/core';
+import { Alert } from '@material-ui/lab';
+import { useAsync } from 'react-use';
+import UserTrend from '../UserTrend';
+import PageLoad from '../PageLoad';
+import SingleValueItem from '../SingleValueItem';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import Settings from '../Settings';
+import { Context } from 'contexts/Context';
+import api from 'api';
+
+const GetStarted: FC<{}> = () => {
+  const CODE = `config.tsx:
+  export const GA_ACCOUNT_ID = "your account id"
+  export const GA_VIEW_ID = "your view id"
+  export const API_KEY = "your api key" 
+  export const CLIENT_ID = "your client id" 
+  `;
+  return (
+    <InfoCard title="Getting Started">
+      <Typography variant="body1">Configure the plugin</Typography>
+      <SyntaxHighlighter language="javascript" style={docco}>
+        {CODE}
+      </SyntaxHighlighter>
+    </InfoCard>
+  );
+};
+
+const Dashboard: FC<{}> = () => {
+  const { view } = useContext(Context);
+  const [isSignedIn, setIsSignedIn] = useState(false);
+  // const [retrigger, setRetrigger] = useState<boolean>(false);
+
+  const { loading, error } = useAsync(async () => {
+    await api.init();
+    setIsSignedIn(api.isSignedIn());
+  }, []);
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return <Alert severity="error">{error.message}</Alert>;
+  }
+
+  if (!isSignedIn) {
+    return (
+      <Grid container>
+        <Grid item>
+          <GetStarted />
+        </Grid>
+      </Grid>
+    );
+  }
+
+  if (!view.id) {
+    return (
+      <Grid container>
+        <Grid item>
+          <Settings />
+        </Grid>
+      </Grid>
+    );
+  }
+
+  const items = [
+    {
+      title: 'Total Users',
+      metric: 'ga:users',
+    },
+    {
+      title: 'New Users',
+      metric: 'ga:newUsers',
+    },
+    {
+      title: 'Session per User',
+      metric: 'ga:sessionsPerUser',
+    },
+  ];
+
+  return (
+    <Grid item container spacing={3}>
+      <Grid item>
+        <PageLoad />
+      </Grid>
+      <Grid item>
+        <InfoCard title="Users">
+          <Grid item container spacing={8}>
+            {items.map(item => (
+              <SingleValueItem key={item.title} item={item} />
+            ))}
+          </Grid>
+        </InfoCard>
+      </Grid>
+      <Grid item xs={3}>
+        <InfoCard title="Trend">
+          <UserTrend />
+        </InfoCard>
+      </Grid>
+      <Grid item xs>
+        <Settings />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default Dashboard;

--- a/plugins/google-analytics-dashboard/src/components/Dashboard/Dashboard.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Dashboard/Dashboard.tsx
@@ -15,40 +15,22 @@
  */
 
 import React, { FC, useState, useContext } from 'react';
-import { Typography, Grid } from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import { InfoCard, Progress } from '@backstage/core';
 import { Alert } from '@material-ui/lab';
 import { useAsync } from 'react-use';
-import UserTrend from '../UserTrend';
-import PageLoad from '../PageLoad';
-import SingleValueItem from '../SingleValueItem';
-import SyntaxHighlighter from 'react-syntax-highlighter';
-import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import Settings from '../Settings';
+import UserTrend from 'components/UserTrend';
+import PageLoad from 'components/PageLoad';
+import SingleValueItem from 'components/SingleValueItem';
+import Settings from 'components/Settings';
 import { Context } from 'contexts/Context';
 import api from 'api';
-
-const GetStarted: FC<{}> = () => {
-  const CODE = `config.tsx:
-  export const GA_ACCOUNT_ID = "your account id"
-  export const GA_VIEW_ID = "your view id"
-  export const API_KEY = "your api key" 
-  export const CLIENT_ID = "your client id" 
-  `;
-  return (
-    <InfoCard title="Getting Started">
-      <Typography variant="body1">Configure the plugin</Typography>
-      <SyntaxHighlighter language="javascript" style={docco}>
-        {CODE}
-      </SyntaxHighlighter>
-    </InfoCard>
-  );
-};
+import { API_KEY, CLIENT_ID } from 'api/config';
+import Intro from 'components/Intro';
 
 const Dashboard: FC<{}> = () => {
   const { view } = useContext(Context);
   const [isSignedIn, setIsSignedIn] = useState(false);
-  // const [retrigger, setRetrigger] = useState<boolean>(false);
 
   const { loading, error } = useAsync(async () => {
     await api.init();
@@ -63,11 +45,11 @@ const Dashboard: FC<{}> = () => {
     return <Alert severity="error">{error.message}</Alert>;
   }
 
-  if (!isSignedIn) {
+  if (!isSignedIn || !API_KEY || !CLIENT_ID) {
     return (
       <Grid container>
         <Grid item>
-          <GetStarted />
+          <Intro isSignedIn={isSignedIn} />
         </Grid>
       </Grid>
     );
@@ -84,18 +66,9 @@ const Dashboard: FC<{}> = () => {
   }
 
   const items = [
-    {
-      title: 'Total Users',
-      metric: 'ga:users',
-    },
-    {
-      title: 'New Users',
-      metric: 'ga:newUsers',
-    },
-    {
-      title: 'Session per User',
-      metric: 'ga:sessionsPerUser',
-    },
+    { title: 'Total Users', metric: 'ga:users' },
+    { title: 'New Users', metric: 'ga:newUsers' },
+    { title: 'Session per User', metric: 'ga:sessionsPerUser' },
   ];
 
   return (

--- a/plugins/google-analytics-dashboard/src/components/Dashboard/index.ts
+++ b/plugins/google-analytics-dashboard/src/components/Dashboard/index.ts
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './Dashboard';

--- a/plugins/google-analytics-dashboard/src/components/Home/Home.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Home/Home.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC } from 'react';
+import {
+  Header,
+  Page,
+  pageTheme,
+  Content,
+  ContentHeader,
+  HeaderLabel,
+  SupportButton,
+} from '@backstage/core';
+import Dashboard from '../Dashboard';
+import { Context, useSettings } from 'contexts/Context';
+
+const Home: FC<{}> = () => {
+  const settings = useSettings();
+
+  return (
+    <Page theme={pageTheme.tool}>
+      <Header
+        title="Google Analytics Dashboard"
+        subtitle="Quick glance at your GA metrics"
+      >
+        <HeaderLabel label="Owner" value="Spotify" />
+        <HeaderLabel label="Lifecycle" value="Alpha" />
+      </Header>
+      <Content>
+        <Context.Provider value={settings}>
+          <ContentHeader title={settings?.view?.name ?? 'Home'}>
+            <SupportButton>
+              A description of your plugin goes here.
+            </SupportButton>
+            <button
+              className="g-signin2"
+              style={{
+                border: 'none',
+                backgroundColor: 'inherit',
+                display: 'none',
+              }}
+              id="loginButton"
+            >
+              Login with Google
+            </button>
+          </ContentHeader>
+          <Dashboard />
+        </Context.Provider>
+      </Content>
+    </Page>
+  );
+};
+
+export default Home;

--- a/plugins/google-analytics-dashboard/src/components/Home/Home.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Home/Home.tsx
@@ -24,9 +24,9 @@ import {
   HeaderLabel,
   SupportButton,
 } from '@backstage/core';
-import Dashboard from '../Dashboard';
-import { Context } from 'contexts/Context';
 import { useSettings } from 'hooks/useSettings';
+import { Context } from 'contexts/Context';
+import Dashboard from 'components/Dashboard';
 
 const Home: FC<{}> = () => {
   const settings = useSettings();

--- a/plugins/google-analytics-dashboard/src/components/Home/Home.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Home/Home.tsx
@@ -25,7 +25,8 @@ import {
   SupportButton,
 } from '@backstage/core';
 import Dashboard from '../Dashboard';
-import { Context, useSettings } from 'contexts/Context';
+import { Context } from 'contexts/Context';
+import { useSettings } from 'hooks/useSettings';
 
 const Home: FC<{}> = () => {
   const settings = useSettings();

--- a/plugins/google-analytics-dashboard/src/components/Home/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Home/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Home';

--- a/plugins/google-analytics-dashboard/src/components/Home/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Home/index.tsx
@@ -1,1 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { default } from './Home';

--- a/plugins/google-analytics-dashboard/src/components/Intro/Intro.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Intro/Intro.tsx
@@ -15,18 +15,20 @@
  */
 
 import React, { FC } from 'react';
-import { Typography, makeStyles } from '@material-ui/core';
+import {
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Paper,
+  makeStyles,
+} from '@material-ui/core';
 import { InfoCard, StatusWarning, StatusOK } from '@backstage/core';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import { API_KEY, CLIENT_ID } from 'api/config';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
 
 const useStyles = makeStyles({
   table: {
@@ -34,40 +36,23 @@ const useStyles = makeStyles({
   },
 });
 
-type Props = {
-  isSignedIn: boolean;
-};
-
-const Intro: FC<Props> = ({ isSignedIn }) => {
+const Intro: FC<{}> = () => {
   const classes = useStyles();
 
   const CODE = `api/config.ts:
 
-  export const API_KEY = "your api key" 
-  export const CLIENT_ID = "your client id" 
+  export const API_KEY = "<your api key>" 
+  export const CLIENT_ID = "<your client id>" 
   `;
+
   return (
     <InfoCard title="Getting Started">
-      {!isSignedIn && (
-        <Typography variant="body1">
-          Sign in to Google using the button in the top right corner
-        </Typography>
-      )}
       <Typography variant="body1">Configure the plugin</Typography>
       <SyntaxHighlighter language="javascript" style={docco}>
         {CODE}
       </SyntaxHighlighter>
-      <Typography variant="body1">Current status</Typography>
       <TableContainer component={Paper}>
         <Table className={classes.table} aria-label="simple table">
-          <TableHead>
-            <TableRow>
-              <TableCell>
-                <pre>api/config.ts</pre>
-              </TableCell>
-              <TableCell align="right">status</TableCell>
-            </TableRow>
-          </TableHead>
           <TableBody>
             <TableRow>
               <TableCell component="th" scope="row">

--- a/plugins/google-analytics-dashboard/src/components/Intro/Intro.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Intro/Intro.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC } from 'react';
+import { Typography, makeStyles } from '@material-ui/core';
+import { InfoCard, StatusWarning, StatusOK } from '@backstage/core';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import { API_KEY, CLIENT_ID } from 'api/config';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+
+const useStyles = makeStyles({
+  table: {
+    minWidth: 650,
+  },
+});
+
+type Props = {
+  isSignedIn: boolean;
+};
+
+const Intro: FC<Props> = ({ isSignedIn }) => {
+  const classes = useStyles();
+
+  const CODE = `api/config.ts:
+
+  export const API_KEY = "your api key" 
+  export const CLIENT_ID = "your client id" 
+  `;
+  return (
+    <InfoCard title="Getting Started">
+      {!isSignedIn && (
+        <Typography variant="body1">
+          Sign in to Google using the button in the top right corner
+        </Typography>
+      )}
+      <Typography variant="body1">Configure the plugin</Typography>
+      <SyntaxHighlighter language="javascript" style={docco}>
+        {CODE}
+      </SyntaxHighlighter>
+      <Typography variant="body1">Current status</Typography>
+      <TableContainer component={Paper}>
+        <Table className={classes.table} aria-label="simple table">
+          <TableHead>
+            <TableRow>
+              <TableCell>
+                <pre>api/config.ts</pre>
+              </TableCell>
+              <TableCell align="right">status</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell component="th" scope="row">
+                <pre>API_KEY</pre>
+              </TableCell>
+              <TableCell align="right">
+                {API_KEY ? <StatusOK /> : <StatusWarning />}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell component="th" scope="row">
+                <pre>CLIENT_ID</pre>
+              </TableCell>
+              <TableCell align="right">
+                {CLIENT_ID ? <StatusOK /> : <StatusWarning />}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </InfoCard>
+  );
+};
+
+export default Intro;

--- a/plugins/google-analytics-dashboard/src/components/Intro/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Intro/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from './Intro';

--- a/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
+++ b/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, useContext } from 'react';
+import { Typography, Grid, makeStyles, Card, Divider } from '@material-ui/core';
+import { Alert, Skeleton } from '@material-ui/lab';
+import api from 'api';
+import { useAsync } from 'react-use';
+import { Context } from 'contexts/Context';
+
+const useStyles = makeStyles(theme => ({
+  white: {
+    fontWeight: 300,
+    fontSize: 75,
+    color: '#4285f4',
+  },
+  divider: {
+    opacity: '0.3',
+  },
+  card: {
+    backgroundColor: '#4285f4',
+  },
+  foo: {
+    background: theme.palette.background.default,
+  },
+}));
+
+const PageLoad: FC<{}> = () => {
+  const classes = useStyles();
+  const { view, timeRange } = useContext(Context);
+
+  const { value, loading, error } = useAsync(async () => {
+    const query = {
+      ids: `ga:${view.id}`,
+      'start-date': timeRange['start-date'],
+      'end-date': timeRange['end-date'],
+      metrics: 'ga:avgPageLoadTime',
+    };
+    return await api.getGaData(query);
+  }, [view, timeRange]);
+
+  if (loading) {
+    return (
+      <Card>
+        <Skeleton variant="rect" width={185} height={64}>
+          <Skeleton variant="text" style={{ padding: 16 }} />
+        </Skeleton>
+        <Divider />
+        <Skeleton variant="rect" width={185} height={160} />
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <Alert severity="error">Some error message</Alert>
+      </Card>
+    );
+  }
+
+  const result = value!.result?.totalsForAllResults;
+
+  return (
+    <Card className={classes.card}>
+      <Typography
+        variant="h5"
+        style={{
+          color: 'white',
+          fontWeight: 700,
+          padding: '16px 16px 16px 20px',
+        }}
+      >
+        Page Load
+      </Typography>
+      <Divider className={classes.divider} />
+      <Grid item style={{ padding: 16 }}>
+        <Typography style={{ color: 'white' }}>Page Load</Typography>
+        <Typography
+          style={{
+            color: 'white',
+            fontWeight: 300,
+            fontSize: 75,
+            margin: '-13px 0px 7px 0px',
+          }}
+        >
+          {`${Number(result['ga:avgPageLoadTime']).toFixed(1)}s`}
+        </Typography>
+      </Grid>
+    </Card>
+  );
+};
+
+export default PageLoad;

--- a/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
+++ b/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
@@ -49,25 +49,47 @@ const PageLoad: FC<{}> = () => {
       'end-date': timeRange['end-date'],
       metrics: 'ga:avgPageLoadTime',
     };
+
     return await api.getGaData(query);
   }, [view, timeRange]);
 
   if (loading) {
     return (
-      <Card>
-        <Skeleton variant="rect" width={185} height={64}>
-          <Skeleton variant="text" style={{ padding: 16 }} />
-        </Skeleton>
-        <Divider />
-        <Skeleton variant="rect" width={185} height={160} />
+      <Card className={classes.card}>
+        <Typography
+          variant="h5"
+          style={{
+            color: 'white',
+            fontWeight: 700,
+            padding: '16px 16px 16px 20px',
+          }}
+        >
+          Page Load
+        </Typography>
+        <Grid item style={{ padding: 16 }}>
+          <Skeleton variant="text" />
+          <Skeleton variant="rect" width={185} height={90} />
+        </Grid>
       </Card>
     );
   }
 
   if (error) {
     return (
-      <Card>
-        <Alert severity="error">Some error message</Alert>
+      <Card className={classes.card}>
+        <Typography
+          variant="h5"
+          style={{
+            color: 'white',
+            fontWeight: 700,
+            padding: '16px 16px 16px 20px',
+          }}
+        >
+          Page Load
+        </Typography>
+        <Grid item style={{ padding: 16 }}>
+          <Alert severity="error">{error.message}</Alert>
+        </Grid>
       </Card>
     );
   }

--- a/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
+++ b/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
@@ -15,18 +15,20 @@
  */
 
 import React, { FC, useContext } from 'react';
-import { Typography, Grid, makeStyles, Card, Divider } from '@material-ui/core';
+import { Typography, Grid, makeStyles } from '@material-ui/core';
 import { Alert, Skeleton } from '@material-ui/lab';
 import api from 'api';
 import { useAsync } from 'react-use';
 import { Context } from 'contexts/Context';
 
 const useStyles = makeStyles({
-  divider: {
-    opacity: '0.3',
+  gridItem: {
+    padding: 16,
   },
-  card: {
-    backgroundColor: '#4285f4',
+  value: {
+    fontWeight: 300,
+    fontSize: 75,
+    margin: '-13px 0px 7px 0px',
   },
 });
 
@@ -47,74 +49,30 @@ const PageLoad: FC<{}> = () => {
 
   if (loading) {
     return (
-      <Card className={classes.card}>
-        <Typography
-          variant="h5"
-          style={{
-            color: 'white',
-            fontWeight: 700,
-            padding: '16px 16px 16px 20px',
-          }}
-        >
-          Page Load
-        </Typography>
-        <Grid item style={{ padding: 16 }}>
-          <Skeleton variant="text" />
-          <Skeleton variant="rect" width={185} height={90} />
-        </Grid>
-      </Card>
+      <Grid item className={classes.gridItem}>
+        <Skeleton variant="text" />
+        <Skeleton variant="rect" width={185} height={90} />
+      </Grid>
     );
   }
 
   if (error) {
     return (
-      <Card className={classes.card}>
-        <Typography
-          variant="h5"
-          style={{
-            color: 'white',
-            fontWeight: 700,
-            padding: '16px 16px 16px 20px',
-          }}
-        >
-          Page Load
-        </Typography>
-        <Grid item style={{ padding: 16 }}>
-          <Alert severity="error">{error.message}</Alert>
-        </Grid>
-      </Card>
+      <Grid item className={classes.gridItem}>
+        <Alert severity="error">{error.message}</Alert>
+      </Grid>
     );
   }
 
-  const result = value!.result?.totalsForAllResults;
+  const result = Number(
+    value!.result?.totalsForAllResults['ga:avgPageLoadTime'],
+  ).toFixed(1);
 
   return (
-    <Card className={classes.card}>
-      <Typography
-        variant="h5"
-        style={{
-          color: 'white',
-          fontWeight: 700,
-          padding: '16px 16px 16px 20px',
-        }}
-      >
-        Page Load
-      </Typography>
-      <Divider className={classes.divider} />
-      <Grid item style={{ padding: 16 }}>
-        <Typography style={{ color: 'white' }}>Page Load</Typography>
-        <Typography
-          style={{
-            color: 'white',
-            fontWeight: 300,
-            fontSize: 75,
-            margin: '-13px 0px 7px 0px',
-          }}
-        >
-          {`${Number(result['ga:avgPageLoadTime']).toFixed(1)}s`}
-        </Typography>
-      </Grid>
-    </Card>
+    <Grid item className={classes.gridItem}>
+      <Typography>Page Load</Typography>
+      <Typography className={classes.value}>{result}</Typography>
+    </Grid>
   );
 };
 

--- a/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
+++ b/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
@@ -21,22 +21,14 @@ import api from 'api';
 import { useAsync } from 'react-use';
 import { Context } from 'contexts/Context';
 
-const useStyles = makeStyles(theme => ({
-  white: {
-    fontWeight: 300,
-    fontSize: 75,
-    color: '#4285f4',
-  },
+const useStyles = makeStyles({
   divider: {
     opacity: '0.3',
   },
   card: {
     backgroundColor: '#4285f4',
   },
-  foo: {
-    background: theme.palette.background.default,
-  },
-}));
+});
 
 const PageLoad: FC<{}> = () => {
   const classes = useStyles();

--- a/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
+++ b/plugins/google-analytics-dashboard/src/components/PageLoad/PageLoad.tsx
@@ -43,7 +43,6 @@ const PageLoad: FC<{}> = () => {
       'end-date': timeRange['end-date'],
       metrics: 'ga:avgPageLoadTime',
     };
-
     return await api.getGaData(query);
   }, [view, timeRange]);
 
@@ -65,8 +64,8 @@ const PageLoad: FC<{}> = () => {
   }
 
   const result = Number(
-    value!.result?.totalsForAllResults['ga:avgPageLoadTime'],
-  ).toFixed(1);
+    value!.result.totalsForAllResults['ga:avgPageLoadTime'],
+  ).toLocaleString(undefined, { maximumFractionDigits: 1 });
 
   return (
     <Grid item className={classes.gridItem}>

--- a/plugins/google-analytics-dashboard/src/components/PageLoad/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/PageLoad/index.tsx
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './PageLoad';

--- a/plugins/google-analytics-dashboard/src/components/Select/Select.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Select/Select.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC } from 'react';
+import {
+  TextField,
+  MenuItem,
+  makeStyles,
+  createStyles,
+} from '@material-ui/core';
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    root: {
+      '& .MuiTextField-root': {
+        width: '25ch',
+      },
+    },
+  }),
+);
+
+type Props = {
+  value: any;
+  handler: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  items: any[];
+};
+const Select: FC<Props> = ({ value, handler, items }) => {
+  const classes = useStyles();
+
+  return (
+    <form className={classes.root} noValidate autoComplete="off">
+      <TextField
+        select
+        label="Select"
+        size="small"
+        value={value}
+        onChange={handler}
+        variant="outlined"
+      >
+        {items.map((option: any) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </TextField>
+    </form>
+  );
+};
+
+export default Select;

--- a/plugins/google-analytics-dashboard/src/components/Select/Select.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Select/Select.tsx
@@ -16,7 +16,6 @@
 
 import React, { FC } from 'react';
 import { TextField, MenuItem, makeStyles } from '@material-ui/core';
-import { Item } from 'components/SingleValueItem/SingleValueItem';
 
 const useStyles = makeStyles({
   root: {
@@ -29,7 +28,7 @@ const useStyles = makeStyles({
 type Props = {
   value: string;
   handler: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  items: Item[];
+  items: any[];
 };
 
 const Select: FC<Props> = ({ value, handler, items }) => {

--- a/plugins/google-analytics-dashboard/src/components/Select/Select.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Select/Select.tsx
@@ -15,28 +15,23 @@
  */
 
 import React, { FC } from 'react';
-import {
-  TextField,
-  MenuItem,
-  makeStyles,
-  createStyles,
-} from '@material-ui/core';
+import { TextField, MenuItem, makeStyles } from '@material-ui/core';
+import { Item } from 'components/SingleValueItem/SingleValueItem';
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    root: {
-      '& .MuiTextField-root': {
-        width: '25ch',
-      },
+const useStyles = makeStyles({
+  root: {
+    '& .MuiTextField-root': {
+      width: '25ch',
     },
-  }),
-);
+  },
+});
 
 type Props = {
-  value: any;
+  value: string;
   handler: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  items: any[];
+  items: Item[];
 };
+
 const Select: FC<Props> = ({ value, handler, items }) => {
   const classes = useStyles();
 

--- a/plugins/google-analytics-dashboard/src/components/Select/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Select/index.tsx
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './Select';

--- a/plugins/google-analytics-dashboard/src/components/Settings/Settings.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Settings/Settings.tsx
@@ -16,7 +16,7 @@
 
 import React, { FC } from 'react';
 import { InfoCard, StructuredMetadataTable } from '@backstage/core';
-import TimeRange from 'components/TimeRange';
+import TimeRanges from 'components/TimeRanges';
 import Views from 'components/Views';
 import Accounts from 'components/Accounts';
 
@@ -24,7 +24,7 @@ const Settings: FC<{}> = () => {
   const metadata = {
     account: <Accounts />,
     view: <Views />,
-    timerange: <TimeRange />,
+    timerange: <TimeRanges />,
   };
 
   return (

--- a/plugins/google-analytics-dashboard/src/components/Settings/Settings.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Settings/Settings.tsx
@@ -14,9 +14,24 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+import React, { FC } from 'react';
+import { InfoCard, StructuredMetadataTable } from '@backstage/core';
+import TimeRange from 'components/TimeRange';
+import Views from 'components/Views';
+import Accounts from 'components/Accounts';
+
+const Settings: FC<{}> = () => {
+  const metadata = {
+    account: <Accounts />,
+    view: <Views />,
+    timerange: <TimeRange />,
+  };
+
+  return (
+    <InfoCard title="Settings">
+      <StructuredMetadataTable metadata={metadata} />
+    </InfoCard>
+  );
+};
+
+export default Settings;

--- a/plugins/google-analytics-dashboard/src/components/Settings/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Settings/index.tsx
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './Settings';

--- a/plugins/google-analytics-dashboard/src/components/SingleValueItem/SingleValueItem.tsx
+++ b/plugins/google-analytics-dashboard/src/components/SingleValueItem/SingleValueItem.tsx
@@ -68,7 +68,11 @@ const SingleValueItem: FC<Props> = ({ item }) => {
   }
 
   if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return (
+      <Grid item>
+        <Alert severity="error">{error.message}</Alert>
+      </Grid>
+    );
   }
 
   const result = value!.result.totalsForAllResults[metric];

--- a/plugins/google-analytics-dashboard/src/components/SingleValueItem/SingleValueItem.tsx
+++ b/plugins/google-analytics-dashboard/src/components/SingleValueItem/SingleValueItem.tsx
@@ -21,18 +21,15 @@ import api from 'api';
 import { useAsync } from 'react-use';
 import { Context } from 'contexts/Context';
 
-const useStyles = makeStyles(theme => ({
-  white: {
+const useStyles = makeStyles({
+  value: {
     fontWeight: 300,
     fontSize: 75,
     color: '#4285f4',
   },
-  foo: {
-    background: theme.palette.background.default,
-  },
-}));
+});
 
-type Item = {
+export type Item = {
   title: string;
   metric: string;
 };
@@ -45,6 +42,7 @@ const SingleValueItem: FC<Props> = ({ item }) => {
   const classes = useStyles();
   const { title, metric } = item;
   const { view, timeRange } = useContext(Context);
+
   const { value, loading, error } = useAsync(async () => {
     const query = {
       ids: `ga:${view.id}`,
@@ -79,7 +77,7 @@ const SingleValueItem: FC<Props> = ({ item }) => {
   return (
     <Grid item>
       <Typography>{title}</Typography>
-      <Typography variant="h2" className={classes.white}>
+      <Typography variant="h2" className={classes.value}>
         {Number(result).toLocaleString(undefined, { maximumFractionDigits: 1 })}
       </Typography>
     </Grid>

--- a/plugins/google-analytics-dashboard/src/components/SingleValueItem/SingleValueItem.tsx
+++ b/plugins/google-analytics-dashboard/src/components/SingleValueItem/SingleValueItem.tsx
@@ -50,9 +50,6 @@ const SingleValueItem: FC<Props> = ({ item }) => {
       'end-date': timeRange['end-date'],
       metrics: metric,
     };
-    // await new Promise(resolve =>
-    //   setTimeout(resolve, Math.floor(Math.random() * 10000) + 1000),
-    // );
     return await api.getGaData(query);
   }, [view, timeRange]);
 
@@ -73,12 +70,15 @@ const SingleValueItem: FC<Props> = ({ item }) => {
     );
   }
 
-  const result = value!.result.totalsForAllResults[metric];
+  const result = Number(
+    value!.result.totalsForAllResults[metric],
+  ).toLocaleString(undefined, { maximumFractionDigits: 1 });
+
   return (
     <Grid item>
       <Typography>{title}</Typography>
       <Typography variant="h2" className={classes.value}>
-        {Number(result).toLocaleString(undefined, { maximumFractionDigits: 1 })}
+        {result}
       </Typography>
     </Grid>
   );

--- a/plugins/google-analytics-dashboard/src/components/SingleValueItem/SingleValueItem.tsx
+++ b/plugins/google-analytics-dashboard/src/components/SingleValueItem/SingleValueItem.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, useContext } from 'react';
+import { Typography, Grid, makeStyles } from '@material-ui/core';
+import { Alert, Skeleton } from '@material-ui/lab';
+import api from 'api';
+import { useAsync } from 'react-use';
+import { Context } from 'contexts/Context';
+
+const useStyles = makeStyles(theme => ({
+  white: {
+    fontWeight: 300,
+    fontSize: 75,
+    color: '#4285f4',
+  },
+  foo: {
+    background: theme.palette.background.default,
+  },
+}));
+
+type Item = {
+  title: string;
+  metric: string;
+};
+
+type Props = {
+  item: Item;
+};
+
+const SingleValueItem: FC<Props> = ({ item }) => {
+  const classes = useStyles();
+  const { title, metric } = item;
+  const { view, timeRange } = useContext(Context);
+  const { value, loading, error } = useAsync(async () => {
+    const query = {
+      ids: `ga:${view.id}`,
+      'start-date': timeRange['start-date'],
+      'end-date': timeRange['end-date'],
+      metrics: metric,
+    };
+    // await new Promise(resolve =>
+    //   setTimeout(resolve, Math.floor(Math.random() * 10000) + 1000),
+    // );
+    return await api.getGaData(query);
+  }, [view, timeRange]);
+
+  if (loading) {
+    return (
+      <Grid item>
+        <Skeleton variant="text" />
+        <Skeleton variant="rect" width={185} height={90} />
+      </Grid>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error">{error.message}</Alert>;
+  }
+
+  const result = value!.result.totalsForAllResults[metric];
+  return (
+    <Grid item>
+      <Typography>{title}</Typography>
+      <Typography variant="h2" className={classes.white}>
+        {Number(result).toLocaleString(undefined, { maximumFractionDigits: 1 })}
+      </Typography>
+    </Grid>
+  );
+};
+
+export default SingleValueItem;

--- a/plugins/google-analytics-dashboard/src/components/SingleValueItem/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/SingleValueItem/index.tsx
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './SingleValueItem';

--- a/plugins/google-analytics-dashboard/src/components/SingleValues/SingleValues.tsx
+++ b/plugins/google-analytics-dashboard/src/components/SingleValues/SingleValues.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC } from 'react';
+import { Grid } from '@material-ui/core';
+import SingleValueItem from 'components/SingleValueItem';
+
+const SingleValues: FC<{}> = () => {
+  const valueItems = [
+    { title: 'Total Users', metric: 'ga:users' },
+    { title: 'New Users', metric: 'ga:newUsers' },
+    { title: 'Session per User', metric: 'ga:sessionsPerUser' },
+  ];
+
+  return (
+    <Grid item container spacing={8}>
+      {valueItems.map(item => (
+        <SingleValueItem key={item.title} item={item} />
+      ))}
+    </Grid>
+  );
+};
+
+export default SingleValues;

--- a/plugins/google-analytics-dashboard/src/components/SingleValues/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/SingleValues/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from './SingleValues';

--- a/plugins/google-analytics-dashboard/src/components/TimeRange/TimeRange.tsx
+++ b/plugins/google-analytics-dashboard/src/components/TimeRange/TimeRange.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, useContext } from 'react';
+import Select from 'components/Select';
+import { Context, TimeRange as TimeRangeType } from 'contexts/Context';
+
+const TimeRange: FC<{}> = () => {
+  const { timeRange, setCurrentTimeRange } = useContext(Context);
+
+  const ranges = [
+    { value: '7daysAgo', label: '1 week' },
+    { value: '30daysAgo', label: '1 Month' },
+  ];
+
+  const handleTimeRange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentTimeRange({
+      'start-date': event.target.value as TimeRangeType['start-date'],
+      'end-date': 'today',
+    });
+  };
+
+  return (
+    <Select
+      value={timeRange['start-date']}
+      handler={handleTimeRange}
+      items={ranges}
+    />
+  );
+};
+
+export default TimeRange;

--- a/plugins/google-analytics-dashboard/src/components/TimeRange/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/TimeRange/index.tsx
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './TimeRange';

--- a/plugins/google-analytics-dashboard/src/components/TimeRanges/TimeRanges.tsx
+++ b/plugins/google-analytics-dashboard/src/components/TimeRanges/TimeRanges.tsx
@@ -16,9 +16,14 @@
 
 import React, { FC, useContext } from 'react';
 import Select from 'components/Select';
-import { Context, TimeRange as TimeRangeType } from 'contexts/Context';
+import { Context } from 'contexts/Context';
 
-const TimeRange: FC<{}> = () => {
+export type TimeRange = {
+  'start-date': '7daysAgo' | '30daysAgo';
+  'end-date': 'today';
+};
+
+const TimeRanges: FC<{}> = () => {
   const { timeRange, setCurrentTimeRange } = useContext(Context);
 
   const ranges = [
@@ -28,7 +33,7 @@ const TimeRange: FC<{}> = () => {
 
   const handleTimeRange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setCurrentTimeRange({
-      'start-date': event.target.value as TimeRangeType['start-date'],
+      'start-date': event.target.value as TimeRange['start-date'],
       'end-date': 'today',
     });
   };
@@ -42,4 +47,4 @@ const TimeRange: FC<{}> = () => {
   );
 };
 
-export default TimeRange;
+export default TimeRanges;

--- a/plugins/google-analytics-dashboard/src/components/TimeRanges/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/TimeRanges/index.tsx
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { default } from './TimeRange';
+export { default } from './TimeRanges';

--- a/plugins/google-analytics-dashboard/src/components/UserTrend/UserTrend.tsx
+++ b/plugins/google-analytics-dashboard/src/components/UserTrend/UserTrend.tsx
@@ -46,14 +46,19 @@ const UserTrend: FC<{}> = () => {
   }
 
   if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return (
+      <Grid item>
+        <Alert severity="error">{error.message}</Alert>
+      </Grid>
+    );
   }
+
+  const data = value.result.rows.map((row: any) => row[1]);
 
   return (
     <Grid item>
       <Typography>User Trend</Typography>
-
-      <Sparklines data={value.result.rows.map((row: any) => row[1])}>
+      <Sparklines data={data} margin={8}>
         <SparklinesBars
           style={{ stroke: 'white', fill: '#41c3f9', fillOpacity: 0.25 }}
         />

--- a/plugins/google-analytics-dashboard/src/components/UserTrend/UserTrend.tsx
+++ b/plugins/google-analytics-dashboard/src/components/UserTrend/UserTrend.tsx
@@ -58,7 +58,7 @@ const UserTrend: FC<{}> = () => {
   return (
     <Grid item>
       <Typography>User Trend</Typography>
-      <Sparklines data={data} margin={8}>
+      <Sparklines data={data}>
         <SparklinesBars
           style={{ stroke: 'white', fill: '#41c3f9', fillOpacity: 0.25 }}
         />

--- a/plugins/google-analytics-dashboard/src/components/UserTrend/UserTrend.tsx
+++ b/plugins/google-analytics-dashboard/src/components/UserTrend/UserTrend.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, useContext } from 'react';
+import { Typography, Grid } from '@material-ui/core';
+import { Alert, Skeleton } from '@material-ui/lab';
+import api from 'api';
+import { useAsync } from 'react-use';
+import { Sparklines, SparklinesBars, SparklinesLine } from 'react-sparklines';
+import { Context } from 'contexts/Context';
+
+const UserTrend: FC<{}> = () => {
+  const { view, timeRange } = useContext(Context);
+
+  const { value, loading, error } = useAsync(async () => {
+    const query = {
+      ids: `ga:${view.id}`,
+      'start-date': timeRange['start-date'],
+      'end-date': timeRange['end-date'],
+      metrics: 'ga:30dayUsers',
+      dimensions: 'ga:day',
+    };
+    return await api.getGaData(query);
+  }, [view, timeRange]);
+
+  if (loading) {
+    return (
+      <Grid item>
+        <Skeleton variant="text" />
+        <Skeleton variant="rect" width={300} height={90} />
+      </Grid>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error">{error.message}</Alert>;
+  }
+
+  return (
+    <Grid item>
+      <Typography>User Trend</Typography>
+
+      <Sparklines data={value.result.rows.map((row: any) => row[1])}>
+        <SparklinesBars
+          style={{ stroke: 'white', fill: '#41c3f9', fillOpacity: 0.25 }}
+        />
+        <SparklinesLine style={{ stroke: '#41c3f9', fill: 'none' }} />
+      </Sparklines>
+    </Grid>
+  );
+};
+
+export default UserTrend;

--- a/plugins/google-analytics-dashboard/src/components/UserTrend/UserTrend.tsx
+++ b/plugins/google-analytics-dashboard/src/components/UserTrend/UserTrend.tsx
@@ -40,7 +40,7 @@ const UserTrend: FC<{}> = () => {
     return (
       <Grid item>
         <Skeleton variant="text" />
-        <Skeleton variant="rect" width={300} height={90} />
+        <Skeleton variant="rect" height={90} />
       </Grid>
     );
   }

--- a/plugins/google-analytics-dashboard/src/components/UserTrend/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/UserTrend/index.tsx
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './UserTrend';

--- a/plugins/google-analytics-dashboard/src/components/Views/Views.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Views/Views.tsx
@@ -22,6 +22,11 @@ import api from 'api';
 import { Progress } from '@backstage/core';
 import { Alert } from '@material-ui/lab';
 
+export type View = {
+  id: string;
+  name: string | undefined;
+};
+
 const Views: FC<{}> = () => {
   const { view, account, setCurrentView } = useContext(Context);
 

--- a/plugins/google-analytics-dashboard/src/components/Views/Views.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Views/Views.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, useContext } from 'react';
+import Select from 'components/Select';
+import { Context } from 'contexts/Context';
+import { useAsync } from 'react-use';
+import api from 'api';
+import { Progress } from '@backstage/core';
+import { Alert } from '@material-ui/lab';
+
+const Views: FC<{}> = () => {
+  const { view, account, setCurrentView } = useContext(Context);
+
+  const { value, loading, error } = useAsync(async () => {
+    const views = account.id ? await api.listViews(account.id) : [];
+    return views;
+  }, [account]);
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return <Alert severity="error">{error.message}</Alert>;
+  }
+
+  const views =
+    value.result?.items?.map((item: any) => ({
+      value: item.id,
+      label: item.websiteUrl,
+    })) ?? [];
+
+  const handleView = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentView({
+      name: views.filter((v: any) => v.value === event.target.value)[0].label,
+      id: event.target.value,
+    });
+  };
+
+  return <Select value={view.id} handler={handleView} items={views} />;
+};
+
+export default Views;

--- a/plugins/google-analytics-dashboard/src/components/Views/index.tsx
+++ b/plugins/google-analytics-dashboard/src/components/Views/index.tsx
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { default } from './Views';

--- a/plugins/google-analytics-dashboard/src/contexts/Context.tsx
+++ b/plugins/google-analytics-dashboard/src/contexts/Context.tsx
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 import { createContext } from 'react';
-
-export type View = {
-  id: string;
-  name: string | undefined;
-};
-
-export type TimeRange = {
-  'start-date': '7daysAgo' | '30daysAgo';
-  'end-date': 'today';
-};
-
-export type Account = {
-  id: string;
-  name: string | undefined;
-};
+import { View } from 'components/Views/Views';
+import { TimeRange } from 'components/TimeRanges/TimeRanges';
+import { Account } from 'components/Accounts/Accounts';
 
 export type ContextType = {
   view: View;

--- a/plugins/google-analytics-dashboard/src/contexts/Context.tsx
+++ b/plugins/google-analytics-dashboard/src/contexts/Context.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createContext, useState, useCallback } from 'react';
+import { createContext } from 'react';
 
 export type View = {
   id: string;
@@ -56,44 +56,3 @@ export const Context = createContext<ContextType>({
   setCurrentTimeRange: () => {},
   setCurrentAccount: () => {},
 });
-
-export const useSettings = (): ContextType => {
-  const [view, setView] = useState<View>({
-    id: '',
-    name: undefined,
-  });
-
-  const [timeRange, setTimeRange] = useState<TimeRange>({
-    'start-date': '7daysAgo',
-    'end-date': 'today',
-  });
-
-  const [account, setAccount] = useState<Account>({
-    id: '',
-    name: undefined,
-  });
-
-  const setCurrentView = useCallback((selectedView: View): void => {
-    setView(selectedView);
-  }, []);
-
-  const setCurrentTimeRange = useCallback(
-    (selectedTimeRange: TimeRange): void => {
-      setTimeRange(selectedTimeRange);
-    },
-    [],
-  );
-
-  const setCurrentAccount = useCallback((selectedAccount: Account): void => {
-    setAccount(selectedAccount);
-  }, []);
-
-  return {
-    view,
-    timeRange,
-    account,
-    setCurrentView,
-    setCurrentTimeRange,
-    setCurrentAccount,
-  };
-};

--- a/plugins/google-analytics-dashboard/src/contexts/Context.tsx
+++ b/plugins/google-analytics-dashboard/src/contexts/Context.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createContext, useState, useCallback } from 'react';
+
+export type View = {
+  id: string;
+  name: string | undefined;
+};
+
+export type TimeRange = {
+  'start-date': '7daysAgo' | '30daysAgo';
+  'end-date': 'today';
+};
+
+export type Account = {
+  id: string;
+  name: string | undefined;
+};
+
+export type ContextType = {
+  view: View;
+  timeRange: TimeRange;
+  account: Account;
+  setCurrentView: (view: View) => void;
+  setCurrentTimeRange: (timeRange: TimeRange) => void;
+  setCurrentAccount: (account: Account) => void;
+};
+
+export const Context = createContext<ContextType>({
+  view: {
+    id: '',
+    name: undefined,
+  },
+  timeRange: {
+    'start-date': '7daysAgo',
+    'end-date': 'today',
+  },
+  account: {
+    id: '',
+    name: undefined,
+  },
+  setCurrentView: () => {},
+  setCurrentTimeRange: () => {},
+  setCurrentAccount: () => {},
+});
+
+export const useSettings = (): ContextType => {
+  const [view, setView] = useState<View>({
+    id: '',
+    name: undefined,
+  });
+
+  const [timeRange, setTimeRange] = useState<TimeRange>({
+    'start-date': '7daysAgo',
+    'end-date': 'today',
+  });
+
+  const [account, setAccount] = useState<Account>({
+    id: '',
+    name: undefined,
+  });
+
+  const setCurrentView = useCallback((selectedView: View): void => {
+    setView(selectedView);
+  }, []);
+
+  const setCurrentTimeRange = useCallback(
+    (selectedTimeRange: TimeRange): void => {
+      setTimeRange(selectedTimeRange);
+    },
+    [],
+  );
+
+  const setCurrentAccount = useCallback((selectedAccount: Account): void => {
+    setAccount(selectedAccount);
+  }, []);
+
+  return {
+    view,
+    timeRange,
+    account,
+    setCurrentView,
+    setCurrentTimeRange,
+    setCurrentAccount,
+  };
+};

--- a/plugins/google-analytics-dashboard/src/hooks/useSettings.tsx
+++ b/plugins/google-analytics-dashboard/src/hooks/useSettings.tsx
@@ -15,7 +15,10 @@
  */
 
 import { useState, useCallback } from 'react';
-import { ContextType, View, TimeRange, Account } from 'contexts/Context';
+import { ContextType } from 'contexts/Context';
+import { View } from 'components/Views/Views';
+import { TimeRange } from 'components/TimeRanges/TimeRanges';
+import { Account } from 'components/Accounts/Accounts';
 
 export const useSettings = (): ContextType => {
   const [view, setView] = useState<View>({

--- a/plugins/google-analytics-dashboard/src/hooks/useSettings.tsx
+++ b/plugins/google-analytics-dashboard/src/hooks/useSettings.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useCallback } from 'react';
+import { ContextType, View, TimeRange, Account } from 'contexts/Context';
+
+export const useSettings = (): ContextType => {
+  const [view, setView] = useState<View>({
+    id:
+      localStorage.getItem('@backstage/google-analytics-plugin/ga_view_id') ||
+      '',
+    name:
+      localStorage.getItem('@backstage/google-analytics-plugin/ga_view_name') ||
+      undefined,
+  });
+
+  const [timeRange, setTimeRange] = useState<TimeRange>({
+    'start-date': '7daysAgo',
+    'end-date': 'today',
+  });
+
+  const [account, setAccount] = useState<Account>({
+    id:
+      localStorage.getItem(
+        '@backstage/google-analytics-plugin/ga_account_id',
+      ) || '',
+    name:
+      localStorage.getItem(
+        '@backstage/google-analytics-plugin/ga_account_name',
+      ) || undefined,
+  });
+
+  const setCurrentView = useCallback((selectedView: View): void => {
+    setView(selectedView);
+    localStorage.setItem(
+      '@backstage/google-analytics-plugin/ga_view_id',
+      selectedView.id,
+    );
+    localStorage.setItem(
+      '@backstage/google-analytics-plugin/ga_view_name',
+      selectedView.name || '',
+    );
+  }, []);
+
+  const setCurrentTimeRange = useCallback(
+    (selectedTimeRange: TimeRange): void => {
+      setTimeRange(selectedTimeRange);
+    },
+    [],
+  );
+
+  const setCurrentAccount = useCallback((selectedAccount: Account): void => {
+    setAccount(selectedAccount);
+    localStorage.setItem(
+      '@backstage/google-analytics-plugin/ga_account_id',
+      selectedAccount.id,
+    );
+    localStorage.setItem(
+      '@backstage/google-analytics-plugin/ga_account_name',
+      selectedAccount.name || '',
+    );
+  }, []);
+
+  return {
+    view,
+    timeRange,
+    account,
+    setCurrentView,
+    setCurrentTimeRange,
+    setCurrentAccount,
+  };
+};

--- a/plugins/google-analytics-dashboard/src/index.ts
+++ b/plugins/google-analytics-dashboard/src/index.ts
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+export { plugin } from './plugin';

--- a/plugins/google-analytics-dashboard/src/plugin.test.ts
+++ b/plugins/google-analytics-dashboard/src/plugin.test.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+import { plugin } from './plugin';
+
+describe('google-analytics-dashboard', () => {
+  it('should export plugin', () => {
+    expect(plugin).toBeDefined();
+  });
+});

--- a/plugins/google-analytics-dashboard/src/plugin.ts
+++ b/plugins/google-analytics-dashboard/src/plugin.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+import { createPlugin } from '@backstage/core';
+import Home from './components/Home';
+
+export const plugin = createPlugin({
+  id: 'google-analytics-dashboard',
+  register({ router }) {
+    router.registerRoute('/google-analytics-dashboard', Home);
+  },
+});

--- a/plugins/google-analytics-dashboard/src/setupTests.ts
+++ b/plugins/google-analytics-dashboard/src/setupTests.ts
@@ -14,9 +14,5 @@
  * limitations under the License.
  */
 
-export { plugin as HomePagePlugin } from '@backstage/plugin-home-page';
-export { plugin as WelcomePlugin } from '@backstage/plugin-welcome';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
-export { plugin as InventoryPlugin } from '@backstage/plugin-inventory';
-export { plugin as TechRadar } from '@backstage/plugin-tech-radar';
-export { plugin as GoogleAnalyticsDashboard } from '@backstage/plugin-google-analytics-dashboard';
+import '@testing-library/jest-dom/extend-expect';
+require('jest-fetch-mock').enableMocks();

--- a/plugins/google-analytics-dashboard/tsconfig.json
+++ b/plugins/google-analytics-dashboard/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
-    "baseUrl": "src",
-    "types": ["gapi.client", "gapi.client.analytics"]
+    "baseUrl": "src"
   }
 }

--- a/plugins/google-analytics-dashboard/tsconfig.json
+++ b/plugins/google-analytics-dashboard/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "types": ["gapi.client", "gapi.client.analytics"]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10458,6 +10458,11 @@ highlight.js@~9.13.0:
   resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
   integrity sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==
 
+highlight.js@~9.15.0, highlight.js@~9.15.1:
+  version "9.15.10"
+  resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
+  integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
+
 history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.npmjs.org/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
@@ -13616,6 +13621,14 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+
+lowlight@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz#014acf8dd73a370e02ff1cc61debcde3bb1681eb"
+  integrity sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==
+  dependencies:
+    fault "^1.0.2"
+    highlight.js "~9.15.0"
 
 lowlight@~1.11.0:
   version "1.11.0"
@@ -17250,6 +17263,17 @@ react-syntax-highlighter@^11.0.2:
     "@babel/runtime" "^7.3.1"
     highlight.js "~9.13.0"
     lowlight "~1.11.0"
+    prismjs "^1.8.4"
+    refractor "^2.4.1"
+
+react-syntax-highlighter@^12.2.1:
+  version "12.2.1"
+  resolved "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz#14d78352da1c1c3f93c6698b70ec7c706b83493e"
+  integrity sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "~9.15.1"
+    lowlight "1.12.1"
     prismjs "^1.8.4"
     refractor "^2.4.1"
 


### PR DESCRIPTION
Plugin that uses Google's [Core Reporting API](https://developers.google.com/analytics/devguides/reporting/core/v3/) for GA to display a small dashboard.

<img width="1673" alt="Screenshot 2020-04-27 at 20 58 44" src="https://user-images.githubusercontent.com/18682151/80409953-0234af80-88ca-11ea-8155-d3bfbb75f0df.png">

Features:
- Uses Google OAuth for Client-side Web Applications and provides an easy way to login with a button using `gapi.signin2`.
- Fetches all GA accounts and views associated with the current user and automatically updates the dashboard.
- Stores settings in `localStorage`. 

Todo:
- Convert the `api` to `ts` which turned out to be tricky with `gapi.client` types
- Customize which metrics to display
- Better Intro section detailing how to set up an `API_KEY` and `CLIENT_ID`
- All kinds of cleaning up and optimizations probably
