### PR TITLE
create-app: fix missing .gitignore file when new app is scaffolded

### DIFF
--- a/packages/create-app/templates/default-app/.gitignore.hbs
+++ b/packages/create-app/templates/default-app/.gitignore.hbs
@@ -1,4 +1,3 @@
-
 # Logs
 logs
 *.log


### PR DESCRIPTION
## Hey, I just made a Pull Request!

when an app is created using `npx @backstage/create-app` there is no gitignore file present.
renamed the file to `.gitignore.hbs` so that it is not ignored by pack, later during templating it is renamed to `.gitignore`

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
