### PR TITLE
Make lighthouse url configurable in example app

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -44,6 +44,9 @@ newrelic:
     baseUrl: 'https://api.newrelic.com/v2'
     key: NEW_RELIC_REST_API_KEY
 
+lighthouse:
+  baseUrl: http://localhost:3003
+
 catalog:
   exampleEntityLocations:
     github:

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -27,6 +27,9 @@ describe('App', () => {
           data: {
             app: { title: 'Test' },
             backend: { baseUrl: 'http://localhost:7000' },
+            lighthouse: {
+              baseUrl: 'http://localhost:3003',
+            },
             techdocs: {
               storageUrl: 'http://localhost:7000/techdocs/static/docs',
             },

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -114,7 +114,7 @@ export const apis = (config: ConfigApi) => {
 
   builder.add(featureFlagsApiRef, new FeatureFlags());
 
-  builder.add(lighthouseApiRef, new LighthouseRestApi('http://localhost:3003'));
+  builder.add(lighthouseApiRef, LighthouseRestApi.fromConfig(config));
 
   builder.add(travisCIApiRef, new TravisCIApi());
   builder.add(githubPullRequestsApiRef, new GithubPullRequestsClient());

--- a/plugins/lighthouse/README.md
+++ b/plugins/lighthouse/README.md
@@ -36,16 +36,24 @@ your [`apis.ts`](https://github.com/spotify/backstage/blob/master/packages/app/s
 
 ```js
 import { ApiHolder, ApiRegistry } from '@backstage/core';
+import { Config } from '@backstage/config';
 import {
   lighthouseApiRef,
   LighthouseRestApi,
 } from '@backstage/plugin-lighthouse';
 
-const builder = ApiRegistry.builder();
+export const apis = (config: ConfigApi) => {
+  const builder = ApiRegistry.builder();
 
-export const lighthouseApi =
-  new LighthouseRestApi(/* your service url here! */);
-builder.add(lighthouseApiRef, lighthouseApi);
+  builder.add(lighthouseApiRef, LighthouseRestApi.fromConfig(config));
 
-export default builder.build() as ApiHolder;
+  return builder.build() as ApiHolder;
+}
+```
+
+Then configure the lighthouse service url in your [`app-config.yaml`](https://github.com/spotify/backstage/blob/master/app-config.yaml).
+
+```yaml
+lighthouse:
+  baseUrl: http://your-service-url
 ```

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -21,6 +21,7 @@
     "start": "backstage-cli plugin:serve"
   },
   "dependencies": {
+    "@backstage/config": "^0.1.1-alpha.20",
     "@backstage/core": "^0.1.1-alpha.20",
     "@backstage/theme": "^0.1.1-alpha.20",
     "@material-ui/core": "^4.9.1",

--- a/plugins/lighthouse/src/api.ts
+++ b/plugins/lighthouse/src/api.ts
@@ -15,6 +15,7 @@
  */
 
 import { createApiRef } from '@backstage/core';
+import { Config } from '@backstage/config';
 
 export type LighthouseCategoryId =
   | 'pwa'
@@ -111,6 +112,10 @@ export const lighthouseApiRef = createApiRef<LighthouseApi>({
 });
 
 export class LighthouseRestApi implements LighthouseApi {
+  static fromConfig(config: Config) {
+    return new LighthouseRestApi(config.getString('lighthouse.baseUrl'));
+  }
+
   constructor(public url: string) {}
 
   private async fetch<T = any>(input: string, init?: RequestInit): Promise<T> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates the example app so the lighthouse url is configurable from the `app-config.yaml`

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
