### PR TITLE
feat(core): Add chip component

### DIFF
--- a/packages/core/src/components/stories/Chip.stories.tsx
+++ b/packages/core/src/components/stories/Chip.stories.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Chip } from '@material-ui/core';
+
+export default {
+  title: 'Chip',
+  component: Chip,
+};
+
+export const Default = () => (
+  <Chip label="Default" />
+);
+
+export const LargeDeletable = () => (
+  <Chip
+    label="Large deletable"
+    size="medium"
+    onDelete={() => ({})}
+  />
+);
+
+export const LargeNotDeletable = () => (
+  <Chip
+    label="Large not deletable"
+    size="medium"
+  />
+);
+
+export const SmallDeletable = () => (
+  <Chip
+    label="Small deletable"
+    size="small"
+    onDelete={() => ({})}
+  />
+);
+
+export const SmallNotDeletable = () => (
+  <Chip
+    label="Small not deletable"
+    size="small"
+  />
+);

--- a/packages/theme/src/baseTheme.ts
+++ b/packages/theme/src/baseTheme.ts
@@ -192,9 +192,30 @@ export function createThemeOverrides(theme: BackstageTheme): Overrides {
     },
     MuiChip: {
       root: {
+        backgroundColor: '#D9D9D9',
         // By default there's no margin, but it's usually wanted, so we add some trailing margin
         marginRight: theme.spacing(1),
         marginBottom: theme.spacing(1),
+      },
+      label: {
+        color: theme.palette.grey[900],
+        lineHeight: `${theme.spacing(2.5)}px`,
+        fontWeight: theme.typography.fontWeightMedium,
+        fontSize: `${theme.spacing(1.75)}px`,
+      },
+      labelSmall: {
+        fontSize: `${theme.spacing(1.5)}px`,
+      },
+      deleteIcon: {
+        color: theme.palette.grey[500],
+        width: `${theme.spacing(3)}px`,
+        height: `${theme.spacing(3)}px`,
+        margin: `0 ${theme.spacing(0.75)}px 0 -${theme.spacing(0.75)}px`,
+      },
+      deleteIconSmall: {
+        width: `${theme.spacing(2)}px`,
+        height: `${theme.spacing(2)}px`,
+        margin: `0 ${theme.spacing(0.5)}px 0 -${theme.spacing(0.5)}px`,
       },
     },
     MuiCardHeader: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes #2219 

This adds the Chip component to the storybook.

**NOTES**: 
- I don't know if we need to add a padding to the chip container to match the design a little more
- I couldn't find an existing color in the palette that matched the chip container background "#D9D9D9"

![Capture d’écran 2020-09-02 à 00 17 58](https://user-images.githubusercontent.com/32459935/91911625-c2d00280-ecb1-11ea-98e6-652b6f699a31.png)
#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
