### PR TITLE
Change templates to use Home theme

### DIFF
--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -95,7 +95,7 @@ export const ScaffolderPage: React.FC<{}> = () => {
           <Typography variant="body2">
             Shoot! Looks like you don't have any templates. Check out the
             documentation{' '}
-            <Link href="docs/backstage/features/software-templates/adding-templates">
+            <Link href="https://backstage.io/docs/features/software-templates/adding-templates">
               here!
             </Link>
           </Typography>

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -64,7 +64,7 @@ export const ScaffolderPage: React.FC<{}> = () => {
   }, [error, errorApi]);
 
   return (
-    <Page theme={pageTheme.other}>
+    <Page theme={pageTheme.home}>
       <Header
         pageTitleOverride="Create a new component"
         title={

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -136,7 +136,7 @@ export const TemplatePage = () => {
   }
 
   return (
-    <Page theme={pageTheme.other}>
+    <Page theme={pageTheme.home}>
       <Header
         pageTitleOverride="Create a new component"
         title={


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Software Templates are part of the core experience and should therefore have the `Home` theme.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
