### PR TITLE
inline styles -> class rule for default alignment

### DIFF
--- a/packages/core/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.tsx
@@ -37,6 +37,7 @@ const useStyles = makeStyles(theme => ({
     },
   },
   header: {
+    display: 'inline-block',
     padding: theme.spacing(2, 2, 2, 2.5),
   },
   headerTitle: {
@@ -202,7 +203,7 @@ export const InfoCard = ({
               }}
               title={title}
               subheader={subheader}
-              style={{ display: 'inline-block', ...headerStyle }}
+              style={{ ...headerStyle }}
               {...headerProps}
             />
             <Divider />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Applies default styles to CardHeader using MUI class rule instead of inline.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
