### PR TITLE
Feature: Filter component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,7 @@
     "@types/react-sparklines": "^1.7.0",
     "classnames": "^2.2.6",
     "clsx": "^1.1.0",
+    "immer": "^7.0.9",
     "lodash": "^4.17.15",
     "material-table": "1.68.0",
     "prop-types": "^15.7.2",

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
@@ -66,7 +66,7 @@ export default {
 
 export const Default = () => (
   <CheckboxTree
-    onChange={el => {}}
+    onChange={() => {}}
     label="default"
     subCategories={CHECKBOX_TREE_ITEMS}
   />

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
@@ -65,5 +65,9 @@ export default {
 };
 
 export const Default = () => (
-  <CheckboxTree label="default" subCategories={CHECKBOX_TREE_ITEMS} />
+  <CheckboxTree
+    onChange={el => {}}
+    label="default"
+    subCategories={CHECKBOX_TREE_ITEMS}
+  />
 );

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
@@ -65,5 +65,5 @@ export default {
 };
 
 export const Default = () => (
-  <CheckboxTree subCategories={CHECKBOX_TREE_ITEMS} />
+  <CheckboxTree label="default" subCategories={CHECKBOX_TREE_ITEMS} />
 );

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { CheckboxTree } from '.';
+
+const CHECKBOX_TREE_ITEMS = [
+  {
+    label: 'Genereic subcategory name 1',
+    options: [
+      {
+        label: 'Option 1',
+        value: 1,
+      },
+      {
+        label: 'Option 2',
+        value: 2,
+      },
+    ],
+  },
+  {
+    label: 'Genereic subcategory name 2',
+    options: [
+      {
+        label: 'Option 1',
+        value: 1,
+      },
+      {
+        label: 'Option 2',
+        value: 2,
+      },
+    ],
+  },
+  {
+    label: 'Genereic subcategory name 3',
+    options: [
+      {
+        label: 'Option 1',
+        value: 1,
+      },
+      {
+        label: 'Option 2',
+        value: 2,
+      },
+    ],
+  },
+];
+
+export default {
+  title: 'CheckboxTree',
+  component: CheckboxTree,
+};
+
+export const Default = () => (
+  <CheckboxTree subCategories={CHECKBOX_TREE_ITEMS} />
+);

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.test.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import { CheckboxTree } from '.';
+
+const CHECKBOX_TREE_ITEMS = [
+  {
+    label: 'Genereic subcategory name 1',
+    options: [
+      {
+        label: 'Option 1',
+        value: 1,
+      },
+      {
+        label: 'Option 2',
+        value: 2,
+      },
+    ],
+  },
+];
+
+const minProps = {
+  onChange: jest.fn(),
+  label: 'Default',
+  subCategories: CHECKBOX_TREE_ITEMS,
+};
+
+describe('<CheckboxTree />', () => {
+  it('renders without exploding', async () => {
+    const { getByText, getByTestId } = render(<CheckboxTree {...minProps} />);
+
+    expect(getByText('Genereic subcategory name 1')).toBeInTheDocument();
+    const checkbox = await getByTestId('expandable');
+
+    // Simulate click on expandable arrow
+    fireEvent.click(checkbox);
+
+    // Simulate click on option
+    const option = getByText('Option 1');
+    expect(getByText('Option 1')).toBeInTheDocument();
+    fireEvent.click(option);
+    expect(minProps.onChange).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
@@ -191,15 +191,16 @@ export const CheckboxTree = (props: CheckboxTreeProps) => {
     dispatch({ type: 'openCategory', payload: value });
   };
 
-  const handleChange = () => {
+  useEffect(() => {
     const values = Object.values(state).map(category => ({
-      category: category.label,
-      selected: Object.values(category.options)
+      category: category.isChecked ? category.label : null,
+      selectedChilds: Object.values(category.options)
         .filter(option => option.isChecked)
         .map(option => option.value),
     }));
     onChange(values);
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
 
   return (
     <div>
@@ -213,13 +214,12 @@ export const CheckboxTree = (props: CheckboxTreeProps) => {
               <ListItem
                 dense
                 button
-                onClick={async () => {
-                  await dispatch({
+                onClick={() =>
+                  dispatch({
                     type: 'checkCategory',
                     payload: item.label,
-                  });
-                  handleChange();
-                }}
+                  })
+                }
               >
                 <ListItemIcon className={classes.listItemIcon}>
                   <Checkbox
@@ -253,16 +253,15 @@ export const CheckboxTree = (props: CheckboxTreeProps) => {
                       button
                       key={option.label}
                       className={classes.nested}
-                      onClick={async () => {
-                        await dispatch({
+                      onClick={() =>
+                        dispatch({
                           type: 'checkOption',
                           payload: {
                             subCategoryLabel: item.label,
                             optionLabel: option.label,
                           },
-                        });
-                        handleChange();
-                      }}
+                        })
+                      }
                     >
                       <ListItemIcon className={classes.listItemIcon}>
                         <Checkbox

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
@@ -41,14 +41,32 @@ const useStyles = makeStyles((theme: Theme) =>
       '&:hover': {
         backgroundColor: 'transparent',
       },
+      '&:active' : {
+        animation: 'none',
+        transform: 'none'
+      },
     },
     nested: {
       paddingLeft: theme.spacing(5),
       height: '32px',
+      '&:hover' : {
+        backgroundColor: 'transparent',
+      },
     },
     listItemIcon: {
       minWidth: 10,
     },
+    listItem: {
+      '&:hover' : {
+        backgroundColor: 'transparent',
+      },
+    },
+    text: {
+      '& span, & svg': {
+        fontWeight: 'normal',
+        fontSize: 14
+      }
+    }
   }),
 );
 
@@ -180,6 +198,7 @@ const indexer = (
     };
   }, {});
 
+
 export const CheckboxTree = (props: CheckboxTreeProps) => {
   const { onChange } = props;
   const classes = useStyles();
@@ -206,15 +225,13 @@ export const CheckboxTree = (props: CheckboxTreeProps) => {
     <div>
       <Typography variant="button">{props.label}</Typography>
       <List className={classes.root}>
-        {Object.values(state).map(item => {
-          const labelId = `checkbox-list-label-${item?.label}`;
-
-          return (
+        {Object.values(state).map(item => 
             <div key={item.label}>
               <ListItem
+                className={classes.listItem}
                 dense
                 button
-                onClick={() =>
+                onClick={() => 
                   dispatch({
                     type: 'checkCategory',
                     payload: item.label,
@@ -228,10 +245,9 @@ export const CheckboxTree = (props: CheckboxTreeProps) => {
                     checked={item.isChecked}
                     tabIndex={-1}
                     disableRipple
-                    inputProps={{ 'aria-labelledby': labelId }}
                   />
                 </ListItemIcon>
-                <ListItemText id={labelId} primary={item.label} />
+                <ListItemText className={classes.text} primary={item.label} />
                 {Object.values(item.options).length ? (
                   <>
                     {item.isOpen ? (
@@ -270,17 +286,15 @@ export const CheckboxTree = (props: CheckboxTreeProps) => {
                           checked={option.isChecked}
                           tabIndex={-1}
                           disableRipple
-                          inputProps={{ 'aria-labelledby': labelId }}
                         />
                       </ListItemIcon>
-                      <ListItemText primary={option.label} />
+                      <ListItemText className={classes.text} primary={option.label} />
                     </ListItem>
                   ))}
                 </List>
               </Collapse>
             </div>
-          );
-        })}
+        )}
       </List>
     </div>
   );

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
@@ -41,15 +41,15 @@ const useStyles = makeStyles((theme: Theme) =>
       '&:hover': {
         backgroundColor: 'transparent',
       },
-      '&:active' : {
+      '&:active': {
         animation: 'none',
-        transform: 'none'
+        transform: 'none',
       },
     },
     nested: {
       paddingLeft: theme.spacing(5),
       height: '32px',
-      '&:hover' : {
+      '&:hover': {
         backgroundColor: 'transparent',
       },
     },
@@ -57,16 +57,16 @@ const useStyles = makeStyles((theme: Theme) =>
       minWidth: 10,
     },
     listItem: {
-      '&:hover' : {
+      '&:hover': {
         backgroundColor: 'transparent',
       },
     },
     text: {
       '& span, & svg': {
         fontWeight: 'normal',
-        fontSize: 14
-      }
-    }
+        fontSize: 14,
+      },
+    },
   }),
 );
 
@@ -198,7 +198,6 @@ const indexer = (
     };
   }, {});
 
-
 export const CheckboxTree = (props: CheckboxTreeProps) => {
   const { onChange } = props;
   const classes = useStyles();
@@ -225,76 +224,79 @@ export const CheckboxTree = (props: CheckboxTreeProps) => {
     <div>
       <Typography variant="button">{props.label}</Typography>
       <List className={classes.root}>
-        {Object.values(state).map(item => 
-            <div key={item.label}>
-              <ListItem
-                className={classes.listItem}
-                dense
-                button
-                onClick={() => 
-                  dispatch({
-                    type: 'checkCategory',
-                    payload: item.label,
-                  })
-                }
-              >
-                <ListItemIcon className={classes.listItemIcon}>
-                  <Checkbox
-                    color="primary"
-                    edge="start"
-                    checked={item.isChecked}
-                    tabIndex={-1}
-                    disableRipple
-                  />
-                </ListItemIcon>
-                <ListItemText className={classes.text} primary={item.label} />
-                {Object.values(item.options).length ? (
-                  <>
-                    {item.isOpen ? (
-                      <ExpandLess
-                        onClick={event => handleOpen(event, item.label)}
+        {Object.values(state).map(item => (
+          <div key={item.label}>
+            <ListItem
+              className={classes.listItem}
+              dense
+              button
+              onClick={() =>
+                dispatch({
+                  type: 'checkCategory',
+                  payload: item.label,
+                })
+              }
+            >
+              <ListItemIcon className={classes.listItemIcon}>
+                <Checkbox
+                  color="primary"
+                  edge="start"
+                  checked={item.isChecked}
+                  tabIndex={-1}
+                  disableRipple
+                />
+              </ListItemIcon>
+              <ListItemText className={classes.text} primary={item.label} />
+              {Object.values(item.options).length ? (
+                <>
+                  {item.isOpen ? (
+                    <ExpandLess
+                      onClick={event => handleOpen(event, item.label)}
+                    />
+                  ) : (
+                    <ExpandMore
+                      onClick={event => handleOpen(event, item.label)}
+                    />
+                  )}
+                </>
+              ) : null}
+            </ListItem>
+            <Collapse in={item.isOpen} timeout="auto" unmountOnExit>
+              <List component="div" disablePadding>
+                {Object.values(item.options).map(option => (
+                  <ListItem
+                    button
+                    key={option.label}
+                    className={classes.nested}
+                    onClick={() =>
+                      dispatch({
+                        type: 'checkOption',
+                        payload: {
+                          subCategoryLabel: item.label,
+                          optionLabel: option.label,
+                        },
+                      })
+                    }
+                  >
+                    <ListItemIcon className={classes.listItemIcon}>
+                      <Checkbox
+                        color="primary"
+                        edge="start"
+                        checked={option.isChecked}
+                        tabIndex={-1}
+                        disableRipple
                       />
-                    ) : (
-                      <ExpandMore
-                        onClick={event => handleOpen(event, item.label)}
-                      />
-                    )}
-                  </>
-                ) : null}
-              </ListItem>
-              <Collapse in={item.isOpen} timeout="auto" unmountOnExit>
-                <List component="div" disablePadding>
-                  {Object.values(item.options).map(option => (
-                    <ListItem
-                      button
-                      key={option.label}
-                      className={classes.nested}
-                      onClick={() =>
-                        dispatch({
-                          type: 'checkOption',
-                          payload: {
-                            subCategoryLabel: item.label,
-                            optionLabel: option.label,
-                          },
-                        })
-                      }
-                    >
-                      <ListItemIcon className={classes.listItemIcon}>
-                        <Checkbox
-                          color="primary"
-                          edge="start"
-                          checked={option.isChecked}
-                          tabIndex={-1}
-                          disableRipple
-                        />
-                      </ListItemIcon>
-                      <ListItemText className={classes.text} primary={option.label} />
-                    </ListItem>
-                  ))}
-                </List>
-              </Collapse>
-            </div>
-        )}
+                    </ListItemIcon>
+                    <ListItemText
+                      className={classes.text}
+                      primary={option.label}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            </Collapse>
+          </div>
+        ))}
       </List>
     </div>
   );

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useReducer } from 'react';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import {
+  List,
+  ListItem,
+  ListItemIcon,
+  Checkbox,
+  ListItemText,
+  Collapse,
+} from '@material-ui/core';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+
+type IndexedObject<T> = {
+  [key: string]: T;
+};
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      maxWidth: 360,
+      backgroundColor: theme.palette.background.paper,
+    },
+    nested: {
+      paddingLeft: theme.spacing(4),
+    },
+  }),
+);
+
+/* SUB_CATEGORY */
+
+type SubCategory = {
+  label: string;
+  isChecked?: boolean;
+  isOpen?: boolean;
+  options?: Option[];
+};
+
+type SubCategoryWithIndexedOptions = {
+  label: string;
+  isChecked?: boolean;
+  isOpen?: boolean;
+  options: IndexedObject<Option>;
+};
+
+/* OPTION */
+
+type Option = {
+  label: string;
+  value: string | number;
+  isChecked?: boolean;
+};
+
+type Props = {
+  subCategories: SubCategory[];
+};
+
+/* REDUCER */
+
+type checkOptionPayload = {
+  subCategoryLabel: string;
+  optionLabel: string;
+};
+
+type Action =
+  | { type: 'checkOption'; payload: checkOptionPayload }
+  | { type: 'checkCategory'; payload: string }
+  | { type: 'openCategory'; payload: string };
+
+const checkAllOptions = (
+  arr: Option[],
+  isChecked: boolean,
+): IndexedObject<Option> =>
+  arr.reduce((accumulator, el) => {
+    return {
+      ...accumulator,
+      [el.label]: { ...el, isChecked },
+    };
+  }, {});
+
+const reducer = (
+  state: IndexedObject<SubCategoryWithIndexedOptions>,
+  action: Action,
+) => {
+  switch (action.type) {
+    case 'checkOption': {
+      const newOptions = {
+        ...state[action.payload.subCategoryLabel].options,
+        [action.payload.optionLabel]: {
+          ...state[action.payload.subCategoryLabel].options[
+            action.payload.optionLabel
+          ],
+          isChecked: !state[action.payload.subCategoryLabel].options[
+            action.payload.optionLabel
+          ].isChecked,
+        },
+      };
+
+      return {
+        ...state,
+        [action.payload.subCategoryLabel]: {
+          ...state[action.payload.subCategoryLabel],
+          isChecked: Object.values(newOptions).every(
+            option => option.isChecked,
+          ),
+          options: newOptions,
+        },
+      };
+    }
+    case 'checkCategory':
+      return {
+        ...state,
+        [action.payload]: {
+          ...state[action.payload],
+          isChecked: !state[action.payload].isChecked,
+          options: checkAllOptions(
+            Object.values(state[action.payload].options),
+            !state[action.payload].isChecked,
+          ),
+        },
+      };
+    case 'openCategory':
+      return {
+        ...state,
+        [action.payload]: {
+          ...state[action.payload],
+          isOpen: !state[action.payload].isOpen,
+        },
+      };
+    default:
+      return state;
+  }
+};
+
+const indexer = (
+  arr: SubCategory[],
+): IndexedObject<SubCategoryWithIndexedOptions> =>
+  arr.reduce((accumulator, el) => {
+    if (el.options) {
+      return {
+        ...accumulator,
+        [el.label]: {
+          label: el.label,
+          isChecked: el.isChecked || false,
+          isOpen: true,
+          options: indexer(el.options),
+        },
+      };
+    }
+    return {
+      ...accumulator,
+      [el.label]: { ...el, isChecked: el.isChecked || false },
+    };
+  }, {});
+
+export const CheckboxTree = (props: Props) => {
+  const classes = useStyles();
+
+  const [state, dispatch] = useReducer(reducer, indexer(props.subCategories));
+
+  const handleOpen = (event: any, value: any) => {
+    event.stopPropagation();
+    dispatch({ type: 'openCategory', payload: value });
+  };
+  return (
+    <List className={classes.root}>
+      {Object.values(state).map(item => {
+        const labelId = `checkbox-list-label-${item?.label}`;
+
+        return (
+          <div key={item.label}>
+            <ListItem
+              dense
+              button
+              onClick={() =>
+                dispatch({
+                  type: 'checkCategory',
+                  payload: item.label,
+                })
+              }
+            >
+              <ListItemIcon>
+                <Checkbox
+                  color="primary"
+                  edge="start"
+                  checked={item.isChecked}
+                  tabIndex={-1}
+                  disableRipple
+                  inputProps={{ 'aria-labelledby': labelId }}
+                />
+              </ListItemIcon>
+              <ListItemText id={labelId} primary={item.label} />
+              {item.options?.length ? (
+                <ExpandLess onClick={event => handleOpen(event, item.label)} />
+              ) : (
+                <ExpandMore onClick={event => handleOpen(event, item.label)} />
+              )}
+            </ListItem>
+            <Collapse in={item.isOpen} timeout="auto" unmountOnExit>
+              <List component="div" disablePadding>
+                {Object.values(item.options).map(option => (
+                  <ListItem
+                    button
+                    key={option.label}
+                    className={classes.nested}
+                    onClick={() =>
+                      dispatch({
+                        type: 'checkOption',
+                        payload: {
+                          subCategoryLabel: item.label,
+                          optionLabel: option.label,
+                        },
+                      })
+                    }
+                  >
+                    <ListItemIcon>
+                      <Checkbox
+                        color="primary"
+                        edge="start"
+                        checked={option.isChecked}
+                        tabIndex={-1}
+                        disableRipple
+                        inputProps={{ 'aria-labelledby': labelId }}
+                      />
+                    </ListItemIcon>
+                    <ListItemText primary={option.label} />
+                  </ListItem>
+                ))}
+              </List>
+            </Collapse>
+          </div>
+        );
+      })}
+    </List>
+  );
+};

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
@@ -22,6 +22,7 @@ import {
   Checkbox,
   ListItemText,
   Collapse,
+  Typography
 } from '@material-ui/core';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
@@ -34,12 +35,20 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       width: '100%',
+      minWidth: 10,
       maxWidth: 360,
-      backgroundColor: theme.palette.background.paper,
+      backgroundColor: 'transparent',
+      "&:hover": {
+        backgroundColor: "transparent"
+    }
     },
     nested: {
-      paddingLeft: theme.spacing(4),
+      paddingLeft: theme.spacing(5),
+      height: '32px'
     },
+    listItemIcon: {
+      minWidth: 10
+    }
   }),
 );
 
@@ -69,6 +78,7 @@ type Option = {
 
 type Props = {
   subCategories: SubCategory[];
+  label: string;
 };
 
 /* REDUCER */
@@ -179,6 +189,8 @@ export const CheckboxTree = (props: Props) => {
     dispatch({ type: 'openCategory', payload: value });
   };
   return (
+    <div>
+    <Typography variant="button">{props.label}</Typography>
     <List className={classes.root}>
       {Object.values(state).map(item => {
         const labelId = `checkbox-list-label-${item?.label}`;
@@ -195,7 +207,7 @@ export const CheckboxTree = (props: Props) => {
                 })
               }
             >
-              <ListItemIcon>
+              <ListItemIcon className={classes.listItemIcon}>
                 <Checkbox
                   color="primary"
                   edge="start"
@@ -229,7 +241,7 @@ export const CheckboxTree = (props: Props) => {
                       })
                     }
                   >
-                    <ListItemIcon>
+                    <ListItemIcon className={classes.listItemIcon}>
                       <Checkbox
                         color="primary"
                         edge="start"
@@ -248,5 +260,6 @@ export const CheckboxTree = (props: Props) => {
         );
       })}
     </List>
+    </div>
   );
 };

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.tsx
@@ -240,10 +240,12 @@ export const CheckboxTree = (props: CheckboxTreeProps) => {
                 <>
                   {item.isOpen ? (
                     <ExpandLess
+                      data-testid="expandable"
                       onClick={event => handleOpen(event, item.label)}
                     />
                   ) : (
                     <ExpandMore
+                      data-testid="expandable"
                       onClick={event => handleOpen(event, item.label)}
                     />
                   )}

--- a/packages/core/src/components/CheckboxTree/index.tsx
+++ b/packages/core/src/components/CheckboxTree/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { CheckboxTree } from './CheckboxTree';

--- a/packages/core/src/components/Select/Select.stories.tsx
+++ b/packages/core/src/components/Select/Select.stories.tsx
@@ -37,4 +37,15 @@ const SELECT_ITEMS = [
   },
 ];
 
-export const Default = () => <Select label="Default" items={SELECT_ITEMS} />;
+export const Default = () => (
+  <Select placeholder="All results" label="Default" items={SELECT_ITEMS} />
+);
+
+export const Multiple = () => (
+  <Select
+    placeholder="All results"
+    label="Multiple"
+    items={SELECT_ITEMS}
+    multiple
+  />
+);

--- a/packages/core/src/components/Select/Select.stories.tsx
+++ b/packages/core/src/components/Select/Select.stories.tsx
@@ -38,7 +38,12 @@ const SELECT_ITEMS = [
 ];
 
 export const Default = () => (
-  <Select placeholder="All results" label="Default" items={SELECT_ITEMS} />
+  <Select
+    onChange={el => {}}
+    placeholder="All results"
+    label="Default"
+    items={SELECT_ITEMS}
+  />
 );
 
 export const Multiple = () => (
@@ -47,5 +52,6 @@ export const Multiple = () => (
     label="Multiple"
     items={SELECT_ITEMS}
     multiple
+    onChange={el => {}}
   />
 );

--- a/packages/core/src/components/Select/Select.stories.tsx
+++ b/packages/core/src/components/Select/Select.stories.tsx
@@ -39,7 +39,7 @@ const SELECT_ITEMS = [
 
 export const Default = () => (
   <Select
-    onChange={el => {}}
+    onChange={() => {}}
     placeholder="All results"
     label="Default"
     items={SELECT_ITEMS}
@@ -52,6 +52,6 @@ export const Multiple = () => (
     label="Multiple"
     items={SELECT_ITEMS}
     multiple
-    onChange={el => {}}
+    onChange={() => {}}
   />
 );

--- a/packages/core/src/components/Select/Select.stories.tsx
+++ b/packages/core/src/components/Select/Select.stories.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Select } from '.';
+
+export default {
+  title: 'Select',
+  component: Select,
+};
+
+const SELECT_ITEMS = [
+  {
+    label: "test 1",
+    value: "test_1"
+  },
+  {
+    label: "test 2",
+    value: "test_2"
+  },
+  {
+    label: "test 3",
+    value: "test_3"
+  }
+]
+
+export const Default = () => (
+  <Select label="Default" items={SELECT_ITEMS} />
+);

--- a/packages/core/src/components/Select/Select.stories.tsx
+++ b/packages/core/src/components/Select/Select.stories.tsx
@@ -24,19 +24,17 @@ export default {
 
 const SELECT_ITEMS = [
   {
-    label: "test 1",
-    value: "test_1"
+    label: 'test 1',
+    value: 'test_1',
   },
   {
-    label: "test 2",
-    value: "test_2"
+    label: 'test 2',
+    value: 'test_2',
   },
   {
-    label: "test 3",
-    value: "test_3"
-  }
-]
+    label: 'test 3',
+    value: 'test_3',
+  },
+];
 
-export const Default = () => (
-  <Select label="Default" items={SELECT_ITEMS} />
-);
+export const Default = () => <Select label="Default" items={SELECT_ITEMS} />;

--- a/packages/core/src/components/Select/Select.test.tsx
+++ b/packages/core/src/components/Select/Select.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+import { Select } from '.';
+
+const SELECT_ITEMS = [
+  {
+    label: 'test 1',
+    value: 'test_1',
+  },
+  {
+    label: 'test 2',
+    value: 'test_2',
+  },
+];
+
+const minProps = {
+  onChange: jest.fn(),
+  label: 'Default',
+  placeholder: 'All results',
+  items: SELECT_ITEMS,
+};
+
+describe('<Select />', () => {
+  it('renders without exploding', async () => {
+    const { getByText, getByTestId } = render(<Select {...minProps} />);
+
+    expect(getByText('Default')).toBeInTheDocument();
+    const input = await getByTestId('select');
+    expect(input.textContent).toBe('All results');
+
+    // Simulate click on input
+    fireEvent.click(input);
+
+    expect(getByText('test 1')).toBeInTheDocument();
+    const option = getByText('test 1');
+
+    // Simulate click on option
+    fireEvent.click(option);
+    expect(input.textContent).toBe('test 1');
+  });
+});

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -24,17 +24,18 @@ import {
 
 import {
   FormControl,
-  InputLabel,
   Select,
   MenuItem,
   InputBase,
   Chip,
   Typography,
   Checkbox,
+  ClickAwayListener
 } from '@material-ui/core';
 
 import ClosedDropdown from './static/ClosedDropdown';
 import OpenedDropdown from './static/OpenedDropdown';
+import { idea } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 
 const BootstrapInput = withStyles((theme: Theme) =>
   createStyles({
@@ -118,8 +119,19 @@ export const SelectComponent = (props: SelectProps) => {
   };
 
   const selectHandleOnOpen = () => {
-    setCanOpen(!canOpen);
+    setCanOpen(previous => {
+      if (multiple) {
+        return true
+      }
+      return !previous
+    });
   };
+
+  const handleClickAway = (event: React.ChangeEvent<any>) => {
+    if (event.target.id !== "menu-item") {
+      setCanOpen(false);
+    }
+  }
 
   const handleDelete = (selectedValue: string | number) => () => {
     const newValue = (value as any[]).filter(chip => chip !== selectedValue)
@@ -130,9 +142,9 @@ export const SelectComponent = (props: SelectProps) => {
   return (
     <div className={classes.root}>
       <Typography variant="button">{label}</Typography>
+      <ClickAwayListener onClickAway={handleClickAway}>
       <FormControl className={classes.formControl}>
         <Select
-          id="select"
           value={value}
           displayEmpty
           multiple={multiple}
@@ -177,13 +189,13 @@ export const SelectComponent = (props: SelectProps) => {
           }}
         >
           {placeholder && (
-            <MenuItem value="" disabled>
+            <MenuItem value={[]}>
               {placeholder}
             </MenuItem>
           )}
           {items &&
             items.map(item => (
-              <MenuItem key={item.value} value={item.value}>
+              <MenuItem id="menu-item" key={item.value} value={item.value}>
                 {multiple && (
                   <Checkbox
                     color="primary"
@@ -196,6 +208,7 @@ export const SelectComponent = (props: SelectProps) => {
             ))}
         </Select>
       </FormControl>
+      </ClickAwayListener>
     </div>
   );
 };

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -114,8 +114,8 @@ export const SelectComponent = (props: SelectProps) => {
   const [canOpen, setCanOpen] = React.useState(false);
 
   useEffect(() => {
-    setValue(multiple ? [] : "")
-  }, [props.triggerReset, multiple])
+    setValue(multiple ? [] : '');
+  }, [props.triggerReset, multiple]);
 
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setValue(event.target.value as any);

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -28,6 +28,9 @@ import {
   Select,
   MenuItem,
   InputBase,
+  Chip,
+  Typography,
+  Checkbox,
 } from '@material-ui/core';
 
 import ClosedDropdown from './static/ClosedDropdown';
@@ -73,6 +76,14 @@ const useStyles = makeStyles((theme: Theme) =>
         color: theme.palette.text.primary,
       },
     },
+    chips: {
+      display: 'flex',
+      flexWrap: 'wrap',
+    },
+    chip: {
+      margin: 2,
+    },
+    checkbox: {},
   }),
 );
 
@@ -85,16 +96,27 @@ type Props = {
   multiple?: boolean;
   items: Item[];
   label: string;
+  placeholder?: string;
 };
 
 export const SelectComponent = (props: Props) => {
-  const { multiple, items, label } = props;
+  const { multiple, items, label, placeholder } = props;
   const classes = useStyles();
-  const [value, setValue] = useState('');
-  const [isOpen, setOpening] = useState(true);
+  const [value, setValue] = useState<any[] | string | number>(
+    multiple ? [] : '',
+  );
+  const [canOpen, setCanOpen] = React.useState(false);
 
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setValue(event.target.value as string);
+  };
+
+  const selectHandleOnOpen = () => {
+    setCanOpen(!canOpen);
+  };
+
+  const handleDelete = (selectedValue: string | number) => () => {
+    setValue(chips => (chips as any[]).filter(chip => chip !== selectedValue));
   };
 
   return (
@@ -105,12 +127,36 @@ export const SelectComponent = (props: Props) => {
       <Select
         id="select"
         value={value}
+        displayEmpty
         multiple={multiple}
         onChange={handleChange}
-        onOpen={() => setOpening(false)}
-        onClose={() => setOpening(true)}
+        onClick={selectHandleOnOpen}
+        open={canOpen}
         input={<BootstrapInput />}
-        IconComponent={() => (isOpen ? <ClosedDropdown /> : <OpenedDropdown />)}
+        renderValue={selected =>
+          multiple && (value as any[]).length !== 0 ? (
+            <div className={classes.chips}>
+              {(selected as string[]).map(selectedValue => (
+                <Chip
+                  key={items.find(el => el.value === selectedValue)?.label}
+                  label={items.find(el => el.value === selectedValue)?.label}
+                  clickable
+                  onDelete={handleDelete(selectedValue)}
+                  className={classes.chip}
+                />
+              ))}
+            </div>
+          ) : (
+            <Typography>
+              {(value as any[]).length === 0
+                ? placeholder || ''
+                : items.find(el => el.value === selected)?.label}
+            </Typography>
+          )
+        }
+        IconComponent={() =>
+          !canOpen ? <ClosedDropdown /> : <OpenedDropdown />
+        }
         MenuProps={{
           anchorOrigin: {
             vertical: 'bottom',
@@ -123,9 +169,21 @@ export const SelectComponent = (props: Props) => {
           getContentAnchorEl: null,
         }}
       >
+        {placeholder && (
+          <MenuItem value="" disabled>
+            {placeholder}
+          </MenuItem>
+        )}
         {items &&
           items.map(item => (
             <MenuItem key={item.value} value={item.value}>
+              {multiple && (
+                <Checkbox
+                  color="primary"
+                  checked={(value as any[]).includes(item.value) || false}
+                  className={classes.checkbox}
+                />
+              )}
               {item.label}
             </MenuItem>
           ))}

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -63,8 +63,8 @@ const BootstrapInput = withStyles((theme: Theme) =>
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     formControl: {
-      margin: theme.spacing(1),
-      minWidth: 315,
+      margin: `${theme.spacing(1)} 0px`,
+      maxWidth: 300,
     },
     label: {
       transform: 'initial',
@@ -84,6 +84,10 @@ const useStyles = makeStyles((theme: Theme) =>
       margin: 2,
     },
     checkbox: {},
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+    },
   }),
 );
 
@@ -92,15 +96,16 @@ type Item = {
   value: string | number;
 };
 
-type Props = {
+export type SelectProps = {
   multiple?: boolean;
   items: Item[];
   label: string;
   placeholder?: string;
+  onChange: (arg: any) => any;
 };
 
-export const SelectComponent = (props: Props) => {
-  const { multiple, items, label, placeholder } = props;
+export const SelectComponent = (props: SelectProps) => {
+  const { multiple, items, label, placeholder, onChange } = props;
   const classes = useStyles();
   const [value, setValue] = useState<any[] | string | number>(
     multiple ? [] : '',
@@ -108,7 +113,8 @@ export const SelectComponent = (props: Props) => {
   const [canOpen, setCanOpen] = React.useState(false);
 
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    setValue(event.target.value as string);
+    setValue(event.target.value as any);
+    onChange(event.target.value);
   };
 
   const selectHandleOnOpen = () => {
@@ -120,74 +126,74 @@ export const SelectComponent = (props: Props) => {
   };
 
   return (
-    <FormControl className={classes.formControl}>
-      <InputLabel className={classes.label} disableAnimation id="select-label">
-        {label}
-      </InputLabel>
-      <Select
-        id="select"
-        value={value}
-        displayEmpty
-        multiple={multiple}
-        onChange={handleChange}
-        onClick={selectHandleOnOpen}
-        open={canOpen}
-        input={<BootstrapInput />}
-        renderValue={selected =>
-          multiple && (value as any[]).length !== 0 ? (
-            <div className={classes.chips}>
-              {(selected as string[]).map(selectedValue => (
-                <Chip
-                  key={items.find(el => el.value === selectedValue)?.label}
-                  label={items.find(el => el.value === selectedValue)?.label}
-                  clickable
-                  onDelete={handleDelete(selectedValue)}
-                  className={classes.chip}
-                />
-              ))}
-            </div>
-          ) : (
-            <Typography>
-              {(value as any[]).length === 0
-                ? placeholder || ''
-                : items.find(el => el.value === selected)?.label}
-            </Typography>
-          )
-        }
-        IconComponent={() =>
-          !canOpen ? <ClosedDropdown /> : <OpenedDropdown />
-        }
-        MenuProps={{
-          anchorOrigin: {
-            vertical: 'bottom',
-            horizontal: 'left',
-          },
-          transformOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          getContentAnchorEl: null,
-        }}
-      >
-        {placeholder && (
-          <MenuItem value="" disabled>
-            {placeholder}
-          </MenuItem>
-        )}
-        {items &&
-          items.map(item => (
-            <MenuItem key={item.value} value={item.value}>
-              {multiple && (
-                <Checkbox
-                  color="primary"
-                  checked={(value as any[]).includes(item.value) || false}
-                  className={classes.checkbox}
-                />
-              )}
-              {item.label}
+    <div className={classes.root}>
+      <Typography variant="button">{label}</Typography>
+      <FormControl className={classes.formControl}>
+        <Select
+          id="select"
+          value={value}
+          displayEmpty
+          multiple={multiple}
+          onChange={handleChange}
+          onClick={selectHandleOnOpen}
+          open={canOpen}
+          input={<BootstrapInput />}
+          renderValue={selected =>
+            multiple && (value as any[]).length !== 0 ? (
+              <div className={classes.chips}>
+                {(selected as string[]).map(selectedValue => (
+                  <Chip
+                    key={items.find(el => el.value === selectedValue)?.value}
+                    label={items.find(el => el.value === selectedValue)?.label}
+                    clickable
+                    onDelete={handleDelete(selectedValue)}
+                    className={classes.chip}
+                  />
+                ))}
+              </div>
+            ) : (
+              <Typography>
+                {(value as any[]).length === 0
+                  ? placeholder || ''
+                  : items.find(el => el.value === selected)?.label}
+              </Typography>
+            )
+          }
+          IconComponent={() =>
+            !canOpen ? <ClosedDropdown /> : <OpenedDropdown />
+          }
+          MenuProps={{
+            anchorOrigin: {
+              vertical: 'bottom',
+              horizontal: 'left',
+            },
+            transformOrigin: {
+              vertical: 'top',
+              horizontal: 'left',
+            },
+            getContentAnchorEl: null,
+          }}
+        >
+          {placeholder && (
+            <MenuItem value="" disabled>
+              {placeholder}
             </MenuItem>
-          ))}
-      </Select>
-    </FormControl>
+          )}
+          {items &&
+            items.map(item => (
+              <MenuItem key={item.value} value={item.value}>
+                {multiple && (
+                  <Checkbox
+                    color="primary"
+                    checked={(value as any[]).includes(item.value) || false}
+                    className={classes.checkbox}
+                  />
+                )}
+                {item.label}
+              </MenuItem>
+            ))}
+        </Select>
+      </FormControl>
+    </div>
   );
 };

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   createStyles,
   makeStyles,
@@ -102,6 +102,7 @@ export type SelectProps = {
   label: string;
   placeholder?: string;
   onChange: (arg: any) => any;
+  triggerReset?: boolean;
 };
 
 export const SelectComponent = (props: SelectProps) => {
@@ -111,6 +112,10 @@ export const SelectComponent = (props: SelectProps) => {
     multiple ? [] : '',
   );
   const [canOpen, setCanOpen] = React.useState(false);
+
+  useEffect(() => {
+    setValue(multiple ? [] : "")
+  }, [props.triggerReset, multiple])
 
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setValue(event.target.value as any);

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -122,7 +122,9 @@ export const SelectComponent = (props: SelectProps) => {
   };
 
   const handleDelete = (selectedValue: string | number) => () => {
-    setValue(chips => (chips as any[]).filter(chip => chip !== selectedValue));
+    const newValue = (value as any[]).filter(chip => chip !== selectedValue)
+    setValue(newValue);
+    onChange(newValue);
   };
 
   return (

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -35,7 +35,6 @@ import {
 
 import ClosedDropdown from './static/ClosedDropdown';
 import OpenedDropdown from './static/OpenedDropdown';
-import { idea } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 
 const BootstrapInput = withStyles((theme: Theme) =>
   createStyles({

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import {
+  createStyles,
+  makeStyles,
+  withStyles,
+  Theme,
+} from '@material-ui/core/styles';
+
+import {
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  InputBase,
+} from '@material-ui/core';
+
+import ClosedDropdown from './static/ClosedDropdown';
+import OpenedDropdown from './static/OpenedDropdown';
+
+const BootstrapInput = withStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      'label + &': {
+        marginTop: theme.spacing(3),
+      },
+    },
+    input: {
+      borderRadius: 4,
+      position: 'relative',
+      backgroundColor: theme.palette.background.paper,
+      border: '1px solid #ced4da',
+      fontSize: 16,
+      padding: '10px 26px 10px 12px',
+      transition: theme.transitions.create(['border-color', 'box-shadow']),
+      fontFamily: 'Helvetica Neue',
+      '&:focus': {
+        background: theme.palette.background.paper,
+        borderRadius: 4,
+      },
+    },
+  }),
+)(InputBase);
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    formControl: {
+      margin: theme.spacing(1),
+      minWidth: 315,
+    },
+    label: {
+      transform: 'initial',
+      fontWeight: 'bold',
+      fontSize: 14,
+      fontFamily: theme.typography.fontFamily,
+      color: theme.palette.text.primary,
+      '&.Mui-focused': {
+        color: theme.palette.text.primary,
+      },
+    },
+  }),
+);
+
+type Item = {
+  label: string;
+  value: string | number;
+};
+
+type Props = {
+  multiple?: boolean;
+  items: Item[];
+  label: string;
+};
+
+export const SelectComponent = (props: Props) => {
+  const { multiple, items, label } = props;
+  const classes = useStyles();
+  const [value, setValue] = useState('');
+  const [isOpen, setOpening] = useState(true);
+
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setValue(event.target.value as string);
+  };
+
+  return (
+    <FormControl className={classes.formControl}>
+      <InputLabel className={classes.label} disableAnimation id="select-label">
+        {label}
+      </InputLabel>
+      <Select
+        id="select"
+        value={value}
+        multiple={multiple}
+        onChange={handleChange}
+        onOpen={() => setOpening(false)}
+        onClose={() => setOpening(true)}
+        input={<BootstrapInput />}
+        IconComponent={() => (
+            isOpen ? <ClosedDropdown /> : <OpenedDropdown />
+        )}
+        MenuProps={{
+          anchorOrigin: {
+            vertical: 'bottom',
+            horizontal: 'left',
+          },
+          transformOrigin: {
+            vertical: 'top',
+            horizontal: 'left',
+          },
+          getContentAnchorEl: null,
+        }}
+      >
+        {items &&
+          items.map(item => (
+            <MenuItem key={item.value} value={item.value}>
+              {item.label}
+            </MenuItem>
+          ))}
+      </Select>
+    </FormControl>
+  );
+};

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -110,9 +110,7 @@ export const SelectComponent = (props: Props) => {
         onOpen={() => setOpening(false)}
         onClose={() => setOpening(true)}
         input={<BootstrapInput />}
-        IconComponent={() => (
-            isOpen ? <ClosedDropdown /> : <OpenedDropdown />
-        )}
+        IconComponent={() => (isOpen ? <ClosedDropdown /> : <OpenedDropdown />)}
         MenuProps={{
           anchorOrigin: {
             vertical: 'bottom',

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -150,6 +150,7 @@ export const SelectComponent = (props: SelectProps) => {
         <FormControl className={classes.formControl}>
           <Select
             value={value}
+            data-testid="select"
             displayEmpty
             multiple={multiple}
             onChange={handleChange}

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -30,7 +30,7 @@ import {
   Chip,
   Typography,
   Checkbox,
-  ClickAwayListener
+  ClickAwayListener,
 } from '@material-ui/core';
 
 import ClosedDropdown from './static/ClosedDropdown';
@@ -121,20 +121,20 @@ export const SelectComponent = (props: SelectProps) => {
   const selectHandleOnOpen = () => {
     setCanOpen(previous => {
       if (multiple) {
-        return true
+        return true;
       }
-      return !previous
+      return !previous;
     });
   };
 
   const handleClickAway = (event: React.ChangeEvent<any>) => {
-    if (event.target.id !== "menu-item") {
+    if (event.target.id !== 'menu-item') {
       setCanOpen(false);
     }
-  }
+  };
 
   const handleDelete = (selectedValue: string | number) => () => {
-    const newValue = (value as any[]).filter(chip => chip !== selectedValue)
+    const newValue = (value as any[]).filter(chip => chip !== selectedValue);
     setValue(newValue);
     onChange(newValue);
   };
@@ -143,71 +143,69 @@ export const SelectComponent = (props: SelectProps) => {
     <div className={classes.root}>
       <Typography variant="button">{label}</Typography>
       <ClickAwayListener onClickAway={handleClickAway}>
-      <FormControl className={classes.formControl}>
-        <Select
-          value={value}
-          displayEmpty
-          multiple={multiple}
-          onChange={handleChange}
-          onClick={selectHandleOnOpen}
-          open={canOpen}
-          input={<BootstrapInput />}
-          renderValue={selected =>
-            multiple && (value as any[]).length !== 0 ? (
-              <div className={classes.chips}>
-                {(selected as string[]).map(selectedValue => (
-                  <Chip
-                    key={items.find(el => el.value === selectedValue)?.value}
-                    label={items.find(el => el.value === selectedValue)?.label}
-                    clickable
-                    onDelete={handleDelete(selectedValue)}
-                    className={classes.chip}
-                  />
-                ))}
-              </div>
-            ) : (
-              <Typography>
-                {(value as any[]).length === 0
-                  ? placeholder || ''
-                  : items.find(el => el.value === selected)?.label}
-              </Typography>
-            )
-          }
-          IconComponent={() =>
-            !canOpen ? <ClosedDropdown /> : <OpenedDropdown />
-          }
-          MenuProps={{
-            anchorOrigin: {
-              vertical: 'bottom',
-              horizontal: 'left',
-            },
-            transformOrigin: {
-              vertical: 'top',
-              horizontal: 'left',
-            },
-            getContentAnchorEl: null,
-          }}
-        >
-          {placeholder && (
-            <MenuItem value={[]}>
-              {placeholder}
-            </MenuItem>
-          )}
-          {items &&
-            items.map(item => (
-              <MenuItem id="menu-item" key={item.value} value={item.value}>
-                {multiple && (
-                  <Checkbox
-                    color="primary"
-                    checked={(value as any[]).includes(item.value) || false}
-                    className={classes.checkbox}
-                  />
-                )}
-                {item.label}
-              </MenuItem>
-            ))}
-        </Select>
-      </FormControl>
+        <FormControl className={classes.formControl}>
+          <Select
+            value={value}
+            displayEmpty
+            multiple={multiple}
+            onChange={handleChange}
+            onClick={selectHandleOnOpen}
+            open={canOpen}
+            input={<BootstrapInput />}
+            renderValue={selected =>
+              multiple && (value as any[]).length !== 0 ? (
+                <div className={classes.chips}>
+                  {(selected as string[]).map(selectedValue => (
+                    <Chip
+                      key={items.find(el => el.value === selectedValue)?.value}
+                      label={
+                        items.find(el => el.value === selectedValue)?.label
+                      }
+                      clickable
+                      onDelete={handleDelete(selectedValue)}
+                      className={classes.chip}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <Typography>
+                  {(value as any[]).length === 0
+                    ? placeholder || ''
+                    : items.find(el => el.value === selected)?.label}
+                </Typography>
+              )
+            }
+            IconComponent={() =>
+              !canOpen ? <ClosedDropdown /> : <OpenedDropdown />
+            }
+            MenuProps={{
+              anchorOrigin: {
+                vertical: 'bottom',
+                horizontal: 'left',
+              },
+              transformOrigin: {
+                vertical: 'top',
+                horizontal: 'left',
+              },
+              getContentAnchorEl: null,
+            }}
+          >
+            {placeholder && <MenuItem value={[]}>{placeholder}</MenuItem>}
+            {items &&
+              items.map(item => (
+                <MenuItem id="menu-item" key={item.value} value={item.value}>
+                  {multiple && (
+                    <Checkbox
+                      color="primary"
+                      checked={(value as any[]).includes(item.value) || false}
+                      className={classes.checkbox}
+                    />
+                  )}
+                  {item.label}
+                </MenuItem>
+              ))}
+          </Select>
+        </FormControl>
       </ClickAwayListener>
     </div>
   );

--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -195,7 +195,9 @@ export const SelectComponent = (props: SelectProps) => {
               getContentAnchorEl: null,
             }}
           >
-            {placeholder && <MenuItem value={[]}>{placeholder}</MenuItem>}
+            {placeholder && !multiple && (
+              <MenuItem value={[]}>{placeholder}</MenuItem>
+            )}
             {items &&
               items.map(item => (
                 <MenuItem id="menu-item" key={item.value} value={item.value}>

--- a/packages/core/src/components/Select/index.tsx
+++ b/packages/core/src/components/Select/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { SelectComponent as Select } from './Select';

--- a/packages/core/src/components/Select/static/ClosedDropdown.tsx
+++ b/packages/core/src/components/Select/static/ClosedDropdown.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { SvgIcon, makeStyles, createStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    icon: {
+      position: 'absolute',
+      right: '4px',
+      pointerEvents: "none"
+    },
+  }),
+);
+
+const ClosedDropdown = () => {
+  const classes = useStyles();
+  return (
+    <SvgIcon
+      className={classes.icon}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M7.5 8L6 9.5L12.0703 15.5703L18.1406 9.5L16.6406 8L12.0703 12.5703L7.5 8Z" fill="#616161"/>
+    </SvgIcon>
+  );
+};
+
+export default ClosedDropdown;

--- a/packages/core/src/components/Select/static/ClosedDropdown.tsx
+++ b/packages/core/src/components/Select/static/ClosedDropdown.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles(() =>
     icon: {
       position: 'absolute',
       right: '4px',
-      pointerEvents: "none"
+      pointerEvents: 'none',
     },
   }),
 );
@@ -34,7 +34,10 @@ const ClosedDropdown = () => {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path d="M7.5 8L6 9.5L12.0703 15.5703L18.1406 9.5L16.6406 8L12.0703 12.5703L7.5 8Z" fill="#616161"/>
+      <path
+        d="M7.5 8L6 9.5L12.0703 15.5703L18.1406 9.5L16.6406 8L12.0703 12.5703L7.5 8Z"
+        fill="#616161"
+      />
     </SvgIcon>
   );
 };

--- a/packages/core/src/components/Select/static/OpenedDropdown.tsx
+++ b/packages/core/src/components/Select/static/OpenedDropdown.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { SvgIcon, makeStyles, createStyles } from '@material-ui/core';
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    icon: {
+      position: 'absolute',
+      right: '4px',
+      pointerEvents: 'none',
+    },
+  }),
+);
+
+const OpenedDropdown = () => {
+  const classes = useStyles();
+  return (
+    <SvgIcon
+    className={classes.icon}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M16.5 16L18 14.5L11.9297 8.42969L5.85938 14.5L7.35938 16L11.9297 11.4297L16.5 16Z" fill="#616161"/>
+    </SvgIcon>
+  );
+};
+
+export default OpenedDropdown;

--- a/packages/core/src/components/Select/static/OpenedDropdown.tsx
+++ b/packages/core/src/components/Select/static/OpenedDropdown.tsx
@@ -30,11 +30,14 @@ const OpenedDropdown = () => {
   const classes = useStyles();
   return (
     <SvgIcon
-    className={classes.icon}
+      className={classes.icon}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path d="M16.5 16L18 14.5L11.9297 8.42969L5.85938 14.5L7.35938 16L11.9297 11.4297L16.5 16Z" fill="#616161"/>
+      <path
+        d="M16.5 16L18 14.5L11.9297 8.42969L5.85938 14.5L7.35938 16L11.9297 11.4297L16.5 16Z"
+        fill="#616161"
+      />
     </SvgIcon>
   );
 };

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -80,7 +80,7 @@ export const Filters = (props: Props) => {
 
   useEffect(() => {
     onChangeFilters(selectedFilters);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFilters]);
 
   // As material table doesn't provide a way to add a column filter tab we will make our own filter logic
@@ -99,12 +99,25 @@ export const Filters = (props: Props) => {
               <CheckboxTree
                 key={filter.element.label}
                 {...(filter.element as CheckboxTreeProps)}
-                onChange={
-                  el => ({})
-                  // setSelectedFilters({
-                  //   ...selectedFilters,
-                  //   [filter.element.label]: el,
-                  // })
+                onChange={el =>
+                  setSelectedFilters({
+                    ...selectedFilters,
+                    [filter.element.label]: el
+                      .filter(
+                        (checkboxFilter: any) =>
+                          checkboxFilter.category ||
+                          checkboxFilter.selectedChilds.length,
+                      )
+                      .map((checkboxFilter: any) =>
+                        checkboxFilter.category
+                          ? [
+                              ...checkboxFilter.selectedChilds,
+                              checkboxFilter.category,
+                            ]
+                          : checkboxFilter.selectedChilds,
+                      )
+                      .flat(),
+                  })
                 }
               />
             ) : (

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -59,6 +59,10 @@ export type Filter = {
     | Without<SelectProps, 'onChange'>;
 };
 
+export type SelectedFilters = {
+  [key: string]: string | string[];
+};
+
 type Props = {
   filters: Filter[];
   onChangeFilters: (arg: any) => any;
@@ -70,7 +74,7 @@ export const Filters = (props: Props) => {
   const { onChangeFilters } = props;
 
   const [filters, setFilters] = useState(props.filters);
-  const [selectedFilters, setSelectedFilters] = useState({});
+  const [selectedFilters, setSelectedFilters] = useState<SelectedFilters>({});
 
   // Trigger re-rendering
   const handleClick = () => {

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -32,7 +32,7 @@ const useSubvalueCellStyles = makeStyles<BackstageTheme>(theme => ({
   },
   value: {
     fontWeight: 'bold',
-    fontSize: 18
+    fontSize: 18,
   },
   header: {
     display: 'flex',

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { BackstageTheme } from '@backstage/theme';
+import { Button, makeStyles } from '@material-ui/core';
+import { Select } from '../Select';
+import { CheckboxTree } from '../CheckboxTree';
+import { CheckboxTreeProps } from '../CheckboxTree/CheckboxTree';
+import { SelectProps } from '../Select/Select';
+
+const useSubvalueCellStyles = makeStyles<BackstageTheme>(theme => ({
+  root: {
+    height: '100%',
+    width: '315px',
+    display: 'flex',
+    flexDirection: 'column',
+    marginRight: theme.spacing(3),
+  },
+  value: {},
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    height: '60px',
+    justifyContent: 'space-between',
+    borderBottom: `1px solid ${theme.palette.grey[500]}`,
+  },
+  filters: {
+    display: 'flex',
+    flexDirection: 'column',
+    '& > *': {
+      marginTop: theme.spacing(2),
+    },
+  },
+  clear: {
+    textTransform: 'none',
+  },
+}));
+
+type Without<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export type Filter = {
+  type: 'select' | 'checkbox-tree' | 'multiple-select';
+  element:
+    | Without<CheckboxTreeProps, 'onChange'>
+    | Without<SelectProps, 'onChange'>;
+};
+
+type Props = {
+  filters: Filter[];
+  onChangeFilters: (arg: any) => any;
+};
+
+export const Filters = (props: Props) => {
+  const classes = useSubvalueCellStyles();
+
+  const { onChangeFilters } = props;
+
+  const [filters, setFilters] = useState(props.filters);
+  const [selectedFilters, setSelectedFilters] = useState({});
+
+  // Trigger re-rendering
+  const handleClick = () => {
+    setSelectedFilters({});
+    setFilters([
+      ...props.filters.map(el => ({
+        type: el.type,
+        element: { ...el.element },
+      })),
+    ]);
+  };
+
+  useEffect(() => {
+    onChangeFilters(selectedFilters);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedFilters]);
+
+  // As material table doesn't provide a way to add a column filter tab we will make our own filter logic
+  return (
+    <div className={classes.root}>
+      <div className={classes.header}>
+        <div className={classes.value}>Filters</div>
+        <Button className={classes.clear} color="primary" onClick={handleClick}>
+          Clear all
+        </Button>
+      </div>
+      <div className={classes.filters}>
+        {filters?.length &&
+          filters.map(filter =>
+            filter.type === 'checkbox-tree' ? (
+              <CheckboxTree
+                key={filter.element.label}
+                {...(filter.element as CheckboxTreeProps)}
+                onChange={
+                  el => ({})
+                  // setSelectedFilters({
+                  //   ...selectedFilters,
+                  //   [filter.element.label]: el,
+                  // })
+                }
+              />
+            ) : (
+              <Select
+                key={filter.element.label}
+                {...(filter.element as SelectProps)}
+                onChange={el =>
+                  setSelectedFilters({
+                    ...selectedFilters,
+                    [filter.element.label]: el,
+                  })
+                }
+              />
+            ),
+          )}
+      </div>
+    </div>
+  );
+};

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -30,7 +30,10 @@ const useSubvalueCellStyles = makeStyles<BackstageTheme>(theme => ({
     flexDirection: 'column',
     marginRight: theme.spacing(3),
   },
-  value: {},
+  value: {
+    fontWeight: 'bold',
+    fontSize: 18
+  },
   header: {
     display: 'flex',
     alignItems: 'center',
@@ -44,9 +47,6 @@ const useSubvalueCellStyles = makeStyles<BackstageTheme>(theme => ({
     '& > *': {
       marginTop: theme.spacing(2),
     },
-  },
-  clear: {
-    textTransform: 'none',
   },
 }));
 
@@ -88,7 +88,7 @@ export const Filters = (props: Props) => {
     <div className={classes.root}>
       <div className={classes.header}>
         <div className={classes.value}>Filters</div>
-        <Button className={classes.clear} color="primary" onClick={handleClick}>
+        <Button color="primary" onClick={handleClick}>
           Clear all
         </Button>
       </div>

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -75,11 +75,13 @@ export const Filters = (props: Props) => {
 
   const [filters, setFilters] = useState(props.filters);
   const [selectedFilters, setSelectedFilters] = useState<SelectedFilters>({});
+  const [reset, triggerReset] = useState(false);
 
   // Trigger re-rendering
   const handleClick = () => {
     setSelectedFilters({});
     setFilters([...props.filters]);
+    triggerReset(el => !el)
   };
 
   useEffect(() => {
@@ -101,6 +103,7 @@ export const Filters = (props: Props) => {
           filters.map(filter =>
             filter.type === 'checkbox-tree' ? (
               <CheckboxTree
+                triggerReset={reset}
                 key={filter.element.label}
                 {...(filter.element as CheckboxTreeProps)}
                 onChange={el =>
@@ -126,6 +129,7 @@ export const Filters = (props: Props) => {
               />
             ) : (
               <Select
+                triggerReset={reset}
                 key={filter.element.label}
                 {...(filter.element as SelectProps)}
                 onChange={el =>

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -75,12 +75,7 @@ export const Filters = (props: Props) => {
   // Trigger re-rendering
   const handleClick = () => {
     setSelectedFilters({});
-    setFilters([
-      ...props.filters.map(el => ({
-        type: el.type,
-        element: { ...el.element },
-      })),
-    ]);
+    setFilters([...props.filters]);
   };
 
   useEffect(() => {

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -81,7 +81,7 @@ export const Filters = (props: Props) => {
   const handleClick = () => {
     setSelectedFilters({});
     setFilters([...props.filters]);
-    triggerReset(el => !el)
+    triggerReset(el => !el);
   };
 
   useEffect(() => {

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -105,11 +105,11 @@ export const Filters = (props: Props) => {
                     [filter.element.label]: el
                       .filter(
                         (checkboxFilter: any) =>
-                          checkboxFilter.category ||
+                          checkboxFilter.category !== null ||
                           checkboxFilter.selectedChilds.length,
                       )
                       .map((checkboxFilter: any) =>
-                        checkboxFilter.category
+                        checkboxFilter.category !== null
                           ? [
                               ...checkboxFilter.selectedChilds,
                               checkboxFilter.category,

--- a/packages/core/src/components/Table/Table.stories.tsx
+++ b/packages/core/src/components/Table/Table.stories.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { Table, SubvalueCell, TableColumn } from './';
+import { TableFilter } from './Table';
 
 export default {
   title: 'Table',
@@ -244,13 +245,28 @@ export const FilterTable = () => {
     },
   ];
 
+  const filters: TableFilter[] = [
+    {
+      column: 'Column 1',
+      type: 'select',
+    },
+    {
+      column: 'Column 2',
+      type: 'multiple-select',
+    },
+    {
+      column: 'Numeric value',
+      type: 'checkbox-tree',
+    },
+  ];
+
   return (
     <div style={containerStyle}>
       <Table
         options={{ paging: false, padding: 'dense' }}
         data={testData10}
         columns={columns}
-        filters={["test"]}
+        filters={filters}
       />
     </div>
   );

--- a/packages/core/src/components/Table/Table.stories.tsx
+++ b/packages/core/src/components/Table/Table.stories.tsx
@@ -220,3 +220,38 @@ export const DenseTable = () => {
     </div>
   );
 };
+
+export const FilterTable = () => {
+  const columns: TableColumn[] = [
+    {
+      title: 'Column 1',
+      field: 'col1',
+      highlight: true,
+    },
+    {
+      title: 'Column 2',
+      field: 'col2',
+    },
+    {
+      title: 'Numeric value',
+      field: 'number',
+      type: 'numeric',
+    },
+    {
+      title: 'A Date',
+      field: 'date',
+      type: 'date',
+    },
+  ];
+
+  return (
+    <div style={containerStyle}>
+      <Table
+        options={{ paging: false, padding: 'dense' }}
+        data={testData10}
+        columns={columns}
+        filters={["test"]}
+      />
+    </div>
+  );
+};

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -133,6 +133,10 @@ const useFilterStyles = makeStyles<BackstageTheme>(() => ({
     alignItems: 'center',
     justifyContent: 'space-between',
   },
+  title: {
+    fontWeight: 'bold',
+    fontSize: 18
+  }
 }));
 
 const useTableStyles = makeStyles<BackstageTheme>(() => ({
@@ -281,7 +285,7 @@ export function Table<T extends object = {}>({
                   >
                     <FilterList />
                   </IconButton>
-                  <Typography variant="h6">
+                  <Typography className={filtersClasses.title}>
                     Filters ({selectedFiltersLength})
                   </Typography>
                 </div>

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -135,8 +135,8 @@ const useFilterStyles = makeStyles<BackstageTheme>(() => ({
   },
   title: {
     fontWeight: 'bold',
-    fontSize: 18
-  }
+    fontSize: 18,
+  },
 }));
 
 const useTableStyles = makeStyles<BackstageTheme>(() => ({

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -1,4 +1,3 @@
-import classes from '*.css';
 /*
  * Copyright 2020 Spotify AB
  *
@@ -45,7 +44,7 @@ import MTable, {
   MTableToolbar,
   Options,
 } from 'material-table';
-import React, { forwardRef, useEffect, useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { Filters } from './Filters';
 
 const tableIcons = {
@@ -199,6 +198,7 @@ export function Table<T extends object = {}>({
   const theme = useTheme<BackstageTheme>();
 
   const [filtersOpen, toggleFilters] = useState(false);
+  const [selectedFiltersLength, setSelectedFiltersLength] = useState(0);
   const [tableData, setTableData] = useState(data as any[]);
 
   const MTColumns = convertColumns(columns, theme);
@@ -212,15 +212,25 @@ export function Table<T extends object = {}>({
   const getFieldByTitle = (titleValue: string | keyof T) =>
     columns.find(el => el.title === titleValue)?.field;
 
-  const onChangeFilters = (selectedFilters: any) => {
-    if (Object.values(selectedFilters).length) {
+    
+    const onChangeFilters = (selectedFilters: any) => {
+    const selectedFiltersArray = Object.values(selectedFilters);
+    if (selectedFiltersArray.flat().length) {
       const newData = (props.data as any[]).filter(
         el =>
           !!Object.entries(selectedFilters).find(
-            ([key, value]) => el[getFieldByTitle(key)] === value,
+            ([key, value]) => {
+              if (Array.isArray(value)) {
+                return value.includes(el[getFieldByTitle(key)])
+              }
+              return el[getFieldByTitle(key)] === value
+            },
           ),
       );
       setTableData(newData);
+      setSelectedFiltersLength(selectedFiltersArray.flat().length)
+    } else {
+      setTableData(props.data as any[]);
     }
   };
 
@@ -273,7 +283,7 @@ export function Table<T extends object = {}>({
                   >
                     <FilterList />
                   </IconButton>
-                  <Typography variant="h6">Filters</Typography>
+            <Typography variant="h6">Filters ({ selectedFiltersLength })</Typography>
                 </div>
                 <MTableToolbar classes={toolbarClasses} {...toolbarProps} />
               </div>

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -136,6 +136,7 @@ const useFilterStyles = makeStyles<BackstageTheme>(() => ({
   title: {
     fontWeight: 'bold',
     fontSize: 18,
+    whiteSpace: 'nowrap',
   },
 }));
 
@@ -311,6 +312,7 @@ export function Table<T extends object = {}>({
           </>
         }
         data={tableData}
+        style={{ width: '100%' }}
         {...propsWithoutData}
       />
     </div>

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -230,10 +230,10 @@ export function Table<T extends object = {}>({
           }),
       );
       setTableData(newData);
-      setSelectedFiltersLength(selectedFiltersArray.flat().length);
     } else {
       setTableData(props.data as any[]);
     }
+    setSelectedFiltersLength(selectedFiltersArray.flat().length);
   };
 
   const constructFilters = (filterConfig: TableFilter[], dataValue: any[]) => {

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -45,7 +45,7 @@ import MTable, {
   Options,
 } from 'material-table';
 import React, { forwardRef, useState } from 'react';
-import { Filters } from './Filters';
+import { Filters, SelectedFilters } from './Filters';
 
 const tableIcons = {
   Add: forwardRef((props, ref: React.Ref<SVGSVGElement>) => (
@@ -217,17 +217,19 @@ export function Table<T extends object = {}>({
   const getFieldByTitle = (titleValue: string | keyof T) =>
     columns.find(el => el.title === titleValue)?.field;
 
-  const onChangeFilters = (selectedFilters: any) => {
+  const onChangeFilters = (selectedFilters: SelectedFilters) => {
     const selectedFiltersArray = Object.values(selectedFilters);
     if (selectedFiltersArray.flat().length) {
       const newData = (props.data as any[]).filter(
         el =>
-          !!Object.entries(selectedFilters).find(([key, value]) => {
-            if (Array.isArray(value)) {
-              return value.includes(el[getFieldByTitle(key)]);
-            }
-            return el[getFieldByTitle(key)] === value;
-          }),
+          !!Object.entries(selectedFilters)
+            .filter(([, value]) => !!value.length)
+            .every(([key, value]) => {
+              if (Array.isArray(value)) {
+                return value.includes(el[getFieldByTitle(key)]);
+              }
+              return el[getFieldByTitle(key)] === value;
+            }),
       );
       setTableData(newData);
     } else {

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -138,6 +138,7 @@ const useFilterStyles = makeStyles<BackstageTheme>(() => ({
 const useTableStyles = makeStyles<BackstageTheme>(() => ({
   root: {
     display: 'flex',
+    alignItems: 'start',
   },
 }));
 
@@ -212,23 +213,20 @@ export function Table<T extends object = {}>({
   const getFieldByTitle = (titleValue: string | keyof T) =>
     columns.find(el => el.title === titleValue)?.field;
 
-    
-    const onChangeFilters = (selectedFilters: any) => {
+  const onChangeFilters = (selectedFilters: any) => {
     const selectedFiltersArray = Object.values(selectedFilters);
     if (selectedFiltersArray.flat().length) {
       const newData = (props.data as any[]).filter(
         el =>
-          !!Object.entries(selectedFilters).find(
-            ([key, value]) => {
-              if (Array.isArray(value)) {
-                return value.includes(el[getFieldByTitle(key)])
-              }
-              return el[getFieldByTitle(key)] === value
-            },
-          ),
+          !!Object.entries(selectedFilters).find(([key, value]) => {
+            if (Array.isArray(value)) {
+              return value.includes(el[getFieldByTitle(key)]);
+            }
+            return el[getFieldByTitle(key)] === value;
+          }),
       );
       setTableData(newData);
-      setSelectedFiltersLength(selectedFiltersArray.flat().length)
+      setSelectedFiltersLength(selectedFiltersArray.flat().length);
     } else {
       setTableData(props.data as any[]);
     }
@@ -283,7 +281,9 @@ export function Table<T extends object = {}>({
                   >
                     <FilterList />
                   </IconButton>
-            <Typography variant="h6">Filters ({ selectedFiltersLength })</Typography>
+                  <Typography variant="h6">
+                    Filters ({selectedFiltersLength})
+                  </Typography>
                 </div>
                 <MTableToolbar classes={toolbarClasses} {...toolbarProps} />
               </div>

--- a/packages/core/src/components/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table.tsx
@@ -1,3 +1,4 @@
+import classes from '*.css';
 /*
  * Copyright 2020 Spotify AB
  *
@@ -15,7 +16,12 @@
  */
 
 import { BackstageTheme } from '@backstage/theme';
-import { makeStyles, Typography, useTheme } from '@material-ui/core';
+import {
+  makeStyles,
+  Typography,
+  useTheme,
+  IconButton,
+} from '@material-ui/core';
 // Material-table is not using the standard icons available in in material-ui. https://github.com/mbrn/material-table/issues/51
 import AddBox from '@material-ui/icons/AddBox';
 import ArrowUpward from '@material-ui/icons/ArrowUpward';
@@ -39,7 +45,7 @@ import MTable, {
   MTableToolbar,
   Options,
 } from 'material-table';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useState } from 'react';
 
 const tableIcons = {
   Add: forwardRef((props, ref: React.Ref<SVGSVGElement>) => (
@@ -107,7 +113,7 @@ const useHeaderStyles = makeStyles<BackstageTheme>(theme => ({
   },
 }));
 
-const useToolbarStyles = makeStyles<BackstageTheme>(theme => ({
+const useToolbarStyles = makeStyles<BackstageTheme>((theme) => ({
   root: {
     padding: theme.spacing(3, 0, 2.5, 2.5),
   },
@@ -119,6 +125,25 @@ const useToolbarStyles = makeStyles<BackstageTheme>(theme => ({
   searchField: {
     paddingRight: theme.spacing(2),
   },
+}));
+
+const useFilterStyles = makeStyles<BackstageTheme>(() => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+}));
+
+const useTableStyles = makeStyles<BackstageTheme>(() => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  filters: {
+    height: '100%',
+    width: '250px',
+  }
 }));
 
 function convertColumns<T extends object>(
@@ -152,6 +177,7 @@ export interface TableProps<T extends object = {}>
   extends MaterialTableProps<T> {
   columns: TableColumn<T>[];
   subtitle?: string;
+  filters?: any[];
 }
 
 export function Table<T extends object = {}>({
@@ -159,11 +185,17 @@ export function Table<T extends object = {}>({
   options,
   title,
   subtitle,
+  filters,
   ...props
 }: TableProps<T>) {
   const headerClasses = useHeaderStyles();
   const toolbarClasses = useToolbarStyles();
+  const tableClasses = useTableStyles();
+  const filtersClasses = useFilterStyles();
+
   const theme = useTheme<BackstageTheme>();
+
+  const [filtersOpen, toggleFilters] = useState(false);
 
   const MTColumns = convertColumns(columns, theme);
 
@@ -174,14 +206,27 @@ export function Table<T extends object = {}>({
   };
 
   return (
+    <div className={tableClasses.root}>
+      {filtersOpen && <div className={tableClasses.filters}>Filters</div>}
     <MTable<T>
       components={{
         Header: headerProps => (
           <MTableHeader classes={headerClasses} {...headerProps} />
         ),
-        Toolbar: toolbarProps => (
-          <MTableToolbar classes={toolbarClasses} {...toolbarProps} />
-        ),
+        Toolbar: toolbarProps =>
+          filters?.length ? (
+            <div className={filtersClasses.root}>
+              <div className={filtersClasses.root}>
+                <IconButton onClick={() => toggleFilters(el => !el)} aria-label="filter list">
+                  <FilterList />
+                </IconButton>
+                <Typography variant="h6">Filters</Typography>
+              </div>
+              <MTableToolbar classes={toolbarClasses} {...toolbarProps} />
+            </div>
+          ) : (
+            <MTableToolbar classes={toolbarClasses} {...toolbarProps} />
+          ),
       }}
       options={{ ...defaultOptions, ...options }}
       columns={MTColumns}
@@ -198,5 +243,6 @@ export function Table<T extends object = {}>({
       }
       {...props}
     />
+    </div>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11749,6 +11749,11 @@ immer@1.10.0:
   resolved "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
+immer@^7.0.9:
+  version "7.0.9"
+  resolved "https://registry.npmjs.org/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
+  integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
+
 immutable@>=3.8.2, immutable@^3.8.1, immutable@^3.8.2, immutable@^3.x.x:
   version "3.8.2"
   resolved "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #2218

This is still a work in progress because I need to do some **adjustments (code + style), refactoring and add tests**. (There is still a lot of messy code)

This PR introduces two new types of components: the `Select` and the `CheckboxTree`.

- `Select`
    - Default
![Capture d’écran 2020-09-15 à 18 29 35](https://user-images.githubusercontent.com/32459935/93238268-83a9b300-f781-11ea-9b36-bfdbc2f0742a.png)

    - Multiple
![Capture d’écran 2020-09-15 à 18 29 59](https://user-images.githubusercontent.com/32459935/93238329-958b5600-f781-11ea-9828-09ee75501940.png)

- `CheckboxTree`
![Capture d’écran 2020-09-15 à 18 29 50](https://user-images.githubusercontent.com/32459935/93238347-99b77380-f781-11ea-9042-363b83a2c1a0.png)

It also introduce the `Filter` component inside the `Table`.
![Capture d’écran 2020-09-15 à 18 30 15](https://user-images.githubusercontent.com/32459935/93238368-9de39100-f781-11ea-9c73-4448e8a350b1.png)

Here is **how it works** [**Outdated**]:
![filter-table](https://user-images.githubusercontent.com/32459935/93237387-53154980-f780-11ea-8683-c22f7e758e57.gif)

## Notes and remarks

Things left to do:
- [x] Add missing tests
- [ ] Add search bar to the multiple select
- [x] Clear all: resets the data without filter but I need to reset the filters initial states
- [ ] Add missing styles
- [ ] Global refactoring

I have some questions about some **UX/UI behaviors**:
- What is the behavior of the filter tab when the number of filters exceeds the size (height) of the table ? Maybe a scroll ?
- I don't know in which case the `CheckboxTree` should have 2 levels ? So I can reproduce a working example.
- Do the filters have to add up?
What I mean is if we have checked `value1` for the column1 and `value2` for the column2 do we have to display the data with the column1 = `value1` and column2 = `value2` ?
(For the moment the logic cover this type of behavior)
[**EDIT**: as @freben said below, we have an AND logic between different groups of filters and an OR logic inside the same group of filter.]

Moreover I find my implementation of the `CheckboxTree` component a bit complex.
For the items `props` we have something like:

```json
[
   {
      "label":"Genereic subcategory name 1",
      "options":[
         {
            "label":"Option 1",
            "value":1
         },
         {
            "label":"Option 2",
            "value":2
         }
      ]
   }
]
```

And then in the component, for performance purpose we need to index each item to obtain something like this:
```json
{
   "Genereic subcategory name 1":{
      "label":"Genereic subcategory name 1",
      "isOpen":false,
      "isChecked":false,
      "options":{
         "Option 1":{
            "label":"Option 1",
            "isChecked":false,
            "value":1
         },
         "Option 2":{
            "label":"Option 2",
            "isChecked":false,
            "value":2
         }
      }
   }
}
```

And we have a **reducer with 3 types of actions**: `checkOption`, `checkCategory` and `openCategory` (that should be named `toggleCategory` [**EDIT**: fixed]) that mutate our state which is our only source of truth.
Maybe we should **split the responsibilities** (a stage managing the checked options, another managing the opening categories...) to have a cleaner codebase.

But I like having an object that contains all of our properties. (This way **we keep the notion of hierarchy between categories and options**). 
The problem with this method is that for every change I have to go deep through my object to change a specific value.

[**EDIT**: fixed by using the [immer](https://immerjs.github.io/immer/docs/produce) `produce` function]

Can I have your point of view on this implementation ?

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
