### PR TITLE
cli: fix version management in create-app

### DIFF
--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -28,6 +28,7 @@ import {
 } from '../../lib/codeowners';
 import { paths } from '../../lib/paths';
 import { Task, templatingTask } from '../../lib/tasks';
+import { version as backstageVersion } from '../../lib/version';
 
 const exec = promisify(execCb);
 
@@ -239,7 +240,11 @@ export default async () => {
     await createTemporaryPluginFolder(tempDir);
 
     Task.section('Preparing files');
-    await templatingTask(templateDir, tempDir, { ...answers, version });
+    await templatingTask(templateDir, tempDir, {
+      ...answers,
+      version,
+      backstageVersion,
+    });
 
     Task.section('Moving to final location');
     await movePlugin(tempDir, pluginDir, answers.id);

--- a/packages/cli/src/commands/plugin/diff.ts
+++ b/packages/cli/src/commands/plugin/diff.ts
@@ -25,7 +25,7 @@ import {
   yesPromptFunc,
 } from '../../lib/diff';
 import { paths } from '../../lib/paths';
-import { version } from '../../lib/version';
+import { version as backstageVersion } from '../../lib/version';
 
 export type PluginData = {
   id: string;
@@ -62,9 +62,12 @@ export default async (cmd: Command) => {
     promptFunc = yesPromptFunc;
   }
 
+  const { version } = await fs.readJson(paths.resolveTargetRoot('lerna.json'));
+
   const data = await readPluginData();
   const templateFiles = await diffTemplateFiles('default-plugin', {
     version,
+    backstageVersion,
     ...data,
   });
   await handleAllFiles(fileHandlers, templateFiles, promptFunc);

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -21,8 +21,8 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@backstage/core": "^{{version}}",
-    "@backstage/theme": "^{{version}}",
+    "@backstage/core": "^{{backstageVersion}}",
+    "@backstage/theme": "^{{backstageVersion}}",
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
@@ -31,8 +31,8 @@
     "react-use": "^15.3.3"
   },
   "devDependencies": {
-    "@backstage/cli": "^{{version}}",
-    "@backstage/dev-utils": "^{{version}}",
+    "@backstage/cli": "^{{backstageVersion}}",
+    "@backstage/dev-utils": "^{{backstageVersion}}",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.4.1",
     "@testing-library/user-event": "^12.0.7",

--- a/packages/create-app/templates/default-app/lerna.json
+++ b/packages/create-app/templates/default-app/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*", "plugins/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "{{version}}"
+  "version": "0.1.0"
 }


### PR DESCRIPTION
`create-app` should use the version of the `backstage-cli` to set the version of the Backstage dependencies, but use the version in `lerna.json` to set the version of the plugin itself.

The lerna version should not be set to the version of the `backstage-cli`, since that should not be tracking the Backstage version and would deviate very quickly. This reverts it back to being set to "0.1.0" for new apps.