### PR TITLE
Auth backend: Nonce and header checks

### DIFF
--- a/plugins/auth-backend/src/providers/google/provider.test.ts
+++ b/plugins/auth-backend/src/providers/google/provider.test.ts
@@ -52,11 +52,15 @@ describe('GoogleAuthProvider', () => {
   });
 
   describe('start authentication handler', () => {
-    const mockResponse = ({} as unknown) as express.Response;
+    const mockResponse = ({
+      send: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown) as express.Response;
     const mockNext: express.NextFunction = jest.fn();
 
     it('should initiate authenticate request with provided scopes', () => {
       const mockRequest = ({
+        header: () => 'XMLHttpRequest',
         query: {
           scope: 'a,b',
         },
@@ -80,6 +84,7 @@ describe('GoogleAuthProvider', () => {
 
     it('should throw error if no scopes provided', () => {
       const mockRequest = ({
+        header: () => 'XMLHttpRequest',
         query: {},
       } as unknown) as express.Request;
 
@@ -93,7 +98,9 @@ describe('GoogleAuthProvider', () => {
   });
 
   describe('logout handler', () => {
-    const mockRequest = ({} as unknown) as express.Request;
+    const mockRequest = ({
+      header: () => 'XMLHttpRequest',
+    } as unknown) as express.Request;
 
     it('should perform logout and respond with 200', () => {
       const mockResponse: any = ({
@@ -122,7 +129,9 @@ describe('GoogleAuthProvider', () => {
   });
 
   describe('redirect frame handler', () => {
-    const mockRequest = ({} as unknown) as express.Request;
+    const mockRequest = ({
+      header: () => 'XMLHttpRequest',
+    } as unknown) as express.Request;
     const mockResponse: any = ({
       status: jest.fn().mockReturnThis(),
       send: jest.fn().mockReturnThis(),
@@ -245,6 +254,7 @@ describe('GoogleAuthProvider', () => {
       it('should respond with a 401', () => {
         const mockRequest = ({
           cookies: jest.fn(),
+          header: () => 'XMLHttpRequest',
         } as unknown) as express.Request;
 
         const googleAuthProvider = new GoogleAuthProvider(
@@ -262,6 +272,7 @@ describe('GoogleAuthProvider', () => {
 
     describe('refresh token cookie, no scope', () => {
       const mockRequest = ({
+        header: () => 'XMLHttpRequest',
         cookies: { 'google-refresh-token': 'REFRESH_TOKEN' },
         query: {},
       } as unknown) as express.Request;
@@ -349,6 +360,7 @@ describe('GoogleAuthProvider', () => {
 
     describe('refresh token cookie and scope', () => {
       const mockRequest = ({
+        header: () => 'XMLHttpRequest',
         cookies: { 'google-refresh-token': 'REFRESH_TOKEN' },
         query: {
           scope: 'a,b',
@@ -386,6 +398,20 @@ describe('GoogleAuthProvider', () => {
           expiresInSeconds: 'EXPIRES_IN',
           scope: 'a,b',
         });
+      });
+
+      it('ensures x-requested-with header', () => {
+        const mockHeaderRequest = ({
+          header: () => 'TEST',
+        } as unknown) as express.Request;
+
+        googleAuthProvider.refresh(mockHeaderRequest, mockResponse);
+        expect(mockResponse.send).toBeCalledTimes(1);
+        expect(mockResponse.send).toBeCalledWith(
+          'Invalid X-Requested-With header',
+        );
+        expect(mockResponse.status).toBeCalledTimes(1);
+        expect(mockResponse.status).toBeCalledWith(401);
       });
     });
   });

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -48,11 +48,11 @@ export class GoogleAuthProvider
       secure: false,
       sameSite: 'none',
       domain: 'localhost',
-      path: `/auth/google/handler`,
+      path: `/auth/${this.providerConfig.provider}/handler`,
       httpOnly: true,
     };
 
-    res.cookie(`google-nonce`, nonce, options);
+    res.cookie(`${this.providerConfig.provider}-nonce`, nonce, options);
 
     const scope = req.query.scope?.toString() ?? '';
     if (!scope) {
@@ -71,7 +71,7 @@ export class GoogleAuthProvider
     res: express.Response,
     next: express.NextFunction,
   ) {
-    const cookieNonce = req.cookies[`google-nonce`];
+    const cookieNonce = req.cookies[`${this.providerConfig.provider}-nonce`];
     const stateNonce = req.query.state;
 
     if (!cookieNonce || !stateNonce) {
@@ -106,11 +106,15 @@ export class GoogleAuthProvider
         secure: false,
         sameSite: 'none',
         domain: 'localhost',
-        path: `/auth/google`,
+        path: `/auth/${this.providerConfig.provider}`,
         httpOnly: true,
       };
 
-      res.cookie(`google-refresh-token`, refreshToken, options);
+      res.cookie(
+        `${this.providerConfig.provider}-refresh-token`,
+        refreshToken,
+        options,
+      );
       return postMessageResponse(res, {
         type: 'auth-result',
         payload: user,
@@ -128,11 +132,11 @@ export class GoogleAuthProvider
       secure: false,
       sameSite: 'none',
       domain: 'localhost',
-      path: `/auth/google`,
+      path: `/auth/${this.providerConfig.provider}`,
       httpOnly: true,
     };
 
-    res.cookie(`google-refresh-token`, '', options);
+    res.cookie(`${this.providerConfig.provider}-refresh-token`, '', options);
     return res.send('logout!');
   }
 
@@ -141,7 +145,8 @@ export class GoogleAuthProvider
       return res.status(401).send('Invalid X-Requested-With header');
     }
 
-    const refreshToken = req.cookies[`google-refresh-token`];
+    const refreshToken =
+      req.cookies[`${this.providerConfig.provider}-refresh-token`];
 
     if (!refreshToken) {
       return res.status(401).send('Missing session cookie');

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -28,7 +28,7 @@ import { postMessageResponse, ensuresXRequestedWith } from './../utils';
 import { InputError } from '@backstage/backend-common';
 
 export const THOUSAND_DAYS_MS = 1000 * 24 * 60 * 60 * 1000;
-const TEN_MINUTES_MS = 600 * 1000;
+export const TEN_MINUTES_MS = 600 * 1000;
 export class GoogleAuthProvider
   implements AuthProvider, AuthProviderRouteHandlers {
   private readonly providerConfig: AuthProviderConfig;

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -23,7 +23,7 @@ import {
   AuthProviderRouteHandlers,
   AuthProviderConfig,
 } from './../types';
-import { postMessageResponse } from './../utils';
+import { postMessageResponse, ensuresXRequestedWith } from './../utils';
 import { InputError } from '@backstage/backend-common';
 
 export const THOUSAND_DAYS_MS = 1000 * 24 * 60 * 60 * 1000;
@@ -95,7 +95,11 @@ export class GoogleAuthProvider
     })(req, res, next);
   }
 
-  async logout(_req: express.Request, res: express.Response) {
+  async logout(req: express.Request, res: express.Response) {
+    if (!ensuresXRequestedWith(req)) {
+      return res.status(401).send('Invalid X-Requested-With header');
+    }
+
     const options: CookieOptions = {
       maxAge: 0,
       secure: false,
@@ -110,6 +114,10 @@ export class GoogleAuthProvider
   }
 
   async refresh(req: express.Request, res: express.Response) {
+    if (!ensuresXRequestedWith(req)) {
+      return res.status(401).send('Invalid X-Requested-With header');
+    }
+
     const refreshToken =
       req.cookies[`${this.providerConfig.provider}-refresh-token`];
 

--- a/plugins/auth-backend/src/providers/index.ts
+++ b/plugins/auth-backend/src/providers/index.ts
@@ -20,11 +20,11 @@ import { ProviderFactories } from './factories';
 
 export const defaultRouter = (provider: AuthProviderRouteHandlers) => {
   const router = Router();
-  router.get('/start', provider.start);
-  router.get('/handler/frame', provider.frameHandler);
-  router.get('/logout', provider.logout);
+  router.get('/start', provider.start.bind(provider));
+  router.get('/handler/frame', provider.frameHandler.bind(provider));
+  router.get('/logout', provider.logout.bind(provider));
   if (provider.refresh) {
-    router.get('/refresh', provider.refresh);
+    router.get('/refresh', provider.refresh.bind(provider));
   }
   return router;
 };

--- a/plugins/auth-backend/src/providers/utils.ts
+++ b/plugins/auth-backend/src/providers/utils.ts
@@ -39,3 +39,12 @@ export const postMessageResponse = (
 </html>
   `);
 };
+
+export const ensuresXRequestedWith = (req: express.Request) => {
+  const requiredHeader = req.header('X-Requested-With');
+
+  if (!requiredHeader || requiredHeader !== 'XMLHttpRequest') {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
- Check if x-requested-with header is present in requests to refresh and logout endpoints
- Add a nonce check for flow from start to frame handler

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
