### PR TITLE
bug: removing the extraneous comma

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -40,7 +40,7 @@ const App: FC<{}> = () => (
     <OAuthRequestDialog />
     <Router>
       <Root>
-        <Route key="login" path="/login" component={LoginPage} exact />,
+        <Route key="login" path="/login" component={LoginPage} exact />
         <AppComponent />
       </Root>
     </Router>


### PR DESCRIPTION
Removing the extra comma that was screwing up the header.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
