### PR TITLE
fix(proxy): working circleci example

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -15,7 +15,7 @@ proxy:
     target: 'https://circleci.com/api/v1.1'
     changeOrigin: true
     pathRewrite:
-      '^/circleci/api/': '/'
+      '^/proxy/circleci/api/': '/'
 
 organization:
   name: Spotify

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -31,7 +31,7 @@ export async function createRouter(
   const router = Router();
   const proxyConfig = options.config.get('proxy') ?? {};
   Object.entries(proxyConfig).forEach(([route, proxyRouteConfig]) => {
-    router.use(createProxyMiddleware(route, proxyRouteConfig));
+    router.use(route, createProxyMiddleware(proxyRouteConfig));
   });
 
   return router;


### PR DESCRIPTION
Fixes #1681 .

We are using the same http-proxy package version now as webpack-dev-server does, but the code was targeting newer version. Plus we moved proxy from '/' -> '/proxy', hence need for route adjustment