### PR TITLE
Fix overlap issue with Sidebar and Dismissable banner

### DIFF
--- a/packages/core/src/components/DismissableBanner/DismissableBanner.tsx
+++ b/packages/core/src/components/DismissableBanner/DismissableBanner.tsx
@@ -31,6 +31,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: -theme.spacing(3),
     display: 'flex',
     flexFlow: 'row nowrap',
+    zIndex: 'unset',
   },
   icon: {
     fontSize: 20,

--- a/packages/core/src/layout/Sidebar/Bar.tsx
+++ b/packages/core/src/layout/Sidebar/Bar.tsx
@@ -23,7 +23,7 @@ import { SidebarPinStateContext } from './Page';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   root: {
-    zIndex: 1401,
+    zIndex: 1000,
     position: 'relative',
     overflow: 'visible',
     width: theme.spacing(7) + 1,

--- a/packages/core/src/layout/Sidebar/Bar.tsx
+++ b/packages/core/src/layout/Sidebar/Bar.tsx
@@ -23,7 +23,7 @@ import { SidebarPinStateContext } from './Page';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   root: {
-    zIndex: 1000,
+    zIndex: 1401,
     position: 'relative',
     overflow: 'visible',
     width: theme.spacing(7) + 1,


### PR DESCRIPTION
As of now, the Sidebar is being overlapped by the Dismissable banner component.

Current

![current](https://user-images.githubusercontent.com/8065913/83323568-b8f5c800-a29a-11ea-8be8-90bded68df4e.gif)

Proposed

![proposed](https://user-images.githubusercontent.com/8065913/83323580-c8751100-a29a-11ea-9ae8-dab9341fba0f.gif)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
