### PR TITLE
github/codecov: switch to informational mode

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,6 +6,7 @@ coverage:
       default:
         threshold: 0% # Ref: https://docs.codecov.io/docs/codecovyml-reference#coveragestatus
         target: auto
+        informational: true # Don't block PRs
 
 # Since Backstage is a mono repo, flags here help in getting the code coverage of individual packages.
 # Documentation: https://docs.codecov.io/docs/flags


### PR DESCRIPTION
Figured we could use codecov to aid in review rather than blocking PRs.