### PR TITLE
Move addLocation to new HigherOrderOperations

### DIFF
--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -23,6 +23,7 @@ import {
   LocationReaders,
   IngestionModels,
   runPeriodically,
+  HigherOrderOperations,
 } from '@backstage/plugin-catalog-backend';
 import { PluginEnvironment } from '../types';
 import { EntityPolicies } from '@backstage/catalog-model';
@@ -32,7 +33,7 @@ export default async function createPlugin({
   database,
 }: PluginEnvironment) {
   const policy = new EntityPolicies();
-  const ingestion = new IngestionModels(
+  const ingestionModel = new IngestionModels(
     new LocationReaders(),
     new DescriptorParsers(),
     new EntityPolicies(),
@@ -40,12 +41,22 @@ export default async function createPlugin({
 
   const db = await DatabaseManager.createDatabase(database, logger);
   runPeriodically(
-    () => DatabaseManager.refreshLocations(db, ingestion, policy, logger),
+    () => DatabaseManager.refreshLocations(db, ingestionModel, policy, logger),
     10000,
   );
 
-  const entitiesCatalog = new DatabaseEntitiesCatalog(db, policy);
-  const locationsCatalog = new DatabaseLocationsCatalog(db, ingestion);
+  const entitiesCatalog = new DatabaseEntitiesCatalog(db);
+  const locationsCatalog = new DatabaseLocationsCatalog(db);
+  const higherOrderOperation = new HigherOrderOperations(
+    entitiesCatalog,
+    locationsCatalog,
+    ingestionModel,
+  );
 
-  return await createRouter({ entitiesCatalog, locationsCatalog, logger });
+  return await createRouter({
+    entitiesCatalog,
+    locationsCatalog,
+    higherOrderOperation,
+    logger,
+  });
 }

--- a/packages/catalog-model/src/index.ts
+++ b/packages/catalog-model/src/index.ts
@@ -17,5 +17,6 @@
 export * from './entity';
 export { EntityPolicies } from './EntityPolicies';
 export * from './kinds';
+export * from './location';
 export type { EntityPolicy } from './types';
 export * from './validation';

--- a/packages/catalog-model/src/location/index.ts
+++ b/packages/catalog-model/src/location/index.ts
@@ -14,18 +14,5 @@
  * limitations under the License.
  */
 
-import type { Entity, Location, LocationSpec } from '@backstage/catalog-model';
-import type { ReaderOutput } from './descriptor/parsers/types';
-
-export type AddLocationResult = {
-  location: Location;
-  entities: Entity[];
-};
-
-export type IngestionModel = {
-  readLocation(type: string, target: string): Promise<ReaderOutput[]>;
-};
-
-export type HigherOrderOperation = {
-  addLocation(spec: LocationSpec): Promise<AddLocationResult>;
-};
+export type { Location, LocationSpec } from './types';
+export { locationSchema, locationSpecSchema } from './validation';

--- a/packages/catalog-model/src/location/types.ts
+++ b/packages/catalog-model/src/location/types.ts
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 
-import type { Entity, Location, LocationSpec } from '@backstage/catalog-model';
-import type { ReaderOutput } from './descriptor/parsers/types';
-
-export type AddLocationResult = {
-  location: Location;
-  entities: Entity[];
+export type LocationSpec = {
+  type: string;
+  target: string;
 };
 
-export type IngestionModel = {
-  readLocation(type: string, target: string): Promise<ReaderOutput[]>;
-};
-
-export type HigherOrderOperation = {
-  addLocation(spec: LocationSpec): Promise<AddLocationResult>;
-};
+export type Location = {
+  id: string;
+} & LocationSpec;

--- a/packages/catalog-model/src/location/validation.ts
+++ b/packages/catalog-model/src/location/validation.ts
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-import type { Entity, Location, LocationSpec } from '@backstage/catalog-model';
-import type { ReaderOutput } from './descriptor/parsers/types';
+import * as yup from 'yup';
+import { LocationSpec, Location } from './types';
 
-export type AddLocationResult = {
-  location: Location;
-  entities: Entity[];
-};
+export const locationSpecSchema = yup
+  .object<LocationSpec>({
+    type: yup.string().required(),
+    target: yup.string().required(),
+  })
+  .noUnknown();
 
-export type IngestionModel = {
-  readLocation(type: string, target: string): Promise<ReaderOutput[]>;
-};
-
-export type HigherOrderOperation = {
-  addLocation(spec: LocationSpec): Promise<AddLocationResult>;
-};
+export const locationSchema = yup
+  .object<Location>({
+    id: yup.string().required(),
+    type: yup.string().required(),
+    target: yup.string().required(),
+  })
+  .noUnknown();

--- a/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.test.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import type { Entity, EntityPolicy } from '@backstage/catalog-model';
+import type { Entity } from '@backstage/catalog-model';
 import type { Database } from '../database';
 import { DatabaseEntitiesCatalog } from './DatabaseEntitiesCatalog';
 
 describe('DatabaseEntitiesCatalog', () => {
   let db: jest.Mocked<Database>;
-  let policy: EntityPolicy;
 
   beforeEach(() => {
     db = {
@@ -38,7 +37,6 @@ describe('DatabaseEntitiesCatalog', () => {
       addLocationUpdateLogEvent: jest.fn(),
     };
     db.transaction.mockImplementation(async f => f('tx'));
-    policy = { enforce: jest.fn(async x => x) };
   });
 
   describe('addOrUpdateEntity', () => {
@@ -55,10 +53,9 @@ describe('DatabaseEntitiesCatalog', () => {
       db.entities.mockResolvedValue([]);
       db.addEntity.mockResolvedValue({ entity });
 
-      const catalog = new DatabaseEntitiesCatalog(db, policy);
+      const catalog = new DatabaseEntitiesCatalog(db);
       const result = await catalog.addOrUpdateEntity(entity);
 
-      expect(policy.enforce).toBeCalledWith(entity);
       expect(db.entities).toHaveBeenCalledTimes(1);
       expect(db.addEntity).toHaveBeenCalledTimes(1);
       expect(result).toBe(entity);
@@ -78,10 +75,9 @@ describe('DatabaseEntitiesCatalog', () => {
       db.entities.mockResolvedValue([]);
       db.updateEntity.mockResolvedValue({ entity });
 
-      const catalog = new DatabaseEntitiesCatalog(db, policy);
+      const catalog = new DatabaseEntitiesCatalog(db);
       const result = await catalog.addOrUpdateEntity(entity);
 
-      expect(policy.enforce).toBeCalledWith(entity);
       expect(db.entities).toHaveBeenCalledTimes(0);
       expect(db.updateEntity).toHaveBeenCalledTimes(1);
       expect(result).toBe(entity);
@@ -108,10 +104,9 @@ describe('DatabaseEntitiesCatalog', () => {
       db.entities.mockResolvedValue([{ entity: existing }]);
       db.updateEntity.mockResolvedValue({ entity: added });
 
-      const catalog = new DatabaseEntitiesCatalog(db, policy);
+      const catalog = new DatabaseEntitiesCatalog(db);
       const result = await catalog.addOrUpdateEntity(added);
 
-      expect(policy.enforce).toBeCalledWith(added);
       expect(db.entities).toHaveBeenCalledTimes(1);
       expect(db.updateEntity).toHaveBeenCalledTimes(1);
       expect(result).toEqual(existing);

--- a/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.test.ts
@@ -21,7 +21,7 @@ import { DatabaseEntitiesCatalog } from './DatabaseEntitiesCatalog';
 describe('DatabaseEntitiesCatalog', () => {
   let db: jest.Mocked<Database>;
 
-  beforeEach(() => {
+  beforeAll(() => {
     db = {
       transaction: jest.fn(),
       addEntity: jest.fn(),
@@ -36,6 +36,10 @@ describe('DatabaseEntitiesCatalog', () => {
       locationHistory: jest.fn(),
       addLocationUpdateLogEvent: jest.fn(),
     };
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
     db.transaction.mockImplementation(async f => f('tx'));
   });
 

--- a/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
@@ -49,13 +49,16 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
     );
   }
 
-  async addOrUpdateEntity(entity: Entity): Promise<Entity> {
+  async addOrUpdateEntity(
+    entity: Entity,
+    locationId?: string,
+  ): Promise<Entity> {
     await this.policy.enforce(entity);
     return await this.database.transaction(async tx => {
       let response: DbEntityResponse;
 
       if (entity.metadata.uid) {
-        response = await this.database.updateEntity(tx, { entity });
+        response = await this.database.updateEntity(tx, { locationId, entity });
       } else {
         const existing = await this.entityByNameInternal(
           tx,
@@ -64,9 +67,12 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
           entity.metadata.namespace,
         );
         if (existing) {
-          response = await this.database.updateEntity(tx, { entity });
+          response = await this.database.updateEntity(tx, {
+            locationId,
+            entity,
+          });
         } else {
-          response = await this.database.addEntity(tx, { entity });
+          response = await this.database.addEntity(tx, { locationId, entity });
         }
       }
 

--- a/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-import type { Entity, EntityPolicy } from '@backstage/catalog-model';
+import type { Entity } from '@backstage/catalog-model';
 import type { Database, DbEntityResponse, EntityFilters } from '../database';
 import type { EntitiesCatalog } from './types';
 
 export class DatabaseEntitiesCatalog implements EntitiesCatalog {
-  constructor(
-    private readonly database: Database,
-    private readonly policy: EntityPolicy,
-  ) {}
+  constructor(private readonly database: Database) {}
 
   async entities(filters?: EntityFilters): Promise<Entity[]> {
     const items = await this.database.transaction(tx =>
@@ -53,7 +50,6 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
     entity: Entity,
     locationId?: string,
   ): Promise<Entity> {
-    await this.policy.enforce(entity);
     return await this.database.transaction(async tx => {
       let response: DbEntityResponse;
 

--- a/plugins/catalog-backend/src/catalog/DatabaseLocationsCatalog.test.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseLocationsCatalog.test.ts
@@ -13,73 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { getVoidLogger } from '@backstage/backend-common';
-import type { Entity } from '@backstage/catalog-model';
 import Knex from 'knex';
 import path from 'path';
 import { CommonDatabase } from '../database';
-import type { Database } from '../database';
-import type { IngestionModel } from '../ingestion/types';
 import { DatabaseLocationsCatalog } from './DatabaseLocationsCatalog';
 
-class MockIngestionModel implements IngestionModel {
-  readLocation = jest.fn(async (type: string, target: string) => {
-    if (type !== 'valid_type') {
-      throw new Error(`Unknown location type ${type}`);
-    }
-    if (target === 'valid_target') {
-      return [{ type: 'data', data: {} as Entity } as const];
-    }
-    throw new Error(
-      `Can't read location at ${target} with error: Something is broken`,
-    );
-  });
-}
-
 describe('DatabaseLocationsCatalog', () => {
-  const knex = Knex({
-    client: 'sqlite3',
-    connection: ':memory:',
-    useNullAsDefault: true,
-  });
-  knex.client.pool.on('createSuccess', (_eventId: any, resource: any) => {
-    resource.run('PRAGMA foreign_keys = ON', () => {});
-  });
-  let db: Database;
   let catalog: DatabaseLocationsCatalog;
-  let ingestionModel: IngestionModel;
 
   beforeEach(async () => {
+    const knex = Knex({
+      client: 'sqlite3',
+      connection: ':memory:',
+      useNullAsDefault: true,
+    });
+    knex.client.pool.on('createSuccess', (_eventId: any, resource: any) => {
+      resource.run('PRAGMA foreign_keys = ON', () => {});
+    });
     await knex.migrate.latest({
       directory: path.resolve(__dirname, '../database/migrations'),
       loadExtensions: ['.ts'],
     });
-    db = new CommonDatabase(knex, getVoidLogger());
-    ingestionModel = new MockIngestionModel();
-    catalog = new DatabaseLocationsCatalog(db, ingestionModel);
+    const db = new CommonDatabase(knex, getVoidLogger());
+    catalog = new DatabaseLocationsCatalog(db);
   });
 
-  it('resolves to location with id', async () => {
-    return expect(
-      catalog.addLocation({ type: 'valid_type', target: 'valid_target' }),
-    ).resolves.toEqual({
-      id: expect.anything(),
+  it('can add a location', async () => {
+    const location = {
+      id: 'dd12620d-0436-422f-93bd-929aa0788123',
       type: 'valid_type',
       target: 'valid_target',
-    });
-  });
-  it('rejects for invalid type', async () => {
-    const type = 'invalid_type';
-    return expect(
-      catalog.addLocation({ type, target: 'valid_target' }),
-    ).rejects.toThrow(/Unknown location type/);
-  });
-  it('rejects for unreadable target ', async () => {
-    const target = 'invalid_target';
-    return expect(
-      catalog.addLocation({ type: 'valid_type', target }),
-    ).rejects.toThrow(
-      `Can't read location at ${target} with error: Something is broken`,
-    );
+    };
+    await expect(catalog.addLocation(location)).resolves.toEqual(location);
+    await expect(
+      catalog.location('dd12620d-0436-422f-93bd-929aa0788123'),
+    ).resolves.toEqual(expect.objectContaining({ data: location }));
+    await expect(catalog.locations()).resolves.toEqual([
+      expect.objectContaining({ data: location }),
+    ]);
   });
 });

--- a/plugins/catalog-backend/src/catalog/DatabaseLocationsCatalog.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseLocationsCatalog.ts
@@ -16,38 +16,12 @@
 
 import type { Database } from '../database';
 import { DatabaseLocationUpdateLogEvent } from '../database/types';
-import { IngestionModel } from '../ingestion/types';
-import {
-  AddLocation,
-  Location,
-  LocationResponse,
-  LocationsCatalog,
-} from './types';
+import { Location, LocationResponse, LocationsCatalog } from './types';
 
 export class DatabaseLocationsCatalog implements LocationsCatalog {
-  constructor(
-    private readonly database: Database,
-    private readonly ingestionModel: IngestionModel,
-  ) {}
+  constructor(private readonly database: Database) {}
 
-  async addLocation(location: AddLocation): Promise<Location> {
-    const outputs = await this.ingestionModel.readLocation(
-      location.type,
-      location.target,
-    );
-    if (!outputs) {
-      throw new Error(
-        `Unknown location type ${location.type} ${location.target}`,
-      );
-    }
-    outputs.forEach(output => {
-      if (output.type === 'error') {
-        throw new Error(
-          `Can't read location at ${location.target}, ${output.error}`,
-        );
-      }
-    });
-
+  async addLocation(location: Location): Promise<Location> {
     const added = await this.database.addLocation(location);
     return added;
   }

--- a/plugins/catalog-backend/src/catalog/DatabaseLocationsCatalog.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseLocationsCatalog.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { Location } from '@backstage/catalog-model';
 import type { Database } from '../database';
 import { DatabaseLocationUpdateLogEvent } from '../database/types';
-import { Location, LocationResponse, LocationsCatalog } from './types';
+import { LocationResponse, LocationsCatalog } from './types';
 
 export class DatabaseLocationsCatalog implements LocationsCatalog {
   constructor(private readonly database: Database) {}

--- a/plugins/catalog-backend/src/catalog/index.ts
+++ b/plugins/catalog-backend/src/catalog/index.ts
@@ -17,9 +17,4 @@
 export { DatabaseEntitiesCatalog } from './DatabaseEntitiesCatalog';
 export { DatabaseLocationsCatalog } from './DatabaseLocationsCatalog';
 export { StaticEntitiesCatalog } from './StaticEntitiesCatalog';
-export type {
-  EntitiesCatalog,
-  Location,
-  LocationsCatalog,
-  LocationSpec,
-} from './types';
+export type { EntitiesCatalog, LocationsCatalog } from './types';

--- a/plugins/catalog-backend/src/catalog/index.ts
+++ b/plugins/catalog-backend/src/catalog/index.ts
@@ -17,10 +17,9 @@
 export { DatabaseEntitiesCatalog } from './DatabaseEntitiesCatalog';
 export { DatabaseLocationsCatalog } from './DatabaseLocationsCatalog';
 export { StaticEntitiesCatalog } from './StaticEntitiesCatalog';
-export { addLocationSchema } from './types';
 export type {
-  AddLocation,
   EntitiesCatalog,
   Location,
   LocationsCatalog,
+  LocationSpec,
 } from './types';

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -15,7 +15,6 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import * as yup from 'yup';
 import type { EntityFilters } from '../database';
 
 //
@@ -52,31 +51,22 @@ export type LocationUpdateLogEvent = {
   message?: string;
 };
 
-export type Location = {
-  id: string;
+export type LocationSpec = {
   type: string;
   target: string;
 };
+
+export type Location = {
+  id: string;
+} & LocationSpec;
 
 export type LocationResponse = {
   data: Location;
   currentStatus: LocationUpdateStatus;
 };
 
-export type AddLocation = {
-  type: string;
-  target: string;
-};
-
-export const addLocationSchema: yup.Schema<AddLocation> = yup
-  .object({
-    type: yup.string().required(),
-    target: yup.string().required(),
-  })
-  .noUnknown();
-
 export type LocationsCatalog = {
-  addLocation(location: AddLocation): Promise<Location>;
+  addLocation(location: Location): Promise<Location>;
   removeLocation(id: string): Promise<void>;
   locations(): Promise<LocationResponse[]>;
   location(id: string): Promise<LocationResponse>;

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -30,7 +30,7 @@ export type EntitiesCatalog = {
     namespace: string | undefined,
     name: string,
   ): Promise<Entity | undefined>;
-  addOrUpdateEntity(entity: Entity): Promise<Entity>;
+  addOrUpdateEntity(entity: Entity, locationId?: string): Promise<Entity>;
   removeEntityByUid(uid: string): Promise<void>;
 };
 

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
+import { Entity, Location } from '@backstage/catalog-model';
 import type { EntityFilters } from '../database';
 
 //
@@ -50,15 +50,6 @@ export type LocationUpdateLogEvent = {
   created_at?: string;
   message?: string;
 };
-
-export type LocationSpec = {
-  type: string;
-  target: string;
-};
-
-export type Location = {
-  id: string;
-} & LocationSpec;
 
 export type LocationResponse = {
   data: Location;

--- a/plugins/catalog-backend/src/database/CommonDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.test.ts
@@ -22,13 +22,12 @@ import {
 import type { Entity } from '@backstage/catalog-model';
 import Knex from 'knex';
 import path from 'path';
+import { Location } from '../catalog';
 import { CommonDatabase } from './CommonDatabase';
 import { DatabaseLocationUpdateLogStatus } from './types';
 import type {
-  AddDatabaseLocation,
   DbEntityRequest,
   DbEntityResponse,
-  DbLocationsRow,
   DbLocationsRowWithStatus,
 } from './types';
 
@@ -87,9 +86,13 @@ describe('CommonDatabase', () => {
 
   it('manages locations', async () => {
     const db = new CommonDatabase(knex, getVoidLogger());
-    const input: AddDatabaseLocation = { type: 'a', target: 'b' };
+    const input: Location = {
+      id: 'dd12620d-0436-422f-93bd-929aa0788123',
+      type: 'a',
+      target: 'b',
+    };
     const output: DbLocationsRowWithStatus = {
-      id: expect.anything(),
+      id: 'dd12620d-0436-422f-93bd-929aa0788123',
       type: 'a',
       target: 'b',
       message: null,
@@ -110,22 +113,6 @@ describe('CommonDatabase', () => {
     await expect(db.location(locations[0].id)).rejects.toThrow(
       /Found no location/,
     );
-  });
-
-  it('instead of adding second location with the same target, returns existing one', async () => {
-    // Prepare
-    const catalog = new CommonDatabase(knex, getVoidLogger());
-    const input: AddDatabaseLocation = { type: 'a', target: 'b' };
-    const output1: DbLocationsRow = await catalog.addLocation(input);
-
-    // Try to insert the same location
-    const output2: DbLocationsRow = await catalog.addLocation(input);
-    const locations = await catalog.locations();
-
-    // Output is the same
-    expect(output2).toEqual(output1);
-    // Locations contain only one record
-    expect(locations[0]).toMatchObject(output1);
   });
 
   describe('addEntity', () => {
@@ -160,27 +147,33 @@ describe('CommonDatabase', () => {
   describe('locationHistory', () => {
     it('outputs the history correctly', async () => {
       const catalog = new CommonDatabase(knex, getVoidLogger());
-      const location: AddDatabaseLocation = { type: 'a', target: 'b' };
-      const { id: locationId } = await catalog.addLocation(location);
+      const location: Location = {
+        id: 'dd12620d-0436-422f-93bd-929aa0788123',
+        type: 'a',
+        target: 'b',
+      };
+      await catalog.addLocation(location);
 
       await catalog.addLocationUpdateLogEvent(
-        locationId,
+        'dd12620d-0436-422f-93bd-929aa0788123',
         DatabaseLocationUpdateLogStatus.SUCCESS,
       );
       await catalog.addLocationUpdateLogEvent(
-        locationId,
+        'dd12620d-0436-422f-93bd-929aa0788123',
         DatabaseLocationUpdateLogStatus.FAIL,
         undefined,
         'Something went wrong',
       );
 
-      const result = await catalog.locationHistory(locationId);
+      const result = await catalog.locationHistory(
+        'dd12620d-0436-422f-93bd-929aa0788123',
+      );
       expect(result).toEqual([
         {
           created_at: expect.anything(),
           entity_name: null,
           id: expect.anything(),
-          location_id: locationId,
+          location_id: 'dd12620d-0436-422f-93bd-929aa0788123',
           message: null,
           status: DatabaseLocationUpdateLogStatus.SUCCESS,
         },
@@ -188,7 +181,7 @@ describe('CommonDatabase', () => {
           created_at: expect.anything(),
           entity_name: null,
           id: expect.anything(),
-          location_id: locationId,
+          location_id: 'dd12620d-0436-422f-93bd-929aa0788123',
           message: 'Something went wrong',
           status: DatabaseLocationUpdateLogStatus.FAIL,
         },

--- a/plugins/catalog-backend/src/database/CommonDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.test.ts
@@ -19,10 +19,9 @@ import {
   getVoidLogger,
   NotFoundError,
 } from '@backstage/backend-common';
-import type { Entity } from '@backstage/catalog-model';
+import type { Entity, Location } from '@backstage/catalog-model';
 import Knex from 'knex';
 import path from 'path';
-import { Location } from '../catalog';
 import { CommonDatabase } from './CommonDatabase';
 import { DatabaseLocationUpdateLogStatus } from './types';
 import type {

--- a/plugins/catalog-backend/src/database/CommonDatabase.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.ts
@@ -19,7 +19,7 @@ import {
   InputError,
   NotFoundError,
 } from '@backstage/backend-common';
-import type { Entity, EntityMeta } from '@backstage/catalog-model';
+import type { Entity, EntityMeta, Location } from '@backstage/catalog-model';
 import Knex from 'knex';
 import lodash from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
@@ -37,7 +37,6 @@ import type {
   DbLocationsRowWithStatus,
   EntityFilters,
 } from './types';
-import { Location } from '../catalog';
 
 function getStrippedMetadata(metadata: EntityMeta): EntityMeta {
   const output = lodash.cloneDeep(metadata);

--- a/plugins/catalog-backend/src/database/migrations/20200511113813_init.ts
+++ b/plugins/catalog-backend/src/database/migrations/20200511113813_init.ts
@@ -26,7 +26,11 @@ export async function up(knex: Knex): Promise<any> {
         table.comment(
           'Registered locations that shall be contiuously scanned for catalog item updates',
         );
-        table.uuid('id').primary().comment('Auto-generated ID of the location');
+        table
+          .uuid('id')
+          .primary()
+          .notNullable()
+          .comment('Auto-generated ID of the location');
         table.string('type').notNullable().comment('The type of location');
         table
           .string('target')

--- a/plugins/catalog-backend/src/database/types.ts
+++ b/plugins/catalog-backend/src/database/types.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import type { Entity } from '@backstage/catalog-model';
-import { Location } from '../catalog';
+import type { Entity, Location } from '@backstage/catalog-model';
 
 export type DbEntitiesRow = {
   id: string;

--- a/plugins/catalog-backend/src/database/types.ts
+++ b/plugins/catalog-backend/src/database/types.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Entity } from '@backstage/catalog-model';
-import * as yup from 'yup';
+import { Location } from '../catalog';
 
 export type DbEntitiesRow = {
   id: string;
@@ -57,18 +57,6 @@ export type DbLocationsRowWithStatus = DbLocationsRow & {
   timestamp: string | null;
   message: string | null;
 };
-
-export type AddDatabaseLocation = {
-  type: string;
-  target: string;
-};
-
-export const addDatabaseLocationSchema: yup.Schema<AddDatabaseLocation> = yup
-  .object({
-    type: yup.string().required(),
-    target: yup.string().required(),
-  })
-  .noUnknown();
 
 export enum DatabaseLocationUpdateLogStatus {
   FAIL = 'fail',
@@ -145,7 +133,7 @@ export type Database = {
 
   removeEntity(tx: unknown, uid: string): Promise<void>;
 
-  addLocation(location: AddDatabaseLocation): Promise<DbLocationsRow>;
+  addLocation(location: Location): Promise<DbLocationsRow>;
 
   removeLocation(id: string): Promise<void>;
 

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.test.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EntitiesCatalog, LocationsCatalog } from '../catalog';
+import { IngestionModel } from './types';
+import { HigherOrderOperations } from './HigherOrderOperations';
+import { Entity } from '@backstage/catalog-model';
+
+describe('HigherOrderOperations', () => {
+  let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
+  let locationsCatalog: jest.Mocked<LocationsCatalog>;
+  let ingestionModel: jest.Mocked<IngestionModel>;
+  let higherOrderOperation: HigherOrderOperations;
+
+  beforeAll(() => {
+    entitiesCatalog = {
+      entities: jest.fn(),
+      entityByUid: jest.fn(),
+      entityByName: jest.fn(),
+      addOrUpdateEntity: jest.fn(),
+      removeEntityByUid: jest.fn(),
+    };
+    locationsCatalog = {
+      addLocation: jest.fn(),
+      removeLocation: jest.fn(),
+      locations: jest.fn(),
+      location: jest.fn(),
+      locationHistory: jest.fn(),
+    };
+    ingestionModel = {
+      readLocation: jest.fn(),
+    };
+    higherOrderOperation = new HigherOrderOperations(
+      entitiesCatalog,
+      locationsCatalog,
+      ingestionModel,
+    );
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('addLocation', () => {
+    it('just inserts the location when there are no entities to read', async () => {
+      const spec = {
+        type: 'a',
+        target: 'b',
+      };
+      locationsCatalog.addLocation.mockImplementation(x => Promise.resolve(x));
+      locationsCatalog.locations.mockResolvedValue([]);
+      ingestionModel.readLocation.mockResolvedValue([]);
+
+      const result = await higherOrderOperation.addLocation(spec);
+
+      expect(result.location).toEqual(
+        expect.objectContaining({
+          id: expect.anything(),
+          ...spec,
+        }),
+      );
+      expect(result.entities).toEqual([]);
+      expect(locationsCatalog.locations).toBeCalledTimes(1);
+      expect(ingestionModel.readLocation).toBeCalledTimes(1);
+      expect(ingestionModel.readLocation).toBeCalledWith('a', 'b');
+      expect(entitiesCatalog.addOrUpdateEntity).not.toBeCalled();
+      expect(locationsCatalog.addLocation).toBeCalledTimes(1);
+      expect(locationsCatalog.addLocation).toBeCalledWith(
+        expect.objectContaining({
+          id: expect.anything(),
+          ...spec,
+        }),
+      );
+    });
+
+    it('reuses the location if a match already existed', async () => {
+      const spec = {
+        type: 'a',
+        target: 'b',
+      };
+      const location = {
+        id: 'dd12620d-0436-422f-93bd-929aa0788123',
+        ...spec,
+      };
+
+      locationsCatalog.locations.mockResolvedValue([
+        {
+          currentStatus: { timestamp: '', status: '', message: '' },
+          data: location,
+        },
+      ]);
+      ingestionModel.readLocation.mockResolvedValue([]);
+
+      const result = await higherOrderOperation.addLocation(spec);
+
+      expect(result.location).toEqual(location);
+      expect(result.entities).toEqual([]);
+      expect(locationsCatalog.locations).toBeCalledTimes(1);
+      expect(ingestionModel.readLocation).toBeCalledTimes(1);
+      expect(ingestionModel.readLocation).toBeCalledWith('a', 'b');
+      expect(entitiesCatalog.addOrUpdateEntity).not.toBeCalled();
+      expect(locationsCatalog.addLocation).not.toBeCalled();
+    });
+
+    it('rejects the whole operation if any entity could not be read', async () => {
+      const spec = {
+        type: 'a',
+        target: 'b',
+      };
+      const entity: Entity = {
+        apiVersion: 'a',
+        kind: 'b',
+        metadata: { name: 'n' },
+      };
+
+      locationsCatalog.locations.mockResolvedValue([]);
+      ingestionModel.readLocation.mockResolvedValue([
+        { type: 'data', data: entity },
+        { type: 'error', error: new Error('abcd') },
+      ]);
+
+      await expect(higherOrderOperation.addLocation(spec)).rejects.toThrow(
+        /abcd/,
+      );
+      expect(locationsCatalog.locations).toBeCalledTimes(1);
+      expect(entitiesCatalog.addOrUpdateEntity).not.toBeCalled();
+      expect(locationsCatalog.addLocation).not.toBeCalled();
+    });
+  });
+});

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
@@ -15,14 +15,9 @@
  */
 
 import { InputError } from '@backstage/backend-common';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, Location, LocationSpec } from '@backstage/catalog-model';
 import { v4 as uuidv4 } from 'uuid';
-import {
-  EntitiesCatalog,
-  Location,
-  LocationsCatalog,
-  LocationSpec,
-} from '../catalog';
+import { EntitiesCatalog, LocationsCatalog } from '../catalog';
 import { IngestionModel } from '../ingestion';
 import { AddLocationResult, HigherOrderOperation } from './types';
 

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/backend-common';
+import { Entity } from '@backstage/catalog-model';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  EntitiesCatalog,
+  Location,
+  LocationsCatalog,
+  LocationSpec,
+} from '../catalog';
+import { IngestionModel } from '../ingestion';
+import { AddLocationResult, HigherOrderOperation } from './types';
+
+const LOCATION_ANNOTATION = 'backstage.io/managed-by-location';
+
+/**
+ * Placeholder for operations that span several catalogs and/or stretches out
+ * in time.
+ *
+ * TODO(freben): Find a better home for these, possibly refactoring to use the
+ * database more directly.
+ */
+export class HigherOrderOperations implements HigherOrderOperation {
+  private readonly entitiesCatalog: EntitiesCatalog;
+  private readonly locationsCatalog: LocationsCatalog;
+  private readonly ingestionModel: IngestionModel;
+
+  constructor(
+    entitiesCatalog: EntitiesCatalog,
+    locationsCatalog: LocationsCatalog,
+    ingestionModel: IngestionModel,
+  ) {
+    this.entitiesCatalog = entitiesCatalog;
+    this.locationsCatalog = locationsCatalog;
+    this.ingestionModel = ingestionModel;
+  }
+
+  /**
+   * Adds a single location to the catalog.
+   *
+   * The location is inspected and fetched, and all of the resulting data is
+   * validated. If everything goes well, the location and entities are stored
+   * in the catalog.
+   *
+   * If the location already existed, the old location is returned instead and
+   * the catalog is left unchanged.
+   *
+   * @param spec The location to add
+   */
+  async addLocation(spec: LocationSpec): Promise<AddLocationResult> {
+    // Attempt to find a previous location matching the spec
+    const previousLocations = await this.locationsCatalog.locations();
+    const previousLocation = previousLocations.find(
+      l => spec.type === l.data.type && spec.target === l.data.target,
+    );
+    const location: Location = previousLocation
+      ? previousLocation.data
+      : {
+          id: uuidv4(),
+          type: spec.type,
+          target: spec.target,
+        };
+
+    // Read the location fully, bailing on any errors
+    const readerOutput = await this.ingestionModel.readLocation(
+      location.type,
+      location.target,
+    );
+    const inputEntities: Entity[] = [];
+    for (const entry of readerOutput) {
+      if (entry.type === 'error') {
+        throw new InputError(
+          `Failed to read location ${location.type} ${location.target}, ${entry.error}`,
+        );
+      } else {
+        // Append the location reference annotation
+        entry.data.metadata.annotations = {
+          ...entry.data.metadata.annotations,
+          [LOCATION_ANNOTATION]: location.id,
+        };
+        inputEntities.push(entry.data);
+      }
+    }
+
+    // TODO(freben): At this point, we could detect orphaned entities, by way
+    // of having a LOCATION_ANNOTATION pointing to the location but not being
+    // in the entities list. But we aren't sure what to do about those yet.
+
+    // Write
+    if (!previousLocation) {
+      await this.locationsCatalog.addLocation(location);
+    }
+    const outputEntities: Entity[] = [];
+    for (const entity of inputEntities) {
+      const out = await this.entitiesCatalog.addOrUpdateEntity(
+        entity,
+        location.id,
+      );
+      outputEntities.push(out);
+    }
+
+    return { location, entities: outputEntities };
+  }
+}

--- a/plugins/catalog-backend/src/ingestion/index.ts
+++ b/plugins/catalog-backend/src/ingestion/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from './descriptor';
+export { HigherOrderOperations } from './HigherOrderOperations';
 export { IngestionModels } from './IngestionModels';
 export * from './source';
 export type { IngestionModel } from './types';

--- a/plugins/catalog-backend/src/ingestion/types.ts
+++ b/plugins/catalog-backend/src/ingestion/types.ts
@@ -14,8 +14,19 @@
  * limitations under the License.
  */
 
+import { Entity } from '@backstage/catalog-model';
+import { Location, LocationSpec } from '../catalog';
 import { ReaderOutput } from './descriptor/parsers/types';
+
+export type AddLocationResult = {
+  location: Location;
+  entities: Entity[];
+};
 
 export type IngestionModel = {
   readLocation(type: string, target: string): Promise<ReaderOutput[]>;
+};
+
+export type HigherOrderOperation = {
+  addLocation(spec: LocationSpec): Promise<AddLocationResult>;
 };

--- a/plugins/catalog-backend/src/service/router.test.ts
+++ b/plugins/catalog-backend/src/service/router.test.ts
@@ -15,10 +15,10 @@
  */
 
 import { getVoidLogger, NotFoundError } from '@backstage/backend-common';
-import type { Entity } from '@backstage/catalog-model';
+import type { Entity, LocationSpec } from '@backstage/catalog-model';
 import express from 'express';
 import request from 'supertest';
-import { EntitiesCatalog, LocationsCatalog, LocationSpec } from '../catalog';
+import { EntitiesCatalog, LocationsCatalog } from '../catalog';
 import { LocationResponse } from '../catalog/types';
 import { HigherOrderOperation } from '../ingestion/types';
 import { createRouter } from './router';
@@ -29,7 +29,7 @@ describe('createRouter', () => {
   let higherOrderOperation: jest.Mocked<HigherOrderOperation>;
   let app: express.Express;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     entitiesCatalog = {
       entities: jest.fn(),
       entityByUid: jest.fn(),
@@ -54,6 +54,10 @@ describe('createRouter', () => {
       logger: getVoidLogger(),
     });
     app = express().use(router);
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
   });
 
   describe('GET /entities', () => {

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -15,12 +15,12 @@
  */
 
 import { errorHandler, InputError } from '@backstage/backend-common';
-import { Entity } from '@backstage/catalog-model';
+import { locationSpecSchema } from '@backstage/catalog-model';
+import type { Entity } from '@backstage/catalog-model';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
-import * as yup from 'yup';
-import { EntitiesCatalog, LocationsCatalog, LocationSpec } from '../catalog';
+import { EntitiesCatalog, LocationsCatalog } from '../catalog';
 import { EntityFilters } from '../database';
 import { HigherOrderOperation } from '../ingestion/types';
 import { requireRequestBody, validateRequestBody } from './util';
@@ -31,13 +31,6 @@ export interface RouterOptions {
   higherOrderOperation?: HigherOrderOperation;
   logger: Logger;
 }
-
-const addLocationSchema = yup
-  .object<LocationSpec>({
-    type: yup.string().required(),
-    target: yup.string().required(),
-  })
-  .noUnknown();
 
 export async function createRouter(
   options: RouterOptions,
@@ -92,7 +85,7 @@ export async function createRouter(
 
   if (higherOrderOperation) {
     router.post('/locations', async (req, res) => {
-      const input = await validateRequestBody(req, addLocationSchema);
+      const input = await validateRequestBody(req, locationSpecSchema);
       const output = await higherOrderOperation.addLocation(input);
       res.status(201).send(output);
     });


### PR DESCRIPTION
Now when adding a location, it will be handled by a new HigherOrderOperations class that acts on the catalogs as seen "from the outside", through their public interfaces. It will fetch and validate everything, and only add them to the database if everything is fine.

The catalogs themselves have been reduced to pretty much only handling basic CRUD without much logic.

The refresh loop will get a similar treatment in an upcoming PR, by being moved out as a higher order operation on the catalogs.