### PR TITLE
Add tags to catalog entities

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -42,6 +42,7 @@ software catalog API.
     "labels": {
       "system": "public-websites"
     },
+    "tags": ["java"],
     "name": "artist-web",
     "uid": "2152f463-549d-4d8d-a94d-ce2b7676c6e2"
   },
@@ -66,6 +67,8 @@ metadata:
   annotations:
     example.com/service-discovery: artistweb
     circleci.com/project-slug: gh/example-org/artist-website
+  tags:
+    - java
 spec:
   type: website
   lifecycle: production
@@ -231,6 +234,20 @@ separated by any of `[-_.]`, at most 63 characters in total.
 The `backstage.io/` prefix is reserved for use by Backstage core components.
 
 Values can be of any length, but are limited to being strings.
+
+### `tags` [optional]
+
+A list of single-valued strings, for example to classify catalog entities in
+various ways. This is different to the labels in metadata, as labels are
+key-value pairs.
+
+The values are user defined, for example the programming language used for the
+component, like `java` or `go`.
+
+This field is optional, and currently has no special semantics.
+
+Each tag must be sequences of `[a-zA-Z0-9]` separated by `-`, at most 63
+characters in total.
 
 ## Kind: Component
 

--- a/packages/catalog-model/examples/artist-lookup-component.yaml
+++ b/packages/catalog-model/examples/artist-lookup-component.yaml
@@ -3,6 +3,9 @@ kind: Component
 metadata:
   name: artist-lookup
   description: Artist Lookup
+  tags:
+    - java
+    - data
 spec:
   type: service
   lifecycle: experimental

--- a/packages/catalog-model/examples/podcast-api-component.yaml
+++ b/packages/catalog-model/examples/podcast-api-component.yaml
@@ -3,6 +3,8 @@ kind: Component
 metadata:
   name: podcast-api
   description: Podcast API
+  tags:
+    - java
 spec:
   type: service
   lifecycle: experimental

--- a/packages/catalog-model/examples/queue-proxy-component.yaml
+++ b/packages/catalog-model/examples/queue-proxy-component.yaml
@@ -3,6 +3,9 @@ kind: Component
 metadata:
   name: queue-proxy
   description: Queue Proxy
+  tags:
+    - go
+    - website
 spec:
   type: website
   lifecycle: production

--- a/packages/catalog-model/examples/searcher-component.yaml
+++ b/packages/catalog-model/examples/searcher-component.yaml
@@ -3,6 +3,8 @@ kind: Component
 metadata:
   name: searcher
   description: Searcher
+  tags:
+    - go
 spec:
   type: service
   lifecycle: production

--- a/packages/catalog-model/examples/shuffle-api-component.yaml
+++ b/packages/catalog-model/examples/shuffle-api-component.yaml
@@ -3,6 +3,8 @@ kind: Component
 metadata:
   name: shuffle-api
   description: Shuffle API
+  tags:
+    - go
 spec:
   type: service
   lifecycle: production

--- a/packages/catalog-model/examples/streetlights-api.yaml
+++ b/packages/catalog-model/examples/streetlights-api.yaml
@@ -3,6 +3,8 @@ kind: API
 metadata:
   name: streetlights
   description: The Smartylighting Streetlights API allows you to remotely manage the city lights.
