### PR TITLE
chore(cli): forbid path imports to other packages/plugins

### DIFF
--- a/packages/cli/config/eslint.js
+++ b/packages/cli/config/eslint.js
@@ -69,6 +69,7 @@ module.exports = {
           },
           ...require('module').builtinModules,
         ],
+        patterns: ['**/../packages/**', '**/../plugins/**'],
       },
     ],
   },


### PR DESCRIPTION
prevents accidental

```ts
import x from '../../../packages/core/x"
```