### PR TITLE
Add Google Analytics support

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ coverage
 templates
 plugins/scaffolder-backend/sample-templates
 .vscode
+dist-types

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -1,6 +1,7 @@
 app:
   title: Backstage Example App
   baseUrl: http://localhost:7000
+  googleAnalyticsTrackingId: # UA-000000-0
 
 backend:
   baseUrl: http://localhost:7000

--- a/contrib/chart/backstage/templates/backstage-app-config.yaml
+++ b/contrib/chart/backstage/templates/backstage-app-config.yaml
@@ -13,6 +13,7 @@ metadata:
 data:
   APP_CONFIG_app_baseUrl: {{ .Values.appConfig.app.baseUrl | quote | quote }}
   APP_CONFIG_app_title: {{ .Values.appConfig.app.title | quote | quote }}
+  APP_CONFIG_app_googleAnalyticsTrackingId: {{ .Values.appConfig.app.googleAnalyticsTrackingId | quote | quote }}
   APP_CONFIG_backend_baseUrl: {{ .Values.appConfig.backend.baseUrl | quote | quote }}
   APP_CONFIG_backend_cors_origin: {{ .Values.appConfig.backend.cors.origin | quote | quote }}
   APP_CONFIG_techdocs_storageUrl: {{ .Values.appConfig.techdocs.storageUrl | quote | quote }}

--- a/contrib/chart/backstage/values.yaml
+++ b/contrib/chart/backstage/values.yaml
@@ -86,6 +86,7 @@ appConfig:
   app:
     baseUrl: https://demo.example.com
     title: Backstage
+    googleAnalyticsTrackingId:
   backend:
     baseUrl: https://demo.example.com
     listen:

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -48,6 +48,23 @@
       }
     </style>
     <title><%= app.title %></title>
+
+    <% if (app.googleAnalyticsTrackingId && typeof app.googleAnalyticsTrackingId
+    === 'string') { %>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=<%= app.googleAnalyticsTrackingId %>"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', '<%= app.googleAnalyticsTrackingId %>');
+    </script>
+    <% } %>
   </head>
   <body style="margin: 0;">
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -111,6 +111,9 @@ export async function createConfig(
         app: {
           title: options.config.getString('app.title'),
           baseUrl: validBaseUrl.href,
+          googleAnalyticsTrackingId: options.config.getOptionalString(
+            'app.googleAnalyticsTrackingId',
+          ),
         },
       },
     }),


### PR DESCRIPTION
Specify a Google Analytics Tracking ID in the `app-config.yaml` to enable Google Analytics tracking.

```
app:
  title:
  baseUrl:
  googleAnalyticsTrackingId: UA-87354845-4
```

If the `googleAnalyticsTrackingId` is not supplied, no tracking script is added to the application and no tracking can occur.

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
