### PR TITLE
Ensure errors are logged in errorHandler

### DIFF
--- a/packages/backend-common/src/middleware/errorHandler.ts
+++ b/packages/backend-common/src/middleware/errorHandler.ts
@@ -15,7 +15,9 @@
  */
 
 import { ErrorRequestHandler, NextFunction, Request, Response } from 'express';
+import { Logger } from 'winston';
 import * as errors from '../errors';
+import { getRootLogger } from '../logging';
 
 export type ErrorHandlerOptions = {
   /**
@@ -24,6 +26,13 @@ export type ErrorHandlerOptions = {
    * If not specified, by default shows stack traces only in development mode.
    */
   showStackTraces?: boolean;
+
+  /**
+   * Logger
+   *
+   * If not specified, by default shows stack traces only in development mode.
+   */
+  logger?: Logger;
 };
 
 /**
@@ -39,11 +48,16 @@ export type ErrorHandlerOptions = {
  *
  * @returns An Express error request handler
  */
+
 export function errorHandler(
   options: ErrorHandlerOptions = {},
 ): ErrorRequestHandler {
   const showStackTraces =
     options.showStackTraces ?? process.env.NODE_ENV === 'development';
+
+  const logger = (options.logger || getRootLogger()).child({
+    type: 'errorHandler',
+  });
 
   /* eslint-disable @typescript-eslint/no-unused-vars */
   return (
@@ -61,6 +75,11 @@ export function errorHandler(
 
     const status = getStatusCode(error);
     const message = showStackTraces ? error.stack : error.message;
+
+    if (logger && status >= 500) {
+      logger.error(error);
+    }
+
     response.status(status).send(message);
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Errors handled by the backend `errorHandler` only get sent back in the response and never logged. This adds logging to the `errorHandler` so errors would be propagated to the appropriately configured winston transports.

Currently this only logs `5xx` errors.

#### :heavy_check_mark: Checklist

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
