### PR TITLE
Using EmptyState in Github Actions Plugin

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -47,8 +47,8 @@ import {
   useEntity,
 } from '@backstage/plugin-catalog';
 import { Entity } from '@backstage/catalog-model';
-import { Grid } from '@material-ui/core';
-import { WarningPanel } from '@backstage/core';
+import { Button, Grid } from '@material-ui/core';
+import { EmptyState } from '@backstage/core';
 
 const CICDSwitcher = ({ entity }: { entity: Entity }) => {
   // This component is just an example of how you can implement your company's logic in entity page.
@@ -66,10 +66,20 @@ const CICDSwitcher = ({ entity }: { entity: Entity }) => {
       return <TravisCIRouter entity={entity} />;
     default:
       return (
-        <WarningPanel title="CI/CD switcher:">
-          No CI/CD is available for this entity. Check corresponding
-          annotations!
-        </WarningPanel>
+        <EmptyState
+          title="No CI/CD available for this entity"
+          missing="info"
+          description="You need to add an annotation to your component if you want to enable CI/CD for it. You can read more about annotations in Backstage by clicking the button below."
+          action={
+            <Button
+              variant="contained"
+              color="primary"
+              href="https://backstage.io/docs/features/software-catalog/well-known-annotations"
+            >
+              Read more
+            </Button>
+          }
+        />
       );
   }
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,6 @@
     "@backstage/config": "^0.1.1-alpha.23",
     "@backstage/core-api": "^0.1.1-alpha.23",
     "@backstage/theme": "^0.1.1-alpha.23",
-    "@backstage/plugin-catalog": "^0.1.1-alpha.23",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "@backstage/config": "^0.1.1-alpha.23",
     "@backstage/core-api": "^0.1.1-alpha.23",
     "@backstage/theme": "^0.1.1-alpha.23",
+    "@backstage/plugin-catalog": "^0.1.1-alpha.23",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco, dark } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 import { useTheme } from '@material-ui/core';
@@ -62,12 +61,4 @@ export const CodeSnippet = ({
       )}
     </div>
   );
-};
-
-// Type check for the JS files using this core component
-CodeSnippet.propTypes = {
-  text: PropTypes.string.isRequired,
-  language: PropTypes.string.isRequired,
-  showLineNumbers: PropTypes.bool,
-  showCopyCodeButton: PropTypes.bool,
 };

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco, dark } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
@@ -27,19 +27,16 @@ type Props = {
   language: string;
   showLineNumbers?: boolean;
   showCopyCodeButton?: boolean;
+  highlightedNumbers?: number[];
 };
 
