### PR TITLE
[Rollbar] Rename rollbar token & minor cleanup

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -67,22 +67,16 @@ async function main() {
   const authEnv = useHotMemoize(module, () => createEnv('auth'));
   const identityEnv = useHotMemoize(module, () => createEnv('identity'));
   const proxyEnv = useHotMemoize(module, () => createEnv('proxy'));
+  const rollbarEnv = useHotMemoize(module, () => createEnv('rollbar'));
+  const sentryEnv = useHotMemoize(module, () => createEnv('sentry'));
   const techdocsEnv = useHotMemoize(module, () => createEnv('techdocs'));
 
   const service = createServiceBuilder(module)
     .loadConfig(configReader)
     .addRouter('/catalog', await catalog(catalogEnv))
-    .addRouter(
-      '/rollbar',
-      await rollbar(
-        getRootLogger().child({ type: 'plugin', plugin: 'rollbar' }),
-      ),
-    )
+    .addRouter('/rollbar', await rollbar(rollbarEnv))
     .addRouter('/scaffolder', await scaffolder(scaffolderEnv))
-    .addRouter(
-      '/sentry',
-      await sentry(getRootLogger().child({ type: 'plugin', plugin: 'sentry' })),
-    )
+    .addRouter('/sentry', await sentry(sentryEnv))
     .addRouter('/auth', await auth(authEnv))
     .addRouter('/identity', await identity(identityEnv))
     .addRouter('/techdocs', await techdocs(techdocsEnv))

--- a/packages/backend/src/plugins/rollbar.ts
+++ b/packages/backend/src/plugins/rollbar.ts
@@ -15,8 +15,8 @@
  */
 
 import { createRouter } from '@backstage/plugin-rollbar-backend';
-import { Logger } from 'winston';
+import type { PluginEnvironment } from '../types';
 
-export default async function createPlugin(logger: Logger) {
+export default async function createPlugin({ logger }: PluginEnvironment) {
   return await createRouter({ logger });
 }

--- a/packages/backend/src/plugins/sentry.ts
+++ b/packages/backend/src/plugins/sentry.ts
@@ -15,8 +15,8 @@
  */
 
 import { createRouter } from '@backstage/plugin-sentry-backend';
-import { Logger } from 'winston';
+import type { PluginEnvironment } from '../types';
 
-export default async function createPlugin(logger: Logger) {
+export default async function createPlugin({ logger }: PluginEnvironment) {
   return await createRouter(logger);
 }

--- a/plugins/rollbar-backend/README.md
+++ b/plugins/rollbar-backend/README.md
@@ -4,7 +4,7 @@ Simple plugin that proxies requests to the [Rollbar](https://rollbar.com) API.
 
 ## Setup
 
-A `ROLLBAR_TOKEN` environment variable must be set to a read access account token.
+A `ROLLBAR_ACCOUNT_TOKEN` environment variable must be set to a read access account token.
 
 ## Links
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some minor cleanup of the `rollbar` plugin:

- Renamed `ROLLBAR_TOKEN` to `ROLLBAR_ACCOUNT_TOKEN` to be more explicit since there are `account` & `project` tokens.
- Updated both `rollbar` & `sentry` in the `example-backend` to use `useHotMemoize` to be more consistent with other backend plugins
- Removed the `createRunAsyncWrapper` helper. Turns out that `express-promise-router` is handling exceptions. However ... the `errrorHandler` middleware doesn't log them. I'm going to create an issue to propose doing so, along with a hook/callback mechanism to allow for custom error logging (e.g. `winston-rollbar`).

#### :heavy_check_mark: Checklist

- [x] All tests are passing `yarn test`
- [x] ~~Screenshots attached (for UI changes)~~
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
