### PR TITLE
create-app: remove discovery api override

### DIFF
--- a/packages/create-app/templates/default-app/packages/app/src/apis.ts
+++ b/packages/create-app/templates/default-app/packages/app/src/apis.ts
@@ -1,17 +1,1 @@
-import {
-  discoveryApiRef,
-  UrlPatternDiscovery,
-  createApiFactory,
-  configApiRef,
-} from '@backstage/core';
-
-export const apis = [
-  createApiFactory({
-    api: discoveryApiRef,
-    deps: { configApi: configApiRef },
-    factory: ({ configApi }) =>
-      UrlPatternDiscovery.compile(
-        `${configApi.getString('backend.baseUrl')}/{{ pluginId }}`,
-      ),
-  }),
-];
+export const apis = [];


### PR DESCRIPTION
This override in the create-app app should be removed, since it also uses /api by default