### PR TITLE
create-app: Prompt for organization name

### DIFF
--- a/.changeset/rich-turtles-call.md
+++ b/.changeset/rich-turtles-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': minor
+---
+
+Prompt for organization name

--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -113,6 +113,19 @@ export default async (cmd: Command): Promise<void> => {
       // @ts-ignore
       choices: ['PostgreSQL', 'SQLite'],
     },
+    {
+      type: 'input',
+      name: 'org',
+      message: chalk.blue(
+        'Please enter the name of your organization [required]',
+      ),
+      validate: (value: any) => {
+        if (!value) {
+          return chalk.red('Please enter a name for your organization');
+        }
+        return true;
+      },
+    },
   ];
   const answers: Answers = await inquirer.prompt(questions);
   answers.dbTypePG = answers.dbType === 'PostgreSQL';

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -3,7 +3,7 @@ app:
   baseUrl: http://localhost:7000
 
 organization:
-  name: Acme Corporation
+  name: {{ org }}
 
 backend:
   baseUrl: http://localhost:7000


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The create-app cli prompts for the name of the organization and uses it for organization.name in the config.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
