### PR TITLE
contrib/kubernetes: added plain single pod deployment example + k8s docs

### DIFF
--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -105,6 +105,7 @@ Monorepo
 monorepos
 msw
 namespace
+namespaces
 Namespaces
 neuro
 newrelic

--- a/contrib/kubernetes/plain_single_backend_deplyoment/README.md
+++ b/contrib/kubernetes/plain_single_backend_deplyoment/README.md
@@ -1,0 +1,42 @@
+# Plain Kubernetes Deployment
+
+This directory contains an example of a simple Kubernetes deployment of Backstage. It is not intended to serve as a complete production deployment, but as a starting point for setting one up.
+
+## Usage
+
+You can try the deployment out as is. The easiest way is to use [Docker Desktop](https://www.docker.com/products/docker-desktop) with [Kubernetes](https://docs.docker.com/get-started/kube-deploy/).
+
+From a fresh clone of this repo, run the following in the root:
+
+```bash
+yarn install
+
+yarn docker-build
+
+kubectl apply -f contrib/kubernetes/plain_single_backend_deplyoment/deployment.yaml
+```
+
+You can use the following commands to monitor the deployment:
+
+```bash
+# List all resources in the backstage namespace
+kubectl -n backstage get all
+
+# Inspect the status of the deployment resource
+kubectl -n backstage describe deployment backstage-backend
+
+# Inspect the status of the pod running the backstage backend
+kubectl -n backstage describe pod -l app=backstage,component=backend
+```
+
+Once the deployment is up and running, you can use the following to set up a proxy to reach the backend locally:
+
+```bash
+kubectl proxy
+```
+
+With the proxy up and running, you should be able to navigate to [http://localhost:8001/api/v1/namespaces/backstage/services/backstage-backend:http/proxy](http://localhost:8001/api/v1/namespaces/backstage/services/backstage-backend:http/proxy) and see Backstage. Note that you'll end up on a 404 page, but hitting the home icon in the sidebar should take you to the catalog page where you can see a few example services.
+
+## Caveats
+
+This deployment is for demonstration purposes only, for a production deployment you will need to set up at least a persistent database and some form of ingress. If your organization doesn't already have established patterns for these, you could look at options of managed PostgreSQL instances from cloud providers, or something like Zalando's [postgres-operator](https://github.com/zalando/postgres-operator). For ingress there are also [plenty of options](https://ramitsurana.gitbook.io/awesome-kubernetes/docs/projects/projects#load-balancing), where `nginx` is a popular choice to get started.

--- a/contrib/kubernetes/plain_single_backend_deplyoment/deployment.yaml
+++ b/contrib/kubernetes/plain_single_backend_deplyoment/deployment.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backstage
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backstage-backend
+  namespace: backstage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backstage
+      component: backend
+  template:
+    metadata:
+      labels:
+        app: backstage
+        component: backend
+    spec:
+      containers:
+        - name: backend
+          # This image is built with `yarn docker-build` in the repo root.
+          # Replace this with your own image to deploy your own Backstage app.
+          image: example-backend:latest
+          imagePullPolicy: Never
+
+          env:
+            # We set this to development to make the backend start with incomplete configuration. In a production
+            # deployment you will want to make sure that you have a full configuration, and remove any plugins that
+            # you are not using.
+            - name: NODE_ENV
+              value: development
+
+              # This makes us load in `app-config.production.yaml` if there is one.
+            - name: APP_ENV
+              value: production
+
+              # This makes it possible for the app to reach the backend when serving through `kubectl proxy`
+              # If you expose the service using for example an ingress controller, you should
+              # switch this out or remove it.
+              #
+              # Note that we're not setting app.baseUrl here, as setting the base path is not working at the moment.
+              # Further work is needed around the routing in the frontend or react-router before we can support that.
+            - name: APP_CONFIG_backend_baseUrl
+              value: http://localhost:8001/api/v1/namespaces/backstage/services/backstage-backend:http/proxy
+
+          ports:
+            - name: http
+              containerPort: 7000
+
+          volumeMounts:
+            - name: config-volume
+              mountPath: /usr/src/app/app-config.local.yaml
+              subPath: app-config.local.yaml
+
+          resources:
+            limits:
+              cpu: 1
+              memory: 0.5Gi
+
+          readinessProbe:
+            httpGet:
+              port: 7000
+              path: /healthcheck
+          livenessProbe:
+            httpGet:
+              port: 7000
+              path: /healthcheck
+
+      volumes:
+        - name: config-volume
+          configMap:
+            name: backstage-config
+            items:
+              - key: app-config
+                path: app-config.local.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backstage-config
+  namespace: backstage
+data:
+  # Note that the config here is only applied to the backend. The frontend config is applied at build time.
+  # To override frontend config in this deployment, use `APP_CONFIG_` env vars.
+  app-config: |
+    app:
+      baseUrl: http://localhost:8001/api/v1/namespaces/backstage/services/backstage-backend:http/proxy
+    backend:
+      baseUrl: http://localhost:8001/api/v1/namespaces/backstage/services/backstage-backend:http/proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backstage-backend
+  namespace: backstage
+spec:
+  selector:
+    app: backstage
+    component: backend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/docs/getting-started/deployment-k8s.md
+++ b/docs/getting-started/deployment-k8s.md
@@ -4,4 +4,10 @@ title: Kubernetes
 description: Documentation on Kubernetes and K8s Deployment
 ---
 
-Coming soon!
+Backstage itself provides tooling up to the point of building docker images.
+Beyond that point we do not have an opinionated way to deploy Backstage within
+Kubernetes, as each cluster has its own unique set of tooling and patterns.
+
+We do provide examples to help you get started though. Check out
+[this example](https://github.com/spotify/backstage/tree/master/contrib/kubernetes/plain_single_backend_deplyoment/)
+for a basic single-deployment setup.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding a simple k8s example to help people get set up quicker, and document a few caveats.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
