### PR TITLE
app: make bundling a regular build command

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -76,8 +76,5 @@ jobs:
       - name: verify plugin template
         run: yarn lerna -- run diff -- --check
 
-      - name: bundle example app
-        run: yarn bundle
-
       - name: verify storybook
         run: yarn workspace storybook build-storybook

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -74,8 +74,6 @@ yarn test:all # test all packages
 
 yarn clean # Remove all output folders and @backstage/cli cache
 
-yarn bundle # Build a production bundle of the example app
-
 yarn diff # Make sure all plugins are up to date with the latest plugin template
 
 yarn create-plugin # Create a new plugin

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   },
   "scripts": {
     "start": "yarn workspace example-app start",
-    "bundle": "yarn workspace example-app bundle",
     "build": "lerna run build",
     "tsc": "tsc",
     "clean": "backstage-cli clean && lerna run clean",
@@ -16,7 +15,7 @@
     "lint": "lerna run lint --since origin/master --",
     "lint:all": "lerna run lint --",
     "lint:type-deps": "node scripts/check-type-dependencies.js",
-    "docker-build": "yarn bundle && docker build . -t spotify/backstage",
+    "docker-build": "yarn workspace example-app build && docker build . -t spotify/backstage",
     "docker-build:all": "yarn tsc && yarn build && yarn docker-build && yarn workspace example-backend build-image",
     "create-plugin": "backstage-cli create-plugin",
     "remove-plugin": "backstage-cli remove-plugin",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "start": "backstage-cli app:serve",
-    "bundle": "backstage-cli app:build",
+    "build": "backstage-cli app:build",
     "clean": "backstage-cli clean",
     "test": "backstage-cli test",
     "test:e2e": "start-server-and-test start http://localhost:3000 cy:dev",

--- a/packages/cli/templates/default-app/package.json.hbs
+++ b/packages/cli/templates/default-app/package.json.hbs
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "start": "yarn workspace app start",
-    "bundle": "yarn workspace app bundle",
     "build": "lerna run build",
     "tsc": "tsc",
     "clean": "backstage-cli clean && lerna run clean",

--- a/packages/cli/templates/default-app/packages/app/package.json.hbs
+++ b/packages/cli/templates/default-app/packages/app/package.json.hbs
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "start": "backstage-cli app:serve",
-    "bundle": "backstage-cli app:build",
+    "build": "backstage-cli app:build",
     "test": "backstage-cli test",
     "lint": "backstage-cli lint",
     "test:e2e": "cross-env PORT=3001 start-server-and-test start http://localhost:3001 cy:dev",


### PR DESCRIPTION
`yarn bundle` really exists only for the historical reason that we used to want to avoid bundling locally during development. But since build isn't part of the local development flow anymore, I think it makes sense to stop treating it separately.