### PR TITLE
Add migration for entity_search column fix

### DIFF
--- a/plugins/catalog-backend/migrations/20200807120600_entitySearch.js
+++ b/plugins/catalog-backend/migrations/20200807120600_entitySearch.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
+  try {
+    await knex.schema.alterTable('entities_search', table => {
+      table.text('value').nullable().alter();
+    });
+  } catch (e) {
+    // Sqlite does not support alter column.
+  }
+};
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
+  try {
+    await knex.schema.alterTable('entities_search', table => {
+      table.string('value').nullable().alter();
+    });
+  } catch (e) {
+    // Sqlite does not support alter column.
+  }
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While running backstage in our dev environment with postgres and testing with some new catalog entities, I got received errors when saving catalog entities with a longer description then 255 chars. 
The metadata column is configured in the migration file as:
```
table
   .text('metadata')
   .notNullable()
   .comment('The entire metadata JSON blob of the entity');
```

and the entity_search entity is configured as: 
```
table
  .string('value')
  .nullable()
  .comment('The corresponding value to match on');
```

For each entity that will be added or updated the `CommonDatabase.updateEntitiesSearch` will be called which recursively stores key/value-pairs with all data from the entity. 

Since there is no limit for metadata, we shouldn't set the default length of "string" to 255.



