### PR TITLE
Add simple healthcheck to app container nginx template

### DIFF
--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -11,6 +11,10 @@ server {
         try_files $uri /index.html;
     }
 
+    location /healthcheck {
+        return 204;
+    }
+
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The default `app` docker container setup does not have an explicit healthcheck. This adds a basic `/healthcheck` route in the nginx config template to support a simple health/liveness check.

#### :heavy_check_mark: Checklist

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
