### PR TITLE
cli: make skipLibCheck default in tsconfig, but provide tsc:full

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: yarn lerna -- run lint --since origin/master
 
       - name: type checking and declarations
-        run: yarn tsc --incremental false
+        run: yarn tsc:full
 
       - name: build changed packages
         if: ${{ steps.yarn-lock.outcome == 'success' }}

--- a/.github/workflows/master-win.yml
+++ b/.github/workflows/master-win.yml
@@ -43,7 +43,7 @@ jobs:
         run: yarn lerna -- run lint
 
       - name: type checking and declarations
-        run: yarn tsc --incremental false
+        run: yarn tsc:full
 
       - name: verify type dependencies
         run: yarn lint:type-deps

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,7 +51,7 @@ jobs:
         run: yarn lerna -- run lint
 
       - name: type checking and declarations
-        run: yarn tsc --incremental false
+        run: yarn tsc:full
 
       - name: build
         run: yarn build

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -65,6 +65,7 @@ yarn storybook # Start local storybook, useful for working on components in @bac
 yarn workspace @backstage/plugin-welcome start # Serve welcome plugin only, also supports --check
 
 yarn tsc # Run typecheck, use --watch for watch mode
+yarn tsc:full # Run full type checking, for example without skipLibCheck, use in CI
 
 yarn build # Build published versions of packages, depends on tsc
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start-backend": "yarn workspace example-backend start",
     "build": "lerna run build",
     "tsc": "tsc",
+    "tsc:full": "tsc --skipLibCheck false --incremental false",
     "clean": "backstage-cli clean && lerna run clean",
     "diff": "lerna run diff --",
     "test": "lerna run test --since origin/master -- --coverage",

--- a/packages/cli/config/tsconfig.json
+++ b/packages/cli/config/tsconfig.json
@@ -25,6 +25,7 @@
     "removeComments": false,
     "resolveJsonModule": true,
     "sourceMap": false,
+    "skipLibCheck": true,
     "strict": true,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -9,6 +9,7 @@
     "start": "yarn workspace app start",
     "build": "lerna run build",
     "tsc": "tsc",
+    "tsc:full": "tsc --skipLibCheck false --incremental false",
     "clean": "backstage-cli clean && lerna run clean",
     "diff": "lerna run diff --",
     "test": "lerna run test --since origin/master -- --coverage",

--- a/packages/create-app/templates/default-app/tsconfig.json
+++ b/packages/create-app/templates/default-app/tsconfig.json
@@ -9,7 +9,6 @@
   "exclude": ["node_modules"],
   "compilerOptions": {
     "outDir": "dist-types",
-    "rootDir": ".",
-    "skipLibCheck": true
+    "rootDir": "."
   }
 }


### PR DESCRIPTION
`skipLibCheck` speeds a local `yarn tsc` up significantly, but it won't catch all issues.

This switches `skipLibCheck` to be set by default, but disables it for `yarn tsc:full`, which is then recommended to be used in CI.