### PR TITLE
feat(create-app): add catalog-info.yaml in the created app

### DIFF
--- a/docs/getting-started/create-an-app.md
+++ b/docs/getting-started/create-an-app.md
@@ -74,6 +74,7 @@ app.
 ```
 app
 ├── app-config.yaml
+├── catalog-info.yaml
 ├── lerna.json
 ├── package.json
 └── packages
@@ -83,6 +84,9 @@ app
 
 - **app-config.yaml**: Main configuration file for the app. See
   [Configuration](https://backstage.io/docs/conf/) for more information.
+- **catalog-info.yaml**: Catalog Entities descriptors. See
+  [Descriptor Format of Catalog Entities](https://backstage.io/docs/features/software-catalog/descriptor-format)
+  to get started.
 - **lerna.json**: Contains information about workspaces and other lerna
   configuration needed for the monorepo setup.
 - **package.json**: Root package.json for the project. _Note: Be sure that you

--- a/packages/create-app/templates/default-app/catalog-info.yaml.hbs
+++ b/packages/create-app/templates/default-app/catalog-info.yaml.hbs
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1 
+kind: Component
+metadata:
+  name: {{name}} 
+  description: An example of a Backstage application.
+  # Example for optional annotations
+  # annotations: 
+    # github.com/project-slug: spotify/backstage
+    # backstage.io/techdocs-ref: github:https://github.com/spotify/backstage.git
+spec:
+  type: website
+  owner: john@example.com
+  lifecycle: experimental


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #2754. Added a `catalog-info.yaml` based on the same file for the source repository. Also, updated the docs to provide more information on working with the catalog file.

See the screenshots below:

<img width="618" alt="Screenshot 2020-10-05 at 10 40 38 PM" src="https://user-images.githubusercontent.com/42670338/95093970-f2b07100-075b-11eb-9aca-32fc221f6ea0.png">
<img width="625" alt="Screenshot 2020-10-05 at 10 41 01 PM" src="https://user-images.githubusercontent.com/42670338/95093979-f47a3480-075b-11eb-86bb-dc51b6a33409.png">


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
