### PR TITLE
Rename googleAuth variable in GitlabAuth tests to gitlabAuth

### DIFF
--- a/packages/core-api/src/apis/implementations/auth/gitlab/GitlabAuth.test.ts
+++ b/packages/core-api/src/apis/implementations/auth/gitlab/GitlabAuth.test.ts
@@ -39,12 +39,12 @@ describe('GitlabAuth', () => {
     ],
     ['read_repository sudo', ['read_repository', 'sudo']],
   ])(`should normalize scopes correctly - %p`, (scope, scopes) => {
-    const googleAuth = GitlabAuth.create({
+    const gitlabAuth = GitlabAuth.create({
       oauthRequestApi: new MockOAuthApi(),
       discoveryApi: UrlPatternDiscovery.compile('http://example.com'),
     });
 
-    googleAuth.getAccessToken(scope);
+    gitlabAuth.getAccessToken(scope);
     expect(getSession).toHaveBeenCalledWith({ scopes: new Set(scopes) });
   });
 });


### PR DESCRIPTION
- Seems like it was probably a copy-paste issue.