### PR TITLE
cli: use regexps to match paths for rollup plugins

### DIFF
--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -88,15 +88,25 @@ export const makeConfigs = async (
         }),
         resolve({ mainFields }),
         commonjs({
-          include: ['node_modules/**', '../../node_modules/**'],
-          exclude: ['**/*.stories.*', '**/*.test.*'],
+          include: /node_modules/,
+          exclude: [/\/[^/]+\.(?:stories|test)\.[^/]+$/],
         }),
         postcss(),
-        imageFiles({ exclude: '**/*.icon.svg' }),
+        imageFiles({
+          exclude: /\.icon\.svg$/,
+          include: [
+            /\.css$/,
+            /\.svg$/,
+            /\.png$/,
+            /\.gif$/,
+            /\.jpg$/,
+            /\.jpeg$/,
+          ],
+        }),
         json(),
         yaml(),
         svgr({
-          include: '**/*.icon.svg',
+          include: /\.icon\.svg$/,
           template: svgrTemplate,
         }),
         esbuild({


### PR DESCRIPTION
Fixes windows build issues, since rollup ends up creating some bad patterns that don't match some files otherwise.

Wasn't able to tie this to any existing or past issue in rollup or surrounding packages, but also cba looking into it furher :p