### PR TITLE
feat(catalog): update trivial tab implementation

### DIFF
--- a/packages/catalog-model/examples/petstore-component.yaml
+++ b/packages/catalog-model/examples/petstore-component.yaml
@@ -7,7 +7,7 @@ spec:
   type: service
   lifecycle: experimental
   owner: pets@example.com
-  implementedApis:
+  implementsApis:
     - petstore
     - streetlights
     - hello-world

--- a/plugins/catalog/src/components/EntityPageApi/EntityPageApi.tsx
+++ b/plugins/catalog/src/components/EntityPageApi/EntityPageApi.tsx
@@ -28,7 +28,7 @@ export const EntityPageApi: FC<{ entity: Entity }> = ({ entity }) => {
 
   const { value: apiEntities, loading } = useAsync(async () => {
     const a = await Promise.all(
-      ((entity?.spec?.implementedApis as string[]) || []).map(api =>
+      ((entity?.spec?.implementsApis as string[]) || []).map(api =>
         catalogApi.getEntityByName({
           kind: 'API',
           name: api,
@@ -48,7 +48,7 @@ export const EntityPageApi: FC<{ entity: Entity }> = ({ entity }) => {
       {loading && <Progress />}
       {!loading && (
         <Grid container spacing={3}>
-          {((entity?.spec?.implementedApis as string[]) || []).map(api => {
+          {((entity?.spec?.implementsApis as string[]) || []).map(api => {
             const apiEntity = apiEntities && apiEntities.get(api);
 
             return (


### PR DESCRIPTION
This is a follow up to #1737. I lost this file during one of my rebases 😢.

This PR adds the change with the trivial tab implementation that enables the API tab on the entity page.