### PR TITLE
Add a message if techdocs takes long time to load

### DIFF
--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { useApi, Progress } from '@backstage/core';
+import { useApi } from '@backstage/core';
 import { useShadowDom } from '..';
 import { useAsync } from 'react-use';
 import { techdocsStorageApiRef } from '../../api';
@@ -23,6 +23,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { ParsedEntityId } from '../../types';
 import { useTheme } from '@material-ui/core';
 import { BackstageTheme } from '@backstage/theme';
+import TechDocsProgressBar from './TechDocsProgressBar';
 
 import transformer, {
   addBaseUrl,
@@ -150,7 +151,7 @@ export const Reader = ({ entityId }: Props) => {
 
   return (
     <>
-      {loading ? <Progress /> : null}
+      {loading ? <TechDocsProgressBar /> : null}
       <div ref={shadowDomRef} />
     </>
   );

--- a/plugins/techdocs/src/reader/components/TechDocsProgressBar.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsProgressBar.test.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import TechDocsProgressBar from './TechDocsProgressBar';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { wrapInTestApp } from '@backstage/test-utils';
+import { act } from 'react-dom/test-utils';
+
+jest.useFakeTimers();
+
+describe('<TechDocsProgressBar />', () => {
+  it('should render a message if techdocs page takes more time to load', () => {
+    const rendered = render(wrapInTestApp(<TechDocsProgressBar />));
+
+    expect(rendered.getByTestId('progress')).toBeDefined();
+    expect(rendered.queryByTestId('delay-reason')).toBeNull();
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(rendered.getByTestId('delay-reason')).toBeDefined();
+  });
+});

--- a/plugins/techdocs/src/reader/components/TechDocsProgressBar.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsProgressBar.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { useMountedState } from 'react-use';
+import { Progress } from '@backstage/core';
+import { Typography } from '@material-ui/core';
+
+const TechDocsProgressBar = () => {
+  const isMounted = useMountedState();
+  const [hasBeenDelayed, setHasBeenDelayed] = useState(false);
+
+  const delayReason = `Docs are still loading...Backstage takes some extra time to load docs
+  for the first time. The subsequent loads are much faster.`;
+
+  // Allowed time that docs can take to load (in milliseconds)
+  const allowedDelayTime = 5000;
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (isMounted()) {
+        setHasBeenDelayed(true);
+      }
+    }, allowedDelayTime);
+  });
+
+  return (
+    <>
+      {hasBeenDelayed ? (
+        <Typography data-testid="delay-reason">{delayReason}</Typography>
+      ) : null}
+      <Progress />
+    </>
+  );
+};
+
+export default TechDocsProgressBar;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #2416. 

The UI after the change should look like this:

![techdocs-progress-bar](https://user-images.githubusercontent.com/33940798/94189286-296ac980-fec8-11ea-9051-1b3db938d12f.gif)

Note; Kindly ignore the time in the preview as it was taking ~ 15min in my system for the techdocs to get loaded for the first time. So, I trimmed that off for better visibility.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [ ] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
