### PR TITLE
fix(microsite): the styling of footer copy on mobile

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -1088,6 +1088,13 @@ code {
 .nav-footer .copyright {
   width: 600px;
   color: #fff;
-  margin: auto;
+  margin: 0 auto;
   font-size: 10pt;
+}
+
+@media only screen and (max-width: 485px) {
+  .nav-footer .copyright {
+    width: auto;
+    margin: 0 1.5em;
+  }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The copyright text inside the footer of website was given fixed width of 600 pixels for all screen sizes, which was causing the issue and was breaking complete website on mobile screen sizes.

The footer is present on all of the pages, so it was causing all of the pages to break on mobile.

Now, the width of copyright text has been updated to auto on mobile screen sizes and some margin have been given on left and right side of the copyright text.

## Screenshots

### Before

<img width="960" alt="homepage-top-bug" src="https://user-images.githubusercontent.com/19193724/96409901-aa855a00-1203-11eb-8e61-0501e868683b.png">
<img width="960" alt="homepage-bottom-bug" src="https://user-images.githubusercontent.com/19193724/96409883-a2c5b580-1203-11eb-88ba-9d428942114b.png">

### After

<img width="960" alt="homepage-top-fix" src="https://user-images.githubusercontent.com/19193724/96409960-c7ba2880-1203-11eb-9be8-4bdc60437bd1.png">

<img width="960" alt="homepage-bottom-fix" src="https://user-images.githubusercontent.com/19193724/96409935-bc66fd00-1203-11eb-8835-80c6f2cbe832.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
