### PR TITLE
Use blue color from figma in theme

### DIFF
--- a/packages/theme/src/themes.ts
+++ b/packages/theme/src/themes.ts
@@ -15,7 +15,7 @@
  */
 
 import { createTheme } from './baseTheme';
-import { blue, yellow } from '@material-ui/core/colors';
+import { yellow } from '@material-ui/core/colors';
 
 export const lightTheme = createTheme({
   palette: {
@@ -39,7 +39,7 @@ export const lightTheme = createTheme({
       },
     },
     primary: {
-      main: blue[500],
+      main: '#2E77D0',
     },
     banner: {
       info: '#2E77D0',
@@ -95,7 +95,7 @@ export const darkTheme = createTheme({
       },
     },
     primary: {
-      main: blue[500],
+      main: '#2E77D0',
     },
     banner: {
       info: '#2E77D0',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Short term solution to https://github.com/spotify/backstage/issues/2217. We will have to revisit the palette and the semantic colors decided upon in the theme and present them similarly in Figma.

Fix https://github.com/spotify/backstage/issues/2217