### PR TITLE
Cleanup & renames to common database code

### DIFF
--- a/packages/backend-common/src/database/connection.test.ts
+++ b/packages/backend-common/src/database/connection.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { createDatabase } from './connection';
+import { createDatabaseClient } from './connection';
 
 describe('database connection', () => {
   const createConfig = (data: any) =>
@@ -26,10 +26,10 @@ describe('database connection', () => {
       },
     ]);
 
-  describe(createDatabase, () => {
+  describe(createDatabaseClient, () => {
     it('returns a postgres connection', () => {
       expect(
-        createDatabase(
+        createDatabaseClient(
           createConfig({
             client: 'pg',
             connection: {
@@ -45,7 +45,7 @@ describe('database connection', () => {
 
     it('returns an sqlite connection', () => {
       expect(
-        createDatabase(
+        createDatabaseClient(
           createConfig({
             client: 'sqlite3',
             connection: ':memory:',
@@ -56,7 +56,7 @@ describe('database connection', () => {
 
     it('tries to create a mysql connection as a passthrough', () => {
       expect(() =>
-        createDatabase(
+        createDatabaseClient(
           createConfig({
             client: 'mysql',
             connection: {
@@ -72,7 +72,7 @@ describe('database connection', () => {
 
     it('accepts overrides', () => {
       expect(
-        createDatabase(
+        createDatabaseClient(
           createConfig({
             client: 'pg',
             connection: {
@@ -93,7 +93,7 @@ describe('database connection', () => {
 
     it('throws an error without a client', () => {
       expect(() =>
-        createDatabase(
+        createDatabaseClient(
           createConfig({
             connection: '',
           }),
@@ -103,7 +103,7 @@ describe('database connection', () => {
 
     it('throws an error without a connection', () => {
       expect(() =>
-        createDatabase(
+        createDatabaseClient(
           createConfig({
             client: 'pg',
           }),

--- a/packages/backend-common/src/database/connection.ts
+++ b/packages/backend-common/src/database/connection.ts
@@ -15,30 +15,36 @@
  */
 
 import knex from 'knex';
-import { ConfigReader } from '@backstage/config';
+import { Config } from '@backstage/config';
 import { mergeDatabaseConfig } from './config';
-import { createPgDatabase } from './postgres';
-import { createSqlite3Database } from './sqlite3';
+import { createPgDatabaseClient } from './postgres';
+import { createSqliteDatabaseClient } from './sqlite3';
 
 type DatabaseClient = 'pg' | 'sqlite3' | string;
 
 /**
  * Creates a knex database connection
  *
- * @param config The database config
+ * @param dbConfig The database config
  * @param overrides Additional options to merge with the config
  */
-export function createDatabase(
-  config: ConfigReader,
+export function createDatabaseClient(
+  dbConfig: Config,
   overrides?: Partial<knex.Config>,
 ) {
-  const client: DatabaseClient = config.getString('client');
+  const client: DatabaseClient = dbConfig.getString('client');
 
   if (client === 'pg') {
-    return createPgDatabase(config, overrides);
+    return createPgDatabaseClient(dbConfig, overrides);
   } else if (client === 'sqlite3') {
-    return createSqlite3Database(config);
+    return createSqliteDatabaseClient(dbConfig);
   }
 
-  return knex(mergeDatabaseConfig(config.get(), overrides));
+  return knex(mergeDatabaseConfig(dbConfig.get(), overrides));
 }
+
+/**
+ * Alias for createDatabaseClient
+ * @deprecated Use createDatabaseClient instead
+ */
+export const createDatabase = createDatabaseClient;

--- a/packages/backend-common/src/database/sqlite3.test.ts
+++ b/packages/backend-common/src/database/sqlite3.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { buildSqlite3DatabaseConfig, createSqlite3Database } from './sqlite3';
+import {
+  buildSqliteDatabaseConfig,
+  createSqliteDatabaseClient,
+} from './sqlite3';
 
 describe('sqlite3', () => {
   const createConfig = (connection: any) =>
@@ -29,9 +32,9 @@ describe('sqlite3', () => {
       },
     ]);
 
-  describe(buildSqlite3DatabaseConfig, () => {
+  describe(buildSqliteDatabaseConfig, () => {
     it('buidls a string connection', () => {
-      expect(buildSqlite3DatabaseConfig(createConfig(':memory:'))).toEqual({
+      expect(buildSqliteDatabaseConfig(createConfig(':memory:'))).toEqual({
         client: 'sqlite3',
         connection: ':memory:',
         useNullAsDefault: true,
@@ -40,7 +43,7 @@ describe('sqlite3', () => {
 
     it('builds a filename connection', () => {
       expect(
-        buildSqlite3DatabaseConfig(
+        buildSqliteDatabaseConfig(
           createConfig({
             filename: '/path/to/foo',
           }),
@@ -56,7 +59,7 @@ describe('sqlite3', () => {
 
     it('replaces the connection with an override', () => {
       expect(
-        buildSqlite3DatabaseConfig(createConfig(':memory:'), {
+        buildSqliteDatabaseConfig(createConfig(':memory:'), {
           connection: { filename: '/path/to/foo' },
         }),
       ).toEqual({
@@ -69,10 +72,10 @@ describe('sqlite3', () => {
     });
   });
 
-  describe(createSqlite3Database, () => {
+  describe(createSqliteDatabaseClient, () => {
     it('creates an in memory knex instance', () => {
       expect(
-        createSqlite3Database(
+        createSqliteDatabaseClient(
           createConfig({
             client: 'sqlite3',
             connection: ':memory:',

--- a/packages/backend-common/src/database/sqlite3.ts
+++ b/packages/backend-common/src/database/sqlite3.ts
@@ -15,7 +15,7 @@
  */
 
 import knex from 'knex';
-import { ConfigReader } from '@backstage/config';
+import { Config } from '@backstage/config';
 import { mergeDatabaseConfig } from './config';
 
 /**
@@ -24,11 +24,11 @@ import { mergeDatabaseConfig } from './config';
  * @param dbConfig The database config
  * @param overrides Additional options to merge with the config
  */
-export function createSqlite3Database(
-  dbConfig: ConfigReader,
+export function createSqliteDatabaseClient(
+  dbConfig: Config,
   overrides?: knex.Config,
 ) {
-  const knexConfig = buildSqlite3DatabaseConfig(dbConfig, overrides);
+  const knexConfig = buildSqliteDatabaseConfig(dbConfig, overrides);
   const database = knex(knexConfig);
 
   database.client.pool.on('createSuccess', (_eventId: any, resource: any) => {
@@ -44,8 +44,8 @@ export function createSqlite3Database(
  * @param dbConfig The database config
  * @param overrides Additional options to merge with the config
  */
-export function buildSqlite3DatabaseConfig(
-  dbConfig: ConfigReader,
+export function buildSqliteDatabaseConfig(
+  dbConfig: Config,
   overrides?: knex.Config,
 ) {
   return mergeDatabaseConfig(

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -23,7 +23,7 @@
  */
 
 import {
-  createDatabase,
+  createDatabaseClient,
   createServiceBuilder,
   loadBackendConfig,
   getRootLogger,
@@ -48,11 +48,14 @@ function makeCreateEnv(loadedConfigs: AppConfig[]) {
 
   return (plugin: string): PluginEnvironment => {
     const logger = getRootLogger().child({ type: 'plugin', plugin });
-    const database = createDatabase(config.getConfig('backend.database'), {
-      connection: {
-        database: `backstage_plugin_${plugin}`,
+    const database = createDatabaseClient(
+      config.getConfig('backend.database'),
+      {
+        connection: {
+          database: `backstage_plugin_${plugin}`,
+        },
       },
-    });
+    );
     return { logger, database, config };
   };
 }

--- a/packages/create-app/templates/default-app/packages/backend/src/index.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/index.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  createDatabase,
+  createDatabaseClient,
   createServiceBuilder,
   loadBackendConfig,
   getRootLogger,
@@ -27,11 +27,14 @@ function makeCreateEnv(loadedConfigs: AppConfig[]) {
 
   return (plugin: string): PluginEnvironment => {
     const logger = getRootLogger().child({ type: 'plugin', plugin });
-    const database = createDatabase(config.getConfig('backend.database'), {
-      connection: {
-        database: `backstage_plugin_${plugin}`,
+    const database = createDatabaseClient(
+      config.getConfig('backend.database'),
+      {
+        connection: {
+          database: `backstage_plugin_${plugin}`,
+        },
       },
-    });
+    );
     return { logger, database, config };
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow up for #1915 and pre-work for adding some migration / db creation helpers.

- renamed `createDatabase` to `createDatabaseClient` to avoid confusion with anything that might create an actual database. I left an alias here with a deprecation flag to avoid breaking any apps that had been generated.
- updated the backend template to use `createDatabaseClient` instead of `createDatabase`
- split out `getPgConnectionConfig` from `buildPgDatabaseConfig` to it can be used independently (e.g. with `pgtools`)
- renamed `createPgDatabase` to `createPgDatabaseClient`
- renamed `createSqlite3Database` to `createSqliteDatabaseClient`
- refactored the `postgres` tests to be more dry + added tests for `getPgConnectionConfig`
- updated code to use `Config` vs `ConfigReader`

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
