### PR TITLE
backend: Log formatting

### DIFF
--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -46,7 +46,8 @@
     "prom-client": "^12.0.0",
     "selfsigned": "^1.10.7",
     "stoppable": "^1.1.0",
-    "winston": "^3.2.1"
+    "winston": "^3.2.1",
+    "logform": "^2.1.1"
   },
   "peerDependencies": {
     "pg-connection-string": "^2.3.0"

--- a/packages/backend-common/src/logging/formats.ts
+++ b/packages/backend-common/src/logging/formats.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as winston from 'winston';
+import { TransformableInfo } from 'logform';
+
+const coloredTemplate = (info: TransformableInfo) => {
+  const { timestamp, level, message, plugin, service } = info;
+  const colorizer = winston.format.colorize();
+  const prefix = plugin || service;
+  const timestampColor = colorizer.colorize('timestamp', timestamp);
+  const prefixColor = colorizer.colorize('prefix', prefix);
+
+  return `${timestampColor} ${prefixColor} ${level} ${message}`;
+};
+
+export const coloredFormat = winston.format.combine(
+  winston.format.timestamp(),
+  winston.format.colorize({
+    colors: { timestamp: 'dim', prefix: 'blue' },
+  }),
+  winston.format.printf(coloredTemplate),
+);

--- a/packages/backend-common/src/logging/rootLogger.ts
+++ b/packages/backend-common/src/logging/rootLogger.ts
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 import * as winston from 'winston';
+import { coloredFormat } from './formats';
 
 let rootLogger: winston.Logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
   format:
     process.env.NODE_ENV === 'production'
       ? winston.format.json()
-      : winston.format.combine(
-          winston.format.colorize(),
-          winston.format.timestamp(),
-          winston.format.simple(),
-        ),
+      : coloredFormat,
   defaultMeta: { service: 'backstage' },
   transports: [
     new winston.transports.Console({

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -34,6 +34,7 @@ export interface RouterOptions {
 // given config.
 function buildMiddleware(
   pathPrefix: string,
+  logger: Logger,
   route: string,
   config: string | ProxyConfig,
 ): Proxy {
@@ -54,6 +55,9 @@ function buildMiddleware(
     fullConfig.changeOrigin = true;
   }
 
+  // Attach the logger to the proxy config
+  fullConfig.logProvider = () => logger;
+
   return createProxyMiddleware(fullConfig);
 }
 
@@ -66,7 +70,12 @@ export async function createRouter(
   Object.entries(proxyConfig).forEach(([route, proxyRouteConfig]) => {
     router.use(
       route,
-      buildMiddleware(options.pathPrefix, route, proxyRouteConfig),
+      buildMiddleware(
+        options.pathPrefix,
+        options.logger,
+        route,
+        proxyRouteConfig,
+      ),
     );
   });
 


### PR DESCRIPTION
Tried to make the logs look a bit nicer for the backend. I also noticed that `http-proxy-middleware` has an option to replace it's log provider, which I thought was neat.

Example:
![Screenshot 2020-09-02 at 11 04 19](https://user-images.githubusercontent.com/18682151/91962525-eecca180-ed0c-11ea-92e6-ca762fbf30ec.png)
