### PR TITLE
fix(github-actions): use only github.com/project-slug annotation

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,10 +3,9 @@ kind: Component
 metadata:
   name: backstage
   description: |
-    Backstage is an open-source developer portal that puts the developer experience first. 
+    Backstage is an open-source developer portal that puts the developer experience first.
   annotations:
     github.com/project-slug: spotify/backstage
-    backstage.io/github-actions-id: spotify/backstage
     backstage.io/techdocs-ref: github:https://github.com/spotify/backstage.git
 spec:
   type: library

--- a/plugins/catalog/src/components/EntityPageCi/EntityPageCi.tsx
+++ b/plugins/catalog/src/components/EntityPageCi/EntityPageCi.tsx
@@ -17,7 +17,10 @@
 // TODO(shmidt-i): move to the app
 import { Entity } from '@backstage/catalog-model';
 import { Content } from '@backstage/core';
-import { LatestWorkflowsForBranchCard } from '@backstage/plugin-github-actions';
+import {
+  LatestWorkflowsForBranchCard,
+  GITHUB_ACTIONS_ANNOTATION,
+} from '@backstage/plugin-github-actions';
 import { Grid } from '@material-ui/core';
 import React, { FC } from 'react';
 
@@ -25,7 +28,7 @@ export const EntityPageCi: FC<{ entity: Entity }> = ({ entity }) => {
   return (
     <Content>
       <Grid container spacing={3}>
-        {entity.metadata?.annotations?.['backstage.io/github-actions-id'] && (
+        {entity.metadata?.annotations?.[GITHUB_ACTIONS_ANNOTATION] && (
           <Grid item sm={12}>
             <LatestWorkflowsForBranchCard entity={entity} branch="master" />
           </Grid>

--- a/plugins/catalog/src/components/EntityPageOverview/EntityPageOverview.tsx
+++ b/plugins/catalog/src/components/EntityPageOverview/EntityPageOverview.tsx
@@ -17,7 +17,10 @@
 // TODO(shmidt-i): move to the app
 import { Entity } from '@backstage/catalog-model';
 import { Content } from '@backstage/core';
-import { LatestWorkflowRunCard } from '@backstage/plugin-github-actions';
+import {
+  LatestWorkflowRunCard,
+  GITHUB_ACTIONS_ANNOTATION,
+} from '@backstage/plugin-github-actions';
 import {
   JenkinsBuildsWidget,
   JenkinsLastBuildWidget,
@@ -47,7 +50,7 @@ export const EntityPageOverview: FC<{ entity: Entity }> = ({ entity }) => {
             <JenkinsBuildsWidget entity={entity} />
           </Grid>
         )}
-        {entity.metadata?.annotations?.['backstage.io/github-actions-id'] && (
+        {entity.metadata?.annotations?.[GITHUB_ACTIONS_ANNOTATION] && (
           <Grid item sm={3}>
             <LatestWorkflowRunCard entity={entity} branch="master" />
           </Grid>

--- a/plugins/github-actions/src/components/Cards/Cards.tsx
+++ b/plugins/github-actions/src/components/Cards/Cards.tsx
@@ -32,6 +32,7 @@ import {
   useApi,
 } from '@backstage/core';
 import ExternalLinkIcon from '@material-ui/icons/Launch';
+import { GITHUB_ACTIONS_ANNOTATION } from '../useProjectName';
 
 const useStyles = makeStyles<Theme>({
   externalLinkIcon: {
@@ -83,7 +84,7 @@ export const LatestWorkflowRunCard = ({
 }) => {
   const errorApi = useApi(errorApiRef);
   const [owner, repo] = (
-    entity?.metadata.annotations?.['backstage.io/github-actions-id'] ?? '/'
+    entity?.metadata.annotations?.[GITHUB_ACTIONS_ANNOTATION] ?? '/'
   ).split('/');
   const [{ runs, loading, error }] = useWorkflowRuns({
     owner,

--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/component-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/component-info.yaml
@@ -5,7 +5,6 @@ metadata:
   description: {{cookiecutter.description}}
   annotations:
     github.com/project-slug: {{cookiecutter.storePath}}
-    backstage.io/github-actions-id: {{cookiecutter.storePath}}
     backstage.io/techdocs-ref: github:https://github.com/{{cookiecutter.storePath}}
 spec:
   type: website

--- a/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/component-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/component-info.yaml
@@ -5,7 +5,6 @@ metadata:
   description: {{cookiecutter.description}}
   annotations:
     github.com/project-slug: {{cookiecutter.storePath}}
-    backstage.io/github-actions-id: {{cookiecutter.storePath}}
 spec:
   type: service
   lifecycle: experimental


### PR DESCRIPTION
Standardises annotation that is used for GitHubActions plugin
`backstage.io/github-actions-id` -> `github.com/project-slug`