### PR TITLE
Use the Templater Property in the Template Definition to choose the templater

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,6 +29,7 @@
     "@backstage/plugin-scaffolder-backend": "^0.1.1-alpha.13",
     "@backstage/plugin-sentry-backend": "^0.1.1-alpha.13",
     "@backstage/plugin-techdocs-backend": "^0.1.1-alpha.13",
+    "@octokit/rest": "^18.0.0",
     "dockerode": "^3.2.0",
     "express": "^4.17.1",
     "knex": "^0.21.1",

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -20,19 +20,34 @@ import {
   FilePreparer,
   GithubPreparer,
   Preparers,
+  GithubPublisher,
+  Templaters,
 } from '@backstage/plugin-scaffolder-backend';
+import { Octokit } from '@octokit/rest';
 import type { PluginEnvironment } from '../types';
 import Docker from 'dockerode';
 
 export default async function createPlugin({ logger }: PluginEnvironment) {
-  const templater = new CookieCutter();
+  const cookiecutterTemplater = new CookieCutter();
+  const templaters = new Templaters();
+  templaters.register('cookiecutter', cookiecutterTemplater);
+
   const filePreparer = new FilePreparer();
   const githubPreparer = new GithubPreparer();
   const preparers = new Preparers();
-  const dockerClient = new Docker();
 
   preparers.register('file', filePreparer);
   preparers.register('github', githubPreparer);
 
-  return await createRouter({ preparers, templater, logger, dockerClient });
+  const githubClient = new Octokit({ auth: process.env.GITHUB_ACCESS_TOKEN });
+  const publisher = new GithubPublisher({ client: githubClient });
+
+  const dockerClient = new Docker();
+  return await createRouter({
+    preparers,
+    templaters,
+    publisher,
+    logger,
+    dockerClient,
+  });
 }

--- a/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.test.ts
@@ -32,7 +32,8 @@ describe('TemplateEntityV1alpah1', () => {
         name: 'test',
       },
       spec: {
-        type: 'cookiecutter',
+        type: 'website',
+        templater: 'cookiecutter',
         schema: {
           $schema: 'http://json-schema.org/draft-07/schema#',
           required: ['storePath', 'owner'],
@@ -78,7 +79,7 @@ describe('TemplateEntityV1alpah1', () => {
     await expect(policy.enforce(entity)).rejects.toThrow(/type/);
   });
 
-  it('acceptps any other type', async () => {
+  it('accepts any other type', async () => {
     (entity as any).spec.type = 'hallo';
     await expect(policy.enforce(entity)).resolves.toBe(entity);
   });
@@ -86,5 +87,10 @@ describe('TemplateEntityV1alpah1', () => {
   it('rejects empty type', async () => {
     (entity as any).spec.type = '';
     await expect(policy.enforce(entity)).rejects.toThrow(/type/);
+  });
+
+  it('rejects missing templater', async () => {
+    (entity as any).spec.templater = '';
+    await expect(policy.enforce(entity)).rejects.toThrow(/templater/);
   });
 });

--- a/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.ts
@@ -26,6 +26,7 @@ export interface TemplateEntityV1alpha1 extends Entity {
   kind: typeof KIND;
   spec: {
     type: string;
+    templater: string;
     path?: string;
     schema: JSONSchema;
   };
@@ -43,6 +44,7 @@ export class TemplateEntityV1alpha1Policy implements EntityPolicy {
           type: yup.string().required().min(1),
           path: yup.string(),
           schema: yup.object().required(),
+          templater: yup.string().required(),
         })
         .required(),
     });

--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml
@@ -8,7 +8,7 @@ metadata:
     - Recommended
     - React
 spec:
-  processor: cookiecutter
+  templater: cookiecutter
   type: website
   path: '.'
   schema:

--- a/plugins/scaffolder-backend/sample-templates/springboot-template/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/springboot-template/template.yaml
@@ -8,7 +8,7 @@ metadata:
     - Recommended
     - Java
 spec:
-  processor: cookiecutter
+  templater: cookiecutter
   type: service
   path: '.'
   schema:

--- a/plugins/scaffolder-backend/src/scaffolder/jobs/processor.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/jobs/processor.test.ts
@@ -37,7 +37,8 @@ describe('JobProcessor', () => {
       generation: 1,
     },
     spec: {
-      type: 'cookiecutter',
+      type: 'website',
+      templater: 'cookiecutter',
       path: './template',
       schema: {
         $schema: 'http://json-schema.org/draft-07/schema#',

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
@@ -47,7 +47,8 @@ describe('GitHubPreparer', () => {
         generation: 1,
       },
       spec: {
-        type: 'cookiecutter',
+        type: 'website',
+        templater: 'cookiecutter',
         path: './template',
         schema: {
           $schema: 'http://json-schema.org/draft-07/schema#',

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/helpers.test.ts
@@ -39,7 +39,8 @@ describe('Helpers', () => {
           generation: 1,
         },
         spec: {
-          type: 'cookiecutter',
+          type: 'website',
+          templater: 'cookiecutter',
           path: './template',
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',
@@ -86,7 +87,8 @@ describe('Helpers', () => {
           generation: 1,
         },
         spec: {
-          type: 'cookiecutter',
+          type: 'website',
+          templater: 'cookiecutter',
           path: './template',
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',
@@ -131,7 +133,8 @@ describe('Helpers', () => {
           generation: 1,
         },
         spec: {
-          type: 'cookiecutter',
+          type: 'website',
+          templater: 'cookiecutter',
           path: './template',
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',
@@ -177,7 +180,8 @@ describe('Helpers', () => {
           generation: 1,
         },
         spec: {
-          type: 'cookiecutter',
+          type: 'website',
+          templater: 'cookiecutter',
           path: './template',
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',
@@ -221,7 +225,8 @@ describe('Helpers', () => {
           generation: 1,
         },
         spec: {
-          type: 'cookiecutter',
+          type: 'website',
+          templater: 'cookiecutter',
           path: './template',
           schema: {
             $schema: 'http://json-schema.org/draft-07/schema#',

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/preparers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/preparers.test.ts
@@ -24,7 +24,7 @@ describe('Preparers', () => {
     metadata: {
       annotations: {
         'backstage.io/managed-by-location':
-          'file:/Users/blam/dev/spotify/backstage/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml',
+          'file:/Users/bingo/spotify/backstage/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml',
       },
       name: 'react-ssr-template',
       title: 'React SSR Template',

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export * from './github';
+export * from './types';

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
@@ -16,6 +16,8 @@
 import { Writable, PassThrough } from 'stream';
 import Docker from 'dockerode';
 import fs from 'fs';
+import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
+import { InputError } from '@backstage/backend-common';
 
 export type RunDockerContainerOptions = {
   imageName: string;
@@ -24,6 +26,20 @@ export type RunDockerContainerOptions = {
   resultDir: string;
   templateDir: string;
   dockerClient: Docker;
+};
+
+/**
+ * Gets the templater key to use for templating from the entity
+ * @param entity Template entity
+ */
+export const getTemplaterKey = (entity: TemplateEntityV1alpha1): string => {
+  const { templater } = entity.spec;
+
+  if (!templater) {
+    throw new InputError('Template does not have a required templating key');
+  }
+
+  return templater;
 };
 
 /**

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/index.ts
@@ -16,3 +16,4 @@
 export * from './cookiecutter';
 export * from './types';
 export * from './helpers';
+export * from './templaters';

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/templaters.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/templaters.test.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Preparers } from '.';
+import { Templaters } from '.';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
-import { FilePreparer } from './file';
+import { CookieCutter } from './cookiecutter';
 
-describe('Preparers', () => {
+describe('Templaters', () => {
   const mockTemplate: TemplateEntityV1alpha1 = {
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'Template',
@@ -56,25 +56,25 @@ describe('Preparers', () => {
       },
     },
   };
-  it('should throw an error when the preparer for the source location is not registered', () => {
-    const preparers = new Preparers();
+  it('should throw an error when the templater is not registered', () => {
+    const templaters = new Templaters();
 
-    expect(() => preparers.get(mockTemplate)).toThrow(
+    expect(() => templaters.get(mockTemplate)).toThrow(
       expect.objectContaining({
-        message: 'No preparer registered for type: "file"',
+        message: 'No templater registered for template: "cookiecutter"',
       }),
     );
   });
-  it('should return the correct preparer when the source matches', () => {
-    const preparers = new Preparers();
-    const preparer = new FilePreparer();
+  it('should return the correct templater when the templater matches', () => {
+    const templaters = new Templaters();
+    const templater = new CookieCutter();
 
-    preparers.register('file', preparer);
+    templaters.register('cookiecutter', templater);
 
-    expect(preparers.get(mockTemplate)).toBe(preparer);
+    expect(templaters.get(mockTemplate)).toBe(templater);
   });
 
-  it('should throw an error if the metadata tag does not exist in the entity', () => {
+  it('should throw an error if the templater does not exist in the entity', () => {
     const brokenTemplate: TemplateEntityV1alpha1 = {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'Template',
@@ -90,8 +90,8 @@ describe('Preparers', () => {
       },
       spec: {
         type: 'website',
-        templater: 'cookiecutter',
         path: '.',
+        templater: '',
         schema: {
           $schema: 'http://json-schema.org/draft-07/schema#',
           required: ['storePath', 'owner'],
@@ -111,11 +111,14 @@ describe('Preparers', () => {
       },
     };
 
-    const preparers = new Preparers();
+    const templaters = new Templaters();
 
-    expect(() => preparers.get(brokenTemplate)).toThrow(
+    expect(() => templaters.get(brokenTemplate)).toThrow(
       expect.objectContaining({
-        message: expect.stringContaining('No location annotation provided'),
+        name: 'InputError',
+        message: expect.stringContaining(
+          'Template does not have a required templating key',
+        ),
       }),
     );
   });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/templaters.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/templaters.test.ts
@@ -24,7 +24,7 @@ describe('Templaters', () => {
     metadata: {
       annotations: {
         'backstage.io/managed-by-location':
-          'file:/Users/blam/dev/spotify/backstage/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml',
+          'file:/Users/bingo/spotify/backstage/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml',
       },
       name: 'react-ssr-template',
       title: 'React SSR Template',

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/templaters.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/templaters.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  TemplaterBase,
+  SupportedTemplatingKey,
+  TemplaterBuilder,
+} from './types';
+
+import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
+import { getTemplaterKey } from './helpers';
+
+export class Templaters implements TemplaterBuilder {
+  private preparerMap = new Map<SupportedTemplatingKey, TemplaterBase>();
+
+  register(templaterKey: SupportedTemplatingKey, templater: TemplaterBase) {
+    this.preparerMap.set(templaterKey, templater);
+  }
+
+  get(template: TemplateEntityV1alpha1): TemplaterBase {
+    const templaterKey = getTemplaterKey(template);
+    const preparer = this.preparerMap.get(templaterKey);
+
+    if (!preparer) {
+      throw new Error(
+        `No templater registered for template: "${templaterKey}"`,
+      );
+    }
+
+    return preparer;
+  }
+}

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/types.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import type { Writable } from 'stream';
 import Docker from 'dockerode';
 import { JsonValue } from '@backstage/config';
+import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 
 /**
  * Currently the required template values. The owner
@@ -54,4 +54,17 @@ export type TemplaterBase = {
 
 export type TemplaterConfig = {
   templater?: TemplaterBase;
+};
+
+/**
+ * List of supported templating options
+ */
+export type SupportedTemplatingKey = 'cookiecutter' | string;
+
+/**
+ * The templater builder holds the templaters ready for run time
+ */
+export type TemplaterBuilder = {
+  register(protocol: SupportedTemplatingKey, templater: TemplaterBase): void;
+  get(template: TemplateEntityV1alpha1): TemplaterBase;
 };


### PR DESCRIPTION
I've been working on documentation for the scaffolder, and this change which closes #1421 make the documentation much simpler on how things work. So I decided to do it ahead of writing documentation for it.

This moves the templaters to be defined elsewhere as well as the publishers, and the templater is picked at run time from the entity using the `templater:` key in the `spec`. Currently we provide `cookiecutter`.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
