### PR TITLE
TechDocs: Get branchname from repo instance instead of location url

### DIFF
--- a/plugins/techdocs-backend/src/techdocs/stages/prepare/helpers.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/prepare/helpers.ts
@@ -79,9 +79,10 @@ export const checkoutGitRepository = async (
 
   if (fs.existsSync(repositoryTmpPath)) {
     const repository = await Repository.open(repositoryTmpPath);
+    const currentBranchName = (await repository.getCurrentBranch()).shorthand();
     await repository.mergeBranches(
-      parsedGitLocation.ref,
-      `origin/${parsedGitLocation.ref}`,
+      currentBranchName,
+      `origin/${currentBranchName}`,
     );
     return repositoryTmpPath;
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
