### PR TITLE
Add backstage.io/github-actions-id to metadata

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,8 @@ metadata:
   description: |
     Backstage is an open-source developer portal that puts the developer experience first. 
   annotations:
-    github.com/project-slug: 'spotify/backstage'
+    github.com/project-slug: spotify/backstage
+    backstage.io/github-actions-id: spotify/backstage
 spec:
   type: library
   owner: Spotify


### PR DESCRIPTION
This will make the GitHub Actions Widget work on the entities page.