### PR TITLE
plugins: almost fully sync plugins with templates

### DIFF
--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -18,9 +18,9 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
     "classnames": "^2.2.6",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-use": "^13.0.0"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-use": "^13.24.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",
@@ -30,7 +30,7 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "@types/testing-library__jest-dom": "5.0.4",
+    "@types/testing-library__jest-dom": "^5.0.4",
     "jest-fetch-mock": "^3.0.3"
   },
   "files": [

--- a/plugins/graphiql/package.json
+++ b/plugins/graphiql/package.json
@@ -33,9 +33,9 @@
     "@material-ui/lab": "4.0.0-alpha.45",
     "graphiql": "^1.0.0-alpha.8",
     "graphql": "15.0.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-use": "^13.0.0"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-use": "^13.24.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",
@@ -46,7 +46,7 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "@types/testing-library__jest-dom": "5.0.4",
+    "@types/testing-library__jest-dom": "^5.0.4",
     "jest-fetch-mock": "^3.0.3",
     "react-router-dom": "^5.1.2"
   },

--- a/plugins/home-page/package.json
+++ b/plugins/home-page/package.json
@@ -18,8 +18,9 @@
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
-    "react": "16.13.1",
-    "react-dom": "16.13.1"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-use": "^13.24.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",
@@ -29,8 +30,9 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "@types/testing-library__jest-dom": "5.0.4",
-    "react-router-dom": "^5.1.2"
+    "@types/testing-library__jest-dom": "^5.0.4",
+    "react-router-dom": "^5.1.2",
+    "jest-fetch-mock": "^3.0.3"
   },
   "files": [
     "dist"

--- a/plugins/inventory/package.json
+++ b/plugins/inventory/package.json
@@ -18,9 +18,9 @@
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-use": "^13.0.0"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-use": "^13.24.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",
@@ -29,7 +29,7 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "@types/testing-library__jest-dom": "5.0.4",
+    "@types/testing-library__jest-dom": "^5.0.4",
     "jest-fetch-mock": "^3.0.3"
   },
   "files": [

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -32,7 +32,7 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "@types/testing-library__jest-dom": "5.0.4",
+    "@types/testing-library__jest-dom": "^5.0.4",
     "jest-fetch-mock": "^3.0.3"
   },
   "files": [

--- a/plugins/lighthouse/tsconfig.json
+++ b/plugins/lighthouse/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src"],
-  "compilerOptions": {
-    "resolveJsonModule": true,
-    "esModuleInterop": true
-  }
+  "compilerOptions": {}
 }

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -18,9 +18,9 @@
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-use": "^13.0.0"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-use": "^13.24.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",
@@ -29,7 +29,7 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "@types/testing-library__jest-dom": "5.0.4",
+    "@types/testing-library__jest-dom": "^5.0.4",
     "jest-fetch-mock": "^3.0.3"
   },
   "files": [

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -21,9 +21,9 @@
     "color": "^3.1.2",
     "d3-force": "^2.0.1",
     "prop-types": "^15.7.2",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-use": "^13.0.0"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-use": "^13.24.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",
@@ -34,7 +34,10 @@
     "@types/d3-force": "^1.2.1",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "@types/testing-library__jest-dom": "5.0.4",
+    "@types/testing-library__jest-dom": "^5.0.4",
     "jest-fetch-mock": "^3.0.3"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -17,9 +17,10 @@
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-router-dom": "5.1.2"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-router-dom": "5.1.2",
+    "react-use": "^13.24.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",
@@ -28,7 +29,8 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
-    "@types/testing-library__jest-dom": "5.0.4"
+    "@types/testing-library__jest-dom": "^5.0.4",
+    "jest-fetch-mock": "^3.0.3"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Ran `diff --yes` across all plugins, skipped some changes related to `plugin:serve` as they're not in the template yet. Once that's in we could add a CI check that makes sure plugin templates are in sync.