### PR TITLE
Fail Storybook build if there are Webpack compilation warnings

### DIFF
--- a/packages/core/src/components/Table/index.ts
+++ b/packages/core/src/components/Table/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
-export { default, TableColumn } from './Table';
+export { default } from './Table';
+export type { TableColumn } from './Table';
 export { default as SubvalueCell } from './SubvalueCell';

--- a/packages/core/src/components/Table/index.ts
+++ b/packages/core/src/components/Table/index.ts
@@ -14,6 +14,5 @@
  * limitations under the License.
  */
 
-export { default } from './Table';
-export type { TableColumn } from './Table';
+export { default, TableColumn } from './Table';
 export { default as SubvalueCell } from './SubvalueCell';

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -54,8 +54,10 @@ module.exports = {
       ({ constructor }) => constructor.name !== 'ProgressPlugin',
     );
 
-    // Fail storybook build if there are webpack warnings
-    config.plugins.push(new WebpackPluginFailBuildOnWarning())
+    // Fail storybook build on CI if there are webpack warnings.
+    if (process.env.CI) {
+      config.plugins.push(new WebpackPluginFailBuildOnWarning())
+    }
 
     return config;
   },

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const WebpackPluginFailBuildOnWarning = require('./webpack-plugin-fail-build-on-warning');
 
 module.exports = {
   stories: [
@@ -52,6 +53,9 @@ module.exports = {
     config.plugins = config.plugins.filter(
       ({ constructor }) => constructor.name !== 'ProgressPlugin',
     );
+
+    // Fail storybook build if there are webpack warnings
+    config.plugins.push(new WebpackPluginFailBuildOnWarning())
 
     return config;
   },

--- a/packages/storybook/.storybook/webpack-plugin-fail-build-on-warning.js
+++ b/packages/storybook/.storybook/webpack-plugin-fail-build-on-warning.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class WebpackPluginFailBuildOnWarning {
+  apply(compiler) {
+    compiler.hooks.done.tap('FailBuildOnWarning', stats => {
+      if (stats.compilation.warnings.length > 0) {
+        process.on('beforeExit', () => {
+          console.log(`You have ${stats.compilation.warnings.length} warning(s) in your webpack build. Exiting process as error.`)
+          process.exit(1);
+        });
+      }
+    })
+  }
+}
+
+module.exports = WebpackPluginFailBuildOnWarning;

--- a/packages/storybook/.storybook/webpack-plugin-fail-build-on-warning.js
+++ b/packages/storybook/.storybook/webpack-plugin-fail-build-on-warning.js
@@ -34,7 +34,7 @@ class WebpackPluginFailBuildOnWarning {
     if (warnings.length > 0) {
       // Throw error if there are unexpected warnings.
       for (let warning of warnings) {
-        if (warning.name in this.warningsWhitelist) {
+        if (!(warning.name in this.warningsWhitelist)) {
           process.on('beforeExit', () => {
             console.log(
               `You have some unexpected warning(s) in your webpack build. Exiting process as error.`,

--- a/packages/storybook/.storybook/webpack-plugin-fail-build-on-warning.js
+++ b/packages/storybook/.storybook/webpack-plugin-fail-build-on-warning.js
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/**
+ * When building storybook, we can have warnings which may cause issues in the future. One of the example case is
+ * https://github.com/spotify/backstage/issues/718. To make sure new warnings are not introduced with new PRs, we
+ * want to fail CI builds if there are warnings when building storybook.
+ *
+ * This webpack plugin makes sure the CI builds fail on Webpack warnings. We also have a whitelist of warnings here
+ * which we think are non-critical.
+ *
+ * Note that this implementation will not detect other warnings emitted by storybook build that are separate from
+ * Webpack. A better solution over this plugin should be preferred, possibly on Storybook level (CLI options etc.)
+ *
+ * The case with #718 is caused because we are using `ts-loader` for `webpack` to load all our JS/TS files, but we
+ * have disabled type checking during build. This is done by setting `transpileOnly` to `true` in storybook/main.js
+ * and it improves the Storybook build speed. Because of this, Webpack emits warnings when we try to re-export types.
+ * Reference: https://github.com/TypeStrong/ts-loader#transpileonly
+ */
 class WebpackPluginFailBuildOnWarning {
   // Ignore the following warnings in the Webpack build.
   warningsWhitelist = new Set([

--- a/packages/storybook/.storybook/webpack-plugin-fail-build-on-warning.js
+++ b/packages/storybook/.storybook/webpack-plugin-fail-build-on-warning.js
@@ -34,7 +34,7 @@ class WebpackPluginFailBuildOnWarning {
     if (warnings.length > 0) {
       // Throw error if there are unexpected warnings.
       for (let warning of warnings) {
-        if (!(warning.name in this.warningsWhitelist)) {
+        if (!this.warningsWhitelist.has(warning.name)) {
           process.on('beforeExit', () => {
             console.log(
               `You have some unexpected warning(s) in your webpack build. Exiting process as error.`,


### PR DESCRIPTION
Closes #718

This PR creates a Webpack plugin which looks for warnings at the end of the build during Storybook compilation.

Reference doc: https://webpack.js.org/contribute/writing-a-plugin/

TODO -
- [x] Use `process.env.CI` to apply this to CI only.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
