### PR TITLE
Add Dockerfile for helm chart

### DIFF
--- a/contrib/docker/kubernetes-example-backend/Dockerfile
+++ b/contrib/docker/kubernetes-example-backend/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:12-buster
+
+WORKDIR /usr/src/app
+
+# (workaround) Install cookiecutter and mkdocs to avoid the need to run docker in docker
+RUN cd /tmp && curl -O https://www.python.org/ftp/python/3.8.2/Python-3.8.2.tar.xz && \
+    tar -xvf Python-3.8.2.tar.xz && \
+    cd Python-3.8.2 && \
+    ./configure --enable-optimizations && \
+    make -j 4 && \
+    make altinstall
+
+RUN apt update
+RUN apt install -y mkdocs
+
+RUN pip3.8 install mkdocs-techdocs-core
+
+RUN pip3.8 install cookiecutter && \
+    apt remove -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev libbz2-dev g++ python-pip python-dev && \
+    rm -rf /var/cache/apt/* /tmp/Python-3.8.2
+
+# Copy repo skeleton first, to avoid unnecessary docker cache invalidation.
+# The skeleton contains the package.json of each package in the monorepo,
+# and along with yarn.lock and the root package.json, that's enough to run yarn install.
+ADD yarn.lock package.json skeleton.tar ./
+
+RUN yarn install --frozen-lockfile --production
+
+# This will copy the contents of the dist-workspace when running the build-image command.
+# Do not use this Dockerfile outside of that command, as it will copy in the source code instead.
+COPY . .
+
+CMD ["node", "packages/backend"]
+
+

--- a/contrib/docker/kubernetes-example-backend/README.md
+++ b/contrib/docker/kubernetes-example-backend/README.md
@@ -1,0 +1,13 @@
+# Example backend Dockerfile
+
+This Dockerfile will build the example backend with certain additional binaries needed to workaround
+the docker requirement in the scaffolder and techdocs.
+
+# Usage
+
+```bash
+yarn docker-build -f <absolute_path_to_the_dockerfile> --tag <your_tag>
+```
+
+> The absolute path is necessary as this directory is not copied to the build workspace when building
+> the docker image.


### PR DESCRIPTION
Add a Dockerfile which can be used to build an image that the helm chart (#2663) will use as default. These images include mkdocs and cookiecutter (for now) in order to work around the docker requirement in kubernetes.

@ebarriosjr @perrymanuk We took this from your comment in the discussion on #2438. We thought it made sense to have this in contrib given the helm chart will rely on it and people can use it themselves if they wish.

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Added a changeset ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
