### PR TITLE
Store catalog location updates in database

### DIFF
--- a/plugins/catalog-backend/src/database/Database.ts
+++ b/plugins/catalog-backend/src/database/Database.ts
@@ -22,6 +22,8 @@ import {
   AddDatabaseLocation,
   DatabaseComponent,
   DatabaseLocation,
+  DatabaseLocationUpdateLogEvent,
+  DatabaseLocationUpdateLogStatus,
 } from './types';
 
 export class Database {
@@ -106,6 +108,23 @@ export class Database {
   }
 
   async locations(): Promise<DatabaseLocation[]> {
-    return await this.database<DatabaseLocation>('locations').select();
+    return this.database<DatabaseLocation>('locations').select();
+  }
+
+  async addLocationUpdateLogEvent(
+    locationId: string,
+    status: DatabaseLocationUpdateLogStatus,
+    componentName?: string,
+    message?: string,
+  ): Promise<void> {
+    return this.database<DatabaseLocationUpdateLogEvent>(
+      'location_update_log',
+    ).insert({
+      id: uuidv4(),
+      status: status,
+      location_id: locationId,
+      component_name: componentName,
+      message,
+    });
   }
 }

--- a/plugins/catalog-backend/src/database/migrations/20200520140700_location_update_log_table.ts
+++ b/plugins/catalog-backend/src/database/migrations/20200520140700_location_update_log_table.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<any> {
+  return knex.schema.createTable('location_update_log', table => {
+    table.uuid('id').primary();
+    table.enum('status', ['success', 'fail']).notNullable();
+    table.dateTime('created_at').defaultTo(knex.fn.now()).notNullable();
+    table.string('message');
+    table
+      .uuid('location_id')
+      .references('id')
+      .inTable('locations')
+      .onUpdate('CASCADE')
+      .onDelete('CASCADE');
+    table.string('component_name').notNullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<any> {
+  return knex.schema.dropTableIfExists('location_update_log');
+}

--- a/plugins/catalog-backend/src/database/types.ts
+++ b/plugins/catalog-backend/src/database/types.ts
@@ -51,3 +51,17 @@ export const addDatabaseLocationSchema: yup.Schema<AddDatabaseLocation> = yup
     target: yup.string().required(),
   })
   .noUnknown();
+
+export enum DatabaseLocationUpdateLogStatus {
+  FAIL = 'fail',
+  SUCCESS = 'success',
+}
+
+export type DatabaseLocationUpdateLogEvent = {
+  id: string;
+  status: DatabaseLocationUpdateLogStatus;
+  location_id: string;
+  component_name: string;
+  created_at?: string;
+  message?: string;
+};

--- a/plugins/catalog-backend/src/ingestion/DescriptorParsers.ts
+++ b/plugins/catalog-backend/src/ingestion/DescriptorParsers.ts
@@ -17,7 +17,7 @@
 import { DescriptorEnvelopeParser } from './descriptors/DescriptorEnvelopeParser';
 import { ComponentDescriptorV1beta1Parser } from './descriptors/ComponentDescriptorV1beta1Parser';
 import { KindParser } from './descriptors/types';
-import { DescriptorParser, ParserOutput } from './types';
+import { DescriptorParser, ParserError, ParserOutput } from './types';
 import { makeValidator } from '../validation';
 
 export class DescriptorParsers implements DescriptorParser {
@@ -41,9 +41,9 @@ export class DescriptorParsers implements DescriptorParser {
         return parsed;
       }
     }
-
-    throw new Error(
+    throw new ParserError(
       `Unsupported object ${envelope.apiVersion}, ${envelope.kind}`,
+      envelope.metadata?.name,
     );
   }
 }

--- a/plugins/catalog-backend/src/ingestion/descriptors/ComponentDescriptorV1beta1Parser.ts
+++ b/plugins/catalog-backend/src/ingestion/descriptors/ComponentDescriptorV1beta1Parser.ts
@@ -15,7 +15,7 @@
  */
 
 import * as yup from 'yup';
-import { ParserOutput } from '../types';
+import { ParserError, ParserOutput } from '../types';
 import { DescriptorEnvelope } from './DescriptorEnvelopeParser';
 import { KindParser } from './types';
 
@@ -62,7 +62,10 @@ export class ComponentDescriptorV1beta1Parser implements KindParser {
         component: await this.schema.validate(envelope, { strict: true }),
       };
     } catch (e) {
-      throw new Error(`Malformed component, ${e}`);
+      throw new ParserError(
+        `Malformed component, ${e}`,
+        envelope.metadata?.name,
+      );
     }
   }
 }

--- a/plugins/catalog-backend/src/ingestion/types.ts
+++ b/plugins/catalog-backend/src/ingestion/types.ts
@@ -34,6 +34,15 @@ export type DescriptorParser = {
   parse(descriptor: object): Promise<ParserOutput>;
 };
 
+export class ParserError extends Error {
+  constructor(message?: string, private _componentName?: string | undefined) {
+    super(message);
+  }
+  get componentName() {
+    return this._componentName;
+  }
+}
+
 export type ReaderOutput =
   | { type: 'error'; error: Error }
   | { type: 'data'; data: object };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Stores location/component updates in `location_update_log` table.

Log table:

| column         | type                      |
|----------------|---------------------------|
| id             | uuid                      |
| status         | enum(['success', 'fail']) |
| created_at     | dateTime                  |
| message        | string                    |
| location_id    | uuid                      |
| component_name | string                    |

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [X] Prettier run on changed files
- [X] Tests added for new functionality
- [ ] Regression tests added for bug fixes
