### PR TITLE
fix(header tabs): use filteredheadertabs instead of tabs

### DIFF
--- a/plugins/catalog/src/components/EntityPage/EntityPage.tsx
+++ b/plugins/catalog/src/components/EntityPage/EntityPage.tsx
@@ -206,10 +206,12 @@ export const EntityPage: FC<{}> = () => {
             tabs={filteredHeaderTabs}
             onChange={idx => {
               navigate(
-                `/catalog/${kind}/${optionalNamespaceAndName}/${tabs[idx].id}`,
+                `/catalog/${kind}/${optionalNamespaceAndName}/${filteredHeaderTabs[idx].id}`,
               );
             }}
-            selectedIndex={tabs.findIndex(tab => tab.id === selectedTabId)}
+            selectedIndex={filteredHeaderTabs.findIndex(
+              tab => tab.id === selectedTabId,
+            )}
           />
 
           {selectedTab && selectedTab.content


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue with navigating between tabs since it was using tabs and not filteredHeaderTabs

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
