### PR TITLE
cli: identify root package by workspaces config + allow non-monorepo

### DIFF
--- a/packages/cli/src/lib/paths.ts
+++ b/packages/cli/src/lib/paths.ts
@@ -47,7 +47,7 @@ export type Paths = {
   resolveTargetRoot: ResolveFunc;
 };
 
-// Looks for a package.json that has name: "root" to identify the root of the monorepo
+// Looks for a package.json with a workspace config to identify the root of the monorepo
 export function findRootPath(topPath: string): string {
   let path = topPath;
 
@@ -58,7 +58,7 @@ export function findRootPath(topPath: string): string {
     if (exists) {
       try {
         const data = fs.readJsonSync(packagePath);
-        if (data.name === 'root' || data.name.includes('backstage-e2e')) {
+        if (data.workspaces?.packages) {
           return path;
         }
       } catch (error) {
@@ -70,9 +70,7 @@ export function findRootPath(topPath: string): string {
 
     const newPath = dirname(path);
     if (newPath === path) {
-      throw new Error(
-        `No package.json with name "root" found as a parent of ${topPath}`,
-      );
+      return topPath; // We didn't find any root package.json, assume we're not in a monorepo
     }
     path = newPath;
   }


### PR DESCRIPTION
Searching for `workspaces.packages` config inside package.json should hopefully be a bit more robust than searching for a package called "root". It does assume a `yarn` workspaces setup but we're pretty opinionated about that for now.

We now also fall back to using the current package as the root if we're not inside a monorepo.