### PR TITLE
docs: add SDA SE to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -5,4 +5,5 @@
 | [DFDS](https://www.dfds.com)       | [@carlsendk](https://github.com/carlsendk) | V2 self-service platform.                                                           |
 | [Roadie](https://roadie.io)        | [@dtuite](https://github.com/dtuite)       | Hosted, managed Backstage with easy set-up                                          |
 | [Roku](https://www.roku.com)       | [@timurista](https://github.com/timurista) | Initial work on Cloud engineering service platform.                                 |
+| [SDA SE](https://sda.se)           | [@Fox32](https://github.com/Fox32)         | Central place for developing and sharing services in our insurance ecosystem.       |
 | [H-E-B](https://www.heb.com)       | [@german-j-rodriguez](https://github.com/german-j-rodriguez) | Initial work on Engineering Portal service platform.                                 |


### PR DESCRIPTION
## Hey, I just made a Pull Request!

@SDA-SE is looking forward to contribute to Backstage! As a first step we are especially interested in extending the catalog capabilities, like adding support for API specs (OpenAPI).
We plan to use Backstage as our central place for developing, managing and sharing services between different groups in our insurance related ecosystem.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
