### PR TITLE
feat: Display the plugins InfoCards on EntityPage Overwiev suitable full height

### DIFF
--- a/.changeset/2826.md
+++ b/.changeset/2826.md
@@ -8,7 +8,7 @@
 '@backstage/plugin-lighthouse': minor
 ---
 
-The InfoCard variant `'height100'` is replaced with `'gridItem'`.
+The InfoCard variant `'height100'` is deprecated. Use variant `'gridItem'` instead.
 
 When the InfoCard is displayed as a grid item within a grid, you may want items to have the same height for all items.
 Set to the `'gridItem'` variant to display the InfoCard with full height suitable for Grid:

--- a/.changeset/2826.md
+++ b/.changeset/2826.md
@@ -1,0 +1,20 @@
+---
+'example-app': minor
+'@backstage/core': minor
+'@backstage/create-app': minor
+'@backstage/plugin-catalog': minor
+'@backstage/plugin-github-actions': minor
+'@backstage/plugin-jenkins': minor
+'@backstage/plugin-lighthouse': minor
+---
+
+The InfoCard variant `'height100'` is replaced with `'gridItem'`.
+
+When the InfoCard is displayed as a grid item within a grid, you may want items to have the same height for all items.
+Set to the `'gridItem'` variant to display the InfoCard with full height suitable for Grid:
+`<InfoCard variant="gridItem">...</InfoCard>`
+
+Changed the InfoCards in '@backstage/plugin-github-actions', '@backstage/plugin-jenkins', '@backstage/plugin-lighthouse'
+to pass an optional variant to the corresponding card of the plugin.
+
+As a result the overview content of the EntityPage shows cards with full height suitable for Grid.

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -108,7 +108,9 @@ const RecentCICDRunsSwitcher = ({ entity }: { entity: Entity }) => {
       content = <JenkinsLatestRunCard branch="master" />;
       break;
     case isGitHubActionsAvailable(entity):
-      content = <RecentWorkflowRunsCard entity={entity} />;
+      content = (
+        <RecentWorkflowRunsCard entity={entity} limit={3} variant="grit-item" />
+      );
       break;
     case isTravisCIAvailable(entity):
       content = <RecentTravisCIBuildsWidget entity={entity} />;
@@ -127,7 +129,7 @@ const RecentCICDRunsSwitcher = ({ entity }: { entity: Entity }) => {
 };
 
 const OverviewContent = ({ entity }: { entity: Entity }) => (
-  <Grid container spacing={3}>
+  <Grid container spacing={3} alignItems="stretch">
     <Grid item md={6}>
       <AboutCard entity={entity} />
     </Grid>

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -105,11 +105,11 @@ const RecentCICDRunsSwitcher = ({ entity }: { entity: Entity }) => {
   let content: ReactNode;
   switch (true) {
     case isJenkinsAvailable(entity):
-      content = <JenkinsLatestRunCard branch="master" variant="grid-item" />;
+      content = <JenkinsLatestRunCard branch="master" variant="gridItem" />;
       break;
     case isGitHubActionsAvailable(entity):
       content = (
-        <RecentWorkflowRunsCard entity={entity} limit={4} variant="grid-item" />
+        <RecentWorkflowRunsCard entity={entity} limit={4} variant="gridItem" />
       );
       break;
     case isTravisCIAvailable(entity):
@@ -131,7 +131,7 @@ const RecentCICDRunsSwitcher = ({ entity }: { entity: Entity }) => {
 const OverviewContent = ({ entity }: { entity: Entity }) => (
   <Grid container spacing={3} alignItems="stretch">
     <Grid item md={6}>
-      <AboutCard entity={entity} variant="grid-item" />
+      <AboutCard entity={entity} variant="gridItem" />
     </Grid>
     <RecentCICDRunsSwitcher entity={entity} />
     {isGitHubAvailable(entity) && (
@@ -147,7 +147,7 @@ const OverviewContent = ({ entity }: { entity: Entity }) => (
     )}
     {isLighthouseAvailable(entity) && (
       <Grid item sm={4}>
-        <LastLighthouseAuditCard variant="grid-item" />
+        <LastLighthouseAuditCard variant="gridItem" />
       </Grid>
     )}
     {isPullRequestsAvailable(entity) && (

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -105,11 +105,11 @@ const RecentCICDRunsSwitcher = ({ entity }: { entity: Entity }) => {
   let content: ReactNode;
   switch (true) {
     case isJenkinsAvailable(entity):
-      content = <JenkinsLatestRunCard branch="master" />;
+      content = <JenkinsLatestRunCard branch="master" variant="grid-item" />;
       break;
     case isGitHubActionsAvailable(entity):
       content = (
-        <RecentWorkflowRunsCard entity={entity} limit={3} variant="grit-item" />
+        <RecentWorkflowRunsCard entity={entity} limit={4} variant="grid-item" />
       );
       break;
     case isTravisCIAvailable(entity):
@@ -131,7 +131,7 @@ const RecentCICDRunsSwitcher = ({ entity }: { entity: Entity }) => {
 const OverviewContent = ({ entity }: { entity: Entity }) => (
   <Grid container spacing={3} alignItems="stretch">
     <Grid item md={6}>
-      <AboutCard entity={entity} />
+      <AboutCard entity={entity} variant="grid-item" />
     </Grid>
     <RecentCICDRunsSwitcher entity={entity} />
     {isGitHubAvailable(entity) && (
@@ -147,7 +147,7 @@ const OverviewContent = ({ entity }: { entity: Entity }) => (
     )}
     {isLighthouseAvailable(entity) && (
       <Grid item sm={4}>
-        <LastLighthouseAuditCard />
+        <LastLighthouseAuditCard variant="grid-item" />
       </Grid>
     )}
     {isPullRequestsAvailable(entity) && (

--- a/packages/core/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.tsx
@@ -76,9 +76,24 @@ const VARIANT_STYLES = {
       height: 'calc(100% - 10px)', // for pages without content header
       marginBottom: '10px',
     },
+    /**
+     * @deprecated This variant is replaced by 'gridItem'.
+     */
+    height100: {
+      display: 'flex',
+      flexDirection: 'column',
+      height: 'calc(100% - 10px)', // for pages without content header
+      marginBottom: '10px',
+    },
   },
   cardContent: {
     fullHeight: {
+      flex: 1,
+    },
+    /**
+     * @deprecated This variant is replaced by 'gridItem'.
+     */
+    height100: {
       flex: 1,
     },
     gridItem: {
@@ -143,17 +158,21 @@ export const InfoCard = ({
   noPadding,
 }: Props): JSX.Element => {
   const classes = useStyles();
-
   /**
    * If variant is specified, we build up styles for that particular variant for both
    * the Card and the CardContent (since these need to be synced)
    */
   let calculatedStyle = {};
   let calculatedCardStyle = {};
-
   if (variant) {
     const variants = variant.split(/[\s]+/g);
     variants.forEach(name => {
+      if (name === 'height100') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "Variant 'height100' of InfoCard is deprecated. Use variant 'gridItem' instead.",
+        );
+      }
       calculatedStyle = {
         ...calculatedStyle,
         ...VARIANT_STYLES.card[name as keyof typeof VARIANT_STYLES['card']],

--- a/packages/core/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.tsx
@@ -70,7 +70,7 @@ const VARIANT_STYLES = {
       flexDirection: 'column',
       height: '100%',
     },
-    height100: {
+    gridItem: {
       display: 'flex',
       flexDirection: 'column',
       height: 'calc(100% - 10px)', // for pages without content header
@@ -81,7 +81,7 @@ const VARIANT_STYLES = {
     fullHeight: {
       flex: 1,
     },
-    height100: {
+    gridItem: {
       flex: 1,
     },
   },
@@ -100,9 +100,10 @@ const VARIANT_STYLES = {
  * By default the InfoCard has no custom layout of its children, but is treated as a block element. A
  * couple common variants are provided and can be specified via the variant property:
  *
- * Display the card full height suitable for DataGrid:
+ * When the InfoCard is displayed as a grid item within a grid, you may want items to have the same height for all items.
+ * Set to the 'gridItem' variant to display the InfoCard with full height suitable for Grid:
  *
- *   <InfoCard variant="height100">...</InfoCard>
+ *   <InfoCard variant="gridItem">...</InfoCard>
  */
 type Props = {
   title?: ReactNode;

--- a/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
@@ -55,7 +55,7 @@ const CICDSwitcher = ({ entity }: { entity: Entity }) => {
 const OverviewContent = ({ entity }: { entity: Entity }) => (
   <Grid container spacing={3} alignItems="stretch">
     <Grid item>
-      <AboutCard entity={entity} variant="grid-item" />
+      <AboutCard entity={entity} variant="gridItem" />
     </Grid>
   </Grid>
 );

--- a/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
@@ -53,9 +53,9 @@ const CICDSwitcher = ({ entity }: { entity: Entity }) => {
 };
 
 const OverviewContent = ({ entity }: { entity: Entity }) => (
-  <Grid container spacing={3}>
+  <Grid container spacing={3} alignItems="stretch">
     <Grid item>
-      <AboutCard entity={entity} />
+      <AboutCard entity={entity} variant="grid-item" />
     </Grid>
   </Grid>
 );
@@ -77,7 +77,7 @@ const ServiceEntityPage = ({ entity }: { entity: Entity }) => (
       title="API"
       element={<ApiDocsRouter entity={entity} />}
     />
-     <EntityPageLayout.Content
+    <EntityPageLayout.Content
       path="/docs/*"
       title="Docs"
       element={<DocsRouter entity={entity} />}
@@ -97,7 +97,7 @@ const WebsiteEntityPage = ({ entity }: { entity: Entity }) => (
       title="CI/CD"
       element={<CICDSwitcher entity={entity} />}
     />
-     <EntityPageLayout.Content
+    <EntityPageLayout.Content
       path="/docs/*"
       title="Docs"
       element={<DocsRouter entity={entity} />}
@@ -112,7 +112,7 @@ const DefaultEntityPage = ({ entity }: { entity: Entity }) => (
       title="Overview"
       element={<OverviewContent entity={entity} />}
     />
-     <EntityPageLayout.Content
+    <EntityPageLayout.Content
       path="/docs/*"
       title="Docs"
       element={<DocsRouter entity={entity} />}

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -98,7 +98,7 @@ export function AboutCard({ entity, variant }: AboutCardProps) {
   const codeLink = getCodeLinkInfo(entity);
 
   return (
-    <Card className={variant === 'grid-item' ? classes.gridItemCard : ''}>
+    <Card className={variant === 'gridItem' ? classes.gridItemCard : ''}>
       <CardHeader
         title="About"
         action={
@@ -124,7 +124,7 @@ export function AboutCard({ entity, variant }: AboutCardProps) {
       />
       <Divider />
       <CardContent
-        className={variant === 'grid-item' ? classes.gridItemCardContent : ''}
+        className={variant === 'gridItem' ? classes.gridItemCardContent : ''}
       >
         <Grid container>
           <AboutField label="Description" gridSizes={{ xs: 12 }}>

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -26,7 +26,8 @@ import {
   makeStyles,
   Typography,
 } from '@material-ui/core';
-import DocsIcon from '@material-ui/icons/Description';import EditIcon from '@material-ui/icons/Edit';
+import DocsIcon from '@material-ui/icons/Description';
+import EditIcon from '@material-ui/icons/Edit';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import React from 'react';
 import { IconLinkVertical } from './IconLinkVertical';

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -26,8 +26,7 @@ import {
   makeStyles,
   Typography,
 } from '@material-ui/core';
-import DocsIcon from '@material-ui/icons/Description';
-import EditIcon from '@material-ui/icons/Edit';
+import DocsIcon from '@material-ui/icons/Description';import EditIcon from '@material-ui/icons/Edit';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import React from 'react';
 import { IconLinkVertical } from './IconLinkVertical';
@@ -58,6 +57,15 @@ const useStyles = makeStyles(theme => ({
   description: {
     wordBreak: 'break-word',
   },
+  gridItemCard: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: 'calc(100% - 10px)', // for pages without content header
+    marginBottom: '10px',
+  },
+  gridItemCardContent: {
+    flex: 1,
+  },
 }));
 
 const iconMap: Record<string, React.ReactNode> = {
@@ -82,14 +90,15 @@ function getCodeLinkInfo(entity: Entity): CodeLinkInfo {
 
 type AboutCardProps = {
   entity: Entity;
+  variant?: string;
 };
 
-export function AboutCard({ entity }: AboutCardProps) {
+export function AboutCard({ entity, variant }: AboutCardProps) {
   const classes = useStyles();
   const codeLink = getCodeLinkInfo(entity);
 
   return (
-    <Card>
+    <Card className={variant === 'grid-item' ? classes.gridItemCard : ''}>
       <CardHeader
         title="About"
         action={
@@ -114,7 +123,9 @@ export function AboutCard({ entity }: AboutCardProps) {
         }
       />
       <Divider />
-      <CardContent>
+      <CardContent
+        className={variant === 'grid-item' ? classes.gridItemCardContent : ''}
+      >
         <Grid container>
           <AboutField label="Description" gridSizes={{ xs: 12 }}>
             <Typography

--- a/plugins/github-actions/src/components/Cards/Cards.tsx
+++ b/plugins/github-actions/src/components/Cards/Cards.tsx
@@ -123,10 +123,7 @@ export const LatestWorkflowsForBranchCard = ({
   branch = 'master',
   variant,
 }: Props) => (
-  <InfoCard
-    title={`Last ${branch} build`}
-    variant={variant === 'grid-item' ? 'height100' : ''}
-  >
+  <InfoCard title={`Last ${branch} build`} variant={variant}>
     <WorkflowRunsTable branch={branch} entity={entity} />
   </InfoCard>
 );

--- a/plugins/github-actions/src/components/Cards/Cards.tsx
+++ b/plugins/github-actions/src/components/Cards/Cards.tsx
@@ -81,10 +81,9 @@ const WidgetContent = ({
 export const LatestWorkflowRunCard = ({
   entity,
   branch = 'master',
-}: {
-  entity: Entity;
-  branch: string;
-}) => {
+  // Display the card full height suitable for
+  variant,
+}: Props) => {
   const errorApi = useApi(errorApiRef);
   const [owner, repo] = (
     entity?.metadata.annotations?.[GITHUB_ACTIONS_ANNOTATION] ?? '/'
@@ -102,7 +101,7 @@ export const LatestWorkflowRunCard = ({
   }, [error, errorApi]);
 
   return (
-    <InfoCard title={`Last ${branch} build`}>
+    <InfoCard title={`Last ${branch} build`} variant={variant}>
       <WidgetContent
         error={error}
         loading={loading}
@@ -113,14 +112,21 @@ export const LatestWorkflowRunCard = ({
   );
 };
 
+type Props = {
+  entity: Entity;
+  branch: string;
+  variant?: string;
+};
+
 export const LatestWorkflowsForBranchCard = ({
   entity,
   branch = 'master',
-}: {
-  entity: Entity;
-  branch: string;
-}) => (
-  <InfoCard title={`Last ${branch} build`}>
+  variant,
+}: Props) => (
+  <InfoCard
+    title={`Last ${branch} build`}
+    variant={variant === 'grid-item' ? 'height100' : ''}
+  >
     <WorkflowRunsTable branch={branch} entity={entity} />
   </InfoCard>
 );

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -73,10 +73,10 @@ export const RecentWorkflowRunsCard = ({
     />
   ) : (
     <InfoCard
-      className={variant === 'grid-item' ? 'height100' : ''}
       title="Recent Workflow Runs"
       subheader={branch ? `Branch: ${branch}` : 'All Branches'}
       noPadding
+      variant={variant === 'grid-item' ? 'height100' : ''}
     >
       <Table
         isLoading={loading}

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -18,9 +18,9 @@ import { errorApiRef, useApi } from '@backstage/core-api';
 import { GITHUB_ACTIONS_ANNOTATION } from '../useProjectName';
 import { useWorkflowRuns } from '../useWorkflowRuns';
 import React, { useEffect } from 'react';
-import { EmptyState, Table } from '@backstage/core';
+import { EmptyState, InfoCard, Table } from '@backstage/core';
 import { WorkflowRunStatus } from '../WorkflowRunStatus';
-import { Button, Card, Link, TableContainer } from '@material-ui/core';
+import { Button, Link } from '@material-ui/core';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
 
 const firstLine = (message: string): string => message.split('\n')[0];
@@ -30,6 +30,7 @@ export type Props = {
   branch?: string;
   dense?: boolean;
   limit?: number;
+  variant?: string;
 };
 
 export const RecentWorkflowRunsCard = ({
@@ -37,6 +38,7 @@ export const RecentWorkflowRunsCard = ({
   branch,
   dense = false,
   limit = 5,
+  variant,
 }: Props) => {
   const errorApi = useApi(errorApiRef);
   const [owner, repo] = (
@@ -70,15 +72,19 @@ export const RecentWorkflowRunsCard = ({
       }
     />
   ) : (
-    <TableContainer component={Card}>
+    <InfoCard
+      className={variant === 'grid-item' ? 'height100' : ''}
+      title="Recent Workflow Runs"
+      subheader={branch ? `Branch: ${branch}` : 'All Branches'}
+      noPadding
+    >
       <Table
-        title="Recent Workflow Runs"
-        subtitle={branch ? `Branch: ${branch}` : 'All Branches'}
         isLoading={loading}
         options={{
           search: false,
           paging: false,
           padding: dense ? 'dense' : 'default',
+          toolbar: false,
         }}
         columns={[
           {
@@ -98,6 +104,6 @@ export const RecentWorkflowRunsCard = ({
         ]}
         data={runs}
       />
-    </TableContainer>
+    </InfoCard>
   );
 };

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -76,7 +76,7 @@ export const RecentWorkflowRunsCard = ({
       title="Recent Workflow Runs"
       subheader={branch ? `Branch: ${branch}` : 'All Branches'}
       noPadding
-      variant={variant === 'grid-item' ? 'height100' : ''}
+      variant={variant}
     >
       <Table
         isLoading={loading}

--- a/plugins/jenkins/src/components/Cards/Cards.tsx
+++ b/plugins/jenkins/src/components/Cards/Cards.tsx
@@ -61,12 +61,21 @@ const WidgetContent = ({
   );
 };
 
-export const LatestRunCard = ({ branch = 'master' }: { branch: string }) => {
+export const LatestRunCard = ({
+  branch = 'master',
+  variant,
+}: {
+  branch: string;
+  variant?: string;
+}) => {
   const { owner, repo } = useProjectSlugFromEntity();
   const [{ builds, loading }] = useBuilds(owner, repo, branch);
   const lastRun = builds ?? {};
   return (
-    <InfoCard title={`Last ${branch} build`}>
+    <InfoCard
+      title={`Last ${branch} build`}
+      variant={variant === 'grid-item' ? 'height100' : ''}
+    >
       <WidgetContent loading={loading} branch={branch} lastRun={lastRun} />
     </InfoCard>
   );

--- a/plugins/jenkins/src/components/Cards/Cards.tsx
+++ b/plugins/jenkins/src/components/Cards/Cards.tsx
@@ -72,10 +72,7 @@ export const LatestRunCard = ({
   const [{ builds, loading }] = useBuilds(owner, repo, branch);
   const lastRun = builds ?? {};
   return (
-    <InfoCard
-      title={`Last ${branch} build`}
-      variant={variant === 'grid-item' ? 'height100' : ''}
-    >
+    <InfoCard title={`Last ${branch} build`} variant={variant}>
       <WidgetContent loading={loading} branch={branch} lastRun={lastRun} />
     </InfoCard>
   );

--- a/plugins/lighthouse/src/components/Cards/LastLighthouseAuditCard.tsx
+++ b/plugins/lighthouse/src/components/Cards/LastLighthouseAuditCard.tsx
@@ -107,10 +107,7 @@ export const LastLighthouseAuditCard: FC<{
     );
   }
   return (
-    <InfoCard
-      title="Lighthouse Audit"
-      variant={variant === 'grid-item' ? 'height100' : ''}
-    >
+    <InfoCard title="Lighthouse Audit" variant={variant}>
       {content}
     </InfoCard>
   );

--- a/plugins/lighthouse/src/components/Cards/LastLighthouseAuditCard.tsx
+++ b/plugins/lighthouse/src/components/Cards/LastLighthouseAuditCard.tsx
@@ -88,9 +88,10 @@ const LighthouseAuditSummary: FC<{ audit: Audit; dense?: boolean }> = ({
   return <StructuredMetadataTable metadata={tableData} dense={dense} />;
 };
 
-export const LastLighthouseAuditCard: FC<{ dense?: boolean }> = ({
-  dense = false,
-}) => {
+export const LastLighthouseAuditCard: FC<{
+  dense?: boolean;
+  variant?: string;
+}> = ({ dense = false, variant }) => {
   const { value: website, loading, error } = useWebsiteForEntity();
 
   let content;
@@ -105,5 +106,12 @@ export const LastLighthouseAuditCard: FC<{ dense?: boolean }> = ({
       <LighthouseAuditSummary audit={website.lastAudit} dense={dense} />
     );
   }
-  return <InfoCard title="Lighthouse Audit">{content}</InfoCard>;
+  return (
+    <InfoCard
+      title="Lighthouse Audit"
+      variant={variant === 'grid-item' ? 'height100' : ''}
+    >
+      {content}
+    </InfoCard>
+  );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!
As mentioned last week by @Fox32, we noticed that all widgets of the EntityPage overview has different heights, which looks weird when it's crowed. 
So I implemented an approach of how it could be configured by the app and handled by the widgets. 

I have only modified the plugins that are currently shown on the overviews, so far. 

Here is an example with the LatestWorkflowRunCard, which is currently not on the entities page, but is used for the example because the RecentWorkflowRunsCard does not provide an InfoCard.

![Bildschirmfoto 2020-10-09 um 11 01 14](https://user-images.githubusercontent.com/61695677/95570497-4acec800-0a27-11eb-8622-f59fd6cf1002.png)


#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Added a changeset ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
