### PR TITLE
TechDocs: View TechDocs link on entity page

### DIFF
--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -104,7 +104,9 @@ export function AboutCard({ entity }: AboutCardProps) {
             <IconLinkVertical
               label="View Techdocs"
               icon={<DocsIcon />}
-              href={`/docs/${''}`}
+              href={`/docs/${entity.kind}:${entity.metadata.namespace ?? ''}:${
+                entity.metadata.name
+              }`}
             />
           </nav>
         }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`View TechDocs` links to actual docs instead of just TechDocs homepage as in `/docs`

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
