### PR TITLE
packages/cli: add publish config sync to plugin:diff

### DIFF
--- a/packages/cli/src/commands/plugin/diff/handlers.ts
+++ b/packages/cli/src/commands/plugin/diff/handlers.ts
@@ -54,6 +54,7 @@ class PackageJsonHandler {
     await this.syncField('types');
     await this.syncField('files');
     await this.syncScripts();
+    await this.syncPublishConfig();
     await this.syncDependencies('dependencies');
     await this.syncDependencies('devDependencies');
   }
@@ -102,6 +103,33 @@ class PackageJsonHandler {
 
     for (const key of Object.keys(pkgScripts)) {
       await this.syncField(key, pkgScripts, targetScripts, 'scripts');
+    }
+  }
+
+  private async syncPublishConfig() {
+    const pkgPublishConf = this.pkg.publishConfig;
+    const targetPublishConf = this.targetPkg.publishConfig;
+
+    // If template doesn't have a publish config we're done
+    if (!pkgPublishConf) {
+      return;
+    }
+
+    // Publish config can be removed the the target, skip in that case
+    if (!targetPublishConf) {
+      return;
+    }
+
+    for (const key of Object.keys(pkgPublishConf)) {
+      // Don't want to mess with peoples internal setup
+      if (!['access', 'registry'].includes(key)) {
+        await this.syncField(
+          key,
+          pkgPublishConf,
+          targetPublishConf,
+          'publishConfig',
+        );
+      }
     }
   }
 

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -5,6 +5,9 @@
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",


### PR DESCRIPTION
About to add some custom publish config that we want to keep in sync.

Afaik it's fine to have a publish config and `package: private`, so things shouldn't get published until the private flag is switched.
