### PR TITLE
Make title meaningful after component creation

### DIFF
--- a/plugins/scaffolder/src/components/JobStatusModal/JobStatusModal.tsx
+++ b/plugins/scaffolder/src/components/JobStatusModal/JobStatusModal.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Dialog,
   LinearProgress,
@@ -43,16 +43,19 @@ export const JobStatusModal = ({
   entity,
 }: Props) => {
   const job = useJobPolling(jobId);
+  const [dialogTitle, setDialogTitle] = useState('Creating component...');
 
   useEffect(() => {
-    if (job?.status === 'COMPLETED') onComplete(job);
-  }, [job, onComplete]);
+    if (job?.status === 'COMPLETED') {
+      setDialogTitle('Successfully created component');
+      onComplete(job);
+    } else if (job?.status === 'FAILED')
+      setDialogTitle('Failed to create component');
+  }, [job, onComplete, setDialogTitle]);
 
   return (
     <Dialog open onClose={onClose} fullWidth>
-      <DialogTitle id="responsive-dialog-title">
-        Creating Component...
-      </DialogTitle>
+      <DialogTitle id="responsive-dialog-title">{dialogTitle}</DialogTitle>
       <DialogContent>
         {!job ? (
           <LinearProgress />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes #2458.

After the change, the UX should look like this:

1. If the component creation was successful:
![successfully-created-component](https://user-images.githubusercontent.com/33940798/94339294-8bd1e000-0016-11eb-885b-7936fcc23b63.gif)

2. If the component creation failed:
![failed-to-create-component](https://user-images.githubusercontent.com/33940798/94339296-90969400-0016-11eb-9a74-ce16b3dd8d88.gif)

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
