### PR TITLE
workflows: run CLI e2e tests with same scope as Frontend CI

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -2,13 +2,9 @@ name: CLI Test
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/cli.yml'
-      - 'packages/cli/**'
-      - 'packages/create-app/**'
-      - 'packages/core/**'
-      - 'packages/core-api/**'
-      - 'yarn.lock'
+    paths-ignore:
+      - 'microsite/**'
+
 
 jobs:
   build:


### PR DESCRIPTION
We've had many issues the past few weeks that would've been caught if these tests were run. Let's run them for changes everywhere, they're faster than the Frontend CI builds anyway :grin:

Fixes #1937