### PR TITLE
chore(gcp): updating gcp projects npm visibility

### DIFF
--- a/plugins/gcp-projects/package.json
+++ b/plugins/gcp-projects/package.json
@@ -4,7 +4,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
## Hey, I just made a Pull Request!
- Makes the `gcp-projects` plugin publishable to npm

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
