### PR TITLE
feat(catalog-backend): simplify the read function in processors

### DIFF
--- a/plugins/catalog-backend/src/ingestion/processors/ApiDefinitionAtLocationProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/ApiDefinitionAtLocationProcessor.ts
@@ -41,19 +41,8 @@ export class ApiDefinitionAtLocationProcessor implements LocationProcessor {
     const reference =
       entity.metadata.annotations[DEFINITION_AT_LOCATION_ANNOTATION];
     const { type, target } = extractReference(reference);
-    const result = await read({ type, target });
-
-    if (result.type === 'error') {
-      throw new Error(`Failed to read location: ${result.error.message}`);
-    }
-
-    if (result.type !== 'data') {
-      throw new Error(
-        `Only supports location processor results of type 'data', but got '${result.type}'`,
-      );
-    }
-
-    const definition = result.data.toString();
+    const data = await read({ type, target });
+    const definition = data.toString();
     const apiEntity = entity as ApiEntity;
     apiEntity.spec.definition = definition;
 

--- a/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.ts
@@ -174,11 +174,8 @@ async function readTextLocation(params: ResolverParams): Promise<string> {
   const newLocation = relativeLocation(params);
 
   try {
-    const response = await params.read(newLocation);
-    if (response.type !== 'data') {
-      throw new Error(`Expected data, got ${response.type}`);
-    }
-    return response.data.toString('utf-8');
+    const data = await params.read(newLocation);
+    return data.toString('utf-8');
   } catch (e) {
     throw new Error(
       `Placeholder \$${params.key} could not read location ${params.value}, ${e}`,

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -66,7 +66,7 @@ export type LocationProcessor = {
    *
    * @param error The error
    * @param location The location where the error occurred
-   * @param emit A sink for items resulting from this handilng
+   * @param emit A sink for items resulting from this handling
    * @returns Nothing
    */
   handleError?(
@@ -110,6 +110,4 @@ export type LocationProcessorResult =
   | LocationProcessorEntityResult
   | LocationProcessorErrorResult;
 
-export type LocationProcessorRead = (
-  location: LocationSpec,
-) => Promise<LocationProcessorResult>;
+export type LocationProcessorRead = (location: LocationSpec) => Promise<Buffer>;


### PR DESCRIPTION
There's no point in it returning a complex type - should just be url -> buffer.