### PR TITLE
Fix CircleCI plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dist
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+
+# Temporary change files created by Vim
+*.swp

--- a/plugins/circleci/src/components/App.tsx
+++ b/plugins/circleci/src/components/App.tsx
@@ -25,11 +25,8 @@ export const App = () => {
     <AppStateProvider>
       <>
         <Routes>
-          <Route path="/circleci" element={<BuildsPage />} />
-          <Route
-            path="/circleci/build/:buildId"
-            element={<DetailedViewPage />}
-          />
+          <Route path="*" element={<BuildsPage />} />
+          <Route path="/build/:buildId" element={<DetailedViewPage />} />
         </Routes>
         <Settings />
       </>

--- a/plugins/circleci/src/components/Settings/Settings.tsx
+++ b/plugins/circleci/src/components/Settings/Settings.tsx
@@ -44,13 +44,13 @@ const Settings = () => {
 
   useEffect(() => {
     if (tokenFromStore !== token) {
-      setToken(tokenFromStore);
+      setToken(token);
     }
     if (ownerFromStore !== owner) {
-      setOwner(ownerFromStore);
+      setOwner(owner);
     }
     if (repoFromStore !== repo) {
-      setRepo(repoFromStore);
+      setRepo(repo);
     }
   }, [ownerFromStore, repoFromStore, tokenFromStore, token, owner, repo]);
 


### PR DESCRIPTION
I discovered a number of problems with the CircleCI plugin.

1. The paths for the CircleCI plugin were too deeply nested causing a blank
page to render when one visited /circleci.
2. The settings could not be edited.

It used to look like this

![Screenshot 2020-06-21 at 15 08 28](https://user-images.githubusercontent.com/562403/85226853-8c345c80-b3d1-11ea-98ad-1e2c9bb97faa.png)

Now it looks like this

![Screenshot 2020-06-21 at 15 29 41](https://user-images.githubusercontent.com/562403/85227234-14b3fc80-b3d4-11ea-84f5-80fcc8397c75.png)


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
