### PR TITLE
Auth Backend: add a skeleton service 

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,6 +19,7 @@
     "@backstage/backend-common": "^0.1.1-alpha.5",
     "@backstage/plugin-catalog-backend": "^0.1.1-alpha.5",
     "@backstage/plugin-scaffolder-backend": "^0.1.1-alpha.5",
+    "@backstage/plugin-auth-backend": "^0.1.1-alpha.5",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -35,6 +35,7 @@ import helmet from 'helmet';
 import knex from 'knex';
 import catalog from './plugins/catalog';
 import scaffolder from './plugins/scaffolder';
+import auth from './plugins/auth';
 import { PluginEnvironment } from './types';
 
 const DEFAULT_PORT = 7000;
@@ -63,6 +64,7 @@ async function main() {
   app.use(requestLoggingHandler());
   app.use('/catalog', await catalog(createEnv('catalog')));
   app.use('/scaffolder', await scaffolder(createEnv('scaffolder')));
+  app.use('/auth', await auth(createEnv('auth')));
   app.use(notFoundHandler());
   app.use(errorHandler());
 

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRouter } from '@backstage/plugin-auth-backend';
+import { PluginEnvironment } from '../types';
+
+export default async function ({ logger }: PluginEnvironment) {
+  return await createRouter({ logger });
+}

--- a/plugins/auth-backend/.eslintrc.js
+++ b/plugins/auth-backend/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint.backend')],
+};

--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -1,0 +1,12 @@
+# Auth Backend
+
+WORK IN PROGRESS
+
+This is the backend part of the auth plugin.
+
+It responds to auth requests from the frontend, and fulfills them by delegating
+to the appropriate provider in the backend.
+
+## Links
+
+- (The Backstage homepage)[https://backstage.io]

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@backstage/plugin-auth-backend",
+  "version": "0.1.1-alpha.5",
+  "main": "dist",
+  "license": "Apache-2.0",
+  "private": true,
+  "scripts": {
+    "start": "tsc-watch --onFirstSuccess \"cross-env NODE_ENV=development nodemon dist/run.js\"",
+    "build": "tsc",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test",
+    "clean": "backstage-cli clean"
+  },
+  "dependencies": {
+    "@backstage/backend-common": "^0.1.1-alpha.5",
+    "compression": "^1.7.4",
+    "cors": "^2.8.5",
+    "express": "^4.17.1",
+    "express-promise-router": "^3.0.3",
+    "fs-extra": "^9.0.0",
+    "helmet": "^3.22.0",
+    "morgan": "^1.10.0",
+    "winston": "^3.2.1",
+    "yn": "^4.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.1.1-alpha.5",
+    "jest-fetch-mock": "^3.0.3",
+    "tsc-watch": "^4.2.3"
+  },
+  "files": [
+    "dist"
+  ],
+  "nodemonConfig": {
+    "watch": "./dist"
+  }
+}

--- a/plugins/auth-backend/src/index.test.ts
+++ b/plugins/auth-backend/src/index.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('test', () => {
+  it('unbreaks the test runner', () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/plugins/auth-backend/src/index.ts
+++ b/plugins/auth-backend/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './service/router';

--- a/plugins/auth-backend/src/run.ts
+++ b/plugins/auth-backend/src/run.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import yn from 'yn';
+import { getRootLogger } from '@backstage/backend-common';
+import { startStandaloneServer } from './service/standaloneServer';
+
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 3003;
+const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
+const logger = getRootLogger();
+
+startStandaloneServer({ port, enableCors, logger }).catch((err) => {
+  logger.error(err);
+  process.exit(1);
+});
+
+process.on('SIGINT', () => {
+  logger.info('CTRL+C pressed; exiting.');
+  process.exit(0);
+});

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import Router from 'express-promise-router';
+import { Logger } from 'winston';
+
+export interface RouterOptions {
+  logger: Logger;
+}
+
+export async function createRouter(
+  options: RouterOptions,
+): Promise<express.Router> {
+  const logger = options.logger.child({ plugin: 'auth' });
+  const router = Router();
+
+  router.get('/ping', async (req, res) => {
+    res.status(200).send('pong');
+  });
+
+  const app = express();
+  app.set('logger', logger);
+  app.use(router);
+
+  return app;
+}

--- a/plugins/auth-backend/src/service/standaloneApplication.ts
+++ b/plugins/auth-backend/src/service/standaloneApplication.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  errorHandler,
+  notFoundHandler,
+  requestLoggingHandler,
+} from '@backstage/backend-common';
+import compression from 'compression';
+import cors from 'cors';
+import express from 'express';
+import helmet from 'helmet';
+import { Logger } from 'winston';
+import { createRouter } from './router';
+
+export interface ApplicationOptions {
+  enableCors: boolean;
+  logger: Logger;
+}
+
+export async function createStandaloneApplication(
+  options: ApplicationOptions,
+): Promise<express.Application> {
+  const { enableCors, logger } = options;
+  const app = express();
+
+  app.use(helmet());
+  if (enableCors) {
+    app.use(cors());
+  }
+  app.use(compression());
+  app.use(express.json());
+  app.use(requestLoggingHandler());
+  app.use('/', await createRouter({ logger }));
+  app.use(notFoundHandler());
+  app.use(errorHandler());
+
+  return app;
+}

--- a/plugins/auth-backend/src/service/standaloneServer.ts
+++ b/plugins/auth-backend/src/service/standaloneServer.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Server } from 'http';
+import { Logger } from 'winston';
+import { createStandaloneApplication } from './standaloneApplication';
+
+export interface ServerOptions {
+  port: number;
+  enableCors: boolean;
+  logger: Logger;
+}
+
+export async function startStandaloneServer(
+  options: ServerOptions,
+): Promise<Server> {
+  const logger = options.logger.child({ service: 'auth-backend' });
+
+  logger.debug('Creating application...');
+  const app = await createStandaloneApplication({
+    enableCors: options.enableCors,
+    logger,
+  });
+
+  logger.debug('Starting application server...');
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(options.port, (err?: Error) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      logger.info(`Listening on port ${options.port}`);
+      resolve(server);
+    });
+  });
+}

--- a/plugins/auth-backend/src/setupTests.ts
+++ b/plugins/auth-backend/src/setupTests.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require('jest-fetch-mock').enableMocks();

--- a/plugins/auth-backend/tsconfig.json
+++ b/plugins/auth-backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "incremental": true,
+    "sourceMap": true,
+    "declaration": true,
+    "strict": true,
+    "target": "es2019",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "lib": ["es2019"],
+    "types": ["node", "jest"]
+  }
+}


### PR DESCRIPTION
Adds a skeleton service with a `/auth/ping` route and responds with `pong`

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
