### PR TITLE
github/workflows: remove global yarn cache from windows build

### DIFF
--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -27,25 +27,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Beginning of yarn setup, keep in sync between all workflows, see ci.yml
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: https://registry.npmjs.org/ # Needed for auth
-      - name: find location of global yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: cache global yarn cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: yarn install
         run: yarn install --frozen-lockfile
-      # End of yarn setup
 
       - run: yarn tsc
       - name: yarn build


### PR DESCRIPTION
Disk access is slow af in windows builds, while networking is pretty fast. Since the global cache fetching causes a bunch of extra disk access, this might actually be quicker ^_>