### PR TITLE
build(microsite): deploy site when docs are changed

### DIFF
--- a/.github/workflows/microsite-with-storybook-deploy.yml
+++ b/.github/workflows/microsite-with-storybook-deploy.yml
@@ -9,6 +9,7 @@ on:
       - 'packages/storybook/**'
       - 'packages/core/src/**'
       - 'microsite/**'
+      - 'docs/**'
 
 jobs:
   deploy-microsite-and-storybook:


### PR DESCRIPTION
Now that the docs are part of the microsite, any doc changes should lead to a rebuild/deploy