### PR TITLE
Add "Example Plugin" to Storybook

### DIFF
--- a/packages/core/src/layout/Page/Page.stories.tsx
+++ b/packages/core/src/layout/Page/Page.stories.tsx
@@ -24,27 +24,30 @@ import {
   pageTheme,
 } from '../';
 import { SupportButton, Table, StatusOK, TableColumn } from '../../components';
-import SettingsIcon from '@material-ui/icons/Settings';
-import Button from '@material-ui/core/Button';
-import { Box, Typography, Link, Chip } from '@material-ui/core';
+import { Box, Typography, Link, Chip, Button } from '@material-ui/core';
 
 export default {
   title: 'Example Plugin',
   component: Page,
 };
 
-const generateTestData: (number: number) => Array<{}> = (rows = 10) => {
-  const data: Array<{}> = [];
+interface TableData {
+  id: number;
+  branch: string;
+  hash: string;
+  status: string;
+}
+
+const generateTestData = (rows = 10) => {
+  const data: Array<TableData> = [];
   while (data.length <= rows) {
     data.push({
-      message: `A very important message`,
       id: data.length + 18534,
-      branchName: 'techdocs: modify documentation header',
+      branch: 'techdocs: modify documentation header',
       hash: 'techdocs/docs-header 5749c98e3f61f8bb116e5cb87b0e4e1 ',
       status: 'Success',
     });
   }
-
   return data;
 };
 
@@ -59,16 +62,16 @@ const columns: TableColumn[] = [
   {
     title: 'Message/Source',
     highlight: true,
-    render: row => (
+    render: (row: Partial<TableData>) => (
       <>
-        <Link>{row.branchName}</Link>
+        <Link>{row.branch}</Link>
         <Typography variant="body2">{row.hash}</Typography>
       </>
     ),
   },
   {
     title: 'Status',
-    render: row => (
+    render: (row: Partial<TableData>) => (
       <Box display="flex" alignItems="center">
         <StatusOK />
         <Typography variant="body2">{row.status}</Typography>
@@ -98,12 +101,16 @@ export const PluginWithTable = () => {
             </Box>
           )}
         >
-          <Button onClick={() => {}} startIcon={<SettingsIcon />}>
+          <Button
+            color="primary"
+            variant="contained"
+            style={{ marginRight: '16px' }}
+          >
             Settings
           </Button>
           <SupportButton>
-            This Plugin is an example. If this would not be an example, this
-            text could provide usefull information for the user.
+            This Plugin is an example. This text could provide usefull
+            information for the user.
           </SupportButton>
         </ContentHeader>
         <Table

--- a/packages/core/src/layout/Page/Page.stories.tsx
+++ b/packages/core/src/layout/Page/Page.stories.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  Header,
+  Page,
+  HeaderLabel,
+  ContentHeader,
+  Content,
+  pageTheme,
+} from '../';
+import { SupportButton, Table, StatusOK, TableColumn } from '../../components';
+import SettingsIcon from '@material-ui/icons/Settings';
+import Button from '@material-ui/core/Button';
+import { Box, Typography, Link, Chip } from '@material-ui/core';
+
+export default {
+  title: 'Example Plugin',
+  component: Page,
+};
+
+const generateTestData: (number: number) => Array<{}> = (rows = 10) => {
+  const data: Array<{}> = [];
+  while (data.length <= rows) {
+    data.push({
+      message: `A very important message`,
+      id: data.length + 18534,
+      branchName: 'techdocs: modify documentation header',
+      hash: 'techdocs/docs-header 5749c98e3f61f8bb116e5cb87b0e4e1 ',
+      status: 'Success',
+    });
+  }
+
+  return data;
+};
+
+const columns: TableColumn[] = [
+  {
+    title: 'ID',
+    field: 'id',
+    highlight: true,
+    type: 'numeric',
+    width: '80px',
+  },
+  {
+    title: 'Message/Source',
+    highlight: true,
+    render: row => (
+      <>
+        <Link>{row.branchName}</Link>
+        <Typography variant="body2">{row.hash}</Typography>
+      </>
+    ),
+  },
+  {
+    title: 'Status',
+    render: row => (
+      <Box display="flex" alignItems="center">
+        <StatusOK />
+        <Typography variant="body2">{row.status}</Typography>
+      </Box>
+    ),
+  },
+  {
+    title: 'Tags',
+    render: () => <Chip label="Tag Name" />,
+    width: '10%',
+  },
+];
+
+export const PluginWithTable = () => {
+  return (
+    <Page theme={pageTheme.tool}>
+      <Header title="Example" subtitle="This an example plugin">
+        <HeaderLabel label="Owner" value="Owner" />
+        <HeaderLabel label="Lifecycle" value="Lifecycle" />
+      </Header>
+      <Content>
+        <ContentHeader
+          title="Plugin Header"
+          titleComponent={() => (
+            <Box alignItems="center" display="flex">
+              <Typography variant="h4">Header</Typography>
+            </Box>
+          )}
+        >
+          <Button onClick={() => {}} startIcon={<SettingsIcon />}>
+            Settings
+          </Button>
+          <SupportButton>
+            This Plugin is an example. If this would not be an example, this
+            text could provide usefull information for the user.
+          </SupportButton>
+        </ContentHeader>
+        <Table
+          options={{ paging: true, padding: 'dense' }}
+          data={generateTestData(10)}
+          columns={columns}
+          title="Example Content"
+        />
+      </Content>
+    </Page>
+  );
+};

--- a/packages/core/src/layout/Page/Page.stories.tsx
+++ b/packages/core/src/layout/Page/Page.stories.tsx
@@ -93,19 +93,8 @@ export const PluginWithTable = () => {
         <HeaderLabel label="Lifecycle" value="Lifecycle" />
       </Header>
       <Content>
-        <ContentHeader
-          title="Plugin Header"
-          titleComponent={() => (
-            <Box alignItems="center" display="flex">
-              <Typography variant="h4">Header</Typography>
-            </Box>
-          )}
-        >
-          <Button
-            color="primary"
-            variant="contained"
-            style={{ marginRight: '16px' }}
-          >
+        <ContentHeader title="Header">
+          <Button color="primary" variant="contained">
             Settings
           </Button>
           <SupportButton>


### PR DESCRIPTION
This pull request adds a story for the basic structure of a plugin. I decided to create a `Page.stories.tsx` as I understand it as the starting point of custom plugins. 

I decided to name the story "Example Plugin" because of the issue name. Maybe it make sense to rename the story from "Example Plugin" to just "Page" so it is more clear, that this story focuses on a possible use case for the Page component. 

![image](https://user-images.githubusercontent.com/8904624/91849788-df8e1b00-ec5c-11ea-86f4-85ca9b8c35e4.png)

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

Closes #2122 
