### PR TITLE
show response status code from k8s API in UI

### DIFF
--- a/plugins/kubernetes/src/components/KubernetesContent/ErrorPanel.test.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent/ErrorPanel.test.tsx
@@ -76,7 +76,7 @@ describe('ErrorPanel', () => {
     expect(getByText('Cluster: THIS_CLUSTER')).toBeInTheDocument();
     expect(
       getByText(
-        "Error fetching Kubernetes resource: 'some/resource', error: SYSTEM_ERROR",
+        "Error fetching Kubernetes resource: 'some/resource', error: SYSTEM_ERROR, status code: 500",
       ),
     ).toBeInTheDocument();
   });

--- a/plugins/kubernetes/src/components/KubernetesContent/ErrorPanel.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent/ErrorPanel.tsx
@@ -29,7 +29,7 @@ const clustersWithErrorsToErrorMessage = (
         {c.errors.map((e, j) => {
           return (
             <Typography variant="body2" key={j}>
-              {`Error fetching Kubernetes resource: '${e.resourcePath}', error: ${e.errorType}`}
+              {`Error fetching Kubernetes resource: '${e.resourcePath}', error: ${e.errorType}, status code: ${e.statusCode}`}
             </Typography>
           );
         })}


### PR DESCRIPTION
This came up on discord, it is easier to debug user's setups if we know how the K8S API is responding.

Show the Kubernetes response status code in the UI to make debugging easier 

![Screen Shot 2020-10-08 at 10 27 17](https://user-images.githubusercontent.com/6514980/95440449-dcb7d180-0950-11eb-99df-4da149565bea.png)


#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
