### PR TITLE
Catalog backend: fetch entities by Id

### DIFF
--- a/packages/catalog-model/src/location/index.ts
+++ b/packages/catalog-model/src/location/index.ts
@@ -16,3 +16,4 @@
 
 export type { Location, LocationSpec } from './types';
 export { locationSchema, locationSpecSchema } from './validation';
+export { LOCATION_ANNOTATION } from './annotation';

--- a/plugins/catalog-backend/src/database/CommonDatabase.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.ts
@@ -19,7 +19,12 @@ import {
   InputError,
   NotFoundError,
 } from '@backstage/backend-common';
-import type { Entity, EntityMeta, Location } from '@backstage/catalog-model';
+import {
+  Entity,
+  EntityMeta,
+  Location,
+  LOCATION_ANNOTATION,
+} from '@backstage/catalog-model';
 import Knex from 'knex';
 import lodash from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
@@ -167,7 +172,7 @@ export class CommonDatabase implements Database {
       annotations: {
         ...(newEntity.metadata?.annotations ?? {}),
         ...(request.locationId
-          ? { 'backstage.io/managed-by-location': request.locationId }
+          ? { [LOCATION_ANNOTATION]: request.locationId }
           : {}),
       },
     };

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
@@ -15,15 +15,18 @@
  */
 
 import { InputError } from '@backstage/backend-common';
-import { Entity, Location, LocationSpec } from '@backstage/catalog-model';
+import {
+  Entity,
+  Location,
+  LocationSpec,
+  LOCATION_ANNOTATION,
+} from '@backstage/catalog-model';
 import lodash from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { EntitiesCatalog, LocationsCatalog } from '../catalog';
 import { IngestionModel } from '../ingestion';
 import { AddLocationResult, HigherOrderOperation } from './types';
 import { Logger } from 'winston';
-
-const LOCATION_ANNOTATION = 'backstage.io/managed-by-location';
 
 /**
  * Placeholder for operations that span several catalogs and/or stretches out

--- a/plugins/catalog/src/api/CatalogClient.ts
+++ b/plugins/catalog/src/api/CatalogClient.ts
@@ -31,6 +31,22 @@ export class CatalogClient implements CatalogApi {
     this.apiOrigin = apiOrigin;
     this.basePath = basePath;
   }
+  async getLocationById(id: String): Promise<Location | undefined> {
+    const response = await fetch(
+      `${this.apiOrigin}${this.basePath}/locations/${id}`,
+    );
+    if (response.ok) {
+      const location = await response.json();
+      if (location) return location.data;
+    }
+    return undefined;
+  }
+  async getEntitiesByLocationId(id: string): Promise<Entity[]> {
+    const response = await fetch(
+      `${this.apiOrigin}${this.basePath}/entities?backstage.io/managed-by-location=${id}`,
+    );
+    return await response.json();
+  }
   async getEntities(): Promise<DescriptorEnvelope[]> {
     const response = await fetch(`${this.apiOrigin}${this.basePath}/entities`);
     return await response.json();
@@ -50,14 +66,8 @@ export class CatalogClient implements CatalogApi {
     const locationId = findLocationIdInEntity(entity);
     if (!locationId) return undefined;
 
-    const response = await fetch(
-      `${this.apiOrigin}${this.basePath}/locations/${locationId}`,
-    );
-    if (response.ok) {
-      const location = await response.json();
-      if (location) return location.data;
-    }
+    const location = this.getLocationById(locationId);
 
-    return undefined;
+    return location;
   }
 }

--- a/plugins/catalog/src/api/CatalogClient.ts
+++ b/plugins/catalog/src/api/CatalogClient.ts
@@ -16,7 +16,11 @@
 
 import { CatalogApi } from './types';
 import { DescriptorEnvelope } from '../types';
-import { Entity, Location } from '@backstage/catalog-model';
+import {
+  Entity,
+  Location,
+  LOCATION_ANNOTATION,
+} from '@backstage/catalog-model';
 
 export class CatalogClient implements CatalogApi {
   private apiOrigin: string;
@@ -43,7 +47,7 @@ export class CatalogClient implements CatalogApi {
   }
   async getEntitiesByLocationId(id: string): Promise<Entity[]> {
     const response = await fetch(
-      `${this.apiOrigin}${this.basePath}/entities?backstage.io/managed-by-location=${id}`,
+      `${this.apiOrigin}${this.basePath}/entities?${LOCATION_ANNOTATION}=${id}`,
     );
     return await response.json();
   }
@@ -60,10 +64,7 @@ export class CatalogClient implements CatalogApi {
     throw new Error(`'Entity not found: ${name}`);
   }
   async getLocationByEntity(entity: Entity): Promise<Location | undefined> {
-    const findLocationIdInEntity = (e: Entity): string | undefined =>
-      e.metadata.annotations?.['backstage.io/managed-by-location'];
-
-    const locationId = findLocationIdInEntity(entity);
+    const locationId = entity.metadata.annotations?.[LOCATION_ANNOTATION];
     if (!locationId) return undefined;
 
     const location = this.getLocationById(locationId);

--- a/plugins/catalog/src/api/types.ts
+++ b/plugins/catalog/src/api/types.ts
@@ -23,7 +23,9 @@ export const catalogApiRef = createApiRef<CatalogApi>({
 });
 
 export interface CatalogApi {
+  getLocationById(id: String): Promise<Location | undefined>;
   getEntities(): Promise<Entity[]>;
   getEntityByName(name: string): Promise<Entity>;
+  getEntitiesByLocationId(id: string): Promise<Entity[]>;
   getLocationByEntity(entity: Entity): Promise<Location | undefined>;
 }

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -99,7 +99,6 @@ const CatalogPage: FC<{}> = () => {
         rowData && rowData.location ? rowData.location.type !== 'github' : true,
     }),
   ];
-
   return (
     <Page theme={pageTheme.home}>
       <Header title="Service Catalog" subtitle="Keep track of your software">

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -77,14 +77,13 @@ const CatalogPage: FC<{}> = () => {
           (location): Location[] =>
             location.filter(loc => !!loc) as Array<Location>,
         )
-        .then(location => {
-          if (isMounted()) return [location];
+        .then(locs => {
+          if (isMounted()) return locs;
           return [];
         });
     }
     return [];
-  }, [value, catalogApi, isMounted]);
-
+  }, [value, catalogApi, isMounted, catalogApi]);
   const actions = [
     (rowData: Component) => ({
       icon: GitHub,
@@ -139,12 +138,11 @@ const CatalogPage: FC<{}> = () => {
               titlePreamble={selectedFilter.label}
               components={
                 (value &&
-                  value.map(val =>
-                    envelopeToComponent(
-                      val,
-                      findLocationForEntity(val, locations) ?? undefined,
-                    ),
-                  )) ||
+                  value.map(val => {
+                    const loc =
+                      findLocationForEntity(val, locations) ?? undefined;
+                    return envelopeToComponent(val, loc);
+                  })) ||
                 []
               }
               loading={loading}

--- a/plugins/catalog/src/components/ComponentPage/ComponentPage.tsx
+++ b/plugins/catalog/src/components/ComponentPage/ComponentPage.tsx
@@ -54,9 +54,10 @@ const ComponentPage: FC<ComponentPageProps> = ({ match, history }) => {
   const errorApi = useApi<ErrorApi>(errorApiRef);
 
   const catalogApi = useApi(catalogApiRef);
-  const catalogRequest = useAsync(() =>
-    catalogApi.getEntityByName(match.params.name),
-  );
+  const catalogRequest = useAsync(async () => {
+    const entity = await catalogApi.getEntityByName(match.params.name);
+    return entity;
+  });
 
   useEffect(() => {
     if (catalogRequest.error) {
@@ -76,6 +77,7 @@ const ComponentPage: FC<ComponentPageProps> = ({ match, history }) => {
     setConfirmationDialogOpen(false);
     setRemovingPending(true);
     // await componentFactory.removeComponentByName(componentName);
+    await catalogApi;
     history.push('/catalog');
   };
 

--- a/plugins/catalog/src/components/ComponentRemovalDialog/ComponentRemovalDialog.tsx
+++ b/plugins/catalog/src/components/ComponentRemovalDialog/ComponentRemovalDialog.tsx
@@ -25,6 +25,9 @@ import {
   useTheme,
 } from '@material-ui/core';
 import { Component } from '../../data/component';
+import { useAsync } from 'react-use';
+import { useApi, Progress } from '@backstage/core';
+import { catalogApiRef } from '../../api/types';
 
 type ComponentRemovalDialogProps = {
   onConfirm: () => any;

--- a/plugins/catalog/src/data/component.ts
+++ b/plugins/catalog/src/data/component.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Location } from '@backstage/catalog-model';
 
 export type Component = {

--- a/plugins/catalog/src/data/utils.ts
+++ b/plugins/catalog/src/data/utils.ts
@@ -14,24 +14,23 @@
  * limitations under the License.
  */
 import { Component } from './component';
