### PR TITLE
Plugin explore: migrate to new routing api

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -28,7 +28,6 @@ import { hot } from 'react-hot-loader/root';
 import { providers } from './identityProviders';
 import { Router as CatalogRouter } from '@backstage/plugin-catalog';
 import { Router as DocsRouter } from '@backstage/plugin-techdocs';
-import { Router as ExploreRouter } from '@backstage/plugin-explore';
 import { Route, Routes, Navigate } from 'react-router';
 
 import { EntityPage } from './components/catalog/EntityPage';
@@ -62,7 +61,6 @@ const AppRoutes = () => (
       element={<CatalogRouter EntityPage={EntityPage} />}
     />
     <Route path="/docs/*" element={<DocsRouter />} />
-    <Route path="/explore/*" element={<ExploreRouter />} />
     {...deprecatedAppRoutes}
   </Routes>
 );

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -28,6 +28,7 @@ import { hot } from 'react-hot-loader/root';
 import { providers } from './identityProviders';
 import { Router as CatalogRouter } from '@backstage/plugin-catalog';
 import { Router as DocsRouter } from '@backstage/plugin-techdocs';
+import { Router as ExploreRouter } from '@backstage/plugin-explore';
 import { Route, Routes, Navigate } from 'react-router';
 
 import { EntityPage } from './components/catalog/EntityPage';
@@ -55,12 +56,13 @@ const deprecatedAppRoutes = app.getRoutes();
 
 const AppRoutes = () => (
   <Routes>
+    <Navigate key="/" to="/catalog" />
     <Route
       path="/catalog/*"
       element={<CatalogRouter EntityPage={EntityPage} />}
     />
     <Route path="/docs/*" element={<DocsRouter />} />
-    <Navigate key="/" to="/catalog" />
+    <Route path="/explore/*" element={<ExploreRouter />} />
     {...deprecatedAppRoutes}
   </Routes>
 );

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -11,6 +11,8 @@ import { AppSidebar } from './sidebar';
 import { Route, Routes, Navigate } from 'react-router';
 import { Router as CatalogRouter } from '@backstage/plugin-catalog';
 import { Router as DocsRouter } from '@backstage/plugin-techdocs';
+import { Router as ExploreRouter } from '@backstage/plugin-explore';
+
 import { EntityPage } from './components/catalog/EntityPage';
 
 const app = createApp({
@@ -30,12 +32,13 @@ const App: FC<{}> = () => (
       <SidebarPage>
         <AppSidebar />
         <Routes>
+          <Navigate key="/" to="/catalog" />
           <Route
             path="/catalog/*"
             element={<CatalogRouter EntityPage={EntityPage} />}
           />
           <Route path="/docs/*" element={<DocsRouter />} />
-          <Navigate key="/" to="/catalog" />
+          <Route path="/explore/*" element={<ExploreRouter />} />
           {deprecatedAppRoutes}
         </Routes>
       </SidebarPage>

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -11,7 +11,6 @@ import { AppSidebar } from './sidebar';
 import { Route, Routes, Navigate } from 'react-router';
 import { Router as CatalogRouter } from '@backstage/plugin-catalog';
 import { Router as DocsRouter } from '@backstage/plugin-techdocs';
-import { Router as ExploreRouter } from '@backstage/plugin-explore';
 
 import { EntityPage } from './components/catalog/EntityPage';
 
@@ -38,7 +37,6 @@ const App: FC<{}> = () => (
             element={<CatalogRouter EntityPage={EntityPage} />}
           />
           <Route path="/docs/*" element={<DocsRouter />} />
-          <Route path="/explore/*" element={<ExploreRouter />} />
           {deprecatedAppRoutes}
         </Routes>
       </SidebarPage>

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -29,7 +29,8 @@
     "classnames": "^2.2.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-use": "^15.3.3"
+    "react-use": "^15.3.3",
+    "react-router": "6.0.0-beta.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.21",

--- a/plugins/explore/src/components/ExplorePluginPage.tsx
+++ b/plugins/explore/src/components/ExplorePluginPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from 'react';
+import React from 'react';
 import { makeStyles, Typography } from '@material-ui/core';
 import {
   Content,
@@ -107,7 +107,7 @@ const toolsCards = [
   },
 ];
 
-const ExplorePluginPage: FC<{}> = () => {
+export const ExplorePluginPage = () => {
   const classes = useStyles();
   return (
     <Page theme={pageTheme.home}>
@@ -130,5 +130,3 @@ const ExplorePluginPage: FC<{}> = () => {
     </Page>
   );
 };
-
-export default ExplorePluginPage;

--- a/plugins/explore/src/components/Router.tsx
+++ b/plugins/explore/src/components/Router.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Route, Routes } from 'react-router';
+import { ExplorePluginPage } from './ExplorePluginPage';
+import { rootRouteRef } from '../plugin';
+
+export const Router = () => (
+  <Routes>
+    <Route path={`/${rootRouteRef.path}`} element={<ExplorePluginPage />} />
+  </Routes>
+);

--- a/plugins/explore/src/components/Router.tsx
+++ b/plugins/explore/src/components/Router.tsx
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { Route, Routes } from 'react-router';
 import { ExplorePluginPage } from './ExplorePluginPage';

--- a/plugins/explore/src/index.ts
+++ b/plugins/explore/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { plugin } from './plugin';
+export { Router } from './components/Router';

--- a/plugins/explore/src/plugin.ts
+++ b/plugins/explore/src/plugin.ts
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-import { createPlugin } from '@backstage/core';
-import ExplorePluginPage from './components/ExplorePluginPage';
+import { createPlugin, createRouteRef } from '@backstage/core';
 
+export const rootRouteRef = createRouteRef({ path: '', title: 'Explore' });
 export const plugin = createPlugin({
   id: 'explore',
-  register({ router }) {
-    router.registerRoute('/explore', ExplorePluginPage);
-  },
 });


### PR DESCRIPTION
One thing: do we even need this plugin now that we have https://backstage.io/plugins? Also, the info inside seems pretty stale, e.g. rollbar and sentry are now part of the catalog entity view and not the standalone plugins-pages. @stefanalund wdyt?