### PR TITLE
microsite: add id to docs demo h1

### DIFF
--- a/microsite/pages/en/demos.js
+++ b/microsite/pages/en/demos.js
@@ -81,7 +81,9 @@ const Background = props => {
       <Block className="stripe-bottom bg-black-grey">
         <Block.Container style={{ justifyContent: 'flex-start' }}>
           <Block.TextBox>
-            <Block.Title>Make documentation easy</Block.Title>
+            <Block.Title id="techdocs-demo">
+              Make documentation easy
+            </Block.Title>
             <Block.Paragraph>
               Documentation! Everyone needs it, no one wants to create it, and
               no one can ever find it. Backstage follows a “docs like code”


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I would like to link to a specific demo on the demos page (the techdocs demo) and therefore added an id to the h1 so that I can do this:

http://backstage.io/demos#techdocs-demo 

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
