### PR TITLE
Techdocs without docker-in-docker

### DIFF
--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -26,6 +26,7 @@
     "@backstage/config": "^0.1.1-alpha.21",
     "@types/dockerode": "^2.5.34",
     "@types/express": "^4.17.6",
+    "command-exists-promise": "^2.0.2",
     "default-branch": "^1.0.8",
     "dockerode": "^3.2.1",
     "express": "^4.17.1",

--- a/plugins/techdocs-backend/src/techdocs/stages/generate/helpers.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/generate/helpers.ts
@@ -18,6 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 import { Writable, PassThrough } from 'stream';
 import Docker from 'dockerode';
 import { SupportedGeneratorKey } from './types';
+import { spawn } from 'child_process';
 
 // TODO: Implement proper support for more generators.
 export function getGeneratorKey(entity: Entity): SupportedGeneratorKey {
@@ -36,6 +37,13 @@ type RunDockerContainerOptions = {
   resultDir: string;
   dockerClient: Docker;
   createOptions?: Docker.ContainerCreateOptions;
+};
+
+export type RunCommandOptions = {
+  command: string;
+  args: string[];
+  options: object;
+  logStream?: Writable;
 };
 
 export async function runDockerContainer({
@@ -88,3 +96,41 @@ export async function runDockerContainer({
 
   return { error, statusCode };
 }
+
+/**
+ *
+ * @param options the options object
+ * @param options.command the command to run
+ * @param options.args the arguments to pass the command
+ * @param options.options options used in spawn
+ * @param options.logStream the log streamer to capture log messages
+ */
+export const runCommand = async ({
+  command,
+  args,
+  options,
+  logStream = new PassThrough(),
+}: RunCommandOptions) => {
+  await new Promise((resolve, reject) => {
+    const process = spawn(command, args, options);
+
+    process.stdout.on('data', stream => {
+      logStream.write(stream);
+    });
+
+    process.stderr.on('data', stream => {
+      logStream.write(stream);
+    });
+
+    process.on('error', error => {
+      return reject(error);
+    });
+
+    process.on('close', code => {
+      if (code !== 0) {
+        return reject(`Command ${command} failed, exit code: ${code}`);
+      }
+      return resolve();
+    });
+  });
+};


### PR DESCRIPTION
We're deploying backstage to GKE and have had issues getting techdocs
volume mount logic to work because of mixing paths between the host and
the container running the backend. So we added a condition where if
mkdocs is found in the backend container it will use that to generate
the docs rather than spinning it up in a docker container.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ x ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ x ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
