### PR TITLE
Fix scaffolder catalog link

### DIFF
--- a/plugins/scaffolder/src/components/JobStatusModal/JobStatusModal.tsx
+++ b/plugins/scaffolder/src/components/JobStatusModal/JobStatusModal.tsx
@@ -72,7 +72,7 @@ export const JobStatusModal = ({
       {entity && (
         <DialogActions>
           <Button
-            to={generatePath(entityRoute.path, {
+            to={generatePath(`/catalog/${entityRoute.path}`, {
               kind: entity.kind,
               optionalNamespaceAndName: [
                 entity.metadata.namespace,


### PR DESCRIPTION
This was incorrectly linking to a relative path which ended up being something like `/create/docs-template/Component/my-component`.
