### PR TITLE
feat(cli): add docker opts to the backend:build-image command

### DIFF
--- a/packages/cli/src/commands/backend/buildImage.ts
+++ b/packages/cli/src/commands/backend/buildImage.ts
@@ -18,10 +18,11 @@ import fs from 'fs-extra';
 import { createDistWorkspace } from '../../lib/packager';
 import { paths } from '../../lib/paths';
 import { run } from '../../lib/run';
+import { Command } from 'commander';
 
 const PKG_PATH = 'package.json';
 
-export default async (imageTag: string) => {
+export default async (imageTag: string, cmd: Command) => {
   const pkgPath = paths.resolveTarget(PKG_PATH);
   const pkg = await fs.readJson(pkgPath);
   const tempDistWorkspace = await createDistWorkspace([pkg.name], {
@@ -34,7 +35,8 @@ export default async (imageTag: string) => {
   });
   console.log(`Dist workspace ready at ${tempDistWorkspace}`);
 
-  await run('docker', ['build', '.', '-t', imageTag], {
+  const dockerOpts = cmd.dockerOpts?.split(' ') || [];
+  await run('docker', ['build', '.', '-t', imageTag, ...dockerOpts], {
     cwd: tempDistWorkspace,
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -44,6 +44,10 @@ const main = (argv: string[]) => {
     .description(
       'Builds a docker image from the package, with all local deps included',
     )
+    .option(
+      '--docker-opts <docker-opts>',
+      'Options that are forwarded to the docker build command. Ex: --docker-opts "--build-arg VAR1 --build-arg VAR2"',
+    )
     .action(
       lazyAction(() => import('./commands/backend/buildImage'), 'default'),
     );


### PR DESCRIPTION
The `docker build` command can be customized by multiple opts. This PR adds a new option to pass the docker-opts to the command in the `backend-cli backend:build-image` command.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
