### PR TITLE
Create CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Backstage Changelog
+
+This is a best-effort changelog where we manually collect breaking changes. It is not an exhaustive list of all changes or even features added.
+
+If you encounter issues while upgrading to a newer version, don't hesitate to reach out on Discord or open an issue!
+
+## Next Release
+
+> Collect changes for the next release below
+
+### @backstage/catalog-backend
+
+- Fixed and issue with duplicated location logs. Applying the database migrations from this fix will clear the existing migration logs. https://github.com/spotify/backstage/pull/1836
+
+## v0.1.1-alpha.17
+
+### @backstage/techdocs-backend
+
+- The techdocs backend now requires more configuration to be supplied when creating the router. See [packages/backend/src/plugins/techdocs.ts](https://github.com/spotify/backstage/blob/0201fd9b4a52429519dd59e9184106ba69456deb/packages/backend/src/plugins/techdocs.ts#L42) for an example. https://github.com/spotify/backstage/pull/1736
+
+### @backstage/cli
+
+- The `create-app` command was moved out from the CLI to a standalone package. It's now invoked with `npx @backstage/create-app` instead. https://github.com/spotify/backstage/pull/1745

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is a best-effort changelog where we manually collect breaking changes. It is not an exhaustive list of all changes or even features added.
 
-If you encounter issues while upgrading to a newer version, don't hesitate to reach out on Discord or open an issue!
+If you encounter issues while upgrading to a newer version, don't hesitate to reach out on [Discord](https://discord.gg/EBHEGzX) or [open an issue](https://github.com/spotify/backstage/issues/new/choose)!
 
 ## Next Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ If you encounter issues while upgrading to a newer version, don't hesitate to re
 
 ### @backstage/catalog-backend
 
-- Fixed and issue with duplicated location logs. Applying the database migrations from this fix will clear the existing migration logs. https://github.com/spotify/backstage/pull/1836
+- Fixed an issue with duplicated location logs. Applying the database migrations from this fix will clear the existing migration logs. https://github.com/spotify/backstage/pull/1836
 
 ## v0.1.1-alpha.17
 


### PR DESCRIPTION
I figured we need this quicker than we can evaluate something like https://github.com/spotify/backstage/issues/1839, so adding a manually curated changelog as a stop-gap.

Idea is that we now have a place to collect breaking changes, preferable in the PR that introduces it. Then we'll manually move them over as we do a release and start collecting changes for the next release.