### PR TITLE
chore(api-docs): the api docs plugin should be published

### DIFF
--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^16.13.1",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^15.3.3",
+    "@types/react": "^16.9",
     "swagger-ui-react": "^3.31.1"
   },
   "devDependencies": {
@@ -44,7 +45,6 @@
     "@testing-library/user-event": "^12.0.7",
     "@types/jest": "^26.0.7",
     "@types/node": "^12.0.0",
-    "@types/react": "^16.9",
     "@types/swagger-ui-react": "^3.23.3",
     "jest-fetch-mock": "^3.0.3"
   },

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -44,6 +44,7 @@
     "@testing-library/user-event": "^12.0.7",
     "@types/jest": "^26.0.7",
     "@types/node": "^12.0.0",
+    "@types/react": "^16.9",
     "@types/swagger-ui-react": "^3.23.3",
     "jest-fetch-mock": "^3.0.3"
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Looks like this is the default of create plugin and one has to change it 🙄 A release won't be possible without it...

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
