### PR TITLE
cli: merge together all jest configs that are found in package.jsons

### DIFF
--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -43,6 +43,9 @@ async function getConfig() {
       ),
     },
 
+    // A bit more opinionated
+    testMatch: ['**/?(*.)test.{js,jsx,mjs,ts,tsx}'],
+
     // Default behaviour is to not apply transforms for node_modules, but we still want
     // to apply the esm-transformer to .esm.js files, since that's what we use in backstage packages.
     transformIgnorePatterns: [


### PR DESCRIPTION
Bit of an experiment to support simpler config in monorepos. This allows the root package.json in a monorepo to define jest config that is shared by all packages.

It forces test files to be named `.test.*`, as jest by default also allows `.spec.*` and `__tests__/*`, which we don't use.
