### PR TITLE
catalog-backend: fix azure ingestion default branch browser url

### DIFF
--- a/plugins/catalog-backend/src/ingestion/processors/AzureApiReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AzureApiReaderProcessor.test.ts
@@ -41,7 +41,15 @@ describe('AzureApiReaderProcessor', () => {
         target:
           'https://dev.azure.com/org-name/project-name/_git/repo-name?path=my-template.yaml&version=GBmaster',
         url: new URL(
-          'https://dev.azure.com/org-name/project-name/_apis/sourceProviders/TfsGit/filecontents?repository=repo-name&commitOrBranch=master&path=my-template.yaml&api-version=6.0-preview.1',
+          'https://dev.azure.com/org-name/project-name/_apis/git/repositories/repo-name/items?path=my-template.yaml&version=master',
+        ),
+        err: undefined,
+      },
+      {
+        target:
+          'https://dev.azure.com/org-name/project-name/_git/repo-name?path=my-template.yaml',
+        url: new URL(
+          'https://dev.azure.com/org-name/project-name/_apis/git/repositories/repo-name/items?path=my-template.yaml',
         ),
         err: undefined,
       },

--- a/plugins/catalog-backend/src/ingestion/processors/AzureApiReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AzureApiReaderProcessor.ts
@@ -83,7 +83,7 @@ export class AzureApiReaderProcessor implements LocationProcessor {
 
   // Converts
   // from: https://dev.azure.com/{organization}/{project}/_git/reponame?path={path}&version=GB{commitOrBranch}&_a=contents
-  // to:   https://dev.azure.com/{organization}/{project}/_apis/sourceProviders/{providerName}/filecontents?repository={repository}&commitOrBranch={commitOrBranch}&path={path}&api-version=6.0-preview.1
+  // to:   https://dev.azure.com/{organization}/{project}/_apis/git/repositories/reponame/items?path={path}&version={commitOrBranch}
   buildRawUrl(target: string): URL {
     try {
       const url = new URL(target);
@@ -119,17 +119,19 @@ export class AzureApiReaderProcessor implements LocationProcessor {
         userOrOrg,
         project,
         '_apis',
-        'sourceProviders',
-        'TfsGit',
-        'filecontents',
+        'git',
+        'repositories',
+        repoName,
+        'items',
       ].join('/');
 
-      url.search = [
-        `repository=${repoName}`,
-        `commitOrBranch=${ref}`,
-        `path=${path}`,
-        'api-version=6.0-preview.1',
-      ].join('&');
+      const queryParams = [`path=${path}`];
+
+      if (ref) {
+        queryParams.push(`version=${ref}`);
+      }
+
+      url.search = queryParams.join('&');
 
       url.protocol = 'https';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fix azure ingestion default branch browser url

the default branch browser url does not contain branch name and is throwing error due to undefined branch being passed to API
e.g. `https://dev.azure.com/{organization}/{project}/_git/{reponame}?path={path}`

the full url with branch name works fine 
e.g. `https://dev.azure.com/{organization}/{project}/_git/reponame?path={path}&version=GBmaster`

changed from source provider api to git api as source provider api does not support optional branch name
git api returns the default branch contents when no branch name is specified

this fixes #2254 


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
