### PR TITLE
changed  down caret to be up caret on user profile in the sidebar

### DIFF
--- a/packages/core/src/layout/Sidebar/Settings/UserProfile.tsx
+++ b/packages/core/src/layout/Sidebar/Settings/UserProfile.tsx
@@ -104,7 +104,7 @@ export const UserProfile: FC<{ open: boolean; setOpen: Function }> = ({
         onClick={handleClick}
         icon={avatar || AccountCircleIcon}
       >
-        {open ? <ExpandLess /> : <ExpandMore />}
+        {open ? <ExpandMore /> : <ExpandLess />}
       </SidebarItem>
     </>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixed the caret in user profile to be pointing the right way

![Screenshot 2020-06-18 at 11 16 52](https://user-images.githubusercontent.com/1236238/85002495-3f445200-b155-11ea-8d1e-594407d7091e.png)

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
