### PR TITLE
TechDocs: Test for docker before attempting to run a container

### DIFF
--- a/plugins/techdocs-backend/src/techdocs/stages/generate/helpers.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/generate/helpers.ts
@@ -47,6 +47,14 @@ export async function runDockerContainer({
   dockerClient,
   createOptions,
 }: RunDockerContainerOptions) {
+  try {
+    await dockerClient.ping();
+  } catch (e) {
+    throw new Error(
+      `This operation requires Docker. Docker does not appear to be available. Docker.ping() failed with: ${e.message}`,
+    );
+  }
+
   await new Promise((resolve, reject) => {
     dockerClient.pull(imageName, {}, (err, stream) => {
       if (err) return reject(err);


### PR DESCRIPTION
Test for docker using ping() before attempting to run the techdocs container. If this fails we know docker is unavailable
and we can fail with a more descriptive error. The idea is to guide users who aren't aware that docker is a pre-requisite to run techdocs in backstage. 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ x] Prettier run on changed files
- [ x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
