### PR TITLE
Added techdocs-ref to backstage entity

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     github.com/project-slug: spotify/backstage
     backstage.io/github-actions-id: spotify/backstage
+    backstage.io/techdocs-ref: github:https://github.com/spotify/backstage.git
 spec:
   type: library
   owner: Spotify

--- a/plugins/github-actions/scripts/sample.yaml
+++ b/plugins/github-actions/scripts/sample.yaml
@@ -5,6 +5,7 @@ metadata:
   description: backstage.io
   annotations:
     github.com/project-slug: 'spotify/backstage'
+    backstage.io/techdocs-ref: github:https://github.com/spotify/backstage.git
 spec:
   type: website
   lifecycle: production


### PR DESCRIPTION
## Hey, I just made a Pull Request!

closes: #2067 

This PR adds a techdocs reference for the backstage entity. We also realized there was a script generating backstage as an entity for the github actions plugin, see `sample.yaml`. So we added it there as well. Let us know if we can focus on adding it to only one of the two yaml files. 

![Screen Shot 2020-08-24 at 3 50 04 PM](https://user-images.githubusercontent.com/25153114/91052579-f2339f00-e621-11ea-8c65-fa6d1a5345bc.png)


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
