### PR TITLE
TechDocs: Fix issue when docs were in repos with long path names/deep nesting

### DIFF
--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -26,6 +26,7 @@ import { InputError } from '@backstage/backend-common';
 import { RemoteProtocol } from './techdocs/stages/prepare/types';
 import { Logger } from 'winston';
 
+// Enables core.longpaths on windows to prevent crashing when checking out repos with long foldernames and/or deep nesting
 // @ts-ignore
 NodeGit.Libgit2.opts(28, 1);
 

--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -17,7 +17,7 @@
 import os from 'os';
 import path from 'path';
 import parseGitUrl from 'git-url-parse';
-import { Clone, Repository } from 'nodegit';
+import NodeGit, { Clone, Repository } from 'nodegit';
 import fs from 'fs-extra';
 // @ts-ignore
 import defaultBranch from 'default-branch';
@@ -25,6 +25,9 @@ import { Entity } from '@backstage/catalog-model';
 import { InputError } from '@backstage/backend-common';
 import { RemoteProtocol } from './techdocs/stages/prepare/types';
 import { Logger } from 'winston';
+
+// @ts-ignore
+NodeGit.Libgit2.opts(28, 1);
 
 export type ParsedLocationAnnotation = {
   type: RemoteProtocol;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This enables gits config core.longpaths on windows when using nodegit in the techdocs-backend, and should enable checkouts of backstage and other repositories with deep nesting/long path names.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
