### PR TITLE
TechDocs: Add docs by default to react ssr template

### DIFF
--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/component-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/component-info.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     github.com/project-slug: {{cookiecutter.storePath}}
     backstage.io/github-actions-id: {{cookiecutter.storePath}}
+    backstage.io/techdocs-ref: github:https://github.com/{{cookiecutter.storePath}}
 spec:
   type: website
   lifecycle: experimental

--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/docs/index.md
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/docs/index.md
@@ -1,0 +1,28 @@
+## {{ cookiecutter.component_id }}
+
+{{ cookiecutter.description }}
+
+## Getting started
+
+Start write your documentation by adding more markdown (.md) files to this folder (/docs) or replace the content in this file.
+
+## Table of Contents
+
+The Table of Contents on the right is generated automatically based on the hierarchy
+of headings. Only use one H1 (`#` in Markdown) per file.
+
+## Site navigation
+
+For new pages to appear in the left hand navigation you need edit the `mkdocs.yml`
+file in root of your repo. The navigation can also link out to other sites.
+
+Alternatively, if there is no `nav` section in `mkdocs.yml`, a navigation section
+will be created for you. However, you will not be able to use alternate titles for
+pages, or include links to other sites.
+
+Note that MkDocs uses `mkdocs.yml`, not `mkdocs.yaml`, although both appear to work.
+See also <https://www.mkdocs.org/user-guide/configuration/>.
+
+## Support
+
+That's it. If you need support, reach out in [#docs-like-code](https://discord.com/channels/687207715902193673/714754240933003266) on Discord.

--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/docs/index.md
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/docs/index.md
@@ -1,4 +1,4 @@
-## {{ cookiecutter.component_id }}
+# {{ cookiecutter.component_id }}
 
 {{ cookiecutter.description }}
 

--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/docs/index.md
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/docs/index.md
@@ -4,7 +4,7 @@
 
 ## Getting started
 
-Start write your documentation by adding more markdown (.md) files to this folder (/docs) or replace the content in this file.
+Start writing your documentation by adding more markdown (.md) files to this folder (/docs) or replace the content in this file.
 
 ## Table of Contents
 

--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/mkdocs.yml
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: {{cookiecutter.component_id}}
+site_description: {{cookiecutter.description}}
+
+nav:
+  - Introduction: index.md
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds docs to the React SSR template so that you get docs by default when creating a new component. Later on it will be possible to select whether you want documentation or not in the create component flow.

![Screen Shot 2020-09-03 at 10 49 09 AM](https://user-images.githubusercontent.com/25153114/92093231-6533d700-edd3-11ea-8cac-3fe99e033bff.png)
![Screen Shot 2020-09-03 at 10 46 21 AM](https://user-images.githubusercontent.com/25153114/92093237-67963100-edd3-11ea-9eba-d4cde676014c.png)

closes: #2262

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

