### PR TITLE
fix(core): pin material-table to fix e2e CI errors in master

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "classnames": "^2.2.6",
     "clsx": "^1.1.0",
     "lodash": "^4.17.15",
-    "material-table": "1.68.x",
+    "material-table": "1.68.0",
     "prop-types": "^15.7.2",
     "rc-progress": "^3.0.0",
     "react": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15310,7 +15310,7 @@ markdown-toc@^1.2.0:
     repeat-string "^1.6.1"
     strip-color "^0.1.0"
 
-material-table@1.68.x:
+material-table@1.68.0:
   version "1.68.0"
   resolved "https://registry.npmjs.org/material-table/-/material-table-1.68.0.tgz#275c3d9a885c40ae4bc5a7461c00e877f92397b9"
   integrity sha512-dyJJaVsS3m+i6sn71AvYcVdA1P9X1XiUOM2PekfvEeeMtkdQb66oChGkk77ndYi3Ja6j4DovGVNrgeVLwXLZiw==


### PR DESCRIPTION
This PR https://github.com/mbrn/material-table/pull/2311 broke webpack based builds of projects that use material-table. We don't see the problem locally since we have the unaffected version in our lockfiles. However when running the e2e (app generation) flows, there is no lockfile so it resolves to the affected broken versions, breaking master builds at the moment.

Pinning to the unaffected version for now.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
