### PR TITLE
chore(navigation/tabs): fixing prop type validation

### DIFF
--- a/packages/core/src/layout/HeaderTabs/index.tsx
+++ b/packages/core/src/layout/HeaderTabs/index.tsx
@@ -48,7 +48,7 @@ export const HeaderTabs: React.FC<{ tabs: Tab[] }> = ({ tabs }) => {
     <div className={styles.tabsWrapper}>
       <Tabs
         indicatorColor="primary"
-        textColor="background"
+        textColor="inherit"
         variant="scrollable"
         scrollButtons="auto"
         aria-label="scrollable auto tabs example"


### PR DESCRIPTION
PropType validation fails with a nice big red error log in the console.

Let's fix that.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
