### PR TITLE
Allow for Kubernetes cluster authentication via google auth

### DIFF
--- a/plugins/kubernetes-backend/src/cluster-locator/MultiTenantConfigClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/MultiTenantConfigClusterLocator.test.ts
@@ -16,6 +16,7 @@
 
 import '@backstage/backend-common';
 import { MultiTenantConfigClusterLocator } from './MultiTenantConfigClusterLocator';
+import { AuthTokens } from '..';
 import { ConfigReader, Config } from '@backstage/config';
 
 describe('MultiTenantConfigClusterLocator', () => {
@@ -31,7 +32,7 @@ describe('MultiTenantConfigClusterLocator', () => {
       config.getConfigArray('clusters'),
     );
 
-    const result = await sut.getClusterByServiceId('ignored');
+    const result = await sut.getClusterByServiceId('ignored', {});
 
     expect(result).toStrictEqual([]);
   });
@@ -53,13 +54,14 @@ describe('MultiTenantConfigClusterLocator', () => {
       config.getConfigArray('clusters'),
     );
 
-    const result = await sut.getClusterByServiceId('ignored');
+    const result = await sut.getClusterByServiceId('ignored', {});
 
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
+        authProvider: 'serviceAccount',
       },
     ]);
   });
@@ -87,19 +89,89 @@ describe('MultiTenantConfigClusterLocator', () => {
       config.getConfigArray('clusters'),
     );
 
-    const result = await sut.getClusterByServiceId('ignored');
+    const result = await sut.getClusterByServiceId('ignored', {});
 
     expect(result).toStrictEqual([
       {
         name: 'cluster1',
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
+        authProvider: 'serviceAccount',
       },
       {
         name: 'cluster2',
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
+        authProvider: 'serviceAccount',
       },
     ]);
+  });
+
+  it('clusters using google auth return cluster details with tokens', async () => {
+    const config: Config = new ConfigReader(
+      {
+        clusters: [
+          {
+            name: 'cluster1',
+            serviceAccountToken: 'abc',
+            url: 'http://localhost:8080',
+          },
+          {
+            name: 'cluster2',
+            url: 'http://localhost:8081',
+            authProvider: 'google',
+          },
+        ],
+      },
+      'ctx',
+    );
+
+    const sut = MultiTenantConfigClusterLocator.fromConfig(
+      config.getConfigArray('clusters'),
+    );
+
+    const authTokens: AuthTokens = {
+      google: 'google_token_123',
+    };
+
+    const result = await sut.getClusterByServiceId('ignored', authTokens);
+
+    expect(result).toStrictEqual([
+      {
+        name: 'cluster1',
+        serviceAccountToken: 'abc',
+        url: 'http://localhost:8080',
+        authProvider: 'serviceAccount',
+      },
+      {
+        name: 'cluster2',
+        serviceAccountToken: 'google_token_123',
+        url: 'http://localhost:8081',
+        authProvider: 'google',
+      },
+    ]);
+  });
+
+  it('using unsupported auth throws error', async () => {
+    const config: Config = new ConfigReader(
+      {
+        clusters: [
+          {
+            name: 'cluster1',
+            url: 'http://localhost:8080',
+            authProvider: 'linode',
+          },
+        ],
+      },
+      'ctx',
+    );
+
+    const sut = MultiTenantConfigClusterLocator.fromConfig(
+      config.getConfigArray('clusters'),
+    );
+
+    await expect(sut.getClusterByServiceId('ignored', {})).rejects.toThrow(
+      'Unsupported Kubernetes auth provider "linode"',
+    );
   });
 });

--- a/plugins/kubernetes-backend/src/cluster-locator/MultiTenantConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/MultiTenantConfigClusterLocator.ts
@@ -15,8 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import { AuthTokens, ClusterDetails, KubernetesClusterLocator } from '..';
-import { AuthProviderType } from './types';
+import { ClusterDetails, KubernetesClusterLocator } from '..';
 
 // This cluster locator assumes that every service is located on every cluster
 // Therefore it will always return all clusters in an app configuration file
@@ -37,9 +36,7 @@ export class MultiTenantConfigClusterLocator
           name: c.getString('name'),
           url: c.getString('url'),
           serviceAccountToken: c.getOptionalString('serviceAccountToken'),
-          authProvider: (c.getOptionalString('authProvider')
-            ? c.getOptionalString('authProvider')
-            : 'serviceAccount') as AuthProviderType,
+          authProvider: c.getString('authProvider'),
         };
       }),
     );
