### PR TITLE
cli: define BUILD_INFO in builds

### DIFF
--- a/packages/cli/src/lib/bundler/bundle.ts
+++ b/packages/cli/src/lib/bundler/bundle.ts
@@ -36,7 +36,7 @@ export async function buildBundle(options: BuildOptions) {
   const { statsJsonEnabled } = options;
 
   const paths = resolveBundlingPaths(options);
-  const config = createConfig(paths, {
+  const config = await createConfig(paths, {
     ...options,
     checksEnabled: false,
     isDev: false,

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -30,7 +30,7 @@ export async function serveBundle(options: ServeOptions) {
   const paths = resolveBundlingPaths(options);
   const pkgPath = paths.targetPackageJson;
   const pkg = await fs.readJson(pkgPath);
-  const config = createConfig(paths, {
+  const config = await createConfig(paths, {
     ...options,
     isDev: true,
     baseUrl: url,


### PR DESCRIPTION
Surfacing for troubleshooting purposes etc

Looks like this:

```ts
process.env.BUILD_INFO = {
  "cliVersion": "0.1.1-alpha.20",
  "gitVersion": "v0.1.1-alpha.20-133-g3fbf052e",
  "packageVersion": "0.1.1-alpha.20",
  "timestamp": 1598889034133,
  "commit": "3fbf052e1286d508756f3966a2f34f640f81909f"
}
```

Probably no reason to make breaking changes once we merge this, but still thinking we keep this as a somewhat private, undocumented API. Main use-case is gonna be to surface in error reports and in an about panel, which can all be part of core anyway.