### PR TITLE
fix(sidebar): do not let sidebar items collapse and shrink

### DIFF
--- a/packages/core/src/layout/Sidebar/Bar.tsx
+++ b/packages/core/src/layout/Sidebar/Bar.tsx
@@ -44,6 +44,9 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.shortest,
     }),
+    '& > *': {
+      flexShrink: 0,
+    },
   },
   drawerOpen: {
     width: sidebarConfig.drawerWidthOpen,


### PR DESCRIPTION
Before:

![Screenshot 2020-07-02 at 14 57 53](https://user-images.githubusercontent.com/3097461/86361662-77c74e00-bc74-11ea-850c-fd2171bb8432.png)

After:

![Screenshot 2020-07-02 at 14 58 03](https://user-images.githubusercontent.com/3097461/86361645-73029a00-bc74-11ea-8d56-1cdb6496ec95.png)
