### PR TITLE
fix(deps): bump http-proxy-middleware from 0.19.1 to 1.0.5

### DIFF
--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -24,7 +24,7 @@
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^3.0.3",
-    "http-proxy-middleware": "^0.19.1",
+    "http-proxy-middleware": "^1.0.5",
     "morgan": "^1.10.0",
     "node-fetch": "^2.6.0",
     "uuid": "^8.0.0",
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.1.1-alpha.24",
-    "@types/http-proxy-middleware": "^0.19.3",
     "@types/node-fetch": "^2.5.7",
     "@types/supertest": "^2.0.8",
     "@types/uuid": "^8.0.0",

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -21,18 +21,22 @@ import {
   loadBackendConfig,
   SingleHostDiscovery,
 } from '@backstage/backend-common';
-import createProxyMiddleware, {
-  Config as ProxyMiddlewareConfig,
-  Proxy,
+import {
+  createProxyMiddleware,
+  Options as ProxyMiddlewareOptions,
+  RequestHandler,
 } from 'http-proxy-middleware';
+import * as express from 'express';
 import * as http from 'http';
 
 jest.mock('http-proxy-middleware', () => {
-  return jest.fn().mockImplementation(
-    (): Proxy => {
-      return () => undefined;
-    },
-  );
+  return {
+    createProxyMiddleware: jest.fn().mockImplementation(
+      (): RequestHandler => {
+        return () => undefined;
+      },
+    ),
+  };
 });
 
 const mockCreateProxyMiddleware = createProxyMiddleware as jest.MockedFunction<
@@ -66,8 +70,8 @@ describe('buildMiddleware', () => {
     expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
 
     const [filter, fullConfig] = mockCreateProxyMiddleware.mock.calls[0] as [
-      (pathname: string, req: Partial<http.IncomingMessage>) => boolean,
-      ProxyMiddlewareConfig,
+      (pathname: string, req: Partial<express.Request>) => boolean,
+      ProxyMiddlewareOptions,
     ];
     expect(filter('', { method: 'GET' })).toBe(true);
     expect(filter('', { method: 'POST' })).toBe(true);
@@ -89,8 +93,8 @@ describe('buildMiddleware', () => {
     expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
 
     const [filter, fullConfig] = mockCreateProxyMiddleware.mock.calls[0] as [
-      (pathname: string, req: Partial<http.IncomingMessage>) => boolean,
-      ProxyMiddlewareConfig,
+      (pathname: string, req: Partial<express.Request>) => boolean,
+      ProxyMiddlewareOptions,
     ];
     expect(filter('', { method: 'GET' })).toBe(true);
     expect(filter('', { method: 'POST' })).toBe(false);
@@ -111,7 +115,7 @@ describe('buildMiddleware', () => {
     expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
 
     const config = mockCreateProxyMiddleware.mock
-      .calls[0][1] as ProxyMiddlewareConfig;
+      .calls[0][1] as ProxyMiddlewareOptions;
 
     const testClientRequest = {
       getHeaderNames: () => [
@@ -136,8 +140,8 @@ describe('buildMiddleware', () => {
 
     config.onProxyReq!(
       testClientRequest as http.ClientRequest,
-      {} as http.IncomingMessage,
-      {} as http.ServerResponse,
+      {} as express.Request,
+      {} as express.Response,
     );
 
     expect(testClientRequest.removeHeader).toHaveBeenCalledTimes(1);
@@ -155,7 +159,7 @@ describe('buildMiddleware', () => {
     expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
 
     const config = mockCreateProxyMiddleware.mock
-      .calls[0][1] as ProxyMiddlewareConfig;
+      .calls[0][1] as ProxyMiddlewareOptions;
 
     const testClientRequest = {
       getHeaderNames: () => ['authorization', 'Cookie'],
@@ -164,8 +168,8 @@ describe('buildMiddleware', () => {
 
     config.onProxyReq!(
       testClientRequest as http.ClientRequest,
-      {} as http.IncomingMessage,
-      {} as http.ServerResponse,
+      {} as express.Request,
+      {} as express.Response,
     );
 
     expect(testClientRequest.removeHeader).toHaveBeenCalledTimes(1);
@@ -181,7 +185,7 @@ describe('buildMiddleware', () => {
     expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
 
     const config = mockCreateProxyMiddleware.mock
-      .calls[0][1] as ProxyMiddlewareConfig;
+      .calls[0][1] as ProxyMiddlewareOptions;
 
     const testClientRequest = {
       getHeaderNames: () => ['authorization', 'Cookie', 'X-Auth-Request-User'],
@@ -190,8 +194,8 @@ describe('buildMiddleware', () => {
 
     config.onProxyReq!(
       testClientRequest as http.ClientRequest,
-      {} as http.IncomingMessage,
-      {} as http.ServerResponse,
+      {} as express.Request,
+      {} as express.Response,
     );
 
     expect(testClientRequest.removeHeader).toHaveBeenCalledTimes(1);

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -17,9 +17,10 @@
 import { Config } from '@backstage/config';
 import express from 'express';
 import Router from 'express-promise-router';
-import createProxyMiddleware, {
-  Config as ProxyMiddlewareConfig,
-  Proxy,
+import {
+  createProxyMiddleware,
+  Options as ProxyMiddlewareOptions,
+  RequestHandler,
 } from 'http-proxy-middleware';
 import { Logger } from 'winston';
 import http from 'http';
@@ -52,7 +53,7 @@ export interface RouterOptions {
   discovery: PluginEndpointDiscovery;
 }
 
-export interface ProxyConfig extends ProxyMiddlewareConfig {
+export interface ProxyConfig extends ProxyMiddlewareOptions {
   allowedMethods?: string[];
   allowedHeaders?: string[];
 }
@@ -64,7 +65,7 @@ export function buildMiddleware(
   logger: Logger,
   route: string,
   config: string | ProxyConfig,
-): Proxy {
+): RequestHandler {
   const fullConfig =
     typeof config === 'string' ? { target: config } : { ...config };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4979,7 +4979,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/http-proxy-middleware@*", "@types/http-proxy-middleware@^0.19.3":
+"@types/http-proxy-middleware@*":
   version "0.19.3"
   resolved "https://registry.npmjs.org/@types/http-proxy-middleware/-/http-proxy-middleware-0.19.3.tgz#b2eb96fbc0f9ac7250b5d9c4c53aade049497d03"
   integrity sha512-lnBTx6HCOUeIJMLbI/LaL5EmdKLhczJY5oeXZpX/cXE4rRqb3RmV7VcMpiEfYkmTjipv3h7IAyIINe4plEv7cA==
@@ -12913,15 +12913,16 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy-middleware@^0.19.1:
-  version "0.19.2"
-  resolved "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.2.tgz#ee73dcc8348165afefe8de2ff717751d181608ee"
-  integrity sha512-aYk1rTKqLTus23X3L96LGNCGNgWpG4cG0XoZIT1GUPhhulEHX/QalnO6Vbo+WmKWi4AL2IidjuC0wZtbpg0yhQ==
+http-proxy-middleware@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.5.tgz#4c6e25d95a411e3d750bc79ccf66290675176dc2"
+  integrity sha512-CKzML7u4RdGob8wuKI//H8Ein6wNTEQR7yjVEzPbhBLGdOfkfvgTnp2HLnniKBDP9QW4eG10/724iTWLBeER3g==
   dependencies:
+    "@types/http-proxy" "^1.17.4"
     http-proxy "^1.18.1"
-    is-glob "^4.0.0"
-    lodash "^4.17.11"
-    micromatch "^3.1.10"
+    is-glob "^4.0.1"
+    lodash "^4.17.19"
+    micromatch "^4.0.2"
 
 http-proxy@^1.17.0, http-proxy@^1.18.1:
   version "1.18.1"


### PR DESCRIPTION
This is a followup of https://github.com/spotify/backstage/pull/2374.

There are some breaking changes in the library but they don't alter the overall functionality. Plus they now ship typings to the `@types/http-proxy-middleware` import is no longer necessary.
