### PR TITLE
fix(e2e): attempt to unbreak e2e tests due to bad rollup-plugin-dts release

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,7 +76,7 @@
     "recursive-readdir": "^2.2.2",
     "replace-in-file": "^6.0.0",
     "rollup": "2.23.x",
-    "rollup-plugin-dts": "^1.4.6",
+    "rollup-plugin-dts": "1.4.11",
     "rollup-plugin-esbuild": "^2.0.0",
     "rollup-plugin-image-files": "^1.4.2",
     "rollup-plugin-peer-deps-external": "^2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20008,10 +20008,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-dts@^1.4.6:
-  version "1.4.10"
-  resolved "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-1.4.10.tgz#0373c4284a2ba4d2d72df69c289271a816bc2736"
-  integrity sha512-bL6MBXc8lK7D5b/tYbHaglxs4ZxMQTQilGA6Xm9KQBEj4h9ZwIDlAsvDooGjJ/cOw23r3POTRtSCEyTHxtzHJg==
+rollup-plugin-dts@1.4.11:
+  version "1.4.11"
+  resolved "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-1.4.11.tgz#aedf0b7bb91d51e20b755e2c18e840edfc7af7a1"
+  integrity sha512-yiScAMKgwH77b44a/IFGgjLsmwSlNfQhEM+eCb2uMrupQMPE1n/12wrnT431+v1u6wYMF1XuHqldh+v/7mTvYA==
   optionalDependencies:
     "@babel/code-frame" "^7.10.4"
 


### PR DESCRIPTION
Without this, it chooses (at least on my machine) the .12 release which exhibits this problem. Weirdly, there isn't even a .12 tag on the project page, so maybe something odd is up. Pinning to .11 makes it build locally at least.