### PR TITLE
feat(catalog-backend): support placeholder replacements for absolute urls

### DIFF
--- a/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.ts
@@ -198,10 +198,19 @@ function relativeLocation({
   try {
     // The two-value form of the URL constructor handles relative paths for us
     url = new URL(value, location.target);
-  } catch (e) {
-    throw new Error(
-      `Placeholder \$${key} could not form an URL out of ${location.target} and ${value}`,
-    );
+  } catch {
+    try {
+      // Check whether value is a valid absolute URL on it's own, if not fail.
+      url = new URL(value);
+    } catch {
+      // The only remaining case that isn't support is a relative file path that should be
+      // resolved using a relative file location. Accessing local file paths can lead to
+      // path traversal attacks and access to any file on the host system. Implementing this
+      // would require additional security measures.
+      throw new Error(
+        `Placeholder \$${key} could not form an URL out of ${location.target} and ${value}`,
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
This adds support, even if the entity itself comes from a relative file location.

@freben I implemented this, but I still have a remaining issue because the `FileReaderProcessor` tries to read the file. I guess the location reader is taken from the location of the entity itself. So if the entity is read from file, all other parts have to come from a file location, too:

```
[1] 2020-10-02T15:27:04.472Z catalog warn Processor PlaceholderProcessor threw an error while processing entity API:default/spotify at file ../catalog-model/examples/spotify-api.yaml, Error: Placeholder $text could not read location https://raw.githubusercontent.com/APIs-guru/openapi-directory/master/APIs/spotify.com/v1/swagger.yaml, NotFoundError: file https://raw.githubusercontent.com/APIs-guru/openapi-directory/master/APIs/spotify.com/v1/swagger.yaml does not exist
```

I would probably expect this to be independent. My usage scenario would be the following:
* Developers specify there catalog YAML files and store them on GitHub (using the GitHub location).
* The developer reference the OpenAPI definitions directly from their services using a simple https:// url (URL location).

I think this case wouldn't work with this approach. But as far as I understand https://github.com/spotify/backstage/pull/2665 we might be able to support it in the future. So I guess this PR is still valuable.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
