### PR TITLE
give aria-label to StatusOk, StatusWarning and StatusError components

### DIFF
--- a/.changeset/swift-peas-argue.md
+++ b/.changeset/swift-peas-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+give aria-label attribute to Status Ok, Warning and Error

--- a/packages/core/src/components/Status/Status.tsx
+++ b/packages/core/src/components/Status/Status.tsx
@@ -65,20 +65,34 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 
 export const StatusOK: FC<{}> = props => {
   const classes = useStyles(props);
-  return <span className={classNames(classes.status, classes.ok)} {...props} />;
+  return (
+    <span
+      className={classNames(classes.status, classes.ok)}
+      aria-label="Status ok"
+      {...props}
+    />
+  );
 };
 
 export const StatusWarning: FC<{}> = props => {
   const classes = useStyles(props);
   return (
-    <span className={classNames(classes.status, classes.warning)} {...props} />
+    <span
+      className={classNames(classes.status, classes.warning)}
+      aria-label="Status warning"
+      {...props}
+    />
   );
 };
 
 export const StatusError: FC<{}> = props => {
   const classes = useStyles(props);
   return (
-    <span className={classNames(classes.status, classes.error)} {...props} />
+    <span
+      className={classNames(classes.status, classes.error)}
+      aria-label="Status error"
+      {...props}
+    />
   );
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We are having total 6 types of Status, those are Ok, Warning, Error, Pending, Running and Aborted. But, we have given aria-label attribute to only 3 of them which are Pending, Running and Aborted. This PR give the aria-label attribute to the rest Status component which includes Ok, Warning and Error.

There are no test cases written for these Status components, I would love to write test cases for them, please let me know if it would be a good idea.

### Screenshots

#### StatusOk

http://localhost:6006/iframe.html?id=feedback-status--status-ok&viewMode=story

<img width="960" alt="status-ok" src="https://user-images.githubusercontent.com/19193724/96327018-5e93b300-1053-11eb-8504-a638b7b5badb.png">

#### StatusWarning

http://localhost:6006/iframe.html?id=feedback-status--status-warning&viewMode=story

<img width="960" alt="status-warning" src="https://user-images.githubusercontent.com/19193724/96327019-5fc4e000-1053-11eb-8122-5587bf771a60.png">

#### StatusError

http://localhost:6006/iframe.html?id=feedback-status--status-error&viewMode=story

<img width="960" alt="status-error" src="https://user-images.githubusercontent.com/19193724/96327010-53d91e00-1053-11eb-9804-b5c5b31a6173.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
