### PR TITLE
packages/config: added .keys()

### DIFF
--- a/packages/config/src/reader.test.ts
+++ b/packages/config/src/reader.test.ts
@@ -37,6 +37,7 @@ const DATA = {
 };
 
 function expectValidValues(config: ConfigReader) {
+  expect(config.keys()).toEqual(Object.keys(DATA));
   expect(config.getNumber('zero')).toBe(0);
   expect(config.getNumber('one')).toBe(1);
   expect(config.getBoolean('true')).toBe(true);
@@ -111,6 +112,7 @@ function expectInvalidValues(config: ConfigReader) {
 describe('ConfigReader', () => {
   it('should read empty config with valid keys', () => {
     const config = new ConfigReader({});
+    expect(config.keys()).toEqual([]);
     expect(config.getOptionalString('x')).toBeUndefined();
     expect(config.getOptionalString('x_x')).toBeUndefined();
     expect(config.getOptionalString('x-X')).toBeUndefined();
@@ -207,6 +209,17 @@ describe('ConfigReader with fallback', () => {
     };
 
     const config = new ConfigReader(a, new ConfigReader(b));
+
+    expect(config.keys()).toEqual(['merged']);
+    expect(config.getConfig('merged').keys()).toEqual([
+      'x',
+      'z',
+      'arr',
+      'config',
+      'configs',
+      'y',
+    ]);
+    expect(config.getConfig('merged.config').keys()).toEqual(['d', 'e']);
 
     expect(config.getString('merged.x')).toBe('x');
     expect(config.getString('merged.y')).toBe('y');

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -68,6 +68,12 @@ export class ConfigReader implements Config {
     private readonly prefix: string = '',
   ) {}
 
+  keys(): string[] {
+    const localKeys = this.data ? Object.keys(this.data) : [];
+    const fallbackKeys = this.fallback?.keys() ?? [];
+    return [...new Set([...localKeys, ...fallbackKeys])];
+  }
+
   getConfig(key: string): ConfigReader {
     const value = this.readValue(key);
     const fallbackConfig = this.fallback?.getConfig(key);

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -27,6 +27,8 @@ export type JsonValue =
 export type AppConfig = JsonObject;
 
 export type Config = {
+  keys(): string[];
+
   getConfig(key: string): Config;
 
   getConfigArray(key: string): Config[];


### PR DESCRIPTION
Gonna need something like this for e.g. auth providers. It's a lot more convenient to list multiple config objects with a known key instead of an array, as that lets you merge together configs.

Config arrays aren't merged together across files, as it's not obvious if you'd want to merge together the elements of the arrays or concatenate them. And even when merging arrays you might want to do it based on some key. We could probably add some special `$merge` directive, but it's probably simpler to just avoid arrays except for at leaf nodes.
