### PR TITLE
Auth0 provider type is incompatible with SignInPage#providers prop

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -45,7 +45,7 @@ const app = createApp({
       return (
         <SignInPage
           {...props}
-          providers={['guest', 'custom', ...providers]}
+          providers={providers}
           title="Select a sign-in method"
           align="center"
         />

--- a/packages/app/src/identityProviders.ts
+++ b/packages/app/src/identityProviders.ts
@@ -20,6 +20,7 @@ import {
   oktaAuthApiRef,
   githubAuthApiRef,
   microsoftAuthApiRef,
+  auth0AuthApiRef,
 } from '@backstage/core';
 
 export const providers = [
@@ -52,5 +53,11 @@ export const providers = [
     title: 'Okta',
     message: 'Sign In using Okta',
     apiRef: oktaAuthApiRef,
+  },
+  {
+    id: 'auth0-auth-provider',
+    title: 'Auth0',
+    message: 'Sign in using Auth0',
+    apiRef: auth0AuthApiRef,
   },
 ];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I'm trying to use Auth0 provider for authentication. It works at runtime but fails when I run `yarn tsc` because of the following error:

![image](https://user-images.githubusercontent.com/74687/93772631-0cdf4080-fbed-11ea-943f-9c2152f9af40.png)

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
