### PR TITLE
catalog: remove sentry widget

### DIFF
--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -27,7 +27,6 @@
     "@backstage/plugin-github-actions": "^0.1.1-alpha.20",
     "@backstage/plugin-jenkins": "^0.1.1-alpha.20",
     "@backstage/plugin-scaffolder": "^0.1.1-alpha.20",
-    "@backstage/plugin-sentry": "^0.1.1-alpha.20",
     "@backstage/plugin-techdocs": "^0.1.1-alpha.20",
     "@backstage/theme": "^0.1.1-alpha.20",
     "@material-ui/core": "^4.9.1",

--- a/plugins/catalog/src/components/EntityPageOverview/EntityPageOverview.tsx
+++ b/plugins/catalog/src/components/EntityPageOverview/EntityPageOverview.tsx
@@ -16,7 +16,6 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { Content } from '@backstage/core';
-import { SentryIssuesWidget } from '@backstage/plugin-sentry';
 import { Widget as GithubActionsWidget } from '@backstage/plugin-github-actions';
 import {
   JenkinsBuildsWidget,
@@ -52,12 +51,6 @@ export const EntityPageOverview: FC<{ entity: Entity }> = ({ entity }) => {
             <GithubActionsWidget entity={entity} branch="master" />
           </Grid>
         )}
-        <Grid item sm={8}>
-          <SentryIssuesWidget
-            sentryProjectId="sample-sentry-project-id"
-            statsFor="24h"
-          />
-        </Grid>
       </Grid>
     </Content>
   );


### PR DESCRIPTION
create-app breaks unless we remove also remove the sentry plugin from the catalog ._.