### PR TITLE
packages/cli: add separate build command for non-plugin packages

### DIFF
--- a/packages/catalog-model/package.json
+++ b/packages/catalog-model/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@backstage/catalog-model",
   "version": "0.1.1-alpha.6",
-  "main": "dist/index.esm.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "main:src": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -10,7 +11,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "prepack": "backstage-cli prepack",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -14,5 +14,10 @@
  * limitations under the License.
  */
 
-export { buildPackage } from './packager';
-export type { BuildOptions, OutputFormat } from './types';
+import { buildPackage } from '../lib/packager';
+
+export default async () => {
+  await buildPackage({
+    outputs: new Set(['types', 'esm', 'cjs']),
+  });
+};

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -14,10 +14,24 @@
  * limitations under the License.
  */
 
-import { buildPackage } from '../lib/packager';
+import { buildPackage, Output } from '../lib/packager';
+import { Command } from 'commander';
 
-export default async () => {
-  await buildPackage({
-    outputs: new Set(['types', 'esm', 'cjs']),
-  });
+export default async (cmd: Command) => {
+  let outputs = new Set<Output>();
+
+  const { outputs: outputsStr } = cmd as { outputs?: string };
+  if (outputsStr) {
+    for (const output of outputsStr.split(',') as (keyof typeof Output)[]) {
+      if (output in Output) {
+        outputs.add(Output[output]);
+      } else {
+        throw new Error(`Unknown output format: ${output}`);
+      }
+    }
+  } else {
+    outputs = new Set([Output.types, Output.esm, Output.cjs]);
+  }
+
+  await buildPackage({ outputs });
 };

--- a/packages/cli/src/commands/plugin/build.ts
+++ b/packages/cli/src/commands/plugin/build.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { buildPackage } from '../../lib/packager';
+import { buildPackage, Output } from '../../lib/packager';
 
 export default async () => {
   await buildPackage({
-    outputs: new Set(['esm', 'types']),
+    outputs: new Set([Output.esm, Output.types]),
   });
 };

--- a/packages/cli/src/commands/plugin/build.ts
+++ b/packages/cli/src/commands/plugin/build.ts
@@ -17,5 +17,7 @@
 import { buildPackage } from '../../lib/packager';
 
 export default async () => {
-  await buildPackage();
+  await buildPackage({
+    outputs: new Set(['esm', 'types']),
+  });
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -79,6 +79,11 @@ const main = (argv: string[]) => {
     .action(actionHandler(() => require('./commands/plugin/diff')));
 
   program
+    .command('build')
+    .description('Build a package for publishing')
+    .action(actionHandler(() => require('./commands/build')));
+
+  program
     .command('lint')
     .option('--fix', 'Attempt to automatically fix violations')
     .description('Lint a package')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -81,6 +81,7 @@ const main = (argv: string[]) => {
   program
     .command('build')
     .description('Build a package for publishing')
+    .option('--outputs <formats>', 'List of formats to output [types,cjs,esm]')
     .action(actionHandler(() => require('./commands/build')));
 
   program

--- a/packages/cli/src/lib/packager/config.ts
+++ b/packages/cli/src/lib/packager/config.ts
@@ -26,7 +26,7 @@ import dts from 'rollup-plugin-dts';
 import json from '@rollup/plugin-json';
 import { RollupOptions, OutputOptions } from 'rollup';
 
-import { BuildOptions } from './types';
+import { BuildOptions, Output } from './types';
 import { paths } from '../paths';
 
 export const makeConfigs = async (
@@ -48,16 +48,16 @@ export const makeConfigs = async (
 
   const configs = new Array<RollupOptions>();
 
-  if (options.outputs.has('cjs') || options.outputs.has('esm')) {
+  if (options.outputs.has(Output.cjs) || options.outputs.has(Output.esm)) {
     const output = new Array<OutputOptions>();
 
-    if (options.outputs.has('cjs')) {
+    if (options.outputs.has(Output.cjs)) {
       output.push({
         file: 'dist/index.cjs.js',
         format: 'commonjs',
       });
     }
-    if (options.outputs.has('esm')) {
+    if (options.outputs.has(Output.esm)) {
       output.push({
         file: 'dist/index.esm.js',
         format: 'module',
@@ -88,7 +88,7 @@ export const makeConfigs = async (
     });
   }
 
-  if (options.outputs.has('types')) {
+  if (options.outputs.has(Output.types)) {
     configs.push({
       input: typesInput,
       output: {

--- a/packages/cli/src/lib/packager/config.ts
+++ b/packages/cli/src/lib/packager/config.ts
@@ -24,11 +24,14 @@ import esbuild from 'rollup-plugin-esbuild';
 import imageFiles from 'rollup-plugin-image-files';
 import dts from 'rollup-plugin-dts';
 import json from '@rollup/plugin-json';
-import { RollupOptions } from 'rollup';
+import { RollupOptions, OutputOptions } from 'rollup';
 
+import { BuildOptions } from './types';
 import { paths } from '../paths';
 
-export const makeConfigs = async (): Promise<RollupOptions[]> => {
+export const makeConfigs = async (
+  options: BuildOptions,
+): Promise<RollupOptions[]> => {
   const typesInput = paths.resolveTargetRoot(
     'dist',
     relativePath(paths.targetRoot, paths.targetDir),
@@ -43,13 +46,27 @@ export const makeConfigs = async (): Promise<RollupOptions[]> => {
     );
   }
 
-  return [
-    {
-      input: 'src/index.ts',
-      output: {
+  const configs = new Array<RollupOptions>();
+
+  if (options.outputs.has('cjs') || options.outputs.has('esm')) {
+    const output = new Array<OutputOptions>();
+
+    if (options.outputs.has('cjs')) {
+      output.push({
+        file: 'dist/index.cjs.js',
+        format: 'commonjs',
+      });
+    }
+    if (options.outputs.has('esm')) {
+      output.push({
         file: 'dist/index.esm.js',
         format: 'module',
-      },
+      });
+    }
+
+    configs.push({
+      input: 'src/index.ts',
+      output,
       plugins: [
         peerDepsExternal({
           includeDependencies: true,
@@ -68,14 +85,19 @@ export const makeConfigs = async (): Promise<RollupOptions[]> => {
           target: 'es2019',
         }),
       ],
-    },
-    {
+    });
+  }
+
+  if (options.outputs.has('types')) {
+    configs.push({
       input: typesInput,
       output: {
         file: 'dist/index.d.ts',
         format: 'es',
       },
       plugins: [dts()],
-    },
-  ];
+    });
+  }
+
+  return configs;
 };

--- a/packages/cli/src/lib/packager/index.ts
+++ b/packages/cli/src/lib/packager/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { buildPackage } from './packager';
-export type { BuildOptions, OutputFormat } from './types';
+export { Output } from './types';
+export type { BuildOptions } from './types';

--- a/packages/cli/src/lib/packager/packager.ts
+++ b/packages/cli/src/lib/packager/packager.ts
@@ -19,6 +19,7 @@ import chalk from 'chalk';
 import { relative as relativePath } from 'path';
 import { paths } from '../paths';
 import { makeConfigs } from './config';
+import { BuildOptions } from './types';
 
 function formatErrorMessage(error: any) {
   let msg = '';
@@ -80,7 +81,7 @@ async function build(config: RollupOptions) {
   }
 }
 
-export const buildPackage = async () => {
-  const configs = await makeConfigs();
+export const buildPackage = async (options: BuildOptions) => {
+  const configs = await makeConfigs(options);
   await Promise.all(configs.map(build));
 };

--- a/packages/cli/src/lib/packager/types.ts
+++ b/packages/cli/src/lib/packager/types.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-export type OutputFormat = 'esm' | 'cjs' | 'types';
+export enum Output {
+  esm,
+  cjs,
+  types,
+}
 
 export type BuildOptions = {
-  outputs: Set<OutputFormat>;
+  outputs: Set<Output>;
 };

--- a/packages/cli/src/lib/packager/types.ts
+++ b/packages/cli/src/lib/packager/types.ts
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-export { buildPackage } from './packager';
-export type { BuildOptions, OutputFormat } from './types';
+export type OutputFormat = 'esm' | 'cjs' | 'types';
+
+export type BuildOptions = {
+  outputs: Set<OutputFormat>;
+};

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -20,7 +20,7 @@
   "main:src": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build --outputs types,esm",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "prepack": "backstage-cli prepack",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "main:src": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build --outputs types,esm",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "prepack": "backstage-cli prepack",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -20,7 +20,7 @@
   "main:src": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build --outputs types,esm",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "prepack": "backstage-cli prepack",

--- a/packages/test-utils-core/package.json
+++ b/packages/test-utils-core/package.json
@@ -20,7 +20,7 @@
   "main:src": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build --outputs types,esm",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "prepack": "backstage-cli prepack",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -20,7 +20,7 @@
   "main:src": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build --outputs types,esm",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "prepack": "backstage-cli prepack",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -20,7 +20,7 @@
   "main:src": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "build": "backstage-cli plugin:build",
+    "build": "backstage-cli build --outputs types,esm",
     "lint": "backstage-cli lint",
     "prepack": "backstage-cli prepack",
     "postpack": "backstage-cli postpack",


### PR DESCRIPTION
Just working on config stuff

https://www.youtube.com/watch?v=_UZFI-8D5uA

...

This adds a `build` command with an `--outputs types,cjs,esm` option. Needing this for packages that are common among frontend and backend, and also think it makes more sense for us to use something else than `plugin:build` for packages.

Keeping `plugin:build` around still though, as a forwards-compatibility thing. I'm thinking we might want to end up having some more tooling around plugins, so doesn't hurt to have a dedicated command still.

This should also get rid of the need for using `esm` in the backend