@@ -47,27 +44,7 @@ export class MultiTenantConfigClusterLocator
 
   // As this implementation always returns all clusters serviceId is ignored here
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async getClusterByServiceId(
-    _serviceId: string,
-    authTokens: AuthTokens,
-  ): Promise<ClusterDetails[]> {
-    return this.clusterDetails.map(cd => {
-      const authProviderKind = cd.authProvider;
-      if (authProviderKind === 'google') {
-        const authToken: string | undefined = authTokens[authProviderKind];
-        const clusterDetailWithAuthToken: ClusterDetails = Object.assign(
-          {},
-          cd,
-        );
-        clusterDetailWithAuthToken.serviceAccountToken = authToken;
-        return clusterDetailWithAuthToken;
-        // TODO: When validation for authProvider key is added, remove allowance of undefined as value
-      } else if (authProviderKind === 'serviceAccount') {
-        return cd;
-      }
-      throw new Error(
-        `Unsupported Kubernetes auth provider "${authProviderKind}"`,
-      );
-    });
+  async getClusterByServiceId(_serviceId: string): Promise<ClusterDetails[]> {
+    return this.clusterDetails;
   }
 }

--- a/plugins/kubernetes-backend/src/cluster-locator/types.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/types.ts
@@ -15,5 +15,4 @@
  */
 
 export type ClusterLocatorMethod = 'configMultiTenant' | 'http';
-// TODO: When validation for authProvider key is added, remove allowance of undefined as value
 export type AuthProviderType = 'google' | 'serviceAccount';

--- a/plugins/kubernetes-backend/src/cluster-locator/types.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/types.ts
@@ -15,3 +15,5 @@
  */
 
 export type ClusterLocatorMethod = 'configMultiTenant' | 'http';
+// TODO: When validation for authProvider key is added, remove allowance of undefined as value
+export type AuthProviderType = 'google' | 'serviceAccount';

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/GoogleKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/GoogleKubernetesAuthTranslator.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthTranslator } from './types';
+import { AuthRequestBody, ClusterDetails } from '../types/types';
+
+export class GoogleKubernetesAuthTranslator
+  implements KubernetesAuthTranslator {
+  async decorateClusterDetailsWithAuth(
+    clusterDetails: ClusterDetails,
+    requestBody: AuthRequestBody,
+  ): Promise<ClusterDetails> {
+    const clusterDetailsWithAuthToken: ClusterDetails = Object.assign(
+      {},
+      clusterDetails,
+    );
+    const authToken: string | undefined = requestBody.auth?.google;
+
+    if (authToken) {
+      clusterDetailsWithAuthToken.serviceAccountToken = authToken;
+    } else {
+      throw new Error(
+        'Google token not found under auth.google in request body',
+      );
+    }
+    return clusterDetailsWithAuthToken;
+  }
+}

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.test.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthTranslator } from './types';
+import { GoogleKubernetesAuthTranslator } from './GoogleKubernetesAuthTranslator';
+import { KubernetesAuthTranslatorGenerator } from './KubernetesAuthTranslatorGenerator';
+import { ServiceAccountKubernetesAuthTranslator } from './ServiceAccountKubernetesAuthTranslator';
+
+describe('getKubernetesAuthTranslatorInstance', () => {
+  const sut = KubernetesAuthTranslatorGenerator;
+
+  it('can return an auth translator for google auth', () => {
+    const authTranslator: KubernetesAuthTranslator = sut.getKubernetesAuthTranslatorInstance(
+      'google',
+    );
+    expect(authTranslator instanceof GoogleKubernetesAuthTranslator).toBe(true);
+  });
+
+  it('can return an auth translator for serviceAccount auth', () => {
+    const authTranslator: KubernetesAuthTranslator = sut.getKubernetesAuthTranslatorInstance(
+      'serviceAccount',
+    );
+    expect(
+      authTranslator instanceof ServiceAccountKubernetesAuthTranslator,
+    ).toBe(true);
+  });
+
+  it('throws an error when asked for an auth translator for an unsupported auth type', () => {
+    expect(() => sut.getKubernetesAuthTranslatorInstance('linode')).toThrow(
+      'authProvider "linode" has no KubernetesAuthTranslator associated with it',
+    );
+  });
+});

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthTranslator } from './types';
+import { GoogleKubernetesAuthTranslator } from './GoogleKubernetesAuthTranslator';
+import { ServiceAccountKubernetesAuthTranslator } from './ServiceAccountKubernetesAuthTranslator';
+
+export class KubernetesAuthTranslatorGenerator {
+  static getKubernetesAuthTranslatorInstance(
+    authProvider: String,
+  ): KubernetesAuthTranslator {
+    switch (authProvider) {
+      case 'google': {
+        return new GoogleKubernetesAuthTranslator();
+      }
+      case 'serviceAccount': {
+        return new ServiceAccountKubernetesAuthTranslator();
+      }
+      default: {
+        throw new Error(
+          `authProvider "${authProvider}" has no KubernetesAuthTranslator associated with it`,
+        );
+      }
+    }
+  }
+}

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/ServiceAccountKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/ServiceAccountKubernetesAuthTranslator.ts
@@ -14,21 +14,18 @@
  * limitations under the License.
  */
 
