### PR TITLE
plugins/catalog-backend: move migrations to JS with type annotations

### DIFF
--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -41,7 +41,7 @@ async function getConfig() {
     for (const pkg of packages) {
       const mainSrc = pkg.get('main:src');
       if (mainSrc) {
-        moduleNameMapper[pkg.name] = path.resolve(pkg.location, mainSrc);
+        moduleNameMapper[`^${pkg.name}$`] = path.resolve(pkg.location, mainSrc);
       }
     }
   }

--- a/plugins/catalog-backend/migrations/20200511113813_init.js
+++ b/plugins/catalog-backend/migrations/20200511113813_init.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// @ts-check
+
 /**
  * @param {import('knex')} knex
  */

--- a/plugins/catalog-backend/migrations/20200511113813_init.js
+++ b/plugins/catalog-backend/migrations/20200511113813_init.js
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import * as Knex from 'knex';
-
-export async function up(knex: Knex): Promise<any> {
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
   return (
     knex.schema
       //
@@ -114,9 +115,12 @@ export async function up(knex: Knex): Promise<any> {
           .comment('The corresponding value to match on');
       })
   );
-}
+};
 
-export async function down(knex: Knex): Promise<any> {
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
   return knex.schema
     .dropTable('entities_search')
     .alterTable('entities', table => {
@@ -124,4 +128,4 @@ export async function down(knex: Knex): Promise<any> {
     })
     .dropTable('entities')
     .dropTable('locations');
-}
+};

--- a/plugins/catalog-backend/migrations/20200520140700_location_update_log_table.js
+++ b/plugins/catalog-backend/migrations/20200520140700_location_update_log_table.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// @ts-check
+
 /**
  * @param {import('knex')} knex
  */

--- a/plugins/catalog-backend/migrations/20200520140700_location_update_log_table.js
+++ b/plugins/catalog-backend/migrations/20200520140700_location_update_log_table.js
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Knex from 'knex';
 
-export async function up(knex: Knex): Promise<any> {
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
   return knex.schema.createTable('location_update_log', table => {
     table.uuid('id').primary();
     table.enum('status', ['success', 'fail']).notNullable();
-    table
-      .dateTime('created_at')
-      .defaultTo(knex.fn.now())
-      .notNullable();
+    table.dateTime('created_at').defaultTo(knex.fn.now()).notNullable();
     table.string('message');
     table
       .uuid('location_id')
@@ -32,8 +31,11 @@ export async function up(knex: Knex): Promise<any> {
       .onDelete('CASCADE');
     table.string('entity_name').nullable();
   });
-}
+};
 
-export async function down(knex: Knex): Promise<any> {
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
   return knex.schema.dropTableIfExists('location_update_log');
-}
+};

--- a/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
+++ b/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// @ts-check
+
 /**
  * @param {import('knex')} knex
  */

--- a/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
+++ b/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Knex from 'knex';
 
-export async function up(knex: Knex): Promise<any> {
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
   // Need to first order by date of creation
   const query = knex
     .select()
@@ -28,8 +30,11 @@ export async function up(knex: Knex): Promise<any> {
   await knex.schema.raw(
     `CREATE VIEW location_update_log_latest AS ${groupedQuery.toString()};`,
   );
-}
+};
 
-export async function down(knex: Knex): Promise<any> {
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
   return knex.schema.raw(`DROP VIEW location_update_log_latest;`);
-}
+};

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -45,7 +45,8 @@
     "tsc-watch": "^4.2.3"
   },
   "files": [
-    "dist"
+    "dist",
+    "migrations"
   ],
   "nodemonConfig": {
     "watch": "./dist"

--- a/plugins/catalog-backend/src/database/DatabaseManager.ts
+++ b/plugins/catalog-backend/src/database/DatabaseManager.ts
@@ -22,6 +22,11 @@ import { Logger } from 'winston';
 import { CommonDatabase } from './CommonDatabase';
 import { Database } from './types';
 
+const migrationsDir = path.resolve(
+  require.resolve('@backstage/plugin-catalog-backend/package.json'),
+  '../migrations',
+);
+
 export type CreateDatabaseOptions = {
   logger: Logger;
   fieldNormalizer: (value: string) => string;
@@ -38,8 +43,7 @@ export class DatabaseManager {
     options: Partial<CreateDatabaseOptions> = {},
   ): Promise<Database> {
     await knex.migrate.latest({
-      directory: path.resolve(__dirname, 'migrations'),
-      loadExtensions: ['.js'],
+      directory: migrationsDir,
     });
     const { logger, fieldNormalizer } = { ...defaultOptions, ...options };
     return new CommonDatabase(knex, fieldNormalizer, logger);
@@ -69,8 +73,7 @@ export class DatabaseManager {
       resource.run('PRAGMA foreign_keys = ON', () => {});
     });
     await knex.migrate.latest({
-      directory: path.resolve(__dirname, 'migrations'),
-      loadExtensions: ['.ts'],
+      directory: migrationsDir,
     });
     const { logger, fieldNormalizer } = defaultOptions;
     return new CommonDatabase(knex, fieldNormalizer, logger);

--- a/plugins/catalog-backend/tsconfig.json
+++ b/plugins/catalog-backend/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "es2019",
     "module": "commonjs",
     "esModuleInterop": true,
+    "allowJs": true,
     "lib": ["es2019"],
     "types": ["node", "jest"]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "@backstage/cli/config/tsconfig.json",
-  "include": ["packages/*/src", "plugins/*/src", "plugins/*/dev"],
+  "include": [
+    "packages/*/src",
+    "plugins/*/src",
+    "plugins/*/dev",
+    "plugins/*/migrations"
+  ],
   "compilerOptions": {
     "outDir": "dist"
   }


### PR DESCRIPTION
Moving migrations to JS and top-level folder in the package. It should make them a lot more portable and easier to use from different sources as they don't require any pre-processing. It should also make it way easier to check the way we build and develop the backend.

We still get the same amount of type-checking and autocompletion as before thanks to JSDoc annotations.
