### PR TITLE
feat: use new UrlReader in PlaceholderProcessor

### DIFF
--- a/.changeset/2798.md
+++ b/.changeset/2798.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Use the new `UrlReader` in `PlaceholderProcessor`.
+This allows to use the placeholder processor to include API definitions in API entities.
+Previously it was only possible to do this if the definition comes from the same location type as the entity itself.

--- a/packages/catalog-model/examples/spotify-api.yaml
+++ b/packages/catalog-model/examples/spotify-api.yaml
@@ -7,8 +7,11 @@ metadata:
     - spotify
     - rest
   annotations:
+    # The annotation is deprecated, we use placeholders (see below) instead, remove it later.
     backstage.io/definition-at-location: 'url:https://raw.githubusercontent.com/APIs-guru/openapi-directory/master/APIs/spotify.com/v1/swagger.yaml'
 spec:
   type: openapi
   lifecycle: production
   owner: spotify@example.com
+  definition:
+    $text: https://github.com/APIs-guru/openapi-directory/blob/master/APIs/spotify.com/v1/swagger.yaml

--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -125,7 +125,7 @@ export class LocationReaders implements LocationReader {
       LdapOrgReaderProcessor.fromConfig(config, { logger }),
       new UrlReaderProcessor(options),
       new YamlProcessor(),
-      PlaceholderProcessor.default(),
+      PlaceholderProcessor.default({ reader: options.reader }),
       new CodeOwnersProcessor(),
       new ApiDefinitionAtLocationProcessor(),
       new EntityPolicyProcessor(entityPolicy),


### PR DESCRIPTION
This allows to use the placeholder processor to include API definitions in API entities. Previously it was only possible to do this, if the definition comes from the same location type as the entity itself.

@freben This is a follow-up for my previous try. If this is the right way I would continue with:

- remove the `backstage.io/definition-at-location` annotation (we might later add a better one to components)
- remove the read parameter from [`processEntity`](https://github.com/spotify/backstage/blob/master/plugins/catalog-backend/src/ingestion/processors/types.ts#L61). I don't think that we still need it with the new `UrlReader` (at least Codeowner is still using it, so I would fix that too).

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
