### PR TITLE
plugins/auth-backend: refactor OAuthProvider to derive options from {app,backend}.baseUrl

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -54,8 +54,6 @@ auth:
   providers:
     google:
       development:
-        appOrigin: 'http://localhost:3000/'
-        secure: false
         clientId:
           $secret:
             env: AUTH_GOOGLE_CLIENT_ID
@@ -64,8 +62,6 @@ auth:
             env: AUTH_GOOGLE_CLIENT_SECRET
     github:
       development:
-        appOrigin: 'http://localhost:3000/'
-        secure: false
         clientId:
           $secret:
             env: AUTH_GITHUB_CLIENT_ID
@@ -77,8 +73,6 @@ auth:
             env: AUTH_GITHUB_ENTERPRISE_INSTANCE_URL
     gitlab:
       development:
-        appOrigin: 'http://localhost:3000/'
-        secure: false
         clientId:
           $secret:
             env: AUTH_GITLAB_CLIENT_ID
@@ -94,8 +88,6 @@ auth:
     #     issuer: "passport-saml"
     okta:
       development:
-        appOrigin: 'http://localhost:3000/'
-        secure: false
         clientId:
           $secret:
             env: AUTH_OKTA_CLIENT_ID
@@ -107,8 +99,6 @@ auth:
             env: AUTH_OKTA_AUDIENCE
     oauth2:
       development:
-        appOrigin: 'http://localhost:3000/'
-        secure: false
         clientId:
           $secret:
             env: AUTH_OAUTH2_CLIENT_ID
@@ -123,8 +113,6 @@ auth:
             env: AUTH_OAUTH2_TOKEN_URL
     auth0:
       development:
-        appOrigin: 'http://localhost:3000/'
-        secure: false
         clientId:
           $secret:
             env: AUTH_AUTH0_CLIENT_ID

