### PR TITLE
make chromatic workflow work for forks

### DIFF
--- a/.github/workflows/chromatic-storybook-test.yml
+++ b/.github/workflows/chromatic-storybook-test.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: 9tzak77m9nj
           storybookBuildDir: 'packages/storybook/dist'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding the token there will let external contributors having their components tested and reviewed using chromatic. There is not a lot of things you can do with the token so it's not a big deal, but if for some reason we see it being used in weird ways we can always revoke it.

https://github.community/t5/GitHub-Actions/Make-secrets-available-to-builds-of-forks/m-p/30678
#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
