### PR TITLE
config-loader: taint secret paths to treat them as secret in later configs as well

### DIFF
--- a/packages/config-loader/src/lib/reader.ts
+++ b/packages/config-loader/src/lib/reader.ts
@@ -35,6 +35,10 @@ export async function readConfigFile(
     obj: JsonValue,
     path: string,
   ): Promise<JsonValue | undefined> {
+    if (ctx.skip(path)) {
+      return undefined;
+    }
+
     if (typeof obj !== 'object') {
       return obj;
     } else if (obj === null) {
@@ -58,7 +62,7 @@ export async function readConfigFile(
       }
 
       try {
-        return await ctx.readSecret(obj.$secret);
+        return await ctx.readSecret(path, obj.$secret);
       } catch (error) {
         throw new Error(`Invalid secret at ${path}: ${error.message}`);
       }

--- a/packages/config-loader/src/lib/secrets.test.ts
+++ b/packages/config-loader/src/lib/secrets.test.ts
@@ -21,6 +21,7 @@ const ctx: ReaderContext = {
   env: {
     SECRET: 'my-secret',
   },
+  skip: () => false,
   readSecret: jest.fn(),
   async readFile(path) {
     const content = ({

--- a/packages/config-loader/src/lib/types.ts
+++ b/packages/config-loader/src/lib/types.ts
@@ -17,13 +17,18 @@
 import { JsonObject } from '@backstage/config';
 
 export type ReadFileFunc = (path: string) => Promise<string>;
-export type ReadSecretFunc = (desc: JsonObject) => Promise<string | undefined>;
+export type ReadSecretFunc = (
+  path: string,
+  desc: JsonObject,
+) => Promise<string | undefined>;
+export type SkipFunc = (path: string) => boolean;
 
 /**
  * Common context that provides all the necessary hooks for reading configuration files.
  */
 export type ReaderContext = {
   env: { [name in string]?: string };
+  skip: SkipFunc;
   readFile: ReadFileFunc;
   readSecret: ReadSecretFunc;
 };

--- a/packages/config-loader/src/loader.test.ts
+++ b/packages/config-loader/src/loader.test.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { loadConfig } from './loader';
+
+jest.mock('fs-extra', () => {
+  const mockFiles: { [path in string]: string } = {
+    '/root/app-config.yaml': `
+      app:
+        title: Example App
+        sessionKey:
+          $secret:
+            file: secrets/session-key.txt
+    `,
+    '/root/app-config.development.yaml': `
+      app:
+        sessionKey: development-key
+    `,
+    '/root/secrets/session-key.txt': 'abc123',
+  };
+
+  return {
+    async readFile(path: string) {
+      if (path in mockFiles) {
+        return mockFiles[path];
+      }
+      throw new Error(`File not found, ${path}`);
+    },
+    async pathExists(path: string) {
+      return path in mockFiles;
+    },
+  };
+});
+
+describe('loadConfig', () => {
+  it('loads config without secrets', async () => {
+    await expect(
+      loadConfig({
+        rootPaths: ['/root'],
+        env: 'production',
+        shouldReadSecrets: false,
+      }),
+    ).resolves.toEqual([
+      {
+        context: 'app-config.yaml',
+        data: {
+          app: {
+            title: 'Example App',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('loads config with secrets', async () => {
+    await expect(
+      loadConfig({
+        rootPaths: ['/root'],
+        env: 'production',
+        shouldReadSecrets: true,
+      }),
+    ).resolves.toEqual([
+      {
+        context: 'app-config.yaml',
+        data: {
+          app: {
+            title: 'Example App',
+            sessionKey: 'abc123',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('loads development config without secrets', async () => {
+    await expect(
+      loadConfig({
+        rootPaths: ['/root'],
+        env: 'development',
+        shouldReadSecrets: false,
+      }),
+    ).resolves.toEqual([
+      {
+        context: 'app-config.yaml',
+        data: {
+          app: {
+            title: 'Example App',
+          },
+        },
+      },
+      {
+        context: 'app-config.development.yaml',
+        data: {
+          app: {},
+        },
+      },
+    ]);
+  });
+
+  it('loads development config with secrets', async () => {
+    await expect(
+      loadConfig({
+        rootPaths: ['/root'],
+        env: 'development',
+        shouldReadSecrets: true,
+      }),
+    ).resolves.toEqual([
+      {
+        context: 'app-config.yaml',
+        data: {
+          app: {
+            title: 'Example App',
+            sessionKey: 'abc123',
+          },
+        },
+      },
+      {
+        context: 'app-config.development.yaml',
+        data: {
+          app: {
+            sessionKey: 'development-key',
+          },
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
This adds a bit of extra safety around supplying secrets through config, such that any config value that is once declared as a secret will always be treated as a secret. This does not apply to config supplied through `APP_CONFIG_` env vars, which should not be used for secrets anyway.