### PR TITLE
Use primary color for checkbox

### DIFF
--- a/plugins/catalog/src/components/ResultsFilter/ResultsFilter.tsx
+++ b/plugins/catalog/src/components/ResultsFilter/ResultsFilter.tsx
@@ -104,6 +104,7 @@ export const ResultsFilter = ({ availableTags }: Props) => {
             >
               <Checkbox
                 edge="start"
+                color="primary"
                 checked={selectedTags.includes(t)}
                 tabIndex={-1}
                 disableRipple


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

![Screenshot 2020-09-04 at 08 55 26](https://user-images.githubusercontent.com/190856/92214997-755fbb00-ee94-11ea-80d6-2a1cd2864bc5.png)

It's beyond my understand why the "default" color in MUI is "secondary": https://material-ui.com/api/checkbox/#props Ideally we would change this default, but I can't find a way to do that system wide.


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Prettier run on changed files
