### PR TITLE
scaffolder: Allow user or org, remove hard coded isOrg

### DIFF
--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -177,9 +177,6 @@ docs on creating private GitHub access tokens is available
 Note that the need for private GitHub access tokens will be replaced with GitHub
 Apps integration further down the line.
 
-> **Right now it is only possible to scaffold repositories inside GitHub
-> organizations, and not under personal accounts.**
-
 The GitHub access token is passed along using the `GITHUB_ACCESS_TOKEN`
 environment variable.
 

--- a/docs/features/techdocs/creating-and-publishing.md
+++ b/docs/features/techdocs/creating-and-publishing.md
@@ -30,11 +30,6 @@ the documentation template.
 Create an entity from the documentation template and you will get the needed
 setup for free.
 
-!!! warning Currently the Backstage Software Templates are limited to create
-repositories inside GitHub organizations. You also need to generate an personal
-access token and use as an environment variable. Read more about this
-[here](../software-templates/installation.md#runtime-dependencies).
-
 ### Manually add documentation setup to already existing repository
 
 Prerequisities:

--- a/plugins/scaffolder-backend/src/scaffolder/__mocks__/@octokit/rest/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/__mocks__/@octokit/rest/index.ts
@@ -19,6 +19,9 @@ export const mockGithubClient = {
     createInOrg: jest.fn(),
     createForAuthenticatedUser: jest.fn(),
   },
+  users: {
+    getByUsername: jest.fn(),
+  },
 };
 
 export class Octokit {

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
@@ -19,11 +19,18 @@ jest.mock('nodegit');
 
 import { Octokit } from '@octokit/rest';
 import * as NodeGit from 'nodegit';
-import { OctokitResponse, ReposCreateInOrgResponseData } from '@octokit/types';
+import {
+  OctokitResponse,
+  ReposCreateInOrgResponseData,
+  UsersGetByUsernameResponseData,
+} from '@octokit/types';
 import { GithubPublisher } from './github';
 
 const { mockGithubClient } = require('@octokit/rest') as {
-  mockGithubClient: { repos: jest.Mocked<Octokit['repos']> };
+  mockGithubClient: {
+    repos: jest.Mocked<Octokit['repos']>;
+    users: jest.Mocked<Octokit['users']>;
+  };
 };
 
 const {
@@ -59,10 +66,14 @@ describe('GitHub Publisher', () => {
           clone_url: 'mockclone',
         },
       } as OctokitResponse<ReposCreateInOrgResponseData>);
+      mockGithubClient.users.getByUsername.mockResolvedValue({
+        data: {
+          type: 'Organization',
+        },
+      } as OctokitResponse<UsersGetByUsernameResponseData>);
 
       await publisher.publish({
         values: {
-          isOrg: true,
           storePath: 'blam/test',
           owner: 'bob',
         },
@@ -81,6 +92,11 @@ describe('GitHub Publisher', () => {
           clone_url: 'mockclone',
         },
       } as OctokitResponse<ReposCreateInOrgResponseData>);
+      mockGithubClient.users.getByUsername.mockResolvedValue({
+        data: {
+          type: 'User',
+        },
+      } as OctokitResponse<UsersGetByUsernameResponseData>);
 
       await publisher.publish({
         values: {
@@ -112,6 +128,12 @@ describe('GitHub Publisher', () => {
         clone_url: 'mockclone',
       },
     } as OctokitResponse<ReposCreateInOrgResponseData>);
+    mockGithubClient.users.getByUsername.mockResolvedValue({
+      data: {
+        type: 'Organization',
+      },
+    } as OctokitResponse<UsersGetByUsernameResponseData>);
+
     it('should call init on the repo with the directory', async () => {
       await publisher.publish({
         values,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -45,9 +45,12 @@ export class GithubPublisher implements PublisherBase {
   ) {
     const [owner, name] = values.storePath.split('/');
 
-    const repoCreationPromise = values.isOrg
-      ? this.client.repos.createInOrg({ name, org: owner })
-      : this.client.repos.createForAuthenticatedUser({ name });
+    const user = await this.client.users.getByUsername({ username: owner });
+
+    const repoCreationPromise =
+      user.data.type === 'Organization'
+        ? this.client.repos.createInOrg({ name, org: owner })
+        : this.client.repos.createForAuthenticatedUser({ name });
 
     const { data } = await repoCreationPromise;
 

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -46,8 +46,7 @@ export class ScaffolderApi {
       headers: {
         'Content-Type': 'application/json',
       },
-      // TODO(shmidt-i): when repo picker is implemented, take isOrg from it
-      body: JSON.stringify({ template, values: { ...values, isOrg: true } }),
+      body: JSON.stringify({ template, values: { ...values } }),
     });
 
     if (response.status !== 201) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Previously the code was hardcoded to organisations only, now you can also store in user repos.
Useful if you don't want to store the repo in org account, i.e. prototyping, learning backstage etc.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
