### PR TITLE
techdocs-backend: use resolvePackagePath instead of __dirname

### DIFF
--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -19,7 +19,6 @@ import express from 'express';
 import Knex from 'knex';
 import fetch from 'node-fetch';
 import { Config } from '@backstage/config';
-import path from 'path';
 import Docker from 'dockerode';
 import {
   GeneratorBuilder,
@@ -27,6 +26,7 @@ import {
   PublisherBase,
   LocalPublish,
 } from '../techdocs';
+import { resolvePackagePath } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 
 type RouterOptions = {
@@ -38,6 +38,11 @@ type RouterOptions = {
   config: Config;
   dockerClient: Docker;
 };
+
+const staticDocsDir = resolvePackagePath(
+  '@backstage/plugin-techdocs-backend',
+  'static/docs',
+);
 
 export async function createRouter({
   preparers,
@@ -102,10 +107,7 @@ export async function createRouter({
   });
 
   if (publisher instanceof LocalPublish) {
-    router.use(
-      '/static/docs/',
-      express.static(path.resolve(__dirname, `../../static/docs`)),
-    );
+    router.use('/static/docs/', express.static(staticDocsDir));
     router.use(
       '/static/docs/:kind/:namespace/:name',
       async (req, res, next) => {

--- a/plugins/techdocs-backend/src/techdocs/stages/publish/local.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/publish/local.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import fs from 'fs-extra';
-import path from 'path';
 import { Logger } from 'winston';
 import { Entity } from '@backstage/catalog-model';
 import { PublisherBase } from './types';
+import { resolvePackagePath } from '@backstage/backend-common';
 
 export class LocalPublish implements PublisherBase {
   private readonly logger: Logger;
@@ -39,9 +39,9 @@ export class LocalPublish implements PublisherBase {
     | { remoteUrl: string } {
     const entityNamespace = entity.metadata.namespace ?? 'default';
 
-    const publishDir = path.resolve(
-      __dirname,
-      '../../../../static/docs/',
+    const publishDir = resolvePackagePath(
+      '@backstage/plugin-techdocs-backend',
+      'static/docs',
       entity.kind,
       entityNamespace,
       entity.metadata.name,


### PR DESCRIPTION
`__dirname` doesn't refer to the same dir in production builds. We'll prolly want to add a lint rule to avoid usage of `__dirname`