### PR TITLE
Add backstage metadata yaml file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  description: |
+    Backstage is an open-source developer portal that puts the developer experience first. 
+  annotations:
+    github.com/project-slug: 'spotify/backstage'
+spec:
+  type: library
+  owner: Spotify
+  lifecycle: experimental

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,7 @@ better yet, a pull request.
     - [ADR005 - Catalog Core Entities](architecture-decisions/adr005-catalog-core-entities.md)
     - [ADR006 - Avoid React.FC and React.SFC](architecture-decisions/adr006-avoid-react-fc.md)
     - [ADR007 - Use MSW for Mocking Network Requests](architecture-decisions/adr007-use-msw-to-mock-service-requests.md)
+    - [ADR008 - Default Catalog File Name](architecture-decisions/adr008-default-catalog-file-name.md)
   - [Contribute](../CONTRIBUTING.md)
   - [Support](overview/support.md)
   - [FAQ](FAQ.md)

--- a/docs/architecture-decisions/adr008-default-catalog-file-name.md
+++ b/docs/architecture-decisions/adr008-default-catalog-file-name.md
@@ -1,0 +1,22 @@
+# ADR008: Default Catalog File Name
+
+## Background
+
+While the spec for the catalog file format is well described in
+[ADR002](./adr002-default-catalog-file-format.md), guidance was note provided as
+to the name of the catalog file.
+
+Following discussion in
+[Issue 1822](https://github.com/spotify/backstage/pull/1822#pullrequestreview-461253670),
+a decision was made.
+
+## Name
+
+The catalog file should be named
+
+```shell
+catalog-info.yaml
+```
+
+This name is a default, **not a requirement**. The catalog file will work with
+Backstage irregardless of its name.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - ADR005 - Catalog Core Entities: 'architecture-decisions/adr005-catalog-core-entities.md'
       - ADR006 - Avoid React.FC and React.SFC: 'architecture-decisions/adr006-avoid-react-fc.md'
       - ADR007 - Use MSW for Network Request Mocking: 'architecture-decisions/adr007-use-msw-to-mock-service-requests.md'
+      - ADR008 - Default Catalog File Name: 'architecture-decisions/adr008-default-catalog-file-name.md'
   - Contribute: '../CONTRIBUTING.md'
   - Support: 'overview/support.md'
   - FAQ: FAQ.md


### PR DESCRIPTION
This will allow me to display the Backstage project itself in my [Backstage Demo](https://backstage-demo.roadie.io/). This way we can see the GitHub Actions widget working in a live demo, show it to people etc.