### PR TITLE
workflows: ensure that working directory is clean at the end of build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,16 @@ jobs:
 
       - name: verify plugin template
         run: yarn lerna -- run diff -- --check
+
+      - name: ensure clean working directory
+        run: |
+          if files=$(git ls-files --exclude-standard --others --modified) && [[ -z "$files" ]]; then
+            exit 0
+          else
+            echo ""
+            echo "Working directory has been modified:"
+            echo ""
+            git status --short
+            echo ""
+            exit 1
+          fi


### PR DESCRIPTION
Making sure people don't forget to commit changes to `yarn.lock` :grin: