### PR TITLE
Remove the open delay for sidebar to fix the animation issue

### DIFF
--- a/packages/core/src/layout/Sidebar/Bar.tsx
+++ b/packages/core/src/layout/Sidebar/Bar.tsx
@@ -63,12 +63,10 @@ enum State {
 }
 
 type Props = {
-  openDelayMs?: number;
   closeDelayMs?: number;
 };
 
 export const Sidebar: FC<Props> = ({
-  openDelayMs = sidebarConfig.defaultOpenDelayMs,
   closeDelayMs = sidebarConfig.defaultCloseDelayMs,
   children,
 }) => {
@@ -85,7 +83,7 @@ export const Sidebar: FC<Props> = ({
       hoverTimerRef.current = setTimeout(() => {
         hoverTimerRef.current = undefined;
         setState(State.Open);
-      }, openDelayMs);
+      }, 0);
 
       setState(State.Peek);
     }

--- a/packages/core/src/layout/Sidebar/config.ts
+++ b/packages/core/src/layout/Sidebar/config.ts
@@ -19,7 +19,6 @@ import { createContext } from 'react';
 export const sidebarConfig = {
   drawerWidthClosed: 64,
   drawerWidthOpen: 220,
-  defaultOpenDelayMs: 400,
   defaultCloseDelayMs: 200,
 };
 


### PR DESCRIPTION
There was a delay in the sidebar opening transition that caused a small pause before the open animation kicks in. This PR is to remove this delay so the animation is more smooth.

Before

![before](https://user-images.githubusercontent.com/4350401/80778863-c9017700-8b37-11ea-9b67-6589c003c34a.gif)

After

![After](https://user-images.githubusercontent.com/4350401/80778895-de76a100-8b37-11ea-86e2-81354ec54e4b.gif)

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
