### PR TITLE
auth-backend: Encode `env` in the OAuth flow into the `state` parameter. Refs #1775

### DIFF
--- a/plugins/auth-backend/src/lib/EnvironmentHandler.ts
+++ b/plugins/auth-backend/src/lib/EnvironmentHandler.ts
@@ -15,7 +15,10 @@
  */
 
 import express from 'express';
-import { AuthProviderRouteHandlers } from '../providers/types';
+import {
+  AuthProviderRouteHandlers,
+  EnvironmentIdentifierFn,
+} from '../providers/types';
 
 export type EnvironmentHandlers = {
   [key: string]: AuthProviderRouteHandlers;
@@ -25,14 +28,14 @@ export class EnvironmentHandler implements AuthProviderRouteHandlers {
   constructor(
     private readonly providerId: string,
     private readonly providers: EnvironmentHandlers,
-    private readonly envIdentifier: (req: express.Request) => string,
+    private readonly envIdentifier: EnvironmentIdentifierFn,
   ) {}
 
   private getProviderForEnv(
     req: express.Request,
     res: express.Response,
   ): AuthProviderRouteHandlers | undefined {
-    const env: string = this.envIdentifier(req);
+    const env: string | undefined = this.envIdentifier(req);
 
     if (env && this.providers.hasOwnProperty(env)) {
       return this.providers[env];

--- a/plugins/auth-backend/src/lib/EnvironmentHandler.ts
+++ b/plugins/auth-backend/src/lib/EnvironmentHandler.ts
@@ -25,13 +25,28 @@ export class EnvironmentHandler implements AuthProviderRouteHandlers {
   constructor(
     private readonly providerId: string,
     private readonly providers: EnvironmentHandlers,
+    private readonly envIdentifier: (req: express.Request) => string,
   ) {}
+
+  /* Return the value of `env` key, if it is exists, encoded within
+     the `state` parameter in the request
+  */
+  private getEnv(stateParams: Array<string>): string {
+    const envParams = stateParams.filter(
+      param => param.split('=')[0] === 'env',
+    );
+
+    if (envParams.length > 0) {
+      return envParams[0].split('=')[1];
+    }
+    return '';
+  }
 
   private getProviderForEnv(
     req: express.Request,
     res: express.Response,
   ): AuthProviderRouteHandlers | undefined {
-    const env = req.query.env?.toString();
+    const env: string = this.envIdentifier(req);
 
     if (env && this.providers.hasOwnProperty(env)) {
       return this.providers[env];

--- a/plugins/auth-backend/src/lib/EnvironmentHandler.ts
+++ b/plugins/auth-backend/src/lib/EnvironmentHandler.ts
@@ -28,20 +28,6 @@ export class EnvironmentHandler implements AuthProviderRouteHandlers {
     private readonly envIdentifier: (req: express.Request) => string,
   ) {}
 
-  /* Return the value of `env` key, if it is exists, encoded within
-     the `state` parameter in the request
-  */
-  private getEnv(stateParams: Array<string>): string {
-    const envParams = stateParams.filter(
-      param => param.split('=')[0] === 'env',
-    );
-
-    if (envParams.length > 0) {
-      return envParams[0].split('=')[1];
-    }
-    return '';
-  }
-
   private getProviderForEnv(
     req: express.Request,
     res: express.Response,

--- a/plugins/auth-backend/src/lib/OAuthProvider.test.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.test.ts
@@ -21,6 +21,7 @@ import {
   THOUSAND_DAYS_MS,
   TEN_MINUTES_MS,
   verifyNonce,
+  encodeState,
   OAuthProvider,
 } from './OAuthProvider';
 import { WebMessageResponse, OAuthProviderHandlers } from '../providers/types';
@@ -43,10 +44,11 @@ const mockResponseData = {
 describe('OAuthProvider Utils', () => {
   describe('verifyNonce', () => {
     it('should throw error if cookie nonce missing', () => {
+      const state = { nonce: 'NONCE', env: 'development' };
       const mockRequest = ({
         cookies: {},
         query: {
-          state: 'NONCE',
+          state: encodeState(state),
         },
       } as unknown) as express.Request;
       expect(() => {
@@ -67,12 +69,13 @@ describe('OAuthProvider Utils', () => {
     });
 
     it('should throw error if nonce mismatch', () => {
+      const state = { nonce: 'NONCEB', env: 'development' };
       const mockRequest = ({
         cookies: {
           'providera-nonce': 'NONCEA',
         },
         query: {
-          state: 'NONCEB',
+          state: encodeState(state),
         },
       } as unknown) as express.Request;
       expect(() => {
@@ -81,12 +84,13 @@ describe('OAuthProvider Utils', () => {
     });
 
     it('should not throw any error if nonce matches', () => {
+      const state = { nonce: 'NONCE', env: 'development' };
       const mockRequest = ({
         cookies: {
           'providera-nonce': 'NONCE',
         },
         query: {
-          state: 'NONCE',
+          state: encodeState(state),
         },
       } as unknown) as express.Request;
       expect(() => {
@@ -249,12 +253,13 @@ describe('OAuthProvider', () => {
       disableRefresh: false,
     });
 
+    const state = { nonce: 'nonce', env: 'development' };
     const mockRequest = ({
       cookies: {
         'test-provider-nonce': 'nonce',
       },
       query: {
-        state: 'nonce',
+        state: encodeState(state),
       },
     } as unknown) as express.Request;
 

--- a/plugins/auth-backend/src/lib/OAuthProvider.test.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.test.ts
@@ -65,7 +65,7 @@ describe('OAuthProvider Utils', () => {
       } as unknown) as express.Request;
       expect(() => {
         verifyNonce(mockRequest, 'providera');
-      }).toThrowError('Auth response is missing state nonce');
+      }).toThrowError('Invalid state passed via request');
     });
 
     it('should throw error if nonce mismatch', () => {
@@ -221,6 +221,7 @@ describe('OAuthProvider', () => {
     const mockRequest = ({
       query: {
         scope: 'user',
+        env: 'development',
       },
     } as unknown) as express.Request;
 

--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -65,18 +65,6 @@ export const encodeState = (state: OAuthState): string => {
   return encodeURIComponent(searchParams.toString());
 };
 
-/*
-export const encodeState = (stateObject: object): string => {
-  const vals = Object.keys(stateObject).map(
-    key =>
-      `${encodeURIComponent(key)}=${encodeURIComponent(
-        Reflect.get(stateObject, key),
-      )}`,
-  );
-
-  return vals.join('&');
-};
-*/
 export const verifyNonce = (req: express.Request, providerId: string) => {
   const cookieNonce = req.cookies[`${providerId}-nonce`];
   const state: OAuthState = readState(req.query.state?.toString() ?? '');

--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -42,8 +42,13 @@ export type Options = {
 /* Return the value of `env` key, if it is exists, encoded within
      the `state` parameter in the request
   */
-const getEnv = (stateParams: Array<string>): string => {
-  const envParams = stateParams.filter(param => param.split('=')[0] === 'env');
+const readStateParameter = (
+  stateParams: Array<string>,
+  parameter: string,
+): string => {
+  const envParams = stateParams.filter(
+    param => param.split('=')[0] === parameter,
+  );
 
   if (envParams.length > 0) {
     return envParams[0].split('=')[1];
@@ -54,9 +59,11 @@ const getEnv = (stateParams: Array<string>): string => {
 const readState = (stateString: string): Array<string> => {
   return decodeURIComponent(stateString).split('&');
 };
+
 export const verifyNonce = (req: express.Request, providerId: string) => {
   const cookieNonce = req.cookies[`${providerId}-nonce`];
-  const stateNonce = req.query.state;
+  const state = req.query.state;
+  const stateNonce = readStateParameter(state, 'nonce');
 
   if (!cookieNonce) {
     throw new Error('Auth response is missing cookie nonce');
@@ -257,11 +264,11 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
     if (reqEnv) {
       return reqEnv;
     }
-    const stateParam = req.query.state?.toString();
-    if (!stateParam) {
+    const stateParams = req.query.state?.toString();
+    if (!stateParams) {
       return '';
     }
-    const env = getEnv(readState(stateParam));
+    const env = readStateParameter(readState(stateParams), 'env');
     return env;
   }
 

--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -42,10 +42,12 @@ export type Options = {
 
 const readState = (stateString: string): OAuthState => {
   try {
-    const state = JSON.parse(decodeURIComponent(stateString));
+    const state = Object.fromEntries(
+      new URLSearchParams(decodeURIComponent(stateString)),
+    );
     return {
-      nonce: state.nonce,
-      env: state.env,
+      nonce: state.nonce ?? undefined,
+      env: state.env ?? undefined,
     };
   } catch (e) {
     return {
@@ -56,7 +58,11 @@ const readState = (stateString: string): OAuthState => {
 };
 
 export const encodeState = (state: OAuthState): string => {
-  return encodeURIComponent(JSON.stringify(state));
+  const searchParams = new URLSearchParams();
+  searchParams.append('nonce', state.nonce ?? '');
+  searchParams.append('env', state.env ?? '');
+
+  return encodeURIComponent(searchParams.toString());
 };
 
 /*

--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -46,13 +46,13 @@ const readState = (stateString: string): OAuthState => {
       new URLSearchParams(decodeURIComponent(stateString)),
     );
     return {
-      nonce: state.nonce ?? undefined,
-      env: state.env ?? undefined,
+      nonce: state.nonce ?? '',
+      env: state.env ?? '',
     };
   } catch (e) {
     return {
-      nonce: undefined,
-      env: undefined,
+      nonce: '',
+      env: '',
     };
   }
 };
@@ -85,7 +85,7 @@ export const verifyNonce = (req: express.Request, providerId: string) => {
   if (!cookieNonce) {
     throw new Error('Auth response is missing cookie nonce');
   }
-  if (!stateNonce) {
+  if (stateNonce.length === 0) {
     throw new Error('Auth response is missing state nonce');
   }
   if (cookieNonce !== stateNonce) {

--- a/plugins/auth-backend/src/providers/factories.ts
+++ b/plugins/auth-backend/src/providers/factories.ts
@@ -55,17 +55,19 @@ export const createAuthProviderRouter = (
   const router = Router();
   const envs = providerConfig.keys();
   const envProviders: EnvironmentHandlers = {};
-  let envIdentifier: (req: express.Request) => string;
+  let envIdentifier: ((req: express.Request) => string) | undefined;
 
   for (const env of envs) {
     const envConfig = providerConfig.getConfig(env);
     const provider = factory(globalConfig, env, envConfig, logger, issuer);
     if (provider) {
       envProviders[env] = provider;
-      if (envIdentifier === undefined) {
-        envIdentifier = provider.identifyEnv;
-      }
+      envIdentifier = provider.identifyEnv;
     }
+  }
+
+  if (typeof envIdentifier === 'undefined') {
+    throw Error(`No envIdentifier provided for '${providerId}'`);
   }
 
   const handler = new EnvironmentHandler(

--- a/plugins/auth-backend/src/providers/factories.ts
+++ b/plugins/auth-backend/src/providers/factories.ts
@@ -15,7 +15,6 @@
  */
 
 import Router from 'express-promise-router';
-import express from 'express';
 import { Logger } from 'winston';
 import { TokenIssuer } from '../identity';
 import { createGithubProvider } from './github';
@@ -24,7 +23,11 @@ import { createGoogleProvider } from './google';
 import { createOAuth2Provider } from './oauth2';
 import { createOktaProvider } from './okta';
 import { createSamlProvider } from './saml';
-import { AuthProviderConfig, AuthProviderFactory } from './types';
+import {
+  AuthProviderConfig,
+  AuthProviderFactory,
+  EnvironmentIdentifierFn,
+} from './types';
 import { Config } from '@backstage/config';
 import {
   EnvironmentHandlers,
@@ -55,7 +58,7 @@ export const createAuthProviderRouter = (
   const router = Router();
   const envs = providerConfig.keys();
   const envProviders: EnvironmentHandlers = {};
-  let envIdentifier: ((req: express.Request) => string) | undefined;
+  let envIdentifier: EnvironmentIdentifierFn | undefined;
 
   for (const env of envs) {
     const envConfig = providerConfig.getConfig(env);

--- a/plugins/auth-backend/src/providers/factories.ts
+++ b/plugins/auth-backend/src/providers/factories.ts
@@ -15,6 +15,7 @@
  */
 
 import Router from 'express-promise-router';
+import express from 'express';
 import { Logger } from 'winston';
 import { TokenIssuer } from '../identity';
 import { createGithubProvider } from './github';
@@ -54,16 +55,24 @@ export const createAuthProviderRouter = (
   const router = Router();
   const envs = providerConfig.keys();
   const envProviders: EnvironmentHandlers = {};
+  let envIdentifier: (req: express.Request) => string;
 
   for (const env of envs) {
     const envConfig = providerConfig.getConfig(env);
     const provider = factory(globalConfig, env, envConfig, logger, issuer);
     if (provider) {
       envProviders[env] = provider;
+      if (envIdentifier === undefined) {
+        envIdentifier = provider.identifyEnv;
+      }
     }
   }
 
-  const handler = new EnvironmentHandler(providerId, envProviders);
+  const handler = new EnvironmentHandler(
+    providerId,
+    envProviders,
+    envIdentifier,
+  );
 
   router.get('/start', handler.start.bind(handler));
   router.get('/handler/frame', handler.frameHandler.bind(handler));

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -126,7 +126,7 @@ export class GithubAuthProvider implements OAuthProviderHandlers {
 
 export function createGithubProvider(
   { baseUrl }: AuthProviderConfig,
-  env: string,
+  _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
@@ -148,7 +148,7 @@ export function createGithubProvider(
   const userProfileURL = enterpriseInstanceUrl
     ? `${enterpriseInstanceUrl}/api/v3/user`
     : undefined;
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame?env=${env}`;
+  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
 
   const opts = {
     clientID,

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -133,7 +133,7 @@ export class GitlabAuthProvider implements OAuthProviderHandlers {
 
 export function createGitlabProvider(
   { baseUrl }: AuthProviderConfig,
-  env: string,
+  _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
@@ -145,7 +145,7 @@ export function createGitlabProvider(
   const clientSecret = envConfig.getString('clientSecret');
   const audience = envConfig.getString('audience');
   const baseURL = audience || 'https://gitlab.com';
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame?env=${env}`;
+  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
 
   const opts = {
     clientID,

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -145,7 +145,7 @@ export class GoogleAuthProvider implements OAuthProviderHandlers {
 
 export function createGoogleProvider(
   { baseUrl }: AuthProviderConfig,
-  env: string,
+  _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
@@ -155,7 +155,7 @@ export function createGoogleProvider(
   const appOrigin = envConfig.getString('appOrigin');
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame?env=${env}`;
+  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
 
   const opts = {
     clientID,

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -143,7 +143,7 @@ export class OAuth2AuthProvider implements OAuthProviderHandlers {
 
 export function createOAuth2Provider(
   { baseUrl }: AuthProviderConfig,
-  env: string,
+  _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
@@ -153,7 +153,7 @@ export function createOAuth2Provider(
   const appOrigin = envConfig.getString('appOrigin');
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame?env=${env}`;
+  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
   const authorizationURL = envConfig.getString('authorizationURL');
   const tokenURL = envConfig.getString('tokenURL');
 

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -165,7 +165,7 @@ export class OktaAuthProvider implements OAuthProviderHandlers {
 
 export function createOktaProvider(
   { baseUrl }: AuthProviderConfig,
-  env: string,
+  _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
@@ -176,7 +176,7 @@ export function createOktaProvider(
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
   const audience = envConfig.getString('audience');
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame?env=${env}`;
+  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
 
   const opts = {
     audience,

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -106,6 +106,10 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
   async logout(_req: express.Request, res: express.Response): Promise<void> {
     res.send('noop');
   }
+
+  identifyEnv(_req: express.Request): string {
+    return '';
+  }
 }
 
 type SAMLProviderOptions = {

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -107,7 +107,7 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
     res.send('noop');
   }
 
-  identifyEnv(_req: express.Request): string {
+  identifyEnv(): string {
     return '';
   }
 }

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -107,8 +107,8 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
     res.send('noop');
   }
 
-  identifyEnv(): string {
-    return '';
+  identifyEnv(): string | undefined {
+    return undefined;
   }
 }
 

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -345,6 +345,6 @@ export type SAMLEnvironmentProviderConfig = {
 export type OAuthState = {
   /* A type for the serialized value in the `state` parameter of the OAuth authorization flow
    */
-  nonce?: string;
-  env?: string;
+  nonce: string;
+  env: string;
 };

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -203,6 +203,15 @@ export interface AuthProviderRouteHandlers {
    * @param {express.Response} res
    */
   logout?(req: express.Request, res: express.Response): Promise<void>;
+
+  /**
+   *(Optional) A method to identify the environment Context of the Request
+   *
+   *Request
+   *- contains the environment context information encoded in the request
+   *  @param {express.Request} req
+   */
+  identifyEnv?(req: express.Request): string;
 }
 
 export type AuthProviderFactory = (

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -211,7 +211,7 @@ export interface AuthProviderRouteHandlers {
    *- contains the environment context information encoded in the request
    *  @param {express.Request} req
    */
-  identifyEnv?(req: express.Request): string;
+  identifyEnv?(req: express.Request): string | undefined;
 }
 
 export type AuthProviderFactory = (
@@ -348,3 +348,7 @@ export type OAuthState = {
   nonce: string;
   env: string;
 };
+
+export type EnvironmentIdentifierFn = (
+  req: express.Request,
+) => string | undefined;

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -341,3 +341,10 @@ export type SAMLProviderConfig = {
 export type SAMLEnvironmentProviderConfig = {
   [key: string]: SAMLProviderConfig;
 };
+
+export type OAuthState = {
+  /* A type for the serialized value in the `state` parameter of the OAuth authorization flow
+   */
+  nonce?: string;
+  env?: string;
+};


### PR DESCRIPTION
`env` param  in the OAuth request flow is now encoded in the state parameter.

The `env`  parameter used to select the right `EnvironmentHandlers` is an explicit parameter that might break the flow for Users of backstage. To solve this issue, the `env` and the `nonce` parameter are encoded in the `state` parameter of the request.

Previously, the `state` parameter contained only the `nonce` used for preventing CSRF attacks. This change will create an object with the `nonce` and `env` as keys in it and URL encode the  object before setting it as the value of the `state`  parameter.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [x] Regression tests added for bug fixes
