### PR TITLE
TechDocs: use the content of the readme as description for the techdocs-core package on pypi

### DIFF
--- a/packages/techdocs-container/techdocs-core/setup.py
+++ b/packages/techdocs-container/techdocs-core/setup.py
@@ -14,13 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from setuptools import setup, find_packages
+from os import path
 
+# read the contents of the README file in the current directory
+this_dir = path.abspath(path.dirname(__file__))
+with open(path.join(this_dir, "README.md"), encoding="utf-8") as file:
+    long_description = file.read()
 
 setup(
     name="mkdocs-techdocs-core",
     version="0.0.8",
     description="A Mkdocs package that contains TechDocs defaults",
-    long_description="",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     keywords="mkdocs",
     url="https://github.com/spotify/backstage",
     author="TechDocs Core",


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Currently, we have no description to our [techdocs-core package on pypi](https://pypi.org/project/mkdocs-techdocs-core/), which we want. And we want to use the README in the techdocs-core package for that to avoid having to update a description in many places. According to [these docs](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#:~:text=README%20files%20can%20help%20your,so%20it%20appears%20on%20PyPI.) this PR should solve that. 

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
