### PR TITLE
logging: Remove newlines added by morgan

### DIFF
--- a/packages/backend-common/src/middleware/requestLoggingHandler.ts
+++ b/packages/backend-common/src/middleware/requestLoggingHandler.ts
@@ -33,7 +33,7 @@ export function requestLoggingHandler(logger?: Logger): RequestHandler {
   return morgan('combined', {
     stream: {
       write(message: String) {
-        actualLogger.info(message);
+        actualLogger.info(message.trim());
       },
     },
   });

--- a/packages/backend-common/src/middleware/requestLoggingHandler.ts
+++ b/packages/backend-common/src/middleware/requestLoggingHandler.ts
@@ -33,7 +33,7 @@ export function requestLoggingHandler(logger?: Logger): RequestHandler {
   return morgan('combined', {
     stream: {
       write(message: String) {
-        actualLogger.info(message.trim());
+        actualLogger.info(message.trimRight());
       },
     },
   });


### PR DESCRIPTION
Getting rid of the newline character apparently added by `morgan` when logging http requests. 