### PR TITLE
auth-backend: refactor OAuthHandlers to receive a single decorated request object

### DIFF
--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -24,9 +24,9 @@ import {
 } from '../../providers/types';
 import { InputError } from '@backstage/backend-common';
 import { TokenIssuer } from '../../identity';
-import { verifyNonce, encodeState } from './helpers';
+import { verifyNonce } from './helpers';
 import { postMessageResponse, ensuresXRequestedWith } from '../flow';
-import { OAuthHandlers } from './types';
+import { OAuthHandlers, OAuthStartRequest } from './types';
 
 export const THOUSAND_DAYS_MS = 1000 * 24 * 60 * 60 * 1000;
 export const TEN_MINUTES_MS = 600 * 1000;
@@ -86,15 +86,12 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
     // set a nonce cookie before redirecting to oauth provider
     this.setNonceCookie(res, nonce);
 
-    const stateObject = { nonce: nonce, env: env };
-    const stateParameter = encodeState(stateObject);
+    const state = { nonce: nonce, env: env };
+    const forwardReq = Object.assign(req, { scope, state });
 
-    const queryParameters = {
-      scope,
-      state: stateParameter,
-    };
-
-    const { url, status } = await this.handlers.start(req, queryParameters);
+    const { url, status } = await this.handlers.start(
+      forwardReq as OAuthStartRequest,
+    );
 
     res.statusCode = status || 302;
     res.setHeader('Location', url);

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -26,7 +26,7 @@ import { InputError } from '@backstage/backend-common';
 import { TokenIssuer } from '../../identity';
 import { verifyNonce } from './helpers';
 import { postMessageResponse, ensuresXRequestedWith } from '../flow';
-import { OAuthHandlers, OAuthStartRequest } from './types';
+import { OAuthHandlers, OAuthStartRequest, OAuthRefreshRequest } from './types';
 
 export const THOUSAND_DAYS_MS = 1000 * 24 * 60 * 60 * 1000;
 export const TEN_MINUTES_MS = 600 * 1000;
@@ -182,8 +182,12 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
 
       const scope = req.query.scope?.toString() ?? '';
 
+      const forwardReq = Object.assign(req, { scope, refreshToken });
+
       // get new access_token
-      const response = await this.handlers.refresh(refreshToken, scope);
+      const response = await this.handlers.refresh(
+        forwardReq as OAuthRefreshRequest,
+      );
 
       await this.populateIdentity(response.backstageIdentity);
 

--- a/plugins/auth-backend/src/lib/oauth/index.ts
+++ b/plugins/auth-backend/src/lib/oauth/index.ts
@@ -16,10 +16,12 @@
 
 export { OAuthEnvironmentHandler } from './OAuthEnvironmentHandler';
 export { OAuthAdapter } from './OAuthAdapter';
+export { encodeState } from './helpers';
 export type {
   OAuthHandlers,
   OAuthProviderInfo,
   OAuthProviderOptions,
   OAuthResponse,
   OAuthState,
+  OAuthStartRequest,
 } from './types';

--- a/plugins/auth-backend/src/lib/oauth/index.ts
+++ b/plugins/auth-backend/src/lib/oauth/index.ts
@@ -24,4 +24,5 @@ export type {
   OAuthResponse,
   OAuthState,
   OAuthStartRequest,
+  OAuthRefreshRequest,
 } from './types';

--- a/plugins/auth-backend/src/lib/oauth/types.ts
+++ b/plugins/auth-backend/src/lib/oauth/types.ts
@@ -67,6 +67,11 @@ export type OAuthState = {
   env: string;
 };
 
+export type OAuthStartRequest = express.Request<{}> & {
+  scope: string;
+  state: OAuthState;
+};
+
 /**
  * Any OAuth provider needs to implement this interface which has provider specific
  * handlers for different methods to perform authentication, get access tokens,
@@ -78,10 +83,7 @@ export interface OAuthHandlers {
    * @param {express.Request} req
    * @param options
    */
