### PR TITLE
create-app: sync backend Dockerfile

### DIFF
--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -2,8 +2,15 @@ FROM node:12
 
 WORKDIR /usr/src/app
 
-COPY . .
+# Copy repo skeleton first, to avoid unnecessary docker cache invalidation.
+# The skeleton contains the package.json of each package in the monorepo,
+# and along with yarn.lock and the root package.json, that's enough to run yarn install.
+ADD yarn.lock package.json skeleton.tar ./
 
 RUN yarn install --frozen-lockfile --production
+
+# This will copy the contents of the dist-workspace when running the build-image command.
+# Do not use this Dockerfile outside of that command, as it will copy in the source code instead.
+COPY . .
 
 CMD ["node", "packages/backend"]


### PR DESCRIPTION
Template one is out of sync with the Dockerfile in the backend of this repo.

Thinking we should ship a default Dockerfile with the CLI too, so that the one in the backend only serves as an optional override.