### PR TITLE
Enable override of sidebar selected indicator color when using createTheme

### DIFF
--- a/docs/reference/utility-apis/AppThemeApi.md
+++ b/docs/reference/utility-apis/AppThemeApi.md
@@ -178,7 +178,10 @@ type PaletteAdditions = {
   linkHover: string;
   link: string;
   gold: string;
-  sidebar: string;
+  navigation: {
+    background: string;
+    indicator: string;
+  };
   tabbar: {
     indicator: string;
   };

--- a/packages/core/src/layout/Sidebar/Bar.tsx
+++ b/packages/core/src/layout/Sidebar/Bar.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
     top: 0,
     bottom: 0,
     padding: 0,
-    background: theme.palette.sidebar.backgroundColor,
+    background: theme.palette.sidebar.background,
     overflowX: 'hidden',
     width: sidebarConfig.drawerWidthClosed,
     transition: theme.transitions.create('width', {

--- a/packages/core/src/layout/Sidebar/Bar.tsx
+++ b/packages/core/src/layout/Sidebar/Bar.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
     top: 0,
     bottom: 0,
     padding: 0,
-    background: theme.palette.sidebar.background,
+    background: theme.palette.navigation.background,
     overflowX: 'hidden',
     width: sidebarConfig.drawerWidthClosed,
     transition: theme.transitions.create('width', {

--- a/packages/core/src/layout/Sidebar/Bar.tsx
+++ b/packages/core/src/layout/Sidebar/Bar.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
     top: 0,
     bottom: 0,
     padding: 0,
-    background: theme.palette.sidebar,
+    background: theme.palette.sidebar.backgroundColor,
     overflowX: 'hidden',
     width: sidebarConfig.drawerWidthClosed,
     transition: theme.transitions.create('width', {

--- a/packages/core/src/layout/Sidebar/Items.tsx
+++ b/packages/core/src/layout/Sidebar/Items.tsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => {
     },
     selected: {
       '&$root': {
-        borderLeft: `solid ${selectedIndicatorWidth}px ${theme.palette.sidebar.indicator}`,
+        borderLeft: `solid ${selectedIndicatorWidth}px ${theme.palette.navigation.indicator}`,
         color: '#ffffff',
       },
       '&$closed': {

--- a/packages/core/src/layout/Sidebar/Items.tsx
+++ b/packages/core/src/layout/Sidebar/Items.tsx
@@ -18,10 +18,10 @@ import {
   makeStyles,
   styled,
   TextField,
-  Theme,
   Typography,
   Badge,
 } from '@material-ui/core';
+import { BackstageTheme } from '@backstage/theme';
 import { IconComponent } from '@backstage/core-api';
 import SearchIcon from '@material-ui/icons/Search';
 import clsx from 'clsx';
@@ -29,7 +29,7 @@ import React, { FC, useContext, useState, KeyboardEventHandler } from 'react';
 import { NavLink } from 'react-router-dom';
 import { sidebarConfig, SidebarContext } from './config';
 
-const useStyles = makeStyles<Theme>(theme => {
+const useStyles = makeStyles<BackstageTheme>(theme => {
   const {
     selectedIndicatorWidth,
     drawerWidthClosed,
@@ -95,7 +95,7 @@ const useStyles = makeStyles<Theme>(theme => {
     },
     selected: {
       '&$root': {
-        borderLeft: `solid ${selectedIndicatorWidth}px #9BF0E1`,
+        borderLeft: `solid ${selectedIndicatorWidth}px ${theme.palette.sidebar.selectedIndicatorColor}`,
         color: '#ffffff',
       },
       '&$closed': {

--- a/packages/core/src/layout/Sidebar/Items.tsx
+++ b/packages/core/src/layout/Sidebar/Items.tsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => {
     },
     selected: {
       '&$root': {
-        borderLeft: `solid ${selectedIndicatorWidth}px ${theme.palette.sidebar.selectedIndicatorColor}`,
+        borderLeft: `solid ${selectedIndicatorWidth}px ${theme.palette.sidebar.indicator}`,
         color: '#ffffff',
       },
       '&$closed': {

--- a/packages/theme/src/themes.ts
+++ b/packages/theme/src/themes.ts
@@ -59,7 +59,10 @@ export const lightTheme = createTheme({
     linkHover: '#2196F3',
     link: '#0A6EBE',
     gold: yellow.A700,
-    sidebar: '#171717',
+    sidebar: {
+      backgroundColor: '#171717',
+      selectedIndicatorColor: '#9BF0E1',
+    },
     pinSidebarButton: {
       icon: '#181818',
       background: '#BDBDBD',
@@ -112,7 +115,10 @@ export const darkTheme = createTheme({
     linkHover: '#2196F3',
     link: '#0A6EBE',
     gold: yellow.A700,
-    sidebar: '#424242',
+    sidebar: {
+      backgroundColor: '#424242',
+      selectedIndicatorColor: '#9BF0E1',
+    },
     pinSidebarButton: {
       icon: '#404040',
       background: '#BDBDBD',

--- a/packages/theme/src/themes.ts
+++ b/packages/theme/src/themes.ts
@@ -60,8 +60,8 @@ export const lightTheme = createTheme({
     link: '#0A6EBE',
     gold: yellow.A700,
     sidebar: {
-      backgroundColor: '#171717',
-      selectedIndicatorColor: '#9BF0E1',
+      background: '#171717',
+      indicator: '#9BF0E1',
     },
     pinSidebarButton: {
       icon: '#181818',
@@ -116,8 +116,8 @@ export const darkTheme = createTheme({
     link: '#0A6EBE',
     gold: yellow.A700,
     sidebar: {
-      backgroundColor: '#424242',
-      selectedIndicatorColor: '#9BF0E1',
+      background: '#424242',
+      indicator: '#9BF0E1',
     },
     pinSidebarButton: {
       icon: '#404040',

--- a/packages/theme/src/themes.ts
+++ b/packages/theme/src/themes.ts
@@ -59,7 +59,7 @@ export const lightTheme = createTheme({
     linkHover: '#2196F3',
     link: '#0A6EBE',
     gold: yellow.A700,
-    sidebar: {
+    navigation: {
       background: '#171717',
       indicator: '#9BF0E1',
     },
@@ -115,7 +115,7 @@ export const darkTheme = createTheme({
     linkHover: '#2196F3',
     link: '#0A6EBE',
     gold: yellow.A700,
-    sidebar: {
+    navigation: {
       background: '#424242',
       indicator: '#9BF0E1',
     },

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -43,7 +43,7 @@ type PaletteAdditions = {
   linkHover: string;
   link: string;
   gold: string;
-  sidebar: {
+  navigation: {
     background: string;
     indicator: string;
   };

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -44,8 +44,8 @@ type PaletteAdditions = {
   link: string;
   gold: string;
   sidebar: {
-    backgroundColor: string;
-    selectedIndicatorColor: string;
+    background: string;
+    indicator: string;
   };
   tabbar: {
     indicator: string;

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -43,7 +43,10 @@ type PaletteAdditions = {
   linkHover: string;
   link: string;
   gold: string;
-  sidebar: string;
+  sidebar: {
+    backgroundColor: string;
+    selectedIndicatorColor: string;
+  };
   tabbar: {
     indicator: string;
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I am working on an internal POC of Backstage and applying some simple brand colors with a custom theme but found the sidebar selected item color is not included in `PaletteAdditions` and is hardcoded in the sidebar layout, so cannot be set via `createTheme`.

With this the default themes are unchanged but are now using refactored sidebar palette properties...

```
sidebar: {
    backgroundColor: string;
    selectedIndicatorColor: string;
};
```

![Default-Dark](https://user-images.githubusercontent.com/25452743/89730459-dad9ab00-da92-11ea-8344-249d147e0ab7.png)
![Default-Light](https://user-images.githubusercontent.com/25452743/89730485-0fe5fd80-da93-11ea-866d-039a7c4ef59e.png)


Using a custom theme now allows the selected indicator to be overridden as desired...

```
sidebar: {
    backgroundColor: '#424242',
    selectedIndicatorColor: '#FF3209',
},
```

![Custom-Dark](https://user-images.githubusercontent.com/25452743/89730528-7ff48380-da93-11ea-8b18-643d6f4d5040.png)
![Custom-Light](https://user-images.githubusercontent.com/25452743/89730529-81be4700-da93-11ea-9d70-7320396c28f5.png)

I hope my understanding is correct. I am brand new to React and am working to understand the Backstage codebase.  
Thanks for the awesome project, this is my first every pull request!

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
