### PR TITLE
Remove  from .dockerignore (Fixes #973)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .git
 node_modules
 packages/*/node_modules
-packages/*/dist
 plugins/*/node_modules
 plugins/*/dist


### PR DESCRIPTION
Fixes #973 

`yarn run docker-build` runs correctly.