### PR TITLE
[Storybook] Fix Storybook compilation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "husky": "^4.2.3",
     "lerna": "^3.20.2",
     "lint-staged": "^10.1.0",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.5"
   },
   "husky": {
     "hooks": {

--- a/packages/core/src/components/Sequence/index.ts
+++ b/packages/core/src/components/Sequence/index.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
-export { default, StepType } from './Sequence';
+export { default } from './Sequence';
+export type StepType = StepType;

--- a/packages/core/src/components/Sequence/index.ts
+++ b/packages/core/src/components/Sequence/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { default } from './Sequence';
-export type StepType = StepType;
+export type { StepType } from './Sequence';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,7 +16,8 @@
 
 export * from './api';
 export { default as Page } from './layout/Page';
-export { gradients, pageTheme, PageTheme } from './layout/Page';
+export { gradients, pageTheme } from './layout/Page';
+export type PageTheme = PageTheme;
 export { default as Content } from './layout/Content/Content';
 export { default as ContentHeader } from './layout/ContentHeader/ContentHeader';
 export { default as Header } from './layout/Header/Header';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,7 @@
 export * from './api';
 export { default as Page } from './layout/Page';
 export { gradients, pageTheme } from './layout/Page';
-export type PageTheme = PageTheme;
+export type { PageTheme } from './layout/Page';
 export { default as Content } from './layout/Content/Content';
 export { default as ContentHeader } from './layout/ContentHeader/ContentHeader';
 export { default as Header } from './layout/Header/Header';

--- a/packages/core/src/layout/BottomLink/index.ts
+++ b/packages/core/src/layout/BottomLink/index.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
-export { default, Props } from './BottomLink';
+export { default } from './BottomLink';
+export type Props = Props;

--- a/packages/core/src/layout/BottomLink/index.ts
+++ b/packages/core/src/layout/BottomLink/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { default } from './BottomLink';
-export type Props = Props;
+export type { Props } from './BottomLink';

--- a/packages/core/src/layout/Page/index.ts
+++ b/packages/core/src/layout/Page/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { default } from './Page';
-export { gradients, pageTheme, PageTheme } from './PageThemeProvider';
+export { gradients, pageTheme } from './PageThemeProvider';
+export type PageTheme = PageTheme;

--- a/packages/core/src/layout/Page/index.ts
+++ b/packages/core/src/layout/Page/index.ts
@@ -16,4 +16,4 @@
 
 export { default } from './Page';
 export { gradients, pageTheme } from './PageThemeProvider';
-export type PageTheme = PageTheme;
+export type { PageTheme } from './PageThemeProvider';

--- a/yarn.lock
+++ b/yarn.lock
@@ -16634,10 +16634,15 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@^1.16.4, prettier@^1.18.2, prettier@^1.19.1:
+prettier@^1.16.4, prettier@^1.18.2:
   version "1.19.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-bytes@5.3.0, pretty-bytes@^5.1.0:
   version "5.3.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fix warnings generated when compiling storybook referenced in issue #700 

The issue seems to be related to that referenced in this article [https://medium.com/javascript-in-plain-english/leveraging-type-only-imports-and-exports-with-typescript-3-8-5c1be8bd17fb](url)

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
