### PR TITLE
Feat/jenkins

### DIFF
--- a/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -118,8 +118,8 @@ const generatedColumns: TableColumn[] = [
         <Link
           component={RouterLink}
           to={generatePath(buildRouteRef.path, {
-            branch: row.source?.branchName,
-            buildNumber: row.buildNumber?.toString(),
+            branch: row.source.branchName,
+            buildNumber: row.buildNumber.toString(),
           })}
         >
           {row.buildName}
@@ -129,6 +129,7 @@ const generatedColumns: TableColumn[] = [
   },
   {
     title: 'Source',
+    field: 'source.branchName',
     render: (row: Partial<CITableBuildInfo>) => (
       <>
         <p>
@@ -142,6 +143,7 @@ const generatedColumns: TableColumn[] = [
   },
   {
     title: 'Status',
+    field: 'status',
     render: (row: Partial<CITableBuildInfo>) => {
       return (
         <Box display="flex" alignItems="center">
@@ -152,6 +154,7 @@ const generatedColumns: TableColumn[] = [
   },
   {
     title: 'Tests',
+    sorting: false,
     render: (row: Partial<CITableBuildInfo>) => {
       return (
         <>
@@ -174,6 +177,7 @@ const generatedColumns: TableColumn[] = [
   },
   {
     title: 'Actions',
+    sorting: false,
     render: (row: Partial<CITableBuildInfo>) => (
       <IconButton onClick={row.onRestartClick}>
         <RetryIcon />

--- a/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -109,17 +109,23 @@ const generatedColumns: TableColumn[] = [
     title: 'Build',
     field: 'buildName',
     highlight: true,
-    render: (row: Partial<CITableBuildInfo>) => (
-      <Link
-        component={RouterLink}
-        to={generatePath(buildRouteRef.path, {
-          branch: row.source?.branchName!,
-          buildNumber: row.buildNumber?.toString()!,
-        })}
-      >
-        {row.buildName}
-      </Link>
-    ),
+    render: (row: Partial<CITableBuildInfo>) => {
+      if (!row.source?.branchName || !row.buildNumber) {
+        return <>{row.buildName}</>;
+      }
+
+      return (
+        <Link
+          component={RouterLink}
+          to={generatePath(buildRouteRef.path, {
+            branch: row.source?.branchName,
+            buildNumber: row.buildNumber?.toString(),
+          })}
+        >
+          {row.buildName}
+        </Link>
+      );
+    },
   },
   {
     title: 'Source',


### PR DESCRIPTION
Our Jenkins returns some strange builds that have no branch name or PR. But it looks like in the API these fields are optional, mind the `!` that was used before. This crashes and makes the Plugin unusable for us 😕 I changed it to handle the null cases.

I also improved the sorting and disable it where it doesn't make sense.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
