### PR TITLE
packages/config: added get and getOptional

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,6 +29,9 @@
     "postpack": "backstage-cli postpack",
     "clean": "backstage-cli clean"
   },
+  "dependencies": {
+    "lodash": "^4.17.15"
+  },
   "devDependencies": {
     "@types/jest": "^25.2.2",
     "@types/node": "^12.0.0"

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -32,6 +32,9 @@ export type AppConfig = {
 export type Config = {
   keys(): string[];
 
+  get(key: string): JsonValue;
+  getOptional(key: string): JsonValue | undefined;
+
   getConfig(key: string): Config;
   getOptionalConfig(key: string): Config | undefined;
 


### PR DESCRIPTION
Added a way to get untyped config values too. It merges together objects from fallback configs so that there's no difference between `config.get('x').y` and `config.getConfig('x').get('y')`