### PR TITLE
Manually bump @testing-library/user-event from 7.2.1 to 10.2.4

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -28,7 +28,7 @@
     "@testing-library/cypress": "^6.0.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/jquery": "^3.3.34",
     "@types/node": "^12.0.0",

--- a/packages/cli/templates/default-app/packages/app/package.json.hbs
+++ b/packages/cli/templates/default-app/packages/app/package.json.hbs
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "@types/react-router-dom": "^5.1.3",

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -34,7 +34,7 @@
     "@backstage/dev-utils": "^{{version}}",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "@types/testing-library__jest-dom": "^5.0.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
     "@backstage/test-utils-core": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2"
+    "@testing-library/user-event": "^10.2.4"
   },
   "files": [
     "dist/**/*.{js,d.ts}"

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -36,7 +36,7 @@
     "@material-ui/icons": "^4.9.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "react": "^16.12.0",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -34,7 +34,7 @@
     "@material-ui/core": "^4.9.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "react": "^16.12.0",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -32,7 +32,7 @@
     "@backstage/test-utils": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "@types/testing-library__jest-dom": "^5.0.4",

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -33,7 +33,7 @@
     "@backstage/test-utils": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "@types/testing-library__jest-dom": "^5.0.4",

--- a/plugins/graphiql/package.json
+++ b/plugins/graphiql/package.json
@@ -47,7 +47,7 @@
     "@backstage/test-utils": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/codemirror": "^0.0.93",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",

--- a/plugins/home-page/package.json
+++ b/plugins/home-page/package.json
@@ -31,7 +31,7 @@
     "@backstage/dev-utils": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "@types/testing-library__jest-dom": "^5.0.4",

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -34,7 +34,7 @@
     "@backstage/test-utils": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "@types/testing-library__jest-dom": "^5.0.4",

--- a/plugins/register-component/package.json
+++ b/plugins/register-component/package.json
@@ -32,7 +32,7 @@
     "@backstage/dev-utils": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "@types/testing-library__jest-dom": "^5.0.4",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -31,7 +31,7 @@
     "@backstage/dev-utils": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "@types/testing-library__jest-dom": "^5.0.4",

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -35,7 +35,7 @@
     "@backstage/dev-utils": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/color": "^3.0.1",
     "@types/d3-force": "^1.2.1",
     "@types/jest": "^25.2.1",

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -32,7 +32,7 @@
     "@backstage/dev-utils": "^0.1.1-alpha.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/user-event": "^10.2.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.0.0",
     "@types/testing-library__jest-dom": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3571,10 +3571,10 @@
     "@testing-library/dom" "^6.15.0"
     "@types/testing-library__react" "^9.1.2"
 
-"@testing-library/user-event@^7.1.2":
-  version "7.2.1"
-  resolved "https://registry.npmjs.org/@testing-library/user-event/-/user-event-7.2.1.tgz#2ad4e844175a3738cb9e7064be5ea070b8863a1c"
-  integrity sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA==
+"@testing-library/user-event@^10.2.4":
+  version "10.3.1"
+  resolved "https://registry.npmjs.org/@testing-library/user-event/-/user-event-10.3.1.tgz#8ed6fbfa40fbb866fa4666c9a62d7f7ff151f93b"
+  integrity sha512-HozvWlr/xHmkoJrrDdZBbUOXAC/STAeXGyNU+g5KgEwWBpLJi1RPCHJKbTjwz8hp2jDFsk/jjfD0530eZjcFEg==
 
 "@theme-ui/color-modes@^0.3.1":
   version "0.3.1"


### PR DESCRIPTION
Additional changes from https://github.com/spotify/backstage/pull/871 were needed to bump this package.