### PR TITLE
cli: Check "NODE_ENV" env var value for config files location

### DIFF
--- a/packages/cli/src/commands/app/build.ts
+++ b/packages/cli/src/commands/app/build.ts
@@ -22,7 +22,7 @@ import { buildBundle } from '../../lib/bundler';
 
 export default async (cmd: Command) => {
   const appConfigs = await loadConfig({
-    env: 'production',
+    env: process.env.NODE_ENV ?? 'production',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
   await buildBundle({

--- a/packages/cli/src/commands/app/serve.ts
+++ b/packages/cli/src/commands/app/serve.ts
@@ -22,7 +22,7 @@ import { serveBundle } from '../../lib/bundler';
 
 export default async (cmd: Command) => {
   const appConfigs = await loadConfig({
-    env: 'development',
+    env: process.env.NODE_ENV ?? 'development',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
   const waitForExit = await serveBundle({

--- a/packages/cli/src/commands/backend/dev.ts
+++ b/packages/cli/src/commands/backend/dev.ts
@@ -22,7 +22,7 @@ import { serveBackend } from '../../lib/bundler/backend';
 
 export default async (cmd: Command) => {
   const appConfigs = await loadConfig({
-    env: 'development',
+    env: process.env.NODE_ENV ?? 'development',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
   const waitForExit = await serveBackend({

--- a/packages/cli/src/commands/plugin/export.ts
+++ b/packages/cli/src/commands/plugin/export.ts
@@ -22,7 +22,7 @@ import { buildBundle } from '../../lib/bundler';
 
 export default async (cmd: Command) => {
   const appConfigs = await loadConfig({
-    env: 'production',
+    env: process.env.NODE_ENV ?? 'production',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
   await buildBundle({

--- a/packages/cli/src/commands/plugin/serve.ts
+++ b/packages/cli/src/commands/plugin/serve.ts
@@ -22,7 +22,7 @@ import { serveBundle } from '../../lib/bundler';
 
 export default async (cmd: Command) => {
   const appConfigs = await loadConfig({
-    env: 'development',
+    env: process.env.NODE_ENV ?? 'development',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
   const waitForExit = await serveBundle({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is a follow-up from #1860. 
`cli` package will consider `NODE_ENV` environment variable to decide which configuration file it will use on its `build` and `serve` commands. If the variable is not set, it will fall back to its original behaviour (search for `app-config.production.yaml` for `build` and `app-config.development.yaml` for `serve`).

#### :heavy_check_mark: Checklist
- [ ] All tests are passing `yarn test` ➡️ Well I did run `yarn test`, but it fail on `@backstage/plugin-catalog-backend` plugin. I'm not sure if there is a pre-test command that I should have executed or something. Here is a screenshot of the error.
![image](https://user-images.githubusercontent.com/13152452/90938067-94634500-e3de-11ea-90de-1daf971941fb.png)
Please let me know if there is something I can do about it.
- [ ] ~Screenshots attached~ (no UIs were harmed in the making of this PR 🙂)
- [ ] ~Relevant documentation updated~ ➡️The documentation already mentioned the usage of `NODE_ENV`, so I guess there is no need to update it.
- [x] Prettier run on changed files
- [ ] Tests added for new functionality ➡️ There were no tests written for these files (Yes, I know this is not an excuse for not writing tests, but I'm still learning React and I'm not fully aware about how to write tests for that. Any help would be really appreciated)
- [ ] Regression tests added for bug fixes ➡️ Please read lame excuse on the item above.
