### PR TITLE
storybook: Group components in the sidebar

### DIFF
--- a/packages/core/src/components/Button/Button.stories.tsx
+++ b/packages/core/src/components/Button/Button.stories.tsx
@@ -24,7 +24,7 @@ const Location = () => {
 };
 
 export default {
-  title: 'Button',
+  title: 'Inputs/Button',
   component: Button,
   decorators: [
     (storyFn: FunctionComponentFactory<{}>) => (

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.stories.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.stories.tsx
@@ -19,7 +19,7 @@ import { CodeSnippet } from './CodeSnippet';
 import { InfoCard } from '../../layout/InfoCard';
 
 export default {
-  title: 'CodeSnippet',
+  title: 'Data Display/CodeSnippet',
   component: CodeSnippet,
 };
 

--- a/packages/core/src/components/CopyTextButton/CopyTextButton.stories.tsx
+++ b/packages/core/src/components/CopyTextButton/CopyTextButton.stories.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { CopyTextButton } from '.';
 
 export default {
-  title: 'CopyTextButton',
+  title: 'Inputs/CopyTextButton',
   component: CopyTextButton,
 };
 

--- a/packages/core/src/components/DismissableBanner/DismissableBanner.stories.tsx
+++ b/packages/core/src/components/DismissableBanner/DismissableBanner.stories.tsx
@@ -28,7 +28,7 @@ import {
 } from '@backstage/core-api';
 
 export default {
-  title: 'DismissableBanner',
+  title: 'Feedback/DismissableBanner',
   component: DismissableBanner,
 };
 

--- a/packages/core/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/core/src/components/EmptyState/EmptyState.stories.tsx
@@ -20,7 +20,7 @@ import { Button } from '@material-ui/core';
 import { MissingAnnotationEmptyState } from './MissingAnnotationEmptyState';
 
 export default {
-  title: 'EmptyState',
+  title: 'Feedback/EmptyState',
   component: EmptyState,
 };
 

--- a/packages/core/src/components/HorizontalScrollGrid/HorizontalScrollGrid.stories.tsx
+++ b/packages/core/src/components/HorizontalScrollGrid/HorizontalScrollGrid.stories.tsx
@@ -21,7 +21,7 @@ const containerStyle = { width: 800, height: 400, margin: 20 };
 const opacityArray = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
 
 export default {
-  title: 'HorizontalScrollGrid',
+  title: 'Layout/HorizontalScrollGrid',
   component: HorizontalScrollGrid,
 };
 

--- a/packages/core/src/components/Lifecycle/Lifecycle.stories.tsx
+++ b/packages/core/src/components/Lifecycle/Lifecycle.stories.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { Lifecycle } from './Lifecycle';
 
 export default {
-  title: 'Lifecycle',
+  title: 'Feedback/Lifecycle',
   component: Lifecycle,
 };
 

--- a/packages/core/src/components/Link/Link.stories.tsx
+++ b/packages/core/src/components/Link/Link.stories.tsx
@@ -29,7 +29,7 @@ const Location = () => {
 };
 
 export default {
-  title: 'Link',
+  title: 'Navigation/Link',
   component: Link,
   decorators: [
     (storyFn: FunctionComponentFactory<{}>) => (

--- a/packages/core/src/components/Progress/Progress.stories.tsx
+++ b/packages/core/src/components/Progress/Progress.stories.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { Progress } from '.';
 
 export default {
-  title: 'Progress',
+  title: 'Feedback/Progress',
   component: Progress,
 };
 

--- a/packages/core/src/components/ProgressBars/Gauge.stories.tsx
+++ b/packages/core/src/components/ProgressBars/Gauge.stories.tsx
@@ -20,7 +20,7 @@ import { Gauge } from './Gauge';
 const containerStyle = { width: 300 };
 
 export default {
-  title: 'Gauge',
+  title: 'Feedback/Gauge',
   component: Gauge,
 };
 

--- a/packages/core/src/components/ProgressBars/GaugeCard.stories.tsx
+++ b/packages/core/src/components/ProgressBars/GaugeCard.stories.tsx
@@ -21,7 +21,7 @@ import { Grid } from '@material-ui/core';
 const linkInfo = { title: 'Go to XYZ Location', link: '#' };
 
 export default {
-  title: 'Progress Card',
+  title: 'Data Display/Progress Card',
   component: GaugeCard,
 };
 

--- a/packages/core/src/components/ProgressBars/LinearGauge.stories.tsx
+++ b/packages/core/src/components/ProgressBars/LinearGauge.stories.tsx
@@ -20,7 +20,7 @@ import { LinearGauge } from './LinearGauge';
 const containerStyle = { width: 300 };
 
 export default {
-  title: 'LinearGauge',
+  title: 'Feedback/LinearGauge',
   component: LinearGauge,
 };
 

--- a/packages/core/src/components/SimpleStepper/SimpleStepper.stories.tsx
+++ b/packages/core/src/components/SimpleStepper/SimpleStepper.stories.tsx
@@ -19,7 +19,7 @@ import { TextField } from '@material-ui/core';
 import { SimpleStepper, SimpleStepperStep } from '.';
 
 export default {
-  title: 'SimpleStepper',
+  title: 'Navigation/SimpleStepper',
   component: SimpleStepper,
 };
 

--- a/packages/core/src/components/Status/Status.stories.tsx
+++ b/packages/core/src/components/Status/Status.stories.tsx
@@ -27,7 +27,7 @@ import { Table } from '../Table';
 import { InfoCard } from '../../layout/InfoCard';
 
 export default {
-  title: 'Status',
+  title: 'Feedback/Status',
   component: StatusOK,
 };
 

--- a/packages/core/src/components/StructuredMetadataTable/StructuredMetadataTable.stories.tsx
+++ b/packages/core/src/components/StructuredMetadataTable/StructuredMetadataTable.stories.tsx
@@ -37,7 +37,7 @@ const metadata = {
 };
 
 export default {
-  title: 'Structured Metadata Table',
+  title: 'Data Display/Structured Metadata Table',
   component: StructuredMetadataTable,
 };
 

--- a/packages/core/src/components/Table/Table.stories.tsx
+++ b/packages/core/src/components/Table/Table.stories.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { Table, SubvalueCell, TableColumn } from './';
 
 export default {
-  title: 'Table',
+  title: 'Data Display/Table',
   component: Table,
 };
 

--- a/packages/core/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/core/src/components/Tabs/Tabs.stories.tsx
@@ -19,7 +19,7 @@ import { Tabs } from './Tabs';
 import AccessAlarmIcon from '@material-ui/icons/AccessAlarm';
 
 export default {
-  title: 'Tabs',
+  title: 'Navigation/Tabs',
   component: Tabs,
 };
 

--- a/packages/core/src/components/TrendLine/TrendLine.stories.tsx
+++ b/packages/core/src/components/TrendLine/TrendLine.stories.tsx
@@ -20,7 +20,7 @@ import { TrendLine } from './TrendLine';
 import { InfoCard } from '../../layout/InfoCard';
 
 export default {
-  title: 'TrendLine',
+  title: 'Data Display/TrendLine',
   component: TrendLine,
 };
 

--- a/packages/core/src/components/WarningPanel/WarningPanel.stories.tsx
+++ b/packages/core/src/components/WarningPanel/WarningPanel.stories.tsx
@@ -19,7 +19,7 @@ import { WarningPanel } from './WarningPanel';
 import { Link, Button } from '@material-ui/core';
 
 export default {
-  title: 'Warning Panel',
+  title: 'Feedback/Warning Panel',
   component: WarningPanel,
 };
 

--- a/packages/core/src/components/stories/Chip.stories.tsx
+++ b/packages/core/src/components/stories/Chip.stories.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { Chip } from '@material-ui/core';
 
 export default {
-  title: 'Chip',
+  title: 'Data Display/Chip',
   component: Chip,
 };
 

--- a/packages/core/src/layout/Header/Header.stories.tsx
+++ b/packages/core/src/layout/Header/Header.stories.tsx
@@ -19,7 +19,7 @@ import { HeaderLabel } from '../HeaderLabel';
 import { Page, pageTheme } from '../Page';
 
 export default {
-  title: 'Header',
+  title: 'Layout/Header',
   component: Header,
 };
 

--- a/packages/core/src/layout/InfoCard/InfoCard.stories.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.stories.tsx
@@ -20,7 +20,7 @@ import { Grid, Typography } from '@material-ui/core';
 const linkInfo = { title: 'Go to XYZ Location', link: '#' };
 
 export default {
-  title: 'Information Card',
+  title: 'Layout/Information Card',
   component: InfoCard,
 };
 

--- a/packages/core/src/layout/ItemCard/ItemCard.stories.tsx
+++ b/packages/core/src/layout/ItemCard/ItemCard.stories.tsx
@@ -18,7 +18,7 @@ import { ItemCard } from '.';
 import { Grid } from '@material-ui/core';
 
 export default {
-  title: 'Item Card',
+  title: 'Layout/Item Card',
   component: ItemCard,
 };
 

--- a/packages/core/src/layout/Page/Page.stories.tsx
+++ b/packages/core/src/layout/Page/Page.stories.tsx
@@ -36,7 +36,7 @@ import {
 import { Box, Typography, Link, Chip, Grid } from '@material-ui/core';
 
 export default {
-  title: 'Example Plugin',
+  title: 'Layout/Example Plugin',
   component: Page,
 };
 

--- a/packages/core/src/layout/Sidebar/Sidebar.stories.tsx
+++ b/packages/core/src/layout/Sidebar/Sidebar.stories.tsx
@@ -28,7 +28,7 @@ import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import { MemoryRouter } from 'react-router-dom';
 
 export default {
-  title: 'Sidebar',
+  title: 'Layout/Sidebar',
   component: Sidebar,
   decorators: [
     (storyFn: () => JSX.Element) => (

--- a/packages/core/src/layout/TabbedCard/TabbedCard.stories.tsx
+++ b/packages/core/src/layout/TabbedCard/TabbedCard.stories.tsx
@@ -20,7 +20,7 @@ import { Grid } from '@material-ui/core';
 const cardContentStyle = { height: 200, width: 500 };
 
 export default {
-  title: 'Tabbed Card',
+  title: 'Layout/Tabbed Card',
   component: TabbedCard,
   decorators: [
     (storyFn: () => JSX.Element) => (

--- a/plugins/user-settings/src/components/SidebarWithSettings.stories.tsx
+++ b/plugins/user-settings/src/components/SidebarWithSettings.stories.tsx
@@ -33,7 +33,7 @@ import { Settings } from './Settings';
 import { SettingsPage } from './SettingsPage';
 
 export default {
-  title: 'Settings',
+  title: 'Plugins/user-settings/Settings',
   component: Settings,
   decorators: [
     (storyFn: () => JSX.Element) => (


### PR DESCRIPTION
As we add more components to our Storybook, It might be easier to display them in different categories. 
Got some inspiration for the name of the groups from https://material-ui.com/

![Skärmavbild 2020-10-08 kl  09 52 37](https://user-images.githubusercontent.com/18682151/95430507-22be6680-094c-11eb-9198-479442f8ce13.png)
