### PR TITLE
workflows: rename Frontend CI to just CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
-name: Frontend CI
+name: CI
 
 on:
   pull_request:
     paths-ignore:
       - 'microsite/**'
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Don't see why it would be called "Frontend CI" anymore? :grin: