### PR TITLE
docs: show how to use config when setting up api

### DIFF
--- a/docs/api/utility-apis.md
+++ b/docs/api/utility-apis.md
@@ -71,18 +71,23 @@ import {
   AlertApiForwarder,
   ErrorApiForwarder,
   ErrorAlerter,
+  ConfigApi
 } from '@backstage/core';
 
-const builder = ApiRegistry.builder();
 
-// The alert API is a self-contained implementation that shows alerts to the user.
-const alertApi = builder.add(alertApiRef, new AlertApiForwarder());
+const apis = (config: ConfigApi) => {
+  const builder = ApiRegistry.builder();
 
-// The error API uses the alert API to send error notifications to the user.
-builder.add(errorApiRef, new ErrorAlerter(alertApi, new ErrorApiForwarder()));
+  // The alert API is a self-contained implementation that shows alerts to the user.
+  const alertApi = builder.add(alertApiRef, new AlertApiForwarder());
+
+  // The error API uses the alert API to send error notifications to the user.
+  builder.add(errorApiRef, new ErrorAlerter(alertApi, new ErrorApiForwarder()));
+  return builder.build();
+}
 
 const app = createApp({
-  apis: apiBuilder.build(),
+  apis,
   // ... other config
 });
 ```


### PR DESCRIPTION
Most API will require some configuration.

It would be more useful to show an example where the config is available when the API's are being wired up

