### PR TITLE
BREAKING CHANGE: no longer add express.json() by default to backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ If you encounter issues while upgrading to a newer version, don't hesitate to re
 
 > Collect changes for the next release below
 
+- The backend plugin
+  [service builder](https://github.com/spotify/backstage/blob/master/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts)
+  no longer adds `express.json()` automatically to all routes. While convenient
+  in a lot of cases, it also led to problems where for example the proxy
+  middleware could hang because the body had already been altered and could not
+  be streamed. Also, plugins that rather wanted to handle e.g. form encoded data
+  still had to cater to that manually. We therefore decided to let plugins add
+  `express.json()` themselves if they happen to deal with JSON data.
+
 ## v0.1.1-alpha.20
 
 - Includes https://github.com/spotify/backstage/pull/2097 to resolve issues with create-plugin command.

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -135,7 +135,6 @@ export class ServiceBuilderImpl implements ServiceBuilder {
       app.use(cors(corsOptions));
     }
     app.use(compression());
-    app.use(express.json());
     if (this.enableMetrics) {
       app.use(metricsHandler());
     }

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -23,7 +23,6 @@
     "@backstage/backend-common": "^0.1.1-alpha.20",
     "@backstage/config": "^0.1.1-alpha.20",
     "@types/express": "^4.17.6",
-    "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -17,7 +17,6 @@
 import express from 'express';
 import Router from 'express-promise-router';
 import cookieParser from 'cookie-parser';
-import bodyParser from 'body-parser';
 import Knex from 'knex';
 import { Logger } from 'winston';
 import { createAuthProviderRouter } from '../providers';
@@ -53,8 +52,8 @@ export async function createRouter(
   });
 
   router.use(cookieParser());
-  router.use(bodyParser.urlencoded({ extended: false }));
-  router.use(bodyParser.json());
+  router.use(express.urlencoded({ extended: false }));
+  router.use(express.json());
 
   const providersConfig = options.config.getConfig('auth.providers');
   const providers = providersConfig.keys();

--- a/plugins/graphql/src/service/router.ts
+++ b/plugins/graphql/src/service/router.ts
@@ -39,8 +39,8 @@ export async function createRouter(
   const server = new ApolloServer({ typeDefs, logger: options.logger });
   const router = Router();
 
-  const apolloMiddlware = server.getMiddleware({ path: '/' });
-  router.use(apolloMiddlware);
+  const apolloMiddleware = server.getMiddleware({ path: '/' });
+  router.use(apolloMiddleware);
 
   router.get('/health', (_, response) => {
     response.send({ status: 'ok' });

--- a/plugins/identity-backend/src/service/router.ts
+++ b/plugins/identity-backend/src/service/router.ts
@@ -27,13 +27,15 @@ export interface RouterOptions {
 
 const makeRouter = (adapter: IdentityApi): express.Router => {
   const router = Router();
+  router.use(express.json());
+
   router.get('/users/:user/groups', async (req, res) => {
     const user = req.params.user;
     const type = req.query.type?.toString() ?? '';
-
     const response = await adapter.getUserGroups({ user, type });
     res.send(response);
   });
+
   return router;
 };
 

--- a/plugins/rollbar-backend/src/service/router.ts
+++ b/plugins/rollbar-backend/src/service/router.ts
@@ -31,6 +31,7 @@ export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const router = Router();
+
   const logger = options.logger.child({ plugin: 'rollbar' });
   const config = options.config.getConfig('rollbar');
   const accessToken = !options.rollbarApi

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -42,6 +42,7 @@ export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const router = Router();
+  router.use(express.json());
 
   const {
     preparers,

--- a/plugins/sentry-backend/src/service/router.ts
+++ b/plugins/sentry-backend/src/service/router.ts
@@ -20,6 +20,8 @@ import { getSentryApiForwarder } from './sentry-api';
 
 export async function createRouter(logger: Logger): Promise<express.Router> {
   const router = Router();
+  router.use(express.json());
+
   const SENTRY_TOKEN = process.env.SENTRY_TOKEN;
   if (!SENTRY_TOKEN) {
     if (process.env.NODE_ENV !== 'development') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6562,7 +6562,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
-body-parser@1.19.0, body-parser@^1.18.3, body-parser@^1.19.0:
+body-parser@1.19.0, body-parser@^1.18.3:
   version "1.19.0"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
This was initially helpful for some, but proved to be problematic for several reasons.