### PR TITLE
Applied theme's background image to template cards

### DIFF
--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -23,8 +23,8 @@ const useStyles = makeStyles(theme => ({
   header: {
     color: theme.palette.common.white,
     padding: theme.spacing(2, 2, 6),
-    backgroundImage: (props: { gradientStart: string; gradientStop: string }) =>
-      `linear-gradient(-137deg, ${props.gradientStart} 0%, ${props.gradientStop} 100%)`,
+    backgroundImage: (props: { backgroundImage: string }) =>
+      props.backgroundImage,
   },
   content: {
     padding: theme.spacing(2),
@@ -56,8 +56,7 @@ export const TemplateCard = ({
   name,
 }: TemplateCardProps) => {
   const theme = pageTheme[type] ?? pageTheme.other;
-  const [gradientStart, gradientStop] = theme.colors;
-  const classes = useStyles({ gradientStart, gradientStop });
+  const classes = useStyles({ backgroundImage: theme.backgroundImage });
   const href = generatePath(templateRoute.path, { templateName: name });
 
   return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #2422.

Updated the TemplateCard component's styles:
- applied `backgroundImage` as in `Header.tsx`
- removed `gradientStart` and `gradientEnd` since it is no longer in use

| Before                                                                                                         | After                                                                                                          |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/29514264/92989247-88fac980-f505-11ea-8a07-22b11acb53de.png) | ![image](https://user-images.githubusercontent.com/29514264/92989221-37ead580-f505-11ea-9ae1-d03a3f89909c.png) |

#### :heavy_check_mark: Checklist

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
