### PR TITLE
Catalog Filters

### DIFF
--- a/packages/core/src/icons/types.ts
+++ b/packages/core/src/icons/types.ts
@@ -16,7 +16,6 @@
 
 import { ComponentType } from 'react';
 import { SvgIconProps } from '@material-ui/core';
-
 export type IconComponent = ComponentType<SvgIconProps>;
 export type SystemIconKey = 'user' | 'group';
 export type SystemIcons = { [key in SystemIconKey]: IconComponent };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,3 +45,4 @@ export { default as TrendLine } from './components/TrendLine';
 export { FeatureCalloutCircular } from './components/FeatureDiscovery/FeatureCalloutCircular';
 export * from './components/Status';
 export { default as WarningPanel } from './components/WarningPanel';
+export { IconComponent } from './icons';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,4 +45,4 @@ export { default as TrendLine } from './components/TrendLine';
 export { FeatureCalloutCircular } from './components/FeatureDiscovery/FeatureCalloutCircular';
 export * from './components/Status';
 export { default as WarningPanel } from './components/WarningPanel';
-export { IconComponent } from './icons';
+export type { IconComponent } from './icons';

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.test.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.test.tsx
@@ -126,6 +126,6 @@ describe('Catalog Filter', () => {
 
     fireEvent.click(element);
 
-    expect(onSelectedChangeHandler).toHaveBeenCalledWith(item.id);
+    expect(onSelectedChangeHandler).toHaveBeenCalledWith(item);
   });
 });

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.test.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { wrapInThemedTestApp } from '@backstage/test-utils';
 import { CatalogFilter, CatalogFilterGroup } from './CatalogFilter';
 
@@ -88,5 +88,44 @@ describe('Catalog Filter', () => {
     for (const item of group.items) {
       expect(await findByText(item.count!.toString())).toBeInTheDocument();
     }
+  });
+
+  it('should fire the callback when an item is clicked', async () => {
+    const mockGroups: CatalogFilterGroup[] = [
+      {
+        name: 'Test Group 1',
+        items: [
+          {
+            id: 'first',
+            label: 'First Label',
+            count: 100,
+          },
+          {
+            id: 'second',
+            label: 'Second Label',
+            count: 400,
+          },
+        ],
+      },
+    ];
+
+    const onSelectedChangeHandler = jest.fn();
+
+    const { findByText } = render(
+      wrapInThemedTestApp(
+        <CatalogFilter
+          groups={mockGroups}
+          onSelectedChange={onSelectedChangeHandler}
+        />,
+      ),
+    );
+
+    const item = mockGroups[0].items[0];
+
+    const element = await findByText(item.label);
+
+    fireEvent.click(element);
+
+    expect(onSelectedChangeHandler).toHaveBeenCalledWith(item.id);
   });
 });

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.test.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.test.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { wrapInThemedTestApp } from '@backstage/test-utils';
+import { CatalogFilter, CatalogFilterGroup } from './CatalogFilter';
+
+describe('Catalog Filter', () => {
+  it('should render the different groups', async () => {
+    const mockGroups: CatalogFilterGroup[] = [
+      { name: 'Test Group 1', items: [] },
+      { name: 'Test Group 2', items: [] },
+    ];
+    const { findByText } = render(
+      wrapInThemedTestApp(<CatalogFilter groups={mockGroups} />),
+    );
+
+    for (const group of mockGroups) {
+      expect(await findByText(group.name)).toBeInTheDocument();
+    }
+  });
+
+  it('should render the different items and their names', async () => {
+    const mockGroups: CatalogFilterGroup[] = [
+      {
+        name: 'Test Group 1',
+        items: [
+          {
+            id: 'first',
+            label: 'First Label',
+          },
+          {
+            id: 'second',
+            label: 'Second Label',
+          },
+        ],
+      },
+    ];
+
+    const { findByText } = render(
+      wrapInThemedTestApp(<CatalogFilter groups={mockGroups} />),
+    );
+
+    const [group] = mockGroups;
+    for (const item of group.items) {
+      expect(await findByText(item.label)).toBeInTheDocument();
+    }
+  });
+
+  it('should render the count in each item', async () => {
+    const mockGroups: CatalogFilterGroup[] = [
+      {
+        name: 'Test Group 1',
+        items: [
+          {
+            id: 'first',
+            label: 'First Label',
+            count: 100,
+          },
+          {
+            id: 'second',
+            label: 'Second Label',
+            count: 400,
+          },
+        ],
+      },
+    ];
+
+    const { findByText } = render(
+      wrapInThemedTestApp(<CatalogFilter groups={mockGroups} />),
+    );
+
+    const [group] = mockGroups;
+    for (const item of group.items) {
+      expect(await findByText(item.count!.toString())).toBeInTheDocument();
+    }
+  });
+});

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
@@ -21,13 +21,15 @@ import {
   ListItemText,
   MenuItem,
   Typography,
+  Theme,
   makeStyles,
 } from '@material-ui/core';
