### PR TITLE
auth: refactor to include backstage identity and use more explicit types

### DIFF
--- a/packages/core-api/src/apis/definitions/IdentityApi.ts
+++ b/packages/core-api/src/apis/definitions/IdentityApi.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { createApiRef } from '../ApiRef';
+import { ProfileInfo } from './auth';
 
 /**
  * The Identity API used to identify and get information about the signed in user.
@@ -28,6 +29,11 @@ export type IdentityApi = {
    *       be possible to fetch all owned components using this ID.
    */
   getUserId(): string;
+
+  /**
+   * The profile of the signed in user.
+   */
+  getProfile(): ProfileInfo;
 
   /**
    * An OpenID Connect ID Token which proves the identity of the signed in user.

--- a/packages/core-api/src/apis/implementations/auth/github/GithubAuth.test.ts
+++ b/packages/core-api/src/apis/implementations/auth/github/GithubAuth.test.ts
@@ -20,7 +20,7 @@ describe('GithubAuth', () => {
   it('should get access token', async () => {
     const getSession = jest
       .fn()
-      .mockResolvedValue({ accessToken: 'access-token' });
+      .mockResolvedValue({ providerInfo: { accessToken: 'access-token' } });
     const githubAuth = new GithubAuth({ getSession } as any);
 
     expect(await githubAuth.getAccessToken()).toBe('access-token');

--- a/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
@@ -19,9 +19,11 @@ import { DefaultAuthConnector } from '../../../../lib/AuthConnector';
 import { GithubSession } from './types';
 import {
   OAuthApi,
-  AccessTokenOptions,
   SessionStateApi,
   SessionState,
+  ProfileInfo,
+  BackstageIdentity,
+  AuthRequestOptions,
 } from '../../../definitions/auth';
 import { OAuthRequestApi, AuthProvider } from '../../../definitions';
 import { SessionManager } from '../../../../lib/AuthSessionManager/types';
@@ -41,10 +43,13 @@ type CreateOptions = {
 };
 
 export type GithubAuthResponse = {
-  accessToken: string;
-  idToken: string;
-  scope: string;
-  expiresInSeconds: number;
+  providerInfo: {
+    accessToken: string;
+    scope: string;
+    expiresInSeconds: number;
+  };
+  profile: ProfileInfo;
+  backstageIdentity: BackstageIdentity;
 };
 
 const DEFAULT_PROVIDER = {
@@ -69,9 +74,14 @@ class GithubAuth implements OAuthApi, SessionStateApi {
       oauthRequestApi: oauthRequestApi,
       sessionTransform(res: GithubAuthResponse): GithubSession {
         return {
-          accessToken: res.accessToken,
-          scopes: GithubAuth.normalizeScope(res.scope),
-          expiresAt: new Date(Date.now() + res.expiresInSeconds * 1000),
+          ...res,
+          providerInfo: {
+            accessToken: res.providerInfo.accessToken,
+            scopes: GithubAuth.normalizeScope(res.providerInfo.scope),
+            expiresAt: new Date(
+              Date.now() + res.providerInfo.expiresInSeconds * 1000,
+            ),
+          },
         };
       },
     });
@@ -79,7 +89,7 @@ class GithubAuth implements OAuthApi, SessionStateApi {
     const sessionManager = new StaticAuthSessionManager({
       connector,
       defaultScopes: new Set(['user']),
-      sessionScopes: session => session.scopes,
+      sessionScopes: (session: GithubSession) => session.providerInfo.scopes,
     });
 
     return new GithubAuth(sessionManager);
@@ -93,7 +103,7 @@ class GithubAuth implements OAuthApi, SessionStateApi {
 
   constructor(private readonly sessionManager: SessionManager<GithubSession>) {}
 
-  async getAccessToken(scope?: string, options?: AccessTokenOptions) {
+  async getAccessToken(scope?: string, options?: AuthRequestOptions) {
     const normalizedScopes = GithubAuth.normalizeScope(scope);
     const session = await this.sessionManager.getSession({
       ...options,
@@ -101,9 +111,23 @@ class GithubAuth implements OAuthApi, SessionStateApi {
     });
     this.sessionStateTracker.setIsSignedId(!!session);
     if (session) {
-      return session.accessToken;
+      return session.providerInfo.accessToken;
     }
     return '';
+  }
+
+  async getBackstageIdentity(
+    options: AuthRequestOptions = {},
+  ): Promise<BackstageIdentity | undefined> {
+    const session = await this.sessionManager.getSession(options);
+    this.sessionStateTracker.setIsSignedId(!!session);
+    return session?.backstageIdentity;
+  }
+
+  async getProfile(options: AuthRequestOptions = {}) {
+    const session = await this.sessionManager.getSession(options);
+    this.sessionStateTracker.setIsSignedId(!!session);
+    return session?.profile;
   }
 
   async logout() {

--- a/packages/core-api/src/apis/implementations/auth/github/types.ts
+++ b/packages/core-api/src/apis/implementations/auth/github/types.ts
@@ -14,8 +14,15 @@
  * limitations under the License.
  */
 
+import { ProfileInfo } from '../../..';
+import { BackstageIdentity } from '../../../definitions';
+
 export type GithubSession = {
-  accessToken: string;
-  scopes: Set<string>;
-  expiresAt: Date;
+  providerInfo: {
+    accessToken: string;
+    scopes: Set<string>;
+    expiresAt: Date;
+  };
+  profile: ProfileInfo;
+  backstageIdentity: BackstageIdentity;
 };

--- a/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.test.ts
+++ b/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.test.ts
@@ -23,9 +23,9 @@ const PREFIX = 'https://www.googleapis.com/auth/';
 
 describe('GoogleAuth', () => {
   it('should get refreshed access token', async () => {
-    const getSession = jest
-      .fn()
-      .mockResolvedValue({ accessToken: 'access-token', expiresAt: theFuture });
+    const getSession = jest.fn().mockResolvedValue({
+      providerInfo: { accessToken: 'access-token', expiresAt: theFuture },
+    });
     const googleAuth = new GoogleAuth({ getSession } as any);
 
     expect(await googleAuth.getAccessToken()).toBe('access-token');
@@ -33,9 +33,9 @@ describe('GoogleAuth', () => {
   });
 
   it('should get refreshed id token', async () => {
-    const getSession = jest
-      .fn()
-      .mockResolvedValue({ idToken: 'id-token', expiresAt: theFuture });
+    const getSession = jest.fn().mockResolvedValue({
+      providerInfo: { idToken: 'id-token', expiresAt: theFuture },
+    });
     const googleAuth = new GoogleAuth({ getSession } as any);
 
     expect(await googleAuth.getIdToken()).toBe('id-token');
@@ -43,9 +43,9 @@ describe('GoogleAuth', () => {
   });
 
   it('should get optional id token', async () => {
-    const getSession = jest
-      .fn()
-      .mockResolvedValue({ idToken: 'id-token', expiresAt: theFuture });
+    const getSession = jest.fn().mockResolvedValue({
+      providerInfo: { idToken: 'id-token', expiresAt: theFuture },
+    });
     const googleAuth = new GoogleAuth({ getSession } as any);
 
     expect(await googleAuth.getIdToken({ optional: true })).toBe('id-token');
@@ -58,9 +58,11 @@ describe('GoogleAuth', () => {
     const getSession = jest
       .fn()
       .mockResolvedValueOnce({
-        accessToken: 'access-token',
-        expiresAt: theFuture,
-        scopes: new Set([`${PREFIX}not-enough`]),
+        providerInfo: {
+          accessToken: 'access-token',
+          expiresAt: theFuture,
+          scopes: new Set([`${PREFIX}not-enough`]),
+        },
       })
       .mockRejectedValue(error);
     const googleAuth = new GoogleAuth({ getSession } as any);
@@ -77,17 +79,21 @@ describe('GoogleAuth', () => {
 
   it('should wait for all session refreshes', async () => {
     const initialSession = {
-      idToken: 'token1',
-      expiresAt: theFuture,
-      scopes: new Set(),
+      providerInfo: {
+        idToken: 'token1',
+        expiresAt: theFuture,
+        scopes: new Set(),
+      },
     };
     const getSession = jest
       .fn()
       .mockResolvedValueOnce(initialSession)
       .mockResolvedValue({
-        idToken: 'token2',
-        expiresAt: theFuture,
-        scopes: new Set(),
+        providerInfo: {
+          idToken: 'token2',
+          expiresAt: theFuture,
+          scopes: new Set(),
+        },
       });
     const googleAuth = new GoogleAuth({ getSession } as any);
 
@@ -95,7 +101,7 @@ describe('GoogleAuth', () => {
     await expect(googleAuth.getIdToken()).resolves.toBe('token1');
     expect(getSession).toBeCalledTimes(1);
 
-    initialSession.expiresAt = thePast;
+    initialSession.providerInfo.expiresAt = thePast;
 
     const promise1 = googleAuth.getIdToken();
     const promise2 = googleAuth.getIdToken();

--- a/packages/core-api/src/apis/implementations/auth/google/types.ts
+++ b/packages/core-api/src/apis/implementations/auth/google/types.ts
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-import { ProfileInfo } from '../../../definitions';
+import { ProfileInfo, BackstageIdentity } from '../../../definitions';
 
 export type GoogleSession = {
+  providerInfo: {
+    idToken: string;
+    accessToken: string;
+    scopes: Set<string>;
+    expiresAt: Date;
+  };
   profile: ProfileInfo;
-  idToken: string;
-  accessToken: string;
-  scopes: Set<string>;
-  expiresAt: Date;
+  backstageIdentity: BackstageIdentity;
 };

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -293,6 +293,10 @@ export class PrivateAppImpl implements BackstageApp {
       if (!SignInPageComponent) {
         this.identityApi.setSignInResult({
           userId: 'guest',
+          profile: {
+            email: 'guest@example.com',
+            displayName: 'Guest',
+          },
         });
 
         return (

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -17,7 +17,6 @@ import React, {
   ComponentType,
   FC,
   useMemo,
-  useCallback,
   useState,
   ReactElement,
 } from 'react';
@@ -258,24 +257,14 @@ export class PrivateAppImpl implements BackstageApp {
       component: ComponentType<SignInPageProps>;
       children: ReactElement;
     }> = ({ component: Component, children }) => {
-      const [done, setDone] = useState(false);
+      const [result, setResult] = useState<SignInResult>();
 
-      const onResult = useCallback(
-        (result: SignInResult) => {
-          if (done) {
-            throw new Error('Identity result callback was called twice');
-          }
-          this.identityApi.setSignInResult(result);
-          setDone(true);
-        },
-        [done],
-      );
-
-      if (done) {
+      if (result) {
+        this.identityApi.setSignInResult(result);
         return children;
       }
 
-      return <Component onResult={onResult} />;
+      return <Component onResult={setResult} />;
     };
 
     const AppRouter: FC<{}> = ({ children }) => {

--- a/packages/core-api/src/app/AppIdentity.ts
+++ b/packages/core-api/src/app/AppIdentity.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IdentityApi } from '../apis';
+import { IdentityApi, ProfileInfo } from '../apis';
 import { SignInResult } from './types';
 
 /**
@@ -24,6 +24,7 @@ import { SignInResult } from './types';
 export class AppIdentity implements IdentityApi {
   private hasIdentity = false;
   private userId?: string;
+  private profile?: ProfileInfo;
   private idTokenFunc?: () => Promise<string>;
   private logoutFunc?: () => Promise<void>;
 
@@ -34,6 +35,15 @@ export class AppIdentity implements IdentityApi {
       );
     }
     return this.userId!;
+  }
+
+  getProfile(): ProfileInfo {
+    if (!this.hasIdentity) {
+      throw new Error(
+        'Tried to access IdentityApi profile before app was loaded',
+      );
+    }
+    return this.profile!;
   }
 
   async getIdToken(): Promise<string | undefined> {
@@ -55,6 +65,7 @@ export class AppIdentity implements IdentityApi {
     location.reload();
   }
 
+  // This is indirectly called by the sign-in page to continue into the app.
   setSignInResult(result: SignInResult) {
     if (this.hasIdentity) {
       return;
@@ -62,8 +73,12 @@ export class AppIdentity implements IdentityApi {
     if (!result.userId) {
       throw new Error('Invalid sign-in result, userId not set');
     }
+    if (!result.profile) {
+      throw new Error('Invalid sign-in result, profile not set');
+    }
     this.hasIdentity = true;
     this.userId = result.userId;
+    this.profile = result.profile;
     this.idTokenFunc = result.getIdToken;
     this.logoutFunc = result.logout;
   }

--- a/packages/core-api/src/app/types.ts
+++ b/packages/core-api/src/app/types.ts
@@ -18,7 +18,7 @@ import { ComponentType } from 'react';
 import { IconComponent, SystemIconKey, SystemIcons } from '../icons';
 import { BackstagePlugin } from '../plugin';
 import { ApiHolder } from '../apis';
-import { AppTheme, ConfigApi } from '../apis/definitions';
+import { AppTheme, ConfigApi, ProfileInfo } from '../apis/definitions';
 import { AppConfig } from '@backstage/config';
 
 export type BootErrorPageProps = {
@@ -31,6 +31,9 @@ export type SignInResult = {
    * User ID that will be returned by the IdentityApi
    */
   userId: string;
+
+  profile: ProfileInfo;
+
   /**
    * Function used to retrieve an ID token for the signed in user.
    */

--- a/packages/core-api/src/lib/loginPopup.test.ts
+++ b/packages/core-api/src/lib/loginPopup.test.ts
@@ -59,7 +59,7 @@ describe('showLoginPopup', () => {
     // None of these should be accepted
     listener({ source: popupMock } as MessageEvent);
     listener({ origin: 'my-origin' } as MessageEvent);
-    listener({ data: { type: 'auth-result' } } as MessageEvent);
+    listener({ data: { type: 'authorization_response' } } as MessageEvent);
     listener({
       source: popupMock,
       origin: 'my-origin',
@@ -68,26 +68,26 @@ describe('showLoginPopup', () => {
     listener({
       source: popupMock,
       origin: 'my-origin',
-      data: { type: 'not-auth-result', payload: {} },
+      data: { type: 'not-auth-result', response: {} },
     } as MessageEvent);
 
     await expect(Promise.race([payloadPromise, 'waiting'])).resolves.toBe(
       'waiting',
     );
 
-    const myPayload = {};
+    const myResponse = {};
 
     // This should be accepted as a valid sessions response
     listener({
       source: popupMock,
       origin: 'my-origin',
       data: {
-        type: 'auth-result',
-        payload: myPayload,
+        type: 'authorization_response',
+        response: myResponse,
       },
     } as MessageEvent);
 
-    await expect(payloadPromise).resolves.toBe(myPayload);
+    await expect(payloadPromise).resolves.toBe(myResponse);
 
     expect(openSpy).toBeCalledTimes(1);
     expect(addEventListenerSpy).toBeCalledTimes(1);
@@ -118,7 +118,7 @@ describe('showLoginPopup', () => {
       source: popupMock,
       origin: 'my-origin',
       data: {
-        type: 'auth-result',
+        type: 'authorization_response',
         error: {
           message: 'NOPE',
           name: 'NopeError',

--- a/packages/core-api/src/lib/loginPopup.ts
+++ b/packages/core-api/src/lib/loginPopup.ts
@@ -46,11 +46,11 @@ export type LoginPopupOptions = {
 
 type AuthResult =
   | {
-      type: 'auth-result';
-      payload: any;
+      type: 'authorization_response';
+      response: unknown;
     }
   | {
-      type: 'auth-result';
+      type: 'authorization_response';
       error: {
         name: string;
         message: string;
@@ -58,12 +58,13 @@ type AuthResult =
     };
 
 /**
- * Show a popup pointing to a URL that starts an auth flow.
+ * Show a popup pointing to a URL that starts an auth flow. Implementing the receiving
+ * end of the postMessage mechanism outlined in https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00
  *
  * The redirect handler of the flow should use postMessage to communicate back
  * to the app window. The message posted to the app must match the AuthResult type.
  *
- * The returned promise resolves to the contents of the message that was posted from the auth popup.
+ * The returned promise resolves to the response of the message that was posted from the auth popup.
  */
 export function showLoginPopup(options: LoginPopupOptions): Promise<any> {
   return new Promise((resolve, reject) => {
@@ -91,7 +92,7 @@ export function showLoginPopup(options: LoginPopupOptions): Promise<any> {
         return;
       }
       const { data } = event;
-      if (data.type !== 'auth-result') {
+      if (data.type !== 'authorization_response') {
         return;
       }
       const authResult = data as AuthResult;
@@ -103,7 +104,7 @@ export function showLoginPopup(options: LoginPopupOptions): Promise<any> {
         // error.extra = authResult.error.extra;
         reject(error);
       } else {
-        resolve(authResult.payload);
+        resolve(authResult.response);
       }
       done();
     };

--- a/packages/core/src/layout/Sidebar/Settings/OAuthProviderSettings.tsx
+++ b/packages/core/src/layout/Sidebar/Settings/OAuthProviderSettings.tsx
@@ -41,22 +41,29 @@ export const OAuthProviderSettings: FC<OAuthProviderSidebarProps> = ({
   const [signedIn, setSignedIn] = useState(false);
 
   useEffect(() => {
+    let didCancel = false;
+
     const checkSession = async () => {
       const session = await api.getAccessToken('', { optional: true });
-      setSignedIn(!!session);
+      if (!didCancel) {
+        setSignedIn(!!session);
+      }
     };
     let subscription: Subscription;
     const observeSession = () => {
       subscription = api
         .sessionState$()
         .subscribe((sessionState: SessionState) => {
-          setSignedIn(sessionState === SessionState.SignedIn);
+          if (!didCancel) {
+            setSignedIn(sessionState === SessionState.SignedIn);
+          }
         });
     };
 
     checkSession();
     observeSession();
     return () => {
+      didCancel = true;
       subscription.unsubscribe();
     };
   }, [api]);

--- a/packages/core/src/layout/Sidebar/Settings/OIDCProviderSettings.tsx
+++ b/packages/core/src/layout/Sidebar/Settings/OIDCProviderSettings.tsx
@@ -41,9 +41,13 @@ export const OIDCProviderSettings: FC<OIDCProviderSidebarProps> = ({
   const [signedIn, setSignedIn] = useState(false);
 
   useEffect(() => {
+    let didCancel = false;
+
     const checkSession = async () => {
       const session = await api.getIdToken({ optional: true });
-      setSignedIn(!!session);
+      if (!didCancel) {
+        setSignedIn(!!session);
+      }
     };
 
     let subscription: Subscription;
@@ -51,13 +55,16 @@ export const OIDCProviderSettings: FC<OIDCProviderSidebarProps> = ({
       subscription = api
         .sessionState$()
         .subscribe((sessionState: SessionState) => {
-          setSignedIn(sessionState === SessionState.SignedIn);
+          if (!didCancel) {
+            setSignedIn(sessionState === SessionState.SignedIn);
+          }
         });
     };
 
     checkSession();
     observeSession();
     return () => {
+      didCancel = true;
       subscription.unsubscribe();
     };
   }, [api]);

--- a/packages/core/src/layout/Sidebar/Settings/UserProfile.tsx
+++ b/packages/core/src/layout/Sidebar/Settings/UserProfile.tsx
@@ -14,19 +14,12 @@
  * limitations under the License.
  */
 
-import React, { FC, useState, useRef, useEffect } from 'react';
+import React, { FC, useRef } from 'react';
 import { makeStyles, Avatar, Divider } from '@material-ui/core';
-import {
-  ProfileInfo,
-  useApi,
-  googleAuthApiRef,
-  Subscription,
-  SessionState,
-} from '@backstage/core-api';
+import { useApi, identityApiRef } from '@backstage/core-api';
 import { SidebarItem } from '../Items';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
-import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 
 const useStyles = makeStyles({
   avatar: {
@@ -39,71 +32,26 @@ export const UserProfile: FC<{ open: boolean; setOpen: Function }> = ({
   open,
   setOpen,
 }) => {
-  const [profile, setProfile] = useState<ProfileInfo>();
   const ref = useRef<Element>(); // for scrolling down when collapse item opens
-  const googleAuth = useApi(googleAuthApiRef);
   const classes = useStyles();
+  const profile = useApi(identityApiRef).getProfile();
 
   const handleClick = () => {
     setOpen(!open);
     setTimeout(() => ref.current?.scrollIntoView({ behavior: 'smooth' }), 300);
   };
 
-  useEffect(() => {
-    const fetchProfile = async () => {
-      await googleAuth
-        .getProfile({ optional: true })
-        .then((userProfile?: ProfileInfo) => {
-          setProfile(userProfile);
-        });
-    };
-
-    let subscription: Subscription;
-    const observeSession = () => {
-      subscription = googleAuth
-        .sessionState$()
-        .subscribe(async (sessionState: SessionState) => {
-          if (sessionState === SessionState.SignedIn) {
-            await fetchProfile();
-          } else {
-            setProfile(undefined);
-          }
-        });
-    };
-
-    fetchProfile();
-    observeSession();
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, [googleAuth]);
-
-  // Handle main auth info that is shown on the collapsible SidebarItem
-  let avatar;
-  let displayName = 'Guest';
-  if (profile) {
-    const email = profile.email;
-    const name = profile.name;
-    const imageUrl = profile.picture;
-    const emailTrimmed = email.split('@')[0];
-    const displayEmail =
-      emailTrimmed.charAt(0).toUpperCase() + emailTrimmed.slice(1);
-    displayName = name ?? displayEmail;
-    avatar = imageUrl
-      ? () => (
-          <Avatar alt={displayName} src={imageUrl} className={classes.avatar} />
-        )
-      : () => <Avatar alt={displayName} className={classes.avatar} />;
-  }
+  const displayName = profile.displayName ?? profile.email;
+  const SignInAvatar = () => (
+    <Avatar src={profile.picture} className={classes.avatar}>
+      {displayName[0]}
+    </Avatar>
+  );
 
   return (
     <>
       <Divider innerRef={ref} />
-      <SidebarItem
-        text={displayName}
-        onClick={handleClick}
-        icon={avatar || AccountCircleIcon}
-      >
+      <SidebarItem text={displayName} onClick={handleClick} icon={SignInAvatar}>
         {open ? <ExpandMore /> : <ExpandLess />}
       </SidebarItem>
     </>

--- a/packages/core/src/layout/SignInPage/customProvider.tsx
+++ b/packages/core/src/layout/SignInPage/customProvider.tsx
@@ -56,6 +56,9 @@ const Component: ProviderComponent = ({ onResult }) => {
   const handleResult = ({ userId, idToken }: Data) => {
     onResult({
       userId,
+      profile: {
+        email: `${userId}@example.com`,
+      },
       getIdToken: idToken ? async () => idToken : undefined,
     });
   };

--- a/packages/core/src/layout/SignInPage/googleProvider.tsx
+++ b/packages/core/src/layout/SignInPage/googleProvider.tsx
@@ -18,16 +18,7 @@ import React from 'react';
 import { Grid, Typography, Button } from '@material-ui/core';
 import { InfoCard } from '../InfoCard/InfoCard';
 import { ProviderComponent, ProviderLoader, SignInProvider } from './types';
-import {
-  useApi,
-  googleAuthApiRef,
-  errorApiRef,
-  ProfileInfo,
-} from '@backstage/core-api';
-
-function parseUserId(profile: ProfileInfo) {
-  return profile!.email.replace(/@.*/, '');
-}
+import { useApi, googleAuthApiRef, errorApiRef } from '@backstage/core-api';
 
 const Component: ProviderComponent = ({ onResult }) => {
   const googleAuthApi = useApi(googleAuthApiRef);
@@ -35,12 +26,17 @@ const Component: ProviderComponent = ({ onResult }) => {
 
   const handleLogin = async () => {
     try {
-      await googleAuthApi.getIdToken({ instantPopup: true });
+      const identity = await googleAuthApi.getBackstageIdentity({
+        instantPopup: true,
+      });
+
       const profile = await googleAuthApi.getProfile();
 
       onResult({
-        userId: parseUserId(profile!),
-        getIdToken: () => googleAuthApi.getIdToken(),
+        userId: identity!.id,
+        profile: profile!,
+        getIdToken: () =>
+          googleAuthApi.getBackstageIdentity().then(i => i!.idToken),
         logout: async () => {
           await googleAuthApi.logout();
         },
@@ -69,11 +65,21 @@ const Component: ProviderComponent = ({ onResult }) => {
 const loader: ProviderLoader = async apis => {
   const googleAuthApi = apis.get(googleAuthApiRef)!;
 
-  const profile = await googleAuthApi.getProfile({ optional: true });
+  const identity = await googleAuthApi.getBackstageIdentity({
+    optional: true,
+  });
+
+  if (!identity) {
+    return undefined;
+  }
+
+  const profile = await googleAuthApi.getProfile();
 
   return {
-    userId: parseUserId(profile!),
-    getIdToken: () => googleAuthApi.getIdToken(),
+    userId: identity.id,
+    profile: profile!,
+    getIdToken: () =>
+      googleAuthApi.getBackstageIdentity().then(i => i!.idToken),
     logout: async () => {
       await googleAuthApi.logout();
     },

--- a/packages/core/src/layout/SignInPage/guestProvider.tsx
+++ b/packages/core/src/layout/SignInPage/guestProvider.tsx
@@ -19,6 +19,14 @@ import { Grid, Typography, Button } from '@material-ui/core';
 import { InfoCard } from '../InfoCard/InfoCard';
 import { ProviderComponent, ProviderLoader, SignInProvider } from './types';
 
+const result = {
+  userId: 'guest',
+  profile: {
+    email: 'guest@example.com',
+    displayName: 'Guest',
+  },
+};
+
 const Component: ProviderComponent = ({ onResult }) => (
   <Grid item>
     <InfoCard
@@ -27,7 +35,7 @@ const Component: ProviderComponent = ({ onResult }) => (
         <Button
           color="primary"
           variant="outlined"
-          onClick={() => onResult({ userId: 'guest' })}
+          onClick={() => onResult(result)}
         >
           Enter
         </Button>
@@ -45,7 +53,7 @@ const Component: ProviderComponent = ({ onResult }) => (
 );
 
 const loader: ProviderLoader = async () => {
-  return { userId: 'guest' };
+  return result;
 };
 
 export const guestProvider: SignInProvider = { Component, loader };

--- a/packages/core/src/layout/SignInPage/providers.tsx
+++ b/packages/core/src/layout/SignInPage/providers.tsx
@@ -93,8 +93,9 @@ export const useSignInProviders = (
         }
         if (result) {
           handleWrappedResult(result);
+        } else {
+          setLoading(false);
         }
-        setLoading(false);
       })
       .catch(error => {
         if (didCancel) {

--- a/packages/storybook/.storybook/apis.js
+++ b/packages/storybook/.storybook/apis.js
@@ -22,6 +22,7 @@ builder.add(errorApiRef, new ErrorAlerter(alertApi, new ErrorApiForwarder()));
 
 builder.add(identityApiRef, {
   getUserId: () => 'guest',
+  getProfile: () => ({ email: 'guest@example.com' }),
   getIdToken: () => undefined,
   logout: async () => {},
 });

--- a/plugins/auth-backend/src/lib/OAuthProvider.test.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.test.ts
@@ -23,7 +23,23 @@ import {
   verifyNonce,
   OAuthProvider,
 } from './OAuthProvider';
-import { AuthResponse, OAuthProviderHandlers } from '../providers/types';
+import {
+  WebMessageResponse,
+  OAuthProviderHandlers,
+  OAuthResponse,
+} from '../providers/types';
+
+const mockResponseData: OAuthResponse = {
+  providerInfo: {
+    accessToken: 'ACCESS_TOKEN',
+    idToken: 'ID_TOKEN',
+    expiresInSeconds: 10,
+    scope: 'email',
+  },
+  profile: {
+    email: 'foo@bar.com',
+  },
+};
 
 describe('OAuthProvider Utils', () => {
   describe('verifyNonce', () => {
@@ -38,6 +54,7 @@ describe('OAuthProvider Utils', () => {
         verifyNonce(mockRequest, 'providera');
       }).toThrowError('Missing nonce');
     });
+
     it('should throw error if state nonce missing', () => {
       const mockRequest = ({
         cookies: {
@@ -49,6 +66,7 @@ describe('OAuthProvider Utils', () => {
         verifyNonce(mockRequest, 'providera');
       }).toThrowError('Missing nonce');
     });
+
     it('should throw error if nonce mismatch', () => {
       const mockRequest = ({
         cookies: {
@@ -62,6 +80,7 @@ describe('OAuthProvider Utils', () => {
         verifyNonce(mockRequest, 'providera');
       }).toThrowError('Invalid nonce');
     });
+
     it('should not throw any error if nonce matches', () => {
       const mockRequest = ({
         cookies: {
@@ -85,13 +104,19 @@ describe('OAuthProvider Utils', () => {
         setHeader: jest.fn().mockReturnThis(),
       } as unknown) as express.Response;
 
-      const data: AuthResponse = {
-        type: 'auth-result',
-        payload: {
-          accessToken: 'ACCESS_TOKEN',
-          idToken: 'ID_TOKEN',
-          expiresInSeconds: 10,
-          scope: 'email',
+      const data: WebMessageResponse = {
+        type: 'authorization_response',
+        response: {
+          providerInfo: {
+            accessToken: 'ACCESS_TOKEN',
+            idToken: 'ID_TOKEN',
+            expiresInSeconds: 10,
+            scope: 'email',
+          },
+          profile: {
+            email: 'foo@bar.com',
+          },
+          userIdToken: 'a.b.c',
         },
       };
       const jsonData = JSON.stringify(data);
@@ -111,8 +136,8 @@ describe('OAuthProvider Utils', () => {
         setHeader: jest.fn().mockReturnThis(),
       } as unknown) as express.Response;
 
-      const data: AuthResponse = {
-        type: 'auth-result',
+      const data: WebMessageResponse = {
+        type: 'authorization_response',
         error: new Error('Unknown error occured'),
       };
       const jsonData = JSON.stringify(data);
@@ -161,16 +186,12 @@ describe('OAuthProvider', () => {
     }
     async handler() {
       return {
-        user: {},
-        info: {
-          refreshToken: 'token',
-        },
+        response: mockResponseData,
+        refreshToken: 'token',
       };
     }
     async refresh() {
-      return {
-        accessToken: 'token',
-      };
+      return mockResponseData;
     }
   }
   const providerInstance = new MyAuthProvider();
@@ -323,11 +344,10 @@ describe('OAuthProvider', () => {
 
     await oauthProvider.refresh(mockRequest, mockResponse);
     expect(mockResponse.send).toHaveBeenCalledTimes(1);
-    expect(mockResponse.send).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accessToken: 'token',
-      }),
-    );
+    expect(mockResponse.send).toHaveBeenCalledWith({
+      ...mockResponseData,
+      userIdToken: 'my-id-token',
+    });
   });
 
   it('handles refresh without capabilities', async () => {

--- a/plugins/auth-backend/src/lib/OAuthProvider.test.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.test.ts
@@ -116,7 +116,10 @@ describe('OAuthProvider Utils', () => {
           profile: {
             email: 'foo@bar.com',
           },
-          userIdToken: 'a.b.c',
+          backstageIdentity: {
+            id: 'a',
+            idToken: 'a.b.c',
+          },
         },
       };
       const jsonData = JSON.stringify(data);
@@ -346,7 +349,10 @@ describe('OAuthProvider', () => {
     expect(mockResponse.send).toHaveBeenCalledTimes(1);
     expect(mockResponse.send).toHaveBeenCalledWith({
       ...mockResponseData,
-      userIdToken: 'my-id-token',
+      backstageIdentity: {
+        id: mockResponseData.profile.email,
+        idToken: 'my-id-token',
+      },
     });
   });
 

--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -147,12 +147,13 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
         this.setRefreshTokenCookie(res, refreshToken);
       }
 
-      const userIdToken = await this.options.tokenIssuer.issueToken({
-        claims: { sub: response.profile.email },
+      const id = response.profile.email;
+      const idToken = await this.options.tokenIssuer.issueToken({
+        claims: { sub: id },
       });
       const fullResponse: AuthResponse<unknown> = {
         ...response,
-        userIdToken,
+        backstageIdentity: { id, idToken },
       };
 
       // post message back to popup if successful
@@ -212,12 +213,13 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
       // get new access_token
       const response = await this.providerHandlers.refresh(refreshToken, scope);
 
-      const userIdToken = await this.options.tokenIssuer.issueToken({
-        claims: { sub: response.profile.email },
+      const id = response.profile.email;
+      const idToken = await this.options.tokenIssuer.issueToken({
+        claims: { sub: id },
       });
       const fullResponse: AuthResponse<unknown> = {
         ...response,
-        userIdToken,
+        backstageIdentity: { id, idToken },
       };
 
       res.send(fullResponse);

--- a/plugins/auth-backend/src/lib/PassportStrategyHelper.test.ts
+++ b/plugins/auth-backend/src/lib/PassportStrategyHelper.test.ts
@@ -82,8 +82,8 @@ describe('PassportStrategyHelper', () => {
       expect(spyAuthenticate).toBeCalledTimes(1);
       await expect(frameHandlerStrategyPromise).resolves.toStrictEqual(
         expect.objectContaining({
-          user: { accessToken: 'ACCESS_TOKEN' },
-          info: { refreshToken: 'REFRESH_TOKEN' },
+          response: { accessToken: 'ACCESS_TOKEN' },
+          privateInfo: { refreshToken: 'REFRESH_TOKEN' },
         }),
       );
     });

--- a/plugins/auth-backend/src/lib/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/lib/PassportStrategyHelper.ts
@@ -31,7 +31,7 @@ export const makeProfileInfo = (
   const { displayName } = profile;
 
   let email: string | undefined = undefined;
-  if (profile.emails) {
+  if (profile.emails && profile.emails.length > 0) {
     const [firstEmail] = profile.emails;
     email = firstEmail.value;
   }

--- a/plugins/auth-backend/src/lib/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/lib/PassportStrategyHelper.ts
@@ -26,42 +26,52 @@ import {
 
 export const makeProfileInfo = (
   profile: passport.Profile,
-  params: any,
+  idToken?: string,
 ): ProfileInfo => {
-  const { displayName: name } = profile;
+  const { displayName } = profile;
 
-  let email = '';
+  let email: string | undefined = undefined;
   if (profile.emails) {
     const [firstEmail] = profile.emails;
     email = firstEmail.value;
   }
 
-  if (!email && params.id_token) {
-    try {
-      const decoded: { email: string } = jwtDecoder(params.id_token);
-      email = decoded.email;
-    } catch (e) {
-      console.error('Failed to parse id token and get profile info');
-    }
-  }
-
-  let picture = '';
+  let picture: string | undefined = undefined;
   if (profile.photos) {
     const [firstPhoto] = profile.photos;
     picture = firstPhoto.value;
   }
 
+  if ((!email || !picture) && idToken) {
+    try {
+      const decoded: Record<string, string> = jwtDecoder(idToken);
+
+      if (!email && decoded.email) {
+        email = decoded.email;
+      }
+      if (!picture && decoded.picture) {
+        picture = decoded.picture;
+      }
+    } catch (e) {
+      throw new Error(`Failed to parse id token and get profile info, ${e}`);
+    }
+  }
+
+  if (!email) {
+    throw new Error('No email received in profile info');
+  }
+
   return {
-    name,
     email,
     picture,
+    displayName,
   };
 };
 
 export const executeRedirectStrategy = async (
   req: express.Request,
   providerStrategy: passport.Strategy,
-  options: any,
+  options: Record<string, string>,
 ): Promise<RedirectInfo> => {
   return new Promise(resolve => {
     const strategy = Object.create(providerStrategy);
@@ -73,30 +83,32 @@ export const executeRedirectStrategy = async (
   });
 };
 
-export const executeFrameHandlerStrategy = async (
+export const executeFrameHandlerStrategy = async <T, PrivateInfo = never>(
   req: express.Request,
   providerStrategy: passport.Strategy,
 ) => {
-  return new Promise<{ user: any; info: any }>((resolve, reject) => {
-    const strategy = Object.create(providerStrategy);
-    strategy.success = (user: any, info: any) => {
-      resolve({ user, info });
-    };
-    strategy.fail = (
-      info: { type: 'success' | 'error'; message?: string },
-      // _status: number,
-    ) => {
-      reject(new Error(`Authentication rejected, ${info.message ?? ''}`));
-    };
-    strategy.error = (error: Error) => {
-      reject(new Error(`Authentication failed, ${error}`));
-    };
-    strategy.redirect = () => {
-      reject(new Error('Unexpected redirect'));
-    };
+  return new Promise<{ response: T; privateInfo: PrivateInfo }>(
+    (resolve, reject) => {
+      const strategy = Object.create(providerStrategy);
+      strategy.success = (response: any, privateInfo: any) => {
+        resolve({ response, privateInfo });
+      };
+      strategy.fail = (
+        info: { type: 'success' | 'error'; message?: string },
+        // _status: number,
+      ) => {
+        reject(new Error(`Authentication rejected, ${info.message ?? ''}`));
+      };
+      strategy.error = (error: Error) => {
+        reject(new Error(`Authentication failed, ${error}`));
+      };
+      strategy.redirect = () => {
+        reject(new Error('Unexpected redirect'));
+      };
 
-    strategy.authenticate(req, {});
-  });
+      strategy.authenticate(req, {});
+    },
+  );
 };
 
 export const executeRefreshTokenStrategy = async (
@@ -151,7 +163,7 @@ export const executeRefreshTokenStrategy = async (
 export const executeFetchUserProfileStrategy = async (
   providerStrategy: passport.Strategy,
   accessToken: string,
-  params: any,
+  idToken?: string,
 ): Promise<ProfileInfo> => {
   return new Promise((resolve, reject) => {
     const anyStrategy = (providerStrategy as unknown) as ProviderStrategy;
@@ -162,7 +174,7 @@ export const executeFetchUserProfileStrategy = async (
           reject(error);
         }
 
-        const profile = makeProfileInfo(passportProfile, params);
+        const profile = makeProfileInfo(passportProfile, idToken);
         resolve(profile);
       },
     );

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -25,14 +25,13 @@ import {
 } from '../../lib/PassportStrategyHelper';
 import {
   OAuthProviderHandlers,
-  AuthInfoBase,
-  AuthInfoPrivate,
   RedirectInfo,
   AuthProviderConfig,
-  AuthInfoWithProfile,
   EnvironmentProviderConfig,
   OAuthProviderOptions,
   OAuthProviderConfig,
+  OAuthResponse,
+  PassportDoneCallback,
 } from '../types';
 import { OAuthProvider } from '../../lib/OAuthProvider';
 import passport from 'passport';
@@ -42,6 +41,10 @@ import {
 } from '../../lib/EnvironmentHandler';
 import { Logger } from 'winston';
 import { TokenIssuer } from '../../identity';
+
+type PrivateInfo = {
+  refreshToken: string;
+};
 
 export class GoogleAuthProvider implements OAuthProviderHandlers {
   private readonly _strategy: GoogleStrategy;
@@ -56,18 +59,20 @@ export class GoogleAuthProvider implements OAuthProviderHandlers {
         accessToken: any,
         refreshToken: any,
         params: any,
-        profile: passport.Profile,
-        done: any,
+        rawProfile: passport.Profile,
+        done: PassportDoneCallback<OAuthResponse, PrivateInfo>,
       ) => {
-        const profileInfo = makeProfileInfo(profile, params);
+        const profile = makeProfileInfo(rawProfile, params.id_token);
         done(
           undefined,
           {
-            profile: profileInfo,
-            idToken: params.id_token,
-            accessToken,
-            scope: params.scope,
-            expiresInSeconds: params.expires_in,
+            providerInfo: {
+              idToken: params.id_token,
+              accessToken,
+              scope: params.scope,
+              expiresInSeconds: params.expires_in,
+            },
+            profile,
           },
           {
             refreshToken,
@@ -77,20 +82,33 @@ export class GoogleAuthProvider implements OAuthProviderHandlers {
     );
   }
 
-  async start(req: express.Request, options: any): Promise<RedirectInfo> {
-    return await executeRedirectStrategy(req, this._strategy, options);
+  async start(
+    req: express.Request,
+    options: Record<string, string>,
+  ): Promise<RedirectInfo> {
+    const providerOptions = {
+      ...options,
+      accessType: 'offline',
+      prompt: 'consent',
+    };
+    return await executeRedirectStrategy(req, this._strategy, providerOptions);
   }
 
   async handler(
     req: express.Request,
-  ): Promise<{ user: AuthInfoBase; info: AuthInfoPrivate }> {
-    return await executeFrameHandlerStrategy(req, this._strategy);
+  ): Promise<{ response: OAuthResponse; refreshToken: string }> {
+    const result = await executeFrameHandlerStrategy<
+      OAuthResponse,
+      PrivateInfo
+    >(req, this._strategy);
+
+    return {
+      response: result.response,
+      refreshToken: result.privateInfo.refreshToken,
+    };
   }
 
-  async refresh(
-    refreshToken: string,
-    scope: string,
-  ): Promise<AuthInfoWithProfile> {
+  async refresh(refreshToken: string, scope: string): Promise<OAuthResponse> {
     const { accessToken, params } = await executeRefreshTokenStrategy(
       this._strategy,
       refreshToken,
@@ -100,14 +118,16 @@ export class GoogleAuthProvider implements OAuthProviderHandlers {
     const profile = await executeFetchUserProfileStrategy(
       this._strategy,
       accessToken,
-      params,
+      params.id_token,
     );
 
     return {
-      accessToken,
-      idToken: params.id_token,
-      expiresInSeconds: params.expires_in,
-      scope: params.scope,
+      providerInfo: {
+        accessToken,
+        idToken: params.id_token,
+        expiresInSeconds: params.expires_in,
+        scope: params.scope,
+      },
       profile,
     };
   }

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -84,8 +84,9 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
         response: { userId, profile },
       } = await executeFrameHandlerStrategy<SamlInfo>(req, this.strategy);
 
-      const userIdToken = await this.tokenIssuer.issueToken({
-        claims: { sub: userId },
+      const id = userId;
+      const idToken = await this.tokenIssuer.issueToken({
+        claims: { sub: id },
       });
 
       return postMessageResponse(res, 'http://localhost:3000', {
@@ -93,7 +94,7 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
         response: {
           providerInfo: {},
           profile,
-          userIdToken,
+          backstageIdentity: { id, idToken },
         },
       });
     } catch (error) {

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -192,13 +192,25 @@ export type AuthProviderFactory = (
 export type AuthResponse<ProviderInfo> = {
   providerInfo: ProviderInfo;
   profile: ProfileInfo;
-  userIdToken: string;
+  backstageIdentity: BackstageIdentity;
 };
 
 export type OAuthResponse = Omit<
   AuthResponse<OAuthProviderInfo>,
-  'userIdToken'
+  'backstageIdentity'
 >;
+
+export type BackstageIdentity = {
+  /**
+   * The backstage user ID.
+   */
+  id: string;
+
+  /**
+   * An ID token that can be used to authenticate the user within Backstage.
+   */
+  idToken: string;
+};
 
 export type OAuthProviderInfo = {
   /**

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -238,8 +238,6 @@ export type OAuthPrivateInfo = {
   refreshToken: string;
 };
 
-// {type: 'authorization_response', response: {...}}
-
 /**
  * Payload sent as a post message after the auth request is complete.
  * If successful then has a valid payload with Auth information else contains an error.
@@ -271,22 +269,12 @@ export type RedirectInfo = {
   status?: number;
 };
 
-/* 
-metadata:
-  name: john
-spec:
-  profile:
-    email: john.doe@example.com
-    displayName: John Doe
-    picture: https://example.com/avatars/john.doe
-
-  identities:
-    - type: google
-      email: john.doe@gmail.com
+/**
+ * Used to display login information to user, i.e. sidebar popup.
+ *
+ * It is also temporarily used as the profile of the signed-in user's Backstage
+ * identity, but we want to replace that with data from identity and/org catalog service
  */
-
-// 1. Link to identity in catalog / within backstage
-// 2. Display login information to user, i.e. sidebar popup
 export type ProfileInfo = {
   /**
    * Email ID of the signed in user.

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -89,25 +89,30 @@ export interface OAuthProviderHandlers {
    * @param {express.Request} req
    * @param options
    */
-  start(req: express.Request, options: any): Promise<any>;
+  start(
+    req: express.Request,
+    options: Record<string, string>,
+  ): Promise<RedirectInfo>;
 
   /**
    * Handles the redirect from the auth provider when the user has signed in.
    * @param {express.Request} req
    */
-  handler(req: express.Request): Promise<any>;
+  handler(
+    req: express.Request,
+  ): Promise<{ response: OAuthResponse; refreshToken?: string }>;
 
   /**
    * (Optional) Given a refresh token and scope fetches a new access token from the auth provider.
    * @param {string} refreshToken
    * @param {string} scope
    */
-  refresh?(refreshToken: string, scope: string): Promise<any>;
+  refresh?(refreshToken: string, scope: string): Promise<OAuthResponse>;
 
   /**
    * (Optional) Sign out of the auth provider.
    */
-  logout?(): Promise<any>;
+  logout?(): Promise<void>;
 }
 
 /**
@@ -134,7 +139,7 @@ export interface AuthProviderRouteHandlers {
    * @param {express.Request} req
    * @param {express.Response} res
    */
-  start(req: express.Request, res: express.Response): Promise<any>;
+  start(req: express.Request, res: express.Response): Promise<void>;
 
   /**
    * Once the user signs in or consents in the OAuth screen, the auth provider redirects to the
@@ -149,7 +154,7 @@ export interface AuthProviderRouteHandlers {
    * @param {express.Request} req
    * @param {express.Response} res
    */
-  frameHandler(req: express.Request, res: express.Response): Promise<any>;
+  frameHandler(req: express.Request, res: express.Response): Promise<void>;
 
   /**
    * (Optional) If the auth provider supports refresh tokens then this method handles
@@ -163,7 +168,7 @@ export interface AuthProviderRouteHandlers {
    * @param {express.Request} req
    * @param {express.Response} res
    */
-  refresh?(req: express.Request, res: express.Response): Promise<any>;
+  refresh?(req: express.Request, res: express.Response): Promise<void>;
 
   /**
    * (Optional) Handles sign out requests
@@ -174,7 +179,7 @@ export interface AuthProviderRouteHandlers {
    * @param {express.Request} req
    * @param {express.Response} res
    */
-  logout?(req: express.Request, res: express.Response): Promise<any>;
+  logout?(req: express.Request, res: express.Response): Promise<void>;
 }
 
 export type AuthProviderFactory = (
@@ -184,7 +189,18 @@ export type AuthProviderFactory = (
   issuer: TokenIssuer,
 ) => AuthProviderRouteHandlers;
 
-export type AuthInfoBase = {
+export type AuthResponse<ProviderInfo> = {
+  providerInfo: ProviderInfo;
+  profile: ProfileInfo;
+  userIdToken: string;
+};
+
+export type OAuthResponse = Omit<
+  AuthResponse<OAuthProviderInfo>,
+  'userIdToken'
+>;
+
+export type OAuthProviderInfo = {
   /**
    * An access token issued for the signed in user.
    */
@@ -203,33 +219,34 @@ export type AuthInfoBase = {
   scope: string;
 };
 
-export type AuthInfoWithProfile = AuthInfoBase & {
-  /**
-   * Profile information of the signed in user.
-   */
-  profile: ProfileInfo | undefined;
-};
-
-export type AuthInfoPrivate = {
+export type OAuthPrivateInfo = {
   /**
    * A refresh token issued for the signed in user.
    */
   refreshToken: string;
 };
 
+// {type: 'authorization_response', response: {...}}
+
 /**
  * Payload sent as a post message after the auth request is complete.
  * If successful then has a valid payload with Auth information else contains an error.
  */
-export type AuthResponse =
+export type WebMessageResponse =
   | {
-      type: 'auth-result';
-      payload: AuthInfoBase | AuthInfoWithProfile;
+      type: 'authorization_response';
+      response: AuthResponse<unknown>;
     }
   | {
-      type: 'auth-result';
+      type: 'authorization_response';
       error: Error;
     };
+
+export type PassportDoneCallback<Res, Private = never> = (
+  err?: Error,
+  response?: Res,
+  privateInfo?: Private,
+) => void;
 
 export type RedirectInfo = {
   /**
@@ -242,6 +259,22 @@ export type RedirectInfo = {
   status?: number;
 };
 
+/* 
+metadata:
+  name: john
+spec:
+  profile:
+    email: john.doe@example.com
+    displayName: John Doe
+    picture: https://example.com/avatars/john.doe
+
+  identities:
+    - type: google
+      email: john.doe@gmail.com
+ */
+
+// 1. Link to identity in catalog / within backstage
+// 2. Display login information to user, i.e. sidebar popup
 export type ProfileInfo = {
   /**
    * Email ID of the signed in user.
@@ -250,12 +283,12 @@ export type ProfileInfo = {
   /**
    * Display name that can be presented to the signed in user.
    */
-  name: string;
+  displayName?: string;
   /**
    * URL to an image that can be used as the display image or avatar of the
    * signed in user.
    */
-  picture: string;
+  picture?: string;
 };
 
 export type RefreshTokenResponse = {

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -67,12 +67,6 @@ export async function createRouter(
             clientId: process.env.AUTH_GOOGLE_CLIENT_ID!,
             clientSecret: process.env.AUTH_GOOGLE_CLIENT_SECRET!,
           },
-          production: {
-            appOrigin: 'http://localhost:3000',
-            secure: false,
-            clientId: '',
-            clientSecret: '',
-          },
         },
         github: {
           development: {


### PR DESCRIPTION
Long mob branch by me, @marcuseide, and @soapraj :grin: 

Fixes #1372
Fixes #1397
Fixes #1396
Fixes #1395

This introduces a `BackstageIdentity` that contains the id and internal id token of the user.

It also standardizes the required profile information in the backend, which in turn will be used to look up users in the identity service and/or catalog.

Aaaand it fixes the main login sidebar item to actually reflect the correct login state.

And it introduces a profile to the IdentityApi

And it fixes some unmounted state access

