### PR TITLE
Initial version of a json schema for the service specification

### DIFF
--- a/docs/service_specification.schema.json
+++ b/docs/service_specification.schema.json
@@ -2,8 +2,8 @@
     "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "backstage.io/v1beta1",
     "type": "object",
-    "title": "A JSON Schema for Backstage service definitions.",
-    "description": "Each Backstage description file has a number of files. This schema matches each of those.",
+    "title": "A JSON Schema for Backstage catalog entities.",
+    "description": "Each descriptor file has a number of entities. This schema matches each of those.",
     "examples": [
         {
             "apiVersion": "backstage.io/v1beta1",
@@ -20,17 +20,16 @@
                 "annnotations": {
                     "docs": "https://github.com/..../tree/develop/doc"
                 },
-                "teams": {
+                "teams": [{
                     "name": "Team super great",
                     "email": "greatTeam@geemel.com"
-                }
+                }]
             }
         }
     ],
     "required": [
         "apiVersion",
         "kind",
-        "spec",
         "metadata"
     ],
     "additionalProperties": false,
@@ -38,7 +37,6 @@
         "apiVersion": {
             "type": "string",
             "description": "Version of the specification format for a particular file is written against.",
-            "default": "backstage.io/v1beta1",
             "enum": [
                 "backstage.io/v1beta1"
             ]
@@ -47,7 +45,7 @@
             "type": "string",
             "description": "High level entity type being described, from the Backstage system model.",
             "enum": [
-                "Compontent"
+                "Component"
             ]
         },
         "spec": {
@@ -78,7 +76,7 @@
             "properties": {
                 "name": {
                     "type": "string",
-                    "pattern": "^[a-z0-9A-Z_\\-\\.]{1,63}$",
+                    "pattern": "^[a-z0-9A-Z_.-]{1,63}$",
                     "description": "The name of the entity. This name is both meant for human eyes to recognize the entity, and for machines and other components to reference the entity"
                 },
                 "description": {
@@ -96,7 +94,7 @@
                     "patternProperties": {
                         "^([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,}\/)?[a-z0-9A-Z_\\-\\.]{1,63}$": {
                             "type": "string",
-                            "pattern": "^[a-z0-9A-Z_\\-\\.]{1,63}$",
+                            "pattern": "^[a-z0-9A-Z_.-]{1,63}$"
                         }
                     }
                 },
@@ -107,7 +105,7 @@
                     "patternProperties": {
                         "^([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,}\/)?[a-z0-9A-Z_\\-\\.]{1,63}$": {
                             "type": "string",
-                            "pattern": "^[a-z0-9A-Z_\\-\\.]{1,63}$",
+                            "pattern": "^[a-z0-9A-Z_.-]{1,63}$"
                         }
                     }
                 }

--- a/docs/service_specification.schema.json
+++ b/docs/service_specification.schema.json
@@ -1,0 +1,117 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "backstage.io/v1beta1",
+    "type": "object",
+    "title": "A JSON Schema for Backstage service definitions.",
+    "description": "Each Backstage description file has a number of files. This schema matches each of those.",
+    "examples": [
+        {
+            "apiVersion": "backstage.io/v1beta1",
+            "kind": "Component",
+            "spec": {
+                "type": "service"
+            },
+            "metadata": {
+                "name": "LoremService",
+                "description": "Creates Lorems like a pro.",
+                "labels": {
+                    "product_name": "Random value Generator"
+                },
+                "annnotations": {
+                    "docs": "https://github.com/..../tree/develop/doc"
+                },
+                "teams": {
+                    "name": "Team super great",
+                    "email": "greatTeam@geemel.com"
+                }
+            }
+        }
+    ],
+    "required": [
+        "apiVersion",
+        "kind",
+        "spec",
+        "metadata"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "apiVersion": {
+            "type": "string",
+            "description": "Version of the specification format for a particular file is written against.",
+            "default": "backstage.io/v1beta1",
+            "enum": [
+                "backstage.io/v1beta1"
+            ]
+        },
+        "kind": {
+            "type": "string",
+            "description": "High level entity type being described, from the Backstage system model.",
+            "enum": [
+                "Compontent"
+            ]
+        },
+        "spec": {
+            "type": "object",
+            "description": "Actual specification data that describes the entity. TODO: shape depend on `kind`",
+            "required": [
+                "type"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of component.",
+                    "default": "",
+                    "examples": [
+                        "service"
+                    ]
+                }
+            }
+        },
+        "metadata": {
+            "type": "object",
+            "description": "Metadata about the entity, i.e. things that aren't directly part of the entity specification itself.",
+            "required": [
+                "name"
+            ],
+            "additionalProperties": true,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9A-Z_\\-\\.]{1,63}$",
+                    "description": "The name of the entity. This name is both meant for human eyes to recognize the entity, and for machines and other components to reference the entity"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "A human readable description of the entity, to be shown in Backstage. Should be kept short and informative."
+                },
+                "namespace": {
+                    "type": "string",
+                    "description": "The name of a namespace that the entity belongs to."
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Labels are optional key/value pairs of that are attached to the entity, and their use is identical to kubernetes object labels.",
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,}\/)?[a-z0-9A-Z_\\-\\.]{1,63}$": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9A-Z_\\-\\.]{1,63}$",
+                        }
+                    }
+                },
+                "annnotations": {
+                    "type": "object",
+                    "description": "Arbitrary non-identifying metadata attached to the entity, identical in use to kubernetes object annotations.",
+                    "additionalProperties": true,
+                    "patternProperties": {
+                        "^([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,}\/)?[a-z0-9A-Z_\\-\\.]{1,63}$": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9A-Z_\\-\\.]{1,63}$",
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
As discussed in #1083, adding a JSON Schema file.

This is NOT ready to merge. This file currently only implements [ADR-02](https://github.com/spotify/backstage/blob/master/docs/architecture-decisions/adr002-default-catalog-file-format.md) but needs to be expanded to support [ADR-05](https://github.com/spotify/backstage/blob/master/docs/architecture-decisions/adr005-catalog-core-entities.md)

In this file, I've left `namespace`, `description`, `labels` and `annotations` as optional and everything else required. You can't add extra keys anywhere except directly inside the `metadata` object.


@freben  @Rugvip 
