### PR TITLE
renamed all instances of GuageProgress component to Guage

### DIFF
--- a/packages/core/src/components/ProgressBars/Gauge.stories.tsx
+++ b/packages/core/src/components/ProgressBars/Gauge.stories.tsx
@@ -15,41 +15,41 @@
  */
 
 import React from 'react';
-import { GaugeProgress } from './GaugeProgress';
+import { Gauge } from './Gauge';
 
 const containerStyle = { width: 300 };
 
 export default {
-  title: 'GaugeProgress',
-  component: GaugeProgress,
+  title: 'Gauge',
+  component: Gauge,
 };
 
 export const Default = () => (
   <div style={containerStyle}>
-    <GaugeProgress value={0.8} />
+    <Gauge value={0.8} />
   </div>
 );
 
 export const MediumProgress = () => (
   <div style={containerStyle}>
-    <GaugeProgress value={0.5} />
+    <Gauge value={0.5} />
   </div>
 );
 
 export const LowProgress = () => (
   <div style={containerStyle}>
-    <GaugeProgress value={0.2} />
+    <Gauge value={0.2} />
   </div>
 );
 
 export const InverseLowProgress = () => (
   <div style={containerStyle}>
-    <GaugeProgress value={0.2} inverse />
+    <Gauge value={0.2} inverse />
   </div>
 );
 
 export const AbsoluteProgress = () => (
   <div style={containerStyle}>
-    <GaugeProgress value={89.2} fractional={false} unit="m/s" />
+    <Gauge value={89.2} fractional={false} unit="m/s" />
   </div>
 );

--- a/packages/core/src/components/ProgressBars/Gauge.test.jsx
+++ b/packages/core/src/components/ProgressBars/Gauge.test.jsx
@@ -17,32 +17,32 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { wrapInTestApp } from '@backstage/test-utils';
-import { GaugeProgress, getProgressColor } from './GaugeProgress';
+import { Gauge, getProgressColor } from './Gauge';
 
-describe('<GaugeProgress />', () => {
+describe('<Gauge />', () => {
   it('renders without exploding', () => {
     const { getByText } = render(
-      wrapInTestApp(<GaugeProgress value={10} fractional={false} />),
+      wrapInTestApp(<Gauge value={10} fractional={false} />),
     );
     getByText('10%');
   });
   it('handles fractional prop', () => {
     const { getByText } = render(
-      wrapInTestApp(<GaugeProgress value={0.1} fractional />),
+      wrapInTestApp(<Gauge value={0.1} fractional />),
     );
     getByText('10%');
   });
 
   it('handles max prop', () => {
     const { getByText } = render(
-      wrapInTestApp(<GaugeProgress value={1} max={10} fractional={false} />),
+      wrapInTestApp(<Gauge value={1} max={10} fractional={false} />),
     );
     getByText('1%');
   });
 
   it('handles unit prop', () => {
     const { getByText } = render(
-      wrapInTestApp(<GaugeProgress value={10} fractional={false} unit="m" />),
+      wrapInTestApp(<Gauge value={10} fractional={false} unit="m" />),
     );
     getByText('10m');
   });

--- a/packages/core/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core/src/components/ProgressBars/Gauge.tsx
@@ -77,7 +77,7 @@ export function getProgressColor(
   return palette.status.ok;
 }
 
-export const GaugeProgress: FC<Props> = props => {
+export const Gauge: FC<Props> = props => {
   const classes = useStyles(props);
   const theme = useTheme<BackstageTheme>();
   const { value, fractional, inverse, unit, max } = {

--- a/packages/core/src/components/ProgressBars/GaugeCard.tsx
+++ b/packages/core/src/components/ProgressBars/GaugeCard.tsx
@@ -18,7 +18,7 @@ import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core';
 import { InfoCard } from '../../layout/InfoCard';
 import { BottomLinkProps } from '../../layout/BottomLink';
-import { GaugeProgress } from './GaugeProgress';
+import { Gauge } from './Gauge';
 
 type Props = {
   title: string;
@@ -48,7 +48,7 @@ export const GaugeCard: FC<Props> = props => {
         deepLink={deepLink}
         variant={variant}
       >
-        <GaugeProgress value={progress} />
+        <Gauge value={progress} />
       </InfoCard>
     </div>
   );

--- a/packages/core/src/components/ProgressBars/LinearGauge.tsx
+++ b/packages/core/src/components/ProgressBars/LinearGauge.tsx
@@ -19,7 +19,7 @@ import { Tooltip, useTheme } from '@material-ui/core';
 // @ts-ignore
 import { Line } from 'rc-progress';
 import { BackstageTheme } from '@backstage/theme';
-import { getProgressColor } from './GaugeProgress';
+import { getProgressColor } from './Gauge';
 
 type Props = {
   /**

--- a/packages/core/src/components/ProgressBars/index.ts
+++ b/packages/core/src/components/ProgressBars/index.ts
@@ -15,5 +15,5 @@
  */
 
 export { GaugeCard } from './GaugeCard';
-export { GaugeProgress } from './GaugeProgress';
+export { Gauge } from './Gauge';
 export { LinearGauge } from './LinearGauge';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
I renamed all instances of GuageProgress to Guage in the components files and its tests as per issue #2773 

The syntax for using it is now:
```typescript
import { Gauge } from './Gauge';
...
<Gauge value={0.8} />
```

I ran `yarn test:all` to be sure and received:
![image](https://user-images.githubusercontent.com/16850875/95231475-7a9d8600-0803-11eb-894e-5caa7aa29384.png)
and
![image](https://user-images.githubusercontent.com/16850875/95231523-8be69280-0803-11eb-8748-460e22538dcc.png)
Which points me to `node_modules\@backstage\plugin-scaffolder-backend\src\scaffolder\stages\templater\cookiecutter.test.ts`  so I am unsure if my renaming has caused that test to fail or not

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
