### PR TITLE
Add bol.com as early adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,3 +1,4 @@
 | Organization | Contact | Description of Use |
 | ------------ | ------- | ------------------ |
 | [Spotify](https://www.spotify.com) |[@alund](https://github.com/alund)| Main interface towards all of Spotify's infrastructure and technical documentation.|
+| [bol.com](https://www.bol.com) |[@RoyJacobs](https://github.com/RoyJacobs)| Initial work being done to unify platform tooling.|


### PR DESCRIPTION
A tiny PR, adding bol.com as an early adopter to `ADOPTERS.md`