### PR TITLE
Fix app entry point with extra comma (Fixes #1028)

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -40,7 +40,7 @@ const App: FC<{}> = () => (
     <OAuthRequestDialog />
     <Router>
       <Root>
-        <Route key="login" path="/login" component={LoginPage} exact />,
+        <Route key="login" path="/login" component={LoginPage} exact />
         <AppComponent />
       </Root>
     </Router>


### PR DESCRIPTION
Fixes #1028 

Small fix -> `,` rendered on all pages