### PR TITLE
cli-common: remove dev dep on cli

### DIFF
--- a/packages/cli-common/package.json
+++ b/packages/cli-common/package.json
@@ -29,7 +29,6 @@
     "clean": "backstage-cli clean"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.1.1-alpha.19",
     "@types/jest": "^26.0.7",
     "@types/node": "^12.0.0"
   },


### PR DESCRIPTION
The CLI will be available anyway, this is just to make yarn not complain about the circular dep :>