### PR TITLE
Use organization name as the prefix for Service Catalog

### DIFF
--- a/packages/create-app/templates/default-app/packages/app/cypress/integration/app.js
+++ b/packages/create-app/templates/default-app/packages/app/cypress/integration/app.js
@@ -1,6 +1,6 @@
 describe('App', () => {
   it('should render the catalog', () => {
     cy.visit('/');
-    cy.contains('Spotify Service Catalog');
+    cy.contains('Backstage Service Catalog');
   });
 });

--- a/packages/create-app/templates/default-app/packages/app/cypress/integration/app.js
+++ b/packages/create-app/templates/default-app/packages/app/cypress/integration/app.js
@@ -1,6 +1,6 @@
 describe('App', () => {
   it('should render the catalog', () => {
     cy.visit('/');
-    cy.contains('Spotify Service Catalog');
+    cy.contains('Acme Corporation Service Catalog');
   });
 });

--- a/packages/create-app/templates/default-app/packages/app/cypress/integration/app.js
+++ b/packages/create-app/templates/default-app/packages/app/cypress/integration/app.js
@@ -1,6 +1,6 @@
 describe('App', () => {
   it('should render the catalog', () => {
     cy.visit('/');
-    cy.contains('Backstage Service Catalog');
+    cy.contains('Spotify Service Catalog');
   });
 });

--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -301,7 +301,7 @@ async function testAppServe(pluginName: string, appDir: string) {
       try {
         const browser = new Browser();
 
-        await waitForPageWithText(browser, '/', 'Backstage Service Catalog');
+        await waitForPageWithText(browser, '/', 'Spotify Service Catalog');
         await waitForPageWithText(
           browser,
           `/${pluginName}`,

--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -301,7 +301,7 @@ async function testAppServe(pluginName: string, appDir: string) {
       try {
         const browser = new Browser();
 
-        await waitForPageWithText(browser, '/', 'Spotify Service Catalog');
+        await waitForPageWithText(browser, '/', 'Backstage Service Catalog');
         await waitForPageWithText(
           browser,
           `/${pluginName}`,

--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -301,7 +301,11 @@ async function testAppServe(pluginName: string, appDir: string) {
       try {
         const browser = new Browser();
 
-        await waitForPageWithText(browser, '/', 'Acme Corporation Service Catalog');
+        await waitForPageWithText(
+          browser,
+          '/',
+          'Acme Corporation Service Catalog',
+        );
         await waitForPageWithText(
           browser,
           `/${pluginName}`,

--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -301,7 +301,7 @@ async function testAppServe(pluginName: string, appDir: string) {
       try {
         const browser = new Browser();
 
-        await waitForPageWithText(browser, '/', 'Backstage Service Catalog');
+        await waitForPageWithText(browser, '/', 'Acme Corporation Service Catalog');
         await waitForPageWithText(
           browser,
           `/${pluginName}`,

--- a/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
@@ -15,6 +15,7 @@
  */
 
 import {
+  configApiRef,
   Header,
   HomepageTimer,
   identityApiRef,
@@ -33,12 +34,13 @@ const CatalogLayout = ({ children }: Props) => {
   const greeting = getTimeBasedGreeting();
   const profile = useApi(identityApiRef).getProfile();
   const userId = useApi(identityApiRef).getUserId();
+  const orgName = useApi(configApiRef).getOptionalString('organization.name');
 
   return (
     <Page theme={pageTheme.home}>
       <Header
         title={`${greeting.greeting}, ${profile.displayName || userId}!`}
-        subtitle="Backstage Service Catalog"
+        subtitle={`${orgName || 'Backstage'} Service Catalog`}
         tooltip={greeting.language}
         pageTitleOverride="Home"
       >


### PR DESCRIPTION
Use organization.name as the prefix for the Service Catalog title in the catalog header and fallback to Backstage if that does not exist. 


<img width="293" alt="Screenshot 2020-10-15 at 2 29 30 PM" src="https://user-images.githubusercontent.com/8716693/96085140-ef9f4880-0ef2-11eb-9685-4676a4ddec4f.png">
<img width="442" alt="Screenshot 2020-10-15 at 2 28 24 PM" src="https://user-images.githubusercontent.com/8716693/96085143-f201a280-0ef2-11eb-91f9-50ad93b992ce.png">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ X] Screenshots attached (for UI changes)
