### PR TITLE
Adds Github to signin page providers

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -33,7 +33,7 @@ const app = createApp({
     SignInPage: props => (
       <SignInPage
         {...props}
-        providers={['guest', 'google', 'custom', 'okta', 'gitlab']}
+        providers={['guest', 'google', 'custom', 'okta', 'gitlab', 'github']}
       />
     ),
   },

--- a/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
@@ -90,7 +90,7 @@ class GithubAuth implements OAuthApi, SessionStateApi {
 
     const sessionManager = new StaticAuthSessionManager({
       connector,
-      defaultScopes: new Set(['user']),
+      defaultScopes: new Set(['read:user']),
       sessionScopes: (session: GithubSession) => session.providerInfo.scopes,
     });
 

--- a/packages/core/src/layout/SignInPage/githubProvider.tsx
+++ b/packages/core/src/layout/SignInPage/githubProvider.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Grid, Typography, Button } from '@material-ui/core';
+import { InfoCard } from '../InfoCard/InfoCard';
+import { ProviderComponent, ProviderLoader, SignInProvider } from './types';
+import { useApi, githubAuthApiRef, errorApiRef } from '@backstage/core-api';
+
+const Component: ProviderComponent = ({ onResult }) => {
+  const githubAuthApi = useApi(githubAuthApiRef);
+  const errorApi = useApi(errorApiRef);
+
+  const handleLogin = async () => {
+    try {
+      const identity = await githubAuthApi.getBackstageIdentity({
+        instantPopup: true,
+      });
+
+      const profile = await githubAuthApi.getProfile();
+      onResult({
+        userId: identity!.id,
+        profile: profile!,
+        getIdToken: () => {
+          return githubAuthApi.getBackstageIdentity().then(i => i!.idToken);
+        },
+        logout: async () => {
+          await githubAuthApi.logout();
+        },
+      });
+    } catch (error) {
+      errorApi.post(error);
+    }
+  };
+
+  return (
+    <Grid item>
+      <InfoCard
+        title="Github"
+        actions={
+          <Button color="primary" variant="outlined" onClick={handleLogin}>
+            Sign In
+          </Button>
+        }
+      >
+        <Typography variant="body1">Sign In using Github</Typography>
+      </InfoCard>
+    </Grid>
+  );
+};
+
+const loader: ProviderLoader = async apis => {
+  const githubAuthApi = apis.get(githubAuthApiRef)!;
+
+  const identity = await githubAuthApi.getBackstageIdentity({
+    optional: true,
+  });
+
+  if (!identity) {
+    return undefined;
+  }
+
+  const profile = await githubAuthApi.getProfile();
+
+  return {
+    userId: identity.id,
+    profile: profile!,
+    getIdToken: () =>
+      githubAuthApi.getBackstageIdentity().then(i => i!.idToken),
+    logout: async () => {
+      await githubAuthApi.logout();
+    },
+  };
+};
+
+export const githubProvider: SignInProvider = { Component, loader };

--- a/packages/core/src/layout/SignInPage/providers.tsx
+++ b/packages/core/src/layout/SignInPage/providers.tsx
@@ -20,6 +20,7 @@ import { googleProvider } from './googleProvider';
 import { customProvider } from './customProvider';
 import { gitlabProvider } from './gitlabProvider';
 import { oktaProvider } from './oktaProvider';
+import { githubProvider } from './githubProvider';
 import {
   SignInPageProps,
   SignInResult,
@@ -37,7 +38,8 @@ export type SignInProviderId =
   | 'google'
   | 'gitlab'
   | 'custom'
-  | 'okta';
+  | 'okta'
+  | 'github';
 
 const signInProviders: { [id in SignInProviderId]: SignInProvider } = {
   guest: guestProvider,
@@ -45,6 +47,7 @@ const signInProviders: { [id in SignInProviderId]: SignInProvider } = {
   gitlab: gitlabProvider,
   custom: customProvider,
   okta: oktaProvider,
+  github: githubProvider,
 };
 
 export const useSignInProviders = (

--- a/plugins/auth-backend/src/providers/github/provider.test.ts
+++ b/plugins/auth-backend/src/providers/github/provider.test.ts
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GithubAuthProvider } from './provider';
+
+describe('GithubAuthProvider', () => {
+  describe('should transform to type OAuthResponse', () => {
+    it('when all fields are present, it should be able to map them', () => {
+      const accessToken = '19xasczxcm9n7gacn9jdgm19me';
+      const rawProfile = {
+        id: 'uid-123',
+        username: 'jimmymarkum',
+        provider: 'github',
+        displayName: 'Jimmy Markum',
+        emails: [
+          {
+            value: 'jimmymarkum@gmail.com',
+          },
+        ],
+        photos: [
+          {
+            value:
+              'https://a1cf74336522e87f135f-2f21ace9a6cf0052456644b80fa06d4f.ssl.cf2.rackcdn.com/images/characters_opt/p-mystic-river-sean-penn.jpg',
+          },
+        ],
+      };
+
+      const params = {
+        scope: 'read:scope',
+      };
+
+      const expected = {
+        backstageIdentity: {
+          id: 'jimmymarkum',
+        },
+        providerInfo: {
+          accessToken: '19xasczxcm9n7gacn9jdgm19me',
+          expiresInSeconds: undefined,
+          idToken: undefined,
+          scope: 'read:scope',
+        },
+        profile: {
+          email: 'jimmymarkum@gmail.com',
+          displayName: 'Jimmy Markum',
+          picture:
+            'https://a1cf74336522e87f135f-2f21ace9a6cf0052456644b80fa06d4f.ssl.cf2.rackcdn.com/images/characters_opt/p-mystic-river-sean-penn.jpg',
+        },
+      };
+      expect(
+        GithubAuthProvider.transformOAuthResponse(
+          accessToken,
+          rawProfile,
+          params,
+        ),
+      ).toEqual(expected);
+    });
+
+    it('when "email" is missing, it should be able to create the profile without it', () => {
+      const accessToken = '19xasczxcm9n7gacn9jdgm19me';
+      const rawProfile = {
+        id: 'uid-123',
+        username: 'jimmymarkum',
+        provider: 'github',
+        displayName: 'Jimmy Markum',
+        emails: null,
+        photos: [
+          {
+            value:
+              'https://a1cf74336522e87f135f-2f21ace9a6cf0052456644b80fa06d4f.ssl.cf2.rackcdn.com/images/characters_opt/p-mystic-river-sean-penn.jpg',
+          },
+        ],
+      };
+
+      const params = {
+        scope: 'read:scope',
+      };
+
+      const expected = {
+        backstageIdentity: {
+          id: 'jimmymarkum',
+        },
+        providerInfo: {
+          accessToken: '19xasczxcm9n7gacn9jdgm19me',
+          expiresInSeconds: undefined,
+          idToken: undefined,
+          scope: 'read:scope',
+        },
+        profile: {
+          displayName: 'Jimmy Markum',
+          picture:
+            'https://a1cf74336522e87f135f-2f21ace9a6cf0052456644b80fa06d4f.ssl.cf2.rackcdn.com/images/characters_opt/p-mystic-river-sean-penn.jpg',
+        },
+      };
+
+      expect(
+        GithubAuthProvider.transformOAuthResponse(
+          accessToken,
+          rawProfile,
+          params,
+        ),
+      ).toEqual(expected);
+    });
+
+    it('when "displayName" is missing, it should be able to create the profile and map "displayName" with "username"', () => {
+      const accessToken = '19xasczxcm9n7gacn9jdgm19me';
+      const rawProfile = {
+        id: 'uid-123',
+        username: 'jimmymarkum',
+        provider: 'github',
+        displayName: null,
+        emails: null,
+        photos: [
+          {
+            value:
+              'https://a1cf74336522e87f135f-2f21ace9a6cf0052456644b80fa06d4f.ssl.cf2.rackcdn.com/images/characters_opt/p-mystic-river-sean-penn.jpg',
+          },
+        ],
+      };
+
+      const params = {
+        scope: 'read:scope',
+      };
+      const expected = {
+        backstageIdentity: {
+          id: 'jimmymarkum',
+        },
+        providerInfo: {
+          accessToken: '19xasczxcm9n7gacn9jdgm19me',
+          expiresInSeconds: undefined,
+          idToken: undefined,
+          scope: 'read:scope',
+        },
+        profile: {
+          displayName: 'jimmymarkum',
+          picture:
+            'https://a1cf74336522e87f135f-2f21ace9a6cf0052456644b80fa06d4f.ssl.cf2.rackcdn.com/images/characters_opt/p-mystic-river-sean-penn.jpg',
+        },
+      };
+
+      expect(
+        GithubAuthProvider.transformOAuthResponse(
+          accessToken,
+          rawProfile,
+          params,
+        ),
+      ).toEqual(expected);
+    });
+
+    it('when "photos" is missing, it should be able to create the profile without it', () => {
+      const accessToken =
+        'ajakljsdoiahoawxbrouawucmbawe.awkxjemaneasdxwe.sodijxqeqwexeqwxe';
+      const rawProfile = {
+        id: 'ipd12039',
+        username: 'daveboyle',
+        provider: 'gitlab',
+        displayName: 'Dave Boyle',
+        emails: [
+          {
+            value: 'daveboyle@gitlab.org',
+          },
+        ],
+      };
+
+      const params = {
+        scope: 'read:user',
+      };
+
+      const expected = {
+        backstageIdentity: {
+          id: 'daveboyle',
+        },
+        providerInfo: {
+          accessToken:
+            'ajakljsdoiahoawxbrouawucmbawe.awkxjemaneasdxwe.sodijxqeqwexeqwxe',
+          scope: 'read:user',
+          expiresInSeconds: undefined,
+          idToken: undefined,
+        },
+        profile: {
+          displayName: 'Dave Boyle',
+          email: 'daveboyle@gitlab.org',
+        },
+      };
+
+      expect(
+        GithubAuthProvider.transformOAuthResponse(
+          accessToken,
+          rawProfile,
+          params,
+        ),
+      ).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added Github for regular `OAuth2 flow` as an experiment to understand the `auth-backend`.

I'm aware that a RFC for Github Apps is still in progress but in the meantime I've considered that it would be useful to help more folks onboard. We could drop this change in the future when Backstage supports Github App.

**The option appears in the SignIn page**
<img width="1254" alt="Screen Shot 2020-07-11 at 1 23 33 PM" src="https://user-images.githubusercontent.com/42963872/87224396-fad75b00-c37c-11ea-9864-984ca658551d.png">

**The ID is displayed with the username**
<img width="540" alt="Screen Shot 2020-07-11 at 1 42 25 PM" src="https://user-images.githubusercontent.com/42963872/87224402-06c31d00-c37d-11ea-810b-824566f61945.png">

**Avatar and username**
<img width="185" alt="Screen Shot 2020-07-11 at 1 42 35 PM" src="https://user-images.githubusercontent.com/42963872/87224430-3bcf6f80-c37d-11ea-877d-0270efdf7923.png">

**Avatar and display name**
<img width="192" alt="Screen Shot 2020-07-11 at 1 44 51 PM" src="https://user-images.githubusercontent.com/42963872/87224437-4c7fe580-c37d-11ea-83d4-773048c9397e.png">

**Scope change**
<img width="434" alt="Screen Shot 2020-07-11 at 1 43 54 PM" src="https://user-images.githubusercontent.com/42963872/87224441-5570b700-c37d-11ea-9166-af5abb067265.png">

Considerations:
* The Id is Github's username.
* Reduced the scope access to read-only. It might be a source of concern if Backstage asks write access to User's Profile.
* Email is provided only if is available in the user's public profile. If having an email is important, we can use `user:email` to fetch emails from another endpoint.
* Display name is provided only if is available in the user's public profile. Username is used as fallback.
* Implementation was based on `Gitlab` provider.

Questions:
Am I supposed to use `BackstageIdentityApi`? Gitlab's implementation is not using but according to `docs/auth/README.md` gitlab and this PR should use it?

Remarks and topics for discussion (and to open another PR):
* The `packages/app/src/App.tsx` lists all providers. So every time there is a new provider, it must be added there. However, i'm concern that folks will face conflicts constantly because their local repositories also have their changes. Are we ok on moving that listing to `app_config.yaml`?
* The same issue occurs in `packages/core/src/layout/SignInPage/providers.tsx`, `plugins/auth-backend/src/service/router.ts`, etc. This seems to be a good point for conflicts any time a new provider is added. What's your take on having a `self-registration` for each new provider, in order to minimize changes to these files?
* The collapse button of the sidebar is well on top of the identity providers and is a pain to try to sign-in/logout since is easy to missclick. Easy to notice after the constant testing 😅 Any issue to move the button to the top?

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [X] All tests are passing `yarn test`
- [X] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [X] Prettier run on changed files
- [X] Tests added for new functionality
- [ ] Regression tests added for bug fixes
