### PR TITLE
github/workflows: fix coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ steps.yarn-lock.outcome == 'failure' }}
         run: |
           yarn lerna -- run test -- --coverage
-          bash <(curl -s https://codecov.io/bash)
+          bash <(curl -s https://codecov.io/bash) -N $(git rev-parse FETCH_HEAD)
 
       - name: verify plugin template
         run: yarn lerna -- run diff -- --check


### PR DESCRIPTION
Working on getting coverage in order, nothing to see here yet

edit: Now there is.

From the codecov bash docs:

```
-N           The commit SHA of the parent for which you are uploading coverage. If not present,
             the parent will be determined using the API of your repository provider.
             When using the repository provider's API, the parent is determined via finding
             the closest ancestor to the commit.
```

So as far as I can tell, given this:

```
      A---B---C PR-branch
     /
D---E---F---G master
```

The default behaviour of codecov is to compare to `E`. During the PR build we merge `PR-branch` into `master` though, which brings in `F` and `G`, which might themselves have coverage diffs. Therefore we want the codecov base to be `G` instead of `E`, which this PR hopefully achieves 😅 