### PR TITLE
bug(gql): use import to import the graphql module

### DIFF
--- a/plugins/catalog-graphql/src/graphql/module.ts
+++ b/plugins/catalog-graphql/src/graphql/module.ts
@@ -22,6 +22,7 @@ import { Config } from '@backstage/config';
 import { CatalogClient } from '../service/client';
 import GraphQLJSON, { GraphQLJSONObject } from 'graphql-type-json';
 import { Entity } from '@backstage/catalog-model';
+import typeDefs from '../schema';
 
 export interface ModuleOptions {
   logger: Logger;
@@ -31,8 +32,6 @@ export interface ModuleOptions {
 export async function createModule(
   options: ModuleOptions,
 ): Promise<GraphQLModule> {
-  const { default: typeDefs } = require('../schema');
-
   const catalogClient = new CatalogClient(
     options.config.getString('backend.baseUrl'),
   );


### PR DESCRIPTION
The schema not added to the built package because it's a javascript file not typescript and we were using `require`

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
