### PR TITLE
fix: update the winston logger to use namespace

### DIFF
--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { createRouter } from './router';
-import winston from 'winston';
+import * as winston from 'winston';
 import { ConfigReader } from '@backstage/config';
 import { loadBackendConfig } from '@backstage/backend-common';
 

--- a/plugins/scaffolder-backend/src/scaffolder/jobs/logger.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/jobs/logger.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { PassThrough } from 'stream';
-import winston from 'winston';
+import * as winston from 'winston';
 import { JsonValue } from '@backstage/config';
 
 export const makeLogStream = (meta: Record<string, JsonValue>) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Hey team, 
I updated the winston reference, because the oldway is breaking when I tried to generate a new template.
I didn't put a regression test because I don't know how test that case, but I can work in that if you has any suggestion about that.

ps: the issue #1874 make reference to the scaffolder, but I replaced every peace of code I find, just for safety

Cheers
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
