### PR TITLE
docker: avoid crash when restarting container

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -22,7 +22,10 @@ function inject_config() {
   >&2 echo "Runtime app config: $config"
 
   local main_js
-  main_js="$(grep -l __APP_INJECTED_RUNTIME_CONFIG__ /usr/share/nginx/html/*.chunk.js)"
+  if ! main_js="$(grep -l __APP_INJECTED_RUNTIME_CONFIG__ /usr/share/nginx/html/*.chunk.js)"; then
+    echo "Runtime config already written"
+    return
+  fi
   echo "Writing runtime config to ${main_js}"
 
   # escape ' and " twice, for both sed and json


### PR DESCRIPTION
2nd time around we've already rewritten the config, so the grep fails