### PR TITLE
Refactor of sign-in page styles

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -33,7 +33,12 @@ const app = createApp({
   components: {
     SignInPage: props => {
       return (
-        <SignInPage {...props} providers={['guest', 'custom', ...providers]} />
+        <SignInPage
+          {...props}
+          providers={['guest', 'custom', ...providers]}
+          title="Select a sign-in method"
+          align="center"
+        />
       );
     },
   },

--- a/packages/core/src/layout/ContentHeader/ContentHeader.tsx
+++ b/packages/core/src/layout/ContentHeader/ContentHeader.tsx
@@ -20,6 +20,7 @@
 
 import React, { ComponentType, Fragment, FC } from 'react';
 import { Typography, makeStyles } from '@material-ui/core';
+import classNames from 'classnames';
 import { Helmet } from 'react-helmet';
 
 const useStyles = makeStyles(theme => ({
@@ -31,6 +32,9 @@ const useStyles = makeStyles(theme => ({
     justifyContent: 'flex-end',
     alignItems: 'center',
     marginBottom: theme.spacing(1),
+  },
+  centered: {
+    textAlign: 'center',
   },
   leftItemsBox: {
     flex: '1 1 auto',
@@ -73,6 +77,7 @@ type ContentHeaderProps = {
   title?: DefaultTitleProps['title'];
   titleComponent?: ComponentType;
   description?: string;
+  centered?: boolean;
 };
 
 export const ContentHeader: FC<ContentHeaderProps> = ({
@@ -80,8 +85,9 @@ export const ContentHeader: FC<ContentHeaderProps> = ({
   title,
   titleComponent: TitleComponent = undefined,
   children,
+  centered,
 }) => {
-  const classes = useStyles();
+  const classes = useStyles(centered);
 
   const renderedTitle = TitleComponent ? (
     <TitleComponent />
@@ -91,7 +97,11 @@ export const ContentHeader: FC<ContentHeaderProps> = ({
   return (
     <Fragment>
       <Helmet title={title} />
-      <div className={classes.container}>
+      <div
+        className={classNames(classes.container, {
+          [classes.centered]: centered,
+        })}
+      >
         <div className={classes.leftItemsBox}>
           {renderedTitle}
           {description && (

--- a/packages/core/src/layout/ContentHeader/ContentHeader.tsx
+++ b/packages/core/src/layout/ContentHeader/ContentHeader.tsx
@@ -20,44 +20,42 @@
 
 import React, { ComponentType, Fragment, FC } from 'react';
 import { Typography, makeStyles } from '@material-ui/core';
-import classNames from 'classnames';
 import { Helmet } from 'react-helmet';
 
-const useStyles = makeStyles(theme => ({
-  container: {
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    marginBottom: theme.spacing(1),
-  },
-  centered: {
-    textAlign: 'center',
-  },
-  leftItemsBox: {
-    flex: '1 1 auto',
-    marginBottom: theme.spacing(1),
-    minWidth: 0,
-    overflow: 'visible',
-  },
-  rightItemsBox: {
-    flex: '0 1 auto',
-    display: 'flex',
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    marginLeft: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-    minWidth: 0,
-    overflow: 'visible',
-  },
-  description: {},
-  title: {
-    display: 'inline-flex',
-  },
-}));
+const useStyles = (props: ContentHeaderProps) =>
+  makeStyles(theme => ({
+    container: {
+      width: '100%',
+      display: 'flex',
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+      marginBottom: theme.spacing(1),
+      textAlign: props.textAlign,
+    },
+    leftItemsBox: {
+      flex: '1 1 auto',
+      marginBottom: theme.spacing(1),
+      minWidth: 0,
+      overflow: 'visible',
+    },
+    rightItemsBox: {
+      flex: '0 1 auto',
+      display: 'flex',
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      marginLeft: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+      minWidth: 0,
+      overflow: 'visible',
+    },
+    description: {},
+    title: {
+      display: 'inline-flex',
+    },
+  }));
 
 type DefaultTitleProps = {
   title?: string;
@@ -77,7 +75,7 @@ type ContentHeaderProps = {
   title?: DefaultTitleProps['title'];
   titleComponent?: ComponentType;
   description?: string;
-  centered?: boolean;
+  textAlign?: 'left' | 'right' | 'center';
 };
 
 export const ContentHeader: FC<ContentHeaderProps> = ({
@@ -85,9 +83,9 @@ export const ContentHeader: FC<ContentHeaderProps> = ({
   title,
   titleComponent: TitleComponent = undefined,
   children,
-  centered,
+  textAlign = 'left',
 }) => {
-  const classes = useStyles(centered);
+  const classes = useStyles({ textAlign })();
 
   const renderedTitle = TitleComponent ? (
     <TitleComponent />
@@ -97,11 +95,7 @@ export const ContentHeader: FC<ContentHeaderProps> = ({
   return (
     <Fragment>
       <Helmet title={title} />
-      <div
-        className={classNames(classes.container, {
-          [classes.centered]: centered,
-        })}
-      >
+      <div className={classes.container}>
         <div className={classes.leftItemsBox}>
           {renderedTitle}
           {description && (

--- a/packages/core/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.tsx
@@ -64,6 +64,12 @@ const VARIANT_STYLES = {
       flexDirection: 'column',
       height: '100%',
     },
+    height100: {
+      display: 'flex',
+      flexDirection: 'column',
+      height: 'calc(100% - 10px)', // for pages without content header
+      marginBottom: '10px',
+    },
     contentheader: {
       height: 'calc(100% - 40px)', // for pages with content header
     },
@@ -80,6 +86,9 @@ const VARIANT_STYLES = {
   },
   cardContent: {
     fullHeight: {
+      flex: 1,
+    },
+    height100: {
       flex: 1,
     },
     contentRow: {
@@ -117,10 +126,10 @@ type Props = {
   deepLink?: BottomLinkProps;
   slackChannel?: string;
   variant?: string;
-  style?: React.CSSProperties;
-  cardStyle?: React.CSSProperties;
+  style?: object;
+  cardStyle?: object;
   children?: ReactNode;
-  headerStyle?: React.CSSProperties;
+  headerStyle?: object;
   headerProps?: object;
   actionsClassName?: string;
   actions?: ReactNode;
@@ -146,8 +155,6 @@ export const InfoCard: FC<Props> = ({
   actionsTopRight,
   className,
   noPadding,
-  style = {},
-  cardStyle = {},
 }) => {
   const classes = useStyles();
 
@@ -175,7 +182,7 @@ export const InfoCard: FC<Props> = ({
   }
 
   return (
-    <Card style={{ ...calculatedStyle, ...style }} className={className}>
+    <Card style={calculatedStyle} className={className}>
       <ErrorBoundary slackChannel={slackChannel}>
         {title && (
           <>
@@ -197,7 +204,7 @@ export const InfoCard: FC<Props> = ({
           className={classNames(cardClassName, {
             [classes.noPadding]: noPadding,
           })}
-          style={{ ...calculatedCardStyle, ...cardStyle }}
+          style={calculatedCardStyle}
         >
           {children}
         </CardContent>

--- a/packages/core/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.tsx
@@ -60,13 +60,9 @@ const VARIANT_STYLES = {
       flexDirection: 'column',
     },
     fullHeight: {
-      height: '100%',
-    },
-    height100: {
       display: 'flex',
       flexDirection: 'column',
-      height: 'calc(100% - 10px)', // for pages without content header
-      marginBottom: '10px',
+      height: '100%',
     },
     contentheader: {
       height: 'calc(100% - 40px)', // for pages with content header
@@ -84,10 +80,7 @@ const VARIANT_STYLES = {
   },
   cardContent: {
     fullHeight: {
-      height: 'calc(100% - 50px)',
-    },
-    height100: {
-      height: 'calc(100% - 50px)',
+      flex: 1,
     },
     contentRow: {
       display: 'flex',
@@ -124,10 +117,10 @@ type Props = {
   deepLink?: BottomLinkProps;
   slackChannel?: string;
   variant?: string;
-  style?: object;
-  cardStyle?: object;
+  style?: React.CSSProperties;
+  cardStyle?: React.CSSProperties;
   children?: ReactNode;
-  headerStyle?: object;
+  headerStyle?: React.CSSProperties;
   headerProps?: object;
   actionsClassName?: string;
   actions?: ReactNode;
@@ -153,6 +146,8 @@ export const InfoCard: FC<Props> = ({
   actionsTopRight,
   className,
   noPadding,
+  style = {},
+  cardStyle = {},
 }) => {
   const classes = useStyles();
 
@@ -180,7 +175,7 @@ export const InfoCard: FC<Props> = ({
   }
 
   return (
-    <Card style={calculatedStyle} className={className}>
+    <Card style={{ ...calculatedStyle, ...style }} className={className}>
       <ErrorBoundary slackChannel={slackChannel}>
         {title && (
           <>
@@ -202,7 +197,7 @@ export const InfoCard: FC<Props> = ({
           className={classNames(cardClassName, {
             [classes.noPadding]: noPadding,
           })}
-          style={calculatedCardStyle}
+          style={{ ...calculatedCardStyle, ...cardStyle }}
         >
           {children}
         </CardContent>

--- a/packages/core/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core/src/layout/SignInPage/SignInPage.tsx
@@ -29,14 +29,14 @@ import { useStyles } from './styles';
 export type Props = SignInPageProps & {
   providers: IdentityProviders;
   title?: string;
-  align?: 'center' | undefined;
+  align?: 'center' | 'left';
 };
 
 export const SignInPage: FC<Props> = ({
   onResult,
   providers = [],
   title,
-  align,
+  align = 'left',
 }) => {
   const configApi = useApi(configApiRef);
   const classes = useStyles();
@@ -55,10 +55,10 @@ export const SignInPage: FC<Props> = ({
     <Page>
       <Header title={configApi.getString('app.title')} />
       <Content>
-        {title && <ContentHeader title={title} centered={!!align} />}
+        {title && <ContentHeader title={title} textAlign={align} />}
         <Grid
           container
-          justify={align}
+          justify={align === 'center' ? align : 'flex-start'}
           spacing={2}
           component="ul"
           classes={classes}

--- a/packages/core/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core/src/layout/SignInPage/SignInPage.tsx
@@ -24,13 +24,22 @@ import { SignInPageProps, useApi, configApiRef } from '@backstage/core-api';
 import { useSignInProviders, getSignInProviders } from './providers';
 import { IdentityProviders } from './types';
 import { Progress } from '../../components/Progress';
+import { useStyles } from './styles';
 
 export type Props = SignInPageProps & {
   providers: IdentityProviders;
+  title?: string;
+  align?: 'center' | undefined;
 };
 
-export const SignInPage: FC<Props> = ({ onResult, providers = [] }) => {
+export const SignInPage: FC<Props> = ({
+  onResult,
+  providers = [],
+  title,
+  align,
+}) => {
   const configApi = useApi(configApiRef);
+  const classes = useStyles();
 
   const signInProviders = getSignInProviders(providers);
   const [loading, providerElements] = useSignInProviders(
@@ -46,8 +55,16 @@ export const SignInPage: FC<Props> = ({ onResult, providers = [] }) => {
     <Page>
       <Header title={configApi.getString('app.title')} />
       <Content>
-        <ContentHeader title="Select a sign-in method" />
-        <Grid container>{providerElements}</Grid>
+        {title && <ContentHeader title={title} centered={!!align} />}
+        <Grid
+          container
+          justify={align}
+          spacing={2}
+          component="ul"
+          classes={classes}
+        >
+          {providerElements}
+        </Grid>
       </Content>
     </Page>
   );

--- a/packages/core/src/layout/SignInPage/commonProvider.tsx
+++ b/packages/core/src/layout/SignInPage/commonProvider.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Grid, Typography, Button } from '@material-ui/core';
+import { Typography, Button } from '@material-ui/core';
 import { InfoCard } from '../InfoCard/InfoCard';
 import {
   ProviderComponent,
@@ -24,6 +24,7 @@ import {
   SignInConfig,
 } from './types';
 import { useApi, errorApiRef } from '@backstage/core-api';
+import { GridItem } from './styles';
 
 const Component: ProviderComponent = ({ config, onResult }) => {
   const { apiRef, title, message } = config as SignInConfig;
@@ -53,8 +54,9 @@ const Component: ProviderComponent = ({ config, onResult }) => {
   };
 
   return (
-    <Grid item>
+    <GridItem>
       <InfoCard
+        variant="fullHeight"
         title={title}
         actions={
           <Button color="primary" variant="outlined" onClick={handleLogin}>
@@ -64,7 +66,7 @@ const Component: ProviderComponent = ({ config, onResult }) => {
       >
         <Typography variant="body1">{message}</Typography>
       </InfoCard>
-    </Grid>
+    </GridItem>
   );
 };
 

--- a/packages/core/src/layout/SignInPage/customProvider.tsx
+++ b/packages/core/src/layout/SignInPage/customProvider.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import {
-  Grid,
   Typography,
   Button,
   FormControl,
@@ -28,6 +27,7 @@ import {
 import isEmpty from 'lodash/isEmpty';
 import { InfoCard } from '../InfoCard/InfoCard';
 import { ProviderComponent, ProviderLoader, SignInProvider } from './types';
+import { GridItem } from './styles';
 
 const ID_TOKEN_REGEX = /^[a-z0-9+/]+\.[a-z0-9+/]+\.[a-z0-9+/]+$/i;
 
@@ -64,8 +64,8 @@ const Component: ProviderComponent = ({ onResult }) => {
   };
 
   return (
-    <Grid item>
-      <InfoCard title="Custom User">
+    <GridItem>
+      <InfoCard title="Custom User" variant="fullHeight">
         <Typography variant="body1">
           Enter your own User ID and credentials.
           <br />
@@ -115,7 +115,7 @@ const Component: ProviderComponent = ({ onResult }) => {
           </Button>
         </form>
       </InfoCard>
-    </Grid>
+    </GridItem>
   );
 };
 

--- a/packages/core/src/layout/SignInPage/guestProvider.tsx
+++ b/packages/core/src/layout/SignInPage/guestProvider.tsx
@@ -15,8 +15,9 @@
  */
 
 import React from 'react';
-import { Grid, Typography, Button } from '@material-ui/core';
+import { Typography, Button } from '@material-ui/core';
 import { InfoCard } from '../InfoCard/InfoCard';
+import { GridItem } from './styles';
 import { ProviderComponent, ProviderLoader, SignInProvider } from './types';
 
 const result = {
@@ -28,9 +29,10 @@ const result = {
 };
 
 const Component: ProviderComponent = ({ onResult }) => (
-  <Grid item>
+  <GridItem>
     <InfoCard
       title="Guest"
+      variant="fullHeight"
       actions={
         <Button
           color="primary"
@@ -49,7 +51,7 @@ const Component: ProviderComponent = ({ onResult }) => (
         meaning some features might be unavailable.
       </Typography>
     </InfoCard>
-  </Grid>
+  </GridItem>
 );
 
 const loader: ProviderLoader = async () => {

--- a/packages/core/src/layout/SignInPage/styles.tsx
+++ b/packages/core/src/layout/SignInPage/styles.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Grid, makeStyles } from '@material-ui/core';
+
+export const useStyles = makeStyles({
+  container: {
+    padding: 0,
+    listStyle: 'none',
+  },
+  item: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    maxWidth: '400px',
+    margin: 0,
+    padding: 0,
+  },
+});
+
+export const GridItem = ({ children }: { children: JSX.Element }) => {
+  const classes = useStyles();
+
+  return (
+    <Grid component="li" item classes={classes}>
+      {children}
+    </Grid>
+  );
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR is a potential implementation that provides customization of a SignInPage layout where the layout can be centered and title omitted.

> #### ⚠️ Note
> I've removed the `height100` class from `InfoCard` component based on assumption that both `height100` and `fullHeight` are trying to achieve the same goal but in different contexts. I believe property `flex: 1` is more flexible 😊 that usage hardcoded values (Unless I don't understand the context of usage). 

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

## 📸 Screenshots
<img width="1440" alt="Screen Shot 2020-08-10 at 3 23 18 PM" src="https://user-images.githubusercontent.com/20128959/89790058-afea6800-db21-11ea-948a-5d7de8eed2f7.png">
<img width="1437" alt="Screen Shot 2020-08-10 at 3 17 16 PM" src="https://user-images.githubusercontent.com/20128959/89790075-b2e55880-db21-11ea-85d5-55bc096b5a5d.png">
<img width="1436" alt="Screen Shot 2020-08-10 at 3 15 04 PM" src="https://user-images.githubusercontent.com/20128959/89790085-b547b280-db21-11ea-8bba-96234e3b7417.png">