### PR TITLE
Clarify catalog info YAML, TechDocs

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -14,6 +14,9 @@ natively. In the API request/response cycle, a JSON representation is used,
 while the descriptor files are on YAML format to be more easily maintainable by
 humans. However, the structure and semantics is the same in both cases.
 
+Although it's possible to name catalog entity descriptor files however you wish,
+we recommend that you name them `catalog-info.yaml`.
+
 ## Contents
 
 - [Overall Shape Of An Entity](#overall-shape-of-an-entity)

--- a/docs/features/techdocs/creating-and-publishing.md
+++ b/docs/features/techdocs/creating-and-publishing.md
@@ -19,6 +19,12 @@ This section will guide you through:
 
 ## Create a basic documentation setup
 
+If you have an existing repository that you'd like to add documentation to, skip
+to the
+[Manually add documentation setup](#manually-add-documentation-setup-to-already-existing-repository)
+section below. Otherwise, continue reading to start a documentation repo from
+scratch.
+
 ### Use the documentation template
 
 Your working Backstage instance should by default have a documentation template
@@ -35,9 +41,11 @@ setup for free.
 
 Prerequisities:
 
-- `catalog-info.yml` file registered to Backstage.
+- An existing component
+  [registered in backstage](../software-catalog/software-catalog-overview#adding-components-to-the-catalog)
+  (e.g. via a `catalog-info.yaml` file).
 
-Create a `mkdocs.yml` file in the root of the repository with the following
+Create an `mkdocs.yml` file in the root of your repository with the following
 content:
 
 ```yaml
@@ -50,8 +58,8 @@ plugins:
   - techdocs-core
 ```
 
-Update your `catalog-info.yaml` file in the root of the repository with the
-following content:
+Update your component's entity description by adding the following lines to its
+`catalog-info.yaml` in the root of its repository:
 
 ```yaml
 metadata:
@@ -59,7 +67,7 @@ metadata:
     backstage.io/techdocs-ref: dir:./
 ```
 
-Create a `/docs` folder in the root of the project with at least a `index.md`
+Create a `/docs` folder in the root of the project with at least an `index.md`
 file. _(If you add more markdown files, make sure to update the nav in the
 mkdocs.yml file to get a proper navigation for your documentation.)_
 

--- a/docs/features/techdocs/creating-and-publishing.md
+++ b/docs/features/techdocs/creating-and-publishing.md
@@ -42,7 +42,7 @@ setup for free.
 Prerequisities:
 
 - An existing component
-  [registered in backstage](../software-catalog/software-catalog-overview#adding-components-to-the-catalog)
+  [registered in backstage](../software-catalog/index.md#adding-components-to-the-catalog)
   (e.g. via a `catalog-info.yaml` file).
 
 Create an `mkdocs.yml` file in the root of your repository with the following


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A user on Discord reported issues getting started with TechDocs; when I helped out, it seemed like the problem arose because there was a lack of guidance around component entity descriptor YAML files + very explicit step-by-step instructions in the TechDocs documentation referring to `catalog-info.yml`.

So I split the difference:

1. Added an explicit recommendation about the file name to the place where the file's schema is defined.
2. Tried to clarify the intention behind the explicit file changes in the TechDocs docs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
