### PR TITLE
auth-backend: set SameSite=Lax for oauth flow cookies

### DIFF
--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -248,7 +248,7 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
     res.cookie(`${this.options.providerId}-nonce`, nonce, {
       maxAge: TEN_MINUTES_MS,
       secure: this.options.secure,
-      sameSite: 'none',
+      sameSite: 'lax',
       domain: this.domain,
       path: `${this.basePath}/${this.options.providerId}/handler`,
       httpOnly: true,
@@ -259,7 +259,7 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
     res.cookie(`${this.options.providerId}-scope`, scope, {
       maxAge: TEN_MINUTES_MS,
       secure: this.options.secure,
-      sameSite: 'none',
+      sameSite: 'lax',
       domain: this.domain,
       path: `${this.basePath}/${this.options.providerId}/handler`,
       httpOnly: true,
@@ -277,7 +277,7 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
     res.cookie(`${this.options.providerId}-refresh-token`, refreshToken, {
       maxAge: THOUSAND_DAYS_MS,
       secure: this.options.secure,
-      sameSite: 'none',
+      sameSite: 'lax',
       domain: this.domain,
       path: `${this.basePath}/${this.options.providerId}`,
       httpOnly: true,
@@ -288,7 +288,7 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
     res.cookie(`${this.options.providerId}-refresh-token`, '', {
       maxAge: 0,
       secure: false,
-      sameSite: 'none',
+      sameSite: 'lax',
       domain: `${this.domain}`,
       path: `${this.basePath}/${this.options.providerId}`,
       httpOnly: true,


### PR DESCRIPTION
The Chrome flag #same-site-by-default-cookies is causing auth to fail for some users. Afaik it's because the flag also enables behaviour that requires SameSite=none cookies to be Secure. This is really the setting we want anyway though.

Verified in Chrome with and without flag + Firefox and Safari