### PR TITLE
TechDocs: Add docs template to default app templates

### DIFF
--- a/packages/create-app/templates/default-app/app-config.yaml
+++ b/packages/create-app/templates/default-app/app-config.yaml
@@ -54,3 +54,5 @@ catalog:
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/create-react-app/template.yaml
     - type: github
       target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
+    - type: github
+      target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR includes the new documentation template in the default app templates

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
