### PR TITLE
Adding name of signed in user to greeting message #1356

### DIFF
--- a/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
@@ -15,23 +15,25 @@
  */
 
 import React, { FC } from 'react';
-import { Header, HomepageTimer, Page, pageTheme } from '@backstage/core';
+import {
+  Header,
+  HomepageTimer,
+  Page,
+  pageTheme,
+  identityApiRef,
+  useApi,
+} from '@backstage/core';
 import { getTimeBasedGreeting } from './utils/timeUtil';
 
 const CatalogLayout: FC<{}> = props => {
   const { children } = props;
-  // const profile = useProfile();
-  const profile = { givenName: 'friend' };
   const greeting = getTimeBasedGreeting();
+  const identityApi = useApi(identityApiRef);
 
   return (
     <Page theme={pageTheme.home}>
       <Header
-        title={
-          profile
-            ? `${greeting.greeting}, ${profile.givenName}!`
-            : greeting.greeting
-        }
+        title={`${greeting.greeting}, ${identityApi.getUserId()}!`}
         subtitle="Backstage Service Catalog"
         tooltip={greeting.language}
         pageTitleOverride="Home"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As discussed in #1356, adding the name of the signed in user to the greeting message, or `guest` when the user isn't signed in. `getUserId()` returns `guest` for users without a "pretty" name, so it's fine to just display the output from that method. 

Screenshot below to show greeting message with a user id.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [X] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [X] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

![Screenshot 2020-06-21 at 20 01 22](https://user-images.githubusercontent.com/26585975/85232874-830bb580-b3fa-11ea-8464-63868a4ae27f.png)

