### PR TITLE
Add configuration for github enterprise

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -48,7 +48,7 @@ auth:
         clientSecret:
           $secret:
             env: AUTH_GITHUB_CLIENT_SECRET
-        enterpriseInstanceURL: 
+        enterpriseInstanceUrl: 
           $secret:
             env: AUTH_GITHUB_ENTERPRISE_INSTANCE_URL
     gitlab:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -48,6 +48,15 @@ auth:
         clientSecret:
           $secret:
             env: AUTH_GITHUB_CLIENT_SECRET
+        authorizationURL: 
+          $secret:
+            env: AUTH_GITHUB_AUTHORIZATION_URL
+        tokenURL:
+          $secret:
+            env: AUTH_GITHUB_TOKEN_URL
+        userProfileUrl:
+          $secret:
+            env: AUTH_GITHUB_USER_PROFILE_URL
     gitlab:
       development:
         appOrigin: "http://localhost:3000/"

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -48,15 +48,9 @@ auth:
         clientSecret:
           $secret:
             env: AUTH_GITHUB_CLIENT_SECRET
-        authorizationURL: 
+        enterpriseInstanceURL: 
           $secret:
-            env: AUTH_GITHUB_AUTHORIZATION_URL
-        tokenURL:
-          $secret:
-            env: AUTH_GITHUB_TOKEN_URL
-        userProfileUrl:
-          $secret:
-            env: AUTH_GITHUB_USER_PROFILE_URL
+            env: AUTH_GITHUB_ENTERPRISE_INSTANCE_URL
     gitlab:
       development:
         appOrigin: "http://localhost:3000/"

--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -37,9 +37,7 @@ for github enterprise:
 ```bash
 export AUTH_GITHUB_CLIENT_ID=x
 export AUTH_GITHUB_CLIENT_SECRET=x
-export AUTH_GITHUB_AUTHORIZATION_URL=https://ENTERPRISE_INSTANCE_URL/login/oauth/authorize
-export AUTH_GITHUB_TOKEN_URL=https://ENTERPRISE_INSTANCE_URL/login/oauth/access_token
-export AUTH_GITHUB_USER_PROFILE_URL=https://ENTERPRISE_INSTANCE_URL/api/v3/user
+export AUTH_GITHUB_ENTERPRISE_INSTANCE_URL=https://x
 ```
 
 ### Gitlab

--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -32,6 +32,16 @@ export AUTH_GITHUB_CLIENT_ID=x
 export AUTH_GITHUB_CLIENT_SECRET=x
 ```
 
+for github enterprise:
+
+```bash
+export AUTH_GITHUB_CLIENT_ID=x
+export AUTH_GITHUB_CLIENT_SECRET=x
+export AUTH_GITHUB_AUTHORIZATION_URL=https://ENTERPRISE_INSTANCE_URL/login/oauth/authorize
+export AUTH_GITHUB_TOKEN_URL=https://ENTERPRISE_INSTANCE_URL/login/oauth/access_token
+export AUTH_GITHUB_USER_PROFILE_URL=https://ENTERPRISE_INSTANCE_URL/api/v3/user
+```
+
 ### Gitlab
 
 ```bash

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -136,11 +136,17 @@ export function createGithubProvider(
   const appOrigin = envConfig.getString('appOrigin');
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
+  const authorizationURL = envConfig.getOptionalString('authorizationURL');
+  const tokenURL = envConfig.getOptionalString('tokenURL');
+  const userProfileURL = envConfig.getOptionalString('userProfileURL');
   const callbackURL = `${baseUrl}/${providerId}/handler/frame?env=${env}`;
 
   const opts = {
     clientID,
     clientSecret,
+    authorizationURL,
+    tokenURL,
+    userProfileURL,
     callbackURL,
   };
 

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -136,9 +136,18 @@ export function createGithubProvider(
   const appOrigin = envConfig.getString('appOrigin');
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
-  const authorizationURL = envConfig.getOptionalString('authorizationURL');
-  const tokenURL = envConfig.getOptionalString('tokenURL');
-  const userProfileURL = envConfig.getOptionalString('userProfileURL');
+  const enterpriseInstanceUrl = envConfig.getOptionalString(
+    'enterpriseInstanceURL',
+  );
+  const authorizationURL = enterpriseInstanceUrl
+    ? `${enterpriseInstanceUrl}/login/oauth/authorize`
+    : undefined;
+  const tokenURL = enterpriseInstanceUrl
+    ? `${enterpriseInstanceUrl}/login/oauth/access_token`
+    : undefined;
+  const userProfileURL = enterpriseInstanceUrl
+    ? `${enterpriseInstanceUrl}/api/v3/user`
+    : undefined;
   const callbackURL = `${baseUrl}/${providerId}/handler/frame?env=${env}`;
 
   const opts = {

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -137,7 +137,7 @@ export function createGithubProvider(
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
   const enterpriseInstanceUrl = envConfig.getOptionalString(
-    'enterpriseInstanceURL',
+    'enterpriseInstanceUrl',
   );
   const authorizationURL = enterpriseInstanceUrl
     ? `${enterpriseInstanceUrl}/login/oauth/authorize`


### PR DESCRIPTION
## Hey, I just made a Pull Request!

User can now authenticate to github enterprise too by adding these 3 environment variables:

```sh
export AUTH_GITHUB_ENTERPRISE_INSTANCE_URL=https://xxxx
```

Note these are optional. If they are not specified, authentication is performed against github.com

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn _test`_
- [x] Relevant documentation updated
