### PR TITLE
app: mark as bundled

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,6 +2,7 @@
   "name": "example-app",
   "version": "0.1.1-alpha.20",
   "private": true,
+  "bundled": true,
   "dependencies": {
     "@backstage/cli": "^0.1.1-alpha.20",
     "@backstage/core": "^0.1.1-alpha.20",

--- a/packages/create-app/templates/default-app/packages/app/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/app/package.json.hbs
@@ -2,6 +2,7 @@
   "name": "app",
   "version": "0.0.0",
   "private": true,
+  "bundled": true,
   "dependencies": {
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
Bringing in a lot of extra dependencies when packaging the backend atm 😅 

This makes the `build-workspace` command stop at the app package when traversing the dependency graph. Without this, all app dependencies are brought in and packaged as part of the backend deployment.