### PR TITLE
cli: fix jest transform pattern termination

### DIFF
--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -37,8 +37,8 @@ async function getConfig() {
     // TODO: jest is working on module support, it's possible that we can remove this in the future
     transform: {
       '\\.esm\\.js$': require.resolve('jest-esm-transformer'),
-      '\\.(js|jsx|ts|tsx)': require.resolve('ts-jest'),
-      '\\.(bmp|gif|jpg|jpeg|png|frag|xml|svg)': require.resolve(
+      '\\.(js|jsx|ts|tsx)$': require.resolve('ts-jest'),
+      '\\.(bmp|gif|jpg|jpeg|png|frag|xml|svg)$': require.resolve(
         './jestFileTransform.js',
       ),
     },


### PR DESCRIPTION
This made the transform matching too broad, especially with `ts-jest` being used for `.json` files.