### PR TITLE
docs: fix jenkins plugin readme with the new /api base path

### DIFF
--- a/plugins/jenkins/README.md
+++ b/plugins/jenkins/README.md
@@ -33,7 +33,7 @@ proxy:
         $secret:
           env: JENKINS_BASIC_AUTH_HEADER
     pathRewrite:
-      '^/proxy/jenkins/api/': '/'
+      '^/api/proxy/jenkins/api/': '/'
 ```
 
 4. Add an environment variable which contains the Jenkins credentials, (note: use an API token not your password)


### PR DESCRIPTION
The `app-config.yaml` is already correct, but we missed it in the README.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
