### PR TITLE
create-app: default to using internal scope for new plugins

### DIFF
--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -16,7 +16,7 @@
     "test:all": "lerna run test -- --coverage",
     "lint": "lerna run lint --since origin/master --",
     "lint:all": "lerna run lint --",
-    "create-plugin": "backstage-cli create-plugin --scope backstage --no-private",
+    "create-plugin": "backstage-cli create-plugin --scope internal --no-private",
     "remove-plugin": "backstage-cli remove-plugin"
   },
   "workspaces": {


### PR DESCRIPTION
Fixes #615