### PR TITLE
chore: add import/newline-after-import lint rule

### DIFF
--- a/packages/backend-common/src/setupTests.ts
+++ b/packages/backend-common/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 require('jest-fetch-mock').enableMocks();
+
 export {};

--- a/packages/cli/config/eslint.backend.js
+++ b/packages/cli/config/eslint.backend.js
@@ -36,6 +36,7 @@ module.exports = {
   rules: {
     'no-console': 0, // Permitted in console programs
     'new-cap': ['error', { capIsNew: false }], // Because Express constructs things e.g. like 'const r = express.Router()'
+    'import/newline-after-import': 'error',
     'import/no-duplicates': 'warn',
     'import/no-extraneous-dependencies': [
       'error',

--- a/packages/cli/config/eslint.js
+++ b/packages/cli/config/eslint.js
@@ -41,6 +41,7 @@ module.exports = {
   },
   ignorePatterns: ['.eslintrc.js', '**/dist/**'],
   rules: {
+    'import/newline-after-import': 'error',
     'import/no-duplicates': 'warn',
     'import/no-extraneous-dependencies': [
       'error',

--- a/packages/cli/e2e-test/helpers.js
+++ b/packages/cli/e2e-test/helpers.js
@@ -15,6 +15,7 @@
  */
 
 const childProcess = require('child_process');
+
 const { spawn } = childProcess;
 
 const EXPECTED_LOAD_ERRORS = /ECONNREFUSED|ECONNRESET|did not get to load all resources/;
@@ -133,7 +134,7 @@ async function waitForPageWithText(
       if (findTextAttempts <= maxFindTextAttempts) {
         await browser.visit(path);
         await new Promise(resolve => setTimeout(resolve, intervalMs));
-        continue
+        continue;
       } else {
         throw error;
       }

--- a/packages/cli/src/commands/create-app/createApp.ts
+++ b/packages/cli/src/commands/create-app/createApp.ts
@@ -24,6 +24,7 @@ import os from 'os';
 import { Task, templatingTask, installWithLocalDeps } from '../../lib/tasks';
 import { paths } from '../../lib/paths';
 import { version } from '../../lib/version';
+
 const exec = promisify(execCb);
 
 async function checkExists(rootDir: string, name: string) {

--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -29,6 +29,7 @@ import {
 import { paths } from '../../lib/paths';
 import { version } from '../../lib/version';
 import { Task, templatingTask, installWithLocalDeps } from '../../lib/tasks';
+
 const exec = promisify(execCb);
 
 async function checkExists(rootDir: string, id: string) {

--- a/packages/cli/src/lib/run.ts
+++ b/packages/cli/src/lib/run.ts
@@ -23,6 +23,7 @@ import {
 import { ExitCodeError } from './errors';
 import { promisify } from 'util';
 import { LogFunc } from './logging';
+
 const execFile = promisify(execFileCb);
 
 type SpawnOptionsPartialEnv = Omit<SpawnOptions, 'env'> & {

--- a/packages/cli/src/lib/tasks.ts
+++ b/packages/cli/src/lib/tasks.ts
@@ -23,6 +23,7 @@ import recursive from 'recursive-readdir';
 import { promisify } from 'util';
 import { exec as execCb } from 'child_process';
 import { paths } from './paths';
+
 const exec = promisify(execCb);
 
 const TASK_NAME_MAX_LENGTH = 14;

--- a/packages/cli/templates/default-plugin/src/setupTests.ts
+++ b/packages/cli/templates/default-plugin/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/packages/core-api/src/index.ts
+++ b/packages/core-api/src/index.ts
@@ -16,4 +16,5 @@
 
 export * from './public';
 import * as privateExports from './private';
+
 export default privateExports;

--- a/packages/core-api/src/setupTests.ts
+++ b/packages/core-api/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/packages/core/src/components/StructuredMetadataTable/MetadataTable.tsx
+++ b/packages/core/src/components/StructuredMetadataTable/MetadataTable.tsx
@@ -25,6 +25,7 @@ import {
   WithStyles,
   Theme,
 } from '@material-ui/core';
+
 const tableTitleCellStyles = (theme: Theme) =>
   createStyles({
     root: {

--- a/packages/core/src/setupTests.ts
+++ b/packages/core/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/packages/test-utils/src/testUtils/appWrappers.tsx
+++ b/packages/test-utils/src/testUtils/appWrappers.tsx
@@ -25,6 +25,7 @@ import privateExports, {
 import { RenderResult } from '@testing-library/react';
 import { renderWithEffects } from '@backstage/test-utils-core';
 import { createMockApiRegistry } from './mockApiRegistry';
+
 const { PrivateAppImpl } = privateExports;
 
 const NotFoundErrorPage = () => {

--- a/plugins/auth-backend/src/setupTests.ts
+++ b/plugins/auth-backend/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 require('jest-fetch-mock').enableMocks();
+
 export {};

--- a/plugins/catalog-backend/src/setupTests.ts
+++ b/plugins/catalog-backend/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 require('jest-fetch-mock').enableMocks();
+
 export {};

--- a/plugins/catalog/src/api/CatalogClient.test.ts
+++ b/plugins/catalog/src/api/CatalogClient.test.ts
@@ -18,6 +18,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { CatalogClient } from './CatalogClient';
 import { Entity } from '@backstage/catalog-model';
+
 const server = setupServer();
 
 describe('CatalogClient', () => {

--- a/plugins/circleci/src/setupTests.ts
+++ b/plugins/circleci/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
+
 require('jest-fetch-mock').enableMocks();

--- a/plugins/circleci/src/state/AppState.tsx
+++ b/plugins/circleci/src/state/AppState.tsx
@@ -16,6 +16,7 @@
 import React, { FC, useReducer, Dispatch, Reducer } from 'react';
 import { circleCIApiRef } from '../api';
 import type { State, Action, SettingsState } from './types';
+
 export type { SettingsState };
 
 export const AppContext = React.createContext<[State, Dispatch<Action>]>(

--- a/plugins/explore/src/setupTests.ts
+++ b/plugins/explore/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/plugins/gitops-profiles/src/setupTests.ts
+++ b/plugins/gitops-profiles/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/plugins/graphiql/src/setupTests.ts
+++ b/plugins/graphiql/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/plugins/identity-backend/src/setupTests.ts
+++ b/plugins/identity-backend/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 require('jest-fetch-mock').enableMocks();
+
 export {};

--- a/plugins/lighthouse/src/setupTests.ts
+++ b/plugins/lighthouse/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/plugins/lighthouse/src/utils.ts
+++ b/plugins/lighthouse/src/utils.ts
@@ -15,6 +15,7 @@
  */
 import { useLocation } from 'react-router-dom';
 import { Website, Audit, LighthouseCategoryId, AuditCompleted } from './api';
+
 export function useQuery(): URLSearchParams {
   return new URLSearchParams(useLocation().search);
 }
@@ -53,13 +54,13 @@ export function buildSparklinesDataForItem(
       (audit: Audit): audit is AuditCompleted => audit.status === 'COMPLETED',
     )
     .reduce((scores, audit) => {
-      Object.values(audit.categories).forEach((category) => {
+      Object.values(audit.categories).forEach(category => {
         scores[category.id] = scores[category.id] || [];
         scores[category.id].unshift(category.score);
       });
 
       // edge case: if only one audit exists, force a "flat" sparkline
-      Object.values(scores).forEach((arr) => {
+      Object.values(scores).forEach(arr => {
         if (arr.length === 1) arr.push(arr[0]);
       });
 

--- a/plugins/register-component/src/setupTests.ts
+++ b/plugins/register-component/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -22,6 +22,7 @@ import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 import Docker from 'dockerode';
 import {} from '@backstage/backend-common';
 import { StageContext } from '../scaffolder/jobs/types';
+
 export interface RouterOptions {
   preparers: PreparerBuilder;
   templater: TemplaterBase;

--- a/plugins/scaffolder/src/setupTests.ts
+++ b/plugins/scaffolder/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/plugins/sentry/src/data/mock-api.ts
+++ b/plugins/sentry/src/data/mock-api.ts
@@ -16,6 +16,7 @@
 import { SentryIssue } from './sentry-issue';
 import { SentryApi } from './sentry-api';
 import mockData from './sentry-issue-mock.json';
+
 function getMockIssue(): SentryIssue {
   const randomizedStats = {
     '12h': new Array(12)

--- a/plugins/sentry/src/setupTests.ts
+++ b/plugins/sentry/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/plugins/tech-radar/src/setupTests.ts
+++ b/plugins/tech-radar/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();

--- a/plugins/techdocs/src/setupTests.ts
+++ b/plugins/techdocs/src/setupTests.ts
@@ -15,4 +15,5 @@
  */
 
 import '@testing-library/jest-dom';
+
 require('jest-fetch-mock').enableMocks();


### PR DESCRIPTION
Nitpicky or nice? I think it gets hard to read when code is immediately attached to the imports, it gets lost in a quick overview of the code when reviewing.

(this rule supports `--fix`)