### PR TITLE
ci: Collect code coverage reports for individual packages

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,13 @@ coverage:
       default:
         threshold: 0% # Ref: https://docs.codecov.io/docs/codecovyml-reference#coveragestatus
         target: auto
+
+# Since Backstage is a mono repo, flags here help in getting the code coverage of individual packages.
+# Documentation: https://docs.codecov.io/docs/flags
+flags:
+  packages-core:
+    paths:
+      - packages/core/
+  packages-core-api:
+    paths:
+      - packages/core-api/

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,9 +10,9 @@ coverage:
 # Since Backstage is a mono repo, flags here help in getting the code coverage of individual packages.
 # Documentation: https://docs.codecov.io/docs/flags
 flags:
-  packages-core:
+  core:
     paths:
       - packages/core/
-  packages-core-api:
+  core-api:
     paths:
       - packages/core-api/

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,8 +64,8 @@ jobs:
           yarn lerna -- run test -- --coverage
           bash <(curl -s https://codecov.io/bash)
           # Upload code coverage for some specific flags. Also see .codecov.yml
-          bash <(curl -s https://codecov.io/bash) -f packages/core/coverage/* -F packages-core
-          bash <(curl -s https://codecov.io/bash) -f packages/core-api/coverage/* -F packages-core-api
+          bash <(curl -s https://codecov.io/bash) -f packages/core/coverage/* -F core
+          bash <(curl -s https://codecov.io/bash) -f packages/core-api/coverage/* -F core-api
 
       # Publishes current version of packages that are not already present in the registry
       - name: publish

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -63,6 +63,9 @@ jobs:
         run: |
           yarn lerna -- run test -- --coverage
           bash <(curl -s https://codecov.io/bash)
+          # Upload code coverage for some specific flags. Also see .codecov.yml
+          bash <(curl -s https://codecov.io/bash) -f packages/core/coverage/* -F packages-core
+          bash <(curl -s https://codecov.io/bash) -f packages/core-api/coverage/* -F packages-core-api
 
       # Publishes current version of packages that are not already present in the registry
       - name: publish


### PR DESCRIPTION
Since Backstage is a mono-repo, each package should be able to set their own Code coverage configurations using something called [Codecov flags](https://docs.codecov.io/docs/flags).

This PR enables two flags for the `core` and `core-api` packages. Codecov should be able to provide specific coverage for these packages along with the one for the mono-repo. We should aim to add more core packages here in future.

Since this change will run on the master branch workflow, I am not 100% that this will work as it is. :)