### PR TITLE
Correct e2e port configuration in default-app template

### DIFF
--- a/packages/cli/templates/default-app/packages/app/package.json.hbs
+++ b/packages/cli/templates/default-app/packages/app/package.json.hbs
@@ -35,8 +35,8 @@
     "bundle": "backstage-cli app:build",
     "test": "backstage-cli test",
     "lint": "backstage-cli lint",
-    "test:e2e": "cross-env PORT=3001 start-server-and-test start http://localhost:3001 cy:dev",
-    "test:e2e:ci": "cross-env PORT=3001 start-server-and-test start http://localhost:3001 cy:run",
+    "test:e2e": "cross-env APP_CONFIG_app_baseUrl='\"\"http://localhost:3001\"\"' start-server-and-test start http://localhost:3001 cy:dev",
+    "test:e2e:ci": "cross-env APP_CONFIG_app_baseUrl='\"\"http://localhost:3001\"\"' start-server-and-test start http://localhost:3001 cy:run",
     "cy:dev": "cypress open",
     "cy:run": "cypress run"
   },


### PR DESCRIPTION
Just ran into this. `test:e2e:ci` fails because it expect port 3001, but the server of a new default-app starts at port 3000.

#1278 changed how the port is configured. This configures the port via APP_CONFIG_app_baseUrl.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
