### PR TITLE
feat: add Docker environment for scaffolded application

### DIFF
--- a/packages/create-app/templates/default-app/README.md
+++ b/packages/create-app/templates/default-app/README.md
@@ -1,3 +1,6 @@
 # [Backstage](https://backstage.io)
 
 This is your newly scaffolded Backstage App, Good Luck!
+
+Run `yarn dev [up|down|<any docker-compose argument>]` to start the development environment.` Visit
+[http://localhost:3000](http://localhost:3000) for the development server.

--- a/packages/create-app/templates/default-app/app-config.development.yaml
+++ b/packages/create-app/templates/default-app/app-config.development.yaml
@@ -1,8 +1,8 @@
 app:
-  baseUrl: http://localhost:3000
+  baseUrl: http://0.0.0.0:3000
 
 backend:
-  baseUrl: http://localhost:7000
+  baseUrl: http://0.0.0.0:7000
   listen:
     port: 7000
   cors:

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -1,12 +1,12 @@
 app:
   title: Scaffolded Backstage App
-  baseUrl: http://localhost:7000
+  baseUrl: http://0.0.0.0.:7000
 
 organization:
   name: Acme Corporation
 
 backend:
-  baseUrl: http://localhost:7000
+  baseUrl: http://0.0.0.0.:7000
   listen:
     port: 7000
   {{#if dbTypeSqlite}}

--- a/packages/create-app/templates/default-app/docker/development/db/0001-backstage-scaffold.sh
+++ b/packages/create-app/templates/default-app/docker/development/db/0001-backstage-scaffold.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-SQL
+    CREATE DATABASE backstage_plugin_auth;
+    CREATE DATABASE backstage_plugin_catalog;
+    CREATE DATABASE backstage_plugin_identity;
+    CREATE DATABASE backstage_plugin_scaffolder;
+    CREATE DATABASE backstage_plugin_proxy;
+    CREATE DATABASE backstage_plugin_techdocs;
+    GRANT ALL PRIVILEGES ON DATABASE backstage_plugin_auth TO backstage;
+    GRANT ALL PRIVILEGES ON DATABASE backstage_plugin_catalog TO backstage;
+    GRANT ALL PRIVILEGES ON DATABASE backstage_plugin_identity TO backstage;
+    GRANT ALL PRIVILEGES ON DATABASE backstage_plugin_scaffolder TO backstage;
+    GRANT ALL PRIVILEGES ON DATABASE backstage_plugin_proxy TO backstage;
+    GRANT ALL PRIVILEGES ON DATABASE backstage_plugin_techdocs TO backstage;
+SQL

--- a/packages/create-app/templates/default-app/docker/development/docker-compose.yml
+++ b/packages/create-app/templates/default-app/docker/development/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+
+volumes:
+  yarn_cache: null
+  node_modules: null
+
+services:
+  main:
+    container_name: backstage
+    build:
+      dockerfile: main.Dockerfile
+      context: .
+    depends_on:
+      - db
+    ports:
+      - '3000:3000'
+      - '7000:7000'
+    command: |
+      bash -c '(yarn install || sleep 600) && exec yarn start'
+    working_dir: /project/backstage
+    volumes:
+      - ../../:/project/backstage
+      - node_modules:/project/backstage/node_modules
+      - yarn_cache:/usr/local/share/.cache/yarn
+    environment:
+      NODE_ENV: development
+      POSTGRES_PORT: '5432'
+      POSTGRES_HOST: 'backstage-db'
+      POSTGRES_USER: 'backstage'
+      POSTGRES_PASSWORD: 'backstage'
+  db:
+    image: 'postgres:11'
+    container_name: backstage-db
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: 'backstage'
+      POSTGRES_USER: 'backstage'
+    volumes:
+      - ./db/:/docker-entrypoint-initdb.d

--- a/packages/create-app/templates/default-app/docker/development/main.Dockerfile
+++ b/packages/create-app/templates/default-app/docker/development/main.Dockerfile
@@ -1,0 +1,9 @@
+FROM node:12-buster-slim
+
+ARG TARGETPLATFORM="${TARGETPLATFORM:-linux/amd64}"
+ARG TARGETOS="${TARGETOS:-linux}"
+ARG TARGETARCH="${TARGETARCH:-amd64}"
+
+RUN apt-get update && \
+  apt-get -y install libkrb5-3 libgssapi-krb5-2 libk5crypto3 git && \
+  rm -rf /var/lib/apt/lists/*

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -6,7 +6,8 @@
     "node": "12"
   },
   "scripts": {
-    "start": "yarn workspace app start",
+    "start": "concurrently 'yarn workspace app start' 'yarn workspace backend start'",
+    "dev": "docker-compose --file ./docker/development/docker-compose.yml",
     "build": "lerna run build",
     "tsc": "tsc",
     "tsc:full": "tsc --skipLibCheck false --incremental false",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@backstage/cli": "^{{version}}",
     "@spotify/prettier-config": "^7.0.0",
+    "concurrently": "^5.3.0",
     "lerna": "^3.20.2",
     "prettier": "^1.19.1"
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Adds a Docker-compose environment for newly initialised applications. This has a base Node image, with the Backstage dependencies installed. Starting up the environment sets up the dev server, a Postgres database, and wires it all up. Node modules are installed in a volume so Docker for Mac users won't have a gigantic performance hit.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

### Questions
 - Should the main Backstage docs be updated for this? Do we separate docs for Backstage, vs docs for scaffolded Backstage applications?
   - There's https://backstage.io/docs/getting-started/running-backstage-locally, https://backstage.io/docs/getting-started/development-environment, and https://backstage.io/docs/getting-started/deployment-other which all talk about the same thing in slightly different contexts
 - At Grab we're trying to unify the tech stack as much as possible. For development we advocate running it in this environment, for production we will utilise a similar method of building Deployment images that can be used either in Docker-compose or Kubernetes. None of the other ways Backstage currently advocates are deprecated (eg directly running on host machine), but this is the fastest way to get a working environment up without worrying about Node versions, dependencies etc. However, given the many ways of starting Backstage today, perhaps it makes sense to start consolidating into a Golden Path? 😉 
    - As a preview of the production deployment stack, the Dockerfiles -- both Backend and Frontend -- are built separately using multi stage builds, with the first stage using this Dockerfile, and the second stage using the `dist/` directory. This gives a minimal Docker image, similar to how the Backstage repo currently has Dockerfiles for (with app-config substitution, etc.)
    - The production deploy is unopinionated about the database - this is Cloud infrastructure territory - we currently deploy using Kubernetes (inspired by the Kubernetes configs in Backstage), but the deployments are applied via Terraform, which will allow us to chain database creation with app deployment.
 - Dockerfiles currently assume Postgres. SQLite doesn't have a "container", so what should be the way ahead for that?