### PR TITLE
Add nvmrc file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ typings/
 # Optional npm cache directory
 .npm
 
+# Node version directives
+.nvmrc
+
 # Optional eslint cache
 .eslintcache
 


### PR DESCRIPTION
The `engines.node` property was recently locked to Node 12. 

I find it is useful to have a `.nvmrc` in my Backstage directory so that nvm will automatically choose that node version to use with the Backstage project.

Some people may not want that file, and it does introduce a second source of truth for the node version to use, so I have added it to the `.gitignore`.

More info on `.nvmrc`: https://github.com/nvm-sh/nvm#nvmrc