### PR TITLE
Improve styling of OpenAPI component (especially in dark mode)

### DIFF
--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
@@ -15,12 +15,61 @@
  */
 
 import React, { FC, useEffect, useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
 import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
+
+// TODO: Schemas
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    '& .swagger-ui, .info h1, .info h2, .info h3, .info h4, .info h': {
+      'font-family': 'inherit',
+      color: theme.palette.text.primary,
+    },
+    '& .scheme-container': {
+      'background-color': theme.palette.background.default,
+    },
+    '& .opblock-tag, .opblock-tag small, table thead tr td, table thead tr th': {
+      color: theme.palette.text.primary,
+      'border-color': theme.palette.divider,
+    },
+    '& section.models, section.models.is-open h4': {
+      'border-color': theme.palette.divider,
+    },
+    '& .opblock .opblock-summary-description, .parameter__type, table.headers td, .model-title, .model .property.primitive': {
+      color: theme.palette.text.secondary,
+    },
+    '& .opblock .opblock-summary-operation-id, .opblock .opblock-summary-path, .opblock .opblock-summary-path__deprecated, .opblock .opblock-section-header h4, .parameter__name, .response-col_status, .response-col_links, .responses-inner h4, .swagger-ui .responses-inner h5, .opblock-section-header .btn, .tab li, .info li, .info p, .info table, section.models h4, .info .title, table.model tr.description, .property-row': {
+      color: theme.palette.text.primary,
+    },
+    '& .opblock .opblock-section-header, .model-box, section.models .model-container': {
+      background: theme.palette.background.default,
+    },
+    '& .prop-format, .parameter__in': {
+      color: theme.palette.text.disabled,
+    },
+    '& ': {
+      color: theme.palette.text.primary,
+      'border-color': theme.palette.divider,
+    },
+    '& .opblock-description-wrapper p, .opblock-external-docs-wrapper p, .opblock-title_normal p, .response-control-media-type__accept-message, .opblock .opblock-section-header>label, .scheme-container .schemes>label, .info .base-url, .model': {
+      color: theme.palette.text.hint,
+    },
+    '& .parameter__name.required:after': {
+      color: theme.palette.warning.dark,
+    },
+    '& .prop-type': {
+      color: theme.palette.primary.main,
+    },
+  },
+}));
 
 export const OpenApiDefinitionWidget: FC<{
   definition: any;
 }> = ({ definition }) => {
+  const classes = useStyles();
+
   // Due to a bug in the swagger-ui-react component, the component needs
   // to be created without content first.
   const [def, setDef] = useState('');
@@ -30,10 +79,8 @@ export const OpenApiDefinitionWidget: FC<{
     return () => clearTimeout(timer);
   }, [definition, setDef]);
 
-  // TODO: This looks fine in the light theme, but wrong in dark mode. We need a custom stylesheet for swagger-ui.
-  // Till then, we add a white background to the swagger-ui to make it usable in dark mode.
   return (
-    <div style={{ backgroundColor: 'white' }}>
+    <div className={classes.root}>
       <SwaggerUI spec={def} />
     </div>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In #1737 we skipped the (dark mode) theming for the OpenAPI display component, so here it is.

![image](https://user-images.githubusercontent.com/648527/90253260-29939600-de41-11ea-8da1-103657268e75.png)
![image](https://user-images.githubusercontent.com/648527/90253294-39ab7580-de41-11ea-9642-54e39cfef76c.png)


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
