### PR TITLE
TechDocs: Fix building if you already have a corrupt git tmp folder

### DIFF
--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -119,14 +119,20 @@ export const checkoutGithubRepository = async (
   const token = process.env.GITHUB_PRIVATE_TOKEN || '';
 
   if (fs.existsSync(repositoryTmpPath)) {
-    const repository = await Repository.open(repositoryTmpPath);
-    const currentBranchName = (await repository.getCurrentBranch()).shorthand();
-    await repository.fetch('origin');
-    await repository.mergeBranches(
-      currentBranchName,
-      `origin/${currentBranchName}`,
-    );
-    return repositoryTmpPath;
+    try {
+      const repository = await Repository.open(repositoryTmpPath);
+      const currentBranchName = (
+        await repository.getCurrentBranch()
+      ).shorthand();
+      await repository.fetch('origin');
+      await repository.mergeBranches(
+        currentBranchName,
+        `origin/${currentBranchName}`,
+      );
+      return repositoryTmpPath;
+    } catch {
+      fs.removeSync(repositoryTmpPath);
+    }
   }
 
   if (user && token) {

--- a/plugins/techdocs-backend/src/service/helpers.ts
+++ b/plugins/techdocs-backend/src/service/helpers.ts
@@ -110,7 +110,7 @@ export class DocsBuilder {
 
     // Should probably be broken out and handled per type later. Doing this for now since we only support github age checks
     if (type === 'github') {
-      const lastCommit = await getLastCommitTimestamp(target);
+      const lastCommit = await getLastCommitTimestamp(target, this.logger);
       const storageTimeStamp = buildMetadataStorage.getTimestamp();
 
       // Check if documentation source is newer than what we have

--- a/plugins/techdocs-backend/src/techdocs/stages/prepare/dir.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/prepare/dir.ts
@@ -43,7 +43,10 @@ export class DirectoryPreparer implements PreparerBase {
     switch (type) {
       case 'github': {
         const parsedGitLocation = parseGitUrl(target);
-        const repoLocation = await checkoutGithubRepository(target);
+        const repoLocation = await checkoutGithubRepository(
+          target,
+          this.logger,
+        );
 
         return path.dirname(
           path.join(repoLocation, parsedGitLocation.filepath),

--- a/plugins/techdocs-backend/src/techdocs/stages/prepare/github.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/prepare/github.ts
@@ -43,7 +43,7 @@ export class GithubPreparer implements PreparerBase {
     }
 
     try {
-      const repoPath = await checkoutGithubRepository(target);
+      const repoPath = await checkoutGithubRepository(target, this.logger);
 
       const parsedGitLocation = parseGitUrl(target);
       return path.join(repoPath, parsedGitLocation.filepath);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue where the checked out repo in tmp used for building docs is sometimes corrupt.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
