### PR TITLE
config: add missing methods to Config type

### DIFF
--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -30,10 +30,12 @@ export type AppConfig = {
 };
 
 export type Config = {
+  has(key: string): boolean;
+
   keys(): string[];
 
-  get(key: string): JsonValue;
-  getOptional(key: string): JsonValue | undefined;
+  get(key?: string): JsonValue;
+  getOptional(key?: string): JsonValue | undefined;
 
   getConfig(key: string): Config;
   getOptionalConfig(key: string): Config | undefined;


### PR DESCRIPTION
Forgot to add these to the interface when adding them to the `ConfigReader` :grin: