### PR TITLE
catalog-backend: add support for static location config + bootstrap location

### DIFF
--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -29,8 +29,9 @@ import { useHotCleanup } from '@backstage/backend-common';
 export default async function createPlugin({
   logger,
   database,
+  config,
 }: PluginEnvironment) {
-  const locationReader = new LocationReaders(logger);
+  const locationReader = new LocationReaders({ logger, config });
 
   const db = await DatabaseManager.createDatabase(database, { logger });
   const entitiesCatalog = new DatabaseEntitiesCatalog(db);

--- a/plugins/catalog-backend/migrations/20200809202832_add_bootstrap_location.js
+++ b/plugins/catalog-backend/migrations/20200809202832_add_bootstrap_location.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
+  // Adds a single 'bootstrap' location that can be used to trigger work in processors.
+  // This is primarily here to fulfill foreign key constraints.
+  await knex('locations').insert({
+    id: 'bootstrap',
+    type: 'bootstrap',
+    target: 'bootstrap',
+  });
+};
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
+  await knex('locations')
+    .where({
+      id: 'bootstrap',
+    })
+    .del();
+};

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@backstage/backend-common": "^0.1.1-alpha.18",
     "@backstage/catalog-model": "^0.1.1-alpha.18",
+    "@backstage/config": "^0.1.1-alpha.18",
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^3.0.3",

--- a/plugins/catalog-backend/src/catalog/DatabaseLocationsCatalog.test.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseLocationsCatalog.test.ts
@@ -17,6 +17,12 @@
 import { DatabaseManager } from '../database';
 import { DatabaseLocationsCatalog } from './DatabaseLocationsCatalog';
 
+const bootstrapLocation = {
+  id: 'bootstrap',
+  type: 'bootstrap',
+  target: 'bootstrap',
+};
+
 describe('DatabaseLocationsCatalog', () => {
   let catalog: DatabaseLocationsCatalog;
 
@@ -35,9 +41,12 @@ describe('DatabaseLocationsCatalog', () => {
     await expect(
       catalog.location('dd12620d-0436-422f-93bd-929aa0788123'),
     ).resolves.toEqual(expect.objectContaining({ data: location }));
-    await expect(catalog.locations()).resolves.toEqual([
-      expect.objectContaining({ data: location }),
-    ]);
+    await expect(catalog.locations()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ data: location }),
+        expect.objectContaining({ data: bootstrapLocation }),
+      ]),
+    );
   });
 
   it('does not return duplicates of rows because of logs', async () => {
@@ -60,11 +69,12 @@ describe('DatabaseLocationsCatalog', () => {
       catalog.logUpdateSuccess(location1.id),
     ).resolves.toBeUndefined();
     const locations = await catalog.locations();
-    expect(locations.length).toBe(2);
+    expect(locations.length).toBe(3);
     expect(locations).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ data: location1 }),
         expect.objectContaining({ data: location2 }),
+        expect.objectContaining({ data: bootstrapLocation }),
       ]),
     );
   });

--- a/plugins/catalog-backend/src/ingestion/processors/StaticLocationProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/StaticLocationProcessor.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LocationSpec } from '@backstage/catalog-model';
+import * as result from './results';
+import { Config } from '@backstage/config';
+import { LocationProcessorEmit } from './types';
+
+export class StaticLocationProcessor implements StaticLocationProcessor {
+  static fromConfig(config: Config): StaticLocationProcessor {
+    const locations: LocationSpec[] = [];
+
+    const lConfigs = config.getOptionalConfigArray('catalog.locations') ?? [];
+    for (const lConfig of lConfigs) {
+      const type = lConfig.getString('type');
+      const target = lConfig.getString('target');
+      locations.push({ type, target });
+    }
+
+    return new StaticLocationProcessor(locations);
+  }
+
+  constructor(private readonly staticLocations: LocationSpec[]) {}
+
+  async readLocation(
+    location: LocationSpec,
+    _optional: boolean,
+    emit: LocationProcessorEmit,
+  ): Promise<boolean> {
+    if (location.type !== 'bootstrap') {
+      return false;
+    }
+
+    for (const staticLocation of this.staticLocations) {
+      emit(result.location(staticLocation, false));
+    }
+
+    return true;
+  }
+}

--- a/plugins/catalog-backend/src/service/standaloneServer.ts
+++ b/plugins/catalog-backend/src/service/standaloneServer.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { createServiceBuilder } from '@backstage/backend-common';
+import {
+  createServiceBuilder,
+  loadBackendConfig,
+} from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { HigherOrderOperations } from '..';
@@ -34,12 +38,13 @@ export async function startStandaloneServer(
   options: ServerOptions,
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'catalog-backend' });
+  const config = ConfigReader.fromConfigs(await loadBackendConfig());
 
   logger.debug('Creating application...');
   const db = await DatabaseManager.createInMemoryDatabase({ logger });
   const entitiesCatalog = new DatabaseEntitiesCatalog(db);
   const locationsCatalog = new DatabaseLocationsCatalog(db);
-  const locationReader = new LocationReaders();
+  const locationReader = new LocationReaders({ logger, config });
   const higherOrderOperation = new HigherOrderOperations(
     entitiesCatalog,
     locationsCatalog,


### PR DESCRIPTION
Fixes #1833

Tried 3 different implementations of this, this is the least ugly one ._.

So this adds a processor that reads a `'bootstrap'` location, of which there always exists one, and it can be used to bootstrap other work.

I tried implementing this as a decorator for the `LocationCatalog`, as you can do more validation of that locations are allowed to be added with that. But that falls apart because the locations aren't added to the database, and entities has a foreign key constraint on the location id.

Another option was to do something similar to this, but use a statically added location entity instead. This felt slightly more clean though.

Overall I ran into a bunch of issues because of the existence of `LocationId`s, and would want to explore if we could completely promote all kinds of locations to entities, and then also get rid of the IDs.

I also noticed the slightly awkward fact that it's the registered location in the database that shows up as the `managed-by` location, even when emitting a location entity that is then read to collect more entities. It's again due to the location id being a requirement, and emitted locations don't receive any ID.