### PR TITLE
feat(catalog-backend): delete log entries older than a cutoff

### DIFF
--- a/plugins/catalog-backend/src/database/CommonDatabase.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.ts
@@ -343,7 +343,14 @@ export class CommonDatabase implements Database {
     entityName?: string,
     message?: string,
   ): Promise<void> {
-    return this.database<DatabaseLocationUpdateLogEvent>(
+    // Remove log entries older than a day
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - 1);
+    await this.database<DatabaseLocationUpdateLogEvent>('location_update_log')
+      .where('created_at', '<', cutoff.toISOString())
+      .del();
+
+    await this.database<DatabaseLocationUpdateLogEvent>(
       'location_update_log',
     ).insert({
       status,


### PR DESCRIPTION
Fixes #2376

This is a bit arbitrary, but pending a proper rewrite of how we handle event logging, this is better than nothing.