### PR TITLE
chore: Add Kiwi.com as a Backstage adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -8,3 +8,4 @@
 | [SDA SE](https://sda.se)           | [@Fox32](https://github.com/Fox32)         | Central place for developing and sharing services in our insurance ecosystem.       |
 | [H-E-B](https://www.heb.com)       | [@german-j-rodriguez](https://github.com/german-j-rodriguez) | Initial work on Engineering Portal service platform.                                 |
 | [American Airlines](https://www.aa.com) | [@paulpach](https://github.com/paulpach) | Central place for developers to develop and maintain applications |
+| [Kiwi.com](https://kiwi.com)       | [@aexvir](https://github.com/aexvir)       | Replacing the frontend of [The Zoo](https://github.com/kiwicom/the-zoo), their service registry.     |


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As we, Kiwi.com, have started working in repurposing our Zoo backend to work with Backstage, it would be great to have us in the adopters list 🙂 
