### PR TITLE
Add Pull Request Plugin to the marketplace

### DIFF
--- a/microsite/data/plugins/github-pull-requests.yaml
+++ b/microsite/data/plugins/github-pull-requests.yaml
@@ -1,0 +1,10 @@
+---
+title: Github Pull Requests
+author: roadie.io
+authorUrl: https://roadie.io/
+category: CI
+description: View Github pull requests for your service in Backstage.
+documentation: https://roadie.io/backstage/plugins/github-pull-requests
+iconUrl: https://roadie.io/static/7f13bb8d861d8dedc5112fb939d215f9/351f2/GitHub-Mark-Light-120px-plus.png
+npmPackageName: '@roadiehq/backstage-plugin-github-pull-requests'
+

--- a/microsite/data/plugins/github-pull-requests.yaml
+++ b/microsite/data/plugins/github-pull-requests.yaml
@@ -1,9 +1,9 @@
 ---
-title: Github Pull Requests
+title: GitHub Pull Requests
 author: roadie.io
 authorUrl: https://roadie.io/
 category: CI
-description: View Github pull requests for your service in Backstage.
+description: View GitHub pull requests for your service in Backstage.
 documentation: https://roadie.io/backstage/plugins/github-pull-requests
 iconUrl: https://roadie.io/static/7f13bb8d861d8dedc5112fb939d215f9/351f2/GitHub-Mark-Light-120px-plus.png
 npmPackageName: '@roadiehq/backstage-plugin-github-pull-requests'


### PR DESCRIPTION
We also have a github pull request plugin which we would like to add to the market place.
https://roadie.io/backstage/plugins/github-pull-requests
I'm not sure if CI is the correct category, open to suggestions...

![image](https://user-images.githubusercontent.com/1415599/91729520-94143800-eb9c-11ea-9bea-4e547e937dc3.png)


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
