### PR TITLE
Conditionally add Sentry widget to component page

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Router as GitHubActionsRouter } from '@backstage/plugin-github-actions';
+import { Router as SentryRouter } from '@backstage/plugin-sentry';
 import React from 'react';
 import {
   EntityPageLayout,
@@ -43,6 +44,11 @@ const ServiceEntityPage = ({ entity }: { entity: Entity }) => (
       title="CI/CD"
       element={<GitHubActionsRouter entity={entity} />}
     />
+    <EntityPageLayout.Content
+      path="/sentry"
+      title="Sentry"
+      element={<SentryRouter entity={entity} />}
+    />
   </EntityPageLayout>
 );
 
@@ -57,6 +63,11 @@ const WebsiteEntityPage = ({ entity }: { entity: Entity }) => (
       path="/ci-cd/*"
       title="CI/CD"
       element={<GitHubActionsRouter entity={entity} />}
+    />
+    <EntityPageLayout.Content
+      path="/sentry"
+      title="Sentry"
+      element={<SentryRouter entity={entity} />}
     />
   </EntityPageLayout>
 );

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -27,6 +27,7 @@
     "@backstage/plugin-github-actions": "^0.1.1-alpha.21",
     "@backstage/plugin-jenkins": "^0.1.1-alpha.21",
     "@backstage/plugin-scaffolder": "^0.1.1-alpha.21",
+    "@backstage/plugin-sentry": "^0.1.1-alpha.21",
     "@backstage/plugin-techdocs": "^0.1.1-alpha.21",
     "@backstage/theme": "^0.1.1-alpha.21",
     "@material-ui/core": "^4.9.1",

--- a/plugins/catalog/src/components/EntityPageOverview/EntityPageOverview.tsx
+++ b/plugins/catalog/src/components/EntityPageOverview/EntityPageOverview.tsx
@@ -17,6 +17,7 @@
 // TODO(shmidt-i): move to the app
 import { Entity } from '@backstage/catalog-model';
 import { Content } from '@backstage/core';
+import { SentryIssuesWidget } from '@backstage/plugin-sentry';
 import { LatestWorkflowRunCard } from '@backstage/plugin-github-actions';
 import {
   JenkinsBuildsWidget,
@@ -50,6 +51,16 @@ export const EntityPageOverview: FC<{ entity: Entity }> = ({ entity }) => {
         {entity.metadata?.annotations?.['backstage.io/github-actions-id'] && (
           <Grid item sm={3}>
             <LatestWorkflowRunCard entity={entity} branch="master" />
+          </Grid>
+        )}
+        {entity.metadata?.annotations?.['backstage.io/sentry-project-id'] && (
+          <Grid item sm={8}>
+            <SentryIssuesWidget
+              sentryProjectId={
+                entity.metadata?.annotations?.['backstage.io/sentry-project-id']
+              }
+              statsFor="24h"
+            />
           </Grid>
         )}
       </Grid>

--- a/plugins/catalog/src/components/EntityPageOverview/EntityPageOverview.tsx
+++ b/plugins/catalog/src/components/EntityPageOverview/EntityPageOverview.tsx
@@ -17,7 +17,6 @@
 // TODO(shmidt-i): move to the app
 import { Entity } from '@backstage/catalog-model';
 import { Content } from '@backstage/core';
-import { SentryIssuesWidget } from '@backstage/plugin-sentry';
 import { LatestWorkflowRunCard } from '@backstage/plugin-github-actions';
 import {
   JenkinsBuildsWidget,
@@ -51,16 +50,6 @@ export const EntityPageOverview: FC<{ entity: Entity }> = ({ entity }) => {
         {entity.metadata?.annotations?.['backstage.io/github-actions-id'] && (
           <Grid item sm={3}>
             <LatestWorkflowRunCard entity={entity} branch="master" />
-          </Grid>
-        )}
-        {entity.metadata?.annotations?.['backstage.io/sentry-project-id'] && (
-          <Grid item sm={8}>
-            <SentryIssuesWidget
-              sentryProjectId={
-                entity.metadata?.annotations?.['backstage.io/sentry-project-id']
-              }
-              statsFor="24h"
-            />
           </Grid>
         )}
       </Grid>

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -21,6 +21,7 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
+    "@backstage/catalog-model": "^0.1.1-alpha.21",
     "@backstage/core": "^0.1.1-alpha.21",
     "@backstage/theme": "^0.1.1-alpha.21",
     "@material-ui/core": "^4.9.1",
@@ -29,6 +30,7 @@
     "@types/react": "^16.9",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-router": "6.0.0-beta.0",
     "react-sparklines": "^1.7.0",
     "react-use": "^15.3.3",
     "timeago.js": "^4.0.2"

--- a/plugins/sentry/src/components/Router.tsx
+++ b/plugins/sentry/src/components/Router.tsx
@@ -19,31 +19,28 @@ import { Routes, Route } from 'react-router';
 import { WarningPanel } from '@backstage/core';
 import { SentryPluginWidget } from './SentryPluginWidget/SentryPluginWidget';
 
-const SENTRY_ANNOTATION = 'sentry.io/project-id';
+const SENTRY_ANNOTATION = 'sentry.io/project-slug';
 
-const isPluginApplicableToEntity = (entity: Entity) =>
-  Boolean(entity.metadata.annotations?.[SENTRY_ANNOTATION]) &&
-  entity.metadata.annotations?.[SENTRY_ANNOTATION] !== '';
+export const Router = ({ entity }: { entity: Entity }) => {
+  const projectId = entity.metadata.annotations?.[SENTRY_ANNOTATION];
 
-export const Router = ({ entity }: { entity: Entity }) =>
-  !isPluginApplicableToEntity(entity) ? (
-    <WarningPanel title="Sentry plugin:">
-      `entity.metadata.annotations['
-      {SENTRY_ANNOTATION}']` key is missing on the entity.{' '}
-    </WarningPanel>
-  ) : (
+  if (!projectId) {
+    return (
+      <WarningPanel title="Sentry plugin:">
+        <pre>{SENTRY_ANNOTATION}</pre> annotation is missing on the entity.
+      </WarningPanel>
+    );
+  }
+
+  return (
     <Routes>
       <Route
         path="/"
         element={
-          <SentryPluginWidget
-            sentryProjectId={
-              entity.metadata.annotations?.[SENTRY_ANNOTATION] || ''
-            }
-            statsFor="24h"
-          />
+          <SentryPluginWidget sentryProjectId={projectId} statsFor="24h" />
         }
       />
       )
     </Routes>
   );
+};

--- a/plugins/sentry/src/components/Router.tsx
+++ b/plugins/sentry/src/components/Router.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Entity } from '@backstage/catalog-model';
+import { Routes, Route } from 'react-router';
+import { WarningPanel } from '@backstage/core';
+import { SentryPluginWidget } from './SentryPluginWidget/SentryPluginWidget';
+
+const SENTRY_ANNOTATION = 'sentry.io/project-id';
+
+const isPluginApplicableToEntity = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[SENTRY_ANNOTATION]) &&
+  entity.metadata.annotations?.[SENTRY_ANNOTATION] !== '';
+
+export const Router = ({ entity }: { entity: Entity }) =>
+  !isPluginApplicableToEntity(entity) ? (
+    <WarningPanel title="Sentry plugin:">
+      `entity.metadata.annotations['
+      {SENTRY_ANNOTATION}']` key is missing on the entity.{' '}
+    </WarningPanel>
+  ) : (
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <SentryPluginWidget
+            sentryProjectId={
+              entity.metadata.annotations?.[SENTRY_ANNOTATION] || ''
+            }
+            statsFor="24h"
+          />
+        }
+      />
+      )
+    </Routes>
+  );

--- a/plugins/sentry/src/index.ts
+++ b/plugins/sentry/src/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { plugin } from './plugin';
+export { Router } from './components/Router';
 export { SentryPluginWidget as SentryIssuesWidget } from './components/SentryPluginWidget/SentryPluginWidget';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the Sentry widget back to the component page (from which it
was removed in #2246) if the component declares its own Sentry project
ID in the annotation named backstage.io/sentry-project-id. The widget
is hidden otherwise.

Previous to #2246, the widget was just displaying an empty list because
it was trying to load data for a hardcoded project name of
sample-sentry-project-id.

Fixes #2257

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

## EDIT
After some discussion, this now adds a new Sentry tab instead of a widget to the component page.

![image](https://user-images.githubusercontent.com/12208771/92238026-ac47c800-eeb8-11ea-9655-cc2abd1a64cb.png)
