### PR TITLE
Dynamically determine the chunk to inject during runtime

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -22,7 +22,7 @@ function inject_config() {
   >&2 echo "Runtime app config: $config"
 
   local main_js
-  main_js="$(ls /usr/share/nginx/html/main.*.chunk.js)"
+  main_js="$(grep -l __APP_INJECTED_RUNTIME_CONFIG__ /usr/share/nginx/html/*.chunk.js)"
   echo "Writing runtime config to ${main_js}"
 
   # escape ' and " twice, for both sed and json


### PR DESCRIPTION
During deployment we've noticed that the run.sh script doesn't actually
inject the values into the built files.

The `__APP_INJECTED_RUNTIME_CONFIG__` value is not always in the main
chunk, so we need to find the right chunk to inject for runtime config.


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes