### PR TITLE
Update techdocs url to the new default

### DIFF
--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -58,7 +58,7 @@ The default storage and request URLs:
 ```yaml
 techdocs:
   storageUrl: http://localhost:7000/api/techdocs/static/docs
-  requestUrl: http://localhost:7000/api/techdocs/docs
+  requestUrl: http://localhost:7000/api/techdocs/
 ```
 
 If you want `techdocs-backend` to manage building and publishing, you want


### PR DESCRIPTION
In https://github.com/spotify/backstage/pull/2682/ the default requestUrl was changed. Adjusting the documentation to reflect that change as well.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
