### PR TITLE
Auth frontend state

### DIFF
--- a/packages/core-api/src/apis/definitions/auth.ts
+++ b/packages/core-api/src/apis/definitions/auth.ts
@@ -143,6 +143,30 @@ export type OpenIdConnectApi = {
   logout(): Promise<void>;
 };
 
+export type ProfileInfoOptions = {
+  /**
+   * If this is set to true, the user will not be prompted to log in,
+   * and an empty profile will be returned if there is no existing session.
+   *
+   * This can be used to perform a check whether the user is logged in, or if you don't
+   * want to force a user to be logged in, but provide functionality if they already are.
+   *
+   * @default false
+   */
+  optional?: boolean;
+};
+
+export type ProfileInfoApi = {
+  getProfile(options?: ProfileInfoOptions): Promise<ProfileInfo | undefined>;
+};
+
+export type ProfileInfo = {
+  provider: string;
+  email: string;
+  name?: string;
+  picture?: string;
+};
+
 /**
  * Provides authentication towards Google APIs and identities.
  *
@@ -151,7 +175,9 @@ export type OpenIdConnectApi = {
  * Note that the ID token payload is only guaranteed to contain the user's numerical Google ID,
  * email and expiration information. Do not rely on any other fields, as they might not be present.
  */
-export const googleAuthApiRef = createApiRef<OAuthApi & OpenIdConnectApi>({
+export const googleAuthApiRef = createApiRef<
+  OAuthApi & OpenIdConnectApi & ProfileInfoApi
+>({
   id: 'core.auth.google',
   description: 'Provides authentication towards Google APIs and identities',
 });

--- a/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.ts
@@ -22,6 +22,9 @@ import {
   OpenIdConnectApi,
   IdTokenOptions,
   AccessTokenOptions,
+  ProfileInfoApi,
+  ProfileInfoOptions,
+  ProfileInfo,
 } from '../../../definitions/auth';
 import { OAuthRequestApi, AuthProvider } from '../../../definitions';
 import { SessionManager } from '../../../../lib/AuthSessionManager/types';
@@ -39,6 +42,7 @@ type CreateOptions = {
 };
 
 export type GoogleAuthResponse = {
+  profile: any;
   accessToken: string;
   idToken: string;
   scope: string;
@@ -53,7 +57,7 @@ const DEFAULT_PROVIDER = {
 
 const SCOPE_PREFIX = 'https://www.googleapis.com/auth/';
 
-class GoogleAuth implements OAuthApi, OpenIdConnectApi {
+class GoogleAuth implements OAuthApi, OpenIdConnectApi, ProfileInfoApi {
   static create({
     apiOrigin,
     basePath,
@@ -69,6 +73,7 @@ class GoogleAuth implements OAuthApi, OpenIdConnectApi {
       oauthRequestApi: oauthRequestApi,
       sessionTransform(res: GoogleAuthResponse): GoogleSession {
         return {
+          profile: res.profile,
           idToken: res.idToken,
           accessToken: res.accessToken,
           scopes: GoogleAuth.normalizeScopes(res.scope),
@@ -121,6 +126,14 @@ class GoogleAuth implements OAuthApi, OpenIdConnectApi {
 
   async logout() {
     await this.sessionManager.removeSession();
+  }
+
+  async getProfile(options: ProfileInfoOptions = {}) {
+    const session = await this.sessionManager.getSession(options);
+    if (!session) {
+      return undefined;
+    }
+    return session.profile;
   }
 
   static normalizeScopes(scopes?: string | string[]): Set<string> {

--- a/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.ts
@@ -24,6 +24,7 @@ import {
   AccessTokenOptions,
   ProfileInfoApi,
   ProfileInfoOptions,
+  ProfileInfo,
 } from '../../../definitions/auth';
 import { OAuthRequestApi, AuthProvider } from '../../../definitions';
 import { SessionManager } from '../../../../lib/AuthSessionManager/types';
@@ -41,7 +42,7 @@ type CreateOptions = {
 };
 
 export type GoogleAuthResponse = {
-  profile: any;
+  profile: ProfileInfo;
   accessToken: string;
   idToken: string;
   scope: string;

--- a/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.ts
@@ -24,7 +24,6 @@ import {
   AccessTokenOptions,
   ProfileInfoApi,
   ProfileInfoOptions,
-  ProfileInfo,
 } from '../../../definitions/auth';
 import { OAuthRequestApi, AuthProvider } from '../../../definitions';
 import { SessionManager } from '../../../../lib/AuthSessionManager/types';

--- a/packages/core-api/src/apis/implementations/auth/google/types.ts
+++ b/packages/core-api/src/apis/implementations/auth/google/types.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import { ProfileInfo } from '../../../definitions';
+
 export type GoogleSession = {
+  profile: ProfileInfo;
   idToken: string;
   accessToken: string;
   scopes: Set<string>;

--- a/packages/core-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
+++ b/packages/core-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
@@ -117,6 +117,10 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
     window.location.reload(); // TODO(Rugvip): make this work without reload?
   }
 
+  async getCurrentSession() {
+    return this.currentSession;
+  }
+
   private async collapsedSessionRefresh(): Promise<T> {
     if (this.refreshPromise) {
       return this.refreshPromise;

--- a/packages/core/src/layout/Sidebar/LoggedUserBadge.tsx
+++ b/packages/core/src/layout/Sidebar/LoggedUserBadge.tsx
@@ -103,6 +103,7 @@ const SessionListItem: FC<{
     );
   }
 
+  //TODO: Not functional yet to sign in from the sidebar
   if (!user) {
     return (
       <ListItem {...props}>

--- a/packages/core/src/layout/Sidebar/LoggedUserBadge.tsx
+++ b/packages/core/src/layout/Sidebar/LoggedUserBadge.tsx
@@ -28,11 +28,12 @@ import {
   ListItemSecondaryAction,
   IconButton,
   Tooltip,
+  Typography,
 } from '@material-ui/core';
 import { blueGrey } from '@material-ui/core/colors';
 import { useSetState } from 'react-use';
 import { Skeleton } from '@material-ui/lab';
-import { useApi, googleAuthApiRef, ProfileInfo } from '@backstage/core';
+import { useApi, googleAuthApiRef, ProfileInfo } from '@backstage/core-api';
 import LogoutIcon from '@material-ui/icons/PowerSettingsNew';
 import ControlPointIcon from '@material-ui/icons/ControlPoint';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
@@ -90,7 +91,6 @@ const SessionListItem: FC<{
           <Skeleton variant="circle" width={40} height={40} />
         </ListItemIcon>
         <ListItemText
-          className={classes.listItemText}
           primary={<Skeleton component="span" width={120} />}
           secondary={<Skeleton component="span" width={60} />}
         />
@@ -103,16 +103,12 @@ const SessionListItem: FC<{
     );
   }
 
-  //TODO: Not functional yet to sign in from the sidebar
+  // TODO: Not functional yet to sign in from the sidebar
   if (!user) {
     return (
       <ListItem {...props}>
         <ListItemIcon style={{ marginRight: 0 }}>{icon}</ListItemIcon>
-        <ListItemText
-          className={classes.listItemText}
-          primary="Sign In"
-          secondary={title}
-        />
+        <ListItemText primary="Sign In" secondary={title} />
         <ListItemSecondaryAction>
           <Tooltip
             title={`Sign in with ${title}`}
@@ -139,7 +135,11 @@ const SessionListItem: FC<{
       </ListItemAvatar>
       <ListItemText
         className={classes.listItemText}
-        primary={id}
+        primary={
+          <Typography className={classes.listItemText} variant="body2">
+            {id}
+          </Typography>
+        }
         secondary={title}
       />
       <ListItemSecondaryAction style={{ marginLeft: '30px' }}>
@@ -163,25 +163,21 @@ const useGoogleLoginState = (open: boolean) => {
   const [profile, setProfile] = useState<ProfileInfo>();
 
   useEffect(() => {
-    if (!open) {
-      return;
-    }
-
     let didCancel = false;
 
-    googleAuth.getProfile().then(profile => {
-      if (didCancel) {
-        return;
-      }
-
-      setProfile(profile);
-      setLoading(false);
-    });
+    if (open) {
+      googleAuth.getProfile().then(_profile => {
+        if (!didCancel) {
+          setProfile(_profile);
+          setLoading(false);
+        }
+      });
+    }
 
     return () => {
       didCancel = true;
     };
-  }, [open]);
+  }, [open, googleAuth]);
 
   if (loading) {
     return { loading: true };
@@ -261,8 +257,11 @@ export const LoggedUserBadge: FC<Props> = ({
           </ListItemAvatar>
           {!collapsedMode && (
             <ListItemText
-              primary={displayName}
-              className={classes.listItemText}
+              primary={
+                <Typography className={classes.listItemText} variant="body2">
+                  {displayName}
+                </Typography>
+              }
             />
           )}
         </ListItem>

--- a/packages/core/src/layout/Sidebar/UserBadge.tsx
+++ b/packages/core/src/layout/Sidebar/UserBadge.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useContext } from 'react';
+import React, { FC, useContext, useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/core';
 import People from '@material-ui/icons/People';
 import { SidebarContext } from './config';
@@ -23,6 +23,7 @@ import { LoggedUserBadge } from './LoggedUserBadge';
 import DoubleArrowIcon from '@material-ui/icons/DoubleArrow';
 import { BackstageTheme } from '@backstage/theme';
 import { SidebarPinStateContext } from './Page';
+import { useApi, googleAuthApiRef, ProfileInfo } from '@backstage/core';
 
 const ARROW_BUTTON_SIZE = 20;
 const useStyles = makeStyles<BackstageTheme, { isPinned: boolean }>(theme => {
@@ -58,18 +59,30 @@ export const SidebarUserBadge: FC<{}> = () => {
     SidebarPinStateContext,
   );
   const classes = useStyles({ isPinned });
+  const googleAuth = useApi(googleAuthApiRef);
+  const [profile, setProfile] = useState<ProfileInfo>();
 
-  const isUserLoggedIn = false;
+  useEffect(() => {
+    //TODO(soapraj): How to observe if the user is logged in
+    //TODO(soapraj): Enumerate all the providers supported by the app and let user log in from here
+    googleAuth.getProfile({ optional: true }).then(googleProfile => {
+      setProfile(googleProfile);
+    });
+  }, [googleAuth]);
+
   return (
     <div className={classes.root}>
-      {isUserLoggedIn ? (
-        <LoggedUserBadge
-          imageUrl="https://via.placeholder.com/200/200"
-          name="Victor Viale"
-          hideName={!isOpen}
-        />
+      {profile ? (
+        <>
+          <LoggedUserBadge
+            email={profile.email}
+            imageUrl={profile.picture}
+            name={profile.name}
+            collapsedMode={!isOpen}
+          />
+        </>
       ) : (
-        <SidebarItem icon={People} text="Log in" to="/login" disableSelected />
+        <SidebarItem icon={People} text="" disableSelected />
       )}
       {isOpen && (
         <button

--- a/packages/core/src/layout/Sidebar/UserBadge.tsx
+++ b/packages/core/src/layout/Sidebar/UserBadge.tsx
@@ -16,14 +16,14 @@
 
 import React, { FC, useContext, useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/core';
-import People from '@material-ui/icons/People';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import { SidebarContext } from './config';
 import { SidebarItem } from './Items';
 import { LoggedUserBadge } from './LoggedUserBadge';
 import DoubleArrowIcon from '@material-ui/icons/DoubleArrow';
 import { BackstageTheme } from '@backstage/theme';
 import { SidebarPinStateContext } from './Page';
-import { useApi, googleAuthApiRef, ProfileInfo } from '@backstage/core';
+import { useApi, googleAuthApiRef, ProfileInfo } from '@backstage/core-api';
 
 const ARROW_BUTTON_SIZE = 20;
 const useStyles = makeStyles<BackstageTheme, { isPinned: boolean }>(theme => {
@@ -63,8 +63,8 @@ export const SidebarUserBadge: FC<{}> = () => {
   const [profile, setProfile] = useState<ProfileInfo>();
 
   useEffect(() => {
-    //TODO(soapraj): How to observe if the user is logged in
-    //TODO(soapraj): Enumerate all the providers supported by the app and let user log in from here
+    // TODO(soapraj): How to observe if the user is logged in
+    // TODO(soapraj): List all the providers supported by the app and let user log in from here
     googleAuth.getProfile({ optional: true }).then(googleProfile => {
       setProfile(googleProfile);
     });
@@ -82,7 +82,7 @@ export const SidebarUserBadge: FC<{}> = () => {
           />
         </>
       ) : (
-        <SidebarItem icon={People} text="" disableSelected />
+        <SidebarItem icon={AccountCircleIcon} text="" disableSelected />
       )}
       {isOpen && (
         <button

--- a/packages/storybook/.storybook/apis.js
+++ b/packages/storybook/.storybook/apis.js
@@ -2,9 +2,13 @@ import {
   ApiRegistry,
   alertApiRef,
   errorApiRef,
+  oauthRequestApiRef,
+  OAuthRequestManager,
+  googleAuthApiRef,
   AlertApiForwarder,
   ErrorApiForwarder,
   ErrorAlerter,
+  GoogleAuth,
 } from '@backstage/core';
 
 const builder = ApiRegistry.builder();
@@ -12,5 +16,19 @@ const builder = ApiRegistry.builder();
 const alertApi = builder.add(alertApiRef, new AlertApiForwarder());
 
 builder.add(errorApiRef, new ErrorAlerter(alertApi, new ErrorApiForwarder()));
+
+const oauthRequestApi = builder.add(
+  oauthRequestApiRef,
+  new OAuthRequestManager(),
+);
+
+builder.add(
+  googleAuthApiRef,
+  GoogleAuth.create({
+    apiOrigin: 'http://localhost:7000',
+    basePath: '/auth/',
+    oauthRequestApi,
+  }),
+);
 
 export const apis = builder.build();

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -34,7 +34,9 @@
     "passport-google-oauth20": "^2.0.0",
     "passport-saml": "^1.3.3",
     "winston": "^3.2.1",
-    "yn": "^4.0.0"
+    "yn": "^4.0.0",
+    "jwt-decode": "2.2.0",
+    "@types/jwt-decode": "2.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.6",

--- a/plugins/auth-backend/src/providers/OAuthProvider.ts
+++ b/plugins/auth-backend/src/providers/OAuthProvider.ts
@@ -199,7 +199,6 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
   }
 
   async logout(req: express.Request, res: express.Response): Promise<any> {
-    //TODO(soapraj): Logout doesnt work yet
     if (!ensuresXRequestedWith(req)) {
       return res.status(401).send('Invalid X-Requested-With header');
     }
@@ -234,7 +233,6 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
 
       // get new access_token
       const refreshInfo = await this.providerHandlers.refresh(
-        this.provider,
         refreshToken,
         scope,
       );

--- a/plugins/auth-backend/src/providers/OAuthProvider.ts
+++ b/plugins/auth-backend/src/providers/OAuthProvider.ts
@@ -199,6 +199,7 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
   }
 
   async logout(req: express.Request, res: express.Response): Promise<any> {
+    //TODO(soapraj): Logout doesnt work yet
     if (!ensuresXRequestedWith(req)) {
       return res.status(401).send('Invalid X-Requested-With header');
     }
@@ -233,6 +234,7 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
 
       // get new access_token
       const refreshInfo = await this.providerHandlers.refresh(
+        this.provider,
         refreshToken,
         scope,
       );

--- a/plugins/auth-backend/src/providers/PassportStrategyHelper.test.ts
+++ b/plugins/auth-backend/src/providers/PassportStrategyHelper.test.ts
@@ -143,6 +143,14 @@ describe('PassportStrategyHelper', () => {
       class MyCustomRefreshTokenSuccess extends passport.Strategy {
         // @ts-ignore
         private _oauth2 = new MyCustomOAuth2Success();
+        userProfile(_accessToken: string, callback: Function) {
+          callback(null, {
+            provider: 'a',
+            email: 'b',
+            name: 'c',
+            picture: 'd',
+          });
+        }
       }
 
       const mockStrategy = new MyCustomRefreshTokenSuccess();

--- a/plugins/auth-backend/src/providers/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/providers/PassportStrategyHelper.ts
@@ -137,9 +137,9 @@ export const executeRefreshTokenStrategy = async (
 
         anyStrategy.userProfile(
           accessToken,
-          (err: Error, passportProfile: passport.Profile) => {
-            if (err) {
-              reject(err);
+          (error: Error, passportProfile: passport.Profile) => {
+            if (error) {
+              reject(error);
             }
 
             const profile = makeProfileInfo(passportProfile, params);

--- a/plugins/auth-backend/src/providers/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/providers/PassportStrategyHelper.ts
@@ -135,21 +135,31 @@ export const executeRefreshTokenStrategy = async (
           );
         }
 
-        anyStrategy.userProfile(
+        resolve({
           accessToken,
-          (error: Error, passportProfile: passport.Profile) => {
-            if (error) {
-              reject(error);
-            }
+          params,
+        });
+      },
+    );
+  });
+};
 
-            const profile = makeProfileInfo(passportProfile, params);
-            resolve({
-              accessToken,
-              params,
-              profile,
-            });
-          },
-        );
+export const executeFetchUserProfileStrategy = async (
+  providerstrategy: passport.Strategy,
+  accessToken: string,
+  params: any,
+): Promise<ProfileInfo> => {
+  return new Promise((resolve, reject) => {
+    const anyStrategy = providerstrategy as any;
+    anyStrategy.userProfile(
+      accessToken,
+      (error: Error, passportProfile: passport.Profile) => {
+        if (error) {
+          reject(error);
+        }
+
+        const profile = makeProfileInfo(passportProfile, params);
+        resolve(profile);
       },
     );
   });

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -21,6 +21,7 @@ import {
   executeRedirectStrategy,
   executeRefreshTokenStrategy,
   makeProfileInfo,
+  executeFetchUserProfileStrategy,
 } from '../PassportStrategyHelper';
 import {
   OAuthProviderHandlers,
@@ -81,10 +82,16 @@ export class GoogleAuthProvider implements OAuthProviderHandlers {
     refreshToken: string,
     scope: string,
   ): Promise<AuthInfoWithProfile> {
-    const { accessToken, params, profile } = await executeRefreshTokenStrategy(
+    const { accessToken, params } = await executeRefreshTokenStrategy(
       this._strategy,
       refreshToken,
       scope,
+    );
+
+    const profile = await executeFetchUserProfileStrategy(
+      this._strategy,
+      accessToken,
+      params,
     );
 
     return {

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -51,6 +51,7 @@ export class GoogleAuthProvider implements OAuthProviderHandlers {
         done(
           undefined,
           {
+            //TODO(soapraj): extract ProfileInfo from passport.Profile and send only that
             profile,
             idToken: params.id_token,
             accessToken,

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -20,6 +20,7 @@ import {
   executeFrameHandlerStrategy,
   executeRedirectStrategy,
   executeRefreshTokenStrategy,
+  makeProfileInfo,
 } from '../PassportStrategyHelper';
 import {
   OAuthProviderHandlers,
@@ -30,6 +31,7 @@ import {
   AuthInfoWithProfile,
 } from '../types';
 import { OAuthProvider } from '../OAuthProvider';
+import passport from 'passport';
 
 export class GoogleAuthProvider implements OAuthProviderHandlers {
   private readonly providerConfig: AuthProviderConfig;
@@ -44,14 +46,14 @@ export class GoogleAuthProvider implements OAuthProviderHandlers {
         accessToken: any,
         refreshToken: any,
         params: any,
-        profile: any,
+        profile: passport.Profile,
         done: any,
       ) => {
+        const profileInfo = makeProfileInfo(profile, params);
         done(
           undefined,
           {
-            //TODO(soapraj): extract ProfileInfo from passport.Profile and send only that
-            profile,
+            profile: profileInfo,
             idToken: params.id_token,
             accessToken,
             scope: params.scope,

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -15,7 +15,6 @@
  */
 
 import express from 'express';
-import jwtDecoder from 'jwt-decode';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import {
   executeFrameHandlerStrategy,
@@ -77,29 +76,14 @@ export class GoogleAuthProvider implements OAuthProviderHandlers {
   }
 
   async refresh(
-    provider: string,
     refreshToken: string,
     scope: string,
   ): Promise<AuthInfoWithProfile> {
-    const { accessToken, params } = await executeRefreshTokenStrategy(
+    const { accessToken, params, profile } = await executeRefreshTokenStrategy(
       this._strategy,
       refreshToken,
       scope,
     );
-
-    // TODO(soapraj): check what happens when you return undefined
-    let profile;
-    try {
-      const { email, name, picture } = jwtDecoder(params.id_token);
-      profile = {
-        provider,
-        email,
-        name,
-        picture,
-      };
-    } catch (e) {
-      console.error('Failed to parse id token and get profile info');
-    }
 
     return {
       accessToken,

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -15,7 +15,6 @@
  */
 
 import express from 'express';
-import passport from 'passport';
 
 export type AuthProviderConfig = {
   provider: string;
@@ -26,7 +25,7 @@ export type AuthProviderConfig = {
 export interface OAuthProviderHandlers {
   start(req: express.Request, options: any): Promise<any>;
   handler(req: express.Request): Promise<any>;
-  refresh?(provider: string, refreshToken: string, scope: string): Promise<any>;
+  refresh?(refreshToken: string, scope: string): Promise<any>;
   logout?(): Promise<any>;
 }
 
@@ -78,7 +77,15 @@ export type RedirectInfo = {
   status?: number;
 };
 
+export type ProfileInfo = {
+  provider: string;
+  email: string;
+  name: string;
+  picture: string;
+};
+
 export type RefreshTokenResponse = {
   accessToken: string;
   params: any;
+  profile: ProfileInfo;
 };

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -26,7 +26,7 @@ export type AuthProviderConfig = {
 export interface OAuthProviderHandlers {
   start(req: express.Request, options: any): Promise<any>;
   handler(req: express.Request): Promise<any>;
-  refresh?(refreshToken: string, scope: string): Promise<any>;
+  refresh?(provider: string, refreshToken: string, scope: string): Promise<any>;
   logout?(): Promise<any>;
 }
 
@@ -49,7 +49,14 @@ export type AuthInfoBase = {
 };
 
 export type AuthInfoWithProfile = AuthInfoBase & {
-  profile: passport.Profile;
+  profile:
+    | {
+        provider: string;
+        email: string;
+        name?: string;
+        picture?: string;
+      }
+    | undefined;
 };
 
 export type AuthInfoPrivate = {

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -87,5 +87,4 @@ export type ProfileInfo = {
 export type RefreshTokenResponse = {
   accessToken: string;
   params: any;
-  profile: ProfileInfo;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3705,6 +3705,11 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/jwt-decode@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
+  integrity sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==
+
 "@types/lodash@^4.14.151":
   version "4.14.155"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
@@ -11899,6 +11904,11 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   dependencies:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
+
+jwt-decode@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
 
 keyv@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
- This is how the auth flow works. Only on page refresh we can pick up the profile information of the user.

![auth-state-flow](https://user-images.githubusercontent.com/3055673/83743576-320a6c00-a65b-11ea-9691-eda435f21180.gif)

- This implementation only considers Google Auth for the auth state in the sidebar. 

- The app config would have to list all the auth providers and an identity provider so that we can list all the providers and show profile information only when the user is authenticated with the identity provider.

- In case of google it is both access and identity provider but it other cases there could be separate identity and access providers.

Raising this draft PR to gather some feedback and thoughts.


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes