### PR TITLE
Move card header bg to up contrast, fix #2558

### DIFF
--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -25,6 +25,7 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(2, 2, 6),
     backgroundImage: (props: { backgroundImage: string }) =>
       props.backgroundImage,
+    backgroundPosition: '0 center',
   },
   content: {
     padding: theme.spacing(2),

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(2, 2, 6),
     backgroundImage: (props: { backgroundImage: string }) =>
       props.backgroundImage,
-    backgroundPosition: '0 center',
+    backgroundPosition: 0,
   },
   content: {
     padding: theme.spacing(2),


### PR DESCRIPTION
## Fix the bg to text contrast
I moved the background so that the darker parts are shown as background for the white text.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)

<img width="1362" alt="Screenshot 2020-10-12 at 10 52 36" src="https://user-images.githubusercontent.com/1020404/95727004-e9526780-0c79-11eb-91f7-178c49ad4ac1.png">
