### PR TITLE
chore(app): use backend.baseUrl

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,13 +76,6 @@
       "pathRewrite": {
         "^/circleci/api/": "/"
       }
-    },
-    "/catalog/api": {
-      "target": "http://localhost:7000",
-      "changeOrigin": true,
-      "pathRewrite": {
-        "^/catalog/api/": "/catalog/"
-      }
     }
   }
 }

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -26,6 +26,7 @@ describe('App', () => {
         {
           data: {
             app: { title: 'Test' },
+            backend: { baseUrl: 'http://localhost:7000' },
           },
           context: 'test',
         },

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -56,6 +56,8 @@ export const apis = (config: ConfigApi) => {
   // eslint-disable-next-line no-console
   console.log(`Creating APIs for ${config.getString('app.title')}`);
 
+  const backendUrl = config.getString('backend.baseUrl');
+
   const builder = ApiRegistry.builder();
 
   const alertApi = builder.add(alertApiRef, new AlertApiForwarder());
@@ -78,7 +80,7 @@ export const apis = (config: ConfigApi) => {
   builder.add(
     googleAuthApiRef,
     GoogleAuth.create({
-      apiOrigin: 'http://localhost:7000',
+      apiOrigin: backendUrl,
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -87,7 +89,7 @@ export const apis = (config: ConfigApi) => {
   const githubAuthApi = builder.add(
     githubAuthApiRef,
     GithubAuth.create({
-      apiOrigin: 'http://localhost:7000',
+      apiOrigin: backendUrl,
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -96,7 +98,7 @@ export const apis = (config: ConfigApi) => {
   builder.add(
     oktaAuthApiRef,
     OktaAuth.create({
-      apiOrigin: 'http://localhost:7000',
+      apiOrigin: backendUrl,
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -113,8 +115,8 @@ export const apis = (config: ConfigApi) => {
   builder.add(
     catalogApiRef,
     new CatalogClient({
-      apiOrigin: 'http://localhost:3000',
-      basePath: '/catalog/api',
+      apiOrigin: backendUrl,
+      basePath: '/catalog',
     }),
   );
 


### PR DESCRIPTION
This starts using the `backend.baseUrl` config parameter in API client creation.

Only some of the core APIs are covered by this PR, and the others will be addressed separately.