### PR TITLE
fix(build-imgae): get package name from env

### DIFF
--- a/packages/cli/src/commands/backend/buildImage.ts
+++ b/packages/cli/src/commands/backend/buildImage.ts
@@ -19,9 +19,12 @@ import { createDistWorkspace } from '../../lib/packager';
 import { paths } from '../../lib/paths';
 import { run } from '../../lib/run';
 
+const PKG_PATH = 'package.json';
+
 export default async (imageTag: string) => {
-  const packageName: string = process.env.npm_package_name!;
-  const tempDistWorkspace = await createDistWorkspace([packageName], {
+  const pkgPath = paths.resolveTarget(PKG_PATH);
+  const pkg = await fs.readJson(pkgPath);
+  const tempDistWorkspace = await createDistWorkspace([pkg.name], {
     files: [
       'package.json',
       'yarn.lock',

--- a/packages/cli/src/commands/backend/buildImage.ts
+++ b/packages/cli/src/commands/backend/buildImage.ts
@@ -20,7 +20,8 @@ import { paths } from '../../lib/paths';
 import { run } from '../../lib/run';
 
 export default async (imageTag: string) => {
-  const tempDistWorkspace = await createDistWorkspace(['example-backend'], {
+  const packageName: string = process.env.npm_package_name!;
+  const tempDistWorkspace = await createDistWorkspace([packageName], {
     files: [
       'package.json',
       'yarn.lock',
@@ -28,7 +29,6 @@ export default async (imageTag: string) => {
       { src: paths.resolveTarget('Dockerfile'), dest: 'Dockerfile' },
     ],
   });
-
   console.log(`Dist workspace ready at ${tempDistWorkspace}`);
 
   await run('docker', ['build', '.', '-t', imageTag], {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I tried to use `buildImage` of the cli. Unfortunately, you can't change the package.json name property to any other name then `"example-backend"`.  I saw in the source code that the `packageNames` are set fix to` ["example-backend"]`. I made it variable depending on the package where calling the command.

