### PR TITLE
storybook config: fix for babel-loader error

### DIFF
--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -22,7 +22,7 @@ module.exports = {
     const [jsLoader] = config.module.rules.splice(0, 1);
     if (jsLoader.use[0].loader !== 'babel-loader') {
       throw new Error(
-        `Unexpected loader removed from storybook config, ${jsonLoader.use[0].loader}`,
+        `Unexpected loader removed from storybook config, ${jsLoader.use[0].loader}`,
       );
     }
 


### PR DESCRIPTION
## Description

`jsonLoader` should be `jsLoader`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
