### PR TITLE
chore(catalog): clean up ComponentPage, use only Entity

### DIFF
--- a/plugins/catalog/src/components/ComponentMetadataCard/ComponentMetadataCard.test.tsx
+++ b/plugins/catalog/src/components/ComponentMetadataCard/ComponentMetadataCard.test.tsx
@@ -13,28 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Entity } from '@backstage/catalog-model';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { ComponentMetadataCard } from './ComponentMetadataCard';
-import { Component } from '../../data/component';
-import { render } from '@testing-library/react';
 
 describe('ComponentMetadataCard component', () => {
   it('should display component name if provided', async () => {
-    const testComponent: Component = {
-      name: 'test',
+    const testEntity: Entity = {
+      apiVersion: 'backstage.io/v1beta1',
       kind: 'Component',
       metadata: { name: 'test' },
-      description: 'Placeholder',
     };
     const rendered = await render(
-      <ComponentMetadataCard loading={false} component={testComponent} />,
+      <ComponentMetadataCard entity={testEntity} />,
     );
     expect(await rendered.findByText('test')).toBeInTheDocument();
-  });
-  it('should display loader when loading is set to true', async () => {
-    const rendered = await render(
-      <ComponentMetadataCard loading component={undefined} />,
-    );
-    expect(await rendered.findByRole('progressbar')).toBeInTheDocument();
   });
 });

--- a/plugins/catalog/src/components/ComponentMetadataCard/ComponentMetadataCard.tsx
+++ b/plugins/catalog/src/components/ComponentMetadataCard/ComponentMetadataCard.tsx
@@ -13,29 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InfoCard, Progress, StructuredMetadataTable } from '@backstage/core';
+import { Entity } from '@backstage/catalog-model';
+import { InfoCard, StructuredMetadataTable } from '@backstage/core';
 import React, { FC } from 'react';
-import { Component } from '../../data/component';
 
 type Props = {
-  loading: boolean;
-  component: Component | undefined;
+  entity: Entity;
 };
 
-export const ComponentMetadataCard: FC<Props> = ({ loading, component }) => {
-  if (loading) {
-    return (
-      <InfoCard title="Metadata">
-        <Progress />
-      </InfoCard>
-    );
-  }
-  if (!component) {
-    return null;
-  }
-  return (
-    <InfoCard title="Metadata">
-      <StructuredMetadataTable metadata={component} />
-    </InfoCard>
-  );
-};
+export const ComponentMetadataCard: FC<Props> = ({ entity }) => (
+  <InfoCard title="Metadata">
+    <StructuredMetadataTable metadata={entity.metadata} />
+  </InfoCard>
+);

--- a/plugins/catalog/src/components/ComponentPage/ComponentPage.test.tsx
+++ b/plugins/catalog/src/components/ComponentPage/ComponentPage.test.tsx
@@ -47,8 +47,8 @@ describe('ComponentPage', () => {
             [
               catalogApiRef,
               ({
-                async getEntity() {},
-              } as unknown) as CatalogApi,
+                async getEntityByName() {},
+              } as Partial<CatalogApi>) as CatalogApi,
             ],
           ])}
         >

--- a/plugins/catalog/src/components/ComponentRemovalDialog/ComponentRemovalDialog.tsx
+++ b/plugins/catalog/src/components/ComponentRemovalDialog/ComponentRemovalDialog.tsx
@@ -32,37 +32,36 @@ import React, { FC } from 'react';
 import { useAsync } from 'react-use';
 import { AsyncState } from 'react-use/lib/useAsync';
 import { catalogApiRef } from '../../api/types';
-import { Component } from '../../data/component';
 
 type ComponentRemovalDialogProps = {
+  open: boolean;
   onConfirm: () => any;
-  onCancel: () => any;
   onClose: () => any;
-  component: Component;
+  entity: Entity;
 };
 
-function useColocatedEntities(component: Component): AsyncState<Entity[]> {
+function useColocatedEntities(entity: Entity): AsyncState<Entity[]> {
   const catalogApi = useApi(catalogApiRef);
   return useAsync(async () => {
-    const myLocation = component.metadata.annotations?.[LOCATION_ANNOTATION];
+    const myLocation = entity.metadata.annotations?.[LOCATION_ANNOTATION];
     return myLocation
       ? await catalogApi.getEntities({ [LOCATION_ANNOTATION]: myLocation })
       : [];
-  }, [catalogApi, component]);
+  }, [catalogApi, entity]);
 }
 
 export const ComponentRemovalDialog: FC<ComponentRemovalDialogProps> = ({
+  open,
   onConfirm,
-  onCancel,
   onClose,
-  component,
+  entity,
 }) => {
-  const { value: entities, loading, error } = useColocatedEntities(component);
+  const { value: entities, loading, error } = useColocatedEntities(entity);
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
-    <Dialog fullScreen={fullScreen} open onClose={onClose}>
+    <Dialog fullScreen={fullScreen} open={open} onClose={onClose}>
       <DialogTitle id="responsive-dialog-title">
         Are you sure you want to unregister this component?
       </DialogTitle>
@@ -102,7 +101,7 @@ export const ComponentRemovalDialog: FC<ComponentRemovalDialogProps> = ({
         ) : null}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>Cancel</Button>
+        <Button onClick={onClose}>Cancel</Button>
         <Button
           disabled={!!(loading || error)}
           onClick={onConfirm}


### PR DESCRIPTION
This cleans up the way that ComponentPage handles errors and progress, and removes its usage of the deprecated Component class, instead replacing it with Entity.

I have not renamed any classes etc yet; there are still multiple occurrences of the "Component" word both in classes and members. But let's clean up that separately, to limit the blast radius of each PR.