### PR TITLE
Auth Provider: make default scopes configurable

### DIFF
--- a/.changeset/2800.md
+++ b/.changeset/2800.md
@@ -1,0 +1,15 @@
+---
+'@backstage/core': minor
+'@backstage/core-api': minor
+---
+
+Updated the `GithubAuth.create` method to configure the default scope of the Github Auth Api. As a result the
+default scope is configurable when overwriting the Core Api in the app.
+
+```
+GithubAuth.create({
+  discoveryApi,
+  oauthRequestApi,
+  defaultScopes: ['read:user', 'repo'],
+}),
+```

--- a/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
@@ -41,6 +41,7 @@ type CreateOptions = {
   discoveryApi: DiscoveryApi;
   oauthRequestApi: OAuthRequestApi;
 
+  defaultScopes?: string[];
   environment?: string;
   provider?: AuthProvider & { id: string };
 };
@@ -67,6 +68,7 @@ class GithubAuth implements OAuthApi, SessionApi {
     environment = 'development',
     provider = DEFAULT_PROVIDER,
     oauthRequestApi,
+    defaultScopes = ['read:user'],
   }: CreateOptions) {
     const connector = new DefaultAuthConnector({
       discoveryApi,
@@ -89,7 +91,7 @@ class GithubAuth implements OAuthApi, SessionApi {
 
     const sessionManager = new StaticAuthSessionManager({
       connector,
-      defaultScopes: new Set(['read:user']),
+      defaultScopes: new Set(defaultScopes),
       sessionScopes: (session: GithubSession) => session.providerInfo.scopes,
     });
 

--- a/packages/core/src/api-wrappers/defaultApis.ts
+++ b/packages/core/src/api-wrappers/defaultApis.ts
@@ -96,7 +96,11 @@ export const defaultApis = [
       oauthRequestApi: oauthRequestApiRef,
     },
     factory: ({ discoveryApi, oauthRequestApi }) =>
-      GithubAuth.create({ discoveryApi, oauthRequestApi }),
+      GithubAuth.create({
+        discoveryApi,
+        oauthRequestApi,
+        defaultScopes: ['read:user'],
+      }),
   }),
   createApiFactory({
     api: oktaAuthApiRef,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Are there any thoughts about making the defaultScopes of the OAuth API configurable via config for the different provider? If you're using the SignIn in User Settings/Authentication Providers for e.g. GitHub it's requesting with the default scope 'read:user'. When using e.g. the Github Actions Plugin which requests the accessToken with scope 'repo' there is a need for the second request because the actual githubSession does not contain the needed scope. Wouldn't it be nice to have as few interactions as possible? Certain scopes like 'repo' are probably requested more often? As the default scopes for the other providers are hard coded as well, it would maybe be useful to delegate the scope configuration from code to configuration. 

I provided a suggestion, how it could look like. I would be happy to hear what you think about it. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
