### PR TITLE
github/workflows: run all tests on yarn.lock changes

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -7,6 +7,7 @@ on:
       - 'packages/cli/**'
       - 'packages/core/**'
       - 'scripts/**'
+      - 'yarn.lock'
 
 jobs:
   build:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: check for yarn.lock changes
+        id: yarn-lock
+        run: git diff --quiet origin/master HEAD -- yarn.lock
+        continue-on-error: true
+
       - name: yarn install
         run: yarn install --frozen-lockfile
 
@@ -57,8 +62,13 @@ jobs:
       - name: build
         run: yarn build
 
-      - name: test
+      - name: test changed packages
+        if: ${{ steps.yarn-lock.outcome == 'success' }}
         run: yarn lerna -- run test --since origin/master -- --coverage
+
+      - name: test all packages
+        if: ${{ steps.yarn-lock.outcome == 'failure' }}
+        run: yarn lerna -- run test -- --coverage
 
       - name: yarn bundle, if app was changed
         run: git diff --quiet origin/master HEAD -- yarn.lock packages/app packages/core || yarn bundle


### PR DESCRIPTION
Breaking changes in https://github.com/spotify/backstage/pull/839 weren't detected because all tests weren't run.

This makes sure we run all tests on yarn.lock changes.
