### PR TITLE
packages/cli: avoid including src/index when serving backend src/run

### DIFF
--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -178,8 +178,7 @@ export function createBackendConfig(
     context: paths.targetPath,
     entry: [
       'webpack/hot/poll?100',
-      paths.targetEntry,
-      ...(paths.targetRunFile ? [paths.targetRunFile] : []),
+      paths.targetRunFile ? paths.targetRunFile : paths.targetEntry,
     ],
     resolve: {
       extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx'],


### PR DESCRIPTION
Including src/index break hot reloads since changes will propagate there and can't be accepted