### PR TITLE
feat: support passing --inspect to backend:dev

### DIFF
--- a/packages/cli/src/commands/backend/dev.ts
+++ b/packages/cli/src/commands/backend/dev.ts
@@ -25,9 +25,11 @@ export default async (cmd: Command) => {
     env: 'development',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
+
   const waitForExit = await serveBackend({
     entry: 'src/index',
     checksEnabled: cmd.check,
+    inspectEnabled: cmd.inspect,
     config: ConfigReader.fromConfigs(appConfigs),
     appConfigs,
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,6 +52,7 @@ const main = (argv: string[]) => {
     .command('backend:dev')
     .description('Start local development server with HMR for the backend')
     .option('--check', 'Enable type checking and linting')
+    .option('--inspect', 'Enable debugger')
     .action(lazyAction(() => import('./commands/backend/dev'), 'default'));
 
   program

--- a/packages/cli/src/lib/bundler/backend.ts
+++ b/packages/cli/src/lib/bundler/backend.ts
@@ -19,7 +19,11 @@ import { createBackendConfig } from './config';
 import { resolveBundlingPaths } from './paths';
 import { ServeOptions } from './types';
 
-export async function serveBackend(options: ServeOptions) {
+export async function serveBackend(
+  options: ServeOptions & {
+    inspectEnabled: boolean;
+  },
+) {
   const paths = resolveBundlingPaths(options);
   const config = createBackendConfig(paths, {
     ...options,

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -200,7 +200,10 @@ export function createBackendConfig(
         : '[name].[chunkhash:8].chunk.js',
     },
     plugins: [
-      new StartServerPlugin('main.js'),
+      new StartServerPlugin({
+        name: 'main.js',
+        nodeArgs: options.inspectEnabled ? ['--inspect'] : undefined,
+      }),
       new webpack.HotModuleReplacementPlugin(),
       ...(checksEnabled
         ? [

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -25,7 +25,9 @@ export type BundlingOptions = {
   baseUrl: URL;
 };
 
-export type BackendBundlingOptions = Omit<BundlingOptions, 'baseUrl'>;
+export type BackendBundlingOptions = Omit<BundlingOptions, 'baseUrl'> & {
+  inspectEnabled: boolean;
+};
 
 export type ServeOptions = BundlingPathsOptions & {
   checksEnabled: boolean;


### PR DESCRIPTION
This allows to debug the nodejs instance. I'm not an expert here, but I would make it optional as it tries to allocate a port. It seems to fail if there is already a debugger open: `Starting inspector on 127.0.0.1:9230 failed: address already in use`.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
