### PR TITLE
ci: Fix codecov for flags, enable carryforward

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,6 +13,8 @@ flags:
   core:
     paths:
       - packages/core/
+    carryforward: true
   core-api:
     paths:
       - packages/core-api/
+    carryforward: true


### PR DESCRIPTION
Our builds for Pull Requests do not upload coverage report for flags (specific packages).
This overrides the coverage data for these flags.
Setting `carryforward` option to `true` prevents the data for flags to be overridden.


Following the expert's advice 😁  
![Screenshot 2020-09-24 at 23 04 10](https://user-images.githubusercontent.com/8065913/94200179-44364180-feba-11ea-9ae9-06fe7d548b2c.png)
