### PR TITLE
feat(catalog-backend): temporary named test db support to aid in debugging

### DIFF
--- a/plugins/catalog-backend/src/database/CommonDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.test.ts
@@ -124,7 +124,7 @@ describe('CommonDatabase', () => {
         {
           ...output,
           status: DatabaseLocationUpdateLogStatus.FAIL,
-          timestamp: expect.any(String),
+          timestamp: expect.anything(),
         },
       ]),
     );
@@ -191,24 +191,26 @@ describe('CommonDatabase', () => {
       const result = await db.locationHistory(
         'dd12620d-0436-422f-93bd-929aa0788123',
       );
-      expect(result).toEqual([
-        {
-          created_at: expect.anything(),
-          entity_name: null,
-          id: expect.anything(),
-          location_id: 'dd12620d-0436-422f-93bd-929aa0788123',
-          message: null,
-          status: DatabaseLocationUpdateLogStatus.SUCCESS,
-        },
-        {
-          created_at: expect.anything(),
-          entity_name: null,
-          id: expect.anything(),
-          location_id: 'dd12620d-0436-422f-93bd-929aa0788123',
-          message: 'Something went wrong',
-          status: DatabaseLocationUpdateLogStatus.FAIL,
-        },
-      ]);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            created_at: expect.anything(),
+            entity_name: null,
+            id: expect.anything(),
+            location_id: 'dd12620d-0436-422f-93bd-929aa0788123',
+            message: null,
+            status: DatabaseLocationUpdateLogStatus.SUCCESS,
+          },
+          {
+            created_at: expect.anything(),
+            entity_name: null,
+            id: expect.anything(),
+            location_id: 'dd12620d-0436-422f-93bd-929aa0788123',
+            message: 'Something went wrong',
+            status: DatabaseLocationUpdateLogStatus.FAIL,
+          },
+        ]),
+      );
     });
   });
 


### PR DESCRIPTION
Fully aware that this isn't pretty. But since I am in the process of debugging migrations and catalog stuff and want to easily run manually against several databases while waiting for proper testcontainers and e2e tests, this at least lets me gain some confidence short term.