### PR TITLE
fix: remove redundant steps from docs build

### DIFF
--- a/microsite/package.json
+++ b/microsite/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",
-    "build": "docusaurus-build && cp static/img/*.svg build/backstage/img/",
+    "build": "docusaurus-build",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",


### PR DESCRIPTION
Additional step of moving static assets became redundant with docusaurus v2 (https://v2.docusaurus.io/docs/static-assets/)