+import { IconComponent } from '@backstage/shared/icons';
 
 export type CatalogFeatureItem = {
   id: string;
   label: string;
-  icon?: React.ReactElement;
+  icon?: IconComponent;
   count?: number;
 };
 
@@ -40,28 +42,31 @@ export type CatalogFilterProps = {
   groups: CatalogFilterGroup[];
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles<Theme>(theme => ({
   root: {
     backgroundColor: 'rgba(0, 0, 0, .11)',
     boxShadow: 'none',
   },
   title: {
-    margin: '10px 0 0 10px',
+    margin: theme.spacing(1, 0, 0, 1),
     textTransform: 'uppercase',
     fontSize: 12,
     fontWeight: 'bold',
   },
   listIcon: {
     minWidth: 30,
-    color: '#000',
+    color: theme.palette.text.primary,
   },
-  selected: {
-    backgroundColor: '#eee !important',
+  menuItem: {
+    minHeight: theme.spacing(6),
+  },
+  groupWrapper: {
+    margin: theme.spacing(1, 1, 2, 1),
   },
   menuTitle: {
     fontWeight: 500,
   },
-});
+}));
 
 export const CatalogFilter: React.FC<CatalogFilterProps> = ({ groups }) => {
   const classes = useStyles();
@@ -73,15 +78,15 @@ export const CatalogFilter: React.FC<CatalogFilterProps> = ({ groups }) => {
           <Typography variant="subtitle2" className={classes.title}>
             {group.name}
           </Typography>
-          <Card style={{ margin: 10, marginBottom: 15, boxShadow: 'none' }}>
+          <Card className={classes.groupWrapper}>
             <List disablePadding dense>
               {group.items.map(item => (
                 <MenuItem
                   key={item.id}
                   button
                   divider
+                  className={classes.menuItem}
                   classes={{ selected: classes.selected }}
-                  style={{ minHeight: '48px' }}
                 >
                   {item.icon && (
                     <ListItemIcon className={classes.listIcon}>

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
@@ -24,7 +24,7 @@ import {
   Theme,
   makeStyles,
 } from '@material-ui/core';
-import { IconComponent } from '@backstage/core';
+import type { IconComponent } from '@backstage/core';
 
 export type CatalogFeatureItem = {
   id: string;
@@ -40,6 +40,8 @@ export type CatalogFilterGroup = {
 
 export type CatalogFilterProps = {
   groups: CatalogFilterGroup[];
+  selectedId?: string;
+  onSelectedChange?: (id: string) => void;
 };
 
 const useStyles = makeStyles<Theme>(theme => ({
@@ -68,9 +70,12 @@ const useStyles = makeStyles<Theme>(theme => ({
   },
 }));
 
-export const CatalogFilter: React.FC<CatalogFilterProps> = ({ groups }) => {
+export const CatalogFilter: React.FC<CatalogFilterProps> = ({
+  groups,
+  selectedId,
+  onSelectedChange,
+}) => {
   const classes = useStyles();
-
   return (
     <Card className={classes.root}>
       {groups.map(group => (
@@ -85,8 +90,9 @@ export const CatalogFilter: React.FC<CatalogFilterProps> = ({ groups }) => {
                   key={item.id}
                   button
                   divider
+                  onClick={() => onSelectedChange?.(item.id)}
+                  selected={item.id === selectedId}
                   className={classes.menuItem}
-                  classes={{ selected: classes.selected }}
                 >
                   {item.icon && (
                     <ListItemIcon className={classes.listIcon}>

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import {
+  Card,
+  List,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
+
+export type CatalogFeatureItem = {
+  id: string;
+  label: string;
+  icon?: React.ReactElement;
+  count?: number;
+};
+
+export type CatalogFilterGroup = {
+  name: string;
+  items: CatalogFeatureItem[];
+};
+
+export type CatalogFilterProps = {
+  groups: CatalogFilterGroup[];
+};
+
+const useStyles = makeStyles({
+  root: {
+    backgroundColor: 'rgba(0, 0, 0, .11)',
+    boxShadow: 'none',
+  },
+  title: {
+    margin: '10px 0 0 10px',
+    textTransform: 'uppercase',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  listIcon: {
+    minWidth: 30,
+    color: '#000',
+  },
+  selected: {
+    backgroundColor: '#eee !important',
+  },
+  menuTitle: {
+    fontWeight: 500,
+  },
+});
+
+export const CatalogFilter: React.FC<CatalogFilterProps> = ({ groups }) => {
+  const classes = useStyles();
+
+  return (
+    <Card className={classes.root}>
+      {groups.map(group => (
+        <React.Fragment key={group.name}>
+          <Typography variant="subtitle2" className={classes.title}>
+            {group.name}
+          </Typography>
+          <Card style={{ margin: 10, marginBottom: 15, boxShadow: 'none' }}>
+            <List disablePadding dense>
+              {group.items.map(item => (
+                <MenuItem
+                  key={item.id}
+                  button
+                  divider
+                  classes={{ selected: classes.selected }}
+                  style={{ minHeight: '48px' }}
+                >
+                  {item.icon && (
+                    <ListItemIcon className={classes.listIcon}>
+                      {item.icon}
+                    </ListItemIcon>
+                  )}
+                  <ListItemText>
+                    <Typography variant="body1" className={classes.menuTitle}>
+                      {item.label}
+                    </Typography>
+                  </ListItemText>
+                  {item.count}
+                </MenuItem>
+              ))}
+            </List>
+          </Card>
+        </React.Fragment>
+      ))}
+    </Card>
+  );
+};
+
+export default CatalogFilter;

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
@@ -31,6 +31,7 @@ export type CatalogFeatureItem = {
   label: string;
   icon?: IconComponent;
   count?: number;
+  loading?: boolean;
 };
 
 export type CatalogFilterGroup = {

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
@@ -24,7 +24,7 @@ import {
   Theme,
   makeStyles,
 } from '@material-ui/core';
-import { IconComponent } from '@backstage/shared/icons';
+import { IconComponent } from '@backstage/core';
 
 export type CatalogFeatureItem = {
   id: string;
@@ -90,7 +90,7 @@ export const CatalogFilter: React.FC<CatalogFilterProps> = ({ groups }) => {
                 >
                   {item.icon && (
                     <ListItemIcon className={classes.listIcon}>
-                      {item.icon}
+                      <item.icon fontSize="small" />
                     </ListItemIcon>
                   )}
                   <ListItemText>
@@ -108,5 +108,3 @@ export const CatalogFilter: React.FC<CatalogFilterProps> = ({ groups }) => {
     </Card>
   );
 };
-
-export default CatalogFilter;

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
@@ -26,7 +26,7 @@ import {
 } from '@material-ui/core';
 import type { IconComponent } from '@backstage/core';
 
-export type CatalogFeatureItem = {
+export type CatalogFilterItem = {
   id: string;
   label: string;
   icon?: IconComponent;
@@ -36,13 +36,13 @@ export type CatalogFeatureItem = {
 
 export type CatalogFilterGroup = {
   name: string;
-  items: CatalogFeatureItem[];
+  items: CatalogFilterItem[];
 };
 
 export type CatalogFilterProps = {
   groups: CatalogFilterGroup[];
   selectedId?: string;
-  onSelectedChange?: (id: string) => void;
+  onSelectedChange?: (item: CatalogFilterItem) => void;
 };
 
 const useStyles = makeStyles<Theme>(theme => ({
@@ -91,7 +91,7 @@ export const CatalogFilter: React.FC<CatalogFilterProps> = ({
                   key={item.id}
                   button
                   divider
-                  onClick={() => onSelectedChange?.(item.id)}
+                  onClick={() => onSelectedChange?.(item)}
                   selected={item.id === selectedId}
                   className={classes.menuItem}
                 >

--- a/plugins/catalog/src/components/CatalogFilter/index.ts
+++ b/plugins/catalog/src/components/CatalogFilter/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { default } from './CatalogFilter';
+export { CatalogFilter } from './CatalogFilter';

--- a/plugins/catalog/src/components/CatalogFilter/index.ts
+++ b/plugins/catalog/src/components/CatalogFilter/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from './CatalogFilter';

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
@@ -17,8 +17,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import CatalogPage from './CatalogPage';
-import { ThemeProvider } from '@material-ui/core';
-import { lightTheme } from '@backstage/theme';
+import { wrapInThemedTestApp } from '@backstage/test-utils';
 import { ComponentFactory } from '../../data/component';
 
 const testComponentFactory: ComponentFactory = {
@@ -28,11 +27,14 @@ const testComponentFactory: ComponentFactory = {
 };
 
 describe('CatalogPage', () => {
+  // this test right now causes some red lines in the log output when running tests
+  // related to some theme issues in mui-table
+  // https://github.com/mbrn/material-table/issues/1293
   it('should render', async () => {
     const rendered = render(
-      <ThemeProvider theme={lightTheme}>
-        <CatalogPage componentFactory={testComponentFactory} />
-      </ThemeProvider>,
+      wrapInThemedTestApp(
+        <CatalogPage componentFactory={testComponentFactory} />,
+      ),
     );
     expect(
       await rendered.findByText('Keep track of your software'),

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -27,9 +27,12 @@ import {
 import { useAsync } from 'react-use';
 import { ComponentFactory } from '../../data/component';
 import CatalogTable from '../CatalogTable/CatalogTable';
-import { CatalogFilter } from '../CatalogFilter/CatalogFilter';
+import {
+  CatalogFilter,
+  CatalogFilterItem,
+} from '../CatalogFilter/CatalogFilter';
 import { Button, makeStyles } from '@material-ui/core';
-import { getFilterGroups, defaultId } from '../../data/filters';
+import { filterGroups, defaultFilter } from '../../data/filters';
 
 const useStyles = makeStyles(theme => ({
   contentWrapper: {
@@ -46,9 +49,14 @@ type CatalogPageProps = {
 
 const CatalogPage: FC<CatalogPageProps> = ({ componentFactory }) => {
   const { value, error, loading } = useAsync(componentFactory.getAllComponents);
-  const [selectedFilter, setSelectedFilter] = React.useState<string>(defaultId);
-  const onFilterSelected = React.useCallback(id => setSelectedFilter(id), []);
-  const filterGroups = getFilterGroups();
+  const [selectedFilter, setSelectedFilter] = React.useState<CatalogFilterItem>(
+    defaultFilter,
+  );
+
+  const onFilterSelected = React.useCallback(
+    selected => setSelectedFilter(selected),
+    [],
+  );
 
   const styles = useStyles();
   return (
@@ -67,11 +75,12 @@ const CatalogPage: FC<CatalogPageProps> = ({ componentFactory }) => {
           <div>
             <CatalogFilter
               groups={filterGroups}
-              selectedId={selectedFilter}
+              selectedId={selectedFilter.id}
               onSelectedChange={onFilterSelected}
             />
           </div>
           <CatalogTable
+            titlePreamble={selectedFilter.label}
             components={value || []}
             loading={loading}
             error={error}

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -27,13 +27,59 @@ import {
 import { useAsync } from 'react-use';
 import { ComponentFactory } from '../../data/component';
 import CatalogTable from '../CatalogTable/CatalogTable';
-import { Button } from '@material-ui/core';
+import CatalogFilter, {
+  CatalogFilterGroup,
+} from '../CatalogFilter/CatalogFilter';
+import { Button, makeStyles } from '@material-ui/core';
+import StarIcon from '@material-ui/icons/Star';
+import SettingsIcon from '@material-ui/icons/Settings';
+
+const useStyles = makeStyles({
+  contentWrapper: {
+    display: 'grid',
+    gridTemplateAreas: '"filters" "table"',
+    gridTemplateColumns: '250px 1fr',
+    gridColumnGap: '16px',
+  },
+});
 
 type CatalogPageProps = {
   componentFactory: ComponentFactory;
 };
+
+const filterGroups: CatalogFilterGroup[] = [
+  {
+    name: 'Personal',
+    items: [
+      {
+        id: 'owned',
+        label: 'Owned',
+        count: 123,
+        icon: <SettingsIcon fontSize="small" />,
+      },
+      {
+        id: 'starred',
+        label: 'Starred',
+        count: 10,
+        icon: <StarIcon fontSize="small" />,
+      },
+    ],
+  },
+  {
+    name: 'Spotify',
+    items: [
+      {
+        id: 'all',
+        label: 'All Services',
+        count: 123,
+      },
+    ],
+  },
+];
+
 const CatalogPage: FC<CatalogPageProps> = ({ componentFactory }) => {
   const { value, error, loading } = useAsync(componentFactory.getAllComponents);
+  const styles = useStyles();
   return (
     <Page theme={pageTheme.home}>
       <Header title="Service Catalog" subtitle="Keep track of your software">
@@ -46,11 +92,16 @@ const CatalogPage: FC<CatalogPageProps> = ({ componentFactory }) => {
           </Button>
           <SupportButton>All your components</SupportButton>
         </ContentHeader>
-        <CatalogTable
-          components={value || []}
-          loading={loading}
-          error={error}
-        />
+        <div className={styles.contentWrapper}>
+          <div>
+            <CatalogFilter groups={filterGroups} />
+          </div>
+          <CatalogTable
+            components={value || []}
+            loading={loading}
+            error={error}
+          />
+        </div>
       </Content>
     </Page>
   );

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -27,13 +27,9 @@ import {
 import { useAsync } from 'react-use';
 import { ComponentFactory } from '../../data/component';
 import CatalogTable from '../CatalogTable/CatalogTable';
-import {
-  CatalogFilter,
-  CatalogFilterGroup,
-} from '../CatalogFilter/CatalogFilter';
+import { CatalogFilter } from '../CatalogFilter/CatalogFilter';
 import { Button, makeStyles } from '@material-ui/core';
-import StarIcon from '@material-ui/icons/Star';
-import SettingsIcon from '@material-ui/icons/Settings';
+import { getFilterGroups, defaultId } from '../../data/filters';
 
 const useStyles = makeStyles(theme => ({
   contentWrapper: {
@@ -48,38 +44,12 @@ type CatalogPageProps = {
   componentFactory: ComponentFactory;
 };
 
-const filterGroups: CatalogFilterGroup[] = [
-  {
-    name: 'Personal',
-    items: [
-      {
-        id: 'owned',
-        label: 'Owned',
-        count: 123,
-        icon: SettingsIcon,
-      },
-      {
-        id: 'starred',
-        label: 'Starred',
-        count: 10,
-        icon: StarIcon,
-      },
-    ],
-  },
-  {
-    name: 'Spotify',
-    items: [
-      {
-        id: 'all',
-        label: 'All Services',
-        count: 123,
-      },
-    ],
-  },
-];
-
 const CatalogPage: FC<CatalogPageProps> = ({ componentFactory }) => {
   const { value, error, loading } = useAsync(componentFactory.getAllComponents);
+  const [selectedFilter, setSelectedFilter] = React.useState<string>(defaultId);
+  const onFilterSelected = React.useCallback(id => setSelectedFilter(id), []);
+  const filterGroups = getFilterGroups();
+
   const styles = useStyles();
   return (
     <Page theme={pageTheme.home}>
@@ -95,7 +65,11 @@ const CatalogPage: FC<CatalogPageProps> = ({ componentFactory }) => {
         </ContentHeader>
         <div className={styles.contentWrapper}>
           <div>
-            <CatalogFilter groups={filterGroups} />
+            <CatalogFilter
+              groups={filterGroups}
+              selectedId={selectedFilter}
+              onSelectedChange={onFilterSelected}
+            />
           </div>
           <CatalogTable
             components={value || []}

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -27,7 +27,8 @@ import {
 import { useAsync } from 'react-use';
 import { ComponentFactory } from '../../data/component';
 import CatalogTable from '../CatalogTable/CatalogTable';
-import CatalogFilter, {
+import {
+  CatalogFilter,
   CatalogFilterGroup,
 } from '../CatalogFilter/CatalogFilter';
 import { Button, makeStyles } from '@material-ui/core';
@@ -37,7 +38,7 @@ import SettingsIcon from '@material-ui/icons/Settings';
 const useStyles = makeStyles(theme => ({
   contentWrapper: {
     display: 'grid',
-    gridTemplateAreas: '"filters" "table"',
+    gridTemplateAreas: "'filters' 'table'",
     gridTemplateColumns: '250px 1fr',
     gridColumnGap: theme.spacing(2),
   },
@@ -55,13 +56,13 @@ const filterGroups: CatalogFilterGroup[] = [
         id: 'owned',
         label: 'Owned',
         count: 123,
-        icon: <SettingsIcon fontSize="small" />,
+        icon: SettingsIcon,
       },
       {
         id: 'starred',
         label: 'Starred',
         count: 10,
-        icon: <StarIcon fontSize="small" />,
+        icon: StarIcon,
       },
     ],
   },

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -34,14 +34,14 @@ import { Button, makeStyles } from '@material-ui/core';
 import StarIcon from '@material-ui/icons/Star';
 import SettingsIcon from '@material-ui/icons/Settings';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   contentWrapper: {
     display: 'grid',
     gridTemplateAreas: '"filters" "table"',
     gridTemplateColumns: '250px 1fr',
-    gridColumnGap: '16px',
+    gridColumnGap: theme.spacing(2),
   },
-});
+}));
 
 type CatalogPageProps = {
   componentFactory: ComponentFactory;

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -28,7 +28,9 @@ const components: Component[] = [
 describe('CatalogTable component', () => {
   it('should render loading when loading prop it set to true', async () => {
     const rendered = render(
-      wrapInThemedTestApp(<CatalogTable components={[]} loading />),
+      wrapInThemedTestApp(
+        <CatalogTable titlePreamble="Owned" components={[]} loading />,
+      ),
     );
     const progress = await rendered.findByTestId('progress');
     expect(progress).toBeInTheDocument();
@@ -38,6 +40,7 @@ describe('CatalogTable component', () => {
     const rendered = render(
       wrapInThemedTestApp(
         <CatalogTable
+          titlePreamble="Owned"
           components={[]}
           loading={false}
           error={{ code: 'error' }}
@@ -53,9 +56,16 @@ describe('CatalogTable component', () => {
   it('should display component names when loading has finished and no error occurred', async () => {
     const rendered = render(
       wrapInThemedTestApp(
-        <CatalogTable components={components} loading={false} />,
+        <CatalogTable
+          titlePreamble="Owned"
+          components={components}
+          loading={false}
+        />,
       ),
     );
+    expect(
+      await rendered.findByText(`Owned (${components.length})`),
+    ).toBeInTheDocument();
     expect(await rendered.findByText('component1')).toBeInTheDocument();
     expect(await rendered.findByText('component2')).toBeInTheDocument();
     expect(await rendered.findByText('component3')).toBeInTheDocument();

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -63,6 +63,7 @@ const columns: TableColumn[] = [
 
 type CatalogTableProps = {
   components: Component[];
+  titlePreamble: string;
   loading: boolean;
   error?: any;
 };
@@ -70,6 +71,7 @@ const CatalogTable: FC<CatalogTableProps> = ({
   components,
   loading,
   error,
+  titlePreamble,
 }) => {
   if (loading) {
     return <Progress />;
@@ -87,7 +89,7 @@ const CatalogTable: FC<CatalogTableProps> = ({
     <Table
       columns={columns}
       options={{ paging: false }}
-      title={`Owned (${(components && components.length) || 0})`}
+      title={`${titlePreamble} (${(components && components.length) || 0})`}
       data={components}
     />
   );

--- a/plugins/catalog/src/data/filters.ts
+++ b/plugins/catalog/src/data/filters.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CatalogFilterGroup } from '../components/CatalogFilter/CatalogFilter';
+import SettingsIcon from '@material-ui/icons/Settings';
+import StarIcon from '@material-ui/icons/Star';
+
+export const defaultId = 'owned';
+export const getFilterGroups = (): CatalogFilterGroup[] => [
+  {
+    name: 'Personal',
+    items: [
+      {
+        id: 'owned',
+        label: 'Owned',
+        count: 123,
+        icon: SettingsIcon,
+      },
+      {
+        id: 'starred',
+        label: 'Starred',
+        count: 10,
+        icon: StarIcon,
+      },
+    ],
+  },
+  {
+    name: 'Spotify',
+    items: [
+      {
+        id: 'all',
+        label: 'All Services',
+        count: 123,
+      },
+    ],
+  },
+];

--- a/plugins/catalog/src/data/filters.ts
+++ b/plugins/catalog/src/data/filters.ts
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CatalogFilterGroup } from '../components/CatalogFilter/CatalogFilter';
+import {
+  CatalogFilterGroup,
+  CatalogFilterItem,
+} from '../components/CatalogFilter/CatalogFilter';
 import SettingsIcon from '@material-ui/icons/Settings';
 import StarIcon from '@material-ui/icons/Star';
 
-export const defaultId = 'owned';
-export const getFilterGroups = (): CatalogFilterGroup[] => [
+export const filterGroups: CatalogFilterGroup[] = [
   {
     name: 'Personal',
     items: [
@@ -47,3 +49,5 @@ export const getFilterGroups = (): CatalogFilterGroup[] => [
     ],
   },
 ];
+
+export const defaultFilter: CatalogFilterItem = filterGroups[0].items[0];


### PR DESCRIPTION
Let's be able to change some stuff in the Catalog table and drill down to things that we care about. This is just the UI right now, with some sample data. Can hook this up to meaningful queries when the search endpoint is done maybe rather than having specific logic in the frontend for this.

I've tried to make it a little more flexible than the one we have internally, but i'd be interested to get some feedback on the data model. Thought that we can set the loading icon instead of a count from the data fetching hook on the sidebar elements so they can come in async.

![2020-05-26 17 15 43](https://user-images.githubusercontent.com/3645856/82918244-baf71880-9f74-11ea-836e-79b8592ef616.gif)
 
#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes

Fixes #988 
