### PR TITLE
create-app: revert to github location type for example templates

### DIFF
--- a/.changeset/ninety-pens-poke.md
+++ b/.changeset/ninety-pens-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Fix for configured templates using 'url' locations even though it's not supported yet

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -83,23 +83,23 @@ catalog:
       target: https://github.com/spotify/backstage/blob/master/packages/catalog-model/examples/all-apis.yaml
 
     # Backstage example templates
-    - type: url
+    - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml
       rules:
         - allow: [Template]
-    - type: url
+    - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/template.yaml
       rules:
         - allow: [Template]
-    - type: url
+    - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/create-react-app/template.yaml
       rules:
         - allow: [Template]
-    - type: url
+    - type: github
       target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
       rules:
         - allow: [Template]
-    - type: url
+    - type: github
       target: https://github.com/spotify/backstage/blob/master/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml
       rules:
         - allow: [Template]


### PR DESCRIPTION
Fixes #2775

Confirmed that this idd fixes `@backstage/create-app`

No change is needed for the main repo, since we use the `all-templates.yaml` here and that still uses the `github` location.