### PR TITLE
fix: use correct rules syntax

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -49,7 +49,7 @@ lighthouse:
 
 catalog:
   rules:
-    allow: [Component, API, Group, Template]
+    - allow: [Component, API, Group, Template, Location]
   processors:
     githubApi:
       privateToken:

--- a/docs/features/software-templates/adding-templates.md
+++ b/docs/features/software-templates/adding-templates.md
@@ -77,7 +77,7 @@ to be ingested from any source, for example:
 ```yaml
 catalog:
   rules:
-    allow: [Component, API, Template]
+    - allow: [Component, API, Template]
 ```
 
 For loading from a file, the following command should work when the backend is


### PR DESCRIPTION
Followup to #2206.

When I start the backend I get the following message:

```
[1] Backend failed to start up TypeError: Invalid type in config for key 'catalog.rules' in 'app-config.yaml', got object, wanted object-array
[1]     at ConfigReader.readConfigValue (webpack-internal:///../config/src/reader.ts:274:15)
[1]     at ConfigReader.getOptionalConfigArray (webpack-internal:///../config/src/reader.ts:155:26)
[1]     at ConfigReader.getConfigArray (webpack-internal:///../config/src/reader.ts:147:24)
[1]     at Function.fromConfig (webpack-internal:///../../plugins/catalog-backend/src/ingestion/CatalogRules.ts:91:34)
[1]     at new LocationReaders (webpack-internal:///../../plugins/catalog-backend/src/ingestion/LocationReaders.ts:117:77)
[1]     at createPlugin (webpack-internal:///./src/plugins/catalog.ts:30:26)
[1]     at main (webpack-internal:///./src/index.ts:91:98)
```

I fixed the wrong syntax in the `app-config.yaml` and the invalid docs that I found.