### PR TITLE
Adventures in using postgres with the backend

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -30,14 +30,15 @@
     "dockerode": "^3.2.0",
     "express": "^4.17.1",
     "knex": "^0.21.1",
+    "pg": "^8.2.1",
     "sqlite3": "^4.2.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.12",
+    "@types/dockerode": "^2.5.32",
     "@types/express": "^4.17.6",
     "@types/express-serve-static-core": "^4.17.5",
-    "@types/helmet": "^0.0.47",
-    "@types/dockerode": "^2.5.32"
+    "@types/helmet": "^0.0.47"
   }
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -42,11 +42,23 @@ function makeCreateEnv(loadedConfigs: AppConfig[]) {
 
   return (plugin: string): PluginEnvironment => {
     const logger = getRootLogger().child({ type: 'plugin', plugin });
+
+    // const database = knex({
+    //   client: 'sqlite3',
+    //   connection: ':memory:',
+    //   useNullAsDefault: true,
+    // });
+
+    // My local development PG database has no password and is on the defalt port and localhost.
     const database = knex({
-      client: 'sqlite3',
-      connection: ':memory:',
+      client: 'pg',
+      connection: {
+        user: process.env.PGUSER,
+        database: process.env.PGDATABASE,
+      },
       useNullAsDefault: true,
     });
+
     database.client.pool.on('createSuccess', (_eventId: any, resource: any) => {
       resource.run('PRAGMA foreign_keys = ON', () => {});
     });

--- a/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
+++ b/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
@@ -20,17 +20,8 @@
  * @param {import('knex')} knex
  */
 exports.up = async function up(knex) {
-  // Need to first order by date of creation
-  const query = knex
-    .select()
-    .from('location_update_log')
-    .orderBy('location_update_log.created_at', 'desc');
-
-  // And only then to do the grouping to get the latest per location
-  const groupedQuery = knex(query).groupBy('location_id').select();
-
   await knex.schema.raw(
-    `CREATE VIEW location_update_log_latest AS ${groupedQuery.toString()};`,
+    `CREATE VIEW location_update_log_latest AS select * from (select * from "location_update_log" order by "location_update_log"."created_at" desc) as myalias group by "location_id";`
   );
 };
 

--- a/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
+++ b/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
@@ -21,7 +21,7 @@
  */
 exports.up = async function up(knex) {
   await knex.schema.raw(
-    `CREATE VIEW location_update_log_latest AS select * from (select * from "location_update_log" order by "location_update_log"."created_at" desc) as myalias group by "location_id";`
+    `CREATE VIEW location_update_log_latest AS select * from (select * from "location_update_log" order by "location_update_log"."created_at" desc) as myalias group by "location_id", "id", "status", "created_at", "message", "entity_name";`
   );
 };
 

--- a/plugins/catalog-backend/src/service/standaloneServer.ts
+++ b/plugins/catalog-backend/src/service/standaloneServer.ts
@@ -17,6 +17,7 @@
 import { createServiceBuilder } from '@backstage/backend-common';
 import { Server } from 'http';
 import { Logger } from 'winston';
+import knex from 'knex';
 import { HigherOrderOperations } from '..';
 import { DatabaseEntitiesCatalog } from '../catalog/DatabaseEntitiesCatalog';
 import { DatabaseLocationsCatalog } from '../catalog/DatabaseLocationsCatalog';
@@ -36,7 +37,16 @@ export async function startStandaloneServer(
   const logger = options.logger.child({ service: 'catalog-backend' });
 
   logger.debug('Creating application...');
-  const db = await DatabaseManager.createInMemoryDatabase({ logger });
+  const database = knex({
+    client: 'pg',
+    connection: {
+      user: process.env.PGUSER,
+      database: process.env.PGDATABASE,
+    },
+    useNullAsDefault: true,
+  });
+
+  const db = await DatabaseManager.createDatabase(database, { logger });
   const entitiesCatalog = new DatabaseEntitiesCatalog(db);
   const locationsCatalog = new DatabaseLocationsCatalog(db);
   const locationReader = new LocationReaders();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5535,6 +5535,11 @@ buffer-indexof@^1.0.0:
   resolved "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
 
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -13804,6 +13809,11 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
+packet-reader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
+  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
 pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -14171,6 +14181,58 @@ pg-connection-string@2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.2.0.tgz#caab4d38a9de4fdc29c9317acceed752897de41c"
   integrity sha512-xB/+wxcpFipUZOQcSzcgkjcNOosGhEoPSjz06jC89lv1dj7mc9bZv6wLVy8M2fVjP0a/xN0N988YDq1L0FhK3A==
+
+pg-connection-string@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.2.3.tgz#48e1158ec37eaa82e98dbcb7307103ec303fe0e7"
+  integrity sha512-I/KCSQGmOrZx6sMHXkOs2MjddrYcqpza3Dtsy0AjIgBr/bZiPJRK9WhABXN1Uy1UDazRbi9gZEzO2sAhL5EqiQ==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz#5f4afc0f58063659aeefa952d36af49fa28b30e0"
+  integrity sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==
+
+pg-protocol@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.4.tgz#3139cac0e51347f1e21e03954b1bb9fe2c20962e"
+  integrity sha512-/8L/G+vW/VhWjTGXpGh8XVkXOFx1ZDY+Yuz//Ab8CfjInzFkreI+fDG3WjCeSra7fIZwAFxzbGptNbm8xSXenw==
+
+pg-types@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.npmjs.org/pg/-/pg-8.2.1.tgz#f5a81f5e2025182fbe701514d3e1a43e68a616ac"
+  integrity sha512-DKzffhpkWRr9jx7vKxA+ur79KG+SKw+PdjMb1IRhMiKI9zqYUGczwFprqy+5Veh/DCcFs1Y6V8lRLN5I1DlleQ==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.2.3"
+    pg-pool "^3.2.1"
+    pg-protocol "^1.2.4"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+    semver "4.3.2"
+
+pgpass@1.x:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz#2a7bb41b6065b67907e91da1b07c1847c877b306"
+  integrity sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=
+  dependencies:
+    split "^1.0.0"
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
@@ -14702,6 +14764,28 @@ postcss@^6.0.1:
     chalk "^2.4.1"
     source-map "^0.6.1"
     supports-color "^5.4.0"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=
+
+postgres-date@~1.0.4:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.5.tgz#710b27de5f27d550f6e80b5d34f7ba189213c2ee"
+  integrity sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -16422,6 +16506,11 @@ semver-regex@^2.0.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
+semver@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
+  integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
 
 semver@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
I've been trying to get the backend to work with PG and I thought I would document how far I have gotten so far and the issues I ran into.

# Steps to repro

Create a local PG DB

```shell
» createdb -O davidtuite -U davidtuite -w backstage_backend
```
Force the code to use postgres (this is the first commit attached).

Run the backend package, get an error because one of the migrations doesn't appear to be valid in PG. The second commit fixes this in a hacky way because I can't figure out how to use knex to add the alias which is required.

```shell
» env PGUSER=davidtuite PGDATABASE=backstage_backend yarn start
yarn run v1.22.1
$ backstage-cli backend:dev
Build succeeded
migration file "20200527114117_location_update_log_latest_view.js" failed
migration failed with error: CREATE VIEW location_update_log_latest AS select * from (select * from "location_update_log" order by "location_update_log"."created_at" desc) group by "location_id"; - subquery in FROM must have an alias
Backend failed to start up, error: CREATE VIEW location_update_log_latest AS select * from (select * from "location_update_log" order by "location_update_log"."created_at" desc) group by "location_id"; - subquery in FROM must have an alias
```

Once that is fixed, I try again and get a different error. The third commit fixes this one.

```shell
» env PGUSER=davidtuite PGDATABASE=backstage_backend yarn start
yarn run v1.22.1
$ backstage-cli backend:dev
Build succeeded
migration file "20200527114117_location_update_log_latest_view.js" failed
migration failed with error: CREATE VIEW location_update_log_latest AS select * from (select * from "location_update_log" order by "location_update_log"."created_at" desc) as myalias group by "location_id"; - column "myalias.id" must appear in the GROUP BY clause or be used in an aggregate function
Backend failed to start up, error: CREATE VIEW location_update_log_latest AS select * from (select * from "location_update_log" order by "location_update_log"."created_at" desc) as myalias group by "location_id"; - column "myalias.id" must appear in the GROUP BY clause or be used in an aggregate function
```

With all that fixed, I have a syntactically correct migration file. Let's recreate the DB to ensure that it's not in some weird state with some migrations ran and others not.

```shell
» dropdb -w backstage_backend
» createdb -O davidtuite -U davidtuite -w backstage_backend
```

Now I get a weird error saying that my migrations directory is corrupt. I don't have a fix for this one yet.

```shell
» env PGUSER=davidtuite PGDATABASE=backstage_backend yarn start                                                                                 146 ↵
yarn run v1.22.1
$ backstage-cli backend:dev
Build succeeded
info: Beginning locations refresh {"type":"plugin","plugin":"catalog","service":"backstage","timestamp":"2020-07-05T08:41:58.326Z"}
warn: Failed to initialize Sentry backend, set SENTRY_TOKEN environment variable to start the API. {"type":"plugin","plugin":"sentry","service":"backstage","timestamp":"2020-07-05T08:41:58.357Z"}
info: Visiting 0 locations {"type":"plugin","plugin":"catalog","service":"backstage","timestamp":"2020-07-05T08:41:58.381Z"}
Backend failed to start up, Error: The migration directory is corrupt, the following files are missing: 20200511113813_init.js, 20200520140700_location_update_log_table.js, 20200527114117_location_update_log_latest_view.js
```

Oddly, If I switch into the plugins/catalog-backend directory it works fine and I can successfully query locations.

```shell
» cd ../../plugins/catalog-backend
» env PGUSER=davidtuite PGDATABASE=backstage_backend yarn start                                                                           130 ↵
yarn run v1.22.1
$ backstage-cli backend:dev
Build succeeded
info: Listening on localhost:7000 {"service":"backstage","timestamp":"2020-07-05T08:46:20.542Z"}
```

```shell
» curl http://localhost:7000/catalog/locations
[]
```

# Open questions

 1. How do I add that alias in an idiomatic knex way.
 2. Why are my migrations corrupt when run from `packages/backend` but not from `plugins/catalog-backend`? Something to do with trying to load the migrations from a known path?

# TODO

- [ ] Switch the auth backend to PG in `plugins/auth-backend/src/service/standaloneServer.ts`.