### PR TITLE
fix(techdocs-cli): make techdocs-cli work on Windows

### DIFF
--- a/packages/techdocs-cli/src/index.ts
+++ b/packages/techdocs-cli/src/index.ts
@@ -20,11 +20,7 @@ import path from 'path';
 import HTTPServer from './lib/httpServer';
 import openBrowser from 'react-dev-utils/openBrowser';
 
-const run = (
-  workingDirectory: string,
-  name: string,
-  args: string[] = [],
-): ChildProcess => {
+const run = (name: string, args: string[] = []): ChildProcess => {
   const [stdin, stdout, stderr] = [
     'inherit' as const,
     'pipe' as const,
@@ -32,7 +28,6 @@ const run = (
   ];
 
   const childProcess = spawn(name, args, {
-    cwd: workingDirectory,
     stdio: [stdin, stdout, stderr],
     shell: true,
     env: {
@@ -59,13 +54,13 @@ const runMkdocsServer = (options?: {
   const devAddr = options?.devAddr ?? '0.0.0.0:8000';
 
   return new Promise(resolve => {
-    const childProcess = run(process.env.PWD!, 'docker', [
+    const childProcess = run('docker', [
       'run',
       '-it',
       '-w',
       '/content',
       '-v',
-      '$(pwd):/content',
+      `${process.cwd()}:/content`,
       '-p',
       '8000:8000',
       'spotify/techdocs',


### PR DESCRIPTION
Please don't judge me 😆 

$(pwd) won't work outside a Unix shell, so I replaced it with process.cwd(). Then it's not important anymore in which directory the docker command is executed.

Tested on both Mac and Windows 😉 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
