### PR TITLE
core/package.json: pin core-api to same version as core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@backstage/config": "^0.1.1-alpha.22",
-    "@backstage/core-api": "^0.1.1-alpha.22",
+    "@backstage/core-api": "0.1.1-alpha.22",
     "@backstage/theme": "^0.1.1-alpha.22",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
`@backstage/core-api` is an internal package that should never be depended on directly. The version of `@backstage/core` should be what determines the version of `@backstage/core-api`, not the lockfile.
