### PR TITLE
chore(backend): make the sentry handling work better

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "backstage-cli watch-deps --build -- tsc-watch --onFirstSuccess \\\"nodemon -r esm\\\"",
+    "start": "backstage-cli watch-deps --build -- tsc-watch --onFirstSuccess \\\"cross-env NODE_ENV=development nodemon -r esm\\\"",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "clean": "backstage-cli clean",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -65,4 +65,7 @@ async function main() {
   });
 }
 
-main();
+main().catch(error => {
+  console.error(`Backend failed to start up, ${error}`);
+  process.exit(1);
+});

--- a/plugins/sentry-backend/src/index.ts
+++ b/plugins/sentry-backend/src/index.ts
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export * from './service/router';


### PR DESCRIPTION
Now the process actually exits in production instead of ending up in a zombie state, if exceptions are thrown during startup. This includes the sentry fix where it threw an exception on missing env var. I also made sure that the backend starts up in development mode.

Now it is possible to start the backend without any flags at all again.