### PR TITLE
Catalog: add deduplication for logs join

### DIFF
--- a/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
+++ b/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
@@ -33,6 +33,7 @@ exports.up = async function up(knex) {
     ) t2
     ON t1.location_id = t2.location_id
     AND t1.created_at = t2.MAXDATE
+    GROUP BY t1.location_id
     ORDER BY created_at DESC;
   `);
 };

--- a/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
+++ b/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
@@ -33,7 +33,6 @@ exports.up = async function up(knex) {
     ) t2
     ON t1.location_id = t2.location_id
     AND t1.created_at = t2.MAXDATE
-    GROUP BY t1.location_id
     ORDER BY created_at DESC;
   `);
 };

--- a/plugins/catalog-backend/migrations/20200721115244_location_update_log_latest_deduplicate.js
+++ b/plugins/catalog-backend/migrations/20200721115244_location_update_log_latest_deduplicate.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+exports.up = function up(knex) {
+  return knex.schema.raw(`DROP VIEW location_update_log_latest;`).raw(`
+  CREATE VIEW location_update_log_latest AS
+  SELECT t1.* FROM location_update_log t1
+  JOIN 
+  (
+     SELECT location_id, MAX(created_at) AS MAXDATE
+     FROM location_update_log
+     GROUP BY location_id
+  ) t2
+  ON t1.location_id = t2.location_id
+  AND t1.created_at = t2.MAXDATE
+  GROUP BY t1.location_id
+  ORDER BY created_at DESC;
+`);
+};
+
+exports.down = function down(knex) {
+  knex.schema.raw(`DROP VIEW location_update_log_latest;`);
+};


### PR DESCRIPTION
Fixes #1637 

Result of latest changes in migrations, needed one more layer of deduplication for `locations_update_log_latest` join.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Prettier run on changed files
- [x] Regression tests added for bug fixes
