### PR TITLE
[Draft] add ADR log to repository

### DIFF
--- a/docs/architecture-decisions/adr001-add-adr-log.md
+++ b/docs/architecture-decisions/adr001-add-adr-log.md
@@ -1,0 +1,11 @@
+## Date: 26.04.2020
+
+## Title: Architecture Decision Record (ADR) log
+
+## Decision: A decision was made to store ADRs in a log in the project repository
+
+## Discussion: There is a need to store big decisions made in a log as a reference point for the team, help with onboarding new members and give context to others interested in the project.
+
+## Risks: People stop adding ADRs to the log and context gets lost
+
+


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Draft for adding ADR log to the app repository. 

The idea is to add a docs/ directory that could contain, amongst other documentation related to the app, an adr decision log. In this case it's named architecture/ and has one example adr.

What do you think of the placement of the log and the naming? 

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
