### PR TITLE
packages,plugins: point types to src/ for development

### DIFF
--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -3,6 +3,7 @@
   "description": "Common functionality library for Backstage backends",
   "version": "0.1.1-alpha.5",
   "main": "dist",
+  "types": "src/index.ts",
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -21,6 +22,8 @@
     "build": "backstage-cli build-cache -- tsc",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/packages/cli/config/tsconfig.json
+++ b/packages/cli/config/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "allowJs": true,
     "noEmit": false,
-    "declarationMap": true,
     "incremental": true,
     "target": "ES2019",
     "module": "ESNext",

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import { paths } from '../lib/paths';
+
+export const pre = async () => {
+  const pkgPath = paths.resolveTarget('package.json');
+
+  const pkg = await fs.readJson(pkgPath);
+  pkg.types = 'dist/index.d.ts';
+  await fs.writeJson(pkgPath, pkg, { encoding: 'utf8', spaces: 2 });
+};
+
+export const post = async () => {
+  const pkgPath = paths.resolveTarget('package.json');
+
+  const pkg = await fs.readJson(pkgPath);
+  pkg.types = 'src/index.ts';
+  await fs.writeJson(pkgPath, pkg, { encoding: 'utf8', spaces: 2 });
+};

--- a/packages/cli/templates/default-app/plugins/welcome/package.json.hbs
+++ b/packages/cli/templates/default-app/plugins/welcome/package.json.hbs
@@ -2,7 +2,7 @@
   "name": "plugin-welcome",
   "version": "0.0.0",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "private": true,
   "scripts": {
     "build": "backstage-cli plugin:build",
@@ -10,6 +10,8 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -2,7 +2,7 @@
   "name": "@backstage/plugin-{{id}}",
   "version": "{{version}}",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
@@ -11,6 +11,8 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,11 +17,13 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -17,11 +17,13 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/packages/test-utils-core/package.json
+++ b/packages/test-utils-core/package.json
@@ -17,11 +17,13 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -17,11 +17,13 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,10 +17,12 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -2,7 +2,7 @@
   "name": "@backstage/plugin-catalog",
   "version": "0.1.1-alpha.5",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
@@ -11,6 +11,8 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -2,7 +2,7 @@
   "name": "@backstage/plugin-explore",
   "version": "0.1.1-alpha.5",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
@@ -11,6 +11,8 @@
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
     "clean": "backstage-cli clean",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "start": "backstage-cli plugin:serve"
   },
   "dependencies": {

--- a/plugins/graphiql/package.json
+++ b/plugins/graphiql/package.json
@@ -17,13 +17,15 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/plugins/home-page/package.json
+++ b/plugins/home-page/package.json
@@ -2,7 +2,7 @@
   "name": "@backstage/plugin-home-page",
   "version": "0.1.1-alpha.5",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
@@ -11,6 +11,8 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -2,7 +2,7 @@
   "name": "@backstage/plugin-lighthouse",
   "version": "0.1.1-alpha.5",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
@@ -11,6 +11,8 @@
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
     "clean": "backstage-cli clean",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "start": "backstage-cli plugin:serve"
   },
   "dependencies": {

--- a/plugins/register-component/package.json
+++ b/plugins/register-component/package.json
@@ -2,7 +2,7 @@
   "name": "@backstage/plugin-register-component",
   "version": "0.1.1-alpha.5",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
@@ -11,6 +11,8 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -2,12 +2,15 @@
   "name": "@backstage/plugin-scaffolder-backend",
   "version": "0.1.1-alpha.5",
   "main": "dist",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
     "build": "tsc",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -2,7 +2,7 @@
   "name": "@backstage/plugin-scaffolder",
   "version": "0.1.1-alpha.5",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
@@ -11,6 +11,8 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
   "dependencies": {

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -2,7 +2,7 @@
   "name": "@backstage/plugin-tech-radar",
   "version": "0.1.1-alpha.5",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
@@ -10,6 +10,8 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean",
     "start": "backstage-cli plugin:serve"
   },

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -2,7 +2,7 @@
   "name": "@backstage/plugin-welcome",
   "version": "0.1.1-alpha.5",
   "main": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "src/index.ts",
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
@@ -10,6 +10,8 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean",
     "start": "backstage-cli plugin:serve"
   },


### PR DESCRIPTION
First and most obvious build setup fix coming out of #834

So my initial approach was to do this through publishConfig, docs for that are [here](https://yarnpkg.com/configuration/manifest#publishConfig). Turns out that their main docs point to the unreleased yarn v2 though, and that feature doesn't exist yet ¯\\_(ツ)_/¯.

Looked though some 10 monrepos you there, mostly from https://github.com/brillout/awesome-react-components. Can't find any repo that has separate types config for published packages, so no prior art for this T_T

I'm thinking that adding pre-/post-pack scripts is the cleanest way to go about this for now. If we switch to yarn 2 me might be able to remove them. Or if we switch to [pnpm](https://pnpm.js.org/) who's had the feature for ages :grin:

The postpack script also doesn't get called right now, bug in yarn, https://github.com/yarnpkg/yarn/issues/7924, so publishing or trying out pack locally leaves some garbage in the packages.