### PR TITLE
add chromatic storybook testing to backstage

### DIFF
--- a/.github/workflows/chromatic-storybook-test.yml
+++ b/.github/workflows/chromatic-storybook-test.yml
@@ -1,0 +1,22 @@
+name: 'test chromatic'
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/chromatic-storybook-test.yml'
+      - 'packages/storybook/**'
+      - 'packages/core/src/components/**'
+      - 'packages/core/src/layout/**'
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Required to retrieve git history
+      - run: yarn install
+      - uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          storybookBuildDir: 'packages/storybook/dist'

--- a/.github/workflows/chromatic-storybook-test.yml
+++ b/.github/workflows/chromatic-storybook-test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Required to retrieve git history
-      - run: yarn install
+      - run: yarn install && yarn build-storybook
       - uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "release": "if [ \"$(git symbolic-ref --short HEAD)\" = master ]; then echo \"don't try to release master\"; exit 1; else lerna version --no-push; fi",
     "lerna": "lerna",
     "postinstall": "patch-package",
-    "storybook": "yarn workspace storybook start"
+    "storybook": "yarn workspace storybook start",
+    "build-storybook": "yarn workspace storybook build-storybook"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It adds a github workflow to submit a new storybook build to Chromatic for UI reviewing and testing. It does so for PRs where files change in `packages/storybook`, `packages/core/src/components` and `packages/core/src/layout`.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
