### PR TITLE
packages: fix ts-node config in local dev versions of CLIs

### DIFF
--- a/packages/cli/bin/backstage-cli
+++ b/packages/cli/bin/backstage-cli
@@ -25,6 +25,7 @@ if (!isLocal || process.env.BACKSTAGE_E2E_CLI_TEST) {
 } else {
   require('ts-node').register({
     transpileOnly: true,
+    project: path.resolve(__dirname, '../../../tsconfig.json'),
     compilerOptions: {
       module: 'CommonJS',
     },

--- a/packages/create-app/bin/backstage-create-app
+++ b/packages/create-app/bin/backstage-create-app
@@ -25,6 +25,7 @@ if (!isLocal || process.env.BACKSTAGE_E2E_CLI_TEST) {
 } else {
   require('ts-node').register({
     transpileOnly: true,
+    project: path.resolve(__dirname, '../../../tsconfig.json'),
     compilerOptions: {
       module: 'CommonJS',
     },

--- a/packages/docgen/bin/backstage-docgen
+++ b/packages/docgen/bin/backstage-docgen
@@ -25,6 +25,7 @@ if (!isLocal || process.env.BACKSTAGE_E2E_CLI_TEST) {
 } else {
   require('ts-node').register({
     transpileOnly: true,
+    project: path.resolve(__dirname, '../../../tsconfig.json'),
     compilerOptions: {
       module: 'CommonJS',
     },

--- a/packages/techdocs-cli/bin/techdocs-cli
+++ b/packages/techdocs-cli/bin/techdocs-cli
@@ -25,6 +25,7 @@ if (!isLocal) {
 } else {
   require('ts-node').register({
     transpileOnly: true,
+    project: path.resolve(__dirname, '../../../tsconfig.json'),
     compilerOptions: {
       module: 'CommonJS',
     },


### PR DESCRIPTION
Not sure exactly what broke this, but the CLI wrappers where no longer finding the `tsconfig.json` in the project root, which in turn made them all fail to run outside of the project.