+  tags:
+    - unstable
 spec:
   type: asyncapi
   definition: |

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -113,6 +113,12 @@ export type EntityMeta = JsonObject & {
    * entity.
    */
   annotations?: Record<string, string>;
+
+  /**
+   * A list of single-valued strings, to for example classify catalog entities in
+   * various ways.
+   */
+  tags?: string[];
 };
 
 /**

--- a/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.test.ts
+++ b/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.test.ts
@@ -35,6 +35,9 @@ describe('FieldFormatEntityPolicy', () => {
           backstage.io/custom: ValueStuff
         annotations:
           example.com/bindings: are-secret
+        tags:
+          - java
+          - data-service
       spec:
         custom: stuff
     `);
@@ -101,5 +104,10 @@ describe('FieldFormatEntityPolicy', () => {
   it('rejects bad annotation value', async () => {
     data.metadata.annotations.a = 7;
     await expect(policy.enforce(data)).rejects.toThrow(/annotation.*7/i);
+  });
+
+  it('rejects bad tag value', async () => {
+    data.metadata.tags.push('Hello World');
+    await expect(policy.enforce(data)).rejects.toThrow(/tags.*"Hello World"/i);
   });
 });

--- a/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.ts
+++ b/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.ts
@@ -83,6 +83,12 @@ export class FieldFormatEntityPolicy implements EntityPolicy {
       require(`annotations.${k}`, v, this.validators.isValidAnnotationValue);
     }
 
+    const tags = entity.metadata.tags ?? [];
+
+    for (let i = 0; i < tags.length; ++i) {
+      require(`tags.${i}`, tags[i], this.validators.isValidTag);
+    }
+
     return entity;
   }
 }

--- a/packages/catalog-model/src/entity/policies/ReservedFieldsEntityPolicy.test.ts
+++ b/packages/catalog-model/src/entity/policies/ReservedFieldsEntityPolicy.test.ts
@@ -35,6 +35,9 @@ describe('ReservedFieldsEntityPolicy', () => {
           backstage.io/custom: ValueStuff
         annotations:
           example.com/bindings: are-secret
+        tags:
+          - java
+          - data
       spec:
         custom: stuff
     `);

--- a/packages/catalog-model/src/entity/policies/ReservedFieldsEntityPolicy.ts
+++ b/packages/catalog-model/src/entity/policies/ReservedFieldsEntityPolicy.ts
@@ -29,6 +29,7 @@ const DEFAULT_RESERVED_ENTITY_FIELDS: string[] = [
   'metadata.description',
   'metadata.labels',
   'metadata.annotations',
+  'metadata.tags',
   // The below items are known to appear in core kinds, and therefore should
   // not be appearing in metadata (which would indicate that the user made a
   // mistake in where to place them).

--- a/packages/catalog-model/src/entity/policies/SchemaValidEntityPolicy.test.ts
+++ b/packages/catalog-model/src/entity/policies/SchemaValidEntityPolicy.test.ts
@@ -36,6 +36,9 @@ describe('SchemaValidEntityPolicy', () => {
           backstage.io/custom: ValueStuff
         annotations:
           example.com/bindings: are-secret
+        tags:
+          - java
+          - data
       spec:
         custom: stuff
     `);
@@ -188,6 +191,11 @@ describe('SchemaValidEntityPolicy', () => {
   it('rejects bad annotations type', async () => {
     data.metadata.annotations = 7;
     await expect(policy.enforce(data)).rejects.toThrow(/annotations/);
+  });
+
+  it('rejects bad tags type', async () => {
+    data.metadata.tags = 7;
+    await expect(policy.enforce(data)).rejects.toThrow(/tags/);
   });
 
   //

--- a/packages/catalog-model/src/entity/policies/SchemaValidEntityPolicy.ts
+++ b/packages/catalog-model/src/entity/policies/SchemaValidEntityPolicy.ts
@@ -31,6 +31,7 @@ const DEFAULT_ENTITY_SCHEMA = yup.object({
       description: yup.string().notRequired(),
       labels: yup.object<Record<string, string>>().notRequired(),
       annotations: yup.object<Record<string, string>>().notRequired(),
+      tags: yup.array<string>().notRequired(),
     })
     .required(),
   spec: yup.object({}).notRequired(),

--- a/packages/catalog-model/src/validation/makeValidator.ts
+++ b/packages/catalog-model/src/validation/makeValidator.ts
@@ -28,6 +28,7 @@ const defaultValidators: Validators = {
   isValidLabelValue: KubernetesValidatorFunctions.isValidLabelValue,
   isValidAnnotationKey: KubernetesValidatorFunctions.isValidAnnotationKey,
   isValidAnnotationValue: KubernetesValidatorFunctions.isValidAnnotationValue,
+  isValidTag: CommonValidatorFunctions.isValidDnsLabel,
 };
 
 export function makeValidator(overrides: Partial<Validators> = {}): Validators {

--- a/packages/catalog-model/src/validation/types.ts
+++ b/packages/catalog-model/src/validation/types.ts
@@ -24,4 +24,5 @@ export type Validators = {
   isValidLabelValue(value: any): boolean;
   isValidAnnotationKey(value: any): boolean;
   isValidAnnotationValue(value: any): boolean;
+  isValidTag(value: any): boolean;
 };

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -127,7 +127,8 @@ function convertColumns<T extends object>(
 ): TableColumn<T>[] {
   return columns.map(column => {
     const headerStyle: React.CSSProperties = {};
-    const cellStyle: React.CSSProperties = {};
+    const cellStyle: React.CSSProperties =
+      typeof column.cellStyle === 'object' ? column.cellStyle : {};
 
     if (column.highlight) {
       headerStyle.color = theme.palette.textContrast;

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -35,6 +35,7 @@ import { CatalogTable } from '../CatalogTable/CatalogTable';
 import CatalogLayout from './CatalogLayout';
 import { CatalogTabs, LabeledComponentType } from './CatalogTabs';
 import { WelcomeBanner } from './WelcomeBanner';
+import { ResultsFilter } from '../ResultsFilter/ResultsFilter';
 
 const useStyles = makeStyles(theme => ({
   contentWrapper: {
@@ -47,7 +48,12 @@ const useStyles = makeStyles(theme => ({
 
 const CatalogPageContents = () => {
   const styles = useStyles();
-  const { loading, error, matchingEntities } = useFilteredEntities();
+  const {
+    loading,
+    error,
+    matchingEntities,
+    availableTags,
+  } = useFilteredEntities();
   const { isStarredEntity } = useStarredEntities();
   const userId = useApi(identityApiRef).getUserId();
   const [selectedTab, setSelectedTab] = useState<string>();
@@ -140,6 +146,7 @@ const CatalogPageContents = () => {
               onChange={({ label }) => setSelectedSidebarItem(label)}
               initiallySelected="owned"
             />
+            <ResultsFilter availableTags={availableTags} />
           </div>
           <CatalogTable
             titlePreamble={selectedSidebarItem ?? ''}

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -15,7 +15,7 @@
  */
 import { Entity, LocationSpec } from '@backstage/catalog-model';
 import { Table, TableColumn, TableProps } from '@backstage/core';
