### PR TITLE
[charts] Add certificate issuer

### DIFF
--- a/contrib/chart/backstage/README.md
+++ b/contrib/chart/backstage/README.md
@@ -62,12 +62,29 @@ backstage-ingress   *       123.1.2.3       80      17m
 
 > **NOTE**: this is not a production ready deployment.
 
-## Caveats
-
-The current implementation does not generate certificates for the ingress which means the browser will alert that the
-site is insecure and using self-signed certificates.
-
 ## Customization
+
+### Issue certificates
+
+These charts can install or reuse a `clusterIssuer` to generate certificates for the backstage `ingress`. To do that:
+
+1. [Install][install-cert-manager] or make sure [cert-manager][cert-manager] is installed in the cluster.
+2. Enable the issuer in the charts. This will first check if there is a `letsencrypt` issuer already deployed in your
+   cluster and deploy one if it doesn't exist.
+
+To enable it you need to provide a valid email address in the chart's values:
+
+```
+issuer:
+  email: me@example.com
+  clusterIssuer: "letsencrypt-prod"
+```
+
+By default, the charts use `letsencrypt-staging` so in the above example we instruct helm to use the production issuer
+instead.
+
+[cert-manager]: https://cert-manager.io/docs/
+[install-cert-manager]: https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm
 
 ### Custom PostgreSQL instance
 

--- a/contrib/chart/backstage/templates/ingress.yaml
+++ b/contrib/chart/backstage/templates/ingress.yaml
@@ -5,16 +5,25 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "backstage.fullname" . }}-ingress
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- if .Values.issuer.email }}
+    cert-manager.io/cluster-issuer: {{ .Values.issuer.clusterIssuer }}
+    {{- end }}
+    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($scheme = https) {
       add_header  Strict-Transport-Security "max-age=0;";
       }
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
+  tls:
+    - secretName: {{ include "backstage.fullname" . }}-tls
+      hosts:
+        - {{ $frontendUrl.host }}
+        - {{ $backendUrl.host }}
+        - {{ $lighthouseUrl.host }}
+
   rules:
     - host: {{ $frontendUrl.host }}
       http:
@@ -56,17 +65,22 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "backstage.fullname" . }}-ingress-lighthouse
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- if .Values.issuer.email }}
+    cert-manager.io/cluster-issuer: {{ .Values.issuer.clusterIssuer }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($scheme = https) {
       add_header  Strict-Transport-Security "max-age=0;";
       }
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
+  tls:
+    - secretName: {{ include "backstage.fullname" . }}-tls
+      hosts:
+        - {{ $lighthouseUrl.host }}
   rules:
     - host: {{ $frontendUrl.host }}
       http:

--- a/contrib/chart/backstage/templates/issuer.yaml
+++ b/contrib/chart/backstage/templates/issuer.yaml
@@ -1,0 +1,19 @@
+{{- if (and (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha2") .Values.issuer.email )  -}}
+{{/*  Only install issuer if it doesn't already exist in the cluster */}}
+{{- if not ( lookup "cert-manager.io/v1alpha2" "ClusterIssuer"  "" .Values.issuer.clusterIssuer  ) }}
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: {{ .Values.issuer.clusterIssuer }}
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: {{ required "expected a valid .Values.issuer.email to enable ClusterIssuer" .Values.issuer.email }}
+    privateKeySecretRef:
+      name: {{ required "expected .Values.issuer.cluster-issuer to not be empty (letsencrypt-prod | letsencrypt-staging)" .Values.issuer.clusterIssuer }}
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+{{- end -}}
+{{- end -}}

--- a/contrib/chart/backstage/values.yaml
+++ b/contrib/chart/backstage/values.yaml
@@ -61,6 +61,10 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
 
+issuer:
+  email:
+  clusterIssuer: 'letsencrypt-staging'
+
 global:
   postgresql:
     postgresqlUsername: backend-user


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds support for generating the necessary certificates for the kubernetes ingress when deploying an example backstage via Helm charts.

To enable the issuer set a valid email address in the values and optionally switch to the production issuer

```
issuer:
  email:
  clusterIssuer: "letsencrypt-prod"
```

### Before

![bad-cert-err](https://user-images.githubusercontent.com/736631/95861244-76242080-0d61-11eb-8ec3-94b4bfad1ac9.png)

### After

![issuer-good-cert](https://user-images.githubusercontent.com/736631/95861257-79b7a780-0d61-11eb-935c-cd255ed28779.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
