### PR TITLE
scripts/check-type-dependencies: only verify type deps for packages that have been built

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -6,7 +6,6 @@ on:
       - '.github/workflows/cli.yml'
       - 'packages/cli/**'
       - 'packages/core/**'
-      - 'scripts/**'
       - 'yarn.lock'
 
 jobs:

--- a/scripts/check-type-dependencies.js
+++ b/scripts/check-type-dependencies.js
@@ -69,7 +69,11 @@ async function main() {
 }
 
 function shouldCheckTypes(pkg) {
-  return !pkg.private && pkg.get('types');
+  return (
+    !pkg.private &&
+    pkg.get('types') &&
+    fs.existsSync(resolvePath(pkg.location, 'dist/index.d.ts'))
+  );
 }
 
 /**


### PR DESCRIPTION
derp'd