### PR TITLE
Manually bump @testing-library/jest-dom from 4.2.4 to 5.7.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@testing-library/cypress": "^6.0.0",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/packages/app/src/setupTests.ts
+++ b/packages/app/src/setupTests.ts
@@ -18,4 +18,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/packages/cli/templates/default-app/packages/app/package.json.hbs
+++ b/packages/cli/templates/default-app/packages/app/package.json.hbs
@@ -16,7 +16,7 @@
     "react-use": "^14.2.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/packages/cli/templates/default-app/packages/app/src/setupTests.ts
+++ b/packages/cli/templates/default-app/packages/app/src/setupTests.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/packages/cli/templates/default-app/plugins/welcome/package.json.hbs
+++ b/packages/cli/templates/default-app/plugins/welcome/package.json.hbs
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@backstage/cli": "^{{version}}",
     "@backstage/dev-utils": "^{{version}}",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@types/testing-library__jest-dom": "^5.0.4",
     "jest-fetch-mock": "^3.0.3"

--- a/packages/cli/templates/default-app/plugins/welcome/src/setupTests.ts
+++ b/packages/cli/templates/default-app/plugins/welcome/src/setupTests.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@backstage/cli": "^{{version}}",
     "@backstage/dev-utils": "^{{version}}",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/packages/cli/templates/default-plugin/src/setupTests.ts
+++ b/packages/cli/templates/default-plugin/src/setupTests.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 require('jest-fetch-mock').enableMocks();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/test-utils": "^0.1.1-alpha.5",
     "@backstage/test-utils-core": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2"
   },

--- a/packages/core/src/setupTests.ts
+++ b/packages/core/src/setupTests.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -34,7 +34,7 @@
     "@backstage/theme": "^0.1.1-alpha.5",
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/packages/dev-utils/src/setupTests.ts
+++ b/packages/dev-utils/src/setupTests.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/packages/test-utils-core/package.json
+++ b/packages/test-utils-core/package.json
@@ -28,7 +28,7 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",

--- a/packages/test-utils-core/src/setupTests.ts
+++ b/packages/test-utils-core/src/setupTests.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -32,7 +32,7 @@
     "@backstage/test-utils-core": "^0.1.1-alpha.5",
     "@backstage/theme": "^0.1.1-alpha.5",
     "@material-ui/core": "^4.9.1",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/packages/test-utils/src/setupTests.ts
+++ b/packages/test-utils/src/setupTests.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -30,7 +30,7 @@
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/dev-utils": "^0.1.1-alpha.5",
     "@backstage/test-utils": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/plugins/catalog/src/setupTests.ts
+++ b/plugins/catalog/src/setupTests.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 require('jest-fetch-mock').enableMocks();

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -31,7 +31,7 @@
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/dev-utils": "^0.1.1-alpha.5",
     "@backstage/test-utils": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/plugins/explore/src/setupTests.ts
+++ b/plugins/explore/src/setupTests.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 require('jest-fetch-mock').enableMocks();

--- a/plugins/graphiql/package.json
+++ b/plugins/graphiql/package.json
@@ -45,7 +45,7 @@
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/dev-utils": "^0.1.1-alpha.5",
     "@backstage/test-utils": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/codemirror": "^0.0.93",

--- a/plugins/graphiql/src/setupTests.ts
+++ b/plugins/graphiql/src/setupTests.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 require('jest-fetch-mock').enableMocks();

--- a/plugins/home-page/package.json
+++ b/plugins/home-page/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/dev-utils": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/plugins/home-page/src/setupTests.ts
+++ b/plugins/home-page/src/setupTests.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -32,7 +32,7 @@
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/dev-utils": "^0.1.1-alpha.5",
     "@backstage/test-utils": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/plugins/lighthouse/src/setupTests.ts
+++ b/plugins/lighthouse/src/setupTests.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 require('jest-fetch-mock').enableMocks();

--- a/plugins/register-component/package.json
+++ b/plugins/register-component/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/dev-utils": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/plugins/register-component/src/setupTests.ts
+++ b/plugins/register-component/src/setupTests.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 require('jest-fetch-mock').enableMocks();

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/dev-utils": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/plugins/scaffolder/src/setupTests.ts
+++ b/plugins/scaffolder/src/setupTests.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 require('jest-fetch-mock').enableMocks();

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/dev-utils": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/color": "^3.0.1",

