### PR TITLE
Update package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "classnames": "^2.2.6",
     "clsx": "^1.1.0",
     "lodash": "^4.17.15",
-    "material-table": "1.68.0",
+    "material-table": "1.69.0",
     "prop-types": "^15.7.2",
     "rc-progress": "^3.0.0",
     "react": "^16.12.0",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This bumps `material-table` to `1.69.0` which bumps `jsPDF` to `2.1.0` which hopefully eliminates the issue with `eligrey/FileSaver.js` that users behind a corporate firewall are plagued by.     see https://github.com/MrRio/jsPDF/issues/2490 for more context, or reach out to me if needed.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
