### PR TITLE
Issue 660: CodeSnippet Reuseable component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,8 @@
     "react-helmet": "5.2.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
-    "react-sparklines": "^1.7.0"
+    "react-sparklines": "^1.7.0",
+    "react-syntax-highlighter": "^12.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.4",

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -22,22 +22,60 @@ export default {
   component: CodeSnippet,
 };
 
-const containerStyle = { width: 500 };
+const containerStyle = { width: 300 };
 
-const javascript = `const greeting = "Hello";
+const JAVASCRIPT = `const greeting = "Hello";
 const world = "World";
 
-const greet = person => gretting + " " + person + "!";
+const greet = person => greeting + " " + person + "!";
+
+greet(world);
+`;
+
+const TYPESCRIPT = `const greeting: string = "Hello";
+const world: string = "World";
+
+const greet = (person: string): string => greeting + " " + person + "!";
+
+greet(world);
+`;
+
+const PYTHON = `greeting = "Hello"
+world = "World"
+
+def greet(person):
+    return f"{greeting} {person}!"
+
+greet(world)
 `;
 
 export const Default = () => (
-  <div style={containerStyle}>
-    <CodeSnippet text={javascript} language="javascript" />
-  </div>
+  <CodeSnippet text={"const hello = 'World';"} language="javascript" />
+);
+
+export const MultipleLines = () => (
+  <CodeSnippet text={JAVASCRIPT} language="javascript" />
 );
 
 export const LineNumbers = () => (
-  <div style={containerStyle}>
-    <CodeSnippet text={javascript} language="javascript" showLineNumbers />
-  </div>
+  <CodeSnippet text={JAVASCRIPT} language="javascript" showLineNumbers />
+);
+
+export const Overflow = () => (
+  <>
+    <div style={containerStyle}>
+      <CodeSnippet text={JAVASCRIPT} language="javascript" />
+    </div>
+    <div style={containerStyle}>
+      <CodeSnippet text={JAVASCRIPT} language="javascript" showLineNumbers />
+    </div>
+  </>
+);
+
+export const Laguages = () => (
+  <>
+    <CodeSnippet text={JAVASCRIPT} language="javascript" showLineNumbers />
+    <CodeSnippet text={TYPESCRIPT} language="typescript" showLineNumbers />
+    <CodeSnippet text={PYTHON} language="python" showLineNumbers />
+  </>
 );

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import CodeSnippet from './CodeSnippet';
+
+export default {
+  title: 'CodeSnippet',
+  component: CodeSnippet,
+};
+
+const containerStyle = { width: 500 };
+
+const javascript = `const greeting = "Hello";
+const world = "World";
+
+const greet = person => gretting + " " + person + "!";
+`;
+
+export const Default = () => (
+  <div style={containerStyle}>
+    <CodeSnippet text={javascript} language="javascript" />
+  </div>
+);
+
+export const LineNumbers = () => (
+  <div style={containerStyle}>
+    <CodeSnippet text={javascript} language="javascript" />
+  </div>
+);

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -38,6 +38,6 @@ export const Default = () => (
 
 export const LineNumbers = () => (
   <div style={containerStyle}>
-    <CodeSnippet text={javascript} language="javascript" />
+    <CodeSnippet text={javascript} language="javascript" showLineNumbers />
   </div>
 );

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { wrapInThemedTestApp } from '@backstage/test-utils';
+import CopyTextButton from './CopyTextButton';
+import { ApiRegistry, errorApiRef, ApiProvider, ErrorApi } from '../../api';
+
+jest.mock('popper.js', () => {
+  const PopperJS = jest.requireActual('popper.js');
+
+  return class {
+    static placements = PopperJS.placements;
+    update() {}
+    destroy() {}
+    scheduleUpdate() {}
+  };
+});
+
+const props = {
+  text: 'mockText',
+  tooltipDelay: 2,
+  tooltipText: 'mockTooltip',
+};
+
+const apiRegistry = ApiRegistry.from([
+  [
+    errorApiRef,
+    {
+      post(error) {
+        throw error;
+      },
+    } as ErrorApi,
+  ],
+]);
+
+describe('<CopyTextButton />', () => {
+  it('renders without exploding', () => {
+    const { getByDisplayValue } = render(
+      wrapInThemedTestApp(
+        <ApiProvider apis={apiRegistry}>
+          <CopyTextButton {...props} />
+        </ApiProvider>,
+      ),
+    );
+    getByDisplayValue('mockText');
+  });
+
+  it('displays tooltip on click', async () => {
+    document.execCommand = jest.fn();
+    const rendered = render(
+      wrapInThemedTestApp(
+        <ApiProvider apis={apiRegistry}>
+          <CopyTextButton {...props} />
+        </ApiProvider>,
+      ),
+    );
+    const button = rendered.getByTitle('mockTooltip');
+    button.click();
+    expect(document.execCommand).toHaveBeenCalled();
+    rendered.getByText('mockTooltip');
+  });
+});

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -47,16 +47,14 @@ describe('<CodeSnippet />', () => {
     expect(queryByText('1')).not.toBeInTheDocument();
     expect(queryByText('2')).not.toBeInTheDocument();
     expect(queryByText('3')).not.toBeInTheDocument();
-    expect(queryByText('4')).not.toBeInTheDocument();
   });
 
   it('renders with line numbers', () => {
-    const { getByText } = render(
+    const { queryByText } = render(
       wrapInThemedTestApp(<CodeSnippet {...minProps} showLineNumbers />),
     );
-    expect(getByText(/1/)).toBeInTheDocument();
-    expect(getByText(/2/)).toBeInTheDocument();
-    expect(getByText(/3/)).toBeInTheDocument();
-    expect(getByText(/4/)).toBeInTheDocument();
+    expect(queryByText(/1/)).toBeInTheDocument();
+    expect(queryByText(/2/)).toBeInTheDocument();
+    expect(queryByText(/3/)).toBeInTheDocument();
   });
 });

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -32,24 +32,25 @@ const minProps = {
 };
 
 describe('<CodeSnippet />', () => {
-  it('renders without exploding', () => {
+  it('renders text without exploding', () => {
     const { getByText } = render(
       wrapInThemedTestApp(<CodeSnippet {...minProps} />),
     );
-    expect(getByText(/const/)).toBeInTheDocument();
+    expect(getByText(/"Hello"/)).toBeInTheDocument();
+    expect(getByText(/"World"/)).toBeInTheDocument();
   });
 
   it('renders without line numbers', () => {
-    const { getByText } = render(
+    const { queryByText } = render(
       wrapInThemedTestApp(<CodeSnippet {...minProps} />),
     );
-    expect(getByText(/1/)).not.toBeInTheDocument();
-    expect(getByText(/2/)).not.toBeInTheDocument();
-    expect(getByText(/3/)).not.toBeInTheDocument();
-    expect(getByText(/4/)).not.toBeInTheDocument();
+    expect(queryByText('1')).not.toBeInTheDocument();
+    expect(queryByText('2')).not.toBeInTheDocument();
+    expect(queryByText('3')).not.toBeInTheDocument();
+    expect(queryByText('4')).not.toBeInTheDocument();
   });
 
-  it('renders line numbers', () => {
+  it('renders with line numbers', () => {
     const { getByText } = render(
       wrapInThemedTestApp(<CodeSnippet {...minProps} showLineNumbers />),
     );
@@ -57,12 +58,5 @@ describe('<CodeSnippet />', () => {
     expect(getByText(/2/)).toBeInTheDocument();
     expect(getByText(/3/)).toBeInTheDocument();
     expect(getByText(/4/)).toBeInTheDocument();
-  });
-
-  it('does not render deepLink', () => {
-    const { queryByText } = render(
-      wrapInThemedTestApp(<CodeSnippet {...minProps} />),
-    );
-    expect(queryByText('View more')).not.toBeInTheDocument();
   });
 });

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -20,14 +20,14 @@ import { wrapInThemedTestApp } from '@backstage/test-utils';
 
 import CodeSnippet from './CodeSnippet';
 
-const javascript = `const greeting = "Hello";
+const JAVASCRIPT = `const greeting = "Hello";
 const world = "World";
 
 const greet = person => gretting + " " + person + "!";
 `;
 
 const minProps = {
-  text: javascript,
+  text: JAVASCRIPT,
   language: 'javascript',
 };
 

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
@@ -25,12 +25,15 @@ import { docco, dark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 type Props = {
   text: string;
   language: string;
+  showLineNumbers?: boolean;
 };
 
-const defaultProps = {};
+const defaultProps = {
+  showLineNumbers: false,
+};
 
 const CodeSnippet: FC<Props> = props => {
-  const { text, language } = {
+  const { text, language, showLineNumbers } = {
     ...defaultProps,
     ...props,
   };
@@ -44,7 +47,11 @@ const CodeSnippet: FC<Props> = props => {
   })();
 
   return (
-    <SyntaxHighlighter language={language} style={mode}>
+    <SyntaxHighlighter
+      language={language}
+      style={mode}
+      showLineNumbers={showLineNumbers}
+    >
       {text}
     </SyntaxHighlighter>
   );

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
@@ -15,12 +15,11 @@
  */
 
 import React, { FC } from 'react';
-import { makeStyles } from '@material-ui/core';
 import PropTypes from 'prop-types';
-import { BackstageTheme } from '@backstage/theme';
-
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco, dark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import { useTheme } from '@material-ui/core';
+import { BackstageTheme } from '@backstage/theme';
 
 type Props = {
   text: string;
@@ -38,13 +37,8 @@ const CodeSnippet: FC<Props> = props => {
     ...props,
   };
 
-  // FIXME: There must be a better way of accessing the theme.
-  //        ThemeContext.Consumer looks promising but didn't cooperate
-  let mode = dark;
-  makeStyles<BackstageTheme>(theme => {
-    mode = theme.palette.type === 'dark' ? dark : docco;
-    return {};
-  })();
+  const theme = useTheme<BackstageTheme>();
+  const mode = theme.palette.type === 'dark' ? dark : docco;
 
   return (
     <SyntaxHighlighter

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC } from 'react';
+import { makeStyles } from '@material-ui/core';
+import PropTypes from 'prop-types';
+import { BackstageTheme } from '@backstage/theme';
+
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { docco, dark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+
+type Props = {
+  text: string;
+  language: string;
+};
+
+const defaultProps = {};
+
+const CodeSnippet: FC<Props> = props => {
+  const { text, language } = {
+    ...defaultProps,
+    ...props,
+  };
+
+  // FIXME: There must be a better way of accessing the theme.
+  //        ThemeContext.Consumer looks promising but didn't cooperate
+  let mode = dark;
+  makeStyles<BackstageTheme>(theme => {
+    mode = theme.palette.type === 'dark' ? dark : docco;
+    return {};
+  })();
+
+  return (
+    <SyntaxHighlighter language={language} style={mode}>
+      {text}
+    </SyntaxHighlighter>
+  );
+};
+
+// Type check for the JS files using this core component
+CodeSnippet.propTypes = {
+  text: PropTypes.string.isRequired,
+  language: PropTypes.string.isRequired,
+};
+
+export default CodeSnippet;

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
@@ -55,6 +55,7 @@ const CodeSnippet: FC<Props> = props => {
 CodeSnippet.propTypes = {
   text: PropTypes.string.isRequired,
   language: PropTypes.string.isRequired,
+  showLineNumbers: PropTypes.bool,
 };
 
 export default CodeSnippet;

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
@@ -17,7 +17,7 @@
 import React, { FC } from 'react';
 import PropTypes from 'prop-types';
 import SyntaxHighlighter from 'react-syntax-highlighter';
-import { docco, dark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import { docco, dark } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 import { useTheme } from '@material-ui/core';
 import { BackstageTheme } from '@backstage/theme';
 

--- a/packages/core/src/components/CodeSnippet/index.tsx
+++ b/packages/core/src/components/CodeSnippet/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from './CodeSnippet';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4512,7 +4512,7 @@
   dependencies:
     pretty-format "^25.1.0"
 
-"@types/testing-library__jest-dom@5.0.4":
+"@types/testing-library__jest-dom@^5.0.4":
   version "5.0.4"
   resolved "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.0.4.tgz#c7bfbafb920cd1ce40506474e70ee73637f33701"
   integrity sha512-Ns69aaNvlxvXkPxIwsqeaWH5vJpwa/pdBIlf8LGkRnbV3tiqUgifs13moLXg1NQ2AM23qRR5CtHarNshvRyEdA==
@@ -4941,11 +4941,6 @@
   version "1.9.4"
   resolved "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.4.tgz#a7dce20b7465bcad29cd6bbb557695e4ea7863cb"
   integrity sha512-o12FCQt/X5n3pgKEWGpt0f/7Eg4mfv3uRwPUrctiOT8ZuxbH3cNLGWfH/8y6KxVJg4L2885ucuXQ6XECZzUiJA==
-
-"@xobotyi/scrollbar-width@1.9.5":
-  version "1.9.5"
-  resolved "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
-  integrity sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -10854,6 +10849,11 @@ highlight.js@~9.13.0:
   resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
   integrity sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==
 
+highlight.js@~9.15.0, highlight.js@~9.15.1:
+  version "9.15.10"
+  resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
+  integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
+
 history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.npmjs.org/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
@@ -14030,6 +14030,14 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+
+lowlight@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz#014acf8dd73a370e02ff1cc61debcde3bb1681eb"
+  integrity sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==
+  dependencies:
+    fault "^1.0.2"
+    highlight.js "~9.15.0"
 
 lowlight@~1.11.0:
   version "1.11.0"
@@ -17470,7 +17478,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@16.13.1, react-dom@^16.12.0, react-dom@^16.13.1, react-dom@^16.8.3:
+react-dom@^16.12.0, react-dom@^16.13.1, react-dom@^16.8.3:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -17732,6 +17740,17 @@ react-syntax-highlighter@^11.0.2:
     prismjs "^1.8.4"
     refractor "^2.4.1"
 
+react-syntax-highlighter@^12.2.1:
+  version "12.2.1"
+  resolved "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz#14d78352da1c1c3f93c6698b70ec7c706b83493e"
+  integrity sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "~9.15.1"
+    lowlight "1.12.1"
+    prismjs "^1.8.4"
+    refractor "^2.4.1"
+
 react-textarea-autosize@^7.1.0:
   version "7.1.2"
   resolved "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz#70fdb333ef86bcca72717e25e623e90c336e2cda"
@@ -17749,25 +17768,6 @@ react-transition-group@^4.0.0, react-transition-group@^4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-use@^13.0.0:
-  version "13.27.1"
-  resolved "https://registry.npmjs.org/react-use/-/react-use-13.27.1.tgz#e2ae2b708dafc7893c4772628801589aab9de370"
-  integrity sha512-bAwdqDMXs5lovEanXnL1izledfrPEUUv1afoTVB59eUiYcDyKul+M/dT/2WcgHjoY/R6QlrTcZoW4R7ifwvBfw==
-  dependencies:
-    "@types/js-cookie" "2.2.5"
-    "@xobotyi/scrollbar-width" "1.9.5"
-    copy-to-clipboard "^3.2.0"
-    fast-deep-equal "^3.1.1"
-    fast-shallow-equal "^1.0.0"
-    js-cookie "^2.2.1"
-    nano-css "^5.2.1"
-    resize-observer-polyfill "^1.5.1"
-    screenfull "^5.0.0"
-    set-harmonic-interval "^1.0.1"
-    throttle-debounce "^2.1.0"
-    ts-easing "^0.2.0"
-    tslib "^1.10.0"
 
 react-use@^13.24.0:
   version "13.27.0"
@@ -17788,7 +17788,7 @@ react-use@^13.24.0:
     ts-easing "^0.2.0"
     tslib "^1.10.0"
 
-react@16.13.1, react@^16.0.0, react@^16.12.0, react@^16.13.1, react@^16.8.3:
+react@^16.0.0, react@^16.12.0, react@^16.13.1, react@^16.8.3:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a very minimal wrapper around [react-syntax-highlighter](https://github.com/conorhastings/react-syntax-highlighter) to produce a reusable component that automatically observes light/dark mode.

This is my first contribution to Backstage, so please advise should my implementation not be fully-aligned with the vision for this component/project. Thanks!

## Features
- Toggleable line numbers
- Automatic light/dark mode support
- Basic test coverage for rendering without runtime errors & with/out line numbers
- Simple stories for potential configurations & common languages

## Notes
- There are [many props](https://github.com/conorhastings/react-syntax-highlighter#props) available that could be observed. With the exception of `showLineNumbers`, none have been touched, so all default values will be used.
- There are also [many languages](https://github.com/conorhastings/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_HLJS.MD) and [many styles](https://github.com/conorhastings/react-syntax-highlighter/blob/master/AVAILABLE_STYLES_HLJS.MD) supported by this component. I have chosen a couple of options that seemed safe and fell in line with someone else's thinking [here](https://github.com/spotify/backstage/pull/662/files#diff-d6eb8446a83ddb7ba0c8110bf5786d77R30)
- The (heavy) default syntax library is being used here. We may opt for the [light version](https://github.com/conorhastings/react-syntax-highlighter#light-build) if we are concerned about the size of this library
- The default syntax library is used in order to honour light mode. Another option [Prism](https://github.com/conorhastings/react-syntax-highlighter#prism) also exists, which provides JSX support but does not provide a light mode at this time
- The commonJS build is being used here as Jest does not appear to be configured with ESM support in Backstage at this time
- As per this [PR comment](https://github.com/spotify/backstage/pull/662/files#r416553092), no, there does not appear to be support for importing the syntax libraries in a more typical style

## Areas for Improvement
- There is no automated test coverage for the light/dark mode support, as testing the style attributes directly felt brittle. I did not think of a more reasonable solution in the absence of snapshot tests. If there is already snapshot test support, I was unable to find it.

Simple Multiline - Light
<img width="1548" alt="Screen Shot 2020-05-10 at 2 53 21 PM" src="https://user-images.githubusercontent.com/21045044/81511428-4c586080-92ce-11ea-9c61-4c86982d53d1.png">

Simple Multiline - Dark
<img width="1546" alt="Screen Shot 2020-05-10 at 2 53 08 PM" src="https://user-images.githubusercontent.com/21045044/81511433-5c704000-92ce-11ea-9ec8-7cdbfc8c296c.png">

Language Examples - Light
<img width="1546" alt="Screen Shot 2020-05-10 at 2 54 01 PM" src="https://user-images.githubusercontent.com/21045044/81511440-6bef8900-92ce-11ea-9f18-ce50a83c2877.png">

Language Examples - Dark
<img width="1541" alt="Screen Shot 2020-05-10 at 2 53 48 PM" src="https://user-images.githubusercontent.com/21045044/81511448-73af2d80-92ce-11ea-9577-ad0e62f86abc.png">

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
