### PR TITLE
packages/core: refactor createApp to just take options + separate out AppContext

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -25,10 +25,13 @@ import * as plugins from './plugins';
 import apis, { alertApiForwarder } from './apis';
 import { ThemeContextType, ThemeContext, useThemeType } from './ThemeContext';
 
-const app = createApp();
-app.registerApis(apis);
-app.registerPlugin(...Object.values(plugins));
-const AppComponent = app.build();
+const app = createApp({
+  apis,
+  plugins: Object.values(plugins),
+});
+
+const AppProvider = app.getProvider();
+const AppComponent = app.getRootComponent();
 
 const App: FC<{}> = () => {
   const [theme, toggleTheme] = useThemeType(
@@ -59,18 +62,20 @@ const App: FC<{}> = () => {
     toggleTheme,
   };
   return (
-    <ThemeContext.Provider value={themeContext}>
-      <ThemeProvider theme={backstageTheme}>
-        <CssBaseline>
-          <AlertDisplay forwarder={alertApiForwarder} />
-          <Router>
-            <Root>
-              <AppComponent />
-            </Root>
-          </Router>
-        </CssBaseline>
-      </ThemeProvider>
-    </ThemeContext.Provider>
+    <AppProvider>
+      <ThemeContext.Provider value={themeContext}>
+        <ThemeProvider theme={backstageTheme}>
+          <CssBaseline>
+            <AlertDisplay forwarder={alertApiForwarder} />
+            <Router>
+              <Root>
+                <AppComponent />
+              </Root>
+            </Router>
+          </CssBaseline>
+        </ThemeProvider>
+      </ThemeContext.Provider>
+    </AppProvider>
   );
 };
 

--- a/packages/cli/templates/default-app/packages/app/src/App.tsx
+++ b/packages/cli/templates/default-app/packages/app/src/App.tsx
@@ -5,7 +5,7 @@ import React, { FC } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import * as plugins from './plugins';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   '@global': {
     html: {
       height: '100%',
@@ -23,20 +23,25 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const app = createApp();
-app.registerPlugin(...Object.values(plugins));
-const AppComponent = app.build();
+const app = createApp({
+  plugins: Object.values(plugins),
+});
+
+const AppProvider = app.getProvider();
+const AppComponent = app.getRootComponent();
 
 const App: FC<{}> = () => {
   useStyles();
   return (
-    <CssBaseline>
+    <AppProvider>
       <ThemeProvider theme={lightTheme}>
-        <Router>
-          <AppComponent />
-        </Router>
+        <CssBaseline>
+          <Router>
+            <AppComponent />
+          </Router>
+        </CssBaseline>
       </ThemeProvider>
-    </CssBaseline>
+    </AppProvider>
   );
 };
 

--- a/packages/core/src/api/app/AppContext.tsx
+++ b/packages/core/src/api/app/AppContext.tsx
@@ -15,19 +15,19 @@
  */
 
 import React, { createContext, useContext, FC } from 'react';
-import { App } from './types';
+import { BackstageApp } from './types';
 
-const Context = createContext<App | undefined>(undefined);
+const Context = createContext<BackstageApp | undefined>(undefined);
 
 type Props = {
-  app: App;
+  app: BackstageApp;
 };
 
 export const AppContextProvider: FC<Props> = ({ app, children }) => (
   <Context.Provider value={app} children={children} />
 );
 
-export const useApp = (): App => {
+export const useApp = (): BackstageApp => {
   const app = useContext(Context);
   if (!app) {
     throw new Error('No app context available');

--- a/packages/core/src/api/app/index.ts
+++ b/packages/core/src/api/app/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export { createApp } from './AppBuilder';
+export { createApp } from './App';
 export { FeatureFlags } from './FeatureFlags';
 export { useApp } from './AppContext';
 export * from './types';

--- a/packages/core/src/api/app/types.ts
+++ b/packages/core/src/api/app/types.ts
@@ -15,15 +15,63 @@
  */
 
 import { ComponentType } from 'react';
-import { IconComponent, SystemIconKey } from '../../icons';
+import { IconComponent, SystemIconKey, SystemIcons } from '../../icons';
+import { BackstagePlugin } from '../plugin';
+import { ApiHolder } from '../apis';
 
-export type App = {
-  getSystemIcon(key: SystemIconKey): IconComponent;
+export type AppComponents = {
+  NotFoundErrorPage: ComponentType<{}>;
 };
 
-export class AppComponentBuilder<T = any> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  build(_app: App): ComponentType<T> {
-    throw new Error('Must override build() in AppComponentBuilder');
-  }
-}
+export type AppOptions = {
+  /**
+   * A holder of all APIs available in the app.
+   *
+   * Use for example ApiRegistry or ApiTestRegistry.
+   */
+  apis?: ApiHolder;
+
+  /**
+   * Supply icons to override the default ones.
+   */
+  icons?: Partial<SystemIcons>;
+
+  /**
+   * A list of all plugins to include in the app.
+   */
+  plugins?: BackstagePlugin[];
+
+  /**
+   * Supply components to the app to override the default ones.
+   */
+  components?: Partial<AppComponents>;
+};
+
+export type BackstageApp = {
+  /**
+   * Get the holder for all APIs available in the app.
+   */
+  getApis(): ApiHolder;
+
+  /**
+   * Returns all plugins registered for the app.
+   */
+  getPlugins(): BackstagePlugin[];
+
+  /**
+   * Get a common icon for this app.
+   */
+  getSystemIcon(key: SystemIconKey): IconComponent;
+
+  /**
+   * Creates a root component for this app, including the App chrome
+   * and routes to all plugins.
+   */
+  getRootComponent(): ComponentType<{}>;
+
+  /**
+   * Provider component that should wrap the App's RootComponent and
+   * any other components that need to be within the app context.
+   */
+  getProvider(): ComponentType<{}>;
+};

--- a/packages/core/src/layout/ErrorPage/ErrorPage.test.tsx
+++ b/packages/core/src/layout/ErrorPage/ErrorPage.test.tsx
@@ -23,11 +23,7 @@ describe('<ErrorPage/>', () => {
   it('should render with status code, status message and go back link', () => {
     const rendered = render(
       wrapInThemedTestApp(
-        <ErrorPage
-          status="404"
-          statusMessage="PAGE NOT FOUND"
-          history={{ goBack: () => {} }}
-        />,
+        <ErrorPage status="404" statusMessage="PAGE NOT FOUND" />,
       ),
     );
     rendered.getByText(/page not found/i);

--- a/packages/core/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core/src/layout/ErrorPage/ErrorPage.tsx
@@ -19,13 +19,11 @@ import { Typography, Link, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { BackstageTheme } from '@backstage/theme';
 import MicDrop from './MicDrop';
+import { useHistory } from 'react-router';
 
 interface IErrorPageProps {
   status: string;
   statusMessage: string;
-  history: {
-    goBack: () => void;
-  };
 }
 
 const useStyles = makeStyles<BackstageTheme>((theme) => ({
@@ -40,8 +38,9 @@ const useStyles = makeStyles<BackstageTheme>((theme) => ({
   },
 }));
 
-const ErrorPage = ({ status, statusMessage, history }: IErrorPageProps) => {
+const ErrorPage = ({ status, statusMessage }: IErrorPageProps) => {
   const classes = useStyles();
+  const history = useHistory();
 
   return (
     <Grid container className={classes.container}>

--- a/packages/dev-utils/src/devApp/render.tsx
+++ b/packages/dev-utils/src/devApp/render.tsx
@@ -66,25 +66,29 @@ class DevAppBuilder {
    * Build a DevApp component using the resources registered so far
    */
   build(): ComponentType<{}> {
-    const app = createApp();
-    app.registerApis(this.setupApiRegistry(this.factories));
-    app.registerPlugin(...this.plugins);
-    const AppComponent = app.build();
+    const app = createApp({
+      apis: this.setupApiRegistry(this.factories),
+      plugins: this.plugins,
+    });
+    const AppProvider = app.getProvider();
+    const AppComponent = app.getRootComponent();
 
     const sidebar = this.setupSidebar(this.plugins);
 
     const DevApp: FC<{}> = () => {
       return (
-        <ThemeProvider theme={lightTheme}>
-          <CssBaseline>
-            <BrowserRouter>
-              <SidebarPage>
-                {sidebar}
-                <AppComponent />
-              </SidebarPage>
-            </BrowserRouter>
-          </CssBaseline>
-        </ThemeProvider>
+        <AppProvider>
+          <ThemeProvider theme={lightTheme}>
+            <CssBaseline>
+              <BrowserRouter>
+                <SidebarPage>
+                  {sidebar}
+                  <AppComponent />
+                </SidebarPage>
+              </BrowserRouter>
+            </CssBaseline>
+          </ThemeProvider>
+        </AppProvider>
       );
     };
 


### PR DESCRIPTION
This syncs the output of the app creation with what we have internally, where the root app component and app context providers are split. This lets you place components outside of the app root that are still able to consume the app context.

I also changed `createApp` from returning a builder to just creating the entire app. I don't think it makes sense that that create function was somehow special and gave you a builder. We should also likely strive for an app setup that is more declarative, and using a config object helps enforce that.