### PR TITLE
packages/cli: add lint rule to avoid cross-package src imports

### DIFF
--- a/packages/cli/config/eslint.backend.js
+++ b/packages/cli/config/eslint.backend.js
@@ -52,6 +52,8 @@ module.exports = {
       'warn',
       { vars: 'all', args: 'after-used', ignoreRestSiblings: true },
     ],
+    // Avoid cross-package imports
+    'no-restricted-imports': [2, { patterns: ['**/../../**/*/src/**'] }],
   },
   overrides: [
     {

--- a/packages/cli/config/eslint.js
+++ b/packages/cli/config/eslint.js
@@ -57,18 +57,19 @@ module.exports = {
       'warn',
       { vars: 'all', args: 'after-used', ignoreRestSiblings: true },
     ],
-
-    // Importing the entire MUI icons packages kills build performance as the list of icons is huge.
     'no-restricted-imports': [
       2,
       {
         paths: [
           {
+            // Importing the entire MUI icons packages kills build performance as the list of icons is huge.
             name: '@material-ui/icons',
             message: "Please import '@material-ui/icons/<Icon>' instead.",
           },
           ...require('module').builtinModules,
         ],
+        // Avoid cross-package imports
+        patterns: ['**/../../**/*/src/**'],
       },
     ],
   },


### PR DESCRIPTION
Stop-gap for `plugin:monorepo` not quite doing its thing. See #1246

This is a bit broken as imports from 2 levels of folders adjacent to `src/` within a package are not allowed, for example `dev/components/MyComponent` would not be allowed to import from `src/`. Probably fine for now though, and better than the possibility of leaking in cross-package src imports.