### PR TITLE
Fix Storybook compilation warning

### DIFF
--- a/packages/core/src/components/Table/index.ts
+++ b/packages/core/src/components/Table/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
-export { default, TableColumn } from './Table';
+export { default } from './Table';
+export type { TableColumn } from './Table';
 export { default as SubvalueCell } from './SubvalueCell';


### PR DESCRIPTION
The warning -

```
WARNING in ../core/src/components/Table/index.ts 1:0-47
"export 'TableColumn' was not found in './Table'
 @ ../core/src/components/Table/Table.stories.tsx
 @ ../core/src/components sync ^\.\/(?:(?:(?!\.)(?:(?:(?!(?:|\/)\.).)*?)\/)?(?!\.)(?=.)[^/]*?\.stories\.tsx\/?)$
 @ ./.storybook/generated-entry.js
 @ multi /Users/himanshu/workspace/spotify/backstage/node_modules/@storybook/react/node_modules/@storybook/core/dist/server/common/polyfills.js /Users/himanshu/workspace/spotify/backstage/node_modules/@storybook/react/node_modules/@storybook/core/dist/server/preview/globals.js ./.storybook/config.js ./.storybook/generated-entry.js (webpack)-hot-middleware/client.js?reload=true&quiet=true
```

Related issue #700
Related PR #701

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
