### PR TITLE
packages/cli: remove cypress version override from app template

### DIFF
--- a/packages/cli/templates/default-app/package.json.hbs
+++ b/packages/cli/templates/default-app/package.json.hbs
@@ -26,8 +26,5 @@
     "@backstage/cli": "^{{version}}",
     "lerna": "^3.20.2",
     "prettier": "^1.19.1"
-  },
-  "resolutions": {
-    "**/cypress": "4.2.0"
   }
 }


### PR DESCRIPTION
One of the things breaking releases atm :grin: