### PR TITLE
eslintignore: add template dirs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,5 @@
 **/.git/**
 **/public/**
 **/microsite/**
+**/templates/**
+**/sample-templates/**


### PR DESCRIPTION
Fixes #2324

The root of the issue is that we're mixing linting of individual packages via lerna and linting from the root of the repo with `lint-staged`

Really no nice solution to that though, since eslint is limited to only using a single ignore file at a time.

Other options are to modify how husky executes the hooks, but that'd require breaking the lint-staged config out to a separate file and adding magic there, which just adds a bunch of code to the repo.

Another option would be to move all linting to the top-level, and that's a bit too big of a change right now at least.
