### PR TITLE
feat(proxy-backend): limit the forwarded http headers to a safe set

### DIFF
--- a/.changeset/2804.md
+++ b/.changeset/2804.md
@@ -1,0 +1,15 @@
+---
+'@backstage/plugin-proxy-backend': minor
+---
+
+Limit the http headers that are forwarded from the request to a safe set of defaults.
+A user can configure additional headers that should be forwarded if the specific applications needs that.
+
+```yaml
+proxy:
+  '/my-api':
+    target: 'https://my-api.com/get'
+    allowedHeaders:
+      # We need to forward the Authorization header that was provided by the caller
+      - Authorization
+```

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -57,6 +57,15 @@ is also possible to limit the forwarded HTTP methods with the configuration
 `allowedMethods`, for example `allowedMethods: ['GET']` to enforce read-only
 access.
 
+By default, the proxy will only forward safe HTTP request headers to the target.
+Those are based on the headers that are considered safe for CORS and includes
+headers like `content-type` or `last-modified`, as well as all headers that are
+set by the proxy. If the proxy should forward other headers like
+`authorization`, this must be enabled by the `allowedHeaders` config, for
+example `allowedHeaders: ['Authorization']`. This should help to not
+accidentally forward confidential headers (`cookie`, `X-Auth-Request-User`) to
+third-parties.
+
 If the value is a string, it is assumed to correspond to:
 
 ```yaml

--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -22,7 +22,6 @@
     "@backstage/backend-common": "^0.1.1-alpha.24",
     "@backstage/config": "^0.1.1-alpha.24",
     "@types/express": "^4.17.6",
-    "@types/http-proxy-middleware": "^0.19.3",
     "express": "^4.17.1",
     "express-promise-router": "^3.0.3",
     "http-proxy-middleware": "^0.19.1",
@@ -36,6 +35,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.24",
+    "@types/http-proxy-middleware": "^0.19.3",
     "@types/node-fetch": "^2.5.7",
     "@types/supertest": "^2.0.8",
     "@types/uuid": "^8.0.0",

--- a/plugins/proxy-backend/src/service/index.ts
+++ b/plugins/proxy-backend/src/service/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './service';
+export { createRouter } from './router';

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -14,13 +14,30 @@
  * limitations under the License.
  */
 
-import { createRouter } from './router';
+import { buildMiddleware, createRouter } from './router';
 import * as winston from 'winston';
 import { ConfigReader } from '@backstage/config';
 import {
   loadBackendConfig,
   SingleHostDiscovery,
 } from '@backstage/backend-common';
+import createProxyMiddleware, {
+  Config as ProxyMiddlewareConfig,
+  Proxy,
+} from 'http-proxy-middleware';
+import * as http from 'http';
+
+jest.mock('http-proxy-middleware', () => {
+  return jest.fn().mockImplementation(
+    (): Proxy => {
+      return () => undefined;
+    },
+  );
+});
+
+const mockCreateProxyMiddleware = createProxyMiddleware as jest.MockedFunction<
+  typeof createProxyMiddleware
+>;
 
 describe('createRouter', () => {
   it('works', async () => {
@@ -33,5 +50,153 @@ describe('createRouter', () => {
       discovery,
     });
     expect(router).toBeDefined();
+  });
+});
+
+describe('buildMiddleware', () => {
+  const logger = winston.createLogger();
+
+  beforeEach(() => {
+    mockCreateProxyMiddleware.mockClear();
+  });
+
+  it('accepts strings', async () => {
+    buildMiddleware('/api/', logger, 'test', 'http://mocked');
+
+    expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
+
+    const [filter, fullConfig] = mockCreateProxyMiddleware.mock.calls[0] as [
+      (pathname: string, req: Partial<http.IncomingMessage>) => boolean,
+      ProxyMiddlewareConfig,
+    ];
+    expect(filter('', { method: 'GET' })).toBe(true);
+    expect(filter('', { method: 'POST' })).toBe(true);
+    expect(filter('', { method: 'PUT' })).toBe(true);
+    expect(filter('', { method: 'PATCH' })).toBe(true);
+    expect(filter('', { method: 'DELETE' })).toBe(true);
+
+    expect(fullConfig.pathRewrite).toEqual({ '^/api/test/': '/' });
+    expect(fullConfig.changeOrigin).toBe(true);
+    expect(fullConfig.logProvider!(logger)).toBe(logger);
+  });
+
+  it('limits allowedMethods', async () => {
+    buildMiddleware('/api/', logger, 'test', {
+      target: 'http://mocked',
+      allowedMethods: ['GET', 'DELETE'],
+    });
+
+    expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
+
+    const [filter, fullConfig] = mockCreateProxyMiddleware.mock.calls[0] as [
+      (pathname: string, req: Partial<http.IncomingMessage>) => boolean,
+      ProxyMiddlewareConfig,
+    ];
+    expect(filter('', { method: 'GET' })).toBe(true);
+    expect(filter('', { method: 'POST' })).toBe(false);
+    expect(filter('', { method: 'PUT' })).toBe(false);
+    expect(filter('', { method: 'PATCH' })).toBe(false);
+    expect(filter('', { method: 'DELETE' })).toBe(true);
+
+    expect(fullConfig.pathRewrite).toEqual({ '^/api/test/': '/' });
+    expect(fullConfig.changeOrigin).toBe(true);
+    expect(fullConfig.logProvider!(logger)).toBe(logger);
+  });
+
+  it('permits default headers', async () => {
+    buildMiddleware('/api/', logger, 'test', {
+      target: 'http://mocked',
+    });
+
+    expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
+
+    const config = mockCreateProxyMiddleware.mock
+      .calls[0][1] as ProxyMiddlewareConfig;
+
+    const testClientRequest = {
+      getHeaderNames: () => [
+        'cache-control',
+        'content-language',
+        'content-length',
+        'content-type',
+        'expires',
+        'last-modified',
+        'pragma',
+        'host',
+        'accept',
+        'accept-language',
+        'user-agent',
+        'cookie',
+      ],
+      removeHeader: jest.fn(),
+    } as Partial<http.ClientRequest>;
+
+    expect(config).toBeDefined();
+    expect(config.onProxyReq).toBeDefined();
+
+    config.onProxyReq!(
+      testClientRequest as http.ClientRequest,
+      {} as http.IncomingMessage,
+      {} as http.ServerResponse,
+    );
+
+    expect(testClientRequest.removeHeader).toHaveBeenCalledTimes(1);
+    expect(testClientRequest.removeHeader).toHaveBeenCalledWith('cookie');
+  });
+
+  it('permits default and configured headers', async () => {
+    buildMiddleware('/api/', logger, 'test', {
+      target: 'http://mocked',
+      headers: {
+        Authorization: 'my-token',
+      },
+    });
+
+    expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
+
+    const config = mockCreateProxyMiddleware.mock
+      .calls[0][1] as ProxyMiddlewareConfig;
+
+    const testClientRequest = {
+      getHeaderNames: () => ['authorization', 'Cookie'],
+      removeHeader: jest.fn(),
+    } as Partial<http.ClientRequest>;
+
+    config.onProxyReq!(
+      testClientRequest as http.ClientRequest,
+      {} as http.IncomingMessage,
+      {} as http.ServerResponse,
+    );
+
+    expect(testClientRequest.removeHeader).toHaveBeenCalledTimes(1);
+    expect(testClientRequest.removeHeader).toHaveBeenCalledWith('Cookie');
+  });
+
+  it('permits configured headers', async () => {
+    buildMiddleware('/api/', logger, 'test', {
+      target: 'http://mocked',
+      allowedHeaders: ['authorization', 'cookie'],
+    });
+
+    expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
+
+    const config = mockCreateProxyMiddleware.mock
+      .calls[0][1] as ProxyMiddlewareConfig;
+
+    const testClientRequest = {
+      getHeaderNames: () => ['authorization', 'Cookie', 'X-Auth-Request-User'],
+      removeHeader: jest.fn(),
+    } as Partial<http.ClientRequest>;
+
+    config.onProxyReq!(
+      testClientRequest as http.ClientRequest,
+      {} as http.IncomingMessage,
+      {} as http.ServerResponse,
+    );
+
+    expect(testClientRequest.removeHeader).toHaveBeenCalledTimes(1);
+    expect(testClientRequest.removeHeader).toHaveBeenCalledWith(
+      'X-Auth-Request-User',
+    );
   });
 });


### PR DESCRIPTION
Closes https://github.com/spotify/backstage/issues/2763

This PR adds the new configuration `allowedHeaders` and limits the http headers that are proxied by default to a minimum.
This should increase the security, while headers can be allowed in the configuration of each proxy target.

I also added tests to check if the configuration of the http-proxy-middleware is correct.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
