### PR TITLE
fix page reload when clicking on logo

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -34,6 +34,7 @@ import {
   SidebarUserBadge,
   SidebarThemeToggle,
 } from '@backstage/core';
+import { NavLink } from 'react-router-dom';
 
 const useSidebarLogoStyles = makeStyles({
   root: {
@@ -56,9 +57,11 @@ const SidebarLogo: FC<{}> = () => {
 
   return (
     <div className={classes.root}>
-      <Link href="/" underline="none" className={classes.link}>
-        {isOpen ? <LogoFull /> : <LogoIcon />}
-      </Link>
+      <NavLink to="/">
+        <Link underline="none" className={classes.link}>
+          {isOpen ? <LogoFull /> : <LogoIcon />}
+        </Link>
+      </NavLink>
     </div>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes issue https://github.com/spotify/backstage/issues/1175

Put the `Link` component from material UI inside `NavLink` of `react-router-dom` for navigation to home without page reload. This is one of my first contributions to open source. Please guide me if any changes are required.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
