### PR TITLE
packages/backend-common: import winston as namespace

### DIFF
--- a/packages/backend-common/src/logging/rootLogger.test.ts
+++ b/packages/backend-common/src/logging/rootLogger.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import winston from 'winston';
+import * as winston from 'winston';
 import { getRootLogger, setRootLogger } from './rootLogger';
 
 describe('rootLogger', () => {

--- a/packages/backend-common/src/logging/rootLogger.ts
+++ b/packages/backend-common/src/logging/rootLogger.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import winston, { Logger } from 'winston';
+import * as winston from 'winston';
 
-let rootLogger: Logger = winston.createLogger({
+let rootLogger: winston.Logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
   format:
     process.env.NODE_ENV === 'production'
@@ -35,10 +35,10 @@ let rootLogger: Logger = winston.createLogger({
   ],
 });
 
-export function getRootLogger(): Logger {
+export function getRootLogger(): winston.Logger {
   return rootLogger;
 }
 
-export function setRootLogger(newLogger: Logger) {
+export function setRootLogger(newLogger: winston.Logger) {
   rootLogger = newLogger;
 }

--- a/packages/backend-common/src/logging/voidLogger.ts
+++ b/packages/backend-common/src/logging/voidLogger.ts
@@ -15,12 +15,12 @@
  */
 
 import { PassThrough } from 'stream';
-import winston, { Logger } from 'winston';
+import * as winston from 'winston';
 
 /**
  * A logger that just throws away all messages.
  */
-export function getVoidLogger(): Logger {
+export function getVoidLogger(): winston.Logger {
   return winston.createLogger({
     transports: [new winston.transports.Stream({ stream: new PassThrough() })],
   });

--- a/packages/backend-common/src/middleware/requestLoggingHandler.test.ts
+++ b/packages/backend-common/src/middleware/requestLoggingHandler.test.ts
@@ -16,7 +16,7 @@
 
 import express from 'express';
 import request from 'supertest';
-import winston from 'winston';
+import * as winston from 'winston';
 import { requestLoggingHandler } from './requestLoggingHandler';
 
 describe('requestLoggingHandler', () => {

--- a/plugins/scaffolder-backend/src/scaffolder/storage/index.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/storage/index.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { StorageBase, createStorage } from '.';
-import winston from 'winston';
+import * as winston from 'winston';
 
 describe('Storage Interface Test', () => {
   const mockStore = new (class MockStorage implements StorageBase {


### PR DESCRIPTION
Proper way to import winston in TS if we want it to work with rollup