### PR TITLE
TechDocs: adjust mkdocs extensions

### DIFF
--- a/packages/techdocs-container/mock-docs/docs/index.md
+++ b/packages/techdocs-container/mock-docs/docs/index.md
@@ -3,9 +3,8 @@
 !!! test
 Testing somethin
 
+Abbreviations: 
 Some text about MOCDOC
-
-\*[MOCDOC]: Mock Documentation
 
 This is a paragraph.
 {: #test_id .test_class }
@@ -61,3 +60,26 @@ digraph G {
 ```
 
 :bulb:
+
+=== "JavaScript"
+    ```javascript
+    import { test } from 'something';
+
+    const addThingToThing = (a, b) a + b;
+    ```
+
+=== "Java"
+    ```java
+    public void function() {
+        test();
+    }
+    ```
+
+```javascript
+import { test } from 'something';
+
+const addThingToThing = (a, b) a + b;
+```
+
+
+*[MOCDOC]: Mock Documentation

--- a/packages/techdocs-container/mock-docs/docs/index.md
+++ b/packages/techdocs-container/mock-docs/docs/index.md
@@ -77,6 +77,18 @@ digraph G {
     }
     ```
 
+```java tab="java"
+    public void function() {
+      test();
+    }
+```
+
+```java tab="java 2"
+    public void function() {
+      test();
+    }
+```
+
 ```javascript
 import { test } from 'something';
 

--- a/packages/techdocs-container/mock-docs/docs/index.md
+++ b/packages/techdocs-container/mock-docs/docs/index.md
@@ -3,7 +3,7 @@
 !!! test
 Testing somethin
 
-Abbreviations: 
+Abbreviations:
 Some text about MOCDOC
 
 This is a paragraph.
@@ -62,6 +62,7 @@ digraph G {
 :bulb:
 
 === "JavaScript"
+
     ```javascript
     import { test } from 'something';
 
@@ -69,6 +70,7 @@ digraph G {
     ```
 
 === "Java"
+
     ```java
     public void function() {
         test();
@@ -81,5 +83,5 @@ import { test } from 'something';
 const addThingToThing = (a, b) a + b;
 ```
 
-
+<!-- prettier-ignore -->
 *[MOCDOC]: Mock Documentation

--- a/packages/techdocs-container/mock-docs/mkdocs.yml
+++ b/packages/techdocs-container/mock-docs/mkdocs.yml
@@ -7,3 +7,8 @@ nav:
 
 plugins:
   - techdocs-core
+
+markdown_extensions:
+  - pymdownx.highlight:
+      linenums: true
+  

--- a/packages/techdocs-container/mock-docs/mkdocs.yml
+++ b/packages/techdocs-container/mock-docs/mkdocs.yml
@@ -7,8 +7,3 @@ nav:
 
 plugins:
   - techdocs-core
-
-markdown_extensions:
-  - pymdownx.highlight:
-      linenums: true
-  

--- a/packages/techdocs-container/techdocs-core/README.md
+++ b/packages/techdocs-container/techdocs-core/README.md
@@ -85,6 +85,29 @@ Extensions:
 
 - Superfences and Codehilite doesn't work very well together (squidfunk/mkdocs-material#1604) so therefore the codehilite extension is replaced by pymdownx.highlight
 
+
+- Uses pymdownx extensions v.7.1 instead of 8.0.0 to allow legacy_tab_classes config. This makes the techdocs core plugin compatible with the usage of tabs for grouping markdown with the following syntax:
+```
+     ```java tab="java 2"
+          public void function() {
+             ....
+         }
+     ```
+```
+
+as well as the new 
+
+```
+    === "Java"
+
+    ```java
+    public void function() {
+        ....
+    }
+    ```
+```
+The pymdownx extension will be bumped too 8.0.0 in the near future.
+
 - pymdownx.tabbed is added to support tabs to group markdown content, such as codeblocks.
 
 - "PyMdown Extensions includes three extensions that are meant to replace their counterpart in the default Python Markdown extensions." Therefore some extensions has been taken away in this version that comes by default from pymdownx.extra which is added now (https://facelessuser.github.io/pymdown-extensions/usage_notes/#incompatible-extensions)

--- a/packages/techdocs-container/techdocs-core/README.md
+++ b/packages/techdocs-container/techdocs-core/README.md
@@ -67,6 +67,7 @@ Extensions:
   - critic
   - details
   - emoji
+  - superfences
   - inlinehilite
   - magiclink
   - mark

--- a/packages/techdocs-container/techdocs-core/README.md
+++ b/packages/techdocs-container/techdocs-core/README.md
@@ -86,19 +86,19 @@ Extensions:
 
 - Superfences and Codehilite doesn't work very well together (squidfunk/mkdocs-material#1604) so therefore the codehilite extension is replaced by pymdownx.highlight
 
+* Uses pymdownx extensions v.7.1 instead of 8.0.0 to allow legacy_tab_classes config. This makes the techdocs core plugin compatible with the usage of tabs for grouping markdown with the following syntax:
 
-- Uses pymdownx extensions v.7.1 instead of 8.0.0 to allow legacy_tab_classes config. This makes the techdocs core plugin compatible with the usage of tabs for grouping markdown with the following syntax:
-```
-     ```java tab="java 2"
-          public void function() {
-             ....
-         }
-     ```
-```
+````
+    ```java tab="java 2"
+        public void function() {
+            ....
+        }
+    ```
+````
 
-as well as the new 
+as well as the new
 
-```
+````
     === "Java"
 
     ```java
@@ -106,7 +106,8 @@ as well as the new
         ....
     }
     ```
-```
+````
+
 The pymdownx extension will be bumped too 8.0.0 in the near future.
 
 - pymdownx.tabbed is added to support tabs to group markdown content, such as codeblocks.

--- a/packages/techdocs-container/techdocs-core/README.md
+++ b/packages/techdocs-container/techdocs-core/README.md
@@ -48,6 +48,35 @@ python -m black src/
 
 **Note:** This will write to all Python files in `src/` with the formatted code. If you would like to only check to see if it passes, simply append the `--check` flag.
 
+## MkDocs plugins and extensions
+
+The TechDocs Core MkDocs plugin comes with a set of extensions and plugins that mkdocs supports. Below you can find a list of all extensions and plugins that are included in the
+TechDocs Core plugin:
+
+Plugins:
+ - search
+ - mkdocs-monorepo-plugin
+
+Extensions:
+  - admonition
+  - toc
+  - pymdown
+      - caret
+      - critic
+      - details
+      - emoji
+      - inlinehilite
+      - magiclink
+      - mark
+      - smartsymobls
+      - highlight
+      - extra
+      - tabbed
+      - tasklist
+      - tilde
+  - markdown_inline_graphviz
+  - plantuml_markdown
+
 ## Changelog
 
 ### 0.0.7

--- a/packages/techdocs-container/techdocs-core/README.md
+++ b/packages/techdocs-container/techdocs-core/README.md
@@ -54,30 +54,40 @@ The TechDocs Core MkDocs plugin comes with a set of extensions and plugins that 
 TechDocs Core plugin:
 
 Plugins:
- - search
- - mkdocs-monorepo-plugin
+
+- search
+- mkdocs-monorepo-plugin
 
 Extensions:
-  - admonition
-  - toc
-  - pymdown
-      - caret
-      - critic
-      - details
-      - emoji
-      - inlinehilite
-      - magiclink
-      - mark
-      - smartsymobls
-      - highlight
-      - extra
-      - tabbed
-      - tasklist
-      - tilde
-  - markdown_inline_graphviz
-  - plantuml_markdown
+
+- admonition
+- toc
+- pymdown
+  - caret
+  - critic
+  - details
+  - emoji
+  - inlinehilite
+  - magiclink
+  - mark
+  - smartsymobls
+  - highlight
+  - extra
+  - tabbed
+  - tasklist
+  - tilde
+- markdown_inline_graphviz
+- plantuml_markdown
 
 ## Changelog
+
+### 0.0.8
+
+- Superfences and Codehilite doesn't work very well together (squidfunk/mkdocs-material#1604) so therefore the codehilite extension is replaced by pymdownx.highlight
+
+- pymdownx.tabbed is added to support tabs to group markdown content, such as codeblocks.
+
+- "PyMdown Extensions includes three extensions that are meant to replace their counterpart in the default Python Markdown extensions." Therefore some extensions has been taken away in this version that comes by default from pymdownx.extra which is added now (https://facelessuser.github.io/pymdown-extensions/usage_notes/#incompatible-extensions)
 
 ### 0.0.7
 

--- a/packages/techdocs-container/techdocs-core/README.md
+++ b/packages/techdocs-container/techdocs-core/README.md
@@ -55,14 +55,14 @@ TechDocs Core plugin:
 
 Plugins:
 
-- search
-- mkdocs-monorepo-plugin
+- [search](https://www.mkdocs.org/user-guide/configuration/#search)
+- [mkdocs-monorepo-plugin](https://github.com/spotify/mkdocs-monorepo-plugin)
 
 Extensions:
 
-- admonition
-- toc
-- pymdown
+- [admonition](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#admonitions)
+- [toc](https://python-markdown.github.io/extensions/toc/)
+- [pymdown](https://facelessuser.github.io/pymdown-extensions/)
   - caret
   - critic
   - details
@@ -76,8 +76,8 @@ Extensions:
   - tabbed
   - tasklist
   - tilde
-- markdown_inline_graphviz
-- plantuml_markdown
+- [markdown_inline_graphviz](https://pypi.org/project/markdown-inline-graphviz/)
+- [plantuml_markdown](https://pypi.org/project/plantuml-markdown/)
 
 ## Changelog
 

--- a/packages/techdocs-container/techdocs-core/requirements.txt
+++ b/packages/techdocs-container/techdocs-core/requirements.txt
@@ -7,7 +7,7 @@ mkdocs-monorepo-plugin==0.4.5
 plantuml-markdown==3.1.2
 markdown_inline_graphviz_extension==1.1
 pygments==2.6.1
-pymdown-extensions==8.0.0
+pymdown-extensions==7.1
 
 # The linter using for Python
 # Note: This requires Python 3.6+ to run, but can format Python 2 code too.

--- a/packages/techdocs-container/techdocs-core/setup.py
+++ b/packages/techdocs-container/techdocs-core/setup.py
@@ -34,7 +34,7 @@ setup(
         "plantuml-markdown==3.1.2",
         "markdown_inline_graphviz_extension==1.1",
         "pygments==2.6.1",
-        "pymdown-extensions==8.0.0",
+        "pymdown-extensions==7.1",
     ],
     classifiers=[
         "Development Status :: 1 - Planning",

--- a/packages/techdocs-container/techdocs-core/setup.py
+++ b/packages/techdocs-container/techdocs-core/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.0.7",
+    version="0.0.8",
     description="A Mkdocs package that contains TechDocs defaults",
     long_description="",
     keywords="mkdocs",

--- a/packages/techdocs-container/techdocs-core/setup.py
+++ b/packages/techdocs-container/techdocs-core/setup.py
@@ -17,38 +17,34 @@ from setuptools import setup, find_packages
 
 
 setup(
-    name='mkdocs-techdocs-core',
-    version='0.0.7',
-    description='A Mkdocs package that contains TechDocs defaults',
-    long_description='',
-    keywords='mkdocs',
-    url='https://github.com/spotify/backstage',
-    author='TechDocs Core',
-    author_email='pulp-fiction@spotify.com',
-    license='Apache-2.0',
-    python_requires='>=3.7',
+    name="mkdocs-techdocs-core",
+    version="0.0.7",
+    description="A Mkdocs package that contains TechDocs defaults",
+    long_description="",
+    keywords="mkdocs",
+    url="https://github.com/spotify/backstage",
+    author="TechDocs Core",
+    author_email="pulp-fiction@spotify.com",
+    license="Apache-2.0",
+    python_requires=">=3.7",
     install_requires=[
-        'mkdocs>=1.1.2',
-        'mkdocs-material==5.3.2',
-        'mkdocs-monorepo-plugin==0.4.5',
-        'plantuml-markdown==3.1.2',
-        'markdown_inline_graphviz_extension==1.1',
-        'pygments==2.6.1',
-        'pymdown-extensions==8.0.0'
+        "mkdocs>=1.1.2",
+        "mkdocs-material==5.3.2",
+        "mkdocs-monorepo-plugin==0.4.5",
+        "plantuml-markdown==3.1.2",
+        "markdown_inline_graphviz_extension==1.1",
+        "pygments==2.6.1",
+        "pymdown-extensions==8.0.0",
     ],
     classifiers=[
-        'Development Status :: 1 - Planning',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Information Technology',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7'
+        "Development Status :: 1 - Planning",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Information Technology",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.7",
     ],
     packages=find_packages(),
-    entry_points={
-        'mkdocs.plugins': [
-            'techdocs-core = src.core:TechDocsCore'
-        ]
-    }
+    entry_points={"mkdocs.plugins": ["techdocs-core = src.core:TechDocsCore"]},
 )

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -32,7 +32,10 @@ class TechDocsCore(BasePlugin):
 
         # Theme
         config["theme"] = Theme(
-            name="material", static_templates=["techdocs_metadata.json",],
+            name="material",
+            static_templates=[
+                "techdocs_metadata.json",
+            ],
         )
         config["theme"].dirs.append(tempfile.gettempdir())
 
@@ -54,25 +57,11 @@ class TechDocsCore(BasePlugin):
 
         # Markdown Extensions
         config["markdown_extensions"].append("admonition")
-        config["markdown_extensions"].append("abbr")
-        config["markdown_extensions"].append("attr_list")
-        config["markdown_extensions"].append("def_list")
-        config["markdown_extensions"].append("codehilite")
-        config["mdx_configs"]["codehilite"] = {
-            "linenums": True,
-            "guess_lang": False,
-            "pygments_style": "friendly",
-        }
         config["markdown_extensions"].append("toc")
         config["mdx_configs"]["toc"] = {
             "permalink": True,
         }
-        config["markdown_extensions"].append("footnotes")
-        config["markdown_extensions"].append("markdown.extensions.tables")
-        config["markdown_extensions"].append("pymdownx.betterem")
-        config["mdx_configs"]["pymdownx.betterem"] = {
-            "smart_enable": "all",
-        }
+
         config["markdown_extensions"].append("pymdownx.caret")
         config["markdown_extensions"].append("pymdownx.critic")
         config["markdown_extensions"].append("pymdownx.details")
@@ -82,7 +71,16 @@ class TechDocsCore(BasePlugin):
         config["markdown_extensions"].append("pymdownx.magiclink")
         config["markdown_extensions"].append("pymdownx.mark")
         config["markdown_extensions"].append("pymdownx.smartsymbols")
-        config["markdown_extensions"].append("pymdownx.superfences")
+        config["markdown_extensions"].append("pymdownx.highlight")
+
+        config["markdown_extensions"].append("pymdownx.extra")
+        config["mdx_configs"]["pymdownx.highlight"] = {
+            "linenums": True,
+        }
+        config["mdx_configs"]["pymdownx.betterem"] = {
+            "smart_enable": "all",
+        }
+        config["markdown_extensions"].append("pymdownx.tabbed")
         config["markdown_extensions"].append("pymdownx.tasklist")
         config["mdx_configs"]["pymdownx.tasklist"] = {
             "custom_checkbox": True,

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -32,10 +32,7 @@ class TechDocsCore(BasePlugin):
 
         # Theme
         config["theme"] = Theme(
-            name="material",
-            static_templates=[
-                "techdocs_metadata.json",
-            ],
+            name="material", static_templates=["techdocs_metadata.json",],
         )
         config["theme"].dirs.append(tempfile.gettempdir())
 

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -68,6 +68,10 @@ class TechDocsCore(BasePlugin):
         config["markdown_extensions"].append("pymdownx.magiclink")
         config["markdown_extensions"].append("pymdownx.mark")
         config["markdown_extensions"].append("pymdownx.smartsymbols")
+        config["markdown_extensions"].append("pymdownx.superfences")
+        config["mdx_configs"]["pymdownx.superfences"] = {
+            "legacy_tab_classes": True,
+        }
         config["markdown_extensions"].append("pymdownx.highlight")
         config["mdx_configs"]["pymdownx.highlight"] = {
             "linenums": True,

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -72,11 +72,10 @@ class TechDocsCore(BasePlugin):
         config["markdown_extensions"].append("pymdownx.mark")
         config["markdown_extensions"].append("pymdownx.smartsymbols")
         config["markdown_extensions"].append("pymdownx.highlight")
-
-        config["markdown_extensions"].append("pymdownx.extra")
         config["mdx_configs"]["pymdownx.highlight"] = {
             "linenums": True,
         }
+        config["markdown_extensions"].append("pymdownx.extra")
         config["mdx_configs"]["pymdownx.betterem"] = {
             "smart_enable": "all",
         }

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -14,7 +14,7 @@
  * limitations under the License.
 """
 
-from mkdocs.plugins import BasePlugin, PluginCollection
+from mkdocs.plugins import BasePlugin
 from mkdocs.theme import Theme
 from mkdocs.contrib.search import SearchPlugin
 from mkdocs_monorepo_plugin.plugin import MonorepoPlugin


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* Superfences and Codehilite doesn't work very well together (https://github.com/squidfunk/mkdocs-material/issues/1604) so therefore the codehilite extension is replaced by `pymdownx.highlight`

* Uses pymdownx extensions v.7.1 instead of 8.0.0 to allow legacy_tab_classes config. This makes the techdocs core plugin compatible with the usage of tabs for grouping markdown with the following syntax:
```
     ```java tab="java 2"
          public void function() {
             ....
         }
     ```
```

instead of the new 

```
    === "Java"

    ```java
    public void function() {
        ....
    }
    ```
```
The pymdownx extension will be bumped too 8.0.0 in the near future.

* `pymdownx.tabbed` is added to support tabs to group markdown content, such as codeblocks
https://github.com/squidfunk/mkdocs-material/issues/1762

* "PyMdown Extensions includes three extensions that are meant to replace their counterpart in the default Python Markdown extensions." Therefore some extensions has been taken away in this PR that comes by default from `pymdownx.extra` which is added now (https://facelessuser.github.io/pymdown-extensions/usage_notes/#incompatible-extensions)


#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
