### PR TITLE
auth-backend: temporary fix for strict CSP being set

### DIFF
--- a/plugins/auth-backend/src/lib/OAuthProvider.test.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.test.ts
@@ -125,7 +125,7 @@ describe('OAuthProvider Utils', () => {
       const base64Data = Buffer.from(jsonData, 'utf8').toString('base64');
 
       postMessageResponse(mockResponse, appOrigin, data);
-      expect(mockResponse.setHeader).toBeCalledTimes(2);
+      expect(mockResponse.setHeader).toBeCalledTimes(3);
       expect(mockResponse.end).toBeCalledTimes(1);
       expect(mockResponse.end).toBeCalledWith(
         expect.stringContaining(base64Data),
@@ -146,7 +146,7 @@ describe('OAuthProvider Utils', () => {
       const base64Data = Buffer.from(jsonData, 'utf8').toString('base64');
 
       postMessageResponse(mockResponse, appOrigin, data);
-      expect(mockResponse.setHeader).toBeCalledTimes(2);
+      expect(mockResponse.setHeader).toBeCalledTimes(3);
       expect(mockResponse.end).toBeCalledTimes(1);
       expect(mockResponse.end).toBeCalledWith(
         expect.stringContaining(base64Data),

--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -64,6 +64,7 @@ export const postMessageResponse = (
 
   res.setHeader('Content-Type', 'text/html');
   res.setHeader('X-Frame-Options', 'sameorigin');
+  res.setHeader('Content-Security-Policy', "script-src 'unsafe-inline'");
 
   // TODO: Make target app origin configurable globally
   res.end(`


### PR DESCRIPTION
Temporary fix for https://github.com/spotify/backstage/issues/1842. We'd rather set the hash instead, but the fixes the auth flow breakage for now.