### PR TITLE
dev-utils: fix deprecated routes not being wrapped in router

### DIFF
--- a/packages/dev-utils/src/devApp/render.tsx
+++ b/packages/dev-utils/src/devApp/render.tsx
@@ -31,6 +31,7 @@ import {
   AnyApiFactory,
 } from '@backstage/core';
 import SentimentDissatisfiedIcon from '@material-ui/icons/SentimentDissatisfied';
+import { Routes } from 'react-router';
 
 // TODO(rugvip): export proper plugin type from core that isn't the plugin class
 type BackstagePlugin = ReturnType<typeof createPlugin>;
@@ -97,7 +98,7 @@ class DevAppBuilder {
           <AppRouter>
             <SidebarPage>
               {sidebar}
-              {deprecatedAppRoutes}
+              <Routes>{deprecatedAppRoutes}</Routes>
             </SidebarPage>
           </AppRouter>
         </AppProvider>


### PR DESCRIPTION
Fixes the mixed in not found page when serving apps in isolation. It still doesn't fully fix the dev-app use-case, since there's no proper way to register routes except for the deprecated `register` method.