### PR TITLE
catalog-backend: add Locations to the set of default allowed kinds

### DIFF
--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -23,16 +23,16 @@ configuration.
 ## Catalog Rules
 
 By default the catalog will only allow ingestion of entities with the kind
-`Component` and `API`. In order to allow entities of other kinds to be added,
-you need to add rules to the catalog. Rules are added either in a separate
-`catalog.rules` key, or added to statically configured locations.
+`Component`, `API` and `Location`. In order to allow entities of other kinds to
+be added, you need to add rules to the catalog. Rules are added either in a
+separate `catalog.rules` key, or added to statically configured locations.
 
 For example, given the following configuration:
 
 ```yaml
 catalog:
   rules:
-    - allow: [Component, API, Template]
+    - allow: [Component, API, Location, Template]
 
   locations:
     - type: github
@@ -41,13 +41,13 @@ catalog:
         - allow: [Group]
 ```
 
-We are able to add entities of kind `Component`, `API`, or `Template` from any
-location, and `Group` entities from the `org-data.yaml`, which will also be read
-as statically configured location.
+We are able to add entities of kind `Component`, `API`, `Location`, or
+`Template` from any location, and `Group` entities from the `org-data.yaml`,
+which will also be read as statically configured location.
 
 Note that if the `catalog.rules` key is present it will replace the default
-value, meaning that you need to add rules for `Component` and `API` kinds if you
-want those to be allowed.
+value, meaning that you need to add rules for the default kinds if you want
+those to still be allowed.
 
 The following configuration will reject any kind of entities from being added to
 the catalog:

--- a/plugins/catalog-backend/src/ingestion/CatalogRules.test.ts
+++ b/plugins/catalog-backend/src/ingestion/CatalogRules.test.ts
@@ -28,6 +28,9 @@ const entity = {
   component: {
     kind: 'component',
   } as Entity,
+  location: {
+    kind: 'Location',
+  } as Entity,
 };
 
 const location: Record<string, LocationSpec> = {
@@ -51,6 +54,7 @@ describe('CatalogRulesEnforcer', () => {
     expect(enforcer.isAllowed(entity.user, location.x)).toBe(false);
     expect(enforcer.isAllowed(entity.group, location.y)).toBe(false);
     expect(enforcer.isAllowed(entity.component, location.z)).toBe(false);
+    expect(enforcer.isAllowed(entity.location, location.z)).toBe(false);
   });
 
   it('should deny all', () => {
@@ -58,15 +62,21 @@ describe('CatalogRulesEnforcer', () => {
     expect(enforcer.isAllowed(entity.user, location.x)).toBe(false);
     expect(enforcer.isAllowed(entity.group, location.y)).toBe(false);
     expect(enforcer.isAllowed(entity.component, location.z)).toBe(false);
+    expect(enforcer.isAllowed(entity.location, location.z)).toBe(false);
   });
 
   it('should allow all', () => {
     const enforcer = new CatalogRulesEnforcer([
-      { allow: [{ kind: 'User' }, { kind: 'Group' }, { kind: 'Component' }] },
+      {
+        allow: ['User', 'Group', 'Component', 'Location'].map(kind => ({
+          kind,
+        })),
+      },
     ]);
     expect(enforcer.isAllowed(entity.user, location.x)).toBe(true);
     expect(enforcer.isAllowed(entity.group, location.y)).toBe(true);
     expect(enforcer.isAllowed(entity.component, location.z)).toBe(true);
+    expect(enforcer.isAllowed(entity.location, location.z)).toBe(true);
   });
 
   it('should deny groups', () => {
@@ -121,6 +131,7 @@ describe('CatalogRulesEnforcer', () => {
       expect(enforcer.isAllowed(entity.user, location.x)).toBe(false);
       expect(enforcer.isAllowed(entity.group, location.y)).toBe(false);
       expect(enforcer.isAllowed(entity.component, location.z)).toBe(true);
+      expect(enforcer.isAllowed(entity.location, location.z)).toBe(true);
     });
 
     it('should deny all', () => {
@@ -130,6 +141,7 @@ describe('CatalogRulesEnforcer', () => {
       expect(enforcer.isAllowed(entity.user, location.x)).toBe(false);
       expect(enforcer.isAllowed(entity.group, location.y)).toBe(false);
       expect(enforcer.isAllowed(entity.component, location.z)).toBe(false);
+      expect(enforcer.isAllowed(entity.location, location.z)).toBe(false);
     });
 
     it('should allow all', () => {
@@ -156,6 +168,7 @@ describe('CatalogRulesEnforcer', () => {
       expect(enforcer.isAllowed(entity.group, location.y)).toBe(false);
       expect(enforcer.isAllowed(entity.group, location.z)).toBe(false);
       expect(enforcer.isAllowed(entity.component, location.z)).toBe(true);
+      expect(enforcer.isAllowed(entity.location, location.z)).toBe(false);
     });
 
     it('should allow groups from a specific github location', () => {
@@ -182,6 +195,7 @@ describe('CatalogRulesEnforcer', () => {
       expect(enforcer.isAllowed(entity.group, location.y)).toBe(false);
       expect(enforcer.isAllowed(entity.group, location.z)).toBe(false);
       expect(enforcer.isAllowed(entity.component, location.z)).toBe(false);
+      expect(enforcer.isAllowed(entity.location, location.z)).toBe(false);
     });
 
     it('should not care about location configuration in catalog.rules', () => {
@@ -197,6 +211,7 @@ describe('CatalogRulesEnforcer', () => {
       expect(enforcer.isAllowed(entity.group, location.y)).toBe(true);
       expect(enforcer.isAllowed(entity.group, location.z)).toBe(true);
       expect(enforcer.isAllowed(entity.component, location.z)).toBe(false);
+      expect(enforcer.isAllowed(entity.location, location.z)).toBe(false);
     });
   });
 });

--- a/plugins/catalog-backend/src/ingestion/CatalogRules.ts
+++ b/plugins/catalog-backend/src/ingestion/CatalogRules.ts
@@ -50,7 +50,7 @@ export class CatalogRulesEnforcer {
    */
   static readonly defaultRules: CatalogRule[] = [
     {
-      allow: [{ kind: 'Component' }, { kind: 'API' }],
+      allow: ['Component', 'API', 'Location'].map(kind => ({ kind })),
     },
   ];
 


### PR DESCRIPTION
Location should be safe to allow, as entities discovered from those locations should be checked against the same rules as all other