### PR TITLE
fix(catalog-backend): make location delete work again

### DIFF
--- a/plugins/catalog-backend/src/database/CommonDatabase.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.ts
@@ -390,6 +390,10 @@ export class CommonDatabase implements Database {
   async removeLocation(txOpaque: unknown, id: string): Promise<void> {
     const tx = txOpaque as Knex.Transaction<any, any>;
 
+    await tx<DbEntitiesRow>('entities')
+      .where({ location_id: id })
+      .update({ location_id: null });
+
     const result = await tx<DbLocationsRow>('locations').where({ id }).del();
 
     if (!result) {


### PR DESCRIPTION
This isn't particularly pretty. I would have preferred if this was an ON DELETE SET NULL on the entity's location column, but these may be going away soon anyway, so it's not worth worrying about.