### PR TITLE
fix: change pg config for config loader pattern

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -49,9 +49,9 @@ function makeCreateEnv(loadedConfigs: AppConfig[]) {
     const logger = getRootLogger().child({ type: 'plugin', plugin });
     // Supported DBs are sqlite and postgres
     const isPg = [
-      'POSTGRES_USER',
-      'POSTGRES_HOST',
-      'POSTGRES_PASSWORD',
+      'POSTGRES.USER',
+      'POSTGRES.HOST',
+      'POSTGRES.PASSWORD',
     ].every(key => config.getOptional(`backend.${key}`));
 
     let knexConfig;
@@ -61,10 +61,10 @@ function makeCreateEnv(loadedConfigs: AppConfig[]) {
         client: 'pg',
         useNullAsDefault: true,
         connection: {
-          port: config.getOptionalNumber('backend.POSTGRES_PORT'),
-          host: config.getString('backend.POSTGRES_HOST'),
-          user: config.getString('backend.POSTGRES_USER'),
-          password: config.getString('backend.POSTGRES_PASSWORD'),
+          port: config.getOptionalNumber('backend.POSTGRES.PORT'),
+          host: config.getString('backend.POSTGRES.HOST'),
+          user: config.getString('backend.POSTGRES.USER'),
+          password: config.getString('backend.POSTGRES.PASSWORD'),
           database: `backstage_plugin_${plugin}`,
         } as PgConnectionConfig,
       };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

If my understanding of the config-loader and how we pass configs via the environment variables is correct, the following envs 
```
APP_CONFIG_backend_POSTGRES_HOST: '"postgres_backstage"'
APP_CONFIG_backend_POSTGRES_USER: '"dbuser"'
```

will produce the config: 

```
{
  "backend": {
    "POSTGRES": {
      "HOST": "postgres_backstage",
      "USER": "dbuser"
    }
  }
}
```

As a result when `config.getString('backend.POSTGRES_HOST')` is called, no result will be found.