### PR TITLE
Display login method based on what specified in app-config.yml

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -27,6 +27,7 @@ describe('App', () => {
           data: {
             app: { title: 'Test' },
             backend: { baseUrl: 'http://localhost:7000' },
+            auth: { providers: {} },
           },
           context: 'test',
         },

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -19,19 +19,23 @@ import {
   AlertDisplay,
   OAuthRequestDialog,
   SignInPage,
+  useApi,
+  configApiRef,
 } from '@backstage/core';
 import React, { FC } from 'react';
 import Root from './components/Root';
 import * as plugins from './plugins';
 import { apis } from './apis';
 import { hot } from 'react-hot-loader/root';
-import { providers } from './identityProviders';
+import { getProviders } from './identityProviders';
 
 const app = createApp({
   apis,
   plugins: Object.values(plugins),
   components: {
     SignInPage: props => {
+      const configApi = useApi(configApiRef);
+      const providers = getProviders(configApi);
       return (
         <SignInPage
           {...props}

--- a/packages/app/src/identityProviders.ts
+++ b/packages/app/src/identityProviders.ts
@@ -19,7 +19,16 @@ import {
   gitlabAuthApiRef,
   oktaAuthApiRef,
   githubAuthApiRef,
+  ConfigApi,
+  ApiRef,
 } from '@backstage/core';
+
+type ProviderConfig = {
+  id: string;
+  title: string;
+  message: string;
+  apiRef: ApiRef<any>;
+};
 
 export const providers = [
   {
@@ -47,3 +56,20 @@ export const providers = [
     apiRef: oktaAuthApiRef,
   },
 ];
+
+/**
+ * Only include the ones that are listed on the config file based on 
+ * the title specified above.
+ */
+export const getProviders = (config: ConfigApi): ProviderConfig[] => {
+  const authProviderConfig = config.getConfig('auth.providers').keys();
+  const activeProvider: ProviderConfig[] = [];
+
+  providers.map(item => {
+    if (authProviderConfig.includes(item.title.toLocaleLowerCase())) {
+      activeProvider.push(item);
+    }
+  });
+
+  return activeProvider;
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Was working on implementing SAML auth for my org, and wanted to have to option to remove sign in method that i'm not using. Looks like it is somewhat hardcoded on  packages/app/src/identityProviders.ts just thought that it would be useful to have it check the config for which sign in method to show. 

(I think 'guest' and 'custom' method should also be something configurable? 🤔 )

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
