### PR TITLE
TechDocs: Use a flag to determine if we should use a local mkdocs or techdocs-container

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -35,6 +35,8 @@ organization:
 techdocs:
   storageUrl: http://localhost:7000/techdocs/static/docs
   requestUrl: http://localhost:7000/techdocs/docs
+  generators:
+    techdocs: 'docker'
 
 sentry:
   organization: spotify

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -78,22 +78,22 @@ frontend of the docs from source files (Markdown). If you are deploying
 Backstage using Docker, this will mean that your Backstage Docker container will
 try to run another Docker container for TechDocs backend.
 
-To avoid this problem, we have a configuration available. If you go to
-`packages/backend/src/plugins/techdocs.ts`, you can find the line where we
-create a new TechDocs Generator. (Also see [Concepts](concepts.md)).
+To avoid this problem, we have a configuration available. You can set a value in
+your `app-config.yaml` that tells the techdocs generator if it should run the
+`local` mkdocs or run it from `docker`. This defaults to running as `docker` if
+no config is provided.
 
-```
-const techdocsGenerator = new TechdocsGenerator(logger);
-```
-
-You can pass an options object as a second argument here.
-
-```
-const techdocsGenerator = new TechdocsGenerator(logger, { useTechdocsContainer: false });
+```yaml
+techdocs:
+  generators:
+    techdocs: local
 ```
 
-Setting `useTechdocsContainer` to `false` means that TechDocs backend will not
-run another Docker container, and will use locally available `mkdocs` instead.
+Setting `generators.techdocs` to `local` means you will have to make sure your
+environment is compatible with techdocs. You will have to install the
+`mkdocs-techdocs-container` and 'mkdocs' package from pip, as well as graphviz
+and plantuml from your package manager. This has only been tested with python
+3.7 and python 3.8.
 
 ## Run Backstage locally
 

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -71,6 +71,30 @@ building and publishing of your documentation, you want to change the
 `requestUrl` to point to your storage. In this case `storageUrl` is not
 required.
 
+### Disable Docker in Docker situation (Optional)
+
+The TechDocs backend plugin runs a docker container with mkdocs to generate the
+frontend of the docs from source files (Markdown). If you are deploying
+Backstage using Docker, this will mean that your Backstage Docker container will
+try to run another Docker container for TechDocs backend.
+
+To avoid this problem, we have a configuration available. If you go to
+`packages/backend/src/plugins/techdocs.ts`, you can find the line where we
+create a new TechDocs Generator. (Also see [Concepts](concepts.md)).
+
+```
+const techdocsGenerator = new TechdocsGenerator(logger);
+```
+
+You can pass an options object as a second argument here.
+
+```
+const techdocsGenerator = new TechdocsGenerator(logger, { useTechdocsContainer: false });
+```
+
+Setting `useTechdocsContainer` to `false` means that TechDocs backend will not
+run another Docker container, and will use locally available `mkdocs` instead.
+
 ## Run Backstage locally
 
 Change folder to `<backstage-project-root>/packages/backend` and run the

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -45,10 +45,13 @@ export default async function createPlugin({
 
   const filePreparer = new FilePreparer();
   const githubPreparer = new GithubPreparer();
+  const gitlabPreparer = new GitlabPreparer(config);
   const preparers = new Preparers();
 
   preparers.register('file', filePreparer);
   preparers.register('github', githubPreparer);
+  preparers.register('gitlab', gitlabPreparer);
+  preparers.register('gitlab/api', gitlabPreparer);
 
   const publishers = new Publishers();
 
@@ -65,6 +68,19 @@ export default async function createPlugin({
   });
   publishers.register('file', githubPublisher);
   publishers.register('github', githubPublisher);
+
+  const gitLabConfig = config.getOptionalConfig('scaffolder.gitlab.api');
+
+  if (gitLabConfig) {
+    const gitLabToken = gitLabConfig.getString('token');
+    const gitLabClient = new Gitlab({
+      host: gitLabConfig.getOptionalString('baseUrl'),
+      token: gitLabToken,
+    });
+    const gitLabPublisher = new GitlabPublisher(gitLabClient, gitLabToken);
+    publishers.register('gitlab', gitLabPublisher);
+    publishers.register('gitlab/api', gitLabPublisher);
+  }
 
   const dockerClient = new Docker();
   return await createRouter({

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -45,13 +45,10 @@ export default async function createPlugin({
 
   const filePreparer = new FilePreparer();
   const githubPreparer = new GithubPreparer();
-  const gitlabPreparer = new GitlabPreparer(config);
   const preparers = new Preparers();
 
   preparers.register('file', filePreparer);
   preparers.register('github', githubPreparer);
-  preparers.register('gitlab', gitlabPreparer);
-  preparers.register('gitlab/api', gitlabPreparer);
 
   const publishers = new Publishers();
 
@@ -68,19 +65,6 @@ export default async function createPlugin({
   });
   publishers.register('file', githubPublisher);
   publishers.register('github', githubPublisher);
-
-  const gitLabConfig = config.getOptionalConfig('scaffolder.gitlab.api');
-
-  if (gitLabConfig) {
-    const gitLabToken = gitLabConfig.getString('token');
-    const gitLabClient = new Gitlab({
-      host: gitLabConfig.getOptionalString('baseUrl'),
-      token: gitLabToken,
-    });
-    const gitLabPublisher = new GitlabPublisher(gitLabClient, gitLabToken);
-    publishers.register('gitlab', gitLabPublisher);
-    publishers.register('gitlab/api', gitLabPublisher);
-  }
 
   const dockerClient = new Docker();
   return await createRouter({

--- a/packages/backend/src/plugins/techdocs.ts
+++ b/packages/backend/src/plugins/techdocs.ts
@@ -31,7 +31,7 @@ export default async function createPlugin({
   config,
 }: PluginEnvironment) {
   const generators = new Generators();
-  const techdocsGenerator = new TechdocsGenerator(logger);
+  const techdocsGenerator = new TechdocsGenerator(logger, config);
   generators.register('techdocs', techdocsGenerator);
 
   const preparers = new Preparers();

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -46,6 +46,8 @@ proxy:
 techdocs:
   storageUrl: http://localhost:7000/techdocs/static/docs
   requestUrl: http://localhost:7000/techdocs/docs
+  generators:
+    techdocs: 'docker'
 
 lighthouse:
   baseUrl: http://localhost:3003

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/techdocs.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/techdocs.ts
@@ -15,7 +15,7 @@ export default async function createPlugin({
   config,
 }: PluginEnvironment) {
   const generators = new Generators();
-  const techdocsGenerator = new TechdocsGenerator(logger);
+  const techdocsGenerator = new TechdocsGenerator(logger, config);
 
   generators.register('techdocs', techdocsGenerator);
 

--- a/plugins/techdocs-backend/src/service/standaloneServer.ts
+++ b/plugins/techdocs-backend/src/service/standaloneServer.ts
@@ -38,6 +38,7 @@ export async function startStandaloneServer(
   options: ServerOptions,
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'techdocs-backend' });
+  const config = ConfigReader.fromConfigs([]);
 
   logger.debug('Creating application...');
   const preparers = new Preparers();
@@ -45,7 +46,7 @@ export async function startStandaloneServer(
   preparers.register('dir', directoryPreparer);
 
   const generators = new Generators();
-  const techdocsGenerator = new TechdocsGenerator(logger);
+  const techdocsGenerator = new TechdocsGenerator(logger, config);
   generators.register('techdocs', techdocsGenerator);
 
   const publisher = new LocalPublish(logger);
@@ -59,7 +60,7 @@ export async function startStandaloneServer(
     logger,
     publisher,
     dockerClient,
-    config: ConfigReader.fromConfigs([]),
+    config,
   });
   const service = createServiceBuilder(module)
     .enableCors({ origin: 'http://localhost:3000' })

--- a/plugins/techdocs-backend/src/techdocs/stages/generate/generators.test.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/generate/generators.test.ts
@@ -16,6 +16,7 @@
 
 import { Generators, TechdocsGenerator } from './';
 import { getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
 
 const logger = getVoidLogger();
 
@@ -38,7 +39,10 @@ describe('generators', () => {
 
   it('should return correct registered generator', async () => {
     const generators = new Generators();
-    const techdocs = new TechdocsGenerator(logger);
+    const techdocs = new TechdocsGenerator(
+      logger,
+      ConfigReader.fromConfigs([]),
+    );
 
     generators.register('techdocs', techdocs);
 

--- a/plugins/techdocs-backend/src/techdocs/stages/generate/techdocs.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/generate/techdocs.ts
@@ -70,7 +70,7 @@ export class TechdocsGenerator implements GeneratorBase {
       path.join(tmpdirResolvedPath, 'techdocs-tmp-'),
     );
     const [log, logStream] = createStream();
-    console.log(this.options.runGeneratorIn);
+
     try {
       switch (this.options.runGeneratorIn) {
         case 'local':


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes the techdocs generator to not try and detect if you have mkdocs available, but provide it as a flag instead. This will hopefully prevent any accidental issues caused by people having mkdocs installed already and just wanting to try out techdocs.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
