### PR TITLE
TechDocs: add docs by default to springboot grpc template

### DIFF
--- a/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/component-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/component-info.yaml
@@ -5,7 +5,6 @@ metadata:
   description: {{cookiecutter.description}}
   annotations:
     github.com/project-slug: {{cookiecutter.storePath}}
-    backstage.io/github-actions-id: {{cookiecutter.storePath}}
     backstage.io/techdocs-ref: github:https://github.com/{{cookiecutter.storePath}}
 spec:
   type: service

--- a/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/component-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/component-info.yaml
@@ -5,6 +5,8 @@ metadata:
   description: {{cookiecutter.description}}
   annotations:
     github.com/project-slug: {{cookiecutter.storePath}}
+    backstage.io/github-actions-id: {{cookiecutter.storePath}}
+    backstage.io/techdocs-ref: github:https://github.com/{{cookiecutter.storePath}}
 spec:
   type: service
   lifecycle: experimental

--- a/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/docs/index.md
+++ b/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/docs/index.md
@@ -1,0 +1,28 @@
+## {{ cookiecutter.component_id }}
+
+{{ cookiecutter.description }}
+
+## Getting started
+
+Start write your documentation by adding more markdown (.md) files to this folder (/docs) or replace the content in this file.
+
+## Table of Contents
+
+The Table of Contents on the right is generated automatically based on the hierarchy
+of headings. Only use one H1 (`#` in Markdown) per file.
+
+## Site navigation
+
+For new pages to appear in the left hand navigation you need edit the `mkdocs.yml`
+file in root of your repo. The navigation can also link out to other sites.
+
+Alternatively, if there is no `nav` section in `mkdocs.yml`, a navigation section
+will be created for you. However, you will not be able to use alternate titles for
+pages, or include links to other sites.
+
+Note that MkDocs uses `mkdocs.yml`, not `mkdocs.yaml`, although both appear to work.
+See also <https://www.mkdocs.org/user-guide/configuration/>.
+
+## Support
+
+That's it. If you need support, reach out in [#docs-like-code](https://discord.com/channels/687207715902193673/714754240933003266) on Discord.

--- a/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/mkdocs.yml
+++ b/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: {{cookiecutter.component_id}}
+site_description: {{cookiecutter.description}}
+
+nav:
+  - Introduction: index.md
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds docs setup by default to the springboot grpc template. 

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
