### PR TITLE
catalog-backend: wrap location-specific rules in an additional rules field

### DIFF
--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -37,7 +37,8 @@ catalog:
   locations:
     - type: github
       target: https://github.com/org/example/blob/master/org-data.yaml
-      allow: [Group]
+      rules:
+        - allow: [Group]
 ```
 
 We are able to add entities of kind `Component`, `API`, or `Template` from any

--- a/docs/features/software-templates/adding-templates.md
+++ b/docs/features/software-templates/adding-templates.md
@@ -67,7 +67,8 @@ catalog:
   locations:
     - type: github
       target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
-      allow: [Template]
+      rules:
+        - allow: [Template]
 ```
 
 Templates can also be added by posting the to the catalog directly. Note that if

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -69,16 +69,21 @@ catalog:
     # Backstage example templates
     - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml
-      allow: [Template]
+      rules:
+        - allow: [Template]
     - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/template.yaml
-      allow: [Template]
+      rules:
+        - allow: [Template]
     - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/create-react-app/template.yaml
-      allow: [Template]
+      rules:
+        - allow: [Template]
     - type: github
       target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
-      allow: [Template]
+      rules:
+        - allow: [Template]
     - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml
-      allow: [Template]
+      rules:
+        - allow: [Template]

--- a/plugins/catalog-backend/src/ingestion/CatalogRules.test.ts
+++ b/plugins/catalog-backend/src/ingestion/CatalogRules.test.ts
@@ -167,7 +167,11 @@ describe('CatalogRulesEnforcer', () => {
               {
                 type: 'github',
                 target: 'https://github.com/a/b/blob/master/x.yaml',
-                allow: ['Group'],
+                rules: [
+                  {
+                    allow: ['Group'],
+                  },
+                ],
               },
             ],
           },

--- a/plugins/catalog-backend/src/ingestion/CatalogRules.ts
+++ b/plugins/catalog-backend/src/ingestion/CatalogRules.ts
@@ -64,7 +64,7 @@ export class CatalogRulesEnforcer {
    * If there is no matching rule to allow an ingested entity, it will be rejected by the catalog.
    *
    * It also reads in rules from `catalog.locations`, where each location can have a list
-   * of allowed entity for the location, specified in an `allow` field.
+   * of rules for that specific location, specified in a `rules` field.
    *
    * For example:
    *
@@ -76,10 +76,12 @@ export class CatalogRulesEnforcer {
    *   locations:
    *   - type: github
    *     target: https://github.com/org/repo/blob/master/users.yaml
-   *     allow: [User, Group]
+   *     rules:
+   *       - allow: [User, Group]
    *   - type: github
    *     target: https://github.com/org/repo/blob/master/systems.yaml
-   *     allow: [System]
+   *     rules:
+   *       - allow: [System]
    * ```
    */
   static fromConfig(config: Config) {
@@ -97,22 +99,17 @@ export class CatalogRulesEnforcer {
     if (config.has('catalog.locations')) {
       const locationRules = config
         .getConfigArray('catalog.locations')
-        .flatMap(sub => {
-          if (!sub.has('allow')) {
+        .flatMap(locConf => {
+          if (!locConf.has('rules')) {
             return [];
           }
+          const type = locConf.getString('type');
+          const target = locConf.getString('target');
 
-          return [
-            {
-              allow: sub.getStringArray('allow').map(kind => ({ kind })),
-              locations: [
-                {
-                  type: sub.getString('type'),
-                  target: sub.getString('target'),
-                },
-              ],
-            },
-          ];
+          return locConf.getConfigArray('rules').map(ruleConf => ({
+            allow: ruleConf.getStringArray('allow').map(kind => ({ kind })),
+            locations: [{ type, target }],
+          }));
         });
 
       rules.push(...locationRules);


### PR DESCRIPTION
Addresses https://github.com/spotify/backstage/pull/2206#discussion_r480988658

This was intended to be part of the original PR, but forgot to make the change 😅 

Also brings up the question, maybe it makes more sense that the location-specific rules override the global ones, instead of add to them?