-import { Entity, Location } from '@backstage/catalog-model';
+import {
+  Entity,
+  Location,
+  LOCATION_ANNOTATION,
+} from '@backstage/catalog-model';
 
-export const envelopeToComponent = (
-  envelope: Entity,
-  location?: Location,
-): Component => {
+export const envelopeToComponent = (envelope: Entity): Component => {
   return {
     name: envelope.metadata?.name ?? '',
     kind: envelope.kind ?? 'unknown',
     description: envelope.metadata?.annotations?.description ?? 'placeholder',
-    location,
   };
 };
 export const findLocationForEntity = (
   entity: Entity,
-  l: Location[],
+  locations: Location[],
 ): Location | undefined => {
-  const entityLocationId =
-    entity.metadata.annotations?.['backstage.io/managed-by-location'];
-  return l.find(location => location.id === entityLocationId);
+  const entityLocationId = entity.metadata.annotations?.[LOCATION_ANNOTATION];
+  return locations.find(location => location.id === entityLocationId);
 };

--- a/plugins/catalog/src/data/utils.ts
+++ b/plugins/catalog/src/data/utils.ts
@@ -16,14 +16,22 @@
 import { Component } from './component';
 import { Entity, Location } from '@backstage/catalog-model';
 
-export function envelopeToComponent(
+export const envelopeToComponent = (
   envelope: Entity,
   location?: Location,
-): Component {
+): Component => {
   return {
     name: envelope.metadata?.name ?? '',
     kind: envelope.kind ?? 'unknown',
     description: envelope.metadata?.annotations?.description ?? 'placeholder',
     location,
   };
-}
+};
+export const findLocationForEntity = (
+  entity: Entity,
+  l: Location[],
+): Location | undefined => {
+  const entityLocationId =
+    entity.metadata.annotations?.['backstage.io/managed-by-location'];
+  return l.find(location => location.id === entityLocationId);
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A new route on catalog-backend `GET /entities/by-location-id/:id`.
The implementation is naive and filtering of entities should be done inside of transaction. The PR is part of https://github.com/spotify/backstage/issues/1091

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
