### PR TITLE
docs: remove unnecessary path rewrite from jenkins plugin docs

### DIFF
--- a/plugins/jenkins/README.md
+++ b/plugins/jenkins/README.md
@@ -32,8 +32,6 @@ proxy:
       Authorization:
         $secret:
           env: JENKINS_BASIC_AUTH_HEADER
-    pathRewrite:
-      '^/api/proxy/jenkins/api/': '/'
 ```
 
 4. Add an environment variable which contains the Jenkins credentials, (note: use an API token not your password)


### PR DESCRIPTION
I just corrected that yesterday, but the parameter is unnecessary, as the path is already correct and requires no rewrite. @freben already [corrected that](https://github.com/spotify/backstage/commit/6d774764cd6e444cfe672af46478ca28781fd92c) in the `app-config.yaml` some weeks ago.