### PR TITLE
core-api: switch auth provider apiOrigin option to backendUrl

### DIFF
--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -66,7 +66,10 @@ import {
 } from '@backstage/plugin-github-actions';
 import { jenkinsApiRef, JenkinsApi } from '@backstage/plugin-jenkins';
 
-import { TravisCIApi, travisCIApiRef } from '@roadiehq/backstage-plugin-travis-ci';
+import {
+  TravisCIApi,
+  travisCIApiRef,
+} from '@roadiehq/backstage-plugin-travis-ci';
 
 export const apis = (config: ConfigApi) => {
   // eslint-disable-next-line no-console
@@ -106,7 +109,7 @@ export const apis = (config: ConfigApi) => {
   builder.add(
     googleAuthApiRef,
     GoogleAuth.create({
-      apiOrigin: backendUrl,
+      backendUrl,
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -115,7 +118,7 @@ export const apis = (config: ConfigApi) => {
   const githubAuthApi = builder.add(
     githubAuthApiRef,
     GithubAuth.create({
-      apiOrigin: backendUrl,
+      backendUrl,
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -124,7 +127,7 @@ export const apis = (config: ConfigApi) => {
   builder.add(
     oktaAuthApiRef,
     OktaAuth.create({
-      apiOrigin: backendUrl,
+      backendUrl,
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -133,16 +136,16 @@ export const apis = (config: ConfigApi) => {
   builder.add(
     gitlabAuthApiRef,
     GitlabAuth.create({
-      apiOrigin: backendUrl,
+      backendUrl,
       basePath: '/auth/',
       oauthRequestApi,
     }),
   );
-  
+
   builder.add(
     auth0AuthApiRef,
     Auth0Auth.create({
-      apiOrigin: backendUrl,
+      backendUrl,
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -151,7 +154,7 @@ export const apis = (config: ConfigApi) => {
   builder.add(
     oauth2ApiRef,
     OAuth2.create({
-      apiOrigin: backendUrl,
+      backendUrl,
       basePath: '/auth/',
       oauthRequestApi,
     }),

--- a/packages/core-api/src/apis/implementations/OAuthRequestApi/OAuthPendingRequests.test.ts
+++ b/packages/core-api/src/apis/implementations/OAuthRequestApi/OAuthPendingRequests.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { wait } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { OAuthPendingRequests } from './OAuthPendingRequests';
 
 describe('OAuthPendingRequests', () => {
@@ -27,7 +27,7 @@ describe('OAuthPendingRequests', () => {
     target.pending().subscribe({ next, error });
     target.request(input);
 
-    await wait(() => expect(next).toBeCalledTimes(2));
+    await waitFor(() => expect(next).toBeCalledTimes(2));
     expect(next.mock.calls[0][0].scopes).toBeUndefined();
     expect(next.mock.calls[1][0].scopes.toString()).toBe(input.toString());
     expect(error.mock.calls.length).toBe(0);

--- a/packages/core-api/src/apis/implementations/auth/auth0/Auth0Auth.ts
+++ b/packages/core-api/src/apis/implementations/auth/auth0/Auth0Auth.ts
@@ -34,7 +34,7 @@ import { Observable } from '../../../../types';
 
 type CreateOptions = {
   // TODO(Following the words of Rugvip): These two should be grabbed from global config when available, they're not unique to Auth0Auth
-  apiOrigin: string;
+  backendUrl: string;
   basePath: string;
 
   oauthRequestApi: OAuthRequestApi;
@@ -67,14 +67,14 @@ class Auth0Auth
     BackstageIdentityApi,
     SessionStateApi {
   static create({
-    apiOrigin,
+    backendUrl,
     basePath,
     environment = 'development',
     provider = DEFAULT_PROVIDER,
     oauthRequestApi,
   }: CreateOptions) {
     const connector = new DefaultAuthConnector({
-      apiOrigin,
+      backendUrl,
       basePath,
       environment,
       provider,
@@ -96,11 +96,7 @@ class Auth0Auth
 
     const sessionManager = new RefreshingAuthSessionManager({
       connector,
-      defaultScopes: new Set([
-        'openid',
-        `email`,
-        `profile`,
-      ]),
+      defaultScopes: new Set(['openid', `email`, `profile`]),
       sessionScopes: (session: Auth0Session) => session.providerInfo.scopes,
       sessionShouldRefresh: (session: Auth0Session) => {
         const expiresInSec =

--- a/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
@@ -35,7 +35,7 @@ import { Observable } from '../../../../types';
 
 type CreateOptions = {
   // TODO(Rugvip): These two should be grabbed from global config when available, they're not unique to GithubAuth
-  apiOrigin: string;
+  backendUrl: string;
   basePath: string;
 
   oauthRequestApi: OAuthRequestApi;
@@ -62,14 +62,14 @@ const DEFAULT_PROVIDER = {
 
 class GithubAuth implements OAuthApi, SessionStateApi {
   static create({
-    apiOrigin,
+    backendUrl,
     basePath,
     environment = 'development',
     provider = DEFAULT_PROVIDER,
     oauthRequestApi,
   }: CreateOptions) {
     const connector = new DefaultAuthConnector({
-      apiOrigin,
+      backendUrl,
       basePath,
       environment,
       provider,

--- a/packages/core-api/src/apis/implementations/auth/gitlab/GitlabAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/gitlab/GitlabAuth.ts
@@ -31,7 +31,7 @@ import { StaticAuthSessionManager } from '../../../../lib/AuthSessionManager';
 import { Observable } from '../../../../types';
 
 type CreateOptions = {
-  apiOrigin: string;
+  backendUrl: string;
   basePath: string;
 
   oauthRequestApi: OAuthRequestApi;
@@ -58,14 +58,14 @@ const DEFAULT_PROVIDER = {
 
 class GitlabAuth implements OAuthApi, SessionStateApi {
   static create({
-    apiOrigin,
+    backendUrl,
     basePath,
     environment = 'development',
     provider = DEFAULT_PROVIDER,
     oauthRequestApi,
   }: CreateOptions) {
     const connector = new DefaultAuthConnector({
-      apiOrigin,
+      backendUrl,
       basePath,
       environment,
       provider,

--- a/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/google/GoogleAuth.ts
@@ -35,7 +35,7 @@ import { Observable } from '../../../../types';
 
 type CreateOptions = {
   // TODO(Rugvip): These two should be grabbed from global config when available, they're not unique to GoogleAuth
-  apiOrigin: string;
+  backendUrl: string;
   basePath: string;
 
   oauthRequestApi: OAuthRequestApi;
@@ -71,14 +71,14 @@ class GoogleAuth
     BackstageIdentityApi,
     SessionStateApi {
   static create({
-    apiOrigin,
+    backendUrl,
     basePath,
     environment = 'development',
     provider = DEFAULT_PROVIDER,
     oauthRequestApi,
   }: CreateOptions) {
     const connector = new DefaultAuthConnector({
-      apiOrigin,
+      backendUrl,
       basePath,
       environment,
       provider,

--- a/packages/core-api/src/apis/implementations/auth/oauth2/OAuth2.ts
+++ b/packages/core-api/src/apis/implementations/auth/oauth2/OAuth2.ts
@@ -33,7 +33,7 @@ import {
 import { OAuth2Session } from './types';
 
 type CreateOptions = {
-  apiOrigin: string;
+  backendUrl: string;
   basePath: string;
 
   oauthRequestApi: OAuthRequestApi;
@@ -64,14 +64,14 @@ const SCOPE_PREFIX = '';
 class OAuth2
   implements OAuthApi, OpenIdConnectApi, ProfileInfoApi, SessionStateApi {
   static create({
-    apiOrigin,
+    backendUrl,
     basePath,
     environment = 'development',
     provider = DEFAULT_PROVIDER,
     oauthRequestApi,
   }: CreateOptions) {
     const connector = new DefaultAuthConnector({
-      apiOrigin,
+      backendUrl,
       basePath,
       environment,
       provider,

--- a/packages/core-api/src/apis/implementations/auth/okta/OktaAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/okta/OktaAuth.ts
@@ -34,7 +34,7 @@ import { RefreshingAuthSessionManager } from '../../../../lib/AuthSessionManager
 import { Observable } from '../../../../types';
 
 type CreateOptions = {
-  apiOrigin: string;
+  backendUrl: string;
   basePath: string;
 
   oauthRequestApi: OAuthRequestApi;
@@ -60,28 +60,34 @@ const DEFAULT_PROVIDER = {
   icon: OktaIcon,
 };
 
-const OKTA_OIDC_SCOPES: Set<String> = new Set(
-  ['openid', 'profile', 'email', 'phone', 'address', 'groups', 'offline_access']
-)
+const OKTA_OIDC_SCOPES: Set<String> = new Set([
+  'openid',
+  'profile',
+  'email',
+  'phone',
+  'address',
+  'groups',
+  'offline_access',
+]);
 
-const OKTA_SCOPE_PREFIX: string = 'okta.'
+const OKTA_SCOPE_PREFIX: string = 'okta.';
 
-class OktaAuth implements
-  OAuthApi,
-  OpenIdConnectApi,
-  ProfileInfoApi,
-  BackstageIdentityApi,
-  SessionStateApi
-{
+class OktaAuth
+  implements
+    OAuthApi,
+    OpenIdConnectApi,
+    ProfileInfoApi,
+    BackstageIdentityApi,
+    SessionStateApi {
   static create({
-    apiOrigin,
+    backendUrl,
     basePath,
     environment = 'development',
     provider = DEFAULT_PROVIDER,
     oauthRequestApi,
   }: CreateOptions) {
     const connector = new DefaultAuthConnector({
-      apiOrigin,
+      backendUrl,
       basePath,
       environment,
       provider,
@@ -103,12 +109,7 @@ class OktaAuth implements
 
     const sessionManager = new RefreshingAuthSessionManager({
       connector,
-      defaultScopes: new Set([
-        'openid',
-        'email',
-        'profile',
-        'offline_access',
-      ]),
+      defaultScopes: new Set(['openid', 'email', 'profile', 'offline_access']),
       sessionScopes: session => session.scopes,
       sessionShouldRefresh: session => {
         const expiresInSec =
@@ -126,10 +127,7 @@ class OktaAuth implements
 
   constructor(private readonly sessionManager: SessionManager<OktaSession>) {}
 
-  async getAccessToken(
-    scope?: string,
-    options?: AuthRequestOptions
-  ) {
+  async getAccessToken(scope?: string, options?: AuthRequestOptions) {
     const session = await this.sessionManager.getSession({
       ...options,
       scopes: OktaAuth.normalizeScopes(scope),
@@ -175,8 +173,8 @@ class OktaAuth implements
       if (scope.startsWith(OKTA_SCOPE_PREFIX)) {
         return scope;
       }
-      
-      return `${OKTA_SCOPE_PREFIX}${scope}`
+
+      return `${OKTA_SCOPE_PREFIX}${scope}`;
     });
 
     return new Set(normalizedScopes);

--- a/packages/core-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
+++ b/packages/core-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
@@ -22,7 +22,7 @@ import * as loginPopup from '../loginPopup';
 const anyFetch = fetch as any;
 
 const defaultOptions = {
-  apiOrigin: 'my-origin',
+  backendUrl: 'http://my-origin',
   environment: 'production',
   provider: {
     id: 'my-provider',
@@ -114,7 +114,8 @@ describe('DefaultAuthConnector', () => {
 
     expect(popupSpy).toBeCalledTimes(1);
     expect(popupSpy.mock.calls[0][0]).toMatchObject({
-      url: 'my-origin/api/auth/my-provider/start?scope=a%20b&env=production',
+      url:
+        'http://my-origin/api/auth/my-provider/start?scope=a%20b&env=production',
     });
 
     await expect(sessionPromise).resolves.toEqual({
@@ -162,7 +163,8 @@ describe('DefaultAuthConnector', () => {
 
     expect(popupSpy).toBeCalledTimes(1);
     expect(popupSpy.mock.calls[0][0]).toMatchObject({
-      url: 'my-origin/api/auth/my-provider/start?scope=-ab-&env=production',
+      url:
+        'http://my-origin/api/auth/my-provider/start?scope=-ab-&env=production',
     });
   });
 });

--- a/packages/core-api/src/lib/AuthConnector/DefaultAuthConnector.ts
+++ b/packages/core-api/src/lib/AuthConnector/DefaultAuthConnector.ts
@@ -23,9 +23,9 @@ const DEFAULT_BASE_PATH = '/api/auth/';
 
 type Options<AuthSession> = {
   /**
-   * Origin of auth requests, defaults to location.origin
+   * The base URL of the auth backend.
    */
-  apiOrigin?: string;
+  backendUrl?: string;
   /**
    * Base path of the auth requests, defaults to /api/auth/
    */
@@ -64,7 +64,7 @@ function defaultJoinScopes(scopes: Set<string>) {
  */
 export class DefaultAuthConnector<AuthSession>
   implements AuthConnector<AuthSession> {
-  private readonly apiOrigin: string;
+  private readonly backendUrl: string;
   private readonly basePath: string;
   private readonly environment: string;
   private readonly provider: AuthProvider & { id: string };
@@ -74,7 +74,7 @@ export class DefaultAuthConnector<AuthSession>
 
   constructor(options: Options<AuthSession>) {
     const {
-      apiOrigin = window.location.origin,
+      backendUrl = window.location.origin,
       basePath = DEFAULT_BASE_PATH,
       environment,
       provider,
@@ -88,7 +88,7 @@ export class DefaultAuthConnector<AuthSession>
       onAuthRequest: scopes => this.showPopup(scopes),
     });
 
-    this.apiOrigin = apiOrigin;
+    this.backendUrl = backendUrl;
     this.basePath = basePath;
     this.environment = environment;
     this.provider = provider;
@@ -154,11 +154,12 @@ export class DefaultAuthConnector<AuthSession>
   private async showPopup(scopes: Set<string>): Promise<AuthSession> {
     const scope = this.joinScopesFunc(scopes);
     const popupUrl = this.buildUrl('/start', { scope });
+    const { origin } = new URL(this.backendUrl);
 
     const payload = await showLoginPopup({
       url: popupUrl,
       name: `${this.provider.title} Login`,
-      origin: this.apiOrigin,
+      origin,
       width: 450,
       height: 730,
     });
@@ -175,7 +176,7 @@ export class DefaultAuthConnector<AuthSession>
       env: this.environment,
     });
 
-    return `${this.apiOrigin}${this.basePath}${this.provider.id}${path}${queryString}`;
+    return `${this.backendUrl}${this.basePath}${this.provider.id}${path}${queryString}`;
   }
 
   private buildQueryString(query?: {

--- a/packages/dev-utils/src/devApp/apiFactories.ts
+++ b/packages/dev-utils/src/devApp/apiFactories.ts
@@ -63,7 +63,7 @@ export const googleAuthApiFactory = createApiFactory({
   deps: { oauthRequestApi: oauthRequestApiRef },
   factory: ({ oauthRequestApi }) =>
     GoogleAuth.create({
-      apiOrigin: 'http://localhost:7000',
+      backendUrl: 'http://localhost:7000',
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -74,7 +74,7 @@ export const githubAuthApiFactory = createApiFactory({
   deps: { oauthRequestApi: oauthRequestApiRef },
   factory: ({ oauthRequestApi }) =>
     GithubAuth.create({
-      apiOrigin: 'http://localhost:7000',
+      backendUrl: 'http://localhost:7000',
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -85,7 +85,7 @@ export const gitlabAuthApiFactory = createApiFactory({
   deps: { oauthRequestApi: oauthRequestApiRef },
   factory: ({ oauthRequestApi }) =>
     GitlabAuth.create({
-      apiOrigin: 'http://localhost:7000',
+      backendUrl: 'http://localhost:7000',
       basePath: '/auth/',
       oauthRequestApi,
     }),
@@ -96,7 +96,7 @@ export const auth0AuthApiFactory = createApiFactory({
   deps: { oauthRequestApi: oauthRequestApiRef },
   factory: ({ oauthRequestApi }) =>
     Auth0Auth.create({
-      apiOrigin: 'http://localhost:7000',
+      backendUrl: 'http://localhost:7000',
       basePath: '/auth/',
       oauthRequestApi,
     }),

--- a/plugins/gitops-profiles/src/components/ProfileCatalog/ProfileCatalog.test.tsx
+++ b/plugins/gitops-profiles/src/components/ProfileCatalog/ProfileCatalog.test.tsx
@@ -37,7 +37,7 @@ describe('ProfileCatalog', () => {
       [
         githubAuthApiRef,
         GithubAuth.create({
-          apiOrigin: 'http://localhost:7000',
+          backendUrl: 'http://localhost:7000',
           basePath: '/auth/',
           oauthRequestApi,
         }),


### PR DESCRIPTION
`apiOrigin` !== `backend.baseUrl`, this fixes that expectation.

Part of trying to figure out how to make url configuration a bit less verbose, and I'm not touching the other API clients yet because of that.