### PR TITLE
Add the ability to configure repository visibility via config

### DIFF
--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -103,6 +103,7 @@ export default async function createPlugin({
   const cookiecutterTemplater = new CookieCutter();
   const craTemplater = new CreateReactAppTemplater();
   const templaters = new Templaters();
+  // Register default templaters
   templaters.register('cookiecutter', cookiecutterTemplater);
   templaters.register('cra', craTemplater);
 
@@ -110,6 +111,7 @@ export default async function createPlugin({
   const githubPreparer = new GithubPreparer();
   const preparers = new Preparers();
 
+  // Register default preparers
   preparers.register('file', filePreparer);
   preparers.register('github', githubPreparer);
 

--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -189,9 +189,9 @@ Apps integration further down the line.
 > **Right now it is only possible to scaffold repositories inside GitHub
 > organizations, and not under personal accounts.**
 
-The Github access token is retrieved from environment variables by the
-config. The config file needs to specify what environment variable the 
-token is retrieved from. Your config should have the following objects.
+The Github access token is retrieved from environment variables by the config.
+The config file needs to specify what environment variable the token is
+retrieved from. Your config should have the following objects.
 
 ```yaml
 scaffolder:

--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -188,10 +188,7 @@ docs on creating private GitHub access tokens is available
 Note that the need for private GitHub access tokens will be replaced with GitHub
 Apps integration further down the line.
 
-> **Right now it is only possible to scaffold repositories inside GitHub
-> organizations, and not under personal accounts.**
-
-The Github access token is retrieved from environment variables by the config.
+The Github access token is retrieved from environment variables via the config.
 The config file needs to specify what environment variable the token is
 retrieved from. Your config should have the following objects.
 
@@ -203,6 +200,11 @@ scaffolder:
         env: GITHUB_ACCESS_TOKEN
     visibility: public # or 'internal' or 'private'
 ```
+
+You can configure who can see the new repositories that the scaffolder creates
+by specifying `visibility` option. Valid options are `public`, `private` and
+`internal`. `internal` options is for GitHub Enterprise clients, which means
+public within the organization.
 
 ### Running the Backend
 

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -23,12 +23,16 @@ import {
   GithubPublisher,
   CreateReactAppTemplater,
   Templaters,
+  RepoVisilityOptions,
 } from '@backstage/plugin-scaffolder-backend';
 import { Octokit } from '@octokit/rest';
 import type { PluginEnvironment } from '../types';
 import Docker from 'dockerode';
 
-export default async function createPlugin({ logger }: PluginEnvironment) {
+export default async function createPlugin({
+  logger,
+  config,
+}: PluginEnvironment) {
   const cookiecutterTemplater = new CookieCutter();
   const craTemplater = new CreateReactAppTemplater();
   const templaters = new Templaters();
@@ -42,8 +46,17 @@ export default async function createPlugin({ logger }: PluginEnvironment) {
   preparers.register('file', filePreparer);
   preparers.register('github', githubPreparer);
 
-  const githubClient = new Octokit({ auth: process.env.GITHUB_ACCESS_TOKEN });
-  const publisher = new GithubPublisher({ client: githubClient });
+  const githubToken = config.getString('scaffolder.github.token');
+  const repoVisibility = config.getString(
+    'scaffolder.github.visibility',
+  ) as RepoVisilityOptions;
+
+  const githubClient = new Octokit({ auth: githubToken });
+  const publisher = new GithubPublisher({
+    client: githubClient,
+    token: githubToken,
+    repoVisibility,
+  });
 
   const dockerClient = new Docker();
   return await createRouter({

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -47,6 +47,13 @@ lighthouse:
 auth:
   providers: {}
 
+scaffolder:
+  github:
+    token:
+      $secret:
+        env: GITHUB_ACCESS_TOKEN
+    visibility: public # or 'internal' or 'private'
+
 catalog:
   locations:
     # Backstage example components

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/scaffolder.ts
@@ -7,12 +7,16 @@ import {
   GithubPublisher,
   CreateReactAppTemplater,
   Templaters,
+  RepoVisilityOptions,
 } from '@backstage/plugin-scaffolder-backend';
 import { Octokit } from '@octokit/rest';
 import type { PluginEnvironment } from '../types';
 import Docker from 'dockerode';
 
-export default async function createPlugin({ logger }: PluginEnvironment) {
+export default async function createPlugin({
+  logger,
+  config,
+}: PluginEnvironment) {
   const cookiecutterTemplater = new CookieCutter();
   const craTemplater = new CreateReactAppTemplater();
   const templaters = new Templaters();
@@ -26,8 +30,17 @@ export default async function createPlugin({ logger }: PluginEnvironment) {
   preparers.register('file', filePreparer);
   preparers.register('github', githubPreparer);
 
-  const githubClient = new Octokit({ auth: process.env.GITHUB_ACCESS_TOKEN });
-  const publisher = new GithubPublisher({ client: githubClient });
+  const githubToken = config.getString('scaffolder.github.token');
+  const repoVisibility = config.getString(
+    'scaffolder.github.visibility',
+  ) as RepoVisilityOptions;
+
+  const githubClient = new Octokit({ auth: githubToken });
+  const publisher = new GithubPublisher({
+    client: githubClient,
+    token: githubToken,
+    repoVisibility,
+  });
 
   const dockerClient = new Docker();
   return await createRouter({

--- a/packages/e2e-test/src/e2e-test.ts
+++ b/packages/e2e-test/src/e2e-test.ts
@@ -196,6 +196,7 @@ async function createApp(
       env: {
         ...process.env,
         APP_CONFIG_app_baseUrl: '"http://localhost:3001"',
+        APP_CONFIG_scaffolder_github_token: '"abc"',
       },
     });
 

--- a/packages/e2e-test/src/e2e-test.ts
+++ b/packages/e2e-test/src/e2e-test.ts
@@ -196,7 +196,6 @@ async function createApp(
       env: {
         ...process.env,
         APP_CONFIG_app_baseUrl: '"http://localhost:3001"',
-        APP_CONFIG_scaffolder_github_token: '"abc"',
       },
     });
 
@@ -273,6 +272,10 @@ async function createPlugin(pluginName: string, appDir: string) {
 async function testAppServe(pluginName: string, appDir: string) {
   const startApp = spawnPiped(['yarn', 'start'], {
     cwd: appDir,
+    env: {
+      ...process.env,
+      GITHUB_ACCESS_TOKEN: 'abc',
+    },
   });
   Browser.localhost('localhost', 3000);
 
@@ -343,6 +346,10 @@ async function testBackendStart(appDir: string, isPostgres: boolean) {
 
   const child = spawnPiped(['yarn', 'workspace', 'backend', 'start'], {
     cwd: appDir,
+    env: {
+      ...process.env,
+      GITHUB_ACCESS_TOKEN: 'abc',
+    },
   });
 
   let stdout = '';

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
@@ -53,14 +53,78 @@ const {
 };
 
 describe('GitHub Publisher', () => {
-  const publisher = new GithubPublisher({ client: new Octokit() });
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('publish: createRemoteInGithub', () => {
-    it('should use octokit to create a repo in an organisation if the organisation property is set', async () => {
+  describe('with public repo visibility', () => {
+    const publisher = new GithubPublisher({
+      client: new Octokit(),
+      token: 'abc',
+      repoVisibility: 'public',
+    });
+
+    describe('publish: createRemoteInGithub', () => {
+      it('should use octokit to create a repo in an organisation if the organisation property is set', async () => {
+        mockGithubClient.repos.createInOrg.mockResolvedValue({
+          data: {
+            clone_url: 'mockclone',
+          },
+        } as OctokitResponse<ReposCreateInOrgResponseData>);
+
+        await publisher.publish({
+          values: {
+            storePath: 'blam/test',
+            owner: 'bob',
+          },
+          directory: '/tmp/test',
+        });
+
+        expect(mockGithubClient.repos.createInOrg).toHaveBeenCalledWith({
+          org: 'blam',
+          name: 'test',
+          private: false,
+          visibility: 'public',
+        });
+      });
+
+      it('should use octokit to create a repo in the authed user if the organisation property is not set', async () => {
+        mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
+          data: {
+            clone_url: 'mockclone',
+          },
+        } as OctokitResponse<ReposCreateInOrgResponseData>);
+        mockGithubClient.users.getByUsername.mockResolvedValue({
+          data: {
+            type: 'User',
+          },
+        } as OctokitResponse<UsersGetByUsernameResponseData>);
+
+        await publisher.publish({
+          values: {
+            storePath: 'blam/test',
+            owner: 'bob',
+          },
+          directory: '/tmp/test',
+        });
+
+        expect(
+          mockGithubClient.repos.createForAuthenticatedUser,
+        ).toHaveBeenCalledWith({
+          name: 'test',
+        });
+      });
+    });
+
+    describe('publish: createGitDirectory', () => {
+      const values = {
+        isOrg: true,
+        storePath: 'blam/test',
+        owner: 'lols',
+      };
+
+      const mockDir = '/tmp/test/dir';
+
       mockGithubClient.repos.createInOrg.mockResolvedValue({
         data: {
           clone_url: 'mockclone',
@@ -72,8 +136,116 @@ describe('GitHub Publisher', () => {
         },
       } as OctokitResponse<UsersGetByUsernameResponseData>);
 
+      it('should call init on the repo with the directory', async () => {
+        await publisher.publish({
+          values,
+          directory: mockDir,
+        });
+
+        expect(Repository.init).toHaveBeenCalledWith(mockDir, 0);
+      });
+
+      it('should call refresh index on the index and write the new files', async () => {
+        await publisher.publish({
+          values,
+          directory: mockDir,
+        });
+
+        expect(mockRepo.refreshIndex).toHaveBeenCalled();
+      });
+
+      it('should call add all files and write', async () => {
+        await publisher.publish({
+          values,
+          directory: mockDir,
+        });
+
+        expect(mockIndex.addAll).toHaveBeenCalled();
+        expect(mockIndex.write).toHaveBeenCalled();
+        expect(mockIndex.writeTree).toHaveBeenCalled();
+      });
+
+      it('should create a commit with on head with the right name and commiter', async () => {
+        const mockSignature = { mockSignature: 'bloblly' };
+        Signature.now.mockReturnValue(mockSignature);
+
+        await publisher.publish({
+          values,
+          directory: mockDir,
+        });
+
+        expect(Signature.now).toHaveBeenCalledTimes(2);
+        expect(Signature.now).toHaveBeenCalledWith(
+          'Scaffolder',
+          'scaffolder@backstage.io',
+        );
+
+        expect(mockRepo.createCommit).toHaveBeenCalledWith(
+          'HEAD',
+          mockSignature,
+          mockSignature,
+          'initial commit',
+          'mockoid',
+          [],
+        );
+      });
+
+      it('creates a remote with the repo and remote', async () => {
+        await publisher.publish({
+          values,
+          directory: mockDir,
+        });
+
+        expect(Remote.create).toHaveBeenCalledWith(
+          mockRepo,
+          'origin',
+          'mockclone',
+        );
+      });
+
+      it('shoud push to the remote repo', async () => {
+        await publisher.publish({
+          values,
+          directory: mockDir,
+        });
+
+        const [remotes, { callbacks }] = mockRemote.push.mock
+          .calls[0] as NodeGit.PushOptions[];
+
+        expect(remotes).toEqual(['refs/heads/master:refs/heads/master']);
+
+        callbacks?.credentials?.();
+
+        expect(Cred.userpassPlaintextNew).toHaveBeenCalledWith(
+          'abc',
+          'x-oauth-basic',
+        );
+      });
+    });
+  });
+
+  describe('with internal repo visibility', () => {
+    const publisher = new GithubPublisher({
+      client: new Octokit(),
+      token: 'abc',
+      repoVisibility: 'internal',
+    });
+
+    it('creates a repo in an organisation with internal visibility', async () => {
+      mockGithubClient.repos.createInOrg.mockResolvedValue({
+        data: {
+          clone_url: 'mockclone',
+        },
+      } as OctokitResponse<ReposCreateInOrgResponseData>);
+      mockGithubClient.users.getByUsername.mockResolvedValue({
+        data: {
+          type: 'Organization',
+        },
+      } as OctokitResponse<UsersGetByUsernameResponseData>);
+      
       await publisher.publish({
         values: {
+          isOrg: true,
           storePath: 'blam/test',
           owner: 'bob',
         },
@@ -83,143 +255,9 @@ describe('GitHub Publisher', () => {
       expect(mockGithubClient.repos.createInOrg).toHaveBeenCalledWith({
         org: 'blam',
         name: 'test',
+        private: true,
+        visibility: 'internal',
       });
-    });
-
-    it('should use octokit to create a repo in the authed user if the organisation property is not set', async () => {
-      mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
-        data: {
-          clone_url: 'mockclone',
-        },
-      } as OctokitResponse<ReposCreateInOrgResponseData>);
-      mockGithubClient.users.getByUsername.mockResolvedValue({
-        data: {
-          type: 'User',
-        },
-      } as OctokitResponse<UsersGetByUsernameResponseData>);
-
-      await publisher.publish({
-        values: {
-          storePath: 'blam/test',
-          owner: 'bob',
-        },
-        directory: '/tmp/test',
-      });
-
-      expect(
-        mockGithubClient.repos.createForAuthenticatedUser,
-      ).toHaveBeenCalledWith({
-        name: 'test',
-      });
-    });
-  });
-
-  describe('publish: createGitDirectory', () => {
-    const values = {
-      isOrg: true,
-      storePath: 'blam/test',
-      owner: 'lols',
-    };
-
-    const mockDir = '/tmp/test/dir';
-
-    mockGithubClient.repos.createInOrg.mockResolvedValue({
-      data: {
-        clone_url: 'mockclone',
-      },
-    } as OctokitResponse<ReposCreateInOrgResponseData>);
-    mockGithubClient.users.getByUsername.mockResolvedValue({
-      data: {
-        type: 'Organization',
-      },
-    } as OctokitResponse<UsersGetByUsernameResponseData>);
-
-    it('should call init on the repo with the directory', async () => {
-      await publisher.publish({
-        values,
-        directory: mockDir,
-      });
-
-      expect(Repository.init).toHaveBeenCalledWith(mockDir, 0);
-    });
-
-    it('should call refresh index on the index and write the new files', async () => {
-      await publisher.publish({
-        values,
-        directory: mockDir,
-      });
-
-      expect(mockRepo.refreshIndex).toHaveBeenCalled();
-    });
-
-    it('should call add all files and write', async () => {
-      await publisher.publish({
-        values,
-        directory: mockDir,
-      });
-
-      expect(mockIndex.addAll).toHaveBeenCalled();
-      expect(mockIndex.write).toHaveBeenCalled();
-      expect(mockIndex.writeTree).toHaveBeenCalled();
-    });
-
-    it('should create a commit with on head with the right name and commiter', async () => {
-      const mockSignature = { mockSignature: 'bloblly' };
-      Signature.now.mockReturnValue(mockSignature);
-
-      await publisher.publish({
-        values,
-        directory: mockDir,
-      });
-
-      expect(Signature.now).toHaveBeenCalledTimes(2);
-      expect(Signature.now).toHaveBeenCalledWith(
-        'Scaffolder',
-        'scaffolder@backstage.io',
-      );
-
-      expect(mockRepo.createCommit).toHaveBeenCalledWith(
-        'HEAD',
-        mockSignature,
-        mockSignature,
-        'initial commit',
-        'mockoid',
-        [],
-      );
-    });
-
-    it('creates a remote with the repo and remote', async () => {
-      await publisher.publish({
-        values,
-        directory: mockDir,
-      });
-
-      expect(Remote.create).toHaveBeenCalledWith(
-        mockRepo,
-        'origin',
-        'mockclone',
-      );
-    });
-
-    it('shoud push to the remote repo', async () => {
-      await publisher.publish({
-        values,
-        directory: mockDir,
-      });
-
-      const [remotes, { callbacks }] = mockRemote.push.mock
-        .calls[0] as NodeGit.PushOptions[];
-
-      expect(remotes).toEqual(['refs/heads/master:refs/heads/master']);
-
-      process.env.GITHUb_ACCESS_TOKEN = 'blob';
-
-      callbacks?.credentials?.();
-
-      expect(Cred.userpassPlaintextNew).toHaveBeenCalledWith(
-        process.env.GITHUB_ACCESS_TOKEN,
-        'x-oauth-basic',
-      );
     });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
@@ -242,7 +242,7 @@ describe('GitHub Publisher', () => {
           type: 'Organization',
         },
       } as OctokitResponse<UsersGetByUsernameResponseData>);
-      
+
       await publisher.publish({
         values: {
           isOrg: true,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
@@ -231,7 +231,7 @@ describe('GitHub Publisher', () => {
       repoVisibility: 'internal',
     });
 
-    it('creates a repo in an organisation with internal visibility', async () => {
+    it('creates a repo in an organisation if the organisation with private visibility', async () => {
       mockGithubClient.repos.createInOrg.mockResolvedValue({
         data: {
           clone_url: 'mockclone',

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
@@ -112,6 +112,7 @@ describe('GitHub Publisher', () => {
           mockGithubClient.repos.createForAuthenticatedUser,
         ).toHaveBeenCalledWith({
           name: 'test',
+          private: false,
         });
       });
     });
@@ -231,7 +232,7 @@ describe('GitHub Publisher', () => {
       repoVisibility: 'internal',
     });
 
-    it('creates a repo in an organisation if the organisation with private visibility', async () => {
+    it('creates a private repository in the organization with visibility set to internal', async () => {
       mockGithubClient.repos.createInOrg.mockResolvedValue({
         data: {
           clone_url: 'mockclone',
@@ -257,6 +258,42 @@ describe('GitHub Publisher', () => {
         name: 'test',
         private: true,
         visibility: 'internal',
+      });
+    });
+  });
+
+  describe('private visibility in a user account', () => {
+    const publisher = new GithubPublisher({
+      client: new Octokit(),
+      token: 'abc',
+      repoVisibility: 'private',
+    });
+
+    it('creates a private repository', async () => {
+      mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
+        data: {
+          clone_url: 'mockclone',
+        },
+      } as OctokitResponse<ReposCreateInOrgResponseData>);
+      mockGithubClient.users.getByUsername.mockResolvedValue({
+        data: {
+          type: 'User',
+        },
+      } as OctokitResponse<UsersGetByUsernameResponseData>);
+
+      await publisher.publish({
+        values: {
+          storePath: 'blam/test',
+          owner: 'bob',
+        },
+        directory: '/tmp/test',
+      });
+
+      expect(
+        mockGithubClient.repos.createForAuthenticatedUser,
+      ).toHaveBeenCalledWith({
+        name: 'test',
+        private: true,
       });
     });
   });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -67,11 +67,11 @@ export class GithubPublisher implements PublisherBase {
     const repoCreationPromise =
       user.data.type === 'Organization'
         ? this.client.repos.createInOrg({
-          name,
-          org: owner,
-          private: this.repoVisibility !== 'public',
-          visibility: this.repoVisibility,
-        })
+            name,
+            org: owner,
+            private: this.repoVisibility !== 'public',
+            visibility: this.repoVisibility,
+          })
         : this.client.repos.createForAuthenticatedUser({ name });
 
     const { data } = await repoCreationPromise;

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -72,7 +72,10 @@ export class GithubPublisher implements PublisherBase {
             private: this.repoVisibility !== 'public',
             visibility: this.repoVisibility,
           })
-        : this.client.repos.createForAuthenticatedUser({ name });
+        : this.client.repos.createForAuthenticatedUser({
+            name,
+            private: this.repoVisibility === 'private',
+          });
 
     const { data } = await repoCreationPromise;
 

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -21,10 +21,27 @@ import { JsonValue } from '@backstage/config';
 import { RequiredTemplateValues } from '../templater';
 import { Repository, Remote, Signature, Cred } from 'nodegit';
 
+export type RepoVisilityOptions = 'private' | 'internal' | 'public';
+
+interface GithubPublisherParams {
+  client: Octokit;
+  token: string;
+  repoVisibility: RepoVisilityOptions;
+}
+
 export class GithubPublisher implements PublisherBase {
   private client: Octokit;
-  constructor({ client }: { client: Octokit }) {
+  private token: string;
+  private repoVisibility: RepoVisilityOptions;
+
+  constructor({
+    client,
+    token,
+    repoVisibility = 'public',
+  }: GithubPublisherParams) {
     this.client = client;
+    this.token = token;
+    this.repoVisibility = repoVisibility;
   }
 
   async publish({
@@ -49,7 +66,12 @@ export class GithubPublisher implements PublisherBase {
 
     const repoCreationPromise =
       user.data.type === 'Organization'
-        ? this.client.repos.createInOrg({ name, org: owner })
+        ? this.client.repos.createInOrg({
+          name,
+          org: owner,
+          private: this.repoVisibility !== 'public',
+          visibility: this.repoVisibility,
+        })
         : this.client.repos.createForAuthenticatedUser({ name });
 
     const { data } = await repoCreationPromise;
@@ -76,10 +98,7 @@ export class GithubPublisher implements PublisherBase {
     await remoteRepo.push(['refs/heads/master:refs/heads/master'], {
       callbacks: {
         credentials: () => {
-          return Cred.userpassPlaintextNew(
-            process.env.GITHUB_ACCESS_TOKEN as string,
-            'x-oauth-basic',
-          );
+          return Cred.userpassPlaintextNew(this.token, 'x-oauth-basic');
         },
       },
     });


### PR DESCRIPTION
Closes #2386 & #2384 

I'm setting up a demo of Backstage for an organization that allows internal repositories to be created but not public. The current code defaulted to creating a public repository which caused repository creation to fail. 

This PR adds the ability to configure repository visibility via app-config.yaml and changes GitHub Publisher to retrieve GitHub token from environment variables. 

## Approach

- GithubPublisher constructor now takes token & repoVisibility params as part of options args
- GithubPublisher passes private flag & visibility to `createInOrg` *(not changing how createForAuthenticatedUser is invoked)*
- Removed use of `env.process.GITHUB_ACCESS_TOKEN` from GithubPublisher
- Changed scaffolder plugin to read `scaffolder.github.token` from config instead of `env.process.GITHUB_ACCESS_TOKEN`
- Changed scaffolder plugin to read `scaffolder.github.visibility` and use it when creating instance of GithubPublisher
- Updated `app-config.yaml.hbs` in create-app to include the new options
- Updated `create-app` scaffolder plugin to use new code
- Updated documentation for scaffolder plugin to reference new config
- Updated documentation for scaffolder to use new code for plugin
- Added GITHUB_ACCESS_TOKEN to environment variables in e2e tests
- Added the ability to create user repositories with private flag

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
