### PR TITLE
feat: support specifying lint output format

### DIFF
--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -22,7 +22,7 @@ export default async (cmd: Command, cmdArgs: string[]) => {
   const args = [
     '--ext=js,jsx,ts,tsx',
     '--max-warnings=0',
-    '--format=eslint-formatter-friendly',
+    `--format=${cmd.format}`,
     ...(cmdArgs ?? [paths.targetDir]),
   ];
   if (cmd.fix) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -113,6 +113,11 @@ const main = (argv: string[]) => {
 
   program
     .command('lint')
+    .option(
+      '--format <format>',
+      'Lint report output format',
+      'eslint-formatter-friendly',
+    )
     .option('--fix', 'Attempt to automatically fix violations')
     .description('Lint a package')
     .action(lazyAction(() => import('./commands/lint'), 'default'));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I'm trying to support running `backstage-cli lint --format=<whatever>` so that we can integrate the output of that with CI pipelines (in my case, [GitLab](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool))

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

### Questions

I've tried to run this using `yarn lerna run --json --loglevel=silent -- lint -- --format=json > output.txt`, but I find that I've got command lines in between each output line:

```
$ backstage-cli lint --format=json
~~snip~~
$ backstage-cli lint --format=json
~~snip~~
```

I'm not sure if there's a way to work around this short of manually listing the workspaces and running `backstage-cli lint` on each workspace individually.