### PR TITLE
Change default organization to be set to My Company

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -41,7 +41,7 @@ proxy:
         $env: NEW_RELIC_REST_API_KEY
 
 organization:
-  name: Spotify
+  name: My Company
 
 techdocs:
   storageUrl: http://localhost:7000/api/techdocs/static/docs
@@ -50,10 +50,10 @@ techdocs:
     techdocs: 'docker'
 
 sentry:
-  organization: spotify
+  organization: my-company
 
 rollbar:
-  organization: spotify
+  organization: my-company
   accountToken:
     $env: ROLLBAR_ACCOUNT_TOKEN
 

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -3,7 +3,7 @@ app:
   baseUrl: http://localhost:7000
 
 organization:
-  name: Acme Corporation
+  name: My Company
 
 backend:
   baseUrl: http://localhost:7000

--- a/packages/create-app/templates/default-app/packages/app/cypress/integration/app.js
+++ b/packages/create-app/templates/default-app/packages/app/cypress/integration/app.js
@@ -1,6 +1,6 @@
 describe('App', () => {
   it('should render the catalog', () => {
     cy.visit('/');
-    cy.contains('Acme Corporation Service Catalog');
+    cy.contains('My Company Service Catalog');
   });
 });

--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -301,11 +301,7 @@ async function testAppServe(pluginName: string, appDir: string) {
       try {
         const browser = new Browser();
 
-        await waitForPageWithText(
-          browser,
-          '/',
-          'Acme Corporation Service Catalog',
-        );
+        await waitForPageWithText(browser, '/', 'My Company Service Catalog');
         await waitForPageWithText(
           browser,
           `/${pluginName}`,


### PR DESCRIPTION
Change default organization to be set to My Company instead of Spotiy or Acme Organization. As referenced in #2908 

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
