### PR TITLE
create-plugin: export a router

### DIFF
--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -26,12 +26,14 @@
   "dependencies": {
     "@backstage/core": "^{{backstageVersion}}",
     "@backstage/theme": "^{{backstageVersion}}",
+    "@backstage/catalog-model": "^{{backstageVersion}}",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-use": "^15.3.3"
+    "react-use": "^15.3.3",
+    "react-router": "6.0.0-beta.0"
   },
   "devDependencies": {
     "@backstage/cli": "^{{backstageVersion}}",

--- a/packages/cli/templates/default-plugin/src/components/Router.tsx.hbs
+++ b/packages/cli/templates/default-plugin/src/components/Router.tsx.hbs
@@ -22,10 +22,10 @@ export const Router = ({ entity }: { entity: Entity }) => {
   return (
     <Routes>
       <Route
+        key={entity.metadata.name}
         path="/"
         element={<ExampleFetchComponent />}
       />
-      )
     </Routes>
   );
 };

--- a/packages/cli/templates/default-plugin/src/components/Router.tsx.hbs
+++ b/packages/cli/templates/default-plugin/src/components/Router.tsx.hbs
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Entity } from '@backstage/catalog-model';
+import { Routes, Route } from 'react-router';
+import ExampleFetchComponent from './ExampleFetchComponent';
+
+export const Router = ({ entity }: { entity: Entity }) => {
+  return (
+    <Routes>
+      <Route
+        path="/"
+        element={<ExampleFetchComponent />}
+      />
+      )
+    </Routes>
+  );
+};

--- a/packages/cli/templates/default-plugin/src/index.ts
+++ b/packages/cli/templates/default-plugin/src/index.ts
@@ -1,1 +1,2 @@
 export { plugin } from './plugin';
+export { Router } from './components/Router';


### PR DESCRIPTION
Plugins when created are standalone being served on its own route. When the plugin needs to be part of the entity view as a tab then it needs to export a Router which is added to the EntityPage.

This PR adds a default Router that can be used.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
