### PR TITLE
feat(github-actions): introduce the old frontend code

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,6 +8,7 @@
     "@backstage/plugin-catalog": "^0.1.1-alpha.12",
     "@backstage/plugin-circleci": "^0.1.1-alpha.12",
     "@backstage/plugin-explore": "^0.1.1-alpha.12",
+    "@backstage/plugin-github-actions": "^0.1.1-alpha.12",
     "@backstage/plugin-gitops-profiles": "^0.1.1-alpha.12",
     "@backstage/plugin-graphiql": "^0.1.1-alpha.12",
     "@backstage/plugin-lighthouse": "^0.1.1-alpha.12",

--- a/packages/app/src/plugins.ts
+++ b/packages/app/src/plugins.ts
@@ -25,3 +25,4 @@ export { plugin as Sentry } from '@backstage/plugin-sentry';
 export { plugin as GitopsProfiles } from '@backstage/plugin-gitops-profiles';
 export { plugin as TechDocs } from '@backstage/plugin-techdocs';
 export { plugin as GraphiQL } from '@backstage/plugin-graphiql';
+export { plugin as GithubActions } from '@backstage/plugin-github-actions';

--- a/plugins/github-actions/.eslintrc.js
+++ b/plugins/github-actions/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint')],
+};

--- a/plugins/github-actions/README.md
+++ b/plugins/github-actions/README.md
@@ -1,0 +1,13 @@
+# github-actions
+
+Welcome to the github-actions plugin!
+
+_This plugin was created through the Backstage CLI_
+
+## Getting started
+
+Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn start` in the root directory, and then navigating to [/github-actions](http://localhost:3000/github-actions).
+
+You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
+This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
+It is only meant for local development, and the setup for it can be found inside the [/dev](/dev) directory.

--- a/plugins/github-actions/dev/index.tsx
+++ b/plugins/github-actions/dev/index.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createDevApp } from '@backstage/dev-utils';
+import { plugin } from '../src/plugin';
+
+createDevApp().registerPlugin(plugin).render();

--- a/plugins/github-actions/package.json
+++ b/plugins/github-actions/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@backstage/plugin-github-actions",
+  "version": "0.1.1-alpha.12",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "scripts": {
+    "build": "backstage-cli plugin:build",
+    "start": "backstage-cli plugin:serve",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test",
+    "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
+    "clean": "backstage-cli clean"
+  },
+  "dependencies": {
+    "@backstage/core": "^0.1.1-alpha.12",
+    "@backstage/theme": "^0.1.1-alpha.12",
+    "@material-ui/core": "^4.9.1",
+    "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "4.0.0-alpha.45",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-router-dom": "6.0.0-beta.0",
+    "react-use": "^14.2.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.1.1-alpha.12",
+    "@backstage/dev-utils": "^0.1.1-alpha.12",
+    "@testing-library/jest-dom": "^5.10.1",
+    "@testing-library/react": "^10.4.1",
+    "@testing-library/user-event": "^12.0.7",
+    "@types/jest": "^25.2.2",
+    "@types/node": "^12.0.0",
+    "jest-fetch-mock": "^3.0.3"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/github-actions/src/apis/builds/BuildsClient.ts
+++ b/plugins/github-actions/src/apis/builds/BuildsClient.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Build, BuildDetails, BuildStatus } from './types';
+
+export class BuildsClient {
+  static create(): BuildsClient {
+    return new BuildsClient();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async listBuilds(_entityUri: string): Promise<Build[]> {
+    return [];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getBuild(_buildUri: string): Promise<BuildDetails> {
+    return {
+      build: {
+        commitId: 'TODO',
+        branch: 'TODO',
+        uri: 'TODO',
+        status: BuildStatus.Running,
+        message: 'TODO',
+      },
+      author: 'TODO',
+      logUrl: 'TODO',
+      overviewUrl: 'TODO',
+    };
+  }
+}

--- a/plugins/github-actions/src/apis/builds/index.ts
+++ b/plugins/github-actions/src/apis/builds/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { BuildsClient } from './BuildsClient';
+export * from './types';

--- a/plugins/github-actions/src/apis/builds/types.ts
+++ b/plugins/github-actions/src/apis/builds/types.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum BuildStatus {
+  Null,
+  Success,
+  Failure,
+  Pending,
+  Running,
+}
+
+export type Build = {
+  commitId: string;
+  message: string;
+  branch: string;
+  status: BuildStatus;
+  uri: string;
+};
+
+export type BuildDetails = {
+  build: Build;
+  author: string;
+  logUrl: string;
+  overviewUrl: string;
+};

--- a/plugins/github-actions/src/components/BuildDetailsPage/BuildDetailsPage.tsx
+++ b/plugins/github-actions/src/components/BuildDetailsPage/BuildDetailsPage.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Link } from '@backstage/core';
+import {
+  Button,
+  ButtonGroup,
+  LinearProgress,
+  makeStyles,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Theme,
+  Typography,
+} from '@material-ui/core';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useAsync } from 'react-use';
+import { BuildsClient } from '../../apis/builds';
+import { BuildStatusIndicator } from '../BuildStatusIndicator';
+
+const useStyles = makeStyles<Theme>(theme => ({
+  root: {
+    maxWidth: 720,
+    margin: theme.spacing(2),
+  },
+  title: {
+    padding: theme.spacing(1, 0, 2, 0),
+  },
+  table: {
+    padding: theme.spacing(1),
+  },
+}));
+
+const client = BuildsClient.create();
+
+export const BuildDetailsPage = () => {
+  const classes = useStyles();
+  const { buildUri } = useParams();
+  const status = useAsync(() => client.getBuild(buildUri), [buildUri]);
+
+  if (status.loading) {
+    return <LinearProgress />;
+  } else if (status.error) {
+    return (
+      <Typography variant="h6" color="error">
+        Failed to load build, {status.error.message}
+      </Typography>
+    );
+  }
+
+  const details = status.value;
+
+  return (
+    <div className={classes.root}>
+      <Typography className={classes.title} variant="h3">
+        <Link to="/builds">
+          <Typography component="span" variant="h3" color="primary">
+            &lt;
+          </Typography>
+        </Link>
+        Build Details
+      </Typography>
+      <TableContainer component={Paper} className={classes.table}>
+        <Table>
+          <TableBody>
+            <TableRow>
+              <TableCell>
+                <Typography noWrap>Branch</Typography>
+              </TableCell>
+              <TableCell>{details?.build.branch}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <Typography noWrap>Message</Typography>
+              </TableCell>
+              <TableCell>{details?.build.message}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <Typography noWrap>Commit ID</Typography>
+              </TableCell>
+              <TableCell>{details?.build.commitId}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <Typography noWrap>Status</Typography>
+              </TableCell>
+              <TableCell>
+                <BuildStatusIndicator status={details?.build.status} />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <Typography noWrap>Author</Typography>
+              </TableCell>
+              <TableCell>{details?.author}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <Typography noWrap>Links</Typography>
+              </TableCell>
+              <TableCell>
+                <ButtonGroup
+                  variant="text"
+                  color="primary"
+                  aria-label="text primary button group"
+                >
+                  {details?.overviewUrl && (
+                    <Button>
+                      <Link to={details.overviewUrl}>GitHub</Link>
+                    </Button>
+                  )}
+                  {details?.logUrl && (
+                    <Button>
+                      <Link to={details.logUrl}>Logs</Link>
+                    </Button>
+                  )}
+                </ButtonGroup>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </div>
+  );
+};

--- a/plugins/github-actions/src/components/BuildDetailsPage/index.ts
+++ b/plugins/github-actions/src/components/BuildDetailsPage/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { BuildDetailsPage } from './BuildDetailsPage';

--- a/plugins/github-actions/src/components/BuildInfoCard/BuildInfoCard.tsx
+++ b/plugins/github-actions/src/components/BuildInfoCard/BuildInfoCard.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Link } from '@backstage/core';
+import {
+  LinearProgress,
+  makeStyles,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Theme,
+  Typography,
+} from '@material-ui/core';
+import React from 'react';
+import { useAsync } from 'react-use';
+import { BuildsClient } from '../../apis/builds';
+import { BuildStatusIndicator } from '../BuildStatusIndicator';
+
+const client = BuildsClient.create();
+
+const useStyles = makeStyles<Theme>(theme => ({
+  root: {
+    // height: 400,
+  },
+  title: {
+    paddingBottom: theme.spacing(1),
+  },
+}));
+
+export const BuildInfoCard = () => {
+  const classes = useStyles();
+  const status = useAsync(() => client.listBuilds('entity:spotify:backstage'));
+
+  let content: JSX.Element;
+
+  if (status.loading) {
+    content = <LinearProgress />;
+  } else if (status.error) {
+    content = (
+      <Typography variant="h2" color="error">
+        Failed to load builds, {status.error.message}
+      </Typography>
+    );
+  } else {
+    const [build] =
+      status.value?.filter(({ branch }) => branch === 'master') ?? [];
+
+    content = (
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>
+              <Typography noWrap>Message</Typography>
+            </TableCell>
+            <TableCell>
+              <Link to={`builds/${encodeURIComponent(build?.uri || '')}`}>
+                <Typography color="primary">{build?.message}</Typography>
+              </Link>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>
+              <Typography noWrap>Commit ID</Typography>
+            </TableCell>
+            <TableCell>{build?.commitId}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>
+              <Typography noWrap>Status</Typography>
+            </TableCell>
+            <TableCell>
+              <BuildStatusIndicator status={build?.status} />
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+  }
+
+  return (
+    <div className={classes.root}>
+      <Typography variant="h2" className={classes.title}>
+        Master Build
+      </Typography>
+      {content}
+    </div>
+  );
+};

--- a/plugins/github-actions/src/components/BuildInfoCard/index.ts
+++ b/plugins/github-actions/src/components/BuildInfoCard/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { BuildInfoCard } from './BuildInfoCard';

--- a/plugins/github-actions/src/components/BuildListPage/BuildListPage.tsx
+++ b/plugins/github-actions/src/components/BuildListPage/BuildListPage.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Link } from '@backstage/core';
+import {
+  LinearProgress,
+  makeStyles,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Theme,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+import React from 'react';
+import { useAsync } from 'react-use';
+import { BuildsClient } from '../../apis/builds';
+import { BuildStatusIndicator } from '../BuildStatusIndicator';
+
+const client = BuildsClient.create();
+
+const LongText = ({ text, max }: { text: string; max: number }) => {
+  if (text.length < max) {
+    return <span>{text}</span>;
+  }
+  return (
+    <Tooltip title={text}>
+      <span>{text.slice(0, max)}...</span>
+    </Tooltip>
+  );
+};
+
+const useStyles = makeStyles<Theme>(theme => ({
+  root: {
+    padding: theme.spacing(2),
+  },
+  title: {
+    padding: theme.spacing(1, 0, 2, 0),
+  },
+}));
+
+const PageContents = () => {
+  const { loading, error, value } = useAsync(() =>
+    client.listBuilds('entity:spotify:backstage'),
+  );
+
+  if (loading) {
+    return <LinearProgress />;
+  }
+
+  if (error) {
+    return (
+      <Typography variant="h2" color="error">
+        Failed to load builds, {error.message}{' '}
+      </Typography>
+    );
+  }
+
+  return (
+    <TableContainer component={Paper}>
+      <Table aria-label="CI/CD builds table">
+        <TableHead>
+          <TableRow>
+            <TableCell>Status</TableCell>
+            <TableCell>Branch</TableCell>
+            <TableCell>Message</TableCell>
+            <TableCell>Commit</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {value!.map(build => (
+            <TableRow key={build.uri}>
+              <TableCell>
+                <BuildStatusIndicator status={build.status} />
+              </TableCell>
+              <TableCell>
+                <Typography>
+                  <LongText text={build.branch} max={30} />
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Link to={`builds/${encodeURIComponent(build.uri)}`}>
+                  <Typography color="primary">
+                    <LongText text={build.message} max={60} />
+                  </Typography>
+                </Link>
+              </TableCell>
+              <TableCell>
+                <Tooltip title={build.commitId}>
+                  <Typography noWrap>{build.commitId.slice(0, 10)}</Typography>
+                </Tooltip>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export const BuildListPage = () => {
+  const classes = useStyles();
+  return (
+    <div className={classes.root}>
+      <Typography variant="h3" className={classes.title}>
+        CI/CD Builds
+      </Typography>
+      <PageContents />
+    </div>
+  );
+};

--- a/plugins/github-actions/src/components/BuildListPage/index.ts
+++ b/plugins/github-actions/src/components/BuildListPage/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { BuildListPage } from './BuildListPage';

--- a/plugins/github-actions/src/components/BuildStatusIndicator/BuildStatusIndicator.tsx
+++ b/plugins/github-actions/src/components/BuildStatusIndicator/BuildStatusIndicator.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IconComponent } from '@backstage/core';
+import { makeStyles, Theme } from '@material-ui/core';
+import ProgressIcon from '@material-ui/icons/Autorenew';
+import SuccessIcon from '@material-ui/icons/CheckCircle';
+import FailureIcon from '@material-ui/icons/Error';
+import UnknownIcon from '@material-ui/icons/Help';
+import React from 'react';
+import { BuildStatus } from '../../apis/builds';
+
+type Props = {
+  status?: BuildStatus;
+};
+
+type StatusStyle = {
+  icon: IconComponent;
+  color: string;
+};
+
+const styles: { [key in BuildStatus]: StatusStyle } = {
+  [BuildStatus.Null]: {
+    icon: UnknownIcon,
+    color: '#f49b20',
+  },
+  [BuildStatus.Success]: {
+    icon: SuccessIcon,
+    color: '#1db855',
+  },
+  [BuildStatus.Failure]: {
+    icon: FailureIcon,
+    color: '#CA001B',
+  },
+  [BuildStatus.Pending]: {
+    icon: UnknownIcon,
+    color: '#5BC0DE',
+  },
+  [BuildStatus.Running]: {
+    icon: ProgressIcon,
+    color: '#BEBEBE',
+  },
+};
+
+const useStyles = makeStyles<Theme, StatusStyle>({
+  icon: style => ({
+    color: style.color,
+  }),
+});
+
+export const BuildStatusIndicator = ({ status }: Props) => {
+  const style = (status && styles[status]) || styles[BuildStatus.Null];
+  const classes = useStyles(style);
+  const Icon = style.icon;
+
+  return (
+    <div className={classes.icon}>
+      <Icon />
+    </div>
+  );
+};

--- a/plugins/github-actions/src/components/BuildStatusIndicator/index.ts
+++ b/plugins/github-actions/src/components/BuildStatusIndicator/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { BuildStatusIndicator } from './BuildStatusIndicator';

--- a/plugins/github-actions/src/index.ts
+++ b/plugins/github-actions/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { plugin } from './plugin';

--- a/plugins/github-actions/src/plugin.test.ts
+++ b/plugins/github-actions/src/plugin.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { plugin } from './plugin';
+
+describe('github-actions', () => {
+  it('should export plugin', () => {
+    expect(plugin).toBeDefined();
+  });
+});

--- a/plugins/github-actions/src/plugin.ts
+++ b/plugins/github-actions/src/plugin.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createPlugin, createRouteRef } from '@backstage/core';
+import { BuildDetailsPage } from './components/BuildDetailsPage';
+import { BuildListPage } from './components/BuildListPage';
+
+// TODO(freben): This is just a demo route for now
+export const rootRouteRef = createRouteRef({
+  path: '/github-actions',
+  title: 'GitHub Actions',
+});
+export const buildRouteRef = createRouteRef({
+  path: '/github-actions/builds/:buildUri',
+  title: 'GitHub Actions Build',
+});
+
+export const plugin = createPlugin({
+  id: 'github-actions',
+  register({ router }) {
+    router.addRoute(rootRouteRef, BuildListPage);
+    router.addRoute(buildRouteRef, BuildDetailsPage);
+  },
+});

--- a/plugins/github-actions/src/setupTests.ts
+++ b/plugins/github-actions/src/setupTests.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+
+require('jest-fetch-mock').enableMocks();


### PR DESCRIPTION
This basically does create-plugin, and then lifts over the old demonstration code for this feature from [this historical state](https://github.com/spotify/backstage/tree/7234da7cd998aa290330ff90efc7a90c8a2b43c3) of master. Then some basic cleanup to make it compile and render.

This is IN NO WAY ready to use :) For one, there was an old backend written in Go, that can be seen in that commit. That has to be reconstructed as a node backend plugin. Also the code uses a fair number of old structures and ideas (i did kill a couple but far from all) that need to be cleaned upp immediately after this.

Mainly the next steps will be to create a very basic backend and pointing the frontend at it, and then transferring over a fair number of concepts from the circleci plugin.