### PR TITLE
Scaffolder: Default to running the Container as the same user as the node process

### DIFF
--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.test.ts
@@ -126,7 +126,7 @@ describe('helpers', () => {
       );
     });
 
-    it('should pass through the user and group id from the host machine', async () => {
+    it('should pass through the user and group id from the host machine and set the home dir', async () => {
       await runDockerContainer({
         imageName,
         args,
@@ -141,6 +141,7 @@ describe('helpers', () => {
         expect.any(Stream),
         expect.objectContaining({
           User: `${process.getuid()}:${process.getgid()}`,
+          Env: ['HOME=/tmp'],
         }),
       );
     });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.test.ts
@@ -126,6 +126,25 @@ describe('helpers', () => {
       );
     });
 
+    it('should pass through the user and group id from the host machine', async () => {
+      await runDockerContainer({
+        imageName,
+        args,
+        templateDir,
+        resultDir,
+        dockerClient: mockDocker,
+      });
+
+      expect(mockDocker.run).toHaveBeenCalledWith(
+        imageName,
+        args,
+        expect.any(Stream),
+        expect.objectContaining({
+          User: `${process.getuid()}:${process.getgid()}`,
+        }),
+      );
+    });
+
     it('should pass through the log stream to the docker client', async () => {
       const logStream = new PassThrough();
       await runDockerContainer({

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
@@ -71,6 +71,9 @@ export const runDockerContainer = async ({
       return undefined;
     });
   });
+
+  const User = `${process.getuid()}:${process.getgid()}`;
+
   const [{ Error: error, StatusCode: statusCode }] = await dockerClient.run(
     imageName,
     args,
@@ -85,6 +88,7 @@ export const runDockerContainer = async ({
           `${await fs.promises.realpath(templateDir)}:/template`,
         ],
       },
+      User,
       ...createOptions,
     },
   );

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
@@ -77,20 +77,21 @@ export const runDockerContainer = async ({
   // volume sharing is done using NFS on Mac and actual mounts in Linux world.
   // So we set the user in the container as the same user and group id as the host.
   const User = `${process.getuid()}:${process.getgid()}`;
-
+  console.warn('running this new');
   const [{ Error: error, StatusCode: statusCode }] = await dockerClient.run(
     imageName,
     args,
     logStream,
     {
       Volumes: { '/result': {}, '/template': {} },
-      WorkingDir: '/tmp',
+      WorkingDir: '/home',
       HostConfig: {
         Binds: [
           // Need to use realpath here as Docker mounting does not like
           // symlinks for binding volumes
           `${await fs.promises.realpath(resultDir)}:/result`,
           `${await fs.promises.realpath(templateDir)}:/template`,
+          `${__dirname}:/home`,
         ],
       },
       User,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
@@ -72,11 +72,6 @@ export const runDockerContainer = async ({
     });
   });
 
-  // Files that are created inside the Docker container will be owned by
-  // root on the host system on non Mac systems, because of reasons. Mainly the fact that
-  // volume sharing is done using NFS on Mac and actual mounts in Linux world.
-  // So we set the user in the container as the same user and group id as the host.
-  const User = `${process.getuid()}:${process.getgid()}`;
   const [{ Error: error, StatusCode: statusCode }] = await dockerClient.run(
     imageName,
     args,
@@ -91,7 +86,13 @@ export const runDockerContainer = async ({
           `${await fs.promises.realpath(templateDir)}:/template`,
         ],
       },
-      User,
+      // Files that are created inside the Docker container will be owned by
+      // root on the host system on non Mac systems, because of reasons. Mainly the fact that
+      // volume sharing is done using NFS on Mac and actual mounts in Linux world.
+      // So we set the user in the container as the same user and group id as the host.
+      User: `${process.getuid()}:${process.getgid()}`,
+      // Set the home directory inside the container as something that applications can
+      // write to, otherwise they will just flop and fail trying to write to /
       Env: ['HOME=/tmp'],
       ...createOptions,
     },

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
@@ -72,6 +72,10 @@ export const runDockerContainer = async ({
     });
   });
 
+  // Files that are created inside the Docker container will be owned by
+  // root on the host system on non Mac systems, because of reasons. Mainly the fact that
+  // volume sharing is done using NFS on Mac and actual mounts in Linux world.
+  // So we set the user in the container as the same user and group id as the host.
   const User = `${process.getuid()}:${process.getgid()}`;
 
   const [{ Error: error, StatusCode: statusCode }] = await dockerClient.run(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
@@ -84,6 +84,7 @@ export const runDockerContainer = async ({
     logStream,
     {
       Volumes: { '/result': {}, '/template': {} },
+      WorkingDir: '/tmp',
       HostConfig: {
         Binds: [
           // Need to use realpath here as Docker mounting does not like

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/helpers.ts
@@ -77,24 +77,22 @@ export const runDockerContainer = async ({
   // volume sharing is done using NFS on Mac and actual mounts in Linux world.
   // So we set the user in the container as the same user and group id as the host.
   const User = `${process.getuid()}:${process.getgid()}`;
-  console.warn('running this new');
   const [{ Error: error, StatusCode: statusCode }] = await dockerClient.run(
     imageName,
     args,
     logStream,
     {
       Volumes: { '/result': {}, '/template': {} },
-      WorkingDir: '/home',
       HostConfig: {
         Binds: [
           // Need to use realpath here as Docker mounting does not like
           // symlinks for binding volumes
           `${await fs.promises.realpath(resultDir)}:/result`,
           `${await fs.promises.realpath(templateDir)}:/template`,
-          `${__dirname}:/home`,
         ],
       },
       User,
+      Env: ['HOME=/tmp'],
       ...createOptions,
     },
   );


### PR DESCRIPTION
- Thanks to how Docker runs on Docker for Mac this issue seems to have crept by
- On Docker for Mac, the volume mounts are done over NFS, which means any file created by the docker container, permissions don't care as NFS just makes things work.
- On Linux, maybe windows too?, files created by Docker containers are always created as root unless otherwise specified, which means that this fails to run `git init` in a folder which has been created by root.
- Now we run the container with the same `uid` and `gid` as the host process, kindly provided by node so it should work for windows too, to the docker client so that it can make stuff we can actually use.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
