### PR TITLE
Update quickstart-app-auth.md

### DIFF
--- a/docs/tutorials/quickstart-app-auth.md
+++ b/docs/tutorials/quickstart-app-auth.md
@@ -41,7 +41,7 @@ From the terminal:
 ℹ ｢wds｣: Project is running at http://localhost:3000/
 ```
 
-Once the app compiles, a browser window should have popped with your stand alone
+Once the app compiles, a browser window should have popped with your stand-alone
 application loaded at `localhost:3000`. This could take a couple minutes.
 
 ```zsh


### PR DESCRIPTION
stand-alone/standalone are used as an adjective. You can think of it as a synonym for independent.
Stand alone is a verb phrase.

## Hey, I just made a Pull Request!

Updated text to grammatically reflect the documentation. 

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
