### PR TITLE
(auth-backend) Bugfix: Do not throw Exception if scopes dont exist. Refs #1786

### DIFF
--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -104,10 +104,6 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
     // retrieve scopes from request
     const scope = req.query.scope?.toString() ?? '';
 
-    if (!scope) {
-      throw new InputError('missing scope parameter');
-    }
-
     if (this.options.persistScopes) {
       this.setScopesCookie(res, scope);
     }


### PR DESCRIPTION
Refs #1786

Currently, the OAuthProvider library in `auth-backend` throws an
Exception if scopes are missing in the `start` (initial) request
in the Authorization flow. Scopes are an optional parameter as per the
spec, so if scopes are empty, simply forward the empty scopes instead of
throwing an Exception

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
