### PR TITLE
docs/tutorials: remove apis.ts secion from app quickstart

### DIFF
--- a/docs/tutorials/quickstart-app-auth.md
+++ b/docs/tutorials/quickstart-app-auth.md
@@ -155,39 +155,7 @@ const app = createApp({
 });
 ```
 
-6. Open and change _root > packages > app > src >_ `apis.ts` as follows
-
-```ts
-// Add the following imports to the existing list from core
-import { githubAuthApiRef, GithubAuth } from '@backstage/core';
-```
-
-7. In the same file, change the builder block for oauthRequestApiRef as follows
-
-_from:_
-
-```ts
-builder.add(oauthRequestApiRef, new OAuthRequestManager());
-```
-
-_to:_
-
-```ts
-const oauthRequestApi = builder.add(
-  oauthRequestApiRef,
-  new OAuthRequestManager(),
-);
-
-builder.add(
-  githubAuthApiRef,
-  GithubAuth.create({
-    discoveryApi,
-    oauthRequestApi,
-  }),
-);
-```
-
-8. Start the backend and frontend as before
+7. Start the backend and frontend as before
 
 When the browser loads, you should be presented with a login page for GitHub.
 Login as usual with your GitHub account. If this is your first time, you will be


### PR DESCRIPTION
This bit isn't needed anymore as the factories for those APIs are shipped by default