### PR TITLE
Set the default dark/light mode for Storybook

### DIFF
--- a/packages/storybook/.storybook/config.js
+++ b/packages/storybook/.storybook/config.js
@@ -1,14 +1,21 @@
 import React from 'react';
-import { addDecorator } from '@storybook/react';
+import { addDecorator, addParameters } from '@storybook/react';
 import { lightTheme, darkTheme } from '@backstage/theme';
 import { CssBaseline, ThemeProvider } from '@material-ui/core';
 import { useDarkMode } from 'storybook-dark-mode';
 import { Content } from '@backstage/core';
 
-addDecorator(story => (
+addDecorator((story) => (
   <ThemeProvider theme={useDarkMode() ? darkTheme : lightTheme}>
     <CssBaseline>
       <Content>{story()}</Content>
     </CssBaseline>
   </ThemeProvider>
 ));
+
+addParameters({
+  darkMode: {
+    // Set the initial theme
+    current: 'light',
+  },
+});


### PR DESCRIPTION
Closes #705

This PR sets the initial Storybook theme to `light`.

Reference documentation: https://github.com/hipstersmoothie/storybook-dark-mode#default-theme

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