--- a/plugins/auth-backend/src/lib/OAuthProvider.test.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.test.ts
@@ -205,8 +205,9 @@ describe('OAuthProvider', () => {
     providerId: 'test-provider',
     secure: false,
     disableRefresh: true,
-    baseUrl: 'http://localhost:7000/auth',
     appOrigin: 'http://localhost:3000',
+    cookieDomain: 'localhost',
+    cookiePath: '/auth/test-provider',
     tokenIssuer: {
       issueToken: async () => 'my-id-token',
       listPublicKeys: async () => ({ keys: [] }),

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -141,19 +141,17 @@ export class Auth0AuthProvider implements OAuthProviderHandlers {
 }
 
 export function createAuth0Provider(
-  { baseUrl }: AuthProviderConfig,
+  config: AuthProviderConfig,
   _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
 ) {
   const providerId = 'auth0';
-  const secure = envConfig.getBoolean('secure');
-  const appOrigin = envConfig.getString('appOrigin');
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
   const domain = envConfig.getString('domain');
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
+  const callbackURL = `${config.baseUrl}/${providerId}/handler/frame`;
 
   const opts = {
     clientID,
@@ -175,12 +173,9 @@ export function createAuth0Provider(
     return undefined;
   }
 
-  return new OAuthProvider(new Auth0AuthProvider(opts), {
+  return OAuthProvider.fromConfig(config, new Auth0AuthProvider(opts), {
     disableRefresh: true,
     providerId,
-    secure,
-    baseUrl,
-    appOrigin,
     tokenIssuer,
   });
 }

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -125,15 +125,13 @@ export class GithubAuthProvider implements OAuthProviderHandlers {
 }
 
 export function createGithubProvider(
-  { baseUrl }: AuthProviderConfig,
+  config: AuthProviderConfig,
   _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
 ) {
   const providerId = 'github';
-  const secure = envConfig.getBoolean('secure');
-  const appOrigin = envConfig.getString('appOrigin');
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
   const enterpriseInstanceUrl = envConfig.getOptionalString(
@@ -148,7 +146,7 @@ export function createGithubProvider(
   const userProfileURL = enterpriseInstanceUrl
     ? `${enterpriseInstanceUrl}/api/v3/user`
     : undefined;
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
+  const callbackURL = `${config.baseUrl}/${providerId}/handler/frame`;
 
   const opts = {
     clientID,
@@ -171,13 +169,10 @@ export function createGithubProvider(
     );
     return undefined;
   }
-  return new OAuthProvider(new GithubAuthProvider(opts), {
+  return OAuthProvider.fromConfig(config, new GithubAuthProvider(opts), {
     disableRefresh: true,
     persistScopes: true,
     providerId,
-    secure,
-    baseUrl,
-    appOrigin,
     tokenIssuer,
   });
 }

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -132,20 +132,18 @@ export class GitlabAuthProvider implements OAuthProviderHandlers {
 }
 
 export function createGitlabProvider(
-  { baseUrl }: AuthProviderConfig,
+  config: AuthProviderConfig,
   _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
 ) {
   const providerId = 'gitlab';
-  const secure = envConfig.getBoolean('secure');
-  const appOrigin = envConfig.getString('appOrigin');
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
   const audience = envConfig.getString('audience');
   const baseURL = audience || 'https://gitlab.com';
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
+  const callbackURL = `${config.baseUrl}/${providerId}/handler/frame`;
 
   const opts = {
     clientID,
@@ -166,12 +164,9 @@ export function createGitlabProvider(
     );
     return undefined;
   }
-  return new OAuthProvider(new GitlabAuthProvider(opts), {
+  return OAuthProvider.fromConfig(config, new GitlabAuthProvider(opts), {
     disableRefresh: true,
     providerId,
-    secure,
-    baseUrl,
-    appOrigin,
     tokenIssuer,
   });
 }

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -144,18 +144,16 @@ export class GoogleAuthProvider implements OAuthProviderHandlers {
 }
 
 export function createGoogleProvider(
-  { baseUrl }: AuthProviderConfig,
+  config: AuthProviderConfig,
   _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
 ) {
   const providerId = 'google';
-  const secure = envConfig.getBoolean('secure');
-  const appOrigin = envConfig.getString('appOrigin');
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
+  const callbackURL = `${config.baseUrl}/${providerId}/handler/frame`;
 
   const opts = {
     clientID,
@@ -175,12 +173,9 @@ export function createGoogleProvider(
     );
     return undefined;
   }
-  return new OAuthProvider(new GoogleAuthProvider(opts), {
+  return OAuthProvider.fromConfig(config, new GoogleAuthProvider(opts), {
     disableRefresh: false,
     providerId,
-    secure,
-    baseUrl,
-    appOrigin,
     tokenIssuer,
   });
 }

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -164,19 +164,17 @@ export class OktaAuthProvider implements OAuthProviderHandlers {
 }
 
 export function createOktaProvider(
-  { baseUrl }: AuthProviderConfig,
+  config: AuthProviderConfig,
   _: string,
   envConfig: Config,
   logger: Logger,
   tokenIssuer: TokenIssuer,
 ) {
   const providerId = 'okta';
-  const secure = envConfig.getBoolean('secure');
-  const appOrigin = envConfig.getString('appOrigin');
   const clientID = envConfig.getString('clientId');
   const clientSecret = envConfig.getString('clientSecret');
   const audience = envConfig.getString('audience');
-  const callbackURL = `${baseUrl}/${providerId}/handler/frame`;
+  const callbackURL = `${config.baseUrl}/${providerId}/handler/frame`;
 
   const opts = {
     audience,
@@ -197,12 +195,9 @@ export function createOktaProvider(
     );
     return undefined;
   }
-  return new OAuthProvider(new OktaAuthProvider(opts), {
+  return OAuthProvider.fromConfig(config, new OktaAuthProvider(opts), {
     disableRefresh: false,
     providerId,
-    secure,
-    baseUrl,
-    appOrigin,
     tokenIssuer,
   });
 }

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -93,6 +93,11 @@ export type AuthProviderConfig = {
    * callbackURL to redirect to once the user signs in to the auth provider.
    */
   baseUrl: string;
+
+  /**
+   * The base URL of the app as provided by app.baseUrl
+   */
+  appUrl: string;
 };
 
 /**

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -36,6 +36,7 @@ export async function createRouter(
   const router = Router();
   const logger = options.logger.child({ plugin: 'auth' });
 
+  const appUrl = options.config.getString('app.baseUrl');
   const backendUrl = options.config.getString('backend.baseUrl');
   const authUrl = `${backendUrl}/auth`;
 
@@ -64,7 +65,7 @@ export async function createRouter(
       const providerConfig = providersConfig.getConfig(providerId);
       const providerRouter = createAuthProviderRouter(
         providerId,
-        { baseUrl: authUrl },
+        { baseUrl: authUrl, appUrl },
         providerConfig,
         logger,
         tokenIssuer,


### PR DESCRIPTION
Whether we need secure cookies can be based on the backend base URL, and the app origin we can grab from the app base URL.