### PR TITLE
use getBy query instead of queryBy when asserting for elements present in document

### DIFF
--- a/.changeset/lovely-suits-flash.md
+++ b/.changeset/lovely-suits-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+update the test cases of CodeSnippet component

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -20,10 +20,10 @@ import { wrapInTestApp } from '@backstage/test-utils';
 
 import { CodeSnippet } from './CodeSnippet';
 
-const JAVASCRIPT = `const greeting = "Hello";
-const world = "World";
-
-const greet = person => gretting + " " + person + "!";
+const JAVASCRIPT = `
+  const greeting = "Hello";
+  const world = "World";
+  const greet = person => gretting + " " + person + "!";
 `;
 
 const minProps = {
@@ -58,10 +58,10 @@ describe('<CodeSnippet />', () => {
 
   it('copy code using button', async () => {
     document.execCommand = jest.fn();
-    const rendered = render(
+    const { getByTitle } = render(
       wrapInTestApp(<CodeSnippet {...minProps} showCopyCodeButton />),
     );
-    const button = rendered.getByTitle('Text copied to clipboard');
+    const button = getByTitle('Text copied to clipboard');
     fireEvent.click(button);
     expect(document.execCommand).toHaveBeenCalled();
   });

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -51,9 +51,9 @@ describe('<CodeSnippet />', () => {
     const { getByText } = render(
       wrapInTestApp(<CodeSnippet {...minProps} showLineNumbers />),
     );
-    expect(getByText(/1/)).toBeInTheDocument();
-    expect(getByText(/2/)).toBeInTheDocument();
-    expect(getByText(/3/)).toBeInTheDocument();
+    expect(getByText('1')).toBeInTheDocument();
+    expect(getByText('2')).toBeInTheDocument();
+    expect(getByText('3')).toBeInTheDocument();
   });
 
   it('copy code using button', async () => {

--- a/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
+++ b/packages/core/src/components/CodeSnippet/CodeSnippet.test.tsx
@@ -48,12 +48,12 @@ describe('<CodeSnippet />', () => {
   });
 
   it('renders with line numbers', () => {
-    const { queryByText } = render(
+    const { getByText } = render(
       wrapInTestApp(<CodeSnippet {...minProps} showLineNumbers />),
     );
-    expect(queryByText(/1/)).toBeInTheDocument();
-    expect(queryByText(/2/)).toBeInTheDocument();
-    expect(queryByText(/3/)).toBeInTheDocument();
+    expect(getByText(/1/)).toBeInTheDocument();
+    expect(getByText(/2/)).toBeInTheDocument();
+    expect(getByText(/3/)).toBeInTheDocument();
   });
 
   it('copy code using button', async () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- use **getBy*** query instead of **queryBy*** query when asserting for elements which are present in the document
- destructure `getByTitle` from render function to make it consistent with other test cases

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
