### PR TITLE
RFC number 2: Improve the way that locations are read

### DIFF
--- a/plugins/catalog-backend/src/ingestion/processors/AnnotateLocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AnnotateLocationEntityProcessor.ts
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-import { Entity, LocationSpec } from '@backstage/catalog-model';
 import lodash from 'lodash';
-import { LocationProcessor } from './types';
+import * as result from './results';
+import { LocationProcessor, LocationProcessorResult } from './types';
 
 export class AnnotateLocationEntityProcessor implements LocationProcessor {
-  async processEntity(entity: Entity, location: LocationSpec): Promise<Entity> {
-    return lodash.merge(
+  async process(
+    item: LocationProcessorResult,
+  ): Promise<LocationProcessorResult | undefined> {
+    if (item.type !== 'entity') {
+      return item;
+    }
+
+    const { location, entity } = item;
+    const output = lodash.merge(
       {
         metadata: {
           annotations: {
@@ -30,5 +37,7 @@ export class AnnotateLocationEntityProcessor implements LocationProcessor {
       },
       entity,
     );
+
+    return result.entity(item.location, output);
   }
 }

--- a/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.ts
@@ -14,20 +14,24 @@
  * limitations under the License.
  */
 
-import { LocationSpec } from '@backstage/catalog-model';
 import fs from 'fs-extra';
 import * as result from './results';
-import { LocationProcessor, LocationProcessorEmit } from './types';
+import {
+  LocationProcessor,
+  LocationProcessorEmit,
+  LocationProcessorResult,
+} from './types';
 
 export class FileReaderProcessor implements LocationProcessor {
-  async readLocation(
-    location: LocationSpec,
-    optional: boolean,
+  async process(
+    item: LocationProcessorResult,
     emit: LocationProcessorEmit,
-  ): Promise<boolean> {
-    if (location.type !== 'file') {
-      return false;
+  ): Promise<LocationProcessorResult | undefined> {
+    if (item.type !== 'location' || item.location.type !== 'file') {
+      return item;
     }
+
+    const { location, optional } = item;
 
     try {
       const exists = await fs.pathExists(location.target);
@@ -43,6 +47,6 @@ export class FileReaderProcessor implements LocationProcessor {
       emit(result.generalError(location, message));
     }
 
-    return true;
+    return undefined;
   }
 }

--- a/plugins/catalog-backend/src/ingestion/processors/GithubReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubReaderProcessor.ts
@@ -14,20 +14,24 @@
  * limitations under the License.
  */
 
-import { LocationSpec } from '@backstage/catalog-model';
 import fetch from 'node-fetch';
 import * as result from './results';
-import { LocationProcessor, LocationProcessorEmit } from './types';
+import {
+  LocationProcessor,
+  LocationProcessorEmit,
+  LocationProcessorResult,
+} from './types';
 
 export class GithubReaderProcessor implements LocationProcessor {
-  async readLocation(
-    location: LocationSpec,
-    optional: boolean,
+  async process(
+    item: LocationProcessorResult,
     emit: LocationProcessorEmit,
-  ): Promise<boolean> {
-    if (location.type !== 'github') {
-      return false;
+  ): Promise<LocationProcessorResult | undefined> {
+    if (item.type !== 'location' || item.location.type !== 'github') {
+      return item;
     }
+
+    const { location, optional } = item;
 
     try {
       const url = this.buildRawUrl(location.target);
@@ -54,7 +58,7 @@ export class GithubReaderProcessor implements LocationProcessor {
       emit(result.generalError(location, message));
     }
 
-    return true;
+    return undefined;
   }
 
   // Converts

--- a/plugins/catalog-backend/src/ingestion/processors/YamlProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/YamlProcessor.ts
@@ -14,28 +14,33 @@
  * limitations under the License.
  */
 
-import { Entity, LocationSpec } from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 import lodash from 'lodash';
 import yaml from 'yaml';
 import * as result from './results';
-import { LocationProcessor, LocationProcessorEmit } from './types';
+import {
+  LocationProcessor,
+  LocationProcessorEmit,
+  LocationProcessorResult,
+} from './types';
 
 export class YamlProcessor implements LocationProcessor {
-  async parseData(
-    data: Buffer,
-    location: LocationSpec,
+  async process(
+    item: LocationProcessorResult,
     emit: LocationProcessorEmit,
-  ): Promise<boolean> {
-    if (!location.target.match(/\.ya?ml$/)) {
-      return false;
+  ): Promise<LocationProcessorResult | undefined> {
+    if (item.type !== 'data' || !item.location.target.match(/\.ya?ml$/)) {
+      return item;
     }
+
+    const { location, data } = item;
 
     let documents: yaml.Document.Parsed[];
     try {
       documents = yaml.parseAllDocuments(data.toString('utf8')).filter(d => d);
     } catch (e) {
       emit(result.generalError(location, `Failed to parse YAML, ${e}`));
-      return true;
+      return undefined;
     }
 
     for (const document of documents) {
@@ -53,6 +58,6 @@ export class YamlProcessor implements LocationProcessor {
       }
     }
 
-    return true;
+    return undefined;
   }
 }

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -17,61 +17,10 @@
 import { Entity, LocationSpec } from '@backstage/catalog-model';
 
 export type LocationProcessor = {
-  /**
-   * Reads the contents of a location.
-   *
-   * @param location The location to read
-   * @param optional Whether a missing target should trigger an error
-   * @param emit A sink for items resulting from the read
-   * @returns True if handled by this processor, false otherwise
-   */
-  readLocation?(
-    location: LocationSpec,
-    optional: boolean,
+  process(
+    item: LocationProcessorResult,
     emit: LocationProcessorEmit,
-  ): Promise<boolean>;
-
-  /**
-   * Parses a raw data buffer that was read from a location.
-   *
-   * @param data The data to parse
-   * @param location The location that the data came from
-   * @param emit A sink for items resulting from the parsing
-   * @returns True if handled by this processor, false otherwise
-   */
-  parseData?(
-    data: Buffer,
-    location: LocationSpec,
-    emit: LocationProcessorEmit,
-  ): Promise<boolean>;
-
-  /**
-   * Processes an emitted entity, e.g. by validating or modifying it.
-   *
-   * @param entity The entity to process
-   * @param location The location that the entity came from
-   * @param emit A sink for auxiliary items resulting from the processing
-   * @returns The same entity or a modifid version of it
-   */
-  processEntity?(
-    entity: Entity,
-    location: LocationSpec,
-    emit: LocationProcessorEmit,
-  ): Promise<Entity>;
-
-  /**
-   * Handles an emitted error.
-   *
-   * @param error The error
-   * @param location The location where the error occurred
-   * @param emit A sink for items resulting from this handilng
-   * @returns Nothing
-   */
-  handleError?(
-    error: Error,
-    location: LocationSpec,
-    emit: LocationProcessorEmit,
-  ): Promise<void>;
+  ): Promise<LocationProcessorResult | undefined>;
 };
 
 export type LocationProcessorEmit = (


### PR DESCRIPTION
BREAKING CHANGE: If we merge this, the annotation backstage.io/managed-by-location will no longer point to a location ID, but to a location on the form <type>:<target>, e.g. "github:https://github.com/spotify/backstage/blob/master/plugins/catalog-backend/fixtures/two_components.yaml". I believe that this is what we want to do long term.

This is a competing solution to #1158.

Here, there's a single `process` method that takes care of all types of entry. Definitely less code.

Drawbacks as I see it:

- Each processor needs to carefully remember to return the incoming item even if they do not care about it, otherwise they short circuit processing; maybe we could arrange that with a more informative return type ("i didn't care about that", "i handled that but have no output", "i handled that and here's something to keep processing")
- It no longer detects that no processor could understand the item; maybe we could arrange that with additional checks
- It no longer has specific error messages for when in the cycle that errors occurred
- You now have to remember to not emit from processors that also accept that same type, or else you can end up in loops - have to balance the use of return vs emit
- The api now permits odd things like handling an entity but returning a location, in the middle of the processor chain, which would risk missing the processor that actually handles that thing; maybe we could narrow the return type but it's a bit of an oddity