### PR TITLE
packages/cli: add lib ES2019 to common tsconfig

### DIFF
--- a/packages/cli/config/tsconfig.json
+++ b/packages/cli/config/tsconfig.json
@@ -10,6 +10,7 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "lib": ["DOM", "DOM.Iterable", "ScriptHost", "ES2019"],
     "types": ["node", "jest"]
   }
 }


### PR DESCRIPTION
To match rollup and backend config. We're already targeting ES2019.