### PR TITLE
packages/cli: avoid packing deps of deps that are marked as bundled

### DIFF
--- a/packages/cli/src/lib/packager/index.ts
+++ b/packages/cli/src/lib/packager/index.ts
@@ -134,11 +134,15 @@ async function findTargetPackages(pkgNames: string[]): Promise<LernaPackage[]> {
       throw new Error(`Package '${name}' not found`);
     }
 
-    const pkgDeps = Object.keys(node.pkg.dependencies);
-    const localDeps: string[] = Array.from(node.localDependencies.keys());
-    const filteredDeps = localDeps.filter(dep => pkgDeps.includes(dep));
+    // Don't include dependencies of packages that are marked as bundled
+    if (!node.pkg.get('bundled')) {
+      const pkgDeps = Object.keys(node.pkg.dependencies);
+      const localDeps: string[] = Array.from(node.localDependencies.keys());
+      const filteredDeps = localDeps.filter(dep => pkgDeps.includes(dep));
 
-    searchNames.push(...filteredDeps);
+      searchNames.push(...filteredDeps);
+    }
+
     targets.set(name, node.pkg);
   }
 


### PR DESCRIPTION
This adds a way for a package to declare that it doesn't need any of its dependencies at runtime. It's for the workspace dist building stuff that is used to package the backend into a docker image.

Had a look at https://github.com/stereobooster/package.json and some other places but can't find any well-known field that is similar, so inventing a new `"bundled": true` field instead.