### PR TITLE
Scaffolder backend- provide base url for creating apps in Enterprise GitHub

### DIFF
--- a/.changeset/selfish-bats-perform.md
+++ b/.changeset/selfish-bats-perform.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+The new `scaffolder.github.baseUrl` config property allows to specify a custom base url for GitHub enterprise instances

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -147,7 +147,7 @@ catalog:
 
 scaffolder:
   github:
-    baseUrl: https://github.com
+    host: https://github.com
     token:
       $env: GITHUB_TOKEN
     visibility: public # or 'internal' or 'private'

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -147,6 +147,7 @@ catalog:
 
 scaffolder:
   github:
+    baseUrl: https://github.com
     token:
       $env: GITHUB_TOKEN
     visibility: public # or 'internal' or 'private'

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -68,10 +68,11 @@ export default async function createPlugin({
       ) as RepoVisibilityOptions;
 
       const githubToken = githubConfig.getString('token');
-      const githubBaseUrl = githubConfig.getString('baseUrl');
+      const githubHost =
+        githubConfig.getOptionalString('host') ?? 'https://github.com';
       const githubClient = new Octokit({
         auth: githubToken,
-        baseUrl: githubBaseUrl,
+        baseUrl: githubHost,
       });
       const githubPublisher = new GithubPublisher({
         client: githubClient,

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -68,7 +68,11 @@ export default async function createPlugin({
       ) as RepoVisibilityOptions;
 
       const githubToken = githubConfig.getString('token');
-      const githubClient = new Octokit({ auth: githubToken });
+      const githubBaseUrl = githubConfig.getString('baseUrl');
+      const githubClient = new Octokit({
+        auth: githubToken,
+        baseUrl: githubBaseUrl,
+      });
       const githubPublisher = new GithubPublisher({
         client: githubClient,
         token: githubToken,

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/scaffolder.ts
@@ -48,8 +48,8 @@ export default async function createPlugin({
       ) as RepoVisibilityOptions;
 
       const githubToken = githubConfig.getString('token');
-      const githubBaseUrl = githubConfig.getString('baseUrl');
-      const githubClient = new Octokit({ auth: githubToken, baseUrl: githubBaseUrl });
+      const githubHost = githubConfig.getOptionalString('host');
+      const githubClient = new Octokit({ auth: githubToken, baseUrl: githubHost });
       const githubPublisher = new GithubPublisher({
         client: githubClient,
         token: githubToken,

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/scaffolder.ts
@@ -48,7 +48,8 @@ export default async function createPlugin({
       ) as RepoVisibilityOptions;
 
       const githubToken = githubConfig.getString('token');
-      const githubClient = new Octokit({ auth: githubToken });
+      const githubBaseUrl = githubConfig.getString('baseUrl');
+      const githubClient = new Octokit({ auth: githubToken, baseUrl: githubBaseUrl });
       const githubPublisher = new GithubPublisher({
         client: githubClient,
         token: githubToken,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR resolves #2906 

- Add `scaffolder.github.baseUrl` to the `app-config.yaml`
- Pass the config value to all `Octokit` instances 

These changes allow configuring a custom GitHub enterprise instance for creating new app repositories.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation: _(I'm not sure where to add)_
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
