### PR TITLE
Encourage shallow clone to speed up getting started.

### DIFF
--- a/docs/getting-started/running-backstage-locally.md
+++ b/docs/getting-started/running-backstage-locally.md
@@ -42,7 +42,7 @@ of GitHub and run an initial build.
 
 ```bash
 # Start from your local development folder
-git clone git@github.com:spotify/backstage.git
+git clone --depth 1 git@github.com:spotify/backstage.git
 cd backstage
 
 # Fetch our dependencies and run an initial build


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While working on a mobile broadband connection, I noticed it took about 4 minutes to freshly clone the backstage repo, which is now about 240MB.  Quite a bit of the growth seems to come from the microsite/blog and various unoptimized assets throughout the repo.

Reducing the initial clone to a depth of 1 reduces the initial download to ~65MB (currently), with corresponding improvement in clone speed.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
