### PR TITLE
fix: make docs table font color white

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -7,6 +7,14 @@
 
 /* your custom css */
 
+/* override font color for new dark tech docs styling */
+table {
+  color: white;
+}
+table tr:nth-child(2n) {
+  background-color: #2b2b2b;
+}
+
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
 }
 


### PR DESCRIPTION
Makes docs tables' font color white.