### PR TITLE
Fallback to string if config value is not json

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -16,7 +16,7 @@ function inject_config() {
     with_entries(select(.key | startswith("APP_CONFIG_")) | .key |= sub("APP_CONFIG_"; "")) |
     to_entries |
     reduce .[] as $item (
-      {}; setpath($item.key | split("_"); $item.value | fromjson)
+      {}; setpath($item.key | split("_"); $item.value | try fromjson catch $item.value)
     )')"
 
   >&2 echo "Runtime app config: $config"

--- a/packages/config-loader/src/lib/env.ts
+++ b/packages/config-loader/src/lib/env.ts
@@ -72,7 +72,7 @@ export function readEnv(env: {
             );
           }
           try {
-            const parsedValue = JSON.parse(value);
+            const [, parsedValue] = safeJsonParse(value);
             if (parsedValue === null) {
               throw new Error('value may not be null');
             }
@@ -88,4 +88,12 @@ export function readEnv(env: {
   }
 
   return data ? [{ data, context: 'env' }] : [];
+}
+
+function safeJsonParse(str: string): [Error | null, any] {
+  try {
+    return [null, JSON.parse(str)];
+  } catch (err) {
+    return [err, str];
+  }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed #1765 - Don't require JSON encoding of config values supplied through env 

<img width="991" alt="image" src="https://user-images.githubusercontent.com/6507159/88990649-8a04ce00-d2ac-11ea-94ae-dc863c236cfd.png">

#### :heavy_check_mark: Checklist

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
