### PR TITLE
Fix view for Table of Contents on smaller screens (Docs and Blog page)

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -203,6 +203,54 @@ td {
   border-radius: 0.25rem;
 }
 
+/*
+ * Fix for viewing Table of Contents bar on documentation
+ * and blog pages on smaller screens.
+ */
+@media only screen and (max-width: 1023px) {
+  /* Nav bar hides the docs toc bar */
+  .docMainWrapper {
+    margin-top: 4rem;
+  }
+
+  /* Toc bar does not have to be fixed */
+  .docsNavContainer {
+    position: unset;
+    width: 95vw;
+    z-index: 100;
+    margin-left: -2vw;
+  }
+
+  /* Toc bar does not have to be fixed when slider is active */
+  .docsSliderActive .toc .navBreadcrumb,
+  .tocActive .navBreadcrumb {
+    position: unset;
+  }
+
+  /* Fix unexpected width increase when toc is toggled */
+  .docsSliderActive .toc .navBreadcrumb,
+  .tocActive .navBreadcrumb {
+    width: inherit;
+  }
+
+  /* This pseudo-element stops toc toggle button to be clicked */
+  header.postHeader::before {
+    height: 2em !important;
+    margin-top: -2em !important;
+  }
+
+  /* This pseudo-element stops toc toggle button to be clicked */
+  #__docusaurus.postHeaderTitle::before {
+    height: 1em;
+    margin-top: -1em;
+  }
+
+  /* Useless button causing trouble */
+  .tocToggler {
+    display: none;
+  }
+}
+
 /* content */
 .postContainer blockquote {
   color: $textColor;
@@ -288,17 +336,17 @@ code {
   background: linear-gradient(70.44deg, #121212 75%, #5d817b 100%);
 }
 .bg-teal-top-right {
-  background: 
+  background:
   /* linear-gradient(
       178.64deg,
       rgba(255, 255, 255, 0) 57.61%,
       rgba(255, 255, 255, 0.17) 127.71%
-    ), */ 
+    ), */
     /* linear-gradient(
       144.35deg,
       rgba(98, 197, 179, 0) 56.68%,
       rgba(98, 197, 179, 0.59) 109.25%
-    ), */ 
+    ), */
     /* linear-gradient(
       192.29deg,
       rgba(155, 240, 225, 0) 54.17%,


### PR DESCRIPTION
On https://backstage.io/docs and https://backstage.io/blog pages, we have a sidebar with Table of Contents. On smaller screens, this sidebar becomes a nav bar on top with a toggle (hamburger) button.
However, we also have an existing main nav bar on the header of the website (with links to GitHub, Newsletter, etc.). This nav bar hinders the view of the TOC bar. Without this TOC, one can not move from one docs page to the other.

This PR fixes the view for Table of Contents on Blog and Docs page on smaller screens.

# Screenshots

## Docs page (current)

![Screenshot 2020-09-11 at 18 15 11](https://user-images.githubusercontent.com/8065913/92949078-c22a2f80-f45a-11ea-87ec-00b38b8f3814.png)

## Docs page (new)

![Screenshot 2020-09-11 at 18 15 48](https://user-images.githubusercontent.com/8065913/92949116-d3733c00-f45a-11ea-8b9d-e5570b52b97f.png)

## Blog page (current)

![Screenshot 2020-09-11 at 18 16 17](https://user-images.githubusercontent.com/8065913/92949155-e5ed7580-f45a-11ea-9658-1fa4ea67f6da.png)

## Blog page (new)

![Screenshot 2020-09-11 at 18 16 37](https://user-images.githubusercontent.com/8065913/92949179-f0a80a80-f45a-11ea-99ca-dff274788bd7.png)

## In action (GIF)

![toc](https://user-images.githubusercontent.com/8065913/92949525-86439a00-f45b-11ea-9bc0-552ce497c337.gif)


#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
