### PR TITLE
Use correct npm package for serving docs

### DIFF
--- a/docs/features/techdocs/creating-and-publishing.md
+++ b/docs/features/techdocs/creating-and-publishing.md
@@ -88,5 +88,5 @@ To do this you can run:
 
 ```bash
 cd ~/<repository-path>/
-npx techdocs-cli serve
+npx @techdocs/cli serve
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

```
$ npx techdocs-cli serve
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/techdocs-cli - Not found
npm ERR! 404
npm ERR! 404  'techdocs-cli@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/timja/.npm/_logs/2020-09-10T08_06_52_353Z-debug.log
Install for [ 'techdocs-cli@latest' ] failed with code 1
```

cc @emmaindal 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
