### PR TITLE
fix(catalog-backend): export types to allow writing processors in custom backends

### DIFF
--- a/plugins/catalog-backend/src/ingestion/processors/index.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/index.ts
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-export { HigherOrderOperations } from './HigherOrderOperations';
-export { LocationReaders } from './LocationReaders';
-export type {
-  AddLocationResult,
-  HigherOrderOperation,
-  LocationReader,
-  ReadLocationEntity,
-  ReadLocationError,
-  ReadLocationResult,
-} from './types';
-export * from './processors';
+import * as results from './results';
+
+export { results };
+export * from './types';


### PR DESCRIPTION
 Hey, I just made a Pull Request!

As discussed in chat, currently it's a bit difficult to create an own processor in a backend, because some important types aren't exported.

I don't like 
```typescript
import * as results from './results';
export const result = results;
```
as Typescript 3.8 seems to support 
```typescript
export * as results from './results';
```
but I couldn't get that to work.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