-const defaultProps = {
-  showLineNumbers: false,
-  showCopyCodeButton: false,
-};
-
-export const CodeSnippet: FC<Props> = props => {
-  const { text, language, showLineNumbers, showCopyCodeButton } = {
-    ...defaultProps,
-    ...props,
-  };
-
+export const CodeSnippet = ({
+  text,
+  language,
+  showLineNumbers = false,
+  showCopyCodeButton = false,
+  highlightedNumbers,
+}: Props) => {
   const theme = useTheme<BackstageTheme>();
   const mode = theme.palette.type === 'dark' ? dark : docco;
 
@@ -49,6 +46,12 @@ export const CodeSnippet: FC<Props> = props => {
         language={language}
         style={mode}
         showLineNumbers={showLineNumbers}
+        wrapLines
+        lineProps={(lineNumber: number) =>
+          highlightedNumbers?.includes(lineNumber)
+            ? { style: { backgroundColor: '#e6ffed' } }
+            : {}
+        }
       >
         {text}
       </SyntaxHighlighter>

--- a/packages/core/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/core/src/components/EmptyState/EmptyState.stories.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { EmptyState } from './EmptyState';
 import { Button } from '@material-ui/core';
+import { MissingAnnotationEmptyState } from './MissingAnnotationEmptyState';
 
 export default {
   title: 'EmptyState',
@@ -25,7 +26,7 @@ export default {
 
 const containerStyle = { width: '100%', height: '100vh' };
 
-export const MissingAnnotation = () => (
+export const Field = () => (
   <div style={containerStyle}>
     <EmptyState
       missing="field"
@@ -35,7 +36,7 @@ export const MissingAnnotation = () => (
   </div>
 );
 
-export const NoInformation = () => (
+export const Info = () => (
   <div style={containerStyle}>
     <EmptyState
       missing="info"
@@ -45,7 +46,7 @@ export const NoInformation = () => (
   </div>
 );
 
-export const CreateComponent = () => (
+export const Content = () => (
   <div style={containerStyle}>
     <EmptyState
       missing="content"
@@ -55,7 +56,7 @@ export const CreateComponent = () => (
   </div>
 );
 
-export const NoBuild = () => (
+export const Data = () => (
   <div style={containerStyle}>
     <EmptyState
       missing="data"
@@ -77,5 +78,11 @@ export const WithAction = () => (
         </Button>
       }
     />
+  </div>
+);
+
+export const MissingAnnotation = () => (
+  <div style={containerStyle}>
+    <MissingAnnotationEmptyState annotation="backstage.io/example" />
   </div>
 );

--- a/packages/core/src/components/EmptyState/EmptyState.tsx
+++ b/packages/core/src/components/EmptyState/EmptyState.tsx
@@ -22,7 +22,7 @@ import Background from './assets/Background.svg';
 const useStyles = makeStyles(theme => ({
   root: {
     backgroundColor: theme.palette.background.default,
-    padding: theme.spacing(10, 0, 0, 0),
+    padding: theme.spacing(2, 0, 0, 0),
   },
   action: {
     marginTop: theme.spacing(2),
@@ -56,7 +56,7 @@ export const EmptyState = ({ title, description, missing, action }: Props) => {
     >
       <Grid item container direction="column" xs={12} md={6}>
         <Grid item>
-          <Typography variant="h3">{title}</Typography>
+          <Typography variant="h5">{title}</Typography>
         </Grid>
         <Grid item>
           <Typography variant="body1">{description}</Typography>

--- a/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -75,7 +75,7 @@ export const MissingAnnotationEmptyState = ({ annotation }: Props) => {
     <EmptyState
       missing="field"
       title="Missing Annotation"
-      description={`The "${annotation}" annotation is missing on "${entity?.metadata?.name}". You need to add the annotation to your component if you want to enable Github Actions for it.`}
+      description={`The "${annotation}" annotation is missing on "${entity?.metadata?.name}". You need to add the annotation to your component if you want to enable this tool for it.`}
       action={
         <>
           <Typography variant="body1">

--- a/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -17,34 +17,7 @@
 import React from 'react';
 import { Button, Typography } from '@material-ui/core';
 import { EmptyState } from './EmptyState';
-import PostAddIcon from '@material-ui/icons/PostAdd';
-import { useEntity } from '@backstage/plugin-catalog';
 import { CodeSnippet } from '../CodeSnippet';
-
-type ActionButtonProps = {
-  type: string;
-  target: string;
-};
-
-const ActionButton = ({ type, target }: ActionButtonProps) =>
-  type === 'github' ? (
-    <Button
-      variant="contained"
-      color="primary"
-      href={target.replace('blob', 'edit')}
-      startIcon={<PostAddIcon />}
-    >
-      Edit component definition
-    </Button>
-  ) : (
-    <Button
-      variant="contained"
-      color="primary"
-      href="https://backstage.io/docs/features/software-catalog/well-known-annotations"
-    >
-      Read more
-    </Button>
-  );
 
 const COMPONENT_YAML = `# Example
 apiVersion: backstage.io/v1alpha1
@@ -65,17 +38,11 @@ type Props = {
 };
 
 export const MissingAnnotationEmptyState = ({ annotation }: Props) => {
-  const { entity } = useEntity();
-  const [type, target] =
-    entity?.metadata?.annotations?.['backstage.io/managed-by-location'].split(
-      /:(.+)/,
-    ) || [];
-
   return (
     <EmptyState
       missing="field"
       title="Missing Annotation"
-      description={`The "${annotation}" annotation is missing on "${entity?.metadata?.name}". You need to add the annotation to your component if you want to enable this tool for it.`}
+      description={`The "${annotation}" annotation is missing. You need to add the annotation to your component if you want to enable this tool for it.`}
       action={
         <>
           <Typography variant="body1">
@@ -88,7 +55,13 @@ export const MissingAnnotationEmptyState = ({ annotation }: Props) => {
             showLineNumbers
             highlightedNumbers={[7, 8]}
           />
-          <ActionButton type={type} target={target} />
+          <Button
+            variant="contained"
+            color="primary"
+            href="https://backstage.io/docs/features/software-catalog/well-known-annotations"
+          >
+            Read more
+          </Button>
         </>
       }
     />

--- a/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Button, Typography } from '@material-ui/core';
+import { EmptyState } from './EmptyState';
+import PostAddIcon from '@material-ui/icons/PostAdd';
+import { useEntity } from '@backstage/plugin-catalog';
+import { CodeSnippet } from '../CodeSnippet';
+
+type ActionButtonProps = {
+  type: string;
+  target: string;
+};
+
+const ActionButton = ({ type, target }: ActionButtonProps) =>
+  type === 'github' ? (
+    <Button
+      variant="contained"
+      color="primary"
+      href={target.replace('blob', 'edit')}
+      startIcon={<PostAddIcon />}
+    >
+      Edit component definition
+    </Button>
+  ) : (
+    <Button
+      variant="contained"
+      color="primary"
+      href="https://backstage.io/docs/features/software-catalog/well-known-annotations"
+    >
+      Read more
+    </Button>
+  );
+
+const COMPONENT_YAML = `# Example
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage
+  description: backstage.io
+  annotations:
+    ANNOTATION: value
+spec:
+  type: website
+  lifecycle: production
+  owner: guest
+`;
+
+type Props = {
+  annotation: string;
+};
+
+export const MissingAnnotationEmptyState = ({ annotation }: Props) => {
+  const { entity } = useEntity();
+  const [type, target] =
+    entity?.metadata?.annotations?.['backstage.io/managed-by-location'].split(
+      /:(.+)/,
+    ) || [];
+
+  return (
+    <EmptyState
+      missing="field"
+      title="Missing Annotation"
+      description={`The "${annotation}" annotation is missing on "${entity?.metadata?.name}". You need to add the annotation to your component if you want to enable Github Actions for it.`}
+      action={
+        <>
+          <Typography variant="body1">
+            Add the annotation to your component YAML as per the highlighted
+            example below:
+          </Typography>
+          <CodeSnippet
+            text={COMPONENT_YAML.replace('ANNOTATION', annotation)}
+            language="yaml"
+            showLineNumbers
+            highlightedNumbers={[7, 8]}
+          />
+          <ActionButton type={type} target={target} />
+        </>
+      }
+    />
+  );
+};

--- a/packages/core/src/components/EmptyState/index.ts
+++ b/packages/core/src/components/EmptyState/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { EmptyState } from './EmptyState';
+export { MissingAnnotationEmptyState } from './MissingAnnotationEmptyState';

--- a/plugins/github-actions/README.md
+++ b/plugins/github-actions/README.md
@@ -11,7 +11,7 @@ TBD
 ### Generic Requirements
 
 1. Provide OAuth credentials:
-   1. [Create an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) with callback URL set to `https://localhost:3000/auth/github`.
+   1. [Create an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) with callback URL set to `http://localhost:7000/api/auth/github`.
    2. Take Client ID and Client Secret from the newly created app's settings page and put them into `AUTH_GITHUB_CLIENT_ID` and `AUTH_GITHUB_CLIENT_SECRET` env variables.
 2. Annotate your component with a correct GitHub Actions repository and owner:
 

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -20,13 +20,7 @@ import { useWorkflowRuns } from '../useWorkflowRuns';
 import React, { useEffect } from 'react';
 import { EmptyState, Table } from '@backstage/core';
 import { WorkflowRunStatus } from '../WorkflowRunStatus';
-import {
-  Button,
-  Card,
-  Link,
-  TableContainer,
-  Typography,
-} from '@material-ui/core';
+import { Button, Card, Link, TableContainer } from '@material-ui/core';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
 
 const firstLine = (message: string): string => message.split('\n')[0];

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -18,9 +18,15 @@ import { errorApiRef, useApi } from '@backstage/core-api';
 import { GITHUB_ACTIONS_ANNOTATION } from '../useProjectName';
 import { useWorkflowRuns } from '../useWorkflowRuns';
 import React, { useEffect } from 'react';
-import { Table } from '@backstage/core';
+import { EmptyState, Table } from '@backstage/core';
 import { WorkflowRunStatus } from '../WorkflowRunStatus';
-import { Card, Link, TableContainer } from '@material-ui/core';
+import {
+  Button,
+  Card,
+  Link,
+  TableContainer,
+  Typography,
+} from '@material-ui/core';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
 
 const firstLine = (message: string): string => message.split('\n')[0];
@@ -54,7 +60,22 @@ export const RecentWorkflowRunsCard = ({
     }
   }, [error, errorApi]);
 
-  return (
+  return !runs.length ? (
+    <EmptyState
+      missing="data"
+      title="No Workflow Data"
+      description="This component has Github Actions enabled, but no data was found. Have you created any Workflows? Click the button below to create a new Workflow."
+      action={
+        <Button
+          variant="contained"
+          color="primary"
+          href={`https://github.com/${owner}/${repo}/actions/new`}
+        >
+          Create new Workflow
+        </Button>
+      }
+    />
+  ) : (
     <TableContainer component={Card}>
       <Table
         title="Recent Workflow Runs"

--- a/plugins/github-actions/src/components/Router.tsx
+++ b/plugins/github-actions/src/components/Router.tsx
@@ -20,18 +20,47 @@ import { rootRouteRef, buildRouteRef } from '../plugin';
 import { WorkflowRunDetails } from './WorkflowRunDetails';
 import { WorkflowRunsTable } from './WorkflowRunsTable';
 import { GITHUB_ACTIONS_ANNOTATION } from './useProjectName';
-import { WarningPanel } from '@backstage/core';
+import { EmptyState } from '@backstage/core';
+import { Button } from '@material-ui/core';
+import PostAddIcon from '@material-ui/icons/PostAdd';
 
 export const isPluginApplicableToEntity = (entity: Entity) =>
   Boolean(entity.metadata.annotations?.[GITHUB_ACTIONS_ANNOTATION]);
 
+const ActionButton = ({ entity }: { entity: Entity }) => {
+  const [type, target] =
+    entity.metadata.annotations?.['backstage.io/managed-by-location'].split(
+      /:(.+)/,
+    ) || [];
+
+  return type === 'github' ? (
+    <Button
+      variant="contained"
+      color="primary"
+      href={target.replace('blob', 'edit')}
+      startIcon={<PostAddIcon />}
+    >
+      Add annotation
+    </Button>
+  ) : (
+    <Button
+      variant="contained"
+      color="primary"
+      href="https://backstage.io/docs/features/software-catalog/well-known-annotations"
+    >
+      Read more
+    </Button>
+  );
+};
+
 export const Router = ({ entity }: { entity: Entity }) =>
-  // TODO(shmidt-i): move warning to a separate standardized component
   !isPluginApplicableToEntity(entity) ? (
-    <WarningPanel title="GitHubActions plugin:">
-      <pre>{GITHUB_ACTIONS_ANNOTATION}</pre> annotation is missing on the
-      entity.
-    </WarningPanel>
+    <EmptyState
+      missing="field"
+      title="Missing Annotation"
+      description={`The "${GITHUB_ACTIONS_ANNOTATION}" annotation is missing on "${entity.metadata.name}". You need to add the annotation to your component if you want to enable Github Actions for it.`}
+      action={<ActionButton entity={entity} />}
+    />
   ) : (
     <Routes>
       <Route

--- a/plugins/github-actions/src/components/Router.tsx
+++ b/plugins/github-actions/src/components/Router.tsx
@@ -20,47 +20,14 @@ import { rootRouteRef, buildRouteRef } from '../plugin';
 import { WorkflowRunDetails } from './WorkflowRunDetails';
 import { WorkflowRunsTable } from './WorkflowRunsTable';
 import { GITHUB_ACTIONS_ANNOTATION } from './useProjectName';
-import { EmptyState } from '@backstage/core';
-import { Button } from '@material-ui/core';
-import PostAddIcon from '@material-ui/icons/PostAdd';
+import { MissingAnnotationEmptyState } from '@backstage/core';
 
 export const isPluginApplicableToEntity = (entity: Entity) =>
   Boolean(entity.metadata.annotations?.[GITHUB_ACTIONS_ANNOTATION]);
 
-const ActionButton = ({ entity }: { entity: Entity }) => {
-  const [type, target] =
-    entity.metadata.annotations?.['backstage.io/managed-by-location'].split(
-      /:(.+)/,
-    ) || [];
-
-  return type === 'github' ? (
-    <Button
-      variant="contained"
-      color="primary"
-      href={target.replace('blob', 'edit')}
-      startIcon={<PostAddIcon />}
-    >
-      Add annotation
-    </Button>
-  ) : (
-    <Button
-      variant="contained"
-      color="primary"
-      href="https://backstage.io/docs/features/software-catalog/well-known-annotations"
-    >
-      Read more
-    </Button>
-  );
-};
-
 export const Router = ({ entity }: { entity: Entity }) =>
   !isPluginApplicableToEntity(entity) ? (
-    <EmptyState
-      missing="field"
-      title="Missing Annotation"
-      description={`The "${GITHUB_ACTIONS_ANNOTATION}" annotation is missing on "${entity.metadata.name}". You need to add the annotation to your component if you want to enable Github Actions for it.`}
-      action={<ActionButton entity={entity} />}
-    />
+    <MissingAnnotationEmptyState annotation={GITHUB_ACTIONS_ANNOTATION} />
   ) : (
     <Routes>
       <Route

--- a/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
@@ -14,11 +14,18 @@
  * limitations under the License.
  */
 import React, { FC } from 'react';
-import { Link, Typography, Box, IconButton, Tooltip } from '@material-ui/core';
+import {
+  Link,
+  Typography,
+  Box,
+  IconButton,
+  Tooltip,
+  Button,
+} from '@material-ui/core';
 import RetryIcon from '@material-ui/icons/Replay';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import { Link as RouterLink, generatePath } from 'react-router-dom';
-import { Table, TableColumn } from '@backstage/core';
+import { EmptyState, Table, TableColumn } from '@backstage/core';
 import { useWorkflowRuns } from '../useWorkflowRuns';
 import { WorkflowRunStatus } from '../WorkflowRunStatus';
 import SyncIcon from '@material-ui/icons/Sync';
@@ -156,15 +163,34 @@ export const WorkflowRunsTable = ({
 }) => {
   const { value: projectName, loading } = useProjectName(entity);
   const [owner, repo] = (projectName ?? '/').split('/');
-  const [tableProps, { retry, setPage, setPageSize }] = useWorkflowRuns({
+  const [
+    { runs, ...tableProps },
+    { retry, setPage, setPageSize },
+  ] = useWorkflowRuns({
     owner,
     repo,
     branch,
   });
 
-  return (
+  return !runs ? (
+    <EmptyState
+      missing="data"
+      title="No Workflow Data"
+      description="This component has Github Actions enabled, but no data was found. Have you created any Workflows? Click the button below to create a new Workflow."
+      action={
+        <Button
+          variant="contained"
+          color="primary"
+          href={`https://github.com/${projectName}/actions/new`}
+        >
+          Create new Workflow
+        </Button>
+      }
+    />
+  ) : (
     <WorkflowRunsTableView
       {...tableProps}
+      runs={runs}
       loading={loading || tableProps.loading}
       retry={retry}
       onChangePageSize={setPageSize}


### PR DESCRIPTION
- [ ] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

This PR closes: https://github.com/spotify/backstage/issues/2634

Make use of EmptyState in different use-cases within Github Action Plugin

CI/CD Switcher
<img width="1752" alt="Screenshot 2020-09-30 at 15 48 18" src="https://user-images.githubusercontent.com/15106494/94694559-44f52a80-0335-11eb-8a7c-5f9b36b97993.png">

No data for recent workflow runs
<img width="1756" alt="Screenshot 2020-09-30 at 15 50 06" src="https://user-images.githubusercontent.com/15106494/94694578-4888b180-0335-11eb-8757-c66953d04d88.png">

No workflow runs
<img width="1764" alt="Screenshot 2020-09-30 at 15 50 50" src="https://user-images.githubusercontent.com/15106494/94694584-4a527500-0335-11eb-8ea3-1b72e945cd4d.png">

Missing annotation
<img width="1761" alt="Screenshot 2020-09-30 at 15 51 30" src="https://user-images.githubusercontent.com/15106494/94694596-4c1c3880-0335-11eb-9938-b506bf2d5129.png">
