### PR TITLE
Add filters to API Explorer

### DIFF
--- a/packages/core/src/components/Select/Select.tsx
+++ b/packages/core/src/components/Select/Select.tsx
@@ -14,25 +14,23 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import {
+  Checkbox,
+  Chip,
+  ClickAwayListener,
+  FormControl,
+  InputBase,
+  MenuItem,
+  Select,
+  Typography,
+} from '@material-ui/core';
 import {
   createStyles,
   makeStyles,
-  withStyles,
   Theme,
+  withStyles,
 } from '@material-ui/core/styles';
-
-import {
-  FormControl,
-  Select,
-  MenuItem,
-  InputBase,
-  Chip,
-  Typography,
-  Checkbox,
-  ClickAwayListener,
-} from '@material-ui/core';
-
+import React, { useEffect, useState } from 'react';
 import ClosedDropdown from './static/ClosedDropdown';
 import OpenedDropdown from './static/OpenedDropdown';
 
@@ -111,7 +109,7 @@ export const SelectComponent = (props: SelectProps) => {
   const [value, setValue] = useState<any[] | string | number>(
     multiple ? [] : '',
   );
-  const [canOpen, setCanOpen] = React.useState(false);
+  const [isOpen, setOpen] = useState(false);
 
   useEffect(() => {
     setValue(multiple ? [] : '');
@@ -122,19 +120,17 @@ export const SelectComponent = (props: SelectProps) => {
     onChange(event.target.value);
   };
 
-  const selectHandleOnOpen = () => {
-    setCanOpen(previous => {
-      if (multiple) {
+  const handleClick = (event: React.ChangeEvent<any>) => {
+    setOpen(previous => {
+      if (multiple && !(event.target instanceof HTMLElement)) {
         return true;
       }
       return !previous;
     });
   };
 
-  const handleClickAway = (event: React.ChangeEvent<any>) => {
-    if (event.target.id !== 'menu-item') {
-      setCanOpen(false);
-    }
+  const handleClickAway = () => {
+    setOpen(false);
   };
 
   const handleDelete = (selectedValue: string | number) => () => {
@@ -154,8 +150,8 @@ export const SelectComponent = (props: SelectProps) => {
             displayEmpty
             multiple={multiple}
             onChange={handleChange}
-            onClick={selectHandleOnOpen}
-            open={canOpen}
+            onClick={handleClick}
+            open={isOpen}
             input={<BootstrapInput />}
             renderValue={selected =>
               multiple && (value as any[]).length !== 0 ? (
@@ -181,7 +177,7 @@ export const SelectComponent = (props: SelectProps) => {
               )
             }
             IconComponent={() =>
-              !canOpen ? <ClosedDropdown /> : <OpenedDropdown />
+              !isOpen ? <ClosedDropdown /> : <OpenedDropdown />
             }
             MenuProps={{
               anchorOrigin: {
@@ -200,7 +196,7 @@ export const SelectComponent = (props: SelectProps) => {
             )}
             {items &&
               items.map(item => (
-                <MenuItem id="menu-item" key={item.value} value={item.value}>
+                <MenuItem key={item.value} value={item.value}>
                   {multiple && (
                     <Checkbox
                       color="primary"

--- a/packages/core/src/components/Table/Filters.tsx
+++ b/packages/core/src/components/Table/Filters.tsx
@@ -50,7 +50,7 @@ const useSubvalueCellStyles = makeStyles<BackstageTheme>(theme => ({
   },
 }));
 
-type Without<T, K> = Pick<T, Exclude<keyof T, K>>;
+export type Without<T, K> = Pick<T, Exclude<keyof T, K>>;
 
 export type Filter = {
   type: 'select' | 'checkbox-tree' | 'multiple-select';

--- a/packages/core/src/components/Table/index.ts
+++ b/packages/core/src/components/Table/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { Table } from './Table';
-export type { TableColumn, TableProps } from './Table';
 export { SubvalueCell } from './SubvalueCell';
+export { Table } from './Table';
+export type { TableColumn, TableFilter, TableProps } from './Table';

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.test.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.test.tsx
@@ -72,6 +72,6 @@ describe('ApiCatalogPage', () => {
   // https://github.com/mbrn/material-table/issues/1293
   it('should render', async () => {
     const { findByText } = renderWrapped(<ApiExplorerPage />);
-    expect(await findByText(/APIs \(2\)/)).toBeInTheDocument();
+    expect(await findByText(/Backstage API Explorer/)).toBeInTheDocument();
   });
 });

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
@@ -44,7 +44,6 @@ export const ApiExplorerPage = () => {
           <SupportButton>All your APIs</SupportButton>
         </ContentHeader>
         <ApiExplorerTable
-          titlePreamble="APIs"
           entities={matchingEntities!}
           loading={loading}
           error={error}

--- a/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.test.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.test.tsx
@@ -53,7 +53,6 @@ describe('ApiCatalogTable component', () => {
       wrapInTestApp(
         <ApiProvider apis={apiRegistry}>
           <ApiExplorerTable
-            titlePreamble="APIs"
             entities={[]}
             loading={false}
             error={{ code: 'error' }}
@@ -71,15 +70,10 @@ describe('ApiCatalogTable component', () => {
     const rendered = render(
       wrapInTestApp(
         <ApiProvider apis={apiRegistry}>
-          <ApiExplorerTable
-            titlePreamble="APIs"
-            entities={entites}
-            loading={false}
-          />
+          <ApiExplorerTable entities={entites} loading={false} />
         </ApiProvider>,
       ),
     );
-    expect(rendered.getByText(/APIs \(3\)/)).toBeInTheDocument();
     expect(rendered.getByText(/api1/)).toBeInTheDocument();
     expect(rendered.getByText(/api2/)).toBeInTheDocument();
     expect(rendered.getByText(/api3/)).toBeInTheDocument();

--- a/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
@@ -15,7 +15,7 @@
  */
 
 import { ApiEntityV1alpha1, Entity } from '@backstage/catalog-model';
-import { Table, TableColumn, useApi } from '@backstage/core';
+import { Table, TableFilter, TableColumn, useApi } from '@backstage/core';
 import { Chip, Link } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import React from 'react';

--- a/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
@@ -90,9 +90,27 @@ const columns: TableColumn<Entity>[] = [
   },
 ];
 
+const filters: TableFilter[] = [
+  {
+    column: 'Owner',
+    type: 'select',
+  },
+  {
+    column: 'Type',
+    type: 'multiple-select',
+  },
+  {
+    column: 'Lifecycle',
+    type: 'multiple-select',
+  },
+  {
+    column: 'Tags',
+    type: 'checkbox-tree',
+  },
+];
+
 type ExplorerTableProps = {
   entities: Entity[];
-  titlePreamble: string;
   loading: boolean;
   error?: any;
 };
@@ -101,7 +119,6 @@ export const ApiExplorerTable = ({
   entities,
   loading,
   error,
-  titlePreamble,
 }: ExplorerTableProps) => {
   if (error) {
     return (
@@ -114,7 +131,7 @@ export const ApiExplorerTable = ({
   }
 
   return (
-    <Table<Entity>
+    <Table
       isLoading={loading}
       columns={columns}
       options={{
@@ -123,8 +140,8 @@ export const ApiExplorerTable = ({
         loadingType: 'linear',
         showEmptyDataSourceMessage: !loading,
       }}
-      title={`${titlePreamble} (${(entities && entities.length) || 0})`}
       data={entities}
+      filters={filters}
     />
   );
 };


### PR DESCRIPTION
I added the new filter table to the API explorer. Sadly the filter table wasn't ready yet, but I added some fixes to improve this.

![image](https://user-images.githubusercontent.com/648527/95580994-84f49580-0a38-11eb-816a-9ba4f31e169c.png)

I fixed the following issues in the table:
* Multi select could not be closed. This was also visible in Storybook, but I guess it now has the expected behavior
* Support for filters on nested fields
* Support for filters on array fields
* Only show distinct filter values in the tree / select.
* Export `TableFilter` type

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] All tests are passing `yarn test`
- [x] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Added a changeset ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
