### PR TITLE
Throw error when failing to generate docs to prevent request loop

### DIFF
--- a/plugins/techdocs-backend/src/techdocs/stages/generate/techdocs.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/generate/techdocs.ts
@@ -61,6 +61,9 @@ export class TechdocsGenerator implements GeneratorBase {
       this.logger.debug(
         `[TechDocs]: Failed to generate docs from ${directory} into ${resultDir}`,
       );
+      throw new Error(
+        `Failed to generate docs from ${directory} into ${resultDir} with error ${error.message}`,
+      );
     }
 
     return { resultDir };


### PR DESCRIPTION
Fixes a issue where the techdocs generation got stuck in a loop if the build failed. This throws an error and returns it to the user instead.