### PR TITLE
fix(cli): make create-app use the same esbuild version

### DIFF
--- a/packages/cli/templates/default-app/package.json.hbs
+++ b/packages/cli/templates/default-app/package.json.hbs
@@ -32,7 +32,7 @@
     "prettier": "^1.19.1"
   },
   "resolutions": {
-    "**/esbuild": "0.5.3"
+    "esbuild": "0.6.3"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {


### PR DESCRIPTION
Should fix #1700 , but we need to bump the package version