### PR TITLE
Catalog: Add config param to Github in deafultProcessor

### DIFF
--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -77,7 +77,7 @@ export class LocationReaders implements LocationReader {
     return [
       StaticLocationProcessor.fromConfig(config),
       new FileReaderProcessor(),
-      new GithubReaderProcessor(),
+      new GithubReaderProcessor(config),
       new GithubApiReaderProcessor(config),
       new GitlabApiReaderProcessor(config),
       new GitlabReaderProcessor(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've added a config param to GithubReaderProcessor i the defaultProcessor, which I just found out I forgot in #2247 

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
