### PR TITLE
Use Config for Filter Org List Header

### DIFF
--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -82,7 +82,7 @@ const CatalogPageContents = () => {
   );
 
   const filterGroups = useMemo<ButtonGroup[]>(
-    (org: orgName) => [
+    () => [
       {
         name: 'Personal',
         items: [
@@ -101,7 +101,7 @@ const CatalogPageContents = () => {
         ],
       },
       {
-        name: org,
+        name: orgName,
         items: [
           {
             id: 'all',
@@ -111,7 +111,7 @@ const CatalogPageContents = () => {
         ],
       },
     ],
-    [isStarredEntity, userId],
+    [isStarredEntity, userId, orgName],
   );
 
   return (

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -19,6 +19,7 @@ import {
   ContentHeader,
   identityApiRef,
   SupportButton,
+  configApiRef,
   useApi,
 } from '@backstage/core';
 import { rootRoute as scaffolderRootRoute } from '@backstage/plugin-scaffolder';
@@ -51,6 +52,8 @@ const CatalogPageContents = () => {
   const userId = useApi(identityApiRef).getUserId();
   const [selectedTab, setSelectedTab] = useState<string>();
   const [selectedSidebarItem, setSelectedSidebarItem] = useState<string>();
+  const orgName =
+    useApi(configApiRef).getOptionalString('organization.name') ?? 'Company';
 
   const tabs = useMemo<LabeledComponentType[]>(
     () => [
@@ -79,7 +82,7 @@ const CatalogPageContents = () => {
   );
 
   const filterGroups = useMemo<ButtonGroup[]>(
-    () => [
+    (org: orgName) => [
       {
         name: 'Personal',
         items: [
@@ -98,7 +101,7 @@ const CatalogPageContents = () => {
         ],
       },
       {
-        name: 'Company', // TODO: Replace with Company name, read from app config.
+        name: org,
         items: [
           {
             id: 'all',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

First attempt at writing some TypeScript, so I thought I'd take a minor task of
making the Catalog filter list title be read from the config `organization.name` value.

![image](https://user-images.githubusercontent.com/1235844/86367454-e061fb00-bc73-11ea-8dab-f604c2316d9a.png)
(`TESTORG` is taken directly from `app-config.yaml`)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
