### PR TITLE
core: Add initial RouteRefRegistry

### DIFF
--- a/packages/core-api/src/routing/RouteRef.ts
+++ b/packages/core-api/src/routing/RouteRef.ts
@@ -84,3 +84,8 @@ export class AbsoluteRouteRef implements ConcreteRoute {
 export function createRouteRef(config: RouteRefConfig): AbsoluteRouteRef {
   return new AbsoluteRouteRef(config);
 }
+
+// TODO(Rugvip): Added for backwards compatibility, remove once old usage is gone
+// We may want to avoid exporting the AbsoluteRouteRef itself though, and consider
+// a different model for how to create sub routes, just avoid this
+export type MutableRouteRef = AbsoluteRouteRef;

--- a/packages/core-api/src/routing/RouteRef.ts
+++ b/packages/core-api/src/routing/RouteRef.ts
@@ -14,30 +14,25 @@
  * limitations under the License.
  */
 
-import type { RouteRefConfig, RouteRefOverrideConfig } from './types';
+import type { RouteRefConfig } from './types';
 
-export class MutableRouteRef {
-  private effectiveConfig: RouteRefConfig = this.config;
-
+export class AbsoluteRouteRef {
   constructor(private readonly config: RouteRefConfig) {}
 
-  override(overrideConfig: RouteRefOverrideConfig) {
-    this.effectiveConfig = { ...this.config, ...overrideConfig };
-  }
-
   get icon() {
-    return this.effectiveConfig.icon;
+    return this.config.icon;
   }
 
+  // TODO(Rugvip): Remove this, routes are looked up via the registry instead
   get path() {
-    return this.effectiveConfig.path;
+    return this.config.path;
   }
 
   get title() {
-    return this.effectiveConfig.title;
+    return this.config.title;
   }
 }
 
-export function createRouteRef(config: RouteRefConfig): MutableRouteRef {
-  return new MutableRouteRef(config);
+export function createRouteRef(config: RouteRefConfig): AbsoluteRouteRef {
+  return new AbsoluteRouteRef(config);
 }

--- a/packages/core-api/src/routing/RouteRef.ts
+++ b/packages/core-api/src/routing/RouteRef.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import type { RouteRefConfig } from './types';
+import { ConcreteRoute, resolveRoute, RouteRefConfig } from './types';
 
-export class AbsoluteRouteRef {
+export class AbsoluteRouteRef implements ConcreteRoute {
   constructor(private readonly config: RouteRefConfig) {}
 
   get icon() {
@@ -30,6 +30,10 @@ export class AbsoluteRouteRef {
 
   get title() {
     return this.config.title;
+  }
+
+  [resolveRoute](path: string) {
+    return path;
   }
 }
 

--- a/packages/core-api/src/routing/RouteRef.ts
+++ b/packages/core-api/src/routing/RouteRef.ts
@@ -14,7 +14,36 @@
  * limitations under the License.
  */
 
-import { ConcreteRoute, resolveRoute, RouteRefConfig } from './types';
+import { ConcreteRoute, ref, resolveRoute, RouteRefConfig } from './types';
+import { generatePath } from 'react-router-dom';
+
+type SubRouteConfig = {
+  path: string;
+};
+
+export class SubRouteRef<T extends { [name in string]: string }> {
+  constructor(
+    private readonly parent: ConcreteRoute,
+    private readonly config: SubRouteConfig,
+  ) {}
+
+  [ref]() {
+    return this;
+  }
+
+  link(params: T): ConcreteRoute {
+    const selfRef = this as unknown;
+
+    return {
+      [ref]: () => selfRef,
+      [resolveRoute]: (path: string) => {
+        const ownPart = generatePath(this.config.path, params);
+        const parentPart = this.parent[resolveRoute](path);
+        return parentPart + ownPart;
+      },
+    };
+  }
+}
 
 export class AbsoluteRouteRef implements ConcreteRoute {
   constructor(private readonly config: RouteRefConfig) {}
@@ -30,6 +59,16 @@ export class AbsoluteRouteRef implements ConcreteRoute {
 
   get title() {
     return this.config.title;
+  }
+
+  createSubRoute<T extends { [name in string]: string }>(
+    config: SubRouteConfig,
+  ) {
+    return new SubRouteRef<T>(this, config);
+  }
+
+  [ref]() {
+    return this;
   }
 
   [resolveRoute](path: string) {

--- a/packages/core-api/src/routing/RouteRef.ts
+++ b/packages/core-api/src/routing/RouteRef.ts
@@ -14,28 +14,33 @@
  * limitations under the License.
  */
 
-import { ConcreteRoute, ref, resolveRoute, RouteRefConfig } from './types';
+import {
+  ConcreteRoute,
+  routeReference,
+  ReferencedRoute,
+  resolveRoute,
+  RouteRefConfig,
+} from './types';
 import { generatePath } from 'react-router-dom';
 
 type SubRouteConfig = {
   path: string;
 };
 
-export class SubRouteRef<T extends { [name in string]: string }> {
+export class SubRouteRef<T extends { [name in string]: string }>
+  implements ReferencedRoute {
   constructor(
     private readonly parent: ConcreteRoute,
     private readonly config: SubRouteConfig,
   ) {}
 
-  [ref]() {
+  get [routeReference]() {
     return this;
   }
 
   link(params: T): ConcreteRoute {
-    const selfRef = this as unknown;
-
     return {
-      [ref]: () => selfRef,
+      [routeReference]: this,
       [resolveRoute]: (path: string) => {
         const ownPart = generatePath(this.config.path, params);
         const parentPart = this.parent[resolveRoute](path);
@@ -67,7 +72,7 @@ export class AbsoluteRouteRef implements ConcreteRoute {
     return new SubRouteRef<T>(this, config);
   }
 
-  [ref]() {
+  get [routeReference]() {
     return this;
   }
 

--- a/packages/core-api/src/routing/RouteRef.ts
+++ b/packages/core-api/src/routing/RouteRef.ts
@@ -27,7 +27,7 @@ type SubRouteConfig = {
   path: string;
 };
 
-export class SubRouteRef<T extends { [name in string]: string }>
+export class SubRouteRef<T extends { [name in string]: string } | never = never>
   implements ReferencedRoute {
   constructor(
     private readonly parent: ConcreteRoute,
@@ -38,11 +38,11 @@ export class SubRouteRef<T extends { [name in string]: string }>
     return this;
   }
 
-  link(params: T): ConcreteRoute {
+  link<Args extends T extends never ? [] : [T]>(...args: Args): ConcreteRoute {
     return {
       [routeReference]: this,
       [resolveRoute]: (path: string) => {
-        const ownPart = generatePath(this.config.path, params);
+        const ownPart = generatePath(this.config.path, args[0] ?? {});
         const parentPart = this.parent[resolveRoute](path);
         return parentPart + ownPart;
       },
@@ -66,7 +66,7 @@ export class AbsoluteRouteRef implements ConcreteRoute {
     return this.config.title;
   }
 
-  createSubRoute<T extends { [name in string]: string }>(
+  createSubRoute<T extends { [name in string]: string } | never = never>(
     config: SubRouteConfig,
   ) {
     return new SubRouteRef<T>(this, config);

--- a/packages/core-api/src/routing/RouteRefRegistry.test.ts
+++ b/packages/core-api/src/routing/RouteRefRegistry.test.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { RouteRefRegistry } from './RouteRefRegistry';
+import { RouteRefRegistry, resolveRoute } from './RouteRefRegistry';
 
-const ref1 = {};
-const ref11 = {};
-const ref12 = {};
-const ref121 = {};
-const ref2 = {};
+const ref1 = { [resolveRoute]: (path: string) => path };
+const ref11 = { [resolveRoute]: (path: string) => path };
+const ref12 = { [resolveRoute]: (path: string) => path };
+const ref121 = { [resolveRoute]: (path: string) => path };
+const ref2 = { [resolveRoute]: (path: string) => path };
 
 describe('RouteRefRegistry', () => {
   it('should be constructed with a root route', () => {
@@ -41,18 +41,20 @@ describe('RouteRefRegistry', () => {
     expect(registry.registerRoute([ref2], '2')).toBe(true);
     expect(registry.registerRoute([ref2], 'duplicate')).toBe(false);
 
-    expect(registry.resolveRoute([], [ref1])).toBe('1');
+    expect(registry.resolveRoute([], [ref1])).toBe('/1');
     expect(registry.resolveRoute([], [ref11])).toBe(undefined);
-    expect(registry.resolveRoute([], [ref1, ref11])).toBe('11');
-    expect(registry.resolveRoute([ref1], [ref11])).toBe('11');
-    expect(registry.resolveRoute([ref1], [ref2])).toBe('2');
-    expect(registry.resolveRoute([ref1, ref12, ref121], [])).toBe('121');
-    expect(registry.resolveRoute([ref1, ref12, ref121], [ref121])).toBe('121');
-    expect(registry.resolveRoute([ref1, ref12, ref121], [ref12, ref121])).toBe(
-      '121',
+    expect(registry.resolveRoute([], [ref1, ref11])).toBe('/1/11');
+    expect(registry.resolveRoute([ref1], [ref11])).toBe('/1/11');
+    expect(registry.resolveRoute([ref1], [ref2])).toBe('/2');
+    expect(registry.resolveRoute([ref1, ref12, ref121], [])).toBe('/1/12/121');
+    expect(registry.resolveRoute([ref1, ref12, ref121], [ref121])).toBe(
+      '/1/12/121',
     );
-    expect(registry.resolveRoute([ref1, ref12, ref121], [ref12])).toBe('12');
-    expect(registry.resolveRoute([ref1, ref12, ref121], [ref1])).toBe('1');
+    expect(registry.resolveRoute([ref1, ref12, ref121], [ref12, ref121])).toBe(
+      '/1/12/121',
+    );
+    expect(registry.resolveRoute([ref1, ref12, ref121], [ref12])).toBe('/1/12');
+    expect(registry.resolveRoute([ref1, ref12, ref121], [ref1])).toBe('/1');
   });
 
   it('should throw when registering routes incorrectly', () => {

--- a/packages/core-api/src/routing/RouteRefRegistry.test.ts
+++ b/packages/core-api/src/routing/RouteRefRegistry.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouteRefRegistry } from './RouteRefRegistry';
+
+const ref1 = {};
+const ref11 = {};
+const ref12 = {};
+const ref121 = {};
+const ref2 = {};
+
+describe('RouteRefRegistry', () => {
+  it('should be constructed with a root route', () => {
+    const registry = new RouteRefRegistry();
+    expect(registry.resolveRoute([], [])).toBe('');
+  });
+
+  it('should register and resolve some routes', () => {
+    const registry = new RouteRefRegistry();
+    expect(registry.registerRoute([ref1], '1')).toBe(true);
+    expect(registry.registerRoute([ref1, ref11], '11')).toBe(true);
+    expect(registry.registerRoute([ref1, ref12], '12')).toBe(true);
+    expect(registry.registerRoute([ref1, ref12, ref121], '121')).toBe(true);
+    expect(registry.registerRoute([ref1, ref12, ref121], 'duplicate')).toBe(
+      false,
+    );
+    expect(registry.registerRoute([ref1, ref12], 'duplicate')).toBe(false);
+    expect(registry.registerRoute([ref2], '2')).toBe(true);
+    expect(registry.registerRoute([ref2], 'duplicate')).toBe(false);
+
+    expect(registry.resolveRoute([], [ref1])).toBe('1');
+    expect(registry.resolveRoute([], [ref11])).toBe(undefined);
+    expect(registry.resolveRoute([], [ref1, ref11])).toBe('11');
+    expect(registry.resolveRoute([ref1], [ref11])).toBe('11');
+    expect(registry.resolveRoute([ref1], [ref2])).toBe('2');
+    expect(registry.resolveRoute([ref1, ref12, ref121], [])).toBe('121');
+    expect(registry.resolveRoute([ref1, ref12, ref121], [ref121])).toBe('121');
+    expect(registry.resolveRoute([ref1, ref12, ref121], [ref12, ref121])).toBe(
+      '121',
+    );
+    expect(registry.resolveRoute([ref1, ref12, ref121], [ref12])).toBe('12');
+    expect(registry.resolveRoute([ref1, ref12, ref121], [ref1])).toBe('1');
+  });
+
+  it('should throw when registering routes incorrectly', () => {
+    const registry = new RouteRefRegistry();
+    expect(() => {
+      registry.registerRoute([ref1, ref11], '11');
+    }).toThrow('Could not find parent for new routing node');
+    expect(() => {
+      registry.registerRoute([], '11');
+    }).toThrow('Must provide at least 1 route to add routing node');
+  });
+});

--- a/packages/core-api/src/routing/RouteRefRegistry.test.ts
+++ b/packages/core-api/src/routing/RouteRefRegistry.test.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { RouteRefRegistry, resolveRoute } from './RouteRefRegistry';
+import { RouteRefRegistry } from './RouteRefRegistry';
+import { resolveRoute } from './types';
 
 const ref1 = { [resolveRoute]: (path: string) => path };
 const ref11 = { [resolveRoute]: (path: string) => path };

--- a/packages/core-api/src/routing/RouteRefRegistry.test.ts
+++ b/packages/core-api/src/routing/RouteRefRegistry.test.ts
@@ -15,13 +15,14 @@
  */
 
 import { RouteRefRegistry } from './RouteRefRegistry';
-import { resolveRoute } from './types';
+import { createRouteRef } from './RouteRef';
 
-const ref1 = { [resolveRoute]: (path: string) => path };
-const ref11 = { [resolveRoute]: (path: string) => path };
-const ref12 = { [resolveRoute]: (path: string) => path };
-const ref121 = { [resolveRoute]: (path: string) => path };
-const ref2 = { [resolveRoute]: (path: string) => path };
+const dummyConfig = { path: '/', icon: null, title: 'my-title' };
+const ref1 = createRouteRef(dummyConfig);
+const ref11 = createRouteRef(dummyConfig);
+const ref12 = createRouteRef(dummyConfig);
+const ref121 = createRouteRef(dummyConfig);
+const ref2 = createRouteRef(dummyConfig);
 
 describe('RouteRefRegistry', () => {
   it('should be constructed with a root route', () => {

--- a/packages/core-api/src/routing/RouteRefRegistry.test.ts
+++ b/packages/core-api/src/routing/RouteRefRegistry.test.ts
@@ -44,6 +44,7 @@ describe('RouteRefRegistry', () => {
     expect(registry.registerRoute([ref1, ref12], 'duplicate')).toBe(false);
     expect(registry.registerRoute([ref2], '2')).toBe(true);
     expect(registry.registerRoute([ref2], 'duplicate')).toBe(false);
+    expect(registry.registerRoute([ref2], '2')).toBe(true);
 
     expect(registry.resolveRoute([], [ref1])).toBe('/1');
     expect(registry.resolveRoute([], [ref11])).toBe(undefined);

--- a/packages/core-api/src/routing/RouteRefRegistry.test.ts
+++ b/packages/core-api/src/routing/RouteRefRegistry.test.ts
@@ -75,12 +75,10 @@ describe('RouteRefRegistry', () => {
 
     expect(registry.resolveRoute([], [ref1])).toBe('/1');
     expect(registry.resolveRoute([], [ref2])).toBe('/2');
-    expect(registry.resolveRoute([], [ref2a.link({}), ref1])).toBe('/2/a/1');
-    expect(registry.resolveRoute([], [ref2a.link({}), ref2])).toBe('/2/a/2');
-    expect(registry.resolveRoute([ref2a.link({})], [ref2])).toBe('/2/a/2');
-    expect(registry.resolveRoute([ref2a.link({}), ref1], [ref2])).toBe(
-      '/2/a/2',
-    );
+    expect(registry.resolveRoute([], [ref2a.link(), ref1])).toBe('/2/a/1');
+    expect(registry.resolveRoute([], [ref2a.link(), ref2])).toBe('/2/a/2');
+    expect(registry.resolveRoute([ref2a.link()], [ref2])).toBe('/2/a/2');
+    expect(registry.resolveRoute([ref2a.link(), ref1], [ref2])).toBe('/2/a/2');
     expect(registry.resolveRoute([], [ref2b.link({ id: 'abc' }), ref1])).toBe(
       '/2/b/abc/1',
     );

--- a/packages/core-api/src/routing/RouteRefRegistry.ts
+++ b/packages/core-api/src/routing/RouteRefRegistry.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-export const resolveRoute = Symbol('resolve-route');
-
-type ConcreteRoute = {
-  [resolveRoute](path: string): string;
-};
+import { ConcreteRoute, resolveRoute } from './types';
 
 const rootRoute: ConcreteRoute = {
   [resolveRoute]: () => '',

--- a/packages/core-api/src/routing/RouteRefRegistry.ts
+++ b/packages/core-api/src/routing/RouteRefRegistry.ts
@@ -68,8 +68,10 @@ class Node {
 
     const lastRoute = routes[routes.length - 1];
     const lastRouteRef = lastRoute[routeReference];
-    if (parentNode.children.has(lastRouteRef)) {
-      return false;
+
+    const existingNode = parentNode.children.get(lastRouteRef);
+    if (existingNode) {
+      return existingNode.path === path;
     }
 
     parentNode.children.set(lastRouteRef, new Node(path, parentNode));

--- a/packages/core-api/src/routing/RouteRefRegistry.ts
+++ b/packages/core-api/src/routing/RouteRefRegistry.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-import { ConcreteRoute, ref, resolveRoute, ReferencedRoute } from './types';
+import {
+  ConcreteRoute,
+  routeReference,
+  resolveRoute,
+  ReferencedRoute,
+} from './types';
 
 const rootRoute: ConcreteRoute = {
-  [ref]() {
+  get [routeReference]() {
     return this;
   },
   [resolveRoute]: () => '',
@@ -39,7 +44,7 @@ class Node {
     let node = this as Node | undefined;
 
     for (let i = 0; i < routes.length; i++) {
-      node = node?.children.get(routes[i][ref]());
+      node = node?.children.get(routes[i][routeReference]);
     }
 
     return node;
@@ -62,7 +67,7 @@ class Node {
     }
 
     const lastRoute = routes[routes.length - 1];
-    const lastRouteRef = lastRoute[ref]();
+    const lastRouteRef = lastRoute[routeReference];
     if (parentNode.children.has(lastRouteRef)) {
       return false;
     }

--- a/packages/core-api/src/routing/index.ts
+++ b/packages/core-api/src/routing/index.ts
@@ -14,6 +14,5 @@
  * limitations under the License.
  */
 
-export * from './types';
+export type { RouteRef, RouteRefConfig, ConcreteRoute } from './types';
 export { createRouteRef } from './RouteRef';
-export type { MutableRouteRef } from './RouteRef';

--- a/packages/core-api/src/routing/index.ts
+++ b/packages/core-api/src/routing/index.ts
@@ -15,4 +15,5 @@
  */
 
 export type { RouteRef, RouteRefConfig, ConcreteRoute } from './types';
+export type { MutableRouteRef, AbsoluteRouteRef } from './RouteRef';
 export { createRouteRef } from './RouteRef';

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -17,8 +17,13 @@
 import { IconComponent } from '../icons';
 
 export const resolveRoute = Symbol('resolve-route');
+export const ref = Symbol('route-ref');
 
-export type ConcreteRoute = {
+export type ReferencedRoute = {
+  [ref](): unknown;
+};
+
+export type ConcreteRoute = ReferencedRoute & {
   [resolveRoute](path: string): string;
 };
 

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -16,7 +16,14 @@
 
 import { IconComponent } from '../icons';
 
+export const resolveRoute = Symbol('resolve-route');
+
+export type ConcreteRoute = {
+  [resolveRoute](path: string): string;
+};
+
 export type RouteRef = {
+  // TODO(Rugvip): Remove path, look up via registry instead
   path: string;
   icon?: IconComponent;
   title: string;
@@ -26,10 +33,4 @@ export type RouteRefConfig = {
   path: string;
   icon?: IconComponent;
   title: string;
-};
-
-export type RouteRefOverrideConfig = {
-  path?: string;
-  icon?: IconComponent;
-  title?: string;
 };

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -17,10 +17,10 @@
 import { IconComponent } from '../icons';
 
 export const resolveRoute = Symbol('resolve-route');
-export const ref = Symbol('route-ref');
+export const routeReference = Symbol('route-ref');
 
 export type ReferencedRoute = {
-  [ref](): unknown;
+  [routeReference]: unknown;
 };
 
 export type ConcreteRoute = ReferencedRoute & {


### PR DESCRIPTION
Starting out some work to bring routing back and working as part of the work towards finalizing https://github.com/spotify/backstage/issues/1536

This is some of the groundwork of an experiment we're working on to enable routing via `RouteRef`s, while letting the app itself look something like this:

```tsx
const App = () => (
  <BackstageRoutes>
    <Navigate key="/" to="/catalog" />
    <CatalogRoute path="/catalog" > // catalogRouteRef
      <EntityPage type="service">
        <OverviewContent path="/">
          <WidgetA />
          <WidgetB />
        </OverviewContent>
        <CICDSwitcher path="/ci-cd" />
        <StatusRoute path="/api-status" /> // statusRouteRef
        <ApiDocsRoute path="/api" />
        <DocsRoute path="/docs" />
      </EntityPage>

      <EntityPage type="website">
        <OverviewContent path="/">
          <WidgetA />
          <WidgetB />
        </OverviewContent>
        <CICDSwitcher path="/ci-cd" />
        <SentryRoute path="/sentry" /> // sentryRouteRef
        <DocsRoute path="/docs" />
      </EntityPage>

      <EntityPage>
        <OverviewContent path="/">
          <WidgetA />
          <WidgetB />
        </OverviewContent>
        <DocsRoute path="/docs" />
      </EntityPage>
    </CatalogRoute>
    <DocsRoute path="/docs" />
    <TechRadarRoute path="/tech-radar" width={1500} height={800} />
    <GraphiQLRoute path="/graphiql" />
    <LighthouseRoute path="/lighthouse" />
  </BackstageRoutes>
)
```

As part of inverting the composition of the app, route refs and routing in general was somewhat broken, intentionally. Right now it's not really possible to easily route to different parts of the app from a plugin, or even different parts of the plugin that are not within the same router.

The core part of the experiment is to construct a map of `ApiRef[]` -> path overrides.  Each key in the map is the list of route refs to traversed to reach a leaf in the routing tree, and the value is the `path` override at that point. For example, the above tree would add entries like `[techDocsRouteRef] -> '/docs'`, and `[entityRouteRef,  apiDocsRouteRef] -> '/api'`. By mapping out the entire app in this structure, the idea is that we can navigate to any point in the app using `RouteRef`s.

The `RouteRefRegistry` is an implementation of such a map, and the idea is to add it in master to make it a bit easier to experiment and iterate. This is not an exposed API at this point.

We've explored a couple of alternatives for how to enable routing, but it's boiled down to either a solution centred around the route map mentioned above, or treating all routes as static and globally unique, with no room for flexibility, customization or conflicts between different plugins. We're starting out pursuing this options :grin:.  We also expect that a the app-wide routing table will make things like dynamic loading a lot cleaner, as there would be a much more clear handoff between the main chunk and dynamic chunks.