### PR TITLE
packages/config: add context to config to display better errors messages

### DIFF
--- a/packages/config-loader/src/lib/env.test.ts
+++ b/packages/config-loader/src/lib/env.test.ts
@@ -45,9 +45,12 @@ describe('readEnv', () => {
       }),
     ).toEqual([
       {
-        foo: 'bar',
-        numbers: { a: 1, b: 2, c: false },
-        very: { deep: { nested: { config: { object: {} } } } },
+        data: {
+          foo: 'bar',
+          numbers: { a: 1, b: 2, c: false },
+          very: { deep: { nested: { config: { object: {} } } } },
+        },
+        context: 'env',
       },
     ]);
   });

--- a/packages/config-loader/src/lib/env.ts
+++ b/packages/config-loader/src/lib/env.ts
@@ -42,7 +42,7 @@ const CONFIG_KEY_PART_PATTERN = /^[a-z][a-z0-9]*(?:[-_][a-z][a-z0-9]*)*$/i;
 export function readEnv(env: {
   [name: string]: string | undefined;
 }): AppConfig[] {
-  let config: JsonObject | undefined = undefined;
+  let data: JsonObject | undefined = undefined;
 
   for (const [name, value] of Object.entries(env)) {
     if (!value) {
@@ -52,7 +52,7 @@ export function readEnv(env: {
       const key = name.replace(ENV_PREFIX, '');
       const keyParts = key.split('_');
 
-      let obj = (config = config ?? {});
+      let obj = (data = data ?? {});
       for (const [index, part] of keyParts.entries()) {
         if (!CONFIG_KEY_PART_PATTERN.test(part)) {
           throw new TypeError(`Invalid env config key '${key}'`);
@@ -87,5 +87,5 @@ export function readEnv(env: {
     }
   }
 
-  return config ? [config] : [];
+  return data ? [{ data, context: 'env' }] : [];
 }

--- a/packages/config-loader/src/lib/reader.test.ts
+++ b/packages/config-loader/src/lib/reader.test.ts
@@ -38,11 +38,14 @@ describe('readConfigFile', () => {
     } as ReaderContext);
 
     await expect(config).resolves.toEqual({
-      app: {
-        title: 'Test',
-        x: 1,
-        y: [true],
+      data: {
+        app: {
+          title: 'Test',
+          x: 1,
+          y: [true],
+        },
       },
+      context: 'app-config.yaml',
     });
   });
 
@@ -83,7 +86,10 @@ describe('readConfigFile', () => {
     });
 
     await expect(config).resolves.toEqual({
-      app: 'secret',
+      data: {
+        app: 'secret',
+      },
+      context: 'app-config.yaml',
     });
     expect(readSecret).toHaveBeenCalledWith({ file: './my-secret' });
   });

--- a/packages/config-loader/src/lib/reader.ts
+++ b/packages/config-loader/src/lib/reader.ts
@@ -15,15 +15,19 @@
  */
 
 import yaml from 'yaml';
+import { basename } from 'path';
 import { isObject } from './utils';
-import { JsonValue, JsonObject } from '@backstage/config';
+import { JsonValue, JsonObject, AppConfig } from '@backstage/config';
 import { ReaderContext } from './types';
 
 /**
  * Reads and parses, and validates, and transforms a single config file.
  * The transformation rewrites any special values, like the $secret key.
  */
-export async function readConfigFile(filePath: string, ctx: ReaderContext) {
+export async function readConfigFile(
+  filePath: string,
+  ctx: ReaderContext,
+): Promise<AppConfig> {
   const configYaml = await ctx.readFile(filePath);
   const config = yaml.parse(configYaml);
 
@@ -76,5 +80,5 @@ export async function readConfigFile(filePath: string, ctx: ReaderContext) {
   if (!isObject(finalConfig)) {
     throw new TypeError('Expected object at config root');
   }
-  return finalConfig;
+  return { data: finalConfig, context: basename(filePath) };
 }

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -24,7 +24,10 @@ export type JsonValue =
   | boolean
   | null;
 
-export type AppConfig = JsonObject;
+export type AppConfig = {
+  context: string;
+  data: JsonObject;
+};
 
 export type Config = {
   keys(): string[];

--- a/packages/core/src/api-wrappers/createApp.tsx
+++ b/packages/core/src/api-wrappers/createApp.tsx
@@ -27,7 +27,7 @@ import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import { ErrorPage } from '../layout/ErrorPage';
 import Progress from '../components/Progress';
 import { lightTheme, darkTheme } from '@backstage/theme';
-import { AppConfig } from '@backstage/config';
+import { AppConfig, JsonObject } from '@backstage/config';
 
 const { PrivateAppImpl } = privateExports;
 
@@ -59,7 +59,8 @@ export const defaultConfigLoader: AppConfigLoader = async (
   // Avoiding this string also being replaced at runtime
   if (runtimeConfigJson !== '__app_injected_runtime_config__'.toUpperCase()) {
     try {
-      configs.unshift(JSON.parse(runtimeConfigJson));
+      const data = JSON.parse(runtimeConfigJson) as JsonObject;
+      configs.unshift({ data, context: 'env' });
     } catch (error) {
       throw new Error(`Failed to load runtime configuration, ${error}`);
     }


### PR DESCRIPTION
Now you get things like

```
TypeError: Invalid type in config for key 'app.baseUrl' in 'app-config.yaml', got string, wanted number

TypeError: Invalid type in config for key 'app.title' in 'env', got string, wanted boolean
```