### PR TITLE
Make local start of catalog work

### DIFF
--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "start": "tsc-watch --onFirstSuccess \"cross-env NODE_ENV=development nodemon dist/run.js\"",
+    "start": "backstage-cli watch-deps --build -- tsc-watch --onFirstSuccess \\\"cross-env NODE_ENV=development nodemon -r esm dist/run.js\\\"",
     "build": "tsc",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
@@ -19,6 +19,7 @@
     "@backstage/catalog-model": "^0.1.1-alpha.6",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
+    "esm": "^3.2.25",
     "express": "^4.17.1",
     "express-promise-router": "^3.0.3",
     "fs-extra": "^9.0.0",

--- a/plugins/catalog-backend/src/ingestion/index.ts
+++ b/plugins/catalog-backend/src/ingestion/index.ts
@@ -18,4 +18,4 @@ export * from './descriptor';
 export { HigherOrderOperations } from './HigherOrderOperations';
 export { IngestionModels } from './IngestionModels';
 export * from './source';
-export type { IngestionModel } from './types';
+export type { HigherOrderOperation, IngestionModel } from './types';

--- a/plugins/catalog-backend/src/service/standaloneApplication.ts
+++ b/plugins/catalog-backend/src/service/standaloneApplication.ts
@@ -25,19 +25,27 @@ import express from 'express';
 import helmet from 'helmet';
 import { Logger } from 'winston';
 import { EntitiesCatalog, LocationsCatalog } from '../catalog';
+import { HigherOrderOperation } from '../ingestion';
 import { createRouter } from './router';
 
 export interface ApplicationOptions {
   enableCors: boolean;
   entitiesCatalog: EntitiesCatalog;
   locationsCatalog?: LocationsCatalog;
+  higherOrderOperation?: HigherOrderOperation;
   logger: Logger;
 }
 
 export async function createStandaloneApplication(
   options: ApplicationOptions,
 ): Promise<express.Application> {
-  const { enableCors, entitiesCatalog, locationsCatalog, logger } = options;
+  const {
+    enableCors,
+    entitiesCatalog,
+    locationsCatalog,
+    higherOrderOperation,
+    logger,
+  } = options;
   const app = express();
 
   app.use(helmet());
@@ -49,7 +57,12 @@ export async function createStandaloneApplication(
   app.use(requestLoggingHandler());
   app.use(
     '/',
-    await createRouter({ entitiesCatalog, locationsCatalog, logger }),
+    await createRouter({
+      entitiesCatalog,
+      locationsCatalog,
+      higherOrderOperation,
+      logger,
+    }),
   );
   app.use(notFoundHandler());
   app.use(errorHandler());


### PR DESCRIPTION
You still need to do `yarn install` and `yarn tsc` at the root first, unfortunately. But at least it now builds dependencies as intended.