### PR TITLE
Fix webpack sourcemap path for debugging

### DIFF
--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -198,6 +198,11 @@ export function createBackendConfig(
       chunkFilename: isDev
         ? '[name].chunk.js'
         : '[name].[chunkhash:8].chunk.js',
+      ...(isDev
+        ? {
+            devtoolModuleFilenameTemplate: 'file:///[absolute-resource-path]',
+          }
+        : {}),
     },
     plugins: [
       new StartServerPlugin('main.js'),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes the webpack sourcemap path to use absolute paths to allow stepping through code when debugging in Visual Studio Code. The assumption is that same problem would exist when using any other IDE since webpack defaults to `webpack:///`

See https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_javascript-source-map-tips
```
Are you using Webpack? By default, it outputs paths with a webpack:/// prefix, which the 
debug adapter can't resolve.You can change this in your Webpack configuration with the 
devtoolModuleFilenameTemplate option, or try using the 'inspector' protocol, which provides 
some extra options for resolving these paths.
```
e.g. `launch.json` for VSC
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "node",
            "cwd": "${workspaceFolder}/packages/backend",
            "request": "launch",
            "name": "Launch backend",
            "runtimeExecutable": "yarn",
            "runtimeArgs": [
                "start"
            ],
            "skipFiles": [
                "<node_internals>/**"
            ],
        }
    ]
}
```
When running the above launch config
- Without the fix, VSC can only step through code in `packages/backend`. Breakpoints in other plugins e.g. `plugins/scaffolder-backend` don't work.
- With the fix, VSC allows to step through the code in `packages/backend` as well as plugins e.g. `plugins/scaffolder-backend`

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
