### PR TITLE
Add standalone building with docker

### DIFF
--- a/contrib/docker/multi-stage-frontend/Dockerfile
+++ b/contrib/docker/multi-stage-frontend/Dockerfile
@@ -1,10 +1,5 @@
 FROM node:12 AS build
 
-# This dockerfile does not require the app to be built on the host machine.
-# simply builds backstage in node image then transfers compiled files to nginx container.
-
-# You can build this image with `docker build -f Dockerfile.standalone -t backstage .`
-
 RUN mkdir /app
 COPY . /app
 WORKDIR /app
@@ -12,7 +7,7 @@ WORKDIR /app
 RUN yarn install
 RUN yarn workspace example-app build
 
-# Contruct backstage image
+# Contruct backstage-frontend image
 FROM nginx:mainline
 
 RUN apt-get update && apt-get -y install jq && rm -rf /var/lib/apt/lists/*

--- a/contrib/docker/multi-stage-frontend/Dockerfile
+++ b/contrib/docker/multi-stage-frontend/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:12 AS build
+
+# This dockerfile does not require the app to be built on the host machine.
+# simply builds backstage in node image then transfers compiled files to nginx container.
+
+# You can build this image with `docker build -f Dockerfile.standalone -t backstage .`
+
+RUN mkdir /app
+COPY . /app
+WORKDIR /app
+
+RUN yarn install
+RUN yarn workspace example-app build
+
+# Contruct backstage image
+FROM nginx:mainline
+
+RUN apt-get update && apt-get -y install jq && rm -rf /var/lib/apt/lists/*
+
+# Copy from build stage
+COPY --from=build /app/packages/app/dist /usr/share/nginx/html
+
+COPY docker/default.conf.template /etc/nginx/conf.d/default.conf.template
+COPY docker/run.sh /usr/local/bin/run.sh
+
+CMD run.sh
+
+ENV PORT 80

--- a/contrib/docker/multi-stage-frontend/README.md
+++ b/contrib/docker/multi-stage-frontend/README.md
@@ -1,0 +1,21 @@
+# Standalone Dockerfile for frontend
+
+This directory contains the resources which will help you build backstage without any requirements
+other than docker itself. It uses a multi-stage Dockerfile to build and ship backstage.
+
+## Usage
+
+You can simply run the following command to build backstage.
+
+```
+# Make sure you are in the root directory of backstage then run
+docker build -t backstage -f ./contrib/docker/multi-stage-frontend/Dockerfile .
+```
+
+After a successful build, You can simply run backstage frontend with the following command.
+
+```
+docker run -it --rm -p 3080:80 backstage
+```
+
+

--- a/contrib/docker/multi-stage-frontend/README.md
+++ b/contrib/docker/multi-stage-frontend/README.md
@@ -9,11 +9,11 @@ You can simply run the following command to build backstage.
 
 ```
 # Make sure you are in the root directory of backstage then run
-docker build -t backstage -f ./contrib/docker/multi-stage-frontend/Dockerfile .
+docker build -t backstage-frontend -f ./contrib/docker/multi-stage-frontend/Dockerfile .
 ```
 
 After a successful build, You can simply run backstage frontend with the following command.
 
 ```
-docker run -it --rm -p 3080:80 backstage
+docker run -it --rm -p 3080:80 backstage-frontend
 ```

--- a/contrib/docker/multi-stage-frontend/README.md
+++ b/contrib/docker/multi-stage-frontend/README.md
@@ -17,5 +17,3 @@ After a successful build, You can simply run backstage frontend with the followi
 ```
 docker run -it --rm -p 3080:80 backstage
 ```
-
-


### PR DESCRIPTION
## Hey, I just made a Pull Request!

So I was just exploring this awesome project and when I tried running it, The build procedure raised some errors related to my node installation being broken. So I tried using docker build for backstage but realized it uses host machine to build.

So I decided to make a standalone multistage Dockerfile so it would be easier to build and less prune to error due to the user systems configuration. I don't know if that is your concern at all, So feel free to terminate this PR if this is irrelevant. 

### What I have changed

  - Added `Dockerfile.standalone` so backstage can be built without host machine setup and build.
  - Fix `build.sh` so it would not run git commands in docker build stage.
  - Add `Dockerfile` and `Dockerfile.standalone` to `.gitignore`.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [x] ~~Screenshots attached (for UI changes)~~
- [x] Relevant documentation updated
- [x] ~~Prettier run on changed files~~
- [ ] Tests added for new functionality
- [x] ~~Regression tests added for bug fixes~~

Thank you.