### PR TITLE
TechDocsPageHeader: Changed repo location icon

### DIFF
--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import GitHubIcon from '@material-ui/icons/GitHub';
+import CodeIcon from '@material-ui/icons/Code';
 import { Header, HeaderLabel, Link } from '@backstage/core';
 import { CircularProgress } from '@material-ui/core';
 import { ParsedEntityId } from '../../types';
@@ -73,7 +73,7 @@ export const TechDocsPageHeader = ({
               target="_blank"
               rel="noopener noreferrer"
             >
-              <GitHubIcon style={{ marginTop: '-25px', fill: '#fff' }} />
+              <CodeIcon style={{ marginTop: '-25px', fill: '#fff' }} />
             </a>
           }
         />


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Resolves issue #2797

Changed the repo location icon in TechDocsPageHeader.tsx so that it isn't always Github but a more general one. 
From: 
![95443771-48a03700-095d-11eb-9391-7918e6310200](https://user-images.githubusercontent.com/16206098/95963468-03ba4b80-0e08-11eb-8e12-1222eb6dd640.png)
To:
<img width="1215" alt="95499911-42827880-09a6-11eb-8902-ad1eb128f71f" src="https://user-images.githubusercontent.com/16206098/95963472-05840f00-0e08-11eb-9933-895106b0377c.png">

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
