### PR TITLE
Auth: fix logout()

### DIFF
--- a/packages/core-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
+++ b/packages/core-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
@@ -76,7 +76,7 @@ describe('DefaultAuthConnector', () => {
 
     const helper = new DefaultAuthConnector(defaultOptions);
     await expect(helper.refreshSession()).rejects.toThrow(
-      'Auth refresh request failed with status NOPE',
+      'Auth refresh request failed, NOPE',
     );
   });
 

--- a/packages/core-api/src/lib/AuthConnector/DefaultAuthConnector.ts
+++ b/packages/core-api/src/lib/AuthConnector/DefaultAuthConnector.ts
@@ -115,7 +115,7 @@ export class DefaultAuthConnector<AuthSession>
 
     if (!res.ok) {
       const error: any = new Error(
-        `Auth refresh request failed with status ${res.statusText}`,
+        `Auth refresh request failed, ${res.statusText}`,
       );
       error.status = res.status;
       throw error;
@@ -140,10 +140,14 @@ export class DefaultAuthConnector<AuthSession>
         'x-requested-with': 'XMLHttpRequest',
       },
       credentials: 'include',
+    }).catch(error => {
+      throw new Error(`Logout request failed, ${error}`);
     });
 
     if (!res.ok) {
-      throw new Error(`Logout request failed with status ${res.status}`);
+      const error: any = new Error(`Logout request failed, ${res.statusText}`);
+      error.status = res.status;
+      throw error;
     }
   }
 

--- a/plugins/auth-backend/src/providers/factories.ts
+++ b/plugins/auth-backend/src/providers/factories.ts
@@ -42,7 +42,7 @@ export const createAuthProviderRouter = (config: AuthProviderConfig) => {
   router.get('/start', provider.start.bind(provider));
   router.get('/handler/frame', provider.frameHandler.bind(provider));
   router.post('/handler/frame', provider.frameHandler.bind(provider));
-  router.get('/logout', provider.logout.bind(provider));
+  router.post('/logout', provider.logout.bind(provider));
   if (provider.refresh) {
     router.get('/refresh', provider.refresh.bind(provider));
   }


### PR DESCRIPTION
Small changes that uses `post` for `logout()` alongside with small changes in error handling.

Fixes #1136 