### PR TITLE
Add newrelic rest api key to helm charts

### DIFF
--- a/contrib/chart/backstage/Chart.yaml
+++ b/contrib/chart/backstage/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/contrib/chart/backstage/templates/backend-secret.yaml
+++ b/contrib/chart/backstage/templates/backend-secret.yaml
@@ -18,4 +18,5 @@ stringData:
   GITHUB_TOKEN: {{ .Values.auth.githubToken }}
   GITLAB_TOKEN: {{ .Values.auth.gitlabToken }}
   AZURE_TOKEN: {{ .Values.auth.azure.api.token }}
+  NEW_RELIC_REST_API_KEY: {{ .Values.auth.newRelicRestApiKey }}
 {{- end }}

--- a/contrib/chart/backstage/values.yaml
+++ b/contrib/chart/backstage/values.yaml
@@ -243,3 +243,4 @@ auth:
   # Used by the scaffolder to create GitHub repos. Must have 'repo' scope.
   githubToken: g
   gitlabToken: g
+  newRelicRestApiKey: r


### PR DESCRIPTION
Supports using the newrelic plugin with a Backstage instance deployed via Helm.