### PR TITLE
auth backend: fix CSP by setting script hash

### DIFF
--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -92,16 +92,19 @@ export const postMessageResponse = (
 
   res.setHeader('Content-Type', 'text/html');
   res.setHeader('X-Frame-Options', 'sameorigin');
-  res.setHeader('Content-Security-Policy', "script-src 'unsafe-inline'");
 
   // TODO: Make target app origin configurable globally
+  const script = `
+    (window.opener || window.parent).postMessage(JSON.parse(atob('${base64Data}')), '${appOrigin}')
+    window.close()
+  `;
+  const hash = crypto.createHash('sha256').update(script).digest('base64');
+  res.setHeader('Content-Security-Policy', `script-src 'sha256-${hash}'`);
+
   res.end(`
 <html>
 <body>
-  <script>
-    (window.opener || window.parent).postMessage(JSON.parse(atob('${base64Data}')), '${appOrigin}')
-    window.close()
-  </script>
+  <script>${script}</script>
 </body>
 </html>
   `);


### PR DESCRIPTION
Fixes #1842 

Sets the script hash in the CSP header which allows it to run without issues. The hash is calculated each time.

Do you want me to add any specific test case for this?

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
