### PR TITLE
feat: environment variables token name inconsistency

### DIFF
--- a/.changeset/long-ways-count.md
+++ b/.changeset/long-ways-count.md
@@ -1,0 +1,57 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+'@backstage/create-app': patch
+---
+
+Updated naming of environment variables. New pattern [NAME]\_TOKEN for Github, Gitlab, Azure & Github enterprise access tokens.
+
+### Detail:
+
+- Previously we have to export same token for both, catalog & scaffolder
+
+```bash
+export GITHUB_ACCESS_TOKEN=foo
+export GITHUB_PRIVATE_TOKEN=foo
+```
+
+with latest changes, only single export is sufficient.
+
+```bash
+export GITHUB_TOKEN=foo
+export GITLAB_TOKEN=foo
+export GHE_TOKEN=foo
+export AZURE_TOKEN=foo
+```
+
+### list:
+
+<table>
+  <tr>
+    <th>Old name</th>
+    <th>New name</th>
+  </tr>
+  <tr>
+    <td>GITHUB_ACCESS_TOKEN</td>
+    <td>GITHUB_TOKEN</td>
+  </tr>
+  <tr>
+    <td>GITHUB_PRIVATE_TOKEN</td>
+    <td>GITHUB_TOKEN</td>
+  </tr>
+  <tr>
+    <td>GITLAB_ACCESS_TOKEN</td>
+    <td>GITLAB_TOKEN</td>
+  </tr>
+  <tr>
+    <td>GITLAB_PRIVATE_TOKEN</td>
+    <td>GITLAB_TOKEN</td>
+  </tr>
+  <tr>
+    <td>AZURE_PRIVATE_TOKEN</td>
+    <td>AZURE_TOKEN</td>
+  </tr>
+  <tr>
+    <td>GHE_PRIVATE_TOKEN</td>
+    <td>GHE_TOKEN</td>
+  </tr>
+</table>

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -67,21 +67,21 @@ integrations:
   github:
     - host: github.com
       token:
-        $env: GITHUB_PRIVATE_TOKEN
+        $env: GITHUB_TOKEN
     ### Example for how to add your GitHub Enterprise instance using the API:
     # - host: ghe.example.net
     #   apiBaseUrl: https://ghe.example.net/api/v3
     #   token:
-    #     $env: GHE_PRIVATE_TOKEN
+    #     $env: GHE_TOKEN
     ### Example for how to add your GitHub Enterprise instance using raw HTTP fetches (token is optional):
     # - host: ghe.example.net
     #   rawBaseUrl: https://ghe.example.net/raw
     #   token:
-    #     $env: GHE_PRIVATE_TOKEN
+    #     $env: GHE_TOKEN
   gitlab:
     - host: gitlab.com
       token:
-        $env: GITLAB_PRIVATE_TOKEN
+        $env: GITLAB_TOKEN
   bitbucket:
     - host: bitbucket.org
       username:
@@ -91,7 +91,7 @@ integrations:
   azure:
     - host: dev.azure.com
       token:
-        $env: AZURE_PRIVATE_TOKEN
+        $env: AZURE_TOKEN
 
 catalog:
   rules:
@@ -102,12 +102,12 @@ catalog:
       providers:
         - target: https://github.com
           token:
-            $env: GITHUB_PRIVATE_TOKEN
+            $env: GITHUB_TOKEN
         #### Example for how to add your GitHub Enterprise instance using the API:
         # - target: https://ghe.example.net
         #   apiBaseUrl: https://ghe.example.net/api/v3
         #   token:
-        #     $env: GHE_PRIVATE_TOKEN
+        #     $env: GHE_TOKEN
     ldapOrg:
       ### Example for how to add your enterprise LDAP server
       # providers:
@@ -146,18 +146,18 @@ catalog:
 scaffolder:
   github:
     token:
-      $env: GITHUB_ACCESS_TOKEN
+      $env: GITHUB_TOKEN
     visibility: public # or 'internal' or 'private'
   gitlab:
     api:
       baseUrl: https://gitlab.com
       token:
-        $env: GITLAB_ACCESS_TOKEN
+        $env: GITLAB_TOKEN
   azure:
     baseUrl: https://dev.azure.com/{your-organization}
     api:
       token:
-        $env: AZURE_PRIVATE_TOKEN
+        $env: AZURE_TOKEN
 
 auth:
   providers:

