### PR TITLE
cli: eslint.backend: disallow default winston import

### DIFF
--- a/packages/cli/config/eslint.backend.js
+++ b/packages/cli/config/eslint.backend.js
@@ -55,6 +55,16 @@ module.exports = {
     ],
     // Avoid cross-package imports
     'no-restricted-imports': [2, { patterns: ['**/../../**/*/src/**'] }],
+    // Avoid default import from winston as it breaks at runtime
+    'no-restricted-syntax': [
+      'error',
+      {
+        message:
+          'Default import from winston is not allowed, import `* as winston` instead.',
+        selector:
+          'ImportDeclaration[source.value="winston"] ImportDefaultSpecifier',
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
So we can avoid #1874 happening again