### PR TITLE
feat(catalog): add back ability for OR/IN type searches

### DIFF
--- a/plugins/catalog/src/api/CatalogClient.test.ts
+++ b/plugins/catalog/src/api/CatalogClient.test.ts
@@ -21,8 +21,12 @@ describe('CatalogClient', () => {
   it('builds entity search filters properly', async () => {
     mockFetch.mockResponse('[]');
     const client = new CatalogClient({ apiOrigin: '', basePath: '' });
-    const entities = await client.getEntities({ a: '1', ö: '=' });
+    const entities = await client.getEntities({
+      a: '1',
+      b: ['2', '3'],
+      ö: '=',
+    });
     expect(entities).toEqual([]);
-    expect(mockFetch).toBeCalledWith('/entities?a=1&%C3%B6=%3D');
+    expect(mockFetch).toBeCalledWith('/entities?a=1&b=2&b=3&%C3%B6=%3D');
   });
 });

--- a/plugins/catalog/src/api/CatalogClient.ts
+++ b/plugins/catalog/src/api/CatalogClient.ts
@@ -76,7 +76,9 @@ export class CatalogClient implements CatalogApi {
     return await this.getOptional(`/locations/${id}`);
   }
 
-  async getEntities(filter?: Record<string, string>): Promise<Entity[]> {
+  async getEntities(
+    filter?: Record<string, string | string[]>,
+  ): Promise<Entity[]> {
     const cachedValue = this.cache.get<Entity[]>(
       `get:${JSON.stringify(filter)}`,
     );
@@ -84,7 +86,17 @@ export class CatalogClient implements CatalogApi {
 
     let path = `/entities`;
     if (filter) {
-      path += `?${new URLSearchParams(filter).toString()}`;
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(filter)) {
+        if (Array.isArray(value)) {
+          for (const v of value) {
+            params.append(key, v);
+          }
+        } else {
+          params.append(key, value);
+        }
+      }
+      path += `?${params.toString()}`;
     }
 
     return await this.getRequired(path);

--- a/plugins/catalog/src/api/types.ts
+++ b/plugins/catalog/src/api/types.ts
@@ -34,7 +34,7 @@ export interface CatalogApi {
   getEntityByName(
     compoundName: EntityCompoundName,
   ): Promise<Entity | undefined>;
-  getEntities(filter?: Record<string, string>): Promise<Entity[]>;
+  getEntities(filter?: Record<string, string | string[]>): Promise<Entity[]>;
   addLocation(type: string, target: string): Promise<AddLocationResponse>;
   getLocationByEntity(entity: Entity): Promise<Location | undefined>;
   removeEntityByUid(uid: string): Promise<void>;


### PR DESCRIPTION
This is needed to be able to search for entities that match on any of a set of possible values (which the backend already supports).