### PR TITLE
auth-backend: leave it to the providers to figure out the backstage identity

### DIFF
--- a/packages/core-api/src/apis/definitions/auth.ts
+++ b/packages/core-api/src/apis/definitions/auth.ts
@@ -173,7 +173,7 @@ export type ProfileInfo = {
   /**
    * Email ID.
    */
-  email: string;
+  email?: string;
 
   /**
    * Display name that can be presented to the user.

--- a/packages/core/src/layout/Sidebar/Settings/UserProfile.tsx
+++ b/packages/core/src/layout/Sidebar/Settings/UserProfile.tsx
@@ -34,14 +34,16 @@ export const UserProfile: FC<{ open: boolean; setOpen: Function }> = ({
 }) => {
   const ref = useRef<Element>(); // for scrolling down when collapse item opens
   const classes = useStyles();
-  const profile = useApi(identityApiRef).getProfile();
+  const identityApi = useApi(identityApiRef);
 
   const handleClick = () => {
     setOpen(!open);
     setTimeout(() => ref.current?.scrollIntoView({ behavior: 'smooth' }), 300);
   };
 
-  const displayName = profile.displayName ?? profile.email;
+  const userId = identityApi.getUserId();
+  const profile = identityApi.getProfile();
+  const displayName = profile.displayName ?? userId;
   const SignInAvatar = () => (
     <Avatar src={profile.picture} className={classes.avatar}>
       {displayName[0]}

--- a/plugins/auth-backend/src/lib/OAuthProvider.test.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.test.ts
@@ -23,13 +23,9 @@ import {
   verifyNonce,
   OAuthProvider,
 } from './OAuthProvider';
-import {
-  WebMessageResponse,
-  OAuthProviderHandlers,
-  OAuthResponse,
-} from '../providers/types';
+import { WebMessageResponse, OAuthProviderHandlers } from '../providers/types';
 
-const mockResponseData: OAuthResponse = {
+const mockResponseData = {
   providerInfo: {
     accessToken: 'ACCESS_TOKEN',
     idToken: 'ID_TOKEN',
@@ -38,6 +34,9 @@ const mockResponseData: OAuthResponse = {
   },
   profile: {
     email: 'foo@bar.com',
+  },
+  backstageIdentity: {
+    id: 'foo',
   },
 };
 
@@ -350,7 +349,7 @@ describe('OAuthProvider', () => {
     expect(mockResponse.send).toHaveBeenCalledWith({
       ...mockResponseData,
       backstageIdentity: {
-        id: mockResponseData.profile.email,
+        id: mockResponseData.backstageIdentity.id,
         idToken: 'my-id-token',
       },
     });

--- a/plugins/auth-backend/src/lib/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/lib/PassportStrategyHelper.ts
@@ -57,10 +57,6 @@ export const makeProfileInfo = (
     }
   }
 
-  if (!email) {
-    throw new Error('No email received in profile info');
-  }
-
   return {
     email,
     picture,

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -72,15 +72,13 @@ export class GithubAuthProvider implements OAuthProviderHandlers {
     return await executeRedirectStrategy(req, this._strategy, options);
   }
 
-  async handler(req: express.Request): Promise<{ response: OAuthResponse }> {
-    const result = await executeFrameHandlerStrategy<OAuthResponse>(
+  async handler(req: express.Request) {
+    const { response } = await executeFrameHandlerStrategy<OAuthResponse>(
       req,
       this._strategy,
     );
 
-    return {
-      response: result.response,
-    };
+    return { response };
   }
 }
 

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -100,14 +100,20 @@ export interface OAuthProviderHandlers {
    */
   handler(
     req: express.Request,
-  ): Promise<{ response: OAuthResponse; refreshToken?: string }>;
+  ): Promise<{
+    response: AuthResponse<OAuthProviderInfo>;
+    refreshToken?: string;
+  }>;
 
   /**
    * (Optional) Given a refresh token and scope fetches a new access token from the auth provider.
    * @param {string} refreshToken
    * @param {string} scope
    */
-  refresh?(refreshToken: string, scope: string): Promise<OAuthResponse>;
+  refresh?(
+    refreshToken: string,
+    scope: string,
+  ): Promise<AuthResponse<OAuthProviderInfo>>;
 
   /**
    * (Optional) Sign out of the auth provider.
@@ -192,13 +198,10 @@ export type AuthProviderFactory = (
 export type AuthResponse<ProviderInfo> = {
   providerInfo: ProviderInfo;
   profile: ProfileInfo;
-  backstageIdentity: BackstageIdentity;
+  backstageIdentity?: BackstageIdentity;
 };
 
-export type OAuthResponse = Omit<
-  AuthResponse<OAuthProviderInfo>,
-  'backstageIdentity'
->;
+export type OAuthResponse = AuthResponse<OAuthProviderInfo>;
 
 export type BackstageIdentity = {
   /**
@@ -209,7 +212,7 @@ export type BackstageIdentity = {
   /**
    * An ID token that can be used to authenticate the user within Backstage.
    */
-  idToken: string;
+  idToken?: string;
 };
 
 export type OAuthProviderInfo = {
@@ -279,7 +282,7 @@ export type ProfileInfo = {
   /**
    * Email ID of the signed in user.
    */
-  email: string;
+  email?: string;
   /**
    * Display name that can be presented to the signed in user.
    */


### PR DESCRIPTION
We went with email as the way to tie together user identities, but e.g. GitHub accounts don't always have an email so we can't use it to derive the Backstage identity.

This change moves the logic for figuring out the user to each auth provider, and also makes it optional to return a Backstage identity from a provider.
