### PR TITLE
Improving github url parsing, supporting branch names with / in them

### DIFF
--- a/plugins/catalog-backend/src/ingestion/processors/GithubReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubReaderProcessor.ts
@@ -62,7 +62,13 @@ export class GithubReaderProcessor implements LocationProcessor {
   // to:   https://raw.githubusercontent.com/a/b/master/c.yaml
   private buildRawUrl(target: string): URL {
     try {
-      const url = new URL(target);
+      // the "blob" that should be removed always comes between the 5th and the 6th slash, so we filter that out and join the string back together
+      const parsedUrl = target
+        .replace('//github.com/', '//raw.githubusercontent.com/')
+        .split('/')
+        .filter((_, index) => index !== 5)
+        .join('/');
+      const url = new URL(parsedUrl);
 
       const [
         empty,
@@ -73,7 +79,7 @@ export class GithubReaderProcessor implements LocationProcessor {
       ] = url.pathname.split('/');
 
       if (
-        url.hostname !== 'github.com' ||
+        url.hostname !== 'raw.githubusercontent.com' ||
         empty !== '' ||
         userOrOrg === '' ||
         repoName === '' ||
@@ -82,11 +88,6 @@ export class GithubReaderProcessor implements LocationProcessor {
       ) {
         throw new Error('Wrong GitHub URL');
       }
-
-      // Removing the "blob" part
-      url.pathname = [empty, userOrOrg, repoName, ...restOfPath].join('/');
-      url.hostname = 'raw.githubusercontent.com';
-      url.protocol = 'https';
 
       return url;
     } catch (e) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As I mentioned in #1315, I was looking for patterns to make the github URL parsing more reliable, and I found that the "blob" that should be removed always comes between the 5th and the 6th slash, so it's fine to split the string at /, get rid of the 5th item in the array and join the string back together. I've tested this with a bunch of scenarios, and it always seem to return the intended URL and this will now support branch names with / in them, like mentioned in the issue.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [X] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
