### PR TITLE
chore(lighthouse): toggle private in package.json

### DIFF
--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -5,7 +5,7 @@
   "main:src": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
+  "private": false,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
After this change `@backstage/plugin-lighthouse` should be published on npm for public consumption.

See https://github.com/spotify/backstage/pull/378#issuecomment-643363971 for more context