### PR TITLE
Add Local Configuration to Development Environment page

### DIFF
--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -93,9 +93,12 @@ yarn create-plugin # Create a new plugin
 
 Backstage allows you to specify the configuration used while running the
 application on your computer. Local configuration is read from
-`app-config.development.local.yaml`. This file is ignored by Git, which means
-that you can safely use it to reference secrets like GitHub tokens worrying
-about these secrets inadvertently ending up in the Git repository.
+`app-config.local.yaml`. This file is ignored by Git, which means that you can
+safely use it to reference secrets like GitHub tokens without worrying about
+these secrets, inadvertently ending up in the Git repository. You do not need to
+copy everything from the default config to the local config.
+`app-config.local.yaml` will be merged with `app-config.yaml` and overwrite the
+default app configs.
 
-You can learn more about local configuration in
+You can learn more about the local configuration in
 [Static Configuration in Backstage](../conf/) section.

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -88,3 +88,14 @@ yarn create-plugin # Create a new plugin
 > See
 > [package.json](https://github.com/spotify/backstage/blob/master/package.json)
 > for other yarn commands/options.
+
+## Local configuration
+
+Backstage allows you to specify the configuration used while running the
+application on your computer. Local configuration is read from
+`app-config.development.local.yaml`. This file is ignored by Git, which means
+that you can safely use it to reference secrets like GitHub tokens worrying
+about these secrets inadvertently ending up in the Git repository.
+
+You can learn more about local configuration in
+[Static Configuration in Backstage](../conf/) section.


### PR DESCRIPTION
Closes #2521 

## Hey, I just made a Pull Request!

I added instructions about `app-config.development.local.yaml` file to the Development Environment section of the site to help people getting started configure their local environment settings.

I added the following text,

```md
## Local configuration

Backstage allows you to specify the configuration used while running the
application on your computer. Local configuration is read from
`app-config.local.yaml`. This file is ignored by Git, which means that you can
safely use it to reference secrets like GitHub tokens without worrying about
these secrets, inadvertently ending up in the Git repository. You do not need to
copy everything from the default config to the local config.
`app-config.local.yaml` will be merged with `app-config.yaml` and overwrite the
default app configs.

You can learn more about the local configuration in
[Static Configuration in Backstage](../conf/) section.
```

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
