### PR TITLE
Missing Config for GithubReaderProcessor

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -57,6 +57,10 @@ catalog:
   rules:
     - allow: [Component, API, Group, Template, Location]
   processors:
+    github:
+      privateToken:
+        $secret:
+          env: GITHUB_PRIVATE_TOKEN
     githubApi:
       privateToken:
         $secret:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I tried to add a private GitHub repository and I got errors. I had setup the token in the
GITHUB_PRIVATE_TOKEN. I found the config was missing from app-config.yaml

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