--- a/docs/features/software-templates/extending/create-your-own-publisher.md
+++ b/docs/features/software-templates/extending/create-your-own-publisher.md
@@ -34,7 +34,7 @@ import { Octokit } from '@octokit/rest';
 import type { PluginEnvironment } from '../types';
 
 export default async function createPlugin({ logger }: PluginEnvironment) {
-  const githubClient = new Octokit({ auth: process.env.GITHUB_ACCESS_TOKEN });
+  const githubClient = new Octokit({ auth: process.env.GITHUB_TOKEN });
   const publisher = new GithubPublisher({ client: githubClient });
 
   return await createRouter({

--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -232,13 +232,13 @@ instance:
 scaffolder:
   github:
     token:
-      $env: GITHUB_ACCESS_TOKEN
+      $env: GITHUB_TOKEN
     visibility: public # or 'internal' or 'private'
   gitlab:
     api:
       baseUrl: https://gitlab.com
       token:
-        $env: SCAFFOLDER_GITLAB_PRIVATE_TOKEN
+        $env: GITLAB_TOKEN
 ```
 
 #### Azure DevOps
@@ -255,7 +255,7 @@ scaffolder:
     baseUrl: https://dev.azure.com/{your-organization}
     api:
       token:
-        $env: AZURE_PRIVATE_TOKEN
+        $env: AZURE_TOKEN
 ```
 
 ### Running the Backend
@@ -265,7 +265,7 @@ backend with the new configuration:
 
 ```bash
 cd packages/backend
-GITHUB_ACCESS_TOKEN=<token> yarn start
+GITHUB_TOKEN=<token> yarn start
 ```
 
 If you've also set up the frontend plugin, so you should be ready to go browse

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -55,7 +55,7 @@ auth:
 scaffolder:
   github:
     token:
-      $env: GITHUB_ACCESS_TOKEN
+      $env: GITHUB_TOKEN
     visibility: public # or 'internal' or 'private'
 
 catalog:
@@ -66,12 +66,12 @@ catalog:
       providers:
         - target: https://github.com
           token:
-            $env: GITHUB_PRIVATE_TOKEN
+            $env: GITHUB_TOKEN
         # Example for how to add your GitHub Enterprise instance:
         # - target: https://ghe.example.net
         #   apiBaseUrl: https://ghe.example.net/api/v3
         #   token:
-        #     $env: GHE_PRIVATE_TOKEN
+        #     $env: GHE_TOKEN
   locations:
     # Backstage example components
     - type: url

--- a/packages/e2e-test/src/e2e-test.ts
+++ b/packages/e2e-test/src/e2e-test.ts
@@ -285,7 +285,7 @@ async function testAppServe(pluginName: string, appDir: string) {
     cwd: appDir,
     env: {
       ...process.env,
-      GITHUB_ACCESS_TOKEN: 'abc',
+      GITHUB_TOKEN: 'abc',
     },
   });
   Browser.localhost('localhost', 3000);
@@ -368,7 +368,7 @@ async function testBackendStart(appDir: string, isPostgres: boolean) {
     cwd: appDir,
     env: {
       ...process.env,
-      GITHUB_ACCESS_TOKEN: 'abc',
+      GITHUB_TOKEN: 'abc',
     },
   });
 

--- a/plugins/techdocs-backend/src/default-branch.ts
+++ b/plugins/techdocs-backend/src/default-branch.ts
@@ -69,7 +69,7 @@ function getGithubRequestOptions(config: Config): RequestInit {
   const token =
     config.getOptionalString('catalog.processors.github.privateToken') ??
     config.getOptionalString('catalog.processors.githubApi.privateToken') ??
-    process.env.GITHUB_PRIVATE_TOKEN;
+    process.env.GITHUB_TOKEN;
 
   if (token) {
     headers.Authorization = `token ${token}`;
@@ -88,7 +88,7 @@ function getGitlabRequestOptions(config: Config): RequestInit {
   const token =
     config.getOptionalString('catalog.processors.gitlab.privateToken') ??
     config.getOptionalString('catalog.processors.gitlabApi.privateToken') ??
-    process.env.GITLAB_ACCESS_TOKEN;
+    process.env.GITLAB_TOKEN;
 
   if (token) {
     headers['PRIVATE-TOKEN'] = token;

--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -126,9 +126,7 @@ export const checkoutGitRepository = async (
     process.env.GITLAB_PRIVATE_TOKEN_USER ||
     '';
   const token =
-    process.env.GITHUB_PRIVATE_TOKEN ||
-    process.env.GITLAB_PRIVATE_TOKEN_USER ||
-    '';
+    process.env.GITHUB_TOKEN || process.env.GITLAB_PRIVATE_TOKEN_USER || '';
 
   if (fs.existsSync(repositoryTmpPath)) {
     try {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #2652 

```
GITHUB_PRIVATE_TOKEN & GITHUB_ACCESS_TOKEN => GITHUB_TOKEN
GITLAB_PRIVATE_TOKEN, GITLAB_ACCESS_TOKEN & SCAFFOLDER_GITLAB_PRIVATE_TOKEN => GITLAB_TOKEN
AZURE_PRIVATE_TOKEN => AZURE_TOKEN
GHE_PRIVATE_TOKEN => GHE_TOKEN
```

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
