### PR TITLE
packages/cli: more strict rollup version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,7 +62,7 @@
     "react-hot-loader": "^4.12.21",
     "recursive-readdir": "^2.2.2",
     "replace-in-file": "^6.0.0",
-    "rollup": "^2.3.2",
+    "rollup": "2.10.x",
     "rollup-plugin-dts": "^1.4.6",
     "rollup-plugin-esbuild": "^1.4.1",
     "rollup-plugin-image-files": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18359,6 +18359,13 @@ rollup@0.64.1:
     "@types/estree" "0.0.39"
     "@types/node" "*"
 
+rollup@2.10.x:
+  version "2.10.9"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-2.10.9.tgz#17dcc6753c619efcc1be2cf61d73a87827eebdf9"
+  integrity sha512-dY/EbjiWC17ZCUSyk14hkxATAMAShkMsD43XmZGWjLrgFj15M3Dw2kEkA9ns64BiLFm9PKN6vTQw8neHwK74eg==
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 rollup@^0.63.4:
   version "0.63.5"
   resolved "https://registry.npmjs.org/rollup/-/rollup-0.63.5.tgz#5543eecac9a1b83b7e1be598b5be84c9c0a089db"
@@ -18366,13 +18373,6 @@ rollup@^0.63.4:
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"
-
-rollup@^2.3.2:
-  version "2.10.9"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-2.10.9.tgz#17dcc6753c619efcc1be2cf61d73a87827eebdf9"
-  integrity sha512-dY/EbjiWC17ZCUSyk14hkxATAMAShkMsD43XmZGWjLrgFj15M3Dw2kEkA9ns64BiLFm9PKN6vTQw8neHwK74eg==
-  optionalDependencies:
-    fsevents "~2.1.2"
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
Should fix broken master

New rollup minor release didn't quite semver properly, so pinning the minor version too.