### PR TITLE
[Backend-Common] Add backend status check handler middleware

### DIFF
--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -35,6 +35,7 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",
+    "express-promise-router": "^3.0.3",
     "helmet": "^3.22.0",
     "morgan": "^1.10.0",
     "stoppable": "^1.1.0",

--- a/packages/backend-common/src/middleware/index.ts
+++ b/packages/backend-common/src/middleware/index.ts
@@ -17,3 +17,4 @@
 export * from './errorHandler';
 export * from './notFoundHandler';
 export * from './requestLoggingHandler';
+export * from './statusCheckHandler';

--- a/packages/backend-common/src/middleware/statusCheckHandler.test.ts
+++ b/packages/backend-common/src/middleware/statusCheckHandler.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { statusCheckHandler } from './statusCheckHandler';
+
+describe('statusCheckHandler', () => {
+  it('gives status 200 when using default', async () => {
+    const app = express();
+    app.use('/healthcheck', await statusCheckHandler());
+
+    const response = await request(app).get('/healthcheck');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe(JSON.stringify({ status: 'ok' }));
+  });
+
+  it('gives status 200 when status function returns true', async () => {
+    const app = express();
+    const status = { foo: 'bar' };
+    const statusCheck = () => Promise.resolve(status);
+    app.use('/healthcheck', await statusCheckHandler({ statusCheck }));
+
+    const response = await request(app).get('/healthcheck');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe(JSON.stringify(status));
+  });
+
+  it('gives status 500 when status check throws an error', async () => {
+    const app = express();
+    const statusCheck = () => {
+      throw Error('error!');
+    };
+    app.use('/healthcheck', await statusCheckHandler({ statusCheck }));
+
+    const response = await request(app).get('/healthcheck');
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/packages/backend-common/src/middleware/statusCheckHandler.ts
+++ b/packages/backend-common/src/middleware/statusCheckHandler.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NextFunction, Request, Response, RequestHandler } from 'express';
+
+export type StatusCheck = () => Promise<any>;
+
+export interface StatusCheckHandlerOptions {
+  /**
+   * Optional status function which returns a message.
+   */
+  statusCheck?: StatusCheck;
+}
+
+/**
+ * Express middleware for status checks.
+ *
+ * This is commonly used to implement healthcheck and readiness routes.
+ *
+ * @param options An optional configuration object.
+ * @returns An Express error request handler
+ */
+export async function statusCheckHandler(
+  options: StatusCheckHandlerOptions = {},
+): Promise<RequestHandler> {
+  const statusCheck: StatusCheck = options.statusCheck
+    ? options.statusCheck
+    : () => Promise.resolve({ status: 'ok' });
+
+  return async (_request: Request, response: Response, next: NextFunction) => {
+    try {
+      const status = await statusCheck();
+      response.status(200).header('').send(status);
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/packages/backend-common/src/service/createStatusCheckRouter.test.ts
+++ b/packages/backend-common/src/service/createStatusCheckRouter.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import * as winston from 'winston';
+import request from 'supertest';
+import { createStatusCheckRouter } from './createStatusCheckRouter';
+
+describe('createStatusCheckRouter', () => {
+  const logger = winston.createLogger();
+
+  it('gives status 200 when using default path', async () => {
+    const app = express();
+    app.use('', await createStatusCheckRouter({ logger }));
+
+    const response = await request(app).get('/healthcheck');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe(JSON.stringify({ status: 'ok' }));
+  });
+
+  it('gives status 200 when using custom path', async () => {
+    const app = express();
+    app.use('', await createStatusCheckRouter({ logger, path: '/ready' }));
+
+    const response = await request(app).get('/ready');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe(JSON.stringify({ status: 'ok' }));
+  });
+
+  it('gives status 500 when status check throws an error', async () => {
+    const app = express();
+    const statusCheck = () => {
+      throw Error('error!');
+    };
+    app.use('', await createStatusCheckRouter({ logger, statusCheck }));
+
+    const response = await request(app).get('/healthcheck');
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/packages/backend-common/src/service/createStatusCheckRouter.ts
+++ b/packages/backend-common/src/service/createStatusCheckRouter.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Logger } from 'winston';
+import Router from 'express-promise-router';
+import express from 'express';
+import { errorHandler, statusCheckHandler, StatusCheck } from '../middleware';
+
+export interface StatusCheckRouterOptions {
+  logger: Logger;
+  path?: string;
+  statusCheck?: StatusCheck;
+}
+
+export async function createStatusCheckRouter(
+  options: StatusCheckRouterOptions,
+): Promise<express.Router> {
+  const router = Router();
+  const { path = '/healthcheck', statusCheck } = options;
+
+  router.use(path, await statusCheckHandler({ statusCheck }));
+  router.use(errorHandler());
+
+  return router;
+}

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -17,7 +17,7 @@
 import { ConfigReader } from '@backstage/config';
 import compression from 'compression';
 import cors from 'cors';
-import express, { Router, RequestHandler } from 'express';
+import express, { Router } from 'express';
 import helmet from 'helmet';
 import { Server } from 'http';
 import stoppable from 'stoppable';
@@ -40,7 +40,7 @@ export class ServiceBuilderImpl implements ServiceBuilder {
   private host: string | undefined;
   private logger: Logger | undefined;
   private corsOptions: cors.CorsOptions | undefined;
-  private routers: [string, Router | RequestHandler][];
+  private routers: [string, Router][];
   // Reference to the module where builder is created - needed for hot module
   // reloading
   private module: NodeModule;
@@ -92,7 +92,7 @@ export class ServiceBuilderImpl implements ServiceBuilder {
     return this;
   }
 
-  addRouter(root: string, router: Router | RequestHandler): ServiceBuilder {
+  addRouter(root: string, router: Router): ServiceBuilder {
     this.routers.push([root, router]);
     return this;
   }

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -17,7 +17,7 @@
 import { ConfigReader } from '@backstage/config';
 import compression from 'compression';
 import cors from 'cors';
-import express, { Router } from 'express';
+import express, { Router, RequestHandler } from 'express';
 import helmet from 'helmet';
 import { Server } from 'http';
 import stoppable from 'stoppable';
@@ -40,7 +40,7 @@ export class ServiceBuilderImpl implements ServiceBuilder {
   private host: string | undefined;
   private logger: Logger | undefined;
   private corsOptions: cors.CorsOptions | undefined;
-  private routers: [string, Router][];
+  private routers: [string, Router | RequestHandler][];
   // Reference to the module where builder is created - needed for hot module
   // reloading
   private module: NodeModule;
@@ -92,7 +92,7 @@ export class ServiceBuilderImpl implements ServiceBuilder {
     return this;
   }
 
-  addRouter(root: string, router: Router): ServiceBuilder {
+  addRouter(root: string, router: Router | RequestHandler): ServiceBuilder {
     this.routers.push([root, router]);
     return this;
   }

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -16,7 +16,7 @@
 
 import { ConfigReader } from '@backstage/config';
 import cors from 'cors';
-import { Router } from 'express';
+import { Router, RequestHandler } from 'express';
 import { Server } from 'http';
 import { Logger } from 'winston';
 
@@ -64,7 +64,7 @@ export type ServiceBuilder = {
    * @param root The root URL to bind to (e.g. "/api/function1")
    * @param router An express router
    */
-  addRouter(root: string, router: Router): ServiceBuilder;
+  addRouter(root: string, router: Router | RequestHandler): ServiceBuilder;
 
   /**
    * Starts the server using the given settings.

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -25,12 +25,12 @@
 import {
   createServiceBuilder,
   getRootLogger,
-  statusCheckHandler,
   useHotMemoize,
 } from '@backstage/backend-common';
 import { ConfigReader, AppConfig } from '@backstage/config';
 import { loadConfig } from '@backstage/config-loader';
 import knex from 'knex';
+import healthcheck from './plugins/healthcheck';
 import auth from './plugins/auth';
 import catalog from './plugins/catalog';
 import identity from './plugins/identity';
@@ -63,6 +63,7 @@ async function main() {
   const configReader = ConfigReader.fromConfigs(configs);
   const createEnv = makeCreateEnv(configs);
 
+  const healthcheckEnv = useHotMemoize(module, () => createEnv('healthcheck'));
   const catalogEnv = useHotMemoize(module, () => createEnv('catalog'));
   const scaffolderEnv = useHotMemoize(module, () => createEnv('scaffolder'));
   const authEnv = useHotMemoize(module, () => createEnv('auth'));
@@ -74,7 +75,7 @@ async function main() {
 
   const service = createServiceBuilder(module)
     .loadConfig(configReader)
-    .addRouter('/healthcheck', await statusCheckHandler())
+    .addRouter('', await healthcheck(healthcheckEnv))
     .addRouter('/catalog', await catalog(catalogEnv))
     .addRouter('/rollbar', await rollbar(rollbarEnv))
     .addRouter('/scaffolder', await scaffolder(scaffolderEnv))

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -25,6 +25,7 @@
 import {
   createServiceBuilder,
   getRootLogger,
+  statusCheckHandler,
   useHotMemoize,
 } from '@backstage/backend-common';
 import { ConfigReader, AppConfig } from '@backstage/config';
@@ -73,6 +74,7 @@ async function main() {
 
   const service = createServiceBuilder(module)
     .loadConfig(configReader)
+    .addRouter('/healthcheck', await statusCheckHandler())
     .addRouter('/catalog', await catalog(catalogEnv))
     .addRouter('/rollbar', await rollbar(rollbarEnv))
     .addRouter('/scaffolder', await scaffolder(scaffolderEnv))

--- a/packages/backend/src/plugins/healthcheck.ts
+++ b/packages/backend/src/plugins/healthcheck.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
-export { createServiceBuilder } from './createServiceBuilder';
-export { createStatusCheckRouter } from './createStatusCheckRouter';
-export type { ServiceBuilder } from './types';
+import { createStatusCheckRouter } from '@backstage/backend-common';
+import { PluginEnvironment } from '../types';
+
+export default async function createRouter({ logger }: PluginEnvironment) {
+  return await createStatusCheckRouter({ logger, path: '/healthcheck' });
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a basic `statusCheckHandler` express middleware which can be used to implement `healthcheck/liveness/readiness` endpoints. It can be provided an optional `status` function that returns a promise which resolves to either true or false (http 200 or 503 respectively). Any errors that occur will be forwarded to next.

NOTE: I expanded the types for `ServiceBuilder.addRouter` to include `RequestHandler` to accomplish this. This of course could be done by adding a new `addHandler` or some other form. Happy to change if another approach is more suitable.

#### :heavy_check_mark: Checklist

- [x] All tests are passing `yarn test`
- ~~[ ] Screenshots attached (for UI changes)~~
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- ~~[ ] Regression tests added for bug fixes~~
