### PR TITLE
packages/test-utils: added MockErrorApi and include in all test apps

### DIFF
--- a/packages/test-utils/src/testUtils/apis/ErrorApi/MockErrorApi.test.ts
+++ b/packages/test-utils/src/testUtils/apis/ErrorApi/MockErrorApi.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MockErrorApi } from './MockErrorApi';
+
+async function ifResolved<T>(promise: Promise<T>): Promise<T | 'not-yet'> {
+  return Promise.race([promise, Promise.resolve<'not-yet'>('not-yet')]);
+}
+
+describe('MockErrorApi', () => {
+  it('should throw errors by default', () => {
+    const api = new MockErrorApi();
+    expect(() => api.post(new Error('NOPE'))).toThrow(
+      'MockErrorApi received unexpected error, Error: NOPE',
+    );
+  });
+
+  it('should collect errors', () => {
+    const api = new MockErrorApi({ collect: true });
+
+    api.post(new Error('e1'));
+    api.post(new Error('e2'), { hidden: true });
+    api.post(new Error('e3'));
+
+    expect(api.getErrors()).toEqual([
+      {
+        error: new Error('e1'),
+      },
+      {
+        error: new Error('e2'),
+        context: { hidden: true },
+      },
+      {
+        error: new Error('e3'),
+      },
+    ]);
+  });
+
+  it('should not emit values', async () => {
+    const api = new MockErrorApi({ collect: true });
+
+    const promise = new Promise((resolve, reject) => {
+      api.error$().subscribe({
+        next({ error }) {
+          reject(error);
+        },
+        error(error) {
+          reject(error);
+        },
+        complete() {
+          reject(new Error('observable was completed'));
+        },
+      });
+
+      setTimeout(() => resolve('timed-out'), 100);
+    });
+
+    await expect(promise).resolves.toBe('timed-out');
+  });
+
+  it('should wait for errors', async () => {
+    const api = new MockErrorApi({ collect: true });
+
+    const wait1 = api.waitForError(/1/);
+    const wait2 = api.waitForError(/2/);
+
+    await expect(ifResolved(wait1)).resolves.toBe('not-yet');
+    await expect(ifResolved(wait2)).resolves.toBe('not-yet');
+    api.post(new Error('e0'));
+    await expect(ifResolved(wait1)).resolves.toBe('not-yet');
+    await expect(ifResolved(wait2)).resolves.toBe('not-yet');
+    api.post(new Error('e1'));
+    await expect(ifResolved(wait1)).resolves.toEqual({
+      error: new Error('e1'),
+    });
+    await expect(ifResolved(wait2)).resolves.toBe('not-yet');
+    api.post(new Error('e2'), { hidden: true });
+    await expect(ifResolved(wait2)).resolves.toEqual({
+      error: new Error('e2'),
+      context: { hidden: true },
+    });
+  });
+
+  it('should time out waiting for error', async () => {
+    const api = new MockErrorApi({ collect: true });
+
+    await expect(api.waitForError(/1/, 1)).rejects.toThrow(
+      'Timed out waiting for error',
+    );
+  });
+});

--- a/packages/test-utils/src/testUtils/apis/ErrorApi/MockErrorApi.ts
+++ b/packages/test-utils/src/testUtils/apis/ErrorApi/MockErrorApi.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ErrorApi,
+  ErrorContext,
+  errorApiRef,
+  Observable,
+} from '@backstage/core-api';
+
+type Options = {
+  collect?: boolean;
+};
+
+type ErrorWithContext = {
+  error: Error;
+  context?: ErrorContext;
+};
+
+type Waiter = {
+  pattern: RegExp;
+  resolve: (err: ErrorWithContext) => void;
+};
+
+const nullObservable = {
+  subscribe: () => ({ unsubscribe: () => {}, closed: true }),
+};
+
+export class MockErrorApi implements ErrorApi {
+  static factory = {
+    implements: errorApiRef,
+    deps: {},
+    factory: () => new MockErrorApi(),
+  };
+
+  private readonly errors = new Array<ErrorWithContext>();
+  private readonly waiters = new Set<Waiter>();
+
+  constructor(private readonly options: Options = {}) {}
+
+  post(error: Error, context?: ErrorContext) {
+    if (this.options.collect) {
+      this.errors.push({ error, context });
+
+      for (const waiter of this.waiters) {
+        if (waiter.pattern.test(error.message)) {
+          this.waiters.delete(waiter);
+          waiter.resolve({ error, context });
+        }
+      }
+
+      return;
+    }
+
+    throw new Error(`MockErrorApi received unexpected error, ${error}`);
+  }
+
+  error$(): Observable<{ error: Error; context?: ErrorContext }> {
+    return nullObservable;
+  }
+
+  getErrors(): ErrorWithContext[] {
+    return this.errors;
+  }
+
+  waitForError(
+    pattern: RegExp,
+    timeoutMs: number = 2000,
+  ): Promise<ErrorWithContext> {
+    return new Promise<ErrorWithContext>((resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error('Timed out waiting for error'));
+      }, timeoutMs);
+
+      this.waiters.add({ resolve, pattern });
+    });
+  }
+}

--- a/packages/test-utils/src/testUtils/apis/ErrorApi/index.ts
+++ b/packages/test-utils/src/testUtils/apis/ErrorApi/index.ts
@@ -14,6 +14,4 @@
  * limitations under the License.
  */
 
-export * from './apis';
-export { default as mockBreakpoint } from './mockBreakpoint';
-export { wrapInTestApp, renderInTestApp } from './appWrappers';
+export { MockErrorApi } from './MockErrorApi';

--- a/packages/test-utils/src/testUtils/apis/index.ts
+++ b/packages/test-utils/src/testUtils/apis/index.ts
@@ -14,6 +14,4 @@
  * limitations under the License.
  */
 
-export * from './apis';
-export { default as mockBreakpoint } from './mockBreakpoint';
-export { wrapInTestApp, renderInTestApp } from './appWrappers';
+export * from './ErrorApi';

--- a/packages/test-utils/src/testUtils/appWrappers.tsx
+++ b/packages/test-utils/src/testUtils/appWrappers.tsx
@@ -20,11 +20,11 @@ import { Route } from 'react-router-dom';
 import { lightTheme } from '@backstage/theme';
 import privateExports, {
   defaultSystemIcons,
-  ApiTestRegistry,
   BootErrorPageProps,
 } from '@backstage/core-api';
 import { RenderResult } from '@testing-library/react';
 import { renderWithEffects } from '@backstage/test-utils-core';
+import { createMockApiRegistry } from './mockApiRegistry';
 const { PrivateAppImpl } = privateExports;
 
 const NotFoundErrorPage = () => {
@@ -57,9 +57,10 @@ export function wrapInTestApp(
   options: TestAppOptions = {},
 ): ReactElement {
   const { routeEntries = ['/'] } = options;
+  const apis = createMockApiRegistry();
 
   const app = new PrivateAppImpl({
-    apis: new ApiTestRegistry(),
+    apis,
     components: {
       NotFoundErrorPage,
       BootErrorPage,

--- a/packages/test-utils/src/testUtils/mockApiRegistry.ts
+++ b/packages/test-utils/src/testUtils/mockApiRegistry.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiTestRegistry } from '@backstage/core-api';
+import { MockErrorApi } from './apis';
+
+export function createMockApiRegistry(): ApiTestRegistry {
+  const registry = new ApiTestRegistry();
+
+  registry.register(MockErrorApi.factory);
+
+  return registry;
+}


### PR DESCRIPTION
Continuation of #1201, implementing the proposed method of overriding APIs for tests.

A downside of this method is that it's very tricky to have the mocked API depend on other APIs in the test registry, but tbh I can't figure out any reason why you'd want to do that. Most likely all mocks you do would be shallow, and the only integration testing of APIs would be done with the API instances themselves.

I did try to find some nicer way to provide single APIs for testing, something like 

```tsx
  <ApiProvider ref={errorApiRef} api={mockErrorApi}>
    <A />
  </ApiProvider>
```

TS wasn't quite on board with that though, so will probably keep digging into that some other time.