### PR TITLE
fix(circleci): add api route prefix to proxy rewrite path

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -16,9 +16,6 @@ backend:
 proxy:
   '/circleci/api':
     target: https://circleci.com/api/v1.1
-    changeOrigin: true
-    pathRewrite:
-      '^/proxy/circleci/api/': '/'
     headers:
       Circle-Token:
         $secret:

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -49,7 +49,7 @@ Each key under the proxy configuration entry is a route to match, below the
 prefix that the proxy plugin is mounted on. It must start with a slash. For
 example, if the backend mounts the proxy plugin as `/proxy`, the above
 configuration will lead to the proxy acting on backend requests to
-`/proxy/simple-example/...` and `/proxy/larger-example/v1/...`.
+`/api/proxy/simple-example/...` and `/api/proxy/larger-example/v1/...`.
 
 The value inside each route is either a simple URL string, or an object on the
 format accepted by
@@ -74,6 +74,6 @@ except with the following caveats for convenience:
   commonly useful value.
 - If `pathRewrite` is not specified, it is set to a single rewrite that removes
   the entire prefix and route. In the above example, a rewrite of
-  `'^/proxy/larger-example/v1/': '/'` is added. That means that a request to
-  `/proxy/larger-example/v1/some/path` will be translated to a request to
+  `'^/api/proxy/larger-example/v1/': '/'` is added. That means that a request to
+  `/api/proxy/larger-example/v1/some/path` will be translated to a request to
   `http://larger.example.com:8080/svc.v1/some/path`.

--- a/plugins/circleci/README.md
+++ b/plugins/circleci/README.md
@@ -55,9 +55,6 @@ import { Router as CircleCIRouter } from '@backstage/plugin-circleci';
 proxy:
   '/circleci/api':
     target: https://circleci.com/api/v1.1
-    changeOrigin: true
-    pathRewrite:
-      '^/proxy/circleci/api/': '/'
     headers:
       Circle-Token:
         $secret:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Looks like this is also a required change for the circleci plugin to work with the recent backend `/api` route changes.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
