### PR TITLE
Add GraphQL support to API Docs 

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -471,6 +471,7 @@ Describes the following entity kind:
 An API describes an interface that can be exposed by a component. The API can be
 defined in different formats, like [OpenAPI](https://swagger.io/specification/),
 [AsyncAPI](https://www.asyncapi.com/docs/specifications/latest/),
+[GraphQL](https://graphql.org/learn/schema/),
 [gRPC](https://developers.google.com/protocol-buffers), or other formats.
 
 Descriptor files for this kind may look as follows.

--- a/packages/catalog-model/examples/swapi-graphql.yaml
+++ b/packages/catalog-model/examples/swapi-graphql.yaml
@@ -1,0 +1,1174 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: starwars-graphql
+  description: SWAPI GraphQL Schema
+spec:
+  type: graphql
+  definition: |
+    schema {
+      query: Root
+    }
+
+    """A single film."""
+    type Film implements Node {
+      """The title of this film."""
+      title: String
+
+      """The episode number of this film."""
+      episodeID: Int
+
+      """The opening paragraphs at the beginning of this film."""
+      openingCrawl: String
+
+      """The name of the director of this film."""
+      director: String
+
+      """The name(s) of the producer(s) of this film."""
+      producers: [String]
+
+      """The ISO 8601 date format of film release at original creator country."""
+      releaseDate: String
+      speciesConnection(after: String, first: Int, before: String, last: Int): FilmSpeciesConnection
+      starshipConnection(after: String, first: Int, before: String, last: Int): FilmStarshipsConnection
+      vehicleConnection(after: String, first: Int, before: String, last: Int): FilmVehiclesConnection
+      characterConnection(after: String, first: Int, before: String, last: Int): FilmCharactersConnection
+      planetConnection(after: String, first: Int, before: String, last: Int): FilmPlanetsConnection
+
+      """The ISO 8601 date format of the time that this resource was created."""
+      created: String
+
+      """The ISO 8601 date format of the time that this resource was edited."""
+      edited: String
+
+      """The ID of an object"""
+      id: ID!
+    }
+
+    """A connection to a list of items."""
+    type FilmCharactersConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [FilmCharactersEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      characters: [Person]
+    }
+
+    """An edge in a connection."""
+    type FilmCharactersEdge {
+      """The item at the end of the edge"""
+      node: Person
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type FilmPlanetsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [FilmPlanetsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      planets: [Planet]
+    }
+
+    """An edge in a connection."""
+    type FilmPlanetsEdge {
+      """The item at the end of the edge"""
+      node: Planet
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type FilmsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [FilmsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      films: [Film]
+    }
+
+    """An edge in a connection."""
+    type FilmsEdge {
+      """The item at the end of the edge"""
+      node: Film
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type FilmSpeciesConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [FilmSpeciesEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      species: [Species]
+    }
+
+    """An edge in a connection."""
+    type FilmSpeciesEdge {
+      """The item at the end of the edge"""
+      node: Species
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type FilmStarshipsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [FilmStarshipsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      starships: [Starship]
+    }
+
+    """An edge in a connection."""
+    type FilmStarshipsEdge {
+      """The item at the end of the edge"""
+      node: Starship
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type FilmVehiclesConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [FilmVehiclesEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      vehicles: [Vehicle]
+    }
+
+    """An edge in a connection."""
+    type FilmVehiclesEdge {
+      """The item at the end of the edge"""
+      node: Vehicle
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """An object with an ID"""
+    interface Node {
+      """The id of the object."""
+      id: ID!
+    }
+
+    """Information about pagination in a connection."""
+    type PageInfo {
+      """When paginating forwards, are there more items?"""
+      hasNextPage: Boolean!
+
+      """When paginating backwards, are there more items?"""
+      hasPreviousPage: Boolean!
+
+      """When paginating backwards, the cursor to continue."""
+      startCursor: String
+
+      """When paginating forwards, the cursor to continue."""
+      endCursor: String
+    }
+
+    """A connection to a list of items."""
+    type PeopleConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [PeopleEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      people: [Person]
+    }
+
+    """An edge in a connection."""
+    type PeopleEdge {
+      """The item at the end of the edge"""
+      node: Person
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """An individual person or character within the Star Wars universe."""
+    type Person implements Node {
+      """The name of this person."""
+      name: String
+
+      """
+      The birth year of the person, using the in-universe standard of BBY or ABY -
+      Before the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is
+      a battle that occurs at the end of Star Wars episode IV: A New Hope.
+      """
+      birthYear: String
+
+      """
+      The eye color of this person. Will be "unknown" if not known or "n/a" if the
+      person does not have an eye.
+      """
+      eyeColor: String
+
+      """
+      The gender of this person. Either "Male", "Female" or "unknown",
+      "n/a" if the person does not have a gender.
+      """
+      gender: String
+
+      """
+      The hair color of this person. Will be "unknown" if not known or "n/a" if the
+      person does not have hair.
+      """
+      hairColor: String
+
+      """The height of the person in centimeters."""
+      height: Int
+
+      """The mass of the person in kilograms."""
+      mass: Float
+
+      """The skin color of this person."""
+      skinColor: String
+
+      """A planet that this person was born on or inhabits."""
+      homeworld: Planet
+      filmConnection(after: String, first: Int, before: String, last: Int): PersonFilmsConnection
+
+      """The species that this person belongs to, or null if unknown."""
+      species: Species
+      starshipConnection(after: String, first: Int, before: String, last: Int): PersonStarshipsConnection
+      vehicleConnection(after: String, first: Int, before: String, last: Int): PersonVehiclesConnection
+
+      """The ISO 8601 date format of the time that this resource was created."""
+      created: String
+
+      """The ISO 8601 date format of the time that this resource was edited."""
+      edited: String
+
+      """The ID of an object"""
+      id: ID!
+    }
+
+    """A connection to a list of items."""
+    type PersonFilmsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [PersonFilmsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      films: [Film]
+    }
+
+    """An edge in a connection."""
+    type PersonFilmsEdge {
+      """The item at the end of the edge"""
+      node: Film
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type PersonStarshipsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [PersonStarshipsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      starships: [Starship]
+    }
+
+    """An edge in a connection."""
+    type PersonStarshipsEdge {
+      """The item at the end of the edge"""
+      node: Starship
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type PersonVehiclesConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [PersonVehiclesEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      vehicles: [Vehicle]
+    }
+
+    """An edge in a connection."""
+    type PersonVehiclesEdge {
+      """The item at the end of the edge"""
+      node: Vehicle
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """
+    A large mass, planet or planetoid in the Star Wars Universe, at the time of
+    0 ABY.
+    """
+    type Planet implements Node {
+      """The name of this planet."""
+      name: String
+
+      """The diameter of this planet in kilometers."""
+      diameter: Int
+
+      """
+      The number of standard hours it takes for this planet to complete a single
+      rotation on its axis.
+      """
+      rotationPeriod: Int
+
+      """
+      The number of standard days it takes for this planet to complete a single orbit
+      of its local star.
+      """
+      orbitalPeriod: Int
+
+      """
+      A number denoting the gravity of this planet, where "1" is normal or 1 standard
+      G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs.
+      """
+      gravity: String
+
+      """The average population of sentient beings inhabiting this planet."""
+      population: Float
+
+      """The climates of this planet."""
+      climates: [String]
+
+      """The terrains of this planet."""
+      terrains: [String]
+
+      """
+      The percentage of the planet surface that is naturally occuring water or bodies
+      of water.
+      """
+      surfaceWater: Float
+      residentConnection(after: String, first: Int, before: String, last: Int): PlanetResidentsConnection
+      filmConnection(after: String, first: Int, before: String, last: Int): PlanetFilmsConnection
+
+      """The ISO 8601 date format of the time that this resource was created."""
+      created: String
+
+      """The ISO 8601 date format of the time that this resource was edited."""
+      edited: String
+
+      """The ID of an object"""
+      id: ID!
+    }
+
+    """A connection to a list of items."""
+    type PlanetFilmsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [PlanetFilmsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      films: [Film]
+    }
+
+    """An edge in a connection."""
+    type PlanetFilmsEdge {
+      """The item at the end of the edge"""
+      node: Film
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type PlanetResidentsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [PlanetResidentsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      residents: [Person]
+    }
+
+    """An edge in a connection."""
+    type PlanetResidentsEdge {
+      """The item at the end of the edge"""
+      node: Person
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type PlanetsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [PlanetsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      planets: [Planet]
+    }
+
+    """An edge in a connection."""
+    type PlanetsEdge {
+      """The item at the end of the edge"""
+      node: Planet
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    type Root {
+      allFilms(after: String, first: Int, before: String, last: Int): FilmsConnection
+      film(id: ID, filmID: ID): Film
+      allPeople(after: String, first: Int, before: String, last: Int): PeopleConnection
+      person(id: ID, personID: ID): Person
+      allPlanets(after: String, first: Int, before: String, last: Int): PlanetsConnection
+      planet(id: ID, planetID: ID): Planet
+      allSpecies(after: String, first: Int, before: String, last: Int): SpeciesConnection
+      species(id: ID, speciesID: ID): Species
+      allStarships(after: String, first: Int, before: String, last: Int): StarshipsConnection
+      starship(id: ID, starshipID: ID): Starship
+      allVehicles(after: String, first: Int, before: String, last: Int): VehiclesConnection
+      vehicle(id: ID, vehicleID: ID): Vehicle
+
+      """Fetches an object given its ID"""
+      node(
+        """The ID of an object"""
+        id: ID!
+      ): Node
+    }
+
+    """A type of person or character within the Star Wars Universe."""
+    type Species implements Node {
+      """The name of this species."""
+      name: String
+
+      """The classification of this species, such as "mammal" or "reptile"."""
+      classification: String
+
+      """The designation of this species, such as "sentient"."""
+      designation: String
+
+      """The average height of this species in centimeters."""
+      averageHeight: Float
+
+      """The average lifespan of this species in years, null if unknown."""
+      averageLifespan: Int
+
+      """
+      Common eye colors for this species, null if this species does not typically
+      have eyes.
+      """
+      eyeColors: [String]
+
+      """
+      Common hair colors for this species, null if this species does not typically
+      have hair.
+      """
+      hairColors: [String]
+
+      """
+      Common skin colors for this species, null if this species does not typically
+      have skin.
+      """
+      skinColors: [String]
+
+      """The language commonly spoken by this species."""
+      language: String
+
+      """A planet that this species originates from."""
+      homeworld: Planet
+      personConnection(after: String, first: Int, before: String, last: Int): SpeciesPeopleConnection
+      filmConnection(after: String, first: Int, before: String, last: Int): SpeciesFilmsConnection
+
+      """The ISO 8601 date format of the time that this resource was created."""
+      created: String
+
+      """The ISO 8601 date format of the time that this resource was edited."""
+      edited: String
+
+      """The ID of an object"""
+      id: ID!
+    }
+
+    """A connection to a list of items."""
+    type SpeciesConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [SpeciesEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      species: [Species]
+    }
+
+    """An edge in a connection."""
+    type SpeciesEdge {
+      """The item at the end of the edge"""
+      node: Species
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type SpeciesFilmsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [SpeciesFilmsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      films: [Film]
+    }
+
+    """An edge in a connection."""
+    type SpeciesFilmsEdge {
+      """The item at the end of the edge"""
+      node: Film
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type SpeciesPeopleConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [SpeciesPeopleEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      people: [Person]
+    }
+
+    """An edge in a connection."""
+    type SpeciesPeopleEdge {
+      """The item at the end of the edge"""
+      node: Person
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A single transport craft that has hyperdrive capability."""
+    type Starship implements Node {
+      """The name of this starship. The common name, such as "Death Star"."""
+      name: String
+
+      """
+      The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
+      Orbital Battle Station".
+      """
+      model: String
+
+      """
+      The class of this starship, such as "Starfighter" or "Deep Space Mobile
+      Battlestation"
+      """
+      starshipClass: String
+
+      """The manufacturers of this starship."""
+      manufacturers: [String]
+
+      """The cost of this starship new, in galactic credits."""
+      costInCredits: Float
+
+      """The length of this starship in meters."""
+      length: Float
+
+      """The number of personnel needed to run or pilot this starship."""
+      crew: String
+
+      """The number of non-essential people this starship can transport."""
+      passengers: String
+
+      """
+      The maximum speed of this starship in atmosphere. null if this starship is
+      incapable of atmosphering flight.
+      """
+      maxAtmospheringSpeed: Int
+
+      """The class of this starships hyperdrive."""
+      hyperdriveRating: Float
+
+      """
+      The Maximum number of Megalights this starship can travel in a standard hour.
+      A "Megalight" is a standard unit of distance and has never been defined before
+      within the Star Wars universe. This figure is only really useful for measuring
+      the difference in speed of starships. We can assume it is similar to AU, the
+      distance between our Sun (Sol) and Earth.
+      """
+      MGLT: Int
+
+      """The maximum number of kilograms that this starship can transport."""
+      cargoCapacity: Float
+
+      """
+      The maximum length of time that this starship can provide consumables for its
+      entire crew without having to resupply.
+      """
+      consumables: String
+      pilotConnection(after: String, first: Int, before: String, last: Int): StarshipPilotsConnection
+      filmConnection(after: String, first: Int, before: String, last: Int): StarshipFilmsConnection
+
+      """The ISO 8601 date format of the time that this resource was created."""
+      created: String
+
+      """The ISO 8601 date format of the time that this resource was edited."""
+      edited: String
+
+      """The ID of an object"""
+      id: ID!
+    }
+
+    """A connection to a list of items."""
+    type StarshipFilmsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [StarshipFilmsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      films: [Film]
+    }
+
+    """An edge in a connection."""
+    type StarshipFilmsEdge {
+      """The item at the end of the edge"""
+      node: Film
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type StarshipPilotsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [StarshipPilotsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      pilots: [Person]
+    }
+
+    """An edge in a connection."""
+    type StarshipPilotsEdge {
+      """The item at the end of the edge"""
+      node: Person
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type StarshipsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [StarshipsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      starships: [Starship]
+    }
+
+    """An edge in a connection."""
+    type StarshipsEdge {
+      """The item at the end of the edge"""
+      node: Starship
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A single transport craft that does not have hyperdrive capability"""
+    type Vehicle implements Node {
+      """
+      The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
+      bike".
+      """
+      name: String
+
+      """
+      The model or official name of this vehicle. Such as "All-Terrain Attack
+      Transport".
+      """
+      model: String
+
+      """The class of this vehicle, such as "Wheeled" or "Repulsorcraft"."""
+      vehicleClass: String
+
+      """The manufacturers of this vehicle."""
+      manufacturers: [String]
+
+      """The cost of this vehicle new, in Galactic Credits."""
+      costInCredits: Float
+
+      """The length of this vehicle in meters."""
+      length: Float
+
+      """The number of personnel needed to run or pilot this vehicle."""
+      crew: String
+
+      """The number of non-essential people this vehicle can transport."""
+      passengers: String
+
+      """The maximum speed of this vehicle in atmosphere."""
+      maxAtmospheringSpeed: Int
+
+      """The maximum number of kilograms that this vehicle can transport."""
+      cargoCapacity: Float
+
+      """
+      The maximum length of time that this vehicle can provide consumables for its
+      entire crew without having to resupply.
+      """
+      consumables: String
+      pilotConnection(after: String, first: Int, before: String, last: Int): VehiclePilotsConnection
+      filmConnection(after: String, first: Int, before: String, last: Int): VehicleFilmsConnection
+
+      """The ISO 8601 date format of the time that this resource was created."""
+      created: String
+
+      """The ISO 8601 date format of the time that this resource was edited."""
+      edited: String
+
+      """The ID of an object"""
+      id: ID!
+    }
+
+    """A connection to a list of items."""
+    type VehicleFilmsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [VehicleFilmsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      films: [Film]
+    }
+
+    """An edge in a connection."""
+    type VehicleFilmsEdge {
+      """The item at the end of the edge"""
+      node: Film
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type VehiclePilotsConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [VehiclePilotsEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      pilots: [Person]
+    }
+
+    """An edge in a connection."""
+    type VehiclePilotsEdge {
+      """The item at the end of the edge"""
+      node: Person
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }
+
+    """A connection to a list of items."""
+    type VehiclesConnection {
+      """Information to aid in pagination."""
+      pageInfo: PageInfo!
+
+      """A list of edges."""
+      edges: [VehiclesEdge]
+
+      """
+      A count of the total number of objects in this connection, ignoring pagination.
+      This allows a client to fetch the first five objects by passing "5" as the
+      argument to "first", then fetch the total count so it could display "5 of 83",
+      for example.
+      """
+      totalCount: Int
+
+      """
+      A list of all of the objects returned in the connection. This is a convenience
+      field provided for quickly exploring the API; rather than querying for
+      "{ edges { node } }" when no edge data is needed, this field can be be used
+      instead. Note that when clients like Relay need to fetch the "cursor" field on
+      the edge to enable efficient pagination, this shortcut cannot be used, and the
+      full "{ edges { node } }" version should be used instead.
+      """
+      vehicles: [Vehicle]
+    }
+
+    """An edge in a connection."""
+    type VehiclesEdge {
+      """The item at the end of the edge"""
+      node: Vehicle
+
+      """A cursor for use in pagination"""
+      cursor: String!
+    }

--- a/plugins/api-docs/README.md
+++ b/plugins/api-docs/README.md
@@ -14,8 +14,9 @@ The plugin provides a standalone list of APIs, as well as an integration into th
 
 Right now, the following API formats are supported:
 
-- [OpenAPI](https://swagger.io/specification/) 2 & 3,
-- [AsyncAPI](https://www.asyncapi.com/docs/specifications/latest/),
+- [OpenAPI](https://swagger.io/specification/) 2 & 3
+- [AsyncAPI](https://www.asyncapi.com/docs/specifications/latest/)
+- [GraphQL](https://graphql.org/learn/schema/)
 
 Other formats are displayed as plain text, but this can easily be extented.
 

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -29,6 +29,8 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
+    "graphiql": "^1.0.0-alpha.10",
+    "graphql": "^15.3.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/api-docs/src/catalog/EntityPageApi/EntityPageApi.tsx
+++ b/plugins/api-docs/src/catalog/EntityPageApi/EntityPageApi.tsx
@@ -16,7 +16,7 @@
 
 import { ComponentEntity, Entity } from '@backstage/catalog-model';
 import { Progress } from '@backstage/core';
-import React, { FC } from 'react';
+import React from 'react';
 import { Grid } from '@material-ui/core';
 import {
   ApiDefinitionCard,
@@ -24,7 +24,11 @@ import {
   useComponentApiNames,
 } from '../../components';
 
-export const EntityPageApi: FC<{ entity: Entity }> = ({ entity }) => {
+type Props = {
+  entity: Entity;
+};
+
+export const EntityPageApi = ({ entity }: Props) => {
   const apiNames = useComponentApiNames(entity as ComponentEntity);
 
   const { apiEntities, loading } = useComponentApiEntities({

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -15,12 +15,13 @@
  */
 
 import { ApiEntity } from '@backstage/catalog-model';
-import { TabbedCard, CardTab } from '@backstage/core';
+import { CardTab, TabbedCard } from '@backstage/core';
+import { Alert } from '@material-ui/lab';
 import React from 'react';
 import { PlainApiDefinitionWidget } from '../PlainApiDefinitionWidget';
-import { Alert } from '@material-ui/lab';
 import { OpenApiDefinitionWidget } from '../OpenApiDefinitionWidget';
 import { AsyncApiDefinitionWidget } from '../AsyncApiDefinitionWidget';
+import { GraphQlDefinitionWidget } from '../GraphQlDefinitionWidget';
 
 type ApiDefinitionWidget = {
   type: string;
@@ -45,6 +46,14 @@ export function defaultDefinitionWidgets(): ApiDefinitionWidget[] {
       rawLanguage: 'yaml',
       component: definition => (
         <AsyncApiDefinitionWidget definition={definition} />
+      ),
+    },
+    {
+      type: 'graphql',
+      title: 'GraphQL',
+      rawLanguage: 'graphql',
+      component: definition => (
+        <GraphQlDefinitionWidget definition={definition} />
       ),
     },
   ];

--- a/plugins/api-docs/src/components/ApiEntityPage/ApiEntityPage.tsx
+++ b/plugins/api-docs/src/components/ApiEntityPage/ApiEntityPage.tsx
@@ -34,6 +34,7 @@ import { useAsync } from 'react-use';
 import { ApiDefinitionCard } from '../ApiDefinitionCard';
 
 const REDIRECT_DELAY = 1000;
+
 function headerProps(
   kind: string,
   namespace: string | undefined,

--- a/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinitionWidget.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Suspense } from 'react';
+import { buildSchema } from 'graphql';
+import { makeStyles } from '@material-ui/core/styles';
+import { Progress } from '@backstage/core';
+import { BackstageTheme } from '@backstage/theme';
+
+const GraphiQL = React.lazy(() => import('graphiql'));
+
+const useStyles = makeStyles<BackstageTheme>(() => ({
+  root: {
+    height: '100%',
+    display: 'flex',
+    flexFlow: 'column nowrap',
+  },
+  graphiQlWrapper: {
+    flex: 1,
+    '@global': {
+      '.graphiql-container': {
+        boxSizing: 'initial',
+        height: '100%',
+        minHeight: '600px',
+        flex: '1 1 auto',
+      },
+    },
+  },
+}));
+
+type Props = {
+  definition: any;
+};
+
+export const GraphQlDefinitionWidget = ({ definition }: Props) => {
+  const classes = useStyles();
+  const schema = buildSchema(definition);
+
+  return (
+    <Suspense fallback={<Progress />}>
+      <div className={classes.root}>
+        <div className={classes.graphiQlWrapper}>
+          <GraphiQL
+            fetcher={() => Promise.resolve(null) as any}
+            schema={schema}
+            docExplorerOpen
+            defaultSecondaryEditorOpen={false}
+          />
+        </div>
+      </div>
+    </Suspense>
+  );
+};

--- a/plugins/api-docs/src/components/GraphQlDefinitionWidget/index.ts
+++ b/plugins/api-docs/src/components/GraphQlDefinitionWidget/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { GraphQlDefinitionWidget } from './GraphQlDefinitionWidget';

--- a/yarn.lock
+++ b/yarn.lock
@@ -17550,7 +17550,7 @@ react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-i
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-lazylog@^4.5.2:
+react-lazylog@^4.5.2, react-lazylog@^4.5.3:
   version "4.5.3"
   resolved "https://registry.npmjs.org/react-lazylog/-/react-lazylog-4.5.3.tgz#289e24995b5599e75943556ac63f5e2c04d0001e"
   integrity sha512-lyov32A/4BqihgXgtNXTHCajXSXkYHPlIEmV8RbYjHIMxCFSnmtdg4kDCI3vATz7dURtiFTvrw5yonHnrS+NNg==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a quick & rough experiment for adding support for `graphql` API types.

- Using `graphiql` for now. Most solutions for generating docs from graphql SDL schemas are tailored for generating static sites (e.g. https://github.com/2fd/graphdoc) and not dynamically. `GraphiQL` has a docs explorer but it's not ideal for documentation only. If anyone knows of something else that would be great.
- Styling is really rough (borrowed from `plugins/graphiql`)

<img width="2193" alt="image" src="https://user-images.githubusercontent.com/6507159/92281229-22ecc180-eec9-11ea-954a-dc02ebb41de2.png">

<img width="2189" alt="image" src="https://user-images.githubusercontent.com/6507159/92281356-68a98a00-eec9-11ea-9795-2cca09e83ac2.png">

<img width="2189" alt="image" src="https://user-images.githubusercontent.com/6507159/92281372-72cb8880-eec9-11ea-8ad8-264d75a20270.png">

<img width="2190" alt="image" src="https://user-images.githubusercontent.com/6507159/92281260-2e3fed00-eec9-11ea-95a2-ac8d1eeea897.png">

#### Future

- Loading the API spec definition from an external location would be ideal. Possibly this could be done with locations (e.g. #2001)
- Would be interesting to extend the API catalog model to support annotations to indicate the URL to a live instance (possibly including params for any required headers, etc.).

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
