### PR TITLE
make saml provider path from globalConfig

### DIFF
--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -118,15 +118,18 @@ type SAMLProviderOptions = {
 };
 
 export const createSamlProvider: AuthProviderFactory = ({
+  globalConfig,
   config,
   tokenIssuer,
 }) => {
+  const url = new URL(globalConfig.baseUrl);
+  const providerId = 'saml';
   const entryPoint = config.getString('entryPoint');
   const issuer = config.getString('issuer');
   const opts = {
     entryPoint,
     issuer,
-    path: '/auth/saml/handler/frame',
+    path: `${url.pathname}/${providerId}/handler/frame`,
     tokenIssuer,
   };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Recent changes in v0.1.1-alpha.24 release where backend routes are now '/api', broke this SAML implementation. It was redirecting back to '/auth/saml' instead of '/api/auth/saml'. My bad, should have not hard coded the path here. 

In the PR I've change the implementation, following the rest of the auth provider using `globalConfig`.

I tested it locally with `start-saml-idp.sh` script. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
