### PR TITLE
Update README.md

### DIFF
--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -35,7 +35,7 @@ Follow this link, [Create new OAuth App](https://github.com/settings/application
 1. You can set the Homepage URL to whatever you want to.
 1. The Authorization Callback URL should match the redirect URI set in Backstage.
    1. Set this to `http://localhost:7000/api/auth/github` for local development.
-   1. Set this to `http://{APP_FQDN}:{APP_BACKEND_PORT}/auth/github` for non-local deployments.
+   1. Set this to `http://{APP_FQDN}:{APP_BACKEND_PORT}/api/auth/github` for non-local deployments.
 
 ```bash
 export AUTH_GITHUB_CLIENT_ID=x


### PR DESCRIPTION
API Path missing on non-local deployment

Github auth path has changed onto /api/auth/github and thus readme should be updated.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