-import { createApiRef } from '@backstage/core';
-import {
-  AuthRequestBody,
-  ObjectsByServiceIdResponse,
-} from '@backstage/plugin-kubernetes-backend';
+import { KubernetesAuthTranslator } from './types';
+import { AuthRequestBody, ClusterDetails } from '../types/types';
 
-export const kubernetesApiRef = createApiRef<KubernetesApi>({
-  id: 'plugin.kubernetes.service',
-  description:
-    'Used by the Kubernetes plugin to make requests to accompanying backend',
-});
-
-export interface KubernetesApi {
-  getObjectsByServiceId(
-    serviceId: String,
-    requestBody: AuthRequestBody,
-  ): Promise<ObjectsByServiceIdResponse>;
+export class ServiceAccountKubernetesAuthTranslator
+  implements KubernetesAuthTranslator {
+  async decorateClusterDetailsWithAuth(
+    clusterDetails: ClusterDetails,
+    // To ignore TS6133 linting error where it detects 'requestBody' is declared but its value is never read.
+    // @ts-ignore-start
+    requestBody: AuthRequestBody, // eslint-disable-line @typescript-eslint/no-unused-vars
+    // @ts-ignore-end
+  ): Promise<ClusterDetails> {
+    return clusterDetails;
+  }
 }

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/types.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/types.ts
@@ -14,21 +14,11 @@
  * limitations under the License.
  */
 
-import { createApiRef } from '@backstage/core';
-import {
-  AuthRequestBody,
-  ObjectsByServiceIdResponse,
-} from '@backstage/plugin-kubernetes-backend';
+import { AuthRequestBody, ClusterDetails } from '../types/types';
 
-export const kubernetesApiRef = createApiRef<KubernetesApi>({
-  id: 'plugin.kubernetes.service',
-  description:
-    'Used by the Kubernetes plugin to make requests to accompanying backend',
-});
-
-export interface KubernetesApi {
-  getObjectsByServiceId(
-    serviceId: String,
+export interface KubernetesAuthTranslator {
+  decorateClusterDetailsWithAuth(
+    clusterDetails: ClusterDetails,
     requestBody: AuthRequestBody,
-  ): Promise<ObjectsByServiceIdResponse>;
+  ): Promise<ClusterDetails>;
 }

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.test.ts
@@ -33,7 +33,7 @@ describe('KubernetesClientProvider', () => {
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
-      authProvider: undefined,
+      authProvider: 'serviceAccount',
     });
 
     expect(result.basePath).toBe('http://localhost:9999');
@@ -56,14 +56,14 @@ describe('KubernetesClientProvider', () => {
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
-      authProvider: undefined,
+      authProvider: 'serviceAccount',
     });
 
     const result2 = sut.getCoreClientByClusterDetails({
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
-      authProvider: undefined,
+      authProvider: 'serviceAccount',
     });
 
     expect(result1.basePath).toBe('http://localhost:9999');
@@ -92,7 +92,7 @@ describe('KubernetesClientProvider', () => {
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
-      authProvider: undefined,
+      authProvider: 'serviceAccount',
     });
 
     expect(result.basePath).toBe('http://localhost:9999');
@@ -115,14 +115,14 @@ describe('KubernetesClientProvider', () => {
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
-      authProvider: undefined,
+      authProvider: 'serviceAccount',
     });
 
     const result2 = sut.getAppsClientByClusterDetails({
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
-      authProvider: undefined,
+      authProvider: 'serviceAccount',
     });
 
     expect(result1.basePath).toBe('http://localhost:9999');

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.test.ts
@@ -33,6 +33,7 @@ describe('KubernetesClientProvider', () => {
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
+      authProvider: undefined,
     });
 
     expect(result.basePath).toBe('http://localhost:9999');
@@ -55,12 +56,14 @@ describe('KubernetesClientProvider', () => {
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
+      authProvider: undefined,
     });
 
     const result2 = sut.getCoreClientByClusterDetails({
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
+      authProvider: undefined,
     });
 
     expect(result1.basePath).toBe('http://localhost:9999');
@@ -89,6 +92,7 @@ describe('KubernetesClientProvider', () => {
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
+      authProvider: undefined,
     });
 
     expect(result.basePath).toBe('http://localhost:9999');
@@ -111,12 +115,14 @@ describe('KubernetesClientProvider', () => {
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
+      authProvider: undefined,
     });
 
     const result2 = sut.getAppsClientByClusterDetails({
       name: 'cluster-name',
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
+      authProvider: undefined,
     });
 
     expect(result1.basePath).toBe('http://localhost:9999');

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -63,6 +63,7 @@ describe('KubernetesClientProvider', () => {
         name: 'cluster1',
         url: 'http://localhost:9999',
         serviceAccountToken: undefined,
+        authProvider: undefined,
       },
       new Set(['pods', 'services']),
     );
@@ -125,6 +126,7 @@ describe('KubernetesClientProvider', () => {
         name: 'cluster1',
         url: 'http://localhost:9999',
         serviceAccountToken: undefined,
+        authProvider: undefined,
       },
       new Set(['pods', 'services']),
     );
@@ -173,6 +175,7 @@ describe('KubernetesClientProvider', () => {
           name: 'cluster1',
           url: 'http://localhost:9999',
           serviceAccountToken: undefined,
+          authProvider: undefined,
         },
         new Set<any>(['foo']),
       ),

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -62,8 +62,8 @@ describe('KubernetesClientProvider', () => {
       {
         name: 'cluster1',
         url: 'http://localhost:9999',
-        serviceAccountToken: undefined,
-        authProvider: undefined,
+        serviceAccountToken: 'token',
+        authProvider: 'serviceAccount',
       },
       new Set(['pods', 'services']),
     );
@@ -125,8 +125,8 @@ describe('KubernetesClientProvider', () => {
       {
         name: 'cluster1',
         url: 'http://localhost:9999',
-        serviceAccountToken: undefined,
-        authProvider: undefined,
+        serviceAccountToken: 'token',
+        authProvider: 'serviceAccount',
       },
       new Set(['pods', 'services']),
     );
@@ -174,8 +174,8 @@ describe('KubernetesClientProvider', () => {
         {
           name: 'cluster1',
           url: 'http://localhost:9999',
-          serviceAccountToken: undefined,
-          authProvider: undefined,
+          serviceAccountToken: 'token',
+          authProvider: 'serviceAccount',
         },
         new Set<any>(['foo']),
       ),

--- a/plugins/kubernetes-backend/src/service/getKubernetesObjectsByServiceIdHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/getKubernetesObjectsByServiceIdHandler.test.ts
@@ -89,6 +89,7 @@ describe('handleGetKubernetesObjectsByServiceId', () => {
         getClusterByServiceId,
       },
       getVoidLogger(),
+      {},
     );
 
     expect(getClusterByServiceId.mock.calls.length).toBe(1);
@@ -160,6 +161,9 @@ describe('handleGetKubernetesObjectsByServiceId', () => {
         getClusterByServiceId,
       },
       getVoidLogger(),
+      {
+        google: 'google_token_123',
+      },
     );
 
     expect(getClusterByServiceId.mock.calls.length).toBe(1);

--- a/plugins/kubernetes-backend/src/service/getKubernetesObjectsByServiceIdHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/getKubernetesObjectsByServiceIdHandler.test.ts
@@ -74,6 +74,7 @@ describe('handleGetKubernetesObjectsByServiceId', () => {
       Promise.resolve([
         {
           name: 'test-cluster',
+          authProvider: 'serviceAccount',
         },
       ]),
     );
@@ -143,9 +144,11 @@ describe('handleGetKubernetesObjectsByServiceId', () => {
       Promise.resolve([
         {
           name: 'test-cluster',
+          authProvider: 'serviceAccount',
         },
         {
           name: 'other-cluster',
+          authProvider: 'google',
         },
       ]),
     );
@@ -162,7 +165,9 @@ describe('handleGetKubernetesObjectsByServiceId', () => {
       },
       getVoidLogger(),
       {
-        google: 'google_token_123',
+        auth: {
+          google: 'google_token_123',
+        },
       },
     );
 

--- a/plugins/kubernetes-backend/src/service/getKubernetesObjectsByServiceIdHandler.ts
+++ b/plugins/kubernetes-backend/src/service/getKubernetesObjectsByServiceIdHandler.ts
@@ -16,19 +16,22 @@
 
 import { Logger } from 'winston';
 import {
-  AuthTokens,
+  AuthRequestBody,
+  ClusterDetails,
   KubernetesClusterLocator,
   KubernetesFetcher,
   KubernetesObjectTypes,
   ObjectsByServiceIdResponse,
-} from '..';
+} from '../types/types';
+import { KubernetesAuthTranslator } from '../kubernetes-auth-translator/types';
+import { KubernetesAuthTranslatorGenerator } from '../kubernetes-auth-translator/KubernetesAuthTranslatorGenerator';
 
 export type GetKubernetesObjectsByServiceIdHandler = (
   serviceId: string,
   fetcher: KubernetesFetcher,
   clusterLocator: KubernetesClusterLocator,
   logger: Logger,
-  authTokens: AuthTokens,
+  requestBody: AuthRequestBody,
   objectsToFetch?: Set<KubernetesObjectTypes>,
 ) => Promise<ObjectsByServiceIdResponse>;
 
@@ -48,22 +51,35 @@ export const handleGetKubernetesObjectsByServiceId: GetKubernetesObjectsByServic
   fetcher,
   clusterLocator,
   logger,
-  authTokens,
+  requestBody,
   objectsToFetch = DEFAULT_OBJECTS,
 ) => {
-  const clusterDetails = await clusterLocator.getClusterByServiceId(
+  const clusterDetails: ClusterDetails[] = await clusterLocator.getClusterByServiceId(
     serviceId,
-    authTokens,
+  );
+
+  // Execute all of these async actions simultaneously/without blocking sequentially as no common object is modified by them
+  const promises: Promise<ClusterDetails>[] = clusterDetails.map(cd => {
+    const kubernetesAuthTranslator: KubernetesAuthTranslator = KubernetesAuthTranslatorGenerator.getKubernetesAuthTranslatorInstance(
+      cd.authProvider,
+    );
+    return kubernetesAuthTranslator.decorateClusterDetailsWithAuth(
+      cd,
+      requestBody,
+    );
+  });
+  const clusterDetailsDecoratedForAuth: ClusterDetails[] = await Promise.all(
+    promises,
   );
 
   logger.info(
-    `serviceId=${serviceId} clusterDetails=[${clusterDetails
+    `serviceId=${serviceId} clusterDetails=[${clusterDetailsDecoratedForAuth
       .map(c => c.name)
       .join(', ')}]`,
   );
 
   return Promise.all(
-    clusterDetails.map(cd => {
+    clusterDetailsDecoratedForAuth.map(cd => {
       return fetcher
         .fetchObjectsByServiceId(serviceId, cd, objectsToFetch)
         .then(result => {

--- a/plugins/kubernetes-backend/src/service/getKubernetesObjectsByServiceIdHandler.ts
+++ b/plugins/kubernetes-backend/src/service/getKubernetesObjectsByServiceIdHandler.ts
@@ -16,6 +16,7 @@
 
 import { Logger } from 'winston';
 import {
+  AuthTokens,
   KubernetesClusterLocator,
   KubernetesFetcher,
   KubernetesObjectTypes,
@@ -27,6 +28,7 @@ export type GetKubernetesObjectsByServiceIdHandler = (
   fetcher: KubernetesFetcher,
   clusterLocator: KubernetesClusterLocator,
   logger: Logger,
+  authTokens: AuthTokens,
   objectsToFetch?: Set<KubernetesObjectTypes>,
 ) => Promise<ObjectsByServiceIdResponse>;
 
@@ -46,9 +48,13 @@ export const handleGetKubernetesObjectsByServiceId: GetKubernetesObjectsByServic
   fetcher,
   clusterLocator,
   logger,
+  authTokens,
   objectsToFetch = DEFAULT_OBJECTS,
 ) => {
-  const clusterDetails = await clusterLocator.getClusterByServiceId(serviceId);
+  const clusterDetails = await clusterLocator.getClusterByServiceId(
+    serviceId,
+    authTokens,
+  );
 
   logger.info(
     `serviceId=${serviceId} clusterDetails=[${clusterDetails

--- a/plugins/kubernetes-backend/src/service/router.ts
+++ b/plugins/kubernetes-backend/src/service/router.ts
@@ -26,7 +26,11 @@ import {
   GetKubernetesObjectsByServiceIdHandler,
   handleGetKubernetesObjectsByServiceId,
 } from './getKubernetesObjectsByServiceIdHandler';
-import { AuthTokens, KubernetesClusterLocator, KubernetesFetcher } from '..';
+import {
+  AuthRequestBody,
+  KubernetesClusterLocator,
+  KubernetesFetcher,
+} from '../types/types';
 
 export interface RouterOptions {
   logger: Logger;
@@ -64,14 +68,14 @@ export const makeRouter = (
   // TODO error handling
   router.post('/services/:serviceId', async (req, res) => {
     const serviceId = req.params.serviceId;
-    const authTokens: AuthTokens = req.body.auth;
+    const requestBody: AuthRequestBody = req.body;
     try {
       const response = await handleGetByServiceId(
         serviceId,
         fetcher,
         clusterLocator,
         logger,
-        authTokens,
+        requestBody,
       );
       res.send(response);
     } catch (e) {

--- a/plugins/kubernetes-backend/src/service/router.ts
+++ b/plugins/kubernetes-backend/src/service/router.ts
@@ -26,7 +26,7 @@ import {
   GetKubernetesObjectsByServiceIdHandler,
   handleGetKubernetesObjectsByServiceId,
 } from './getKubernetesObjectsByServiceIdHandler';
-import { KubernetesClusterLocator, KubernetesFetcher } from '..';
+import { AuthTokens, KubernetesClusterLocator, KubernetesFetcher } from '..';
 
 export interface RouterOptions {
   logger: Logger;
@@ -62,15 +62,16 @@ export const makeRouter = (
   router.use(express.json());
 
   // TODO error handling
-  router.get('/services/:serviceId', async (req, res) => {
+  router.post('/services/:serviceId', async (req, res) => {
     const serviceId = req.params.serviceId;
-
+    const authTokens: AuthTokens = req.body.auth;
     try {
       const response = await handleGetByServiceId(
         serviceId,
         fetcher,
         clusterLocator,
         logger,
+        authTokens,
       );
       res.send(response);
     } catch (e) {

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -24,15 +24,17 @@ import {
   V1Service,
 } from '@kubernetes/client-node';
 
-export interface AuthTokens {
-  google?: string;
-}
-
 export interface ClusterDetails {
   name: string;
   url: string;
-  authProvider: string | undefined;
+  authProvider: string;
   serviceAccountToken?: string | undefined;
+}
+
+export interface AuthRequestBody {
+  auth?: {
+    google?: string;
+  };
 }
 
 export interface ClusterObjects {
@@ -117,10 +119,7 @@ export interface KubernetesFetcher {
 
 // Used to locate which cluster(s) a service is running on
 export interface KubernetesClusterLocator {
-  getClusterByServiceId(
-    serviceId: string,
-    authTokens: AuthTokens,
-  ): Promise<ClusterDetails[]>;
+  getClusterByServiceId(serviceId: string): Promise<ClusterDetails[]>;
 }
 
 export type KubernetesErrorTypes =

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -24,11 +24,15 @@ import {
   V1Service,
 } from '@kubernetes/client-node';
 
+export interface AuthTokens {
+  google?: string;
+}
+
 export interface ClusterDetails {
   name: string;
   url: string;
-  // TODO this will eventually be configured by the auth translation work
-  serviceAccountToken: string | undefined;
+  authProvider: string | undefined;
+  serviceAccountToken?: string | undefined;
 }
 
 export interface ClusterObjects {
@@ -113,7 +117,10 @@ export interface KubernetesFetcher {
 
 // Used to locate which cluster(s) a service is running on
 export interface KubernetesClusterLocator {
-  getClusterByServiceId(serviceId: string): Promise<ClusterDetails[]>;
+  getClusterByServiceId(
+    serviceId: string,
+    authTokens: AuthTokens,
+  ): Promise<ClusterDetails[]>;
 }
 
 export type KubernetesErrorTypes =

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@backstage/catalog-model": "^0.1.1-alpha.24",
+    "@backstage/config": "^0.1.1-alpha.24",
     "@backstage/core": "^0.1.1-alpha.24",
     "@backstage/plugin-kubernetes-backend": "^0.1.1-alpha.24",
     "@backstage/theme": "^0.1.1-alpha.24",

--- a/plugins/kubernetes/src/api/KubernetesBackendClient.ts
+++ b/plugins/kubernetes/src/api/KubernetesBackendClient.ts
@@ -17,7 +17,7 @@
 import { DiscoveryApi } from '@backstage/core';
 import { KubernetesApi } from './types';
 import {
-  AuthTokens,
+  AuthRequestBody,
   ObjectsByServiceIdResponse,
 } from '@backstage/plugin-kubernetes-backend';
 
@@ -30,11 +30,9 @@ export class KubernetesBackendClient implements KubernetesApi {
 
   private async getRequired(
     path: string,
-    authTokens: AuthTokens,
+    requestBody: AuthRequestBody,
   ): Promise<any> {
     const url = `${await this.discoveryApi.getBaseUrl('kubernetes')}${path}`;
-    const requestBody: Object = { auth: authTokens };
-
     const response = await fetch(url, {
       method: 'POST',
       headers: {
@@ -54,8 +52,8 @@ export class KubernetesBackendClient implements KubernetesApi {
 
   async getObjectsByServiceId(
     serviceId: String,
-    authTokens: AuthTokens,
+    requestBody: AuthRequestBody,
   ): Promise<ObjectsByServiceIdResponse> {
-    return await this.getRequired(`/services/${serviceId}`, authTokens);
+    return await this.getRequired(`/services/${serviceId}`, requestBody);
   }
 }

--- a/plugins/kubernetes/src/api/types.ts
+++ b/plugins/kubernetes/src/api/types.ts
@@ -15,7 +15,10 @@
  */
 
 import { createApiRef } from '@backstage/core';
-import { ObjectsByServiceIdResponse } from '@backstage/plugin-kubernetes-backend';
+import {
+  AuthTokens,
+  ObjectsByServiceIdResponse,
+} from '@backstage/plugin-kubernetes-backend';
 
 export const kubernetesApiRef = createApiRef<KubernetesApi>({
   id: 'plugin.kubernetes.service',
@@ -24,5 +27,8 @@ export const kubernetesApiRef = createApiRef<KubernetesApi>({
 });
 
 export interface KubernetesApi {
-  getObjectsByServiceId(serviceId: String): Promise<ObjectsByServiceIdResponse>;
+  getObjectsByServiceId(
+    serviceId: String,
+    authTokens: AuthTokens,
+  ): Promise<ObjectsByServiceIdResponse>;
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/GoogleKubernetesAuthProvider.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OAuthApi } from '@backstage/core';
+import { KubernetesAuthProvider } from './types';
+import { AuthRequestBody } from '@backstage/plugin-kubernetes-backend';
+
+export class GoogleKubernetesAuthProvider implements KubernetesAuthProvider {
+  authProvider: OAuthApi;
+
+  constructor(authProvider: OAuthApi) {
+    this.authProvider = authProvider;
+  }
+
+  async decorateRequestBodyForAuth(
+    requestBody: AuthRequestBody,
+  ): Promise<AuthRequestBody> {
+    const googleAuthToken: string = await this.authProvider.getAccessToken(
+      'https://www.googleapis.com/auth/cloud-platform',
+    );
+    if ('auth' in requestBody) {
+      requestBody.auth!.google = googleAuthToken;
+    } else {
+      requestBody.auth = { google: googleAuthToken };
+    }
+    return requestBody;
+  }
+}

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OAuthApi } from '@backstage/core';
+import { AuthRequestBody } from '@backstage/plugin-kubernetes-backend';
+import { KubernetesAuthProvider, KubernetesAuthProvidersApi } from './types';
+import { GoogleKubernetesAuthProvider } from './GoogleKubernetesAuthProvider';
+import { ServiceAccountKubernetesAuthProvider } from './ServiceAccountKubernetesAuthProvider';
+
+export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
+  private readonly kubernetesAuthProviderMap: Map<
+    string,
+    KubernetesAuthProvider
+  >;
+
+  constructor(options: { googleAuthApi: OAuthApi }) {
+    this.kubernetesAuthProviderMap = new Map<string, KubernetesAuthProvider>();
+    this.kubernetesAuthProviderMap.set(
+      'google',
+      new GoogleKubernetesAuthProvider(options.googleAuthApi),
+    );
+    this.kubernetesAuthProviderMap.set(
+      'serviceAccount',
+      new ServiceAccountKubernetesAuthProvider(),
+    );
+  }
+
+  async decorateRequestBodyForAuth(
+    authProvider: string,
+    requestBody: AuthRequestBody,
+  ): Promise<AuthRequestBody> {
+    const kubernetesAuthProvider:
+      | KubernetesAuthProvider
+      | undefined = this.kubernetesAuthProviderMap.get(authProvider);
+    if (kubernetesAuthProvider) {
+      return await kubernetesAuthProvider.decorateRequestBodyForAuth(
+        requestBody,
+      );
+    }
+    throw new Error(
+      `authProvider "${authProvider}" has no KubernetesAuthProvider defined for it`,
+    );
+  }
+}

--- a/plugins/kubernetes/src/kubernetes-auth-provider/ServiceAccountKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/ServiceAccountKubernetesAuthProvider.ts
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-import { createApiRef } from '@backstage/core';
-import {
-  AuthRequestBody,
-  ObjectsByServiceIdResponse,
-} from '@backstage/plugin-kubernetes-backend';
+import { KubernetesAuthProvider } from './types';
+import { AuthRequestBody } from '@backstage/plugin-kubernetes-backend';
 
-export const kubernetesApiRef = createApiRef<KubernetesApi>({
-  id: 'plugin.kubernetes.service',
-  description:
-    'Used by the Kubernetes plugin to make requests to accompanying backend',
-});
-
-export interface KubernetesApi {
-  getObjectsByServiceId(
-    serviceId: String,
+export class ServiceAccountKubernetesAuthProvider
+  implements KubernetesAuthProvider {
+  async decorateRequestBodyForAuth(
     requestBody: AuthRequestBody,
-  ): Promise<ObjectsByServiceIdResponse>;
+  ): Promise<AuthRequestBody> {
+    // No-op, with service account for auth, cluster config/details should already have serviceAccountToken
+    return requestBody;
+  }
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/types.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/types.ts
@@ -15,20 +15,24 @@
  */
 
 import { createApiRef } from '@backstage/core';
-import {
-  AuthRequestBody,
-  ObjectsByServiceIdResponse,
-} from '@backstage/plugin-kubernetes-backend';
+import { AuthRequestBody } from '@backstage/plugin-kubernetes-backend';
 
-export const kubernetesApiRef = createApiRef<KubernetesApi>({
-  id: 'plugin.kubernetes.service',
-  description:
-    'Used by the Kubernetes plugin to make requests to accompanying backend',
+export interface KubernetesAuthProvider {
+  decorateRequestBodyForAuth(
+    requestBody: AuthRequestBody,
+  ): Promise<AuthRequestBody>;
+}
+
+export const kubernetesAuthProvidersApiRef = createApiRef<
+  KubernetesAuthProvidersApi
+>({
+  id: 'plugin.kubernetes-auth-providers.service',
+  description: 'Used by the Kubernetes plugin to fetch KubernetesAuthProviders',
 });
 
-export interface KubernetesApi {
-  getObjectsByServiceId(
-    serviceId: String,
+export interface KubernetesAuthProvidersApi {
+  decorateRequestBodyForAuth(
+    authProvider: string,
     requestBody: AuthRequestBody,
-  ): Promise<ObjectsByServiceIdResponse>;
+  ): Promise<AuthRequestBody>;
 }

--- a/plugins/kubernetes/src/plugin.ts
+++ b/plugins/kubernetes/src/plugin.ts
@@ -18,9 +18,12 @@ import {
   createPlugin,
   createRouteRef,
   discoveryApiRef,
+  googleAuthApiRef,
 } from '@backstage/core';
 import { KubernetesBackendClient } from './api/KubernetesBackendClient';
 import { kubernetesApiRef } from './api/types';
+import { kubernetesAuthProvidersApiRef } from './kubernetes-auth-provider/types';
+import { KubernetesAuthProviders } from './kubernetes-auth-provider/KubernetesAuthProviders';
 
 export const rootCatalogKubernetesRouteRef = createRouteRef({
   path: '*',
@@ -35,6 +38,13 @@ export const plugin = createPlugin({
       deps: { discoveryApi: discoveryApiRef },
       factory: ({ discoveryApi }) =>
         new KubernetesBackendClient({ discoveryApi }),
+    }),
+    createApiFactory({
+      api: kubernetesAuthProvidersApiRef,
+      deps: { googleAuthApi: googleAuthApiRef },
+      factory: ({ googleAuthApi }) => {
+        return new KubernetesAuthProviders({ googleAuthApi });
+      },
     }),
   ],
 });


### PR DESCRIPTION
- For the kubernetes and kubernetes-backend plugins
  - The kubernetes (front-end) plugin uses the googleAuthApi and goes
    through oauth flow to fetch a Google auth token for the current user
    and pass that in a request to the kubernetes-backend plugin, which
    uses this token as the service account token (and hence as the
    authentication token for making K8s API requests).
- Related to https://github.com/spotify/backstage/issues/2552