### PR TITLE
config: added config.has() and allow config.get() to be called with no args

### DIFF
--- a/docs/reference/utility-apis/AlertApi.md
+++ b/docs/reference/utility-apis/AlertApi.md
@@ -1,7 +1,7 @@
 # AlertApi
 
 The AlertApi type is defined at
-[packages/core-api/src/apis/definitions/AlertApi.ts:29](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/AlertApi.ts#L29).
+[packages/core-api/src/apis/definitions/AlertApi.ts:29](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/AlertApi.ts#L29).
 
 The following Utility API implements this type: [alertApiRef](./README.md#alert)
 
@@ -38,7 +38,7 @@ export type AlertMessage = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/AlertApi.ts:19](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/AlertApi.ts#L19).
+[packages/core-api/src/apis/definitions/AlertApi.ts:19](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/AlertApi.ts#L19).
 
 Referenced by: [post](#post), [alert\$](#alert).
 
@@ -67,7 +67,7 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L53).
 
 Referenced by: [alert\$](#alert).
 
@@ -86,7 +86,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -109,6 +109,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/AppThemeApi.md
+++ b/docs/reference/utility-apis/AppThemeApi.md
@@ -1,7 +1,7 @@
 # AppThemeApi
 
 The AppThemeApi type is defined at
-[packages/core-api/src/apis/definitions/AppThemeApi.ts:50](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/AppThemeApi.ts#L50).
+[packages/core-api/src/apis/definitions/AppThemeApi.ts:50](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/AppThemeApi.ts#L50).
 
 The following Utility API implements this type:
 [appThemeApiRef](./README.md#apptheme)
@@ -76,7 +76,7 @@ export type AppTheme = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/AppThemeApi.ts:24](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/AppThemeApi.ts#L24).
+[packages/core-api/src/apis/definitions/AppThemeApi.ts:24](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/AppThemeApi.ts#L24).
 
 Referenced by: [getInstalledThemes](#getinstalledthemes).
 
@@ -87,7 +87,7 @@ export type BackstagePalette = Palette &amp; <a href="#paletteadditions">Palette
 </pre>
 
 Defined at
-[packages/theme/src/types.ts:63](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/theme/src/types.ts#L63).
+[packages/theme/src/types.ts:67](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/theme/src/types.ts#L67).
 
 Referenced by: [BackstageTheme](#backstagetheme).
 
@@ -100,7 +100,7 @@ export interface BackstageTheme extends Theme {
 </pre>
 
 Defined at
-[packages/theme/src/types.ts:66](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/theme/src/types.ts#L66).
+[packages/theme/src/types.ts:70](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/theme/src/types.ts#L70).
 
 Referenced by: [AppTheme](#apptheme).
 
@@ -129,7 +129,7 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L53).
 
 Referenced by: [activeThemeId\$](#activethemeid).
 
@@ -148,7 +148,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -193,11 +193,15 @@ type PaletteAdditions = {
     icon: string;
     background: string;
   };
+  banner: {
+    info: string;
+    error: string;
+  };
 }
 </pre>
 
 Defined at
-[packages/theme/src/types.ts:23](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/theme/src/types.ts#L23).
+[packages/theme/src/types.ts:23](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/theme/src/types.ts#L23).
 
 Referenced by: [BackstagePalette](#backstagepalette).
 
@@ -220,6 +224,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/BackstageIdentityApi.md
+++ b/docs/reference/utility-apis/BackstageIdentityApi.md
@@ -1,7 +1,7 @@
 # BackstageIdentityApi
 
 The BackstageIdentityApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:144](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L144).
+[packages/core-api/src/apis/definitions/auth.ts:144](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L144).
 
 The following Utility APIs implement this type:
 
@@ -62,7 +62,7 @@ export type AuthRequestOptions = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L40).
+[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L40).
 
 Referenced by: [getBackstageIdentity](#getbackstageidentity).
 
@@ -83,6 +83,6 @@ export type BackstageIdentity = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:157](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L157).
+[packages/core-api/src/apis/definitions/auth.ts:157](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L157).
 
 Referenced by: [getBackstageIdentity](#getbackstageidentity).

--- a/docs/reference/utility-apis/Config.md
+++ b/docs/reference/utility-apis/Config.md
@@ -1,7 +1,7 @@
 # Config
 
 The Config type is defined at
-[packages/config/src/types.ts:32](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/config/src/types.ts#L32).
+[packages/config/src/types.ts:32](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/config/src/types.ts#L32).
 
 The following Utility API implements this type:
 [configApiRef](./README.md#config)
@@ -132,7 +132,7 @@ export type Config = {
 </pre>
 
 Defined at
-[packages/config/src/types.ts:32](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/config/src/types.ts#L32).
+[packages/config/src/types.ts:32](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/config/src/types.ts#L32).
 
 Referenced by: [getConfig](#getconfig), [getOptionalConfig](#getoptionalconfig),
 [getConfigArray](#getconfigarray),
@@ -145,7 +145,7 @@ export type JsonArray = <a href="#jsonvalue">JsonValue</a>[]
 </pre>
 
 Defined at
-[packages/config/src/types.ts:18](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/config/src/types.ts#L18).
+[packages/config/src/types.ts:18](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/config/src/types.ts#L18).
 
 Referenced by: [JsonValue](#jsonvalue).
 
@@ -156,7 +156,7 @@ export type JsonObject = { [key in string]?: <a href="#jsonvalue">JsonValue</a> 
 </pre>
 
 Defined at
-[packages/config/src/types.ts:17](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/config/src/types.ts#L17).
+[packages/config/src/types.ts:17](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/config/src/types.ts#L17).
 
 Referenced by: [JsonValue](#jsonvalue).
 
@@ -173,7 +173,7 @@ export type JsonValue =
 </pre>
 
 Defined at
-[packages/config/src/types.ts:19](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/config/src/types.ts#L19).
+[packages/config/src/types.ts:19](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/config/src/types.ts#L19).
 
 Referenced by: [get](#get), [getOptional](#getoptional),
 [JsonObject](#jsonobject), [JsonArray](#jsonarray), [Config](#config).

--- a/docs/reference/utility-apis/ErrorApi.md
+++ b/docs/reference/utility-apis/ErrorApi.md
@@ -1,7 +1,7 @@
 # ErrorApi
 
 The ErrorApi type is defined at
-[packages/core-api/src/apis/definitions/ErrorApi.ts:53](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/ErrorApi.ts#L53).
+[packages/core-api/src/apis/definitions/ErrorApi.ts:53](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/ErrorApi.ts#L53).
 
 The following Utility API implements this type: [errorApiRef](./README.md#error)
 
@@ -41,7 +41,7 @@ type Error = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/ErrorApi.ts:24](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/ErrorApi.ts#L24).
+[packages/core-api/src/apis/definitions/ErrorApi.ts:24](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/ErrorApi.ts#L24).
 
 Referenced by: [post](#post), [error\$](#error).
 
@@ -58,7 +58,7 @@ export type ErrorContext = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/ErrorApi.ts:33](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/ErrorApi.ts#L33).
+[packages/core-api/src/apis/definitions/ErrorApi.ts:33](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/ErrorApi.ts#L33).
 
 Referenced by: [post](#post), [error\$](#error).
 
@@ -87,7 +87,7 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L53).
 
 Referenced by: [error\$](#error).
 
@@ -106,7 +106,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -129,6 +129,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/FeatureFlagsApi.md
+++ b/docs/reference/utility-apis/FeatureFlagsApi.md
@@ -1,7 +1,7 @@
 # FeatureFlagsApi
 
 The FeatureFlagsApi type is defined at
-[packages/core-api/src/apis/definitions/FeatureFlagsApi.ts:41](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L41).
+[packages/core-api/src/apis/definitions/FeatureFlagsApi.ts:41](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L41).
 
 The following Utility API implements this type:
 [featureFlagsApiRef](./README.md#featureflags)

--- a/docs/reference/utility-apis/IdentityApi.md
+++ b/docs/reference/utility-apis/IdentityApi.md
@@ -1,7 +1,7 @@
 # IdentityApi
 
 The IdentityApi type is defined at
-[packages/core-api/src/apis/definitions/IdentityApi.ts:22](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/IdentityApi.ts#L22).
+[packages/core-api/src/apis/definitions/IdentityApi.ts:22](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/IdentityApi.ts#L22).
 
 The following Utility API implements this type:
 [identityApiRef](./README.md#identity)
@@ -76,6 +76,6 @@ export type ProfileInfo = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:172](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L172).
+[packages/core-api/src/apis/definitions/auth.ts:172](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L172).
 
 Referenced by: [getProfile](#getprofile).

--- a/docs/reference/utility-apis/OAuthApi.md
+++ b/docs/reference/utility-apis/OAuthApi.md
@@ -1,7 +1,7 @@
 # OAuthApi
 
 The OAuthApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:67](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L67).
+[packages/core-api/src/apis/definitions/auth.ts:67](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L67).
 
 The following Utility APIs implement this type:
 
@@ -88,7 +88,7 @@ export type AuthRequestOptions = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L40).
+[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L40).
 
 Referenced by: [getAccessToken](#getaccesstoken).
 
@@ -114,6 +114,6 @@ export type OAuthScope = string | string[]
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:38](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L38).
+[packages/core-api/src/apis/definitions/auth.ts:38](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L38).
 
 Referenced by: [getAccessToken](#getaccesstoken).

--- a/docs/reference/utility-apis/OAuthRequestApi.md
+++ b/docs/reference/utility-apis/OAuthRequestApi.md
@@ -1,7 +1,7 @@
 # OAuthRequestApi
 
 The OAuthRequestApi type is defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:99](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L99).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:99](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L99).
 
 The following Utility API implements this type:
 [oauthRequestApiRef](./README.md#oauthrequest)
@@ -72,7 +72,7 @@ export type AuthProvider = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:27](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L27).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:27](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L27).
 
 Referenced by: [AuthRequesterOptions](#authrequesteroptions),
 [PendingAuthRequest](#pendingauthrequest).
@@ -96,7 +96,7 @@ export type AuthRequester&lt;AuthResponse&gt; = (
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:66](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L66).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:66](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L66).
 
 Referenced by: [createAuthRequester](#createauthrequester).
 
@@ -121,7 +121,7 @@ export type AuthRequesterOptions&lt;AuthResponse&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:43](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L43).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:43](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L43).
 
 Referenced by: [createAuthRequester](#createauthrequester).
 
@@ -150,7 +150,7 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L53).
 
 Referenced by: [authRequest\$](#authrequest).
 
@@ -169,7 +169,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -204,7 +204,7 @@ export type PendingAuthRequest = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:77](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L77).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:77](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L77).
 
 Referenced by: [authRequest\$](#authrequest).
 
@@ -227,6 +227,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/OpenIdConnectApi.md
+++ b/docs/reference/utility-apis/OpenIdConnectApi.md
@@ -1,7 +1,7 @@
 # OpenIdConnectApi
 
 The OpenIdConnectApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:104](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L104).
+[packages/core-api/src/apis/definitions/auth.ts:104](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L104).
 
 The following Utility APIs implement this type:
 
@@ -70,6 +70,6 @@ export type AuthRequestOptions = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L40).
+[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L40).
 
 Referenced by: [getIdToken](#getidtoken).

--- a/docs/reference/utility-apis/ProfileInfoApi.md
+++ b/docs/reference/utility-apis/ProfileInfoApi.md
@@ -1,7 +1,7 @@
 # ProfileInfoApi
 
 The ProfileInfoApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:127](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L127).
+[packages/core-api/src/apis/definitions/auth.ts:127](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L127).
 
 The following Utility APIs implement this type:
 
@@ -61,7 +61,7 @@ export type AuthRequestOptions = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L40).
+[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L40).
 
 Referenced by: [getProfile](#getprofile).
 
@@ -89,6 +89,6 @@ export type ProfileInfo = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:172](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L172).
+[packages/core-api/src/apis/definitions/auth.ts:172](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L172).
 
 Referenced by: [getProfile](#getprofile).

--- a/docs/reference/utility-apis/README.md
+++ b/docs/reference/utility-apis/README.md
@@ -12,7 +12,7 @@ Used to report alerts and forward them to the app
 Implemented type: [AlertApi](./AlertApi.md)
 
 ApiRef:
-[alertApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/AlertApi.ts#L41)
+[alertApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/AlertApi.ts#L41)
 
 ### appTheme
 
@@ -21,7 +21,7 @@ API Used to configure the app theme, and enumerate options
 Implemented type: [AppThemeApi](./AppThemeApi.md)
 
 ApiRef:
-[appThemeApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/AppThemeApi.ts#L74)
+[appThemeApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/AppThemeApi.ts#L74)
 
 ### config
 
@@ -30,7 +30,7 @@ Used to access runtime configuration
 Implemented type: [Config](./Config.md)
 
 ApiRef:
-[configApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/ConfigApi.ts#L22)
+[configApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/ConfigApi.ts#L22)
 
 ### error
 
@@ -39,7 +39,7 @@ Used to report errors and forward them to the app
 Implemented type: [ErrorApi](./ErrorApi.md)
 
 ApiRef:
-[errorApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/ErrorApi.ts#L65)
+[errorApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/ErrorApi.ts#L65)
 
 ### featureFlags
 
@@ -48,7 +48,7 @@ Used to toggle functionality in features across Backstage
 Implemented type: [FeatureFlagsApi](./FeatureFlagsApi.md)
 
 ApiRef:
-[featureFlagsApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L58)
+[featureFlagsApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L58)
 
 ### githubAuth
 
@@ -60,7 +60,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [SessionStateApi](./SessionStateApi.md)
 
 ApiRef:
-[githubAuthApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L230)
+[githubAuthApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L230)
 
 ### gitlabAuth
 
@@ -72,7 +72,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [SessionStateApi](./SessionStateApi.md)
 
 ApiRef:
-[gitlabAuthApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L260)
+[gitlabAuthApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L260)
 
 ### googleAuth
 
@@ -85,7 +85,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [SessionStateApi](./SessionStateApi.md)
 
 ApiRef:
-[googleAuthApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L213)
+[googleAuthApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L213)
 
 ### identity
 
@@ -94,7 +94,7 @@ Provides access to the identity of the signed in user
 Implemented type: [IdentityApi](./IdentityApi.md)
 
 ApiRef:
-[identityApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/IdentityApi.ts#L54)
+[identityApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/IdentityApi.ts#L54)
 
 ### oauth2
 
@@ -105,7 +105,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [ProfileInfoApi](./ProfileInfoApi.md), [SessionStateApi](./SessionStateApi.md)
 
 ApiRef:
-[oauth2ApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L270)
+[oauth2ApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L270)
 
 ### oauthRequest
 
@@ -114,7 +114,7 @@ An API for implementing unified OAuth flows in Backstage
 Implemented type: [OAuthRequestApi](./OAuthRequestApi.md)
 
 ApiRef:
-[oauthRequestApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L130)
+[oauthRequestApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L130)
 
 ### oktaAuth
 
@@ -127,7 +127,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [SessionStateApi](./SessionStateApi.md)
 
 ApiRef:
-[oktaAuthApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L243)
+[oktaAuthApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L243)
 
 ### storage
 
@@ -136,4 +136,4 @@ Provides the ability to store data which is unique to the user
 Implemented type: [StorageApi](./StorageApi.md)
 
 ApiRef:
-[storageApiRef](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/StorageApi.ts#L68)
+[storageApiRef](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/StorageApi.ts#L68)

--- a/docs/reference/utility-apis/SessionStateApi.md
+++ b/docs/reference/utility-apis/SessionStateApi.md
@@ -1,7 +1,7 @@
 # SessionStateApi
 
 The SessionStateApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:201](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L201).
+[packages/core-api/src/apis/definitions/auth.ts:201](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L201).
 
 The following Utility APIs implement this type:
 
@@ -52,7 +52,7 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L53).
 
 Referenced by: [sessionState\$](#sessionstate).
 
@@ -71,7 +71,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -87,7 +87,7 @@ export enum SessionState {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:192](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/auth.ts#L192).
+[packages/core-api/src/apis/definitions/auth.ts:192](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/auth.ts#L192).
 
 Referenced by: [sessionState\$](#sessionstate).
 
@@ -110,6 +110,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/StorageApi.md
+++ b/docs/reference/utility-apis/StorageApi.md
@@ -1,7 +1,7 @@
 # StorageApi
 
 The StorageApi type is defined at
-[packages/core-api/src/apis/definitions/StorageApi.ts:31](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/StorageApi.ts#L31).
+[packages/core-api/src/apis/definitions/StorageApi.ts:31](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/StorageApi.ts#L31).
 
 The following Utility API implements this type:
 [storageApiRef](./README.md#storage)
@@ -79,7 +79,7 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L53).
 
 Referenced by: [observe\$](#observe), [StorageApi](#storageapi).
 
@@ -98,7 +98,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -144,7 +144,7 @@ export interface StorageApi {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/StorageApi.ts:31](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/StorageApi.ts#L31).
+[packages/core-api/src/apis/definitions/StorageApi.ts:31](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/StorageApi.ts#L31).
 
 Referenced by: [forBucket](#forbucket).
 
@@ -158,7 +158,7 @@ export type StorageValueChange&lt;T = any&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/StorageApi.ts:21](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/apis/definitions/StorageApi.ts#L21).
+[packages/core-api/src/apis/definitions/StorageApi.ts:21](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/apis/definitions/StorageApi.ts#L21).
 
 Referenced by: [observe\$](#observe), [StorageApi](#storageapi).
 
@@ -181,6 +181,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/53a229ea7576b1432835e54e41e0b9526038afa4/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/f8780ff32509d0326bc513791ea60846d7614b34/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/packages/config/src/reader.test.ts
+++ b/packages/config/src/reader.test.ts
@@ -137,6 +137,8 @@ describe('ConfigReader', () => {
   it('should read empty config with valid keys', () => {
     const config = new ConfigReader({}, CTX);
     expect(config.keys()).toEqual([]);
+    expect(config.getOptional()).toEqual({});
+    expect(config.getOptional('x')).toBeUndefined();
     expect(config.getOptionalString('x')).toBeUndefined();
     expect(config.getOptionalString('x_x')).toBeUndefined();
     expect(config.getOptionalString('x-X')).toBeUndefined();
@@ -442,6 +444,21 @@ describe('ConfigReader.get()', () => {
   });
 
   it('should merge in fallback configs', () => {
+    expect(
+      ConfigReader.fromConfigs([configs[0], configs[1], configs[2]]).get(),
+    ).toEqual({
+      a: {
+        x: 'x1',
+        y: ['y11', 'y12', 'y13'],
+        z: false,
+      },
+      b: {
+        x: 'x2',
+        y: ['y21', 'y22'],
+        z: 'z2',
+      },
+      c: { c1: 'c1' },
+    });
     expect(ConfigReader.fromConfigs([configs[1], configs[0]]).get('a')).toEqual(
       {
         x: 'x1',
@@ -545,5 +562,22 @@ describe('ConfigReader.get()', () => {
     expect(config.get('f')).toEqual('foo');
     expect(config.get('g')).toEqual({ z: 'z' });
     expect(config.get('h')).toEqual({ a: 'a1', b: 'b2', c: 'c1' });
+    expect(config.getConfig('h').get()).toEqual({ a: 'a1', b: 'b2', c: 'c1' });
+    expect(config.getOptional()).toEqual({
+      a: ['1', '2'],
+      b: ['1'],
+      c: [],
+      d: {
+        x: 'x',
+      },
+      e: ['3'],
+      f: 'foo',
+      g: { z: 'z' },
+      h: {
+        a: 'a1',
+        b: 'b2',
+        c: 'c1',
+      },
+    });
   });
 });

--- a/packages/config/src/reader.test.ts
+++ b/packages/config/src/reader.test.ts
@@ -30,6 +30,7 @@ const DATA = {
   worstStrings: ['string1', 'string2', {}] as string[],
   nested: {
     one: 1,
+    null: null,
     string: 'string',
     strings: ['string1', 'string2'],
   },
@@ -39,6 +40,13 @@ const DATA = {
 function expectValidValues(config: ConfigReader) {
   expect(config.keys()).toEqual(Object.keys(DATA));
   expect(config.get('zero')).toBe(0);
+  expect(config.has('zero')).toBe(true);
+  expect(config.has('false')).toBe(true);
+  expect(config.has('null')).toBe(true);
+  expect(config.has('missing')).toBe(false);
+  expect(config.has('nested.one')).toBe(true);
+  expect(config.has('nested.missing')).toBe(false);
+  expect(config.has('nested.null')).toBe(true);
   expect(config.getNumber('zero')).toBe(0);
   expect(config.getNumber('one')).toBe(1);
   expect(config.getOptional('true')).toBe(true);
@@ -50,6 +58,7 @@ function expectValidValues(config: ConfigReader) {
   expect(config.getConfig('nested').getNumber('one')).toBe(1);
   expect(config.get('nested')).toEqual({
     one: 1,
+    null: null,
     string: 'string',
     strings: ['string1', 'string2'],
   });
@@ -144,14 +153,14 @@ describe('ConfigReader', () => {
   it('should throw on invalid keys', () => {
     const config = new ConfigReader({}, CTX);
 
-    expect(() => config.getString('.')).toThrow(/^Invalid config key/);
-    expect(() => config.getString('0')).toThrow(/^Invalid config key/);
-    expect(() => config.getString('(')).toThrow(/^Invalid config key/);
+    expect(() => config.has('.')).toThrow(/^Invalid config key/);
+    expect(() => config.get('0')).toThrow(/^Invalid config key/);
+    expect(() => config.getOptional('(')).toThrow(/^Invalid config key/);
     expect(() => config.getString('z-_')).toThrow(/^Invalid config key/);
-    expect(() => config.getString('-')).toThrow(/^Invalid config key/);
-    expect(() => config.getString('.a')).toThrow(/^Invalid config key/);
-    expect(() => config.getString('0.a')).toThrow(/^Invalid config key/);
-    expect(() => config.getString('0a')).toThrow(/^Invalid config key/);
+    expect(() => config.getOptionalString('-')).toThrow(/^Invalid config key/);
+    expect(() => config.getNumber('.a')).toThrow(/^Invalid config key/);
+    expect(() => config.getConfig('0.a')).toThrow(/^Invalid config key/);
+    expect(() => config.getOptionalConfig('0a')).toThrow(/^Invalid config key/);
     expect(() => config.getString('a.0a')).toThrow(/^Invalid config key/);
     expect(() => config.getString('a..a')).toThrow(/^Invalid config key/);
     expect(() => config.getString('a.')).toThrow(/^Invalid config key/);
@@ -308,6 +317,12 @@ describe('ConfigReader with fallback', () => {
     const config = new ConfigReader(a, CTX, new ConfigReader(b, CTX));
 
     expect(config.keys()).toEqual(['merged']);
+    expect(config.has('merged.x')).toBe(true);
+    expect(config.has('merged.y')).toBe(true);
+    expect(config.has('merged.w')).toBe(false);
+    expect(config.getConfig('merged').has('x')).toBe(true);
+    expect(config.getConfig('merged').has('y')).toBe(true);
+    expect(config.getConfig('merged').has('w')).toBe(false);
     expect(config.getConfig('merged').keys()).toEqual([
       'x',
       'z',

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -71,6 +71,14 @@ export class ConfigReader implements Config {
     private readonly prefix: string = '',
   ) {}
 
+  has(key: string): boolean {
+    const value = this.readValue(key);
+    if (value !== undefined) {
+      return true;
+    }
+    return this.fallback?.has(key) ?? false;
+  }
+
   keys(): string[] {
     const localKeys = this.data ? Object.keys(this.data) : [];
     const fallbackKeys = this.fallback?.keys() ?? [];

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -85,15 +85,15 @@ export class ConfigReader implements Config {
     return [...new Set([...localKeys, ...fallbackKeys])];
   }
 
-  get(key: string): JsonValue {
+  get(key?: string): JsonValue {
     const value = this.getOptional(key);
     if (value === undefined) {
-      throw new Error(errors.missing(this.fullKey(key)));
+      throw new Error(errors.missing(this.fullKey(key ?? '')));
     }
     return value;
   }
 
-  getOptional(key: string): JsonValue | undefined {
+  getOptional(key?: string): JsonValue | undefined {
     const value = this.readValue(key);
     const fallbackValue = this.fallback?.getOptional(key);
 
@@ -279,8 +279,8 @@ export class ConfigReader implements Config {
     return value as T;
   }
 
-  private readValue(key: string): JsonValue | undefined {
-    const parts = key.split('.');
+  private readValue(key?: string): JsonValue | undefined {
+    const parts = key ? key.split('.') : [];
     for (const part of parts) {
       if (!CONFIG_KEY_PART_PATTERN.test(part)) {
         throw new TypeError(`Invalid config key '${key}'`);


### PR DESCRIPTION
Had enough of awkward `config.getOptionalConfig(...) !== undefined` workarounds, let's add `config.has(key)` 😅 

Also allows `config.get()` to be called without args to serialize the entire config view.