### PR TITLE
fix: github actions subpage was working only for default service

### DIFF
--- a/plugins/github-actions/src/plugin.ts
+++ b/plugins/github-actions/src/plugin.ts
@@ -23,6 +23,10 @@ export const rootRouteRef = createRouteRef({
   path: '/github-actions',
   title: 'GitHub Actions',
 });
+export const projectRouteRef = createRouteRef({
+  path: '/github-actions/:kind/:optionalNamespaceAndName/',
+  title: 'GitHub Actions for project',
+});
 export const buildRouteRef = createRouteRef({
   path: '/github-actions/workflow-run/:id',
   title: 'GitHub Actions Workflow Run',
@@ -32,6 +36,7 @@ export const plugin = createPlugin({
   id: 'github-actions',
   register({ router }) {
     router.addRoute(rootRouteRef, WorkflowRunsPage);
+    router.addRoute(projectRouteRef, WorkflowRunsPage);
     router.addRoute(buildRouteRef, WorkflowRunDetailsPage);
   },
 });


### PR DESCRIPTION
It was only possible to see the actions run for the spotify/backstage service. With this change, something like http://localhost:3000/github-actions/Component/sample-service will work as long as you have a `sample-service` in your catalog.