### PR TITLE
core: pin material-table to 1.62.x

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "classnames": "^2.2.6",
     "clsx": "^1.1.0",
     "lodash": "^4.17.15",
-    "material-table": "^1.58.0",
+    "material-table": "1.62.x",
     "prop-types": "^15.7.2",
     "rc-progress": "^3.0.0",
     "react": "^16.12.0",


### PR DESCRIPTION
1.63.1 introduces a dependency on jsPDF, which is turn has some other weird deps: https://github.com/MrRio/jsPDF/blob/f14bac45183666e0f4ec0eb3333b8e761cb0288a/package.json#L27

Thinking we pin to 1.62 for now and stay tuned for updates