-import { Link } from '@material-ui/core';
+import { Link, Chip } from '@material-ui/core';
 import Edit from '@material-ui/icons/Edit';
 import GitHub from '@material-ui/icons/GitHub';
 import { Alert } from '@material-ui/lab';
@@ -62,6 +62,21 @@ const columns: TableColumn<Entity>[] = [
   {
     title: 'Description',
     field: 'metadata.description',
+  },
+  {
+    title: 'Tags',
+    field: 'metadata.tags',
+    cellStyle: {
+      padding: '0px 16px 0px 20px',
+    },
+    render: (entity: Entity) => (
+      <>
+        {entity.metadata.tags &&
+          entity.metadata.tags.map(t => (
+            <Chip label={t} color="secondary" style={{ marginBottom: '0px' }} />
+          ))}
+      </>
+    ),
   },
 ];
 

--- a/plugins/catalog/src/components/ResultsFilter/ResultsFilter.test.tsx
+++ b/plugins/catalog/src/components/ResultsFilter/ResultsFilter.test.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  ApiProvider,
+  ApiRegistry,
+  IdentityApi,
+  identityApiRef,
+  storageApiRef,
+} from '@backstage/core';
+import { MockStorageApi, wrapInTestApp } from '@backstage/test-utils';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { CatalogApi, catalogApiRef } from '../../api/types';
+import { EntityFilterGroupsProvider } from '../../filter';
+import { ResultsFilter } from './ResultsFilter';
+
+describe('Results Filter', () => {
+  const catalogApi: Partial<CatalogApi> = {
+    getEntities: () =>
+      Promise.resolve([
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: {
+            name: 'Entity1',
+            tags: ['java'],
+          },
+          spec: {
+            owner: 'tools@example.com',
+            type: 'service',
+          },
+        },
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: {
+            name: 'Entity2',
+          },
+          spec: {
+            owner: 'not-tools@example.com',
+            type: 'service',
+          },
+        },
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: {
+            name: 'Entity3',
+            tags: ['java', 'test'],
+          },
+          spec: {
+            owner: 'tools@example.com',
+            type: 'service',
+          },
+        },
+      ] as Entity[]),
+  };
+
+  const indentityApi: Partial<IdentityApi> = {
+    getUserId: () => 'tools@example.com',
+  };
+
+  const renderWrapped = (children: React.ReactNode) =>
+    render(
+      wrapInTestApp(
+        <ApiProvider
+          apis={ApiRegistry.from([
+            [catalogApiRef, catalogApi],
+            [identityApiRef, indentityApi],
+            [storageApiRef, MockStorageApi.create()],
+          ])}
+        >
+          <EntityFilterGroupsProvider>{children}</EntityFilterGroupsProvider>,
+        </ApiProvider>,
+      ),
+    );
+
+  it('should render all available tags', async () => {
+    const tags = ['test', 'java'];
+    const { findByText } = renderWrapped(
+      <ResultsFilter availableTags={tags} />,
+    );
+    for (const tag of tags) {
+      expect(await findByText(tag)).toBeInTheDocument();
+    }
+  });
+});

--- a/plugins/catalog/src/components/ResultsFilter/ResultsFilter.tsx
+++ b/plugins/catalog/src/components/ResultsFilter/ResultsFilter.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Button,
+  Checkbox,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  makeStyles,
+  Theme,
+  Typography,
+} from '@material-ui/core';
+import React, { useCallback, useContext, useState } from 'react';
+import { filterGroupsContext } from '../../filter/context';
+
+const useStyles = makeStyles<Theme>(theme => ({
+  filterBox: {
+    display: 'flex',
+    margin: theme.spacing(2, 0, 0, 0),
+  },
+  filterBoxTitle: {
+    margin: theme.spacing(1, 0, 0, 1),
+    fontWeight: 'bold',
+    flex: 1,
+  },
+  title: {
+    margin: theme.spacing(1, 0, 0, 1),
+    textTransform: 'uppercase',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  checkbox: {
+    padding: theme.spacing(0, 1, 0, 1),
+  },
+}));
+
+type Props = {
+  availableTags: string[];
+};
+
+/**
+ * The additional results filter in the sidebar.
+ */
+export const ResultsFilter = ({ availableTags }: Props) => {
+  const classes = useStyles();
+
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const context = useContext(filterGroupsContext);
+  if (!context) {
+    throw new Error(`Must be used inside an EntityFilterGroupsProvider`);
+  }
+  const setSelectedTagsFilter = context?.setSelectedTags;
+
+  const updateSelectedTags = useCallback(
+    (tags: string[]) => {
+      setSelectedTags(tags);
+      setSelectedTagsFilter(tags);
+    },
+    [setSelectedTags, setSelectedTagsFilter],
+  );
+
+  return (
+    <>
+      <div className={classes.filterBox}>
+        <Typography variant="subtitle2" className={classes.filterBoxTitle}>
+          Refine Results
+        </Typography>{' '}
+        <Button onClick={() => updateSelectedTags([])}>Clear</Button>
+      </div>
+      <Divider />
+      <Typography variant="subtitle2" className={classes.title}>
+        Tags
+      </Typography>
+      <List disablePadding dense>
+        {availableTags.map(t => {
+          const labelId = `checkbox-list-label-${t}`;
+          return (
+            <ListItem
+              key={t}
+              dense
+              button
+              onClick={() =>
+                updateSelectedTags(
+                  selectedTags.includes(t)
+                    ? selectedTags.filter(s => s !== t)
+                    : [...selectedTags, t],
+                )
+              }
+            >
+              <Checkbox
+                edge="start"
+                checked={selectedTags.includes(t)}
+                tabIndex={-1}
+                disableRipple
+                className={classes.checkbox}
+                inputProps={{ 'aria-labelledby': labelId }}
+              />
+              <ListItemText id={labelId} primary={t} />
+            </ListItem>
+          );
+        })}
+      </List>
+    </>
+  );
+};

--- a/plugins/catalog/src/filter/context.ts
+++ b/plugins/catalog/src/filter/context.ts
@@ -26,10 +26,12 @@ export type FilterGroupsContext = {
   ) => void;
   unregister: (filterGroupId: string) => void;
   setGroupSelectedFilters: (filterGroupId: string, filterIds: string[]) => void;
+  setSelectedTags: (tags: string[]) => void;
   loading: boolean;
   error?: Error;
   filterGroupStates: { [filterGroupId: string]: FilterGroupStates };
   matchingEntities: Entity[];
+  availableTags: string[];
 };
 
 /**

--- a/plugins/catalog/src/filter/useFilteredEntities.ts
+++ b/plugins/catalog/src/filter/useFilteredEntities.ts
@@ -30,5 +30,6 @@ export function useFilteredEntities() {
     loading: context.loading,
     error: context.error,
     matchingEntities: context.matchingEntities,
+    availableTags: context.availableTags,
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds tags to the metadata of catalog entities. Closes  #1997
Right now the tags are only displayed in the table.

![image](https://user-images.githubusercontent.com/648527/90548036-a9489a00-e18c-11ea-8a24-73cd007911c3.png)

On the entity details page it is only displayed as a list of strings:

![image](https://user-images.githubusercontent.com/648527/90548758-b7e38100-e18d-11ea-87a5-a16ed3452eb6.png)

Here it is quite difficult to display it as chips in the table. The `StructuredMetadataTable` is too generic to implement tags there, I would have to duplicate the code to the `EntityMetadataCard`. For now I skipped it.

Filtering is done similar to the mockup:

![image](https://user-images.githubusercontent.com/648527/90558967-31cf3680-e19d-11ea-9e73-c4b9ad0d502f.png)

This PR has separate commits, if you are not satisfied with the filter implementation, I can move it into a separate PR 😉 

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
