### PR TITLE
fix: docs build short-term

### DIFF
--- a/microsite/i18n/en.json
+++ b/microsite/i18n/en.json
@@ -50,6 +50,9 @@
       "auth/add-auth-provider": {
         "title": "Adding authentication providers"
       },
+      "auth/auth-backend-classes": {
+        "title": "auth/auth-backend-classes"
+      },
       "auth/auth-backend": {
         "title": "Auth backend"
       },


### PR DESCRIPTION
Updated i18n files for docusaurus, this fixes master build short-term, but we need to alter the CI process to ensure i18n either regenerated before merging to master or is not checked during build phase (.gitignore?)