### PR TITLE
config,docs: add templates as allowed kind and document process

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -48,6 +48,8 @@ lighthouse:
   baseUrl: http://localhost:3003
 
 catalog:
+  rules:
+    allow: [Component, API, Group, Template]
   processors:
     githubApi:
       privateToken:

--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -32,7 +32,7 @@ For example, given the following configuration:
 ```yaml
 catalog:
   rules:
-    - allow: [Component, API, System]
+    - allow: [Component, API, Template]
 
   locations:
     - type: github
@@ -40,7 +40,7 @@ catalog:
       allow: [Group]
 ```
 
-We are able to add entities of kind `Component`, `API`, or `System` from any
+We are able to add entities of kind `Component`, `API`, or `Template` from any
 location, and `Group` entities from the `org-data.yaml`, which will also be read
 as statically configured location.
 

--- a/docs/features/software-templates/adding-templates.md
+++ b/docs/features/software-templates/adding-templates.md
@@ -58,6 +58,28 @@ Currently the catalog supports loading definitions from GitHub + Local Files. To
 load from other places, not only will there need to be another preparer, but the
 support to load the location will also need to be added to the Catalog.
 
+You can add the template files to the catalog through
+[static location configuration](../software-catalog/configuration.md#static-location-configuration),
+for example
+
+```yaml
+catalog:
+  locations:
+    - type: github
+      target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
+      allow: [Template]
+```
+
+Templates can also be added by posting the to the catalog directly. Note that if
+you're doing this, you need to configure the catalog to allow template entities
+to be ingested from any source, for example:
+
+```yaml
+catalog:
+  rules:
+    allow: [Component, API, Template]
+```
+
 For loading from a file, the following command should work when the backend is
 running:
 

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -69,11 +69,16 @@ catalog:
     # Backstage example templates
     - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml
+      allow: [Template]
     - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/template.yaml
+      allow: [Template]
     - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/create-react-app/template.yaml
+      allow: [Template]
     - type: github
       target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
+      allow: [Template]
     - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml
+      allow: [Template]


### PR DESCRIPTION
Scaffolder is a bit broken atm since you're not allowed to ingest the example templates 😅 

Opted for adding it to config instead of allow templates by default. I don't think defaulting to allowing templates is sane long-term, as that's something you'll likely want to lock down a bit.