-  start(
-    req: express.Request,
-    options: Record<string, string>,
-  ): Promise<RedirectInfo>;
+  start(req: OAuthStartRequest): Promise<RedirectInfo>;
 
   /**
    * Handles the redirect from the auth provider when the user has signed in.

--- a/plugins/auth-backend/src/lib/oauth/types.ts
+++ b/plugins/auth-backend/src/lib/oauth/types.ts
@@ -72,6 +72,11 @@ export type OAuthStartRequest = express.Request<{}> & {
   state: OAuthState;
 };
 
+export type OAuthRefreshRequest = express.Request<{}> & {
+  scope: string;
+  refreshToken: string;
+};
+
 /**
  * Any OAuth provider needs to implement this interface which has provider specific
  * handlers for different methods to perform authentication, get access tokens,
@@ -101,10 +106,7 @@ export interface OAuthHandlers {
    * @param {string} refreshToken
    * @param {string} scope
    */
-  refresh?(
-    refreshToken: string,
-    scope: string,
-  ): Promise<AuthResponse<OAuthProviderInfo>>;
+  refresh?(req: OAuthRefreshRequest): Promise<AuthResponse<OAuthProviderInfo>>;
 
   /**
    * (Optional) Sign out of the auth provider.

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -25,6 +25,7 @@ import {
   OAuthEnvironmentHandler,
   OAuthStartRequest,
   encodeState,
+  OAuthRefreshRequest,
 } from '../../lib/oauth';
 import {
   executeFetchUserProfileStrategy,
@@ -106,11 +107,11 @@ export class Auth0AuthProvider implements OAuthHandlers {
     };
   }
 
-  async refresh(refreshToken: string, scope: string): Promise<OAuthResponse> {
+  async refresh(req: OAuthRefreshRequest): Promise<OAuthResponse> {
     const { accessToken, params } = await executeRefreshTokenStrategy(
       this._strategy,
-      refreshToken,
-      scope,
+      req.refreshToken,
+      req.scope,
     );
 
     const profile = await executeFetchUserProfileStrategy(

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -23,6 +23,8 @@ import {
   OAuthHandlers,
   OAuthResponse,
   OAuthEnvironmentHandler,
+  OAuthStartRequest,
+  encodeState,
 } from '../../lib/oauth';
 import {
   executeFetchUserProfileStrategy,
@@ -81,16 +83,13 @@ export class Auth0AuthProvider implements OAuthHandlers {
     );
   }
 
-  async start(
-    req: express.Request,
-    options: Record<string, string>,
-  ): Promise<RedirectInfo> {
-    const providerOptions = {
-      ...options,
+  async start(req: OAuthStartRequest): Promise<RedirectInfo> {
+    return await executeRedirectStrategy(req, this._strategy, {
       accessType: 'offline',
       prompt: 'consent',
-    };
-    return await executeRedirectStrategy(req, this._strategy, providerOptions);
+      scope: req.scope,
+      state: encodeState(req.state),
+    });
   }
 
   async handler(

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -29,6 +29,8 @@ import {
   OAuthHandlers,
   OAuthResponse,
   OAuthEnvironmentHandler,
+  OAuthStartRequest,
+  encodeState,
 } from '../../lib/oauth';
 import passport from 'passport';
 
@@ -117,11 +119,11 @@ export class GithubAuthProvider implements OAuthHandlers {
     );
   }
 
-  async start(
-    req: express.Request,
-    options: Record<string, string>,
-  ): Promise<RedirectInfo> {
-    return await executeRedirectStrategy(req, this._strategy, options);
+  async start(req: OAuthStartRequest): Promise<RedirectInfo> {
+    return await executeRedirectStrategy(req, this._strategy, {
+      scope: req.scope,
+      state: encodeState(req.state),
+    });
   }
 
   async handler(req: express.Request) {

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -29,6 +29,8 @@ import {
   OAuthHandlers,
   OAuthResponse,
   OAuthEnvironmentHandler,
+  OAuthStartRequest,
+  encodeState,
 } from '../../lib/oauth';
 import passport from 'passport';
 
@@ -122,11 +124,11 @@ export class GitlabAuthProvider implements OAuthHandlers {
     );
   }
 
-  async start(
-    req: express.Request,
-    options: Record<string, string>,
-  ): Promise<RedirectInfo> {
-    return await executeRedirectStrategy(req, this._strategy, options);
+  async start(req: OAuthStartRequest): Promise<RedirectInfo> {
+    return await executeRedirectStrategy(req, this._strategy, {
+      scope: req.scope,
+      state: encodeState(req.state),
+    });
   }
 
   async handler(req: express.Request): Promise<{ response: OAuthResponse }> {

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -31,6 +31,8 @@ import {
   OAuthProviderOptions,
   OAuthResponse,
   OAuthEnvironmentHandler,
+  OAuthStartRequest,
+  encodeState,
 } from '../../lib/oauth';
 import passport from 'passport';
 
@@ -79,16 +81,13 @@ export class GoogleAuthProvider implements OAuthHandlers {
     );
   }
 
-  async start(
-    req: express.Request,
-    options: Record<string, string>,
-  ): Promise<RedirectInfo> {
-    const providerOptions = {
-      ...options,
+  async start(req: OAuthStartRequest): Promise<RedirectInfo> {
+    return await executeRedirectStrategy(req, this._strategy, {
       accessType: 'offline',
       prompt: 'consent',
-    };
-    return await executeRedirectStrategy(req, this._strategy, providerOptions);
+      scope: req.scope,
+      state: encodeState(req.state),
+    });
   }
 
   async handler(

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -33,6 +33,7 @@ import {
   OAuthEnvironmentHandler,
   OAuthStartRequest,
   encodeState,
+  OAuthRefreshRequest,
 } from '../../lib/oauth';
 import passport from 'passport';
 
@@ -104,11 +105,11 @@ export class GoogleAuthProvider implements OAuthHandlers {
     };
   }
 
-  async refresh(refreshToken: string, scope: string): Promise<OAuthResponse> {
+  async refresh(req: OAuthRefreshRequest): Promise<OAuthResponse> {
     const { accessToken, params } = await executeRefreshTokenStrategy(
       this._strategy,
-      refreshToken,
-      scope,
+      req.refreshToken,
+      req.scope,
     );
 
     const profile = await executeFetchUserProfileStrategy(

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -35,6 +35,8 @@ import {
   OAuthHandlers,
   OAuthResponse,
   OAuthEnvironmentHandler,
+  OAuthStartRequest,
+  encodeState,
 } from '../../lib/oauth';
 
 import got from 'got';
@@ -111,11 +113,11 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
     );
   }
 
-  async start(
-    req: express.Request,
-    options: Record<string, string>,
-  ): Promise<RedirectInfo> {
-    return await executeRedirectStrategy(req, this._strategy, options);
+  async start(req: OAuthStartRequest): Promise<RedirectInfo> {
+    return await executeRedirectStrategy(req, this._strategy, {
+      scope: req.scope,
+      state: encodeState(req.state),
+    });
   }
 
   async handler(

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -37,6 +37,7 @@ import {
   OAuthEnvironmentHandler,
   OAuthStartRequest,
   encodeState,
+  OAuthRefreshRequest,
 } from '../../lib/oauth';
 
 import got from 'got';
@@ -134,11 +135,11 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
     };
   }
 
-  async refresh(refreshToken: string, scope: string): Promise<OAuthResponse> {
+  async refresh(req: OAuthRefreshRequest): Promise<OAuthResponse> {
     const { accessToken, params } = await executeRefreshTokenStrategy(
       this._strategy,
-      refreshToken,
-      scope,
+      req.refreshToken,
+      req.scope,
     );
 
     const profile = await executeFetchUserProfileStrategy(

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -25,6 +25,7 @@ import {
   OAuthEnvironmentHandler,
   OAuthStartRequest,
   encodeState,
+  OAuthRefreshRequest,
 } from '../../lib/oauth';
 import {
   executeFetchUserProfileStrategy,
@@ -109,11 +110,11 @@ export class OAuth2AuthProvider implements OAuthHandlers {
     };
   }
 
-  async refresh(refreshToken: string, scope: string): Promise<OAuthResponse> {
+  async refresh(req: OAuthRefreshRequest): Promise<OAuthResponse> {
     const refreshTokenResponse = await executeRefreshTokenStrategy(
       this._strategy,
-      refreshToken,
-      scope,
+      req.refreshToken,
+      req.scope,
     );
     const {
       accessToken,

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -23,6 +23,8 @@ import {
   OAuthHandlers,
   OAuthResponse,
   OAuthEnvironmentHandler,
+  OAuthStartRequest,
+  encodeState,
 } from '../../lib/oauth';
 import {
   executeFetchUserProfileStrategy,
@@ -84,16 +86,13 @@ export class OAuth2AuthProvider implements OAuthHandlers {
     );
   }
 
-  async start(
-    req: express.Request,
-    options: Record<string, string>,
-  ): Promise<RedirectInfo> {
-    const providerOptions = {
-      ...options,
+  async start(req: OAuthStartRequest): Promise<RedirectInfo> {
+    return await executeRedirectStrategy(req, this._strategy, {
       accessType: 'offline',
       prompt: 'consent',
-    };
-    return await executeRedirectStrategy(req, this._strategy, providerOptions);
+      scope: req.scope,
+      state: encodeState(req.state),
+    });
   }
 
   async handler(

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -22,6 +22,7 @@ import {
   OAuthEnvironmentHandler,
   OAuthStartRequest,
   encodeState,
+  OAuthRefreshRequest,
 } from '../../lib/oauth';
 import { Strategy as OktaStrategy } from 'passport-okta-oauth';
 import passport from 'passport';
@@ -126,11 +127,11 @@ export class OktaAuthProvider implements OAuthHandlers {
     };
   }
 
-  async refresh(refreshToken: string, scope: string): Promise<OAuthResponse> {
+  async refresh(req: OAuthRefreshRequest): Promise<OAuthResponse> {
     const { accessToken, params } = await executeRefreshTokenStrategy(
       this._strategy,
-      refreshToken,
-      scope,
+      req.refreshToken,
+      req.scope,
     );
 
     const profile = await executeFetchUserProfileStrategy(

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -20,6 +20,8 @@ import {
   OAuthHandlers,
   OAuthResponse,
   OAuthEnvironmentHandler,
+  OAuthStartRequest,
+  encodeState,
 } from '../../lib/oauth';
 import { Strategy as OktaStrategy } from 'passport-okta-oauth';
 import passport from 'passport';
@@ -101,16 +103,13 @@ export class OktaAuthProvider implements OAuthHandlers {
     );
   }
 
-  async start(
-    req: express.Request,
-    options: Record<string, string>,
-  ): Promise<RedirectInfo> {
-    const providerOptions = {
-      ...options,
+  async start(req: OAuthStartRequest): Promise<RedirectInfo> {
+    return await executeRedirectStrategy(req, this._strategy, {
       accessType: 'offline',
       prompt: 'consent',
-    };
-    return await executeRedirectStrategy(req, this._strategy, providerOptions);
+      scope: req.scope,
+      state: encodeState(req.state),
+    });
   }
 
   async handler(


### PR DESCRIPTION
Bit more forwards-compatible and slimmer interface. This also exposes the `state` object for `start` method to allow extensions, although it doesn't forward it for the `handler` yet.