### PR TITLE
feat(core): Tabs component

### DIFF
--- a/packages/core/src/components/Tabs/Tab.test.tsx
+++ b/packages/core/src/components/Tabs/Tab.test.tsx
@@ -17,11 +17,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { wrapInTestApp } from '@backstage/test-utils';
-import Tab from './Tab';
+import { StyledTab } from './Tab';
 
 describe('<Tab />', () => {
   it('renders without exploding', () => {
-    const rendered = render(wrapInTestApp(<Tab label="test" />));
+    const rendered = render(wrapInTestApp(<StyledTab label="test" />));
     expect(rendered.getByText('test')).toBeInTheDocument();
   });
 });

--- a/packages/core/src/components/Tabs/Tab.test.tsx
+++ b/packages/core/src/components/Tabs/Tab.test.tsx
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { wrapInTestApp } from '@backstage/test-utils';
+import Tab from './Tab';
+
+describe('<Tab />', () => {
+  it('renders without exploding', () => {
+    const rendered = render(wrapInTestApp(<Tab label="test" />));
+    expect(rendered.getByText('test')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Tab, withStyles, Theme } from '@material-ui/core';
+import { BackstageTheme } from '@backstage/theme';
+
+const withStylesProps = (styles: any) => (Component: any) => (props: any) => {
+  const Comp = withStyles((theme: Theme) => styles(props, theme))(Component);
+  return <Comp {...props} />;
+};
+
+interface StyledTabProps {
+  label: string;
+  isFirstNav?: boolean;
+  isFirstIndex?: boolean;
+}
+
+const tabMarginLeft = (isFirstNav: boolean, isFirstIndex: boolean) => {
+  if (isFirstIndex) {
+    if (isFirstNav) {
+      return '20px';
+    }
+    return '0';
+  }
+  return '40px';
+};
+
+const tabStyles = (props: any, theme: BackstageTheme) => ({
+  root: {
+    textTransform: 'none',
+    height: '64px',
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.pxToRem(13),
+    color: theme.palette.textSubtle,
+    marginLeft: tabMarginLeft(props.isFirstNav, props.isFirstIndex),
+    width: '130px',
+    minWidth: '130px',
+    '&:hover': {
+      outline: 'none',
+      backgroundColor: 'transparent',
+      color: theme.palette.textSubtle,
+    },
+  },
+});
+
+const StyledTab = withStylesProps(tabStyles)((props: StyledTabProps) => {
+  const { isFirstNav, isFirstIndex, ...rest } = props;
+  return <Tab disableRipple {...rest} />;
+});
+
+export default StyledTab;

--- a/packages/core/src/components/Tabs/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab.tsx
@@ -15,18 +15,15 @@
  */
 
 import React from 'react';
-import { Tab, withStyles, Theme } from '@material-ui/core';
+import { Tab, makeStyles } from '@material-ui/core';
 import { BackstageTheme } from '@backstage/theme';
 
-const withStylesProps = (styles: any) => (Component: any) => (props: any) => {
-  const Comp = withStyles((theme: Theme) => styles(props, theme))(Component);
-  return <Comp {...props} />;
-};
-
 interface StyledTabProps {
-  label: string;
+  label?: string;
+  icon?: any; // TODO: define type for material-ui icons
   isFirstNav?: boolean;
   isFirstIndex?: boolean;
+  value?: any;
 }
 
 const tabMarginLeft = (isFirstNav: boolean, isFirstIndex: boolean) => {
@@ -39,14 +36,15 @@ const tabMarginLeft = (isFirstNav: boolean, isFirstIndex: boolean) => {
   return '40px';
 };
 
-const tabStyles = (props: any, theme: BackstageTheme) => ({
+const useStyles = makeStyles<BackstageTheme, StyledTabProps>(theme => ({
   root: {
     textTransform: 'none',
     height: '64px',
     fontWeight: theme.typography.fontWeightBold,
     fontSize: theme.typography.pxToRem(13),
     color: theme.palette.textSubtle,
-    marginLeft: tabMarginLeft(props.isFirstNav, props.isFirstIndex),
+    marginLeft: props =>
+      tabMarginLeft(props.isFirstNav as boolean, props.isFirstIndex as boolean),
     width: '130px',
     minWidth: '130px',
     '&:hover': {
@@ -55,11 +53,10 @@ const tabStyles = (props: any, theme: BackstageTheme) => ({
       color: theme.palette.textSubtle,
     },
   },
-});
+}));
 
-const StyledTab = withStylesProps(tabStyles)((props: StyledTabProps) => {
+export const StyledTab = (props: StyledTabProps) => {
+  const classes = useStyles(props);
   const { isFirstNav, isFirstIndex, ...rest } = props;
-  return <Tab disableRipple {...rest} />;
-});
-
-export default StyledTab;
+  return <Tab className={classes.root} disableRipple {...rest} />;
+};

--- a/packages/core/src/components/Tabs/TabBar.tsx
+++ b/packages/core/src/components/Tabs/TabBar.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC } from 'react';
+import { Tabs, makeStyles } from '@material-ui/core';
+import { BackstageTheme } from '@backstage/theme';
+
+interface StyledTabsProps {
+  value: number;
+  onChange: (event: React.ChangeEvent<{}>, newValue: number) => void;
+}
+
+const useStyles = makeStyles<BackstageTheme>(theme => ({
+  indicator: {
+    display: 'flex',
+    justifyContent: 'center',
+    backgroundColor: theme.palette.tabbar.indicator,
+    height: '4px',
+  },
+  flexContainer: {
+    alignItems: 'center',
+  },
+  root: {
+    '&:last-child': {
+      marginLeft: 'auto',
+    },
+  },
+}));
+
+const StyledTabs: FC<StyledTabsProps> = props => {
+  const classes = useStyles(props);
+  return (
+    <Tabs
+      classes={classes}
+      {...props}
+      TabIndicatorProps={{ children: <span /> }}
+    />
+  );
+};
+
+export default StyledTabs;

--- a/packages/core/src/components/Tabs/TabBar.tsx
+++ b/packages/core/src/components/Tabs/TabBar.tsx
@@ -19,7 +19,7 @@ import { Tabs, makeStyles } from '@material-ui/core';
 import { BackstageTheme } from '@backstage/theme';
 
 interface StyledTabsProps {
-  value: number;
+  value: number | boolean;
   onChange: (event: React.ChangeEvent<{}>, newValue: number) => void;
 }
 
@@ -40,7 +40,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
   },
 }));
 
-const StyledTabs: FC<StyledTabsProps> = props => {
+export const StyledTabs: FC<StyledTabsProps> = props => {
   const classes = useStyles(props);
   return (
     <Tabs
@@ -50,5 +50,3 @@ const StyledTabs: FC<StyledTabsProps> = props => {
     />
   );
 };
-
-export default StyledTabs;

--- a/packages/core/src/components/Tabs/TabIcon.tsx
+++ b/packages/core/src/components/Tabs/TabIcon.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { IconButton, withStyles, Theme } from '@material-ui/core';
+
+export const withStylesProps = (styles: any) => (Component: any) => (
+  props: any,
+) => {
+  const Comp = withStyles((theme: Theme) => styles(props, theme))(Component);
+  return <Comp {...props} />;
+};
+
+interface StyledIconProps {
+  ariaLabel: string;
+  children: any;
+  classes: any;
+  isNext?: boolean;
+  onClick: any;
+}
+
+const iconStyles = (props: StyledIconProps) => ({
+  root: {
+    color: '#6E6E6E',
+    overflow: 'visible',
+    fontSize: '1.5rem',
+    textAlign: 'center',
+    borderRadius: '50%',
+    backgroundColor: '#E6E6E6',
+    marginLeft: props.isNext ? 'auto' : '0',
+    marginRight: props.isNext ? '0' : '10px',
+    '&:hover': {
+      backgroundColor: '#E6E6E6',
+      opacity: '1',
+    },
+  },
+});
+
+const StyledIcon = withStylesProps(iconStyles)((props: StyledIconProps) => {
+  const {
+    classes: { root },
+    ariaLabel,
+    onClick,
+  } = props;
+  return (
+    <IconButton
+      onClick={onClick}
+      className={root}
+      size="small"
+      disableRipple
+      disableFocusRipple
+      aria-label={ariaLabel}
+    >
+      {props.children}
+    </IconButton>
+  );
+});
+
+export default StyledIcon;

--- a/packages/core/src/components/Tabs/TabIcon.tsx
+++ b/packages/core/src/components/Tabs/TabIcon.tsx
@@ -15,24 +15,17 @@
  */
 
 import React from 'react';
-import { IconButton, withStyles, Theme } from '@material-ui/core';
-
-export const withStylesProps = (styles: any) => (Component: any) => (
-  props: any,
-) => {
-  const Comp = withStyles((theme: Theme) => styles(props, theme))(Component);
-  return <Comp {...props} />;
-};
+import { IconButton, makeStyles } from '@material-ui/core';
+import { BackstageTheme } from '@backstage/theme';
 
 interface StyledIconProps {
   ariaLabel: string;
   children: any;
-  classes: any;
   isNext?: boolean;
   onClick: any;
 }
 
-const iconStyles = (props: StyledIconProps) => ({
+const useStyles = makeStyles<BackstageTheme, StyledIconProps>(() => ({
   root: {
     color: '#6E6E6E',
     overflow: 'visible',
@@ -40,25 +33,22 @@ const iconStyles = (props: StyledIconProps) => ({
     textAlign: 'center',
     borderRadius: '50%',
     backgroundColor: '#E6E6E6',
-    marginLeft: props.isNext ? 'auto' : '0',
-    marginRight: props.isNext ? '0' : '10px',
+    marginLeft: props => (props.isNext ? 'auto' : '0'),
+    marginRight: props => (props.isNext ? '0' : '10px'),
     '&:hover': {
       backgroundColor: '#E6E6E6',
       opacity: '1',
     },
   },
-});
+}));
 
-const StyledIcon = withStylesProps(iconStyles)((props: StyledIconProps) => {
-  const {
-    classes: { root },
-    ariaLabel,
-    onClick,
-  } = props;
+export const StyledIcon = (props: StyledIconProps) => {
+  const classes = useStyles(props);
+  const { ariaLabel, onClick } = props;
   return (
     <IconButton
       onClick={onClick}
-      className={root}
+      className={classes.root}
       size="small"
       disableRipple
       disableFocusRipple
@@ -67,6 +57,4 @@ const StyledIcon = withStylesProps(iconStyles)((props: StyledIconProps) => {
       {props.children}
     </IconButton>
   );
-});
-
-export default StyledIcon;
+};

--- a/packages/core/src/components/Tabs/TabPanel.tsx
+++ b/packages/core/src/components/Tabs/TabPanel.tsx
@@ -19,18 +19,17 @@ import Box from '@material-ui/core/Box';
 
 export interface TabPanelProps {
   children: any;
-  value: any;
-  index: number;
+  value?: any;
+  index?: number;
 }
 
-const TabPanel: FC<TabPanelProps> = props => {
+export const TabPanel: FC<TabPanelProps> = props => {
   const { children, value, index, ...other } = props;
 
   return (
     <div
       role="tabpanel"
       hidden={value !== index}
-      id={`scrollable-auto-tabpanel-${index}`}
       aria-labelledby={`scrollable-auto-tab-${index}`}
       {...other}
     >
@@ -38,5 +37,3 @@ const TabPanel: FC<TabPanelProps> = props => {
     </div>
   );
 };
-
-export default TabPanel;

--- a/packages/core/src/components/Tabs/TabPanel.tsx
+++ b/packages/core/src/components/Tabs/TabPanel.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC } from 'react';
+import Box from '@material-ui/core/Box';
+
+export interface TabPanelProps {
+  children: any;
+  value: any;
+  index: number;
+}
+
+const TabPanel: FC<TabPanelProps> = props => {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`scrollable-auto-tabpanel-${index}`}
+      aria-labelledby={`scrollable-auto-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box p={3}>{children}</Box>}
+    </div>
+  );
+};
+
+export default TabPanel;

--- a/packages/core/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/core/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import Tabs from './Tabs';
+
+export default {
+  title: 'Tabs',
+  component: Tabs,
+};
+
+const containerStyle = {};
+
+export const Default = () => (
+  <div style={containerStyle}>
+    <Tabs
+      tabs={[...Array(4)].map((_, index) => ({
+        label: `ANOTHER TAB`,
+        content: <div>Content {index}</div>,
+      }))}
+    />
+  </div>
+);
+
+export const Expandable = () => (
+  <div style={containerStyle}>
+    <Tabs
+      tabs={[...Array(31)].map((_, index) => ({
+        label: `ANOTHER TAB`,
+        content: <div>Content {index}</div>,
+      }))}
+    />
+  </div>
+);

--- a/packages/core/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/core/src/components/Tabs/Tabs.stories.tsx
@@ -15,7 +15,8 @@
  */
 
 import React from 'react';
-import Tabs from './Tabs';
+import { Tabs } from './Tabs';
+import AccessAlarmIcon from '@material-ui/icons/AccessAlarm';
 
 export default {
   title: 'Tabs',
@@ -39,6 +40,29 @@ export const Expandable = () => (
   <div style={containerStyle}>
     <Tabs
       tabs={[...Array(31)].map((_, index) => ({
+        label: `ANOTHER TAB`,
+        content: <div>Content {index}</div>,
+      }))}
+    />
+  </div>
+);
+
+export const Icons = () => (
+  <div style={containerStyle}>
+    <Tabs
+      tabs={[...Array(4)].map((_, index) => ({
+        icon: <AccessAlarmIcon />,
+        content: <div>Content {index}</div>,
+      }))}
+    />
+  </div>
+);
+
+export const IconsAndLabels = () => (
+  <div style={containerStyle}>
+    <Tabs
+      tabs={[...Array(4)].map((_, index) => ({
+        icon: <AccessAlarmIcon />,
         label: `ANOTHER TAB`,
         content: <div>Content {index}</div>,
       }))}

--- a/packages/core/src/components/Tabs/Tabs.tsx
+++ b/packages/core/src/components/Tabs/Tabs.tsx
@@ -104,7 +104,7 @@ export const Tabs: FC<TabsProps> = ({ tabs }) => {
       Math.floor(flattenIndex / newChunkedElementSize),
       flattenIndex % newChunkedElementSize,
     ]);
-  }, [width]);
+  }, [width, navIndex, numberOfChunkedElement, tabs, value]);
 
   const currentIndex = navIndex === value[0] ? value[1] : false;
 

--- a/packages/core/src/components/Tabs/Tabs.tsx
+++ b/packages/core/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FC, useRef, useEffect, MutableRefObject } from 'react';
+import { BackstageTheme } from '@backstage/theme';
+import { AppBar } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
+import NavigateNextIcon from '@material-ui/icons/NavigateNext';
+import { chunkArray, useWindowWidth } from './utils';
+
+/* Import Components */
+
+import TabPanel from './TabPanel';
+import TabIcon from './TabIcon';
+import Tab from './Tab';
+import TabBar from './TabBar';
+
+/* Props Types */
+
+interface TabProps {
+  label: string;
+  content: any;
+}
+
+export interface TabsProps {
+  tabs: TabProps[];
+}
+
+const useStyles = makeStyles<BackstageTheme>((theme: BackstageTheme) => ({
+  root: {
+    flexGrow: 1,
+    width: '100%',
+  },
+  styledTabs: {
+    backgroundColor: theme.palette.tabbar.background,
+  },
+  appbar: {
+    boxShadow: 'none',
+    backgroundColor: theme.palette.tabbar.background,
+    paddingLeft: '10px',
+    paddingRight: '10px',
+  },
+}));
+
+const Tabs: FC<TabsProps> = ({ tabs }) => {
+  const classes = useStyles();
+  const [value, setValue] = React.useState(0);
+  const [navIndex, setNavIndex] = React.useState(0);
+  const [chunkedTabs, setChunkedTabs] = React.useState([[]] as TabProps[][]);
+  const wrapper = useRef() as MutableRefObject<HTMLDivElement>;
+
+  const size = useWindowWidth();
+
+  const handleChange = (_: React.ChangeEvent<{}>, newValue: number) => {
+    setValue(newValue);
+  };
+
+  const navigateToPrevChunk = () => {
+    setValue(navIndex - 1 === 0 ? 0 : 1);
+    setNavIndex(navIndex - 1);
+  };
+
+  const navigateToNextChunk = () => {
+    setValue(1);
+    setNavIndex(navIndex + 1);
+  };
+
+  const hasNextNavIndex = () => navIndex + 1 < chunkedTabs.length;
+
+  useEffect(() => {
+    // Each time the window is resized we calculate how many tabs wwe can render given the window width
+    const padding = 20; // The AppBar padding
+
+    const numberOfTabIcons = navIndex === 0 ? 1 : 2;
+    const wrapperWidth =
+      wrapper.current.offsetWidth - padding - numberOfTabIcons * 30;
+
+    const numberOfChunkedElement = Math.floor(wrapperWidth / 170);
+    setChunkedTabs(
+      chunkArray([...tabs], numberOfChunkedElement) as TabProps[][],
+    );
+  }, [size]);
+
+  return (
+    <div className={classes.root}>
+      <AppBar ref={wrapper} className={classes.appbar} position="static">
+        <div className={classes.root2}>
+          <TabBar value={value} onChange={handleChange}>
+            {navIndex !== 0 && (
+              <TabIcon
+                onClick={navigateToPrevChunk}
+                ariaLabel="navigate-before"
+              >
+                <NavigateBeforeIcon />
+              </TabIcon>
+            )}
+            {chunkedTabs[navIndex].map((tab, index) => (
+              <Tab
+                isFirstIndex={index === 0}
+                isFirstNav={navIndex === 0}
+                key={index}
+                label={tab.label}
+              />
+            ))}
+            {hasNextNavIndex() && (
+              <TabIcon
+                isNext
+                onClick={navigateToNextChunk}
+                ariaLabel="navigate-next"
+              >
+                <NavigateNextIcon />
+              </TabIcon>
+            )}
+          </TabBar>
+        </div>
+      </AppBar>
+      {chunkedTabs[navIndex].map((tab, index) => (
+        <TabPanel
+          key={index}
+          // Used to prevent issues with TabIcon inside the TabBar
+          value={navIndex === 0 ? value : value - 1}
+          index={index}
+        >
+          {tab.content}
+        </TabPanel>
+      ))}
+    </div>
+  );
+};
+
+export default Tabs;

--- a/packages/core/src/components/Tabs/Tabs.tsx
+++ b/packages/core/src/components/Tabs/Tabs.tsx
@@ -104,7 +104,8 @@ export const Tabs: FC<TabsProps> = ({ tabs }) => {
       Math.floor(flattenIndex / newChunkedElementSize),
       flattenIndex % newChunkedElementSize,
     ]);
-  }, [width, navIndex, numberOfChunkedElement, tabs, value]);
+    // eslint-disable-next-line
+  }, [width, tabs]);
 
   const currentIndex = navIndex === value[0] ? value[1] : false;
 

--- a/packages/core/src/components/Tabs/index.ts
+++ b/packages/core/src/components/Tabs/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { default } from './Tabs';
+export { Tabs as default } from './Tabs';

--- a/packages/core/src/components/Tabs/index.ts
+++ b/packages/core/src/components/Tabs/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from './Tabs';

--- a/packages/core/src/components/Tabs/utils.ts
+++ b/packages/core/src/components/Tabs/utils.ts
@@ -13,30 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState, useEffect } from 'react';
+import { TabProps } from './Tabs';
 
-export const chunkArray = (myArray: any[], chunkSize: number) => {
+export const chunkArray = (
+  myArray: TabProps[],
+  chunkSize: number,
+): TabProps[][] => {
   const results = [];
   while (myArray.length) {
     results.push(myArray.splice(0, chunkSize));
   }
   return results;
-};
-
-export const useWindowWidth = () => {
-  const isClient = typeof window === 'object';
-  const getWidth = () => (isClient ? window.innerWidth : undefined);
-  const [windowWidth, setWindowWidth] = useState(getWidth);
-
-  useEffect((): any => {
-    if (!isClient) {
-      return false;
-    }
-
-    const handleResize = () => setWindowWidth(getWidth());
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-  return windowWidth;
 };

--- a/packages/core/src/components/Tabs/utils.ts
+++ b/packages/core/src/components/Tabs/utils.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState, useEffect } from 'react';
+
+export const chunkArray = (myArray: any[], chunkSize: number) => {
+  const results = [];
+  while (myArray.length) {
+    results.push(myArray.splice(0, chunkSize));
+  }
+  return results;
+};
+
+export const useWindowWidth = () => {
+  const isClient = typeof window === 'object';
+  const getWidth = () => (isClient ? window.innerWidth : undefined);
+  const [windowWidth, setWindowWidth] = useState(getWidth);
+
+  useEffect((): any => {
+    if (!isClient) {
+      return false;
+    }
+
+    const handleResize = () => setWindowWidth(getWidth());
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+  return windowWidth;
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,3 +39,4 @@ export { default as TrendLine } from './components/TrendLine';
 export { FeatureCalloutCircular } from './components/FeatureDiscovery/FeatureCalloutCircular';
 export * from './components/Status';
 export { default as WarningPanel } from './components/WarningPanel';
+export { default as Tabs } from './components/Tabs';

--- a/packages/theme/src/themes.ts
+++ b/packages/theme/src/themes.ts
@@ -62,7 +62,6 @@ export const lightTheme = createTheme({
     },
     tabbar: {
       indicator: '#9BF0E1',
-      background: '#FFFFFF',
     },
   },
 });
@@ -112,7 +111,6 @@ export const darkTheme = createTheme({
     },
     tabbar: {
       indicator: '#9BF0E1',
-      background: '#424242',
     },
   },
 });

--- a/packages/theme/src/themes.ts
+++ b/packages/theme/src/themes.ts
@@ -60,6 +60,10 @@ export const lightTheme = createTheme({
       icon: '#BDBDBD',
       background: '#404040',
     },
+    tabbar: {
+      indicator: '#9BF0E1',
+      background: '#FFFFFF',
+    },
   },
 });
 
@@ -105,6 +109,10 @@ export const darkTheme = createTheme({
     pinSidebarButton: {
       icon: '#181818',
       background: '#BDBDBD',
+    },
+    tabbar: {
+      indicator: '#9BF0E1',
+      background: '#424242',
     },
   },
 });

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -46,7 +46,6 @@ type PaletteAdditions = {
   sidebar: string;
   tabbar: {
     indicator: string;
-    background: string;
   };
   bursts: {
     fontColor: string;

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -44,6 +44,10 @@ type PaletteAdditions = {
   link: string;
   gold: string;
   sidebar: string;
+  tabbar: {
+    indicator: string;
+    background: string;
+  };
   bursts: {
     fontColor: string;
     slackChannelText: string;


### PR DESCRIPTION
#125  Hey, I just made a Pull Request!

Closes #922 

This is still a **work in progress** because I need to do some **adjustments, refactoring and add tests**.
I want to have your point of view on my implementation.

First of all, I looked about what @shmidt-i and @Rugvip said about the way we could re-use some scrollable components on the backstage source code and on material-ui to achieve ours. The problem is that, as I can see on the expected behavior of the component, the user is not supposed to be able to scroll in the component. It is more like a **navigation-steps**.   

Here are some sketches about the way I tried to create the component:
<img width="1282" alt="nav_steps" src="https://user-images.githubusercontent.com/32459935/83316921-41d41b80-a229-11ea-9ad7-8b67497deca1.png">
<img width="1143" alt="nav_builder" src="https://user-images.githubusercontent.com/32459935/83316924-4bf61a00-a229-11ea-909a-43fb2eb4248e.png">
<img width="1146" alt="components" src="https://user-images.githubusercontent.com/32459935/83316928-52849180-a229-11ea-90e9-1673825967fb.png">

For the moment the component looks like this:
- Light default:
<img width="1194" alt="light1" src="https://user-images.githubusercontent.com/32459935/83316980-c58e0800-a229-11ea-9b47-813a0dae1080.png">

- Light expandable:
<img width="1189" alt="light2" src="https://user-images.githubusercontent.com/32459935/83316984-c9218f00-a229-11ea-96ec-e6af9dc5627e.png">

- Dark default:
<img width="1192" alt="dark1" src="https://user-images.githubusercontent.com/32459935/83316994-d8084180-a229-11ea-9478-d8f456b8a8f8.png">

- Dark expandable:
<img width="1186" alt="dark2" src="https://user-images.githubusercontent.com/32459935/83317003-df2f4f80-a229-11ea-8b27-7406d5d789d6.png">

For the moment, the component has this **navigation behavior**:

![backstage-tab](https://user-images.githubusercontent.com/32459935/83316937-747e1400-a229-11ea-85e0-ae7bdbde0628.gif)

And this **resizable behavior**:   

![resize](https://user-images.githubusercontent.com/32459935/83317609-40f1b880-a22e-11ea-8add-6afc387a06cf.gif)

My code seems too complicated with a bunch of messy code for the moment and I wanted to have your opinion on my conception-architecture before going further 👍

Tested components:
- [ ] Tab
- [ ] TabBar
- [ ] TabIcon
- [ ] TabPanel
- [ ] Tabs


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
