### PR TITLE
feat: remove LocationProcessor.processEntity

### DIFF
--- a/.changeset/remove-location-processor-read.md
+++ b/.changeset/remove-location-processor-read.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Remove the `read` argument of `LocationProcessor.processEntity`.
+Instead, pass the `UrlReader` into the constructor of your `LocationProcessor`.

--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -251,12 +251,7 @@ export class LocationReaders implements LocationReader {
     for (const processor of this.processors) {
       if (processor.processEntity) {
         try {
-          current = await processor.processEntity(
-            current,
-            item.location,
-            emit,
-            this.readLocation.bind(this),
-          );
+          current = await processor.processEntity(current, item.location, emit);
         } catch (e) {
           // Construct the name carefully, if we got validation errors we do
           // not want to crash here due to missing metadata or so
@@ -293,41 +288,5 @@ export class LocationReaders implements LocationReader {
         }
       }
     }
-  }
-
-  private async readLocation(location: LocationSpec): Promise<Buffer> {
-    let data: Buffer | undefined = undefined;
-    let error: Error | undefined = undefined;
-
-    await this.handleLocation(
-      {
-        type: 'location',
-        location,
-        optional: false,
-      },
-      output => {
-        if (output.type === 'error' && !error) {
-          error = output.error;
-        } else if (output.type === 'data') {
-          if (data) {
-            if (!error) {
-              error = new Error(
-                'More than one piece of data loaded unexpectedly',
-              );
-            }
-          } else {
-            data = output.data;
-          }
-        }
-      },
-    );
-
-    if (error) {
-      throw error;
-    } else if (!data) {
-      throw new Error('No data loaded');
-    }
-
-    return data;
   }
 }

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -58,7 +58,6 @@ export type LocationProcessor = {
     entity: Entity,
     location: LocationSpec,
     emit: LocationProcessorEmit,
-    read: LocationProcessorRead,
   ): Promise<Entity>;
 
   /**
@@ -109,5 +108,3 @@ export type LocationProcessorResult =
   | LocationProcessorDataResult
   | LocationProcessorEntityResult
   | LocationProcessorErrorResult;
-
-export type LocationProcessorRead = (location: LocationSpec) => Promise<Buffer>;


### PR DESCRIPTION
Instead, pass the `UrlReader` into the constructor of your `LocationProcessor`.

~This one depends on #2805 #2803 and #2798 . Till then the build is broken, but should give an idea in what direction this should go.~

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
