### PR TITLE
Get backend base URL from config in Sentry plugin

### DIFF
--- a/plugins/sentry/src/components/SentryPluginWidget/SentryPluginWidget.tsx
+++ b/plugins/sentry/src/components/SentryPluginWidget/SentryPluginWidget.tsx
@@ -34,7 +34,8 @@ export const SentryPluginWidget: FC<{
   const errorApi = useApi<ErrorApi>(errorApiRef);
   const configApi = useApi(configApiRef);
   const org = configApi.getString('sentry.organization');
-  const api = sentryApiFactory(org);
+  const backendBaseUrl = configApi.getString('backend.baseUrl');
+  const api = sentryApiFactory(org, backendBaseUrl);
 
   const { loading, value, error } = useAsync(
     () => api.fetchIssues(sentryProjectId, statsFor),

--- a/plugins/sentry/src/data/api-factory.ts
+++ b/plugins/sentry/src/data/api-factory.ts
@@ -17,9 +17,12 @@ import { SentryApi } from './sentry-api';
 import { MockSentryApi } from './mock-api';
 import { ProductionSentryApi } from './production-api';
 
-export function sentryApiFactory(organization: string): SentryApi {
+export function sentryApiFactory(
+  organization: string,
+  backendBaseUrl: string,
+): SentryApi {
   if (process.env.NODE_ENV === 'production') {
-    return new ProductionSentryApi(organization);
+    return new ProductionSentryApi(organization, backendBaseUrl);
   }
   return new MockSentryApi();
 }

--- a/plugins/sentry/src/data/production-api.ts
+++ b/plugins/sentry/src/data/production-api.ts
@@ -16,20 +16,21 @@
 import { SentryIssue } from './sentry-issue';
 import { SentryApi } from './sentry-api';
 
-const API_HOST = process.env.API_HOST || 'http://localhost:7000';
-const API_BASE_URL = `${API_HOST}/sentry/api/0/projects/`;
-
 export class ProductionSentryApi implements SentryApi {
   private organization: string;
+  private backendBaseUrl: string;
 
-  constructor(organization: string) {
+  constructor(organization: string, backendBaseUrl: string) {
     this.organization = organization;
+    this.backendBaseUrl = backendBaseUrl;
   }
 
   async fetchIssues(project: string, statsFor: string): Promise<SentryIssue[]> {
     try {
+      const apiBaseUrl = `${this.backendBaseUrl}/sentry/api/0/projects/`;
+
       const response = await fetch(
-        `${API_BASE_URL}/${this.organization}/${project}/issues/?statsFor=${statsFor}`,
+        `${apiBaseUrl}/${this.organization}/${project}/issues/?statsFor=${statsFor}`,
       );
 
       if (response.status >= 400 && response.status < 600) {


### PR DESCRIPTION
Previously this was set to `process.env.API_HOST` with a fallback to `http://localhost:7000`.