### PR TITLE
#2534 Refactored WorkflowRunStatus to also account for the build run's conclusion

### DIFF
--- a/plugins/github-actions/src/components/Cards/Cards.tsx
+++ b/plugins/github-actions/src/components/Cards/Cards.tsx
@@ -60,7 +60,10 @@ const WidgetContent = ({
       metadata={{
         status: (
           <>
-            <WorkflowRunStatus status={lastRun.status} />
+            <WorkflowRunStatus
+              status={lastRun.status}
+              conclusion={lastRun.conclusion}
+            />
           </>
         ),
         message: lastRun.message,

--- a/plugins/github-actions/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
@@ -106,7 +106,10 @@ const StepView = ({ step }: { step: Step }) => {
         />
       </TableCell>
       <TableCell>
-        <WorkflowRunStatus status={step.status.toUpperCase()} />
+        <WorkflowRunStatus
+          status={step.status.toUpperCase()}
+          conclusion={step.conclusion.toUpperCase()}
+        />
       </TableCell>
     </TableRow>
   );
@@ -204,7 +207,10 @@ export const WorkflowRunDetails = ({ entity }: { entity: Entity }) => {
                 <Typography noWrap>Status</Typography>
               </TableCell>
               <TableCell>
-                <WorkflowRunStatus status={details.value?.status} />
+                <WorkflowRunStatus
+                  status={details.value?.status}
+                  conclusion={details.value?.conclusion}
+                />
               </TableCell>
             </TableRow>
             <TableRow>

--- a/plugins/github-actions/src/components/WorkflowRunStatus/WorkflowRunStatus.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunStatus/WorkflowRunStatus.tsx
@@ -14,13 +14,22 @@
  * limitations under the License.
  */
 
-import { StatusPending, StatusRunning, StatusOK } from '@backstage/core';
+import {
+  StatusPending,
+  StatusRunning,
+  StatusOK,
+  StatusWarning,
+  StatusAborted,
+  StatusError,
+} from '@backstage/core';
 import React from 'react';
 
 export const WorkflowRunStatus = ({
   status,
+  conclusion,
 }: {
   status: string | undefined;
+  conclusion: string | undefined;
 }) => {
   if (status === undefined) return null;
   switch (status.toLowerCase()) {
@@ -37,11 +46,32 @@ export const WorkflowRunStatus = ({
         </>
       );
     case 'completed':
-      return (
-        <>
-          <StatusOK /> Completed
-        </>
-      );
+      switch (conclusion?.toLowerCase()) {
+        case 'skipped' || 'canceled':
+          return (
+            <>
+              <StatusAborted /> Aborted
+            </>
+          );
+        case 'timed_out':
+          return (
+            <>
+              <StatusWarning /> Timed out
+            </>
+          );
+        case 'failure':
+          return (
+            <>
+              <StatusError /> Error
+            </>
+          );
+        default:
+          return (
+            <>
+              <StatusOK /> Completed
+            </>
+          );
+      }
     default:
       return (
         <>

--- a/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
@@ -46,6 +46,7 @@ export type WorkflowRun = {
     };
   };
   status: string;
+  conclusion: string;
   onReRunClick: () => void;
 };
 
@@ -84,7 +85,7 @@ const generatedColumns: TableColumn[] = [
 
     render: (row: Partial<WorkflowRun>) => (
       <Box display="flex" alignItems="center">
-        <WorkflowRunStatus status={row.status} />
+        <WorkflowRunStatus status={row.status} conclusion={row.conclusion} />
       </Box>
     ),
   },

--- a/plugins/github-actions/src/components/useWorkflowRuns.ts
+++ b/plugins/github-actions/src/components/useWorkflowRuns.ts
@@ -87,6 +87,7 @@ export function useWorkflowRuns({
                 },
               },
               status: run.status,
+              conclusion: run.conclusion,
               url: run.url,
               githubUrl: run.html_url,
             }));


### PR DESCRIPTION
Hey, I just made a Pull Request!

The Github check-run api returns both a `status` and a `conclusion` where the `conclusion` is what represents whether a build-step has failed or not. I have refactored WorkflowRunStatus for the Github Actions plugin to better reflect the build status using the build's conclusion. Instead of always being green and set as "complete", the build status now shows that an error occurred or if a step was skipped/aborted. 
<img width="1280" alt="Screenshot 2020-10-05 at 15 50 31" src="https://user-images.githubusercontent.com/16206098/95089444-7189b780-0724-11eb-8d4a-3949ad071aaa.png">
<img width="1280" alt="Screenshot 2020-10-05 at 15 50 41" src="https://user-images.githubusercontent.com/16206098/95089446-72224e00-0724-11eb-8562-b34366ba273c.png">
<img width="1280" alt="Screenshot 2020-10-05 at 15 50 56" src="https://user-images.githubusercontent.com/16206098/95089450-73537b00-0724-11eb-9710-e56f3fe05b1e.png">
<img width="1280" alt="Screenshot 2020-10-05 at 15 51 09" src="https://user-images.githubusercontent.com/16206098/95089452-73ec1180-0724-11eb-9c82-28d0037eb8f9.png">


#### :heavy_check_mark: Checklist
- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes

Fixes #2534
