### PR TITLE
Send template description to GitHub

### DIFF
--- a/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml
@@ -17,6 +17,7 @@ spec:
   schema:
     required: 
       - component_id
+      - description
     properties:
       component_id:
         title: Name

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
@@ -147,6 +147,7 @@ describe('GitHub Publisher', () => {
           storePath: 'blam/test',
           owner: 'bob',
           access: 'bob',
+          description: 'description',
         },
         directory: '/tmp/test',
       });
@@ -154,6 +155,7 @@ describe('GitHub Publisher', () => {
       expect(
         mockGithubClient.repos.createForAuthenticatedUser,
       ).toHaveBeenCalledWith({
+        description: 'description',
         name: 'test',
         private: false,
       });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -61,6 +61,7 @@ export class GithubPublisher implements PublisherBase {
     values: RequiredTemplateValues & Record<string, JsonValue>,
   ) {
     const [owner, name] = values.storePath.split('/');
+    const description = values.description as string;
 
     const user = await this.client.users.getByUsername({ username: owner });
 
@@ -71,10 +72,12 @@ export class GithubPublisher implements PublisherBase {
             org: owner,
             private: this.repoVisibility !== 'public',
             visibility: this.repoVisibility,
+            description,
           })
         : this.client.repos.createForAuthenticatedUser({
             name,
             private: this.repoVisibility === 'private',
+            description,
           });
 
     const { data } = await repoCreationPromise;


### PR DESCRIPTION
This should help people on GitHub understand what the repo is for.

If the user doesn't enter a description then there is no effect on GitHub. The description there is just empty. I believe only the CRA template will run successfully with no description set so that's really the only case where that can happen.