### PR TITLE
feat(cli): backstage-cli plugin:export

### DIFF
--- a/packages/cli/src/commands/plugin/export.ts
+++ b/packages/cli/src/commands/plugin/export.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Command } from 'commander';
+import { loadConfig } from '@backstage/config-loader';
+import { ConfigReader } from '@backstage/config';
+import { buildBundle } from '../../lib/bundler';
+
+export default async (cmd: Command) => {
+  const appConfigs = await loadConfig();
+  await buildBundle({
+    entry: 'dev/index',
+    statsJsonEnabled: cmd.stats,
+    config: ConfigReader.fromConfigs(appConfigs),
+    appConfigs,
+  });
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -104,6 +104,12 @@ const main = (argv: string[]) => {
     .action(lazyAction(() => import('./commands/plugin/serve'), 'default'));
 
   program
+    .command('plugin:export')
+    .description('Exports the dev/ folder of a plugin')
+    .option('--stats', 'Write bundle stats to output directory')
+    .action(lazyAction(() => import('./commands/plugin/export'), 'default'));
+
+  program
     .command('plugin:diff')
     .option('--check', 'Fail if changes are required')
     .option('--yes', 'Apply all changes')

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "backstage-cli plugin:build",
+    "export": "backstage-cli plugin:export",
     "start": "backstage-cli plugin:serve",
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3960,13 +3960,6 @@
     "@types/node" "*"
     rollup "^0.63.4"
 
-"@types/sanitize-html@^1.23.3":
-  version "1.23.3"
-  resolved "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-1.23.3.tgz#26527783aba3bf195ad8a3c3e51bd3713526fc0d"
-  integrity sha512-Isg8N0ifKdDq6/kaNlIcWfapDXxxquMSk2XC5THsOICRyOIhQGds95XH75/PL/g9mExi4bL8otIqJM/Wo96WxA==
-  dependencies:
-    htmlparser2 "^4.1.0"
-
 "@types/serve-static@*":
   version "1.13.3"
   resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"


### PR DESCRIPTION
This introduces a `backstage-cli plugin:export` option that simply builds one-time what `backstage-cli plugin:serve` would do. The use case for this is to support Backstage local documentation previews, although this could also later down the line be helpful for live demos of Backstage plugins.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes