### PR TITLE
fix(unregister-entities): UI handling when no entities are available from api

### DIFF
--- a/.changeset/eighty-lamps-smell.md
+++ b/.changeset/eighty-lamps-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+handle the case where no entities are available to show

--- a/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -85,7 +85,7 @@ export const UnregisterEntityDialog: FC<Props> = ({
             {error.toString()}
           </Alert>
         ) : null}
-        {entities ? (
+        {entities?.length ? (
           <>
             <DialogContentText>
               This action will unregister the following entities:
@@ -107,11 +107,11 @@ export const UnregisterEntityDialog: FC<Props> = ({
                 </li>
               </ul>
             </Typography>
-            <DialogContentText>
-              To undo, just re-register the entity in Backstage.
-            </DialogContentText>
           </>
         ) : null}
+        <DialogContentText>
+          To undo, just re-register the entity in Backstage.
+        </DialogContentText>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} color="primary">


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://github.com/spotify/backstage/issues/2939

The UnregisterEntityDialog component is not having any test cases, I would love to pick that task up in a separate PR.

### Screenshot's

#### Before

<img width="960" alt="before" src="https://user-images.githubusercontent.com/19193724/96395994-b3663380-11e3-11eb-8348-6c90e78cdafb.png">

#### After

<img width="960" alt="after" src="https://user-images.githubusercontent.com/19193724/96395867-5e2a2200-11e3-11eb-8398-b8318e604a5b.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
