### PR TITLE
workflows: no need to include deps in build for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,7 @@ jobs:
 
       - name: build changed packages
         if: ${{ steps.yarn-lock.outcome == 'success' }}
-        # Need to build all dependencies as well to be able to run tests later
-        run: yarn lerna -- run build --since origin/master --include-dependencies
+        run: yarn lerna -- run build --since origin/master
 
       - name: build all packages
         if: ${{ steps.yarn-lock.outcome == 'failure' }}


### PR DESCRIPTION
Tests in CI no longer use dist version of packages, so no need to build all deps anymore :grin: