### PR TITLE
Allow templates to be located on non-default branch

### DIFF
--- a/.changeset/happy-ads-behave.md
+++ b/.changeset/happy-ads-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Allow templates to be located on non-default branch

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
@@ -76,7 +76,9 @@ describe('GitHubPreparer', () => {
       1,
       'https://github.com/benjdlambert/backstage-graphql-template',
       expect.any(String),
-      {},
+      {
+        checkoutBranch: 'master',
+      },
     );
   });
   it('calls the clone command with the correct arguments for a repository when no path is provided', async () => {
@@ -87,7 +89,9 @@ describe('GitHubPreparer', () => {
       1,
       'https://github.com/benjdlambert/backstage-graphql-template',
       expect.any(String),
-      {},
+      {
+        checkoutBranch: 'master',
+      },
     );
   });
   it('return the temp directory with the path to the folder if it is specified', async () => {
@@ -107,6 +111,7 @@ describe('GitHubPreparer', () => {
       'https://github.com/benjdlambert/backstage-graphql-template',
       expect.any(String),
       {
+        checkoutBranch: 'master',
         fetchOpts: {
           callbacks: {
             credentials: expect.any(Function),

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
@@ -64,7 +64,22 @@ export class GithubPreparer implements PreparerBase {
         }
       : {};
 
-    await Clone.clone(repositoryCheckoutUrl, tempDir, cloneOptions);
+    const repository = await Clone.clone(
+      repositoryCheckoutUrl,
+      tempDir,
+      cloneOptions,
+    );
+    const currentBranch = await repository.getCurrentBranch();
+
+    const references = await repository.getReferences();
+
+    const target = references.find(
+      reference => reference.shorthand() === `origin/${parsedGitLocation.ref}`,
+    );
+
+    if (target && currentBranch !== target) {
+      await repository.checkoutBranch(target);
+    }
 
     return path.resolve(tempDir, templateDirectory);
   }

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
@@ -78,7 +78,7 @@ export class GithubPreparer implements PreparerBase {
     );
 
     if (target && currentBranch !== target) {
-      await repository.checkoutBranch(target);
+      await repository.checkoutRef(target);
     }
 
     return path.resolve(tempDir, templateDirectory);

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.test.ts
@@ -13,15 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-jest.mock('./helpers', () => ({ runDockerContainer: jest.fn() }));
+jest.mock('./helpers', () => ({
+  runDockerContainer: jest.fn(),
+  runCommand: jest.fn(),
+}));
+jest.mock('command-exists-promise', () => jest.fn());
 
 import { CookieCutter } from './cookiecutter';
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
-import { RunDockerContainerOptions } from './helpers';
+import { RunDockerContainerOptions, RunCommandOptions } from './helpers';
 import { PassThrough } from 'stream';
 import Docker from 'dockerode';
+
+const commandExists = require('command-exists-promise');
 
 describe('CookieCutter Templater', () => {
   const cookie = new CookieCutter();
@@ -31,6 +37,10 @@ describe('CookieCutter Templater', () => {
   }: {
     runDockerContainer: jest.Mock<RunDockerContainerOptions>;
   } = require('./helpers');
+
+  jest
+    .spyOn(fs, 'readdir')
+    .mockImplementation(() => Promise.resolve(['newthing']));
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -172,6 +182,73 @@ describe('CookieCutter Templater', () => {
       resultDir: expect.stringContaining(`${tempdir}-result`),
       logStream: stream,
       dockerClient: mockDocker,
+    });
+  });
+
+  describe('when cookiecutter is available', () => {
+    beforeAll(() => {
+      commandExists.mockImplementation(() => () => true);
+    });
+
+    it('use the binary', async () => {
+      const {
+        runCommand,
+      }: {
+        runCommand: jest.Mock<RunCommandOptions>;
+      } = require('./helpers');
+
+      const stream = new PassThrough();
+
+      const tempdir = await mkTemp();
+
+      const values = {
+        owner: 'blobby',
+        storePath: 'spotify/end-repo',
+        component_id: 'newthing',
+      };
+
+      await cookie.run({
+        directory: tempdir,
+        values,
+        logStream: stream,
+        dockerClient: mockDocker,
+      });
+
+      expect(runCommand).toHaveBeenCalledWith({
+        command: 'cookiecutter',
+        args: expect.arrayContaining([
+          '--no-input',
+          '-o',
+          tempdir,
+          expect.stringContaining(`${tempdir}-result`),
+          '--verbose',
+        ]),
+        logStream: stream,
+      });
+    });
+  });
+
+  describe('when nothing was generated', () => {
+    beforeEach(() => {
+      jest.spyOn(fs, 'readdir').mockImplementation(() => Promise.resolve([]));
+    });
+
+    it('throws an error', async () => {
+      const stream = new PassThrough();
+
+      const tempdir = await mkTemp();
+
+      return expect(
+        cookie.run({
+          directory: tempdir,
+          values: {
+            owner: 'blobby',
+            storePath: 'spotify/end-repo',
+          },
+          logStream: stream,
+          dockerClient: mockDocker,
+        }),
+      ).rejects.toThrow(/Cookie Cutter did not generate anything/);
     });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
@@ -78,8 +78,10 @@ export class CookieCutter implements TemplaterBase {
       });
     }
 
+    const [generated] = await fs.readdir(resultDir);
+
     return {
-      resultDir: path.resolve(resultDir, options.values.component_id as string),
+      resultDir: path.resolve(resultDir, generated),
     };
   }
 }

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
@@ -78,6 +78,8 @@ export class CookieCutter implements TemplaterBase {
       });
     }
 
+    // if cookiecutter was successful, resultDir will contain
+    // exactly one directory.
     const [generated] = await fs.readdir(resultDir);
 
     if (generated === undefined) {

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
@@ -78,7 +78,7 @@ export class CookieCutter implements TemplaterBase {
       });
     }
 
-    const [generated] = await fs.readdir(resultDir);
+    const [generated = ''] = await fs.readdir(resultDir);
 
     return {
       resultDir: path.resolve(resultDir, generated),

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
@@ -78,7 +78,11 @@ export class CookieCutter implements TemplaterBase {
       });
     }
 
-    const [generated = ''] = await fs.readdir(resultDir);
+    const [generated] = await fs.readdir(resultDir);
+
+    if (generated === undefined) {
+      throw new Error('Cookie Cutter did not generate anything');
+    }
 
     return {
       resultDir: path.resolve(resultDir, generated),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds the ability to use a template from a non-default branch.

## Motivation

I have a GitHub repository that has a GitHub template. I converted it into a cookiecutter template on a branch. I would like to use this branch with the scaffolder.

## Approach

Checkout to the branch specified by the URL of the template. This solution will be susceptible to #2815 which I'm not addressing here. 

I also changed how the path to the generated output is created. Instead of relying on user-specified component_id, I'm just taking the only generated directory in the template directory. This allows me to generate component_id using cookiecutter variables.  

#### :heavy_check_mark: Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [ ] Regression tests added for bug fixes
- [ ] Added a changeset ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
