### PR TITLE
docs: fix create-app command and link

### DIFF
--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -28,7 +28,7 @@ installed:
 To create a new Backstage application for TechDocs, run the following command:
 
 ```bash
-npx @backstage/cli create-app
+npx @backstage/create-app
 ```
 
 You will then be prompted to enter a name for your application. Once that's

--- a/microsite/blog/2020-04-30-how-to-quickly-set-up-backstage.md
+++ b/microsite/blog/2020-04-30-how-to-quickly-set-up-backstage.md
@@ -34,7 +34,7 @@ You get to take full advantage of a platform that we at Spotify have been using 
 Just run the backstage-cli:
 
 ```bash
-npx @backstage/cli create-app
+npx @backstage/create-app
 ```
 
 Name your app, and we will create everything you need:
@@ -50,7 +50,7 @@ yarn start
 
 And you are good to go! 👍
 
-Read the full documentation on how to [create an app](/docs/getting-started/create-an-app.md) on GitHub.
+Read the full documentation on how to [create an app](/docs/getting-started/create-an-app) on GitHub.
 
 ## What do I get? (Let's get technical...)
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update create-app command
Updated link on [blog post](https://backstage.io/blog/2020/04/30/how-to-quickly-set-up-backstage)
Broken link : https://backstage.io/docs/getting-started/create-an-app.md
Correct link : https://backstage.io/docs/getting-started/create-an-app 

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
