### PR TITLE
Bump TS to 3.9

### DIFF
--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -39,7 +39,7 @@
     "jest": "^25.1.0",
     "jest-fetch-mock": "^3.0.3",
     "supertest": "^4.0.2",
-    "typescript": "^3.8.3"
+    "typescript": "^3.9.2"
   },
   "files": [
     "dist"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -36,7 +36,7 @@
     "@types/helmet": "^0.0.45",
     "jest": "^25.1.0",
     "tsc-watch": "^4.2.3",
-    "typescript": "^3.8.3",
+    "typescript": "^3.9.2",
     "winston": "^3.2.1"
   },
   "nodemonConfig": {

--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.componentId}}/package.json
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.componentId}}/package.json
@@ -30,7 +30,7 @@
     "@types/styled-components": "^4.1.18",
     "husky": "^2.7.0",
     "jest-junit": "^8.0.0",
-    "typescript": "^3.4.5"
+    "typescript": "^3.9.2"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20892,10 +20892,15 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.4, typescript@^3.8.3:
+typescript@^3.7.4:
   version "3.8.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+typescript@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
+  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
builds core in a little over 20 seconds 😮 

```
$ yarn build
yarn run v1.22.1
$ lerna run build
lerna notice cli v3.20.2
lerna info Executing command in 19 packages: "yarn run build"
lerna info run Ran npm script 'build' in '@backstage/test-utils-core' in 2.8s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/cli' in 6.5s:
$ backstage-cli build-cache -- tsc --project tsconfig.build.json
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/theme' in 2.9s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/backend-common' in 3.3s:
$ backstage-cli build-cache -- tsc
[build-cache] input directory is dirty, skipping cache
lerna info run Ran npm script 'build' in '@backstage/plugin-scaffolder-backend' in 1.8s:
$ tsc
lerna info run Ran npm script 'build' in '@backstage/plugin-catalog-backend' in 2.4s:
$ tsc
lerna info run Ran npm script 'build' in '@backstage/test-utils' in 3.0s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in 'example-backend' in 2.9s:
$ tsc
lerna info run Ran npm script 'build' in '@backstage/core' in 22.5s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/dev-utils' in 3.0s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/plugin-catalog' in 6.5s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/plugin-scaffolder' in 6.5s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/plugin-welcome' in 7.0s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/plugin-explore' in 7.9s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/plugin-home-page' in 7.9s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/plugin-register-component' in 8.3s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/plugin-tech-radar' in 9.2s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/plugin-graphiql' in 9.4s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna info run Ran npm script 'build' in '@backstage/plugin-lighthouse' in 12.0s:
$ backstage-cli plugin:build
[build-cache] cache miss, need to build
lerna success run Ran npm script 'build' in 19 packages in 49.9s:
```