--- a/plugins/tech-radar/src/setupTests.ts
+++ b/plugins/tech-radar/src/setupTests.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 require('jest-fetch-mock').enableMocks();

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.5",
     "@backstage/dev-utils": "^0.1.1-alpha.5",
-    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^25.2.1",

--- a/plugins/welcome/src/setupTests.ts
+++ b/plugins/welcome/src/setupTests.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,7 +870,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.9.6"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
   integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
@@ -3545,19 +3545,19 @@
     dom-accessibility-api "^0.4.2"
     pretty-format "^25.1.0"
 
-"@testing-library/jest-dom@^4.2.4":
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz#00dfa0cbdd837d9a3c2a7f3f0a248ea6e7b89742"
-  integrity sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==
+"@testing-library/jest-dom@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.7.0.tgz#b2e2acb4c088a293d52ba2cd1674b526282a2f87"
+  integrity sha512-ZV0OtBXmTDEDxrIbqJXiOcXCZ6aIMpmDlmfHj0hGNsSuQ/nX0qPAs9HWmCzXvPfTrhufTiH2nJLvDJu/LgHzwQ==
   dependencies:
-    "@babel/runtime" "^7.5.1"
-    chalk "^2.4.1"
-    css "^2.2.3"
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.0.2"
+    chalk "^3.0.0"
+    css "^2.2.4"
     css.escape "^1.5.1"
-    jest-diff "^24.0.0"
-    jest-matcher-utils "^24.0.0"
-    lodash "^4.17.11"
-    pretty-format "^24.0.0"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
     redent "^3.0.0"
 
 "@testing-library/react@^9.3.2":
@@ -4323,6 +4323,13 @@
   integrity sha512-1TEPWyqQ6IQ7R1hCegZmFSA3KrBQjdzJW7yC9ybpRcFst5XuPOqBGNr0mTAKbxwI/TrTyc1skeyLJrpcvAf93w==
   dependencies:
     pretty-format "^25.1.0"
+
+"@types/testing-library__jest-dom@^5.0.2":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.7.0.tgz#078790bf4dc89152a74428591a228ec5f9433251"
+  integrity sha512-LoZ3uonlnAbJUz4bg6UoeFl+frfndXngmkCItSjJ8DD5WlRfVqPC5/LgJASsY/dy7AHH2YJ7PcsdASOydcVeFA==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/testing-library__jest-dom@^5.0.4":
   version "5.0.4"
@@ -7366,7 +7373,7 @@ css.escape@^1.5.1:
   resolved "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
-css@^2.2.3:
+css@^2.2.4:
   version "2.2.4"
   resolved "https://registry.npmjs.org/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -7941,11 +7948,6 @@ diagnostics@^1.1.1:
     colorspace "1.1.x"
     enabled "1.0.x"
     kuler "1.0.x"
-
-diff-sequences@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
-  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -11855,16 +11857,6 @@ jest-css-modules@^2.1.0:
   dependencies:
     identity-obj-proxy "3.0.0"
 
-jest-diff@^24.0.0, jest-diff@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
-  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
-  dependencies:
-    chalk "^2.0.1"
-    diff-sequences "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
 jest-diff@^25.1.0, jest-diff@^25.2.1:
   version "25.5.0"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -12006,16 +11998,6 @@ jest-leak-detector@^25.1.0:
   dependencies:
     jest-get-type "^25.1.0"
     pretty-format "^25.1.0"
-
-jest-matcher-utils@^24.0.0:
-  version "24.9.0"
-  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz#f5b3661d5e628dffe6dd65251dfdae0e87c3a073"
-  integrity sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==
-  dependencies:
-    chalk "^2.0.1"
-    jest-diff "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
 
 jest-matcher-utils@^25.1.0:
   version "25.1.0"
@@ -16005,7 +15987,7 @@ pretty-error@^2.0.2, pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.3.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==


### PR DESCRIPTION
Additional changes from https://github.com/spotify/backstage/pull/825 were needed to bump this package.