### PR TITLE
Allow passing custom app template to create-app

### DIFF
--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -118,7 +118,6 @@ export default async (cmd: Command): Promise<void> => {
   answers.dbTypePG = answers.dbType === 'PostgreSQL';
   answers.dbTypeSqlite = answers.dbType === 'SQLite';
 
-  const templateDir = paths.resolveOwn('templates/default-app');
   const tempDir = resolvePath(os.tmpdir(), answers.name);
   const appDir = resolvePath(paths.targetDir, answers.name);
 
@@ -133,6 +132,11 @@ export default async (cmd: Command): Promise<void> => {
     await createTemporaryAppFolder(tempDir);
 
     Task.section('Preparing files');
+    let templateDir = paths.resolveOwn('templates/default-app');
+    if (cmd.templateDir) {
+      Task.log(`Using custom app template from ${cmd.templateDir}`);
+      templateDir = cmd.templateDir;
+    }
     await templatingTask(templateDir, tempDir, { ...answers, version });
 
     Task.section('Moving to final location');

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -28,6 +28,10 @@ const main = (argv: string[]) => {
       '--skip-install',
       'Skip the install and builds steps after creating the app',
     )
+    .option(
+      '--template-dir',
+      'Provide a path to a custom app template',
+    )
     .action(createApp);
 
   program.parse(argv);


### PR DESCRIPTION
I would like to be able to iterate on the template that ships with Backstage. To do this, I need to either modify the template in `packages/create-app/templates/default-app` in place and then run `create-app` locally so it picks up my modified template (which as you'll see I can't figure out how to do), or run `npx @backstage/create-app` and pass in a modified template as an option.

To be honest, I have no idea if this works because I can't figure out how to run my modified version of `create-app` locally.

----
Here's what I see when I try to run this (this might be a really dumb problem - monorepos confuse me 🤯 )

```shell
» cd packages/create-app
» yarn tsc && yarn build
» node dist/index.cjs.js --help
/Users/davidtuite/dev/roadie/backstage/packages/cli-common/src/index.ts:17
export { findPaths } from './paths';
^^^^^^

SyntaxError: Unexpected token 'export'
    at wrapSafe (internal/modules/cjs/loader.js:1054:16)
    at Module._compile (internal/modules/cjs/loader.js:1102:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
```