### PR TITLE
feat: applications should be able to add custom middleware

### DIFF
--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -67,6 +67,13 @@ export type ServiceBuilder = {
   addRouter(root: string, router: Router | RequestHandler): ServiceBuilder;
 
   /**
+   * Adds a custom middleware function. Same as express.use(handler)
+   *
+   * @param handler A custom middleware function for the request
+   */
+  use(handler: RequestHandler): ServiceBuilder;
+
+  /**
    * Starts the server using the given settings.
    */
   start(): Promise<Server>;


### PR DESCRIPTION
Applications may want to add their own middleware, such as express-session or others.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Relevant documentation updated
