### PR TITLE
Add GitHub pull requests plugin

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -27,6 +27,7 @@
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",
     "@octokit/rest": "^18.0.0",
+    "@roadiehq/backstage-plugin-github-pull-requests": "0.3.0",
     "@roadiehq/backstage-plugin-travis-ci": "^0.1.3",
     "history": "^5.0.0",
     "prop-types": "^15.7.2",

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -74,6 +74,7 @@ import {
   TravisCIApi,
   travisCIApiRef,
 } from '@roadiehq/backstage-plugin-travis-ci';
+import { GithubPullRequestsClient, githubPullRequestsApiRef } from '@roadiehq/backstage-plugin-github-pull-requests';
 
 export const apis = (config: ConfigApi) => {
   // eslint-disable-next-line no-console
@@ -105,6 +106,7 @@ export const apis = (config: ConfigApi) => {
   builder.add(lighthouseApiRef, new LighthouseRestApi('http://localhost:3003'));
 
   builder.add(travisCIApiRef, new TravisCIApi());
+  builder.add(githubPullRequestsApiRef, new GithubPullRequestsClient());
 
   const oauthRequestApi = builder.add(
     oauthRequestApiRef,

--- a/packages/app/src/plugins.ts
+++ b/packages/app/src/plugins.ts
@@ -31,3 +31,4 @@ export { plugin as Newrelic } from '@backstage/plugin-newrelic';
 export { plugin as TravisCI } from '@roadiehq/backstage-plugin-travis-ci';
 export { plugin as Jenkins } from '@backstage/plugin-jenkins';
 export { plugin as ApiDocs } from '@backstage/plugin-api-docs';
+export { plugin as GithubPullRequests } from '@roadiehq/backstage-plugin-github-pull-requests';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3308,6 +3308,29 @@
   resolved "https://registry.npmjs.org/@rjsf/material-ui/-/material-ui-2.3.0.tgz#a051eb4db2ad778e39933a31ba806f415dd3ba90"
   integrity sha512-v/xZ4Xk18ZgBARcCe99IDqdO97GU0UC784gG8PhGGFDdy5Rbdy7ixTjHkGYttkr43PB7SX6ttohNhkKSW4nATQ==
 
+"@roadiehq/backstage-plugin-github-pull-requests@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-github-pull-requests/-/backstage-plugin-github-pull-requests-0.3.0.tgz#465cb74b1dab6f34a5a5bf4fa57b6c1d312bc5b7"
+  integrity sha512-nSyMh8p3SAYj1yj5/+Po82g7aZwF5pWb+fh7bLPdf+ywl5pa+aKQxAVNCvlvgfN2WZ9gDTMbCPyWDgCfeJ/V9g==
+  dependencies:
+    "@backstage/catalog-model" "^0.1.1-alpha.16"
+    "@backstage/core" "^0.1.1-alpha.16"
+    "@backstage/core-api" "^0.1.1-alpha.16"
+    "@backstage/plugin-catalog" "^0.1.1-alpha.16"
+    "@backstage/theme" "^0.1.1-alpha.16"
+    "@material-ui/core" "^4.9.1"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.45"
+    "@octokit/rest" "^18.0.0"
+    "@octokit/types" "^5.0.1"
+    "@types/react-dom" "^16.9.8"
+    history "^5.0.0"
+    moment "^2.27.0"
+    react "^16.13.1"
+    react-dom "^16.13.1"
+    react-router-dom "6.0.0-beta.0"
+    react-use "^15.3.3"
+
 "@roadiehq/backstage-plugin-travis-ci@^0.1.3":
   version "0.1.3"
   resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-travis-ci/-/backstage-plugin-travis-ci-0.1.3.tgz#597882bb6db119b9c8970f15cc506c5d70ba2c41"


### PR DESCRIPTION
See pull requests against your entities/services, and see statistics for your last N pull requests.

For now, everything is available on `/github-pull-requests`. We will move the CI table to the tabs on the entities page once a tabs implementation is merged. We will also move the statistics widget to the overview page.

[Code here.](https://github.com/RoadieHQ/backstage-plugin-github-pull-requests) The readme will be updated with install instructions today.

![Screenshot 2020-08-17 at 15 09 49](https://user-images.githubusercontent.com/562403/90405824-37912300-e09c-11ea-95b5-07f30393ba2f.png)

Closes #1808 
