### PR TITLE
feat(proxy-backend): support limiting the proxied HTTP methods

### DIFF
--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -52,7 +52,10 @@ configuration will lead to the proxy acting on backend requests to
 
 The value inside each route is either a simple URL string, or an object on the
 format accepted by
-[http-proxy-middleware](https://www.npmjs.com/package/http-proxy-middleware).
+[http-proxy-middleware](https://www.npmjs.com/package/http-proxy-middleware). It
+is also possible to limit the forwarded HTTP methods with the configuration
+`allowedMethods`, for example `allowedMethods: ['GET']` to enforce read-only
+access.
 
 If the value is a string, it is assumed to correspond to:
 

--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -22,6 +22,7 @@
     "@backstage/backend-common": "^0.1.1-alpha.21",
     "@backstage/config": "^0.1.1-alpha.21",
     "@types/express": "^4.17.6",
+    "@types/http-proxy-middleware": "^0.19.3",
     "express": "^4.17.1",
     "express-promise-router": "^3.0.3",
     "http-proxy-middleware": "^0.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4209,7 +4209,7 @@
   resolved "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.0.tgz#682477dbbbd07cd032731cb3b0e7eaee3d026b69"
   integrity sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==
 
-"@types/http-proxy-middleware@*":
+"@types/http-proxy-middleware@*", "@types/http-proxy-middleware@^0.19.3":
   version "0.19.3"
   resolved "https://registry.npmjs.org/@types/http-proxy-middleware/-/http-proxy-middleware-0.19.3.tgz#b2eb96fbc0f9ac7250b5d9c4c53aade049497d03"
   integrity sha512-lnBTx6HCOUeIJMLbI/LaL5EmdKLhczJY5oeXZpX/cXE4rRqb3RmV7VcMpiEfYkmTjipv3h7IAyIINe4plEv7cA==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The proxy backend proxies all requests and can add authorization headers. Some services don't support fine-grained authorization policies so it would be nice to at least be able to limit the access to certain HTTP methods.

Example:
```yaml
proxy:
  '/myservice':
    target: https://myservice.domain.io/api
    # only proxy read-only APIs
    allowedMethods: ['GET']
    headers:
      Authorization: Token asdf
```

Do you think this is a good idea or would you solve that differently?

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
