### PR TITLE
docs: fix link to plugin documentation

### DIFF
--- a/packages/create-app/templates/default-app/plugins/welcome/src/components/WelcomePage/WelcomePage.tsx
+++ b/packages/create-app/templates/default-app/plugins/welcome/src/components/WelcomePage/WelcomePage.tsx
@@ -71,7 +71,7 @@ const WelcomePage: FC<{}> = () => {
               </Typography>
               <Typography variant="body1" paragraph>
                 We suggest you either check out the documentation for{' '}
-                <Link href="https://github.com/spotify/backstage/blob/master/docs/getting-started/create-a-plugin.md">
+                <Link href="https://github.com/spotify/backstage/blob/master/docs/plugins/create-a-plugin.md">
                   creating a plugin
                 </Link>{' '}
                 or have a look in the code for the{' '}
@@ -90,7 +90,7 @@ const WelcomePage: FC<{}> = () => {
                   <Link href="https://backstage.io">backstage.io</Link>
                 </ListItem>
                 <ListItem>
-                  <Link href="https://github.com/spotify/backstage/blob/master/docs/getting-started/create-a-plugin.md">
+                  <Link href="https://github.com/spotify/backstage/blob/master/docs/plugins/create-a-plugin.md">
                     Create a plugin
                   </Link>
                 </ListItem>

--- a/plugins/welcome/src/components/WelcomePage/WelcomePage.tsx
+++ b/plugins/welcome/src/components/WelcomePage/WelcomePage.tsx
@@ -113,7 +113,7 @@ const WelcomePage = () => {
               </Typography>
               <Typography variant="body1" paragraph>
                 We suggest you either check out the documentation for{' '}
-                <Link href="https://github.com/spotify/backstage/blob/master/docs/getting-started/create-a-plugin.md">
+                <Link href="https://github.com/spotify/backstage/blob/master/docs/plugins/create-a-plugin.md">
                   creating a plugin
                 </Link>{' '}
                 or have a look in the code for the{' '}
@@ -135,7 +135,7 @@ const WelcomePage = () => {
                   <Link href="https://backstage.io">backstage.io</Link>
                 </ListItem>
                 <ListItem>
-                  <Link href="https://github.com/spotify/backstage/blob/master/docs/getting-started/create-a-plugin.md">
+                  <Link href="https://github.com/spotify/backstage/blob/master/docs/plugins/create-a-plugin.md">
                     Create a plugin
                   </Link>
                 </ListItem>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hey Backstage team, Thanks for that great project.
I created a [Backstage App](https://github.com/spotify/backstage/blob/master/docs/getting-started/create-an-app.md) and catch a link error:

![Backstage project](https://user-images.githubusercontent.com/1574240/89699177-a5e72000-d8fb-11ea-8b31-000deb65219e.png)

The **creating a plugin** has the following link:
https://github.com/spotify/backstage/blob/master/docs/getting-started/create-a-plugin.md (404)
I fix this to:
https://github.com/spotify/backstage/blob/master/docs/plugins/create-a-plugin.md

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
