### PR TITLE
Configure Codecov bot

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,8 @@
-comment: false
+comment: false # Ref: https://docs.codecov.io/docs/pull-request-comments
 
 coverage:
   status:
     project:
       default:
-        threshold: 2%
+        threshold: 2% # Ref: https://docs.codecov.io/docs/codecovyml-reference#coveragestatus
         target: auto

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,5 +4,5 @@ coverage:
   status:
     project:
       default:
-        threshold: 2% # Ref: https://docs.codecov.io/docs/codecovyml-reference#coveragestatus
+        threshold: 0% # Ref: https://docs.codecov.io/docs/codecovyml-reference#coveragestatus
         target: auto

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,8 @@
 comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2%
+        target: auto


### PR DESCRIPTION
* Disable codecov report in PR comments.
* Set coverage change threshold to 2%. This threshold is for the GitHub check on PRs.

As seen in https://github.com/spotify/backstage/pull/2437#issuecomment-691678223, the comment is not useful. We can re-enable it when we feel it is needed. However the GitHub check and the master code coverage adds value.