### PR TITLE
Update docker base image to buster for node

### DIFF
--- a/contrib/docker/multi-stage-frontend/Dockerfile
+++ b/contrib/docker/multi-stage-frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12 AS build
+FROM node:12-buster AS build
 
 RUN mkdir /app
 COPY . /app

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12-buster
 
 WORKDIR /usr/src/app
 

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12-buster
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The version of python in debian slim (3.5) is too old for mkdocs-techdocs-core to be installed via package manager, buster ships with 3.7 which is new enough to work

Without this change you get:
```
  Could not find a version that satisfies the requirement mkdocs-techdocs-core (from versions: )
Cleaning up...
No matching distribution found for mkdocs-techdocs-core
```

Which is not very informative and took me awhile to figure out (especially because of slow docker builds 👅 )


#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
