### PR TITLE
Update Refresh Token, if provided by the server in the refresh grant. Refs #2128

### DIFF
--- a/plugins/auth-backend/src/lib/OAuthProvider.ts
+++ b/plugins/auth-backend/src/lib/OAuthProvider.ts
@@ -258,6 +258,13 @@ export class OAuthProvider implements AuthProviderRouteHandlers {
 
       await this.populateIdentity(response.backstageIdentity);
 
+      if (
+        response.providerInfo.refreshToken &&
+        response.providerInfo.refreshToken !== refreshToken
+      ) {
+        this.setRefreshTokenCookie(res, response.providerInfo.refreshToken);
+      }
+
       res.send(response);
     } catch (error) {
       res.status(401).send(`${error.message}`);

--- a/plugins/auth-backend/src/lib/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/lib/PassportStrategyHelper.ts
@@ -45,7 +45,6 @@ export const makeProfileInfo = (
   if ((!email || !picture) && idToken) {
     try {
       const decoded: Record<string, string> = jwtDecoder(idToken);
-
       if (!email && decoded.email) {
         email = decoded.email;
       }
@@ -133,7 +132,7 @@ export const executeRefreshTokenStrategy = async (
       (
         err: Error | null,
         accessToken: string,
-        _refreshToken: string,
+        newRefreshToken: string,
         params: any,
       ) => {
         if (err) {
@@ -149,6 +148,7 @@ export const executeRefreshTokenStrategy = async (
 
         resolve({
           accessToken,
+          refreshToken: newRefreshToken,
           params,
         });
       },

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -107,13 +107,16 @@ export class OAuth2AuthProvider implements OAuthProviderHandlers {
       refreshToken,
       scope,
     );
-    const { accessToken, params } = refreshTokenResponse;
-    const updatedRefreshToken = refreshTokenResponse.refreshToken;
+    const {
+      accessToken,
+      params,
+      refreshToken: updatedRefreshToken,
+    } = refreshTokenResponse;
 
     const profile = await executeFetchUserProfileStrategy(
       this._strategy,
-      refreshTokenResponse.accessToken,
-      refreshTokenResponse.params.id_token,
+      accessToken,
+      params.id_token,
     );
 
     return this.populateIdentity({

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -259,6 +259,10 @@ export type OAuthProviderInfo = {
    * Scopes granted for the access token.
    */
   scope: string;
+  /**
+   * A refresh token issued for the signed in user
+   */
+  refreshToken?: string;
 };
 
 export type OAuthPrivateInfo = {
@@ -326,6 +330,10 @@ export type RefreshTokenResponse = {
    * An access token issued for the signed in user.
    */
   accessToken: string;
+  /**
+   * Optionally, the server can issue a new Refresh Token for the user
+   */
+  refreshToken?: string;
   params: any;
 };
 


### PR DESCRIPTION
Refs #2128 
The OAuth2 specifications specify that during the refresh grant, the
server may provide an alternate refresh Token along with the access
Token when performing a token refresh.
The oauth2 provider in the `auth-backend` ignores the newer refresh
token during the refresh grant.
This commit will update the refresh token cookie at the end of the
call to the `/auth/oauth2/refresh` endpoint if the server provides a new
refresh token during the `refresh_token` grant.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
