### PR TITLE
backend-common: add resolvePackagePath

### DIFF
--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -20,4 +20,5 @@ export * from './errors';
 export * from './logging';
 export * from './middleware';
 export * from './service';
+export * from './paths';
 export * from './hot';

--- a/packages/backend-common/src/paths.ts
+++ b/packages/backend-common/src/paths.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/camelcase */
+
+import { resolve as resolvePath } from 'path';
+
+/**
+ * Resolve a path relative to the root of a package directory.
+ * Additional path arguments are resolved relative to the package dir.
+ *
+ * This is particularly useful when you want to access assets shipped with
+ * your backend plugin package. When doing so, do not forget to include the assets
+ * in your published package by adding them to `files` in your `package.json`.
+ */
+export function resolvePackagePath(name: string, ...paths: string[]) {
+  const req =
+    typeof __non_webpack_require__ === 'undefined'
+      ? require
+      : __non_webpack_require__;
+
+  return resolvePath(req.resolve(`${name}/package.json`), '..', ...paths);
+}

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { resolve as resolvePath, dirname } from 'path';
-import { notFoundHandler } from '@backstage/backend-common';
+import { resolve as resolvePath } from 'path';
+import { notFoundHandler, resolvePackagePath } from '@backstage/backend-common';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
@@ -23,19 +23,14 @@ import { injectEnvConfig } from '../lib/config';
 
 export interface RouterOptions {
   logger: Logger;
-  appPackageName?: string;
+  appPackageName: string;
   staticFallbackHandler?: express.Handler;
 }
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const appDistDir = resolvePath(
-    dirname(
-      __non_webpack_require__.resolve(`${options.appPackageName}/package.json`),
-    ),
-    'dist',
-  );
+  const appDistDir = resolvePackagePath(options.appPackageName, 'dist');
   options.logger.info(`Serving static app content from ${appDistDir}`);
 
   await injectEnvConfig({

--- a/plugins/auth-backend/src/identity/DatabaseKeyStore.ts
+++ b/plugins/auth-backend/src/identity/DatabaseKeyStore.ts
@@ -15,13 +15,13 @@
  */
 
 import Knex from 'knex';
-import path from 'path';
 import { utc } from 'moment';
+import { resolvePackagePath } from '@backstage/backend-common';
 import { AnyJWK, KeyStore, StoredKey } from './types';
 
-const migrationsDir = path.resolve(
-  require.resolve('@backstage/plugin-auth-backend/package.json'),
-  '../migrations',
+const migrationsDir = resolvePackagePath(
+  '@backstage/plugin-auth-backend',
+  'migrations',
 );
 
 const TABLE = 'signing_keys';

--- a/plugins/catalog-backend/src/database/DatabaseManager.ts
+++ b/plugins/catalog-backend/src/database/DatabaseManager.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import { getVoidLogger } from '@backstage/backend-common';
+import { getVoidLogger, resolvePackagePath } from '@backstage/backend-common';
 import { makeValidator } from '@backstage/catalog-model';
 import Knex from 'knex';
-import path from 'path';
 import { Logger } from 'winston';
 import { CommonDatabase } from './CommonDatabase';
 import { Database } from './types';
 
-const migrationsDir = path.resolve(
-  require.resolve('@backstage/plugin-catalog-backend/package.json'),
-  '../migrations',
+const migrationsDir = resolvePackagePath(
+  '@backstage/plugin-catalog-backend',
+  'migrations',
 );
 
 export type CreateDatabaseOptions = {

--- a/plugins/graphql/src/service/router.ts
+++ b/plugins/graphql/src/service/router.ts
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import { errorHandler } from '@backstage/backend-common';
+import { errorHandler, resolvePackagePath } from '@backstage/backend-common';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
 import fs from 'fs';
-import path from 'path';
 import { ApolloServer } from 'apollo-server-express';
 
-const schemaPath = path.resolve(
-  require.resolve('@backstage/plugin-graphql-backend/package.json'),
-  '../schema.gql',
+const schemaPath = resolvePackagePath(
+  '@backstage/plugin-graphql-backend',
+  'schema.gql',
 );
 
 export interface RouterOptions {


### PR DESCRIPTION
Finally think I found a clean solution for accessing assets shipped with a backend plugin 😅 

Also fixes the `__non_webpack_require__ is not defined` errors you'll see if trying to deploy latest master.