### PR TITLE
Add Jenkins plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 # https://help.github.com/articles/about-codeowners/
 
 *                @spotify/backstage-core
+/plugins/jenkins david@larder.dev

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -9,6 +9,7 @@
     "@backstage/plugin-circleci": "^0.1.1-alpha.9",
     "@backstage/plugin-explore": "^0.1.1-alpha.9",
     "@backstage/plugin-gitops-profiles": "^0.1.1-alpha.9",
+    "@backstage/plugin-jenkins": "^0.1.1-alpha.9",
     "@backstage/plugin-lighthouse": "^0.1.1-alpha.9",
     "@backstage/plugin-register-component": "^0.1.1-alpha.9",
     "@backstage/plugin-scaffolder": "^0.1.1-alpha.9",

--- a/packages/app/src/plugins.ts
+++ b/packages/app/src/plugins.ts
@@ -23,3 +23,4 @@ export { plugin as Circleci } from '@backstage/plugin-circleci';
 export { plugin as RegisterComponent } from '@backstage/plugin-register-component';
 export { plugin as Sentry } from '@backstage/plugin-sentry';
 export { plugin as GitopsProfiles } from '@backstage/plugin-gitops-profiles';
+export { plugin as Jenkins } from '@backstage/plugin-jenkins';

--- a/plugins/jenkins/.eslintrc.js
+++ b/plugins/jenkins/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint')],
+};

--- a/plugins/jenkins/README.md
+++ b/plugins/jenkins/README.md
@@ -1,0 +1,13 @@
+# jenkins
+
+Welcome to the jenkins plugin!
+
+_This plugin was created through the Backstage CLI_
+
+## Getting started
+
+Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn start` in the root directory, and then navigating to [/jenkins](http://localhost:3000/jenkins).
+
+You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
+This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
+It is only meant for local development, and the setup for it can be found inside the [/dev](/dev) directory.

--- a/plugins/jenkins/dev/index.tsx
+++ b/plugins/jenkins/dev/index.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createDevApp } from '@backstage/dev-utils';
+import { plugin } from '../src/plugin';
+
+createDevApp().registerPlugin(plugin).render();

--- a/plugins/jenkins/package.json
+++ b/plugins/jenkins/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@backstage/plugin-jenkins",
+  "version": "0.1.1-alpha.9",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "scripts": {
+    "build": "backstage-cli plugin:build",
+    "start": "backstage-cli plugin:serve",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test",
+    "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
+    "clean": "backstage-cli clean"
+  },
+  "dependencies": {
+    "@backstage/core": "^0.1.1-alpha.9",
+    "@backstage/theme": "^0.1.1-alpha.9",
+    "@material-ui/core": "^4.9.1",
+    "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "4.0.0-alpha.45",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-use": "^14.2.0",
+    "react-router": "^6.0.0-alpha.5",
+    "react-router-dom": "^6.0.0-alpha.5"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.1.1-alpha.9",
+    "@backstage/dev-utils": "^0.1.1-alpha.9",
+    "@testing-library/jest-dom": "^5.7.0",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/user-event": "^10.2.4",
+    "@types/jest": "^25.2.2",
+    "@types/node": "^12.0.0",
+    "@types/testing-library__jest-dom": "^5.0.4",
+    "jest-fetch-mock": "^3.0.3"
+  },
+  "files": [
+    "dist/**/*.{js,d.ts}"
+  ]
+}

--- a/plugins/jenkins/src/components/App.tsx
+++ b/plugins/jenkins/src/components/App.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Route, Routes } from 'react-router';
+import { BuildsPage } from '../pages/BuildsPage';
+
+export const App = () => {
+  return (
+    <>
+      <Routes>
+        <Route path="*" element={<BuildsPage />} />
+      </Routes>
+    </>
+  );
+};

--- a/plugins/jenkins/src/components/Layout/Layout.tsx
+++ b/plugins/jenkins/src/components/Layout/Layout.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Header, Page, pageTheme, HeaderLabel } from '@backstage/core';
+
+export const Layout: React.FC = ({ children }) => {
+  return (
+    <Page theme={pageTheme.tool}>
+      <Header title="Jenkins" subtitle="See recent builds and their status">
+        <HeaderLabel label="Owner" value="Spotify" />
+        <HeaderLabel label="Lifecycle" value="Alpha" />
+      </Header>
+      {children}
+    </Page>
+  );
+};

--- a/plugins/jenkins/src/components/Layout/index.ts
+++ b/plugins/jenkins/src/components/Layout/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './Layout';

--- a/plugins/jenkins/src/components/PluginHeader/PluginHeader.tsx
+++ b/plugins/jenkins/src/components/PluginHeader/PluginHeader.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { FC } from 'react';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { ContentHeader, SupportButton } from '@backstage/core';
+import { Button, IconButton, Box, Typography } from '@material-ui/core';
+import ArrowBack from '@material-ui/icons/ArrowBack';
+import SettingsIcon from '@material-ui/icons/Settings';
+
+export type Props = { title?: string };
+export const PluginHeader: FC<Props> = ({ title = 'CircleCI' }) => {
+  const location = useLocation();
+  const notRoot = !location.pathname.match(/\/circleci\/?$/);
+
+  return (
+    <ContentHeader
+      title={title}
+      titleComponent={() => (
+        <Box alignItems="center" display="flex">
+          {notRoot && (
+            <IconButton component={RouterLink} to="/circleci">
+              <ArrowBack />
+            </IconButton>
+          )}
+          <Typography variant="h4">{title}</Typography>
+        </Box>
+      )}
+    >
+      <Button
+        onClick={() => {
+          // eslint-disable-next-line no-console
+          console.log('Not implemented yet');
+        }}
+        startIcon={<SettingsIcon />}
+      >
+        Settings
+      </Button>
+
+      <SupportButton>
+        This plugin allows you to view and interact with your builds in Jenkins.
+      </SupportButton>
+    </ContentHeader>
+  );
+};

--- a/plugins/jenkins/src/components/PluginHeader/index.ts
+++ b/plugins/jenkins/src/components/PluginHeader/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './PluginHeader';

--- a/plugins/jenkins/src/index.ts
+++ b/plugins/jenkins/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { plugin } from './plugin';

--- a/plugins/jenkins/src/pages/BuildsPage/BuildsPage.tsx
+++ b/plugins/jenkins/src/pages/BuildsPage/BuildsPage.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { FC } from 'react';
+import { Content } from '@backstage/core';
+import { Grid } from '@material-ui/core';
+import { Builds as BuildsComp } from './lib/Builds';
+import { Layout } from '../../components/Layout';
+import { PluginHeader } from '../../components/PluginHeader';
+
+const BuildsPage: FC<{}> = () => (
+  <Layout>
+    <Content>
+      <Builds />
+    </Content>
+  </Layout>
+);
+
+const Builds = () => (
+  <>
+    <PluginHeader title="All builds" />
+    <Grid container spacing={3} direction="column">
+      <Grid item>
+        <BuildsComp />
+      </Grid>
+    </Grid>
+  </>
+);
+
+export default BuildsPage;
+export { Builds };

--- a/plugins/jenkins/src/pages/BuildsPage/index.ts
+++ b/plugins/jenkins/src/pages/BuildsPage/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { default as BuildsPage, Builds } from './BuildsPage';

--- a/plugins/jenkins/src/pages/BuildsPage/lib/Builds/Builds.tsx
+++ b/plugins/jenkins/src/pages/BuildsPage/lib/Builds/Builds.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { FC } from 'react';
+// import { useBuilds } from '../../../../state';
+
+export const Builds: FC<{}> = () => {
+  // const [
+  //   { total, loading, value, projectName, page, pageSize },
+  //   { setPage, retry, setPageSize },
+  // ] = useBuilds();
+
+  return <div>Builds go here</div>;
+};

--- a/plugins/jenkins/src/pages/BuildsPage/lib/Builds/index.ts
+++ b/plugins/jenkins/src/pages/BuildsPage/lib/Builds/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { Builds } from './Builds';

--- a/plugins/jenkins/src/plugin.test.ts
+++ b/plugins/jenkins/src/plugin.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { plugin } from './plugin';
+
+describe('jenkins', () => {
+  it('should export plugin', () => {
+    expect(plugin).toBeDefined();
+  });
+});

--- a/plugins/jenkins/src/plugin.ts
+++ b/plugins/jenkins/src/plugin.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createPlugin, createRouteRef } from '@backstage/core';
+import { App } from './components/App';
+
+export const rootRouteRef = createRouteRef({
+  path: '/jenkins',
+  title: 'jenkins',
+});
+
+export const plugin = createPlugin({
+  id: 'jenkins',
+  register({ router }) {
+    router.addRoute(rootRouteRef, App, { exact: false });
+  },
+});

--- a/plugins/jenkins/src/setupTests.ts
+++ b/plugins/jenkins/src/setupTests.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+require('jest-fetch-mock').enableMocks();


### PR DESCRIPTION
It doesn't do anything yet other than render "Builds go here" in a DOM but the scaffold is there to start making API calls. 

This plugin borrows heavily from the CircleCI plugin.

### TODO

- [x] Scaffold a jenkins plugin at `/jenkins`
- [ ] Show a list of builds in the page with dummy data
- [ ] Request builds from the Jenkins API (with hardcoded auth variables) and show them in the page instead of dummy data
- [ ] Implement an auth modal similar to the CircleCI plugin


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
