### PR TITLE
TechDocs: Automatically add new Issues/PRs to GitHub project board

### DIFF
--- a/.github/workflows/techdocs-project-board.yml
+++ b/.github/workflows/techdocs-project-board.yml
@@ -12,9 +12,9 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  assign_issue_to_project:
+  assign_issue_or_pr_to_project:
     runs-on: ubuntu-latest
-    name: Issue
+    name: Triage
     steps:
       - name: Assign new issue to Incoming based on its title.
         uses: srggrs/assign-one-project-github-action@1.2.0
@@ -34,10 +34,6 @@ jobs:
           project: 'https://github.com/spotify/backstage/projects/5'
           column_name: 'Incoming'
 
-  assign_pull_request_to_project:
-    runs-on: ubuntu-latest
-    name: PR
-    steps:
       - name: Assign new PR to Incoming based on its title.
         uses: srggrs/assign-one-project-github-action@1.2.0
         if: |
@@ -47,6 +43,7 @@ jobs:
         with:
           project: 'https://github.com/spotify/backstage/projects/5'
           column_name: 'Incoming'
+
       - name: Assign new PR to Incoming based on its label.
         uses: srggrs/assign-one-project-github-action@1.2.0
         if: |

--- a/.github/workflows/techdocs-project-board.yml
+++ b/.github/workflows/techdocs-project-board.yml
@@ -1,0 +1,56 @@
+name: Automatically add new TechDocs Issues and PRs to the GitHub project board
+# Development of TechDocs in Backstage is managed by this Kanban board - https://github.com/spotify/backstage/projects/5
+# New issues with TechDocs in their title or docs-like-code label will be added to the board.
+
+on:
+  issues:
+    types: [opened, reopened, labeled, edited]
+  pull_request:
+    types: [opened, reopened, labeled, edited]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_issue_to_project:
+    runs-on: ubuntu-latest
+    name: Issue
+    steps:
+      - name: Assign new issue to Incoming based on its title.
+        uses: srggrs/assign-one-project-github-action@1.2.0
+        if: |
+          contains(github.event.issue.title, 'TechDocs') ||
+          contains(github.event.issue.title, 'techdocs') ||
+          contains(github.event.issue.title, 'Techdocs')
+        with:
+          project: 'https://github.com/spotify/backstage/projects/5'
+          column_name: 'Incoming'
+
+      - name: Assign new issue to Incoming based on its label.
+        uses: srggrs/assign-one-project-github-action@1.2.0
+        if: |
+          contains(github.event.issue.labels.*.name, 'docs-like-code')
+        with:
+          project: 'https://github.com/spotify/backstage/projects/5'
+          column_name: 'Incoming'
+
+  assign_pull_request_to_project:
+    runs-on: ubuntu-latest
+    name: PR
+    steps:
+      - name: Assign new PR to Incoming based on its title.
+        uses: srggrs/assign-one-project-github-action@1.2.0
+        if: |
+          contains(github.event.pull_request.title, 'TechDocs') ||
+          contains(github.event.pull_request.title, 'techdocs') ||
+          contains(github.event.pull_request.title, 'Techdocs')
+        with:
+          project: 'https://github.com/spotify/backstage/projects/5'
+          column_name: 'Incoming'
+      - name: Assign new PR to Incoming based on its label.
+        uses: srggrs/assign-one-project-github-action@1.2.0
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'docs-like-code')
+        with:
+          project: 'https://github.com/spotify/backstage/projects/5'
+          column_name: 'Incoming'


### PR DESCRIPTION
Closes #2440 

* This enables us to be more reliant on our GitHub project board for TechDocs development.
* New Issues/PRs from contributors will have more visibility from the team.
* This saves us from manual triaging overload.

(I can't believe how powerful GitHub Actions sometimes can be. 🙏 )

Workflow tested on [my fork](https://github.com/OrkoHunter/backstage/projects/1).
