### PR TITLE
Tweak confusing deployment wording

### DIFF
--- a/plugins/cost-insights/README.md
+++ b/plugins/cost-insights/README.md
@@ -9,7 +9,7 @@ At Spotify, we find that cloud costs are optimized organically when:
 - The data is shown in software terms familiar to them.
 - Alerts and recommendations are targeted and actionable.
 
-Cost Insights shows trends over time, at the granularity of your software deployments - rather than the cloud provider's concepts. It can be used to troubleshoot cost anomalies, and promote cost-saving infrastructure migrations.
+Cost Insights shows trends over time, at the granularity of Backstage catalog entities - rather than the cloud provider's concepts. It can be used to troubleshoot cost anomalies, and promote cost-saving infrastructure migrations.
 
 ## Install
 


### PR DESCRIPTION
Feedback from @dtuite, `software deployments` is misleading terminology here. We mean catalog entities (though this is arguably a bit hand-wavey pending #2646).

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
