### PR TITLE
Bumped esbuild version from 0.6.3 to 0.6.9 to support win32

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "css-loader": "^3.5.3",
     "dashify": "^2.0.0",
     "diff": "^4.0.2",
-    "esbuild": "0.6.3",
+    "esbuild": "0.6.9",
     "eslint": "^7.1.0",
     "eslint-formatter-friendly": "^7.0.0",
     "eslint-plugin-import": "^2.20.2",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bumped esbuild version to 0.6.9 to support win32.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
