### PR TITLE
The backend listens to all interfaces by default

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -5,7 +5,6 @@ app:
 backend:
   baseUrl: http://localhost:7000
   listen:
-    host: 0.0.0.0
     port: 7000
   cors:
     origin: http://localhost:3000

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -33,7 +33,7 @@ import { ServiceBuilder } from '../types';
 import { readBaseOptions, readCorsOptions } from './config';
 
 const DEFAULT_PORT = 7000;
-const DEFAULT_HOST = 'localhost';
+const DEFAULT_HOST = '';
 
 export class ServiceBuilderImpl implements ServiceBuilder {
   private port: number | undefined;

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -33,6 +33,7 @@ import { ServiceBuilder } from '../types';
 import { readBaseOptions, readCorsOptions } from './config';
 
 const DEFAULT_PORT = 7000;
+// '' is express default, which listens to all interfaces
 const DEFAULT_HOST = '';
 
 export class ServiceBuilderImpl implements ServiceBuilder {

--- a/packages/create-app/templates/default-app/app-config.yaml
+++ b/packages/create-app/templates/default-app/app-config.yaml
@@ -8,7 +8,6 @@ organization:
 backend:
   baseUrl: http://localhost:7000
   listen:
-    host: 0.0.0.0
     port: 7000
   cors:
     origin: http://localhost:3000


### PR DESCRIPTION
Previously,  if you did not specify a host,  it would only
listen to localhost,  so it would not accept connections from the network.

If you use the default generated app,  it is configured to listen to 0.0.0.0
which only listens to IPv4 interfaces.

This changes the default behavior, just listen to all interfaces.
