### PR TITLE
Include "Added a changeset" in PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,4 @@
 - [ ] Prettier run on changed files
 - [ ] Tests added for new functionality
 - [ ] Regression tests added for bug fixes
+- [ ] Added a changeset ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#2437 introduced changesets as a way to gather CHANGELOG entries from contributors. I added an item to the PR Checklist to remind contributors to create changesets when proposing changes.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
