### PR TITLE
feat(plugin-register-component): Remove the "Host type" from the form and always use url target

### DIFF
--- a/.changeset/ten-mirrors-love.md
+++ b/.changeset/ten-mirrors-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-register-component': minor
+---
+
+Remove the "Host type" from the register component from and always use url targets

--- a/plugins/register-component/src/components/RegisterComponentForm/RegisterComponentForm.tsx
+++ b/plugins/register-component/src/components/RegisterComponentForm/RegisterComponentForm.tsx
@@ -19,15 +19,12 @@ import {
   Button,
   FormControl,
   FormHelperText,
-  InputLabel,
   LinearProgress,
-  MenuItem,
-  Select,
   TextField,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { ComponentIdValidators } from '../../util/validate';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
@@ -50,7 +47,7 @@ export type Props = {
 };
 
 export const RegisterComponentForm = ({ onSubmit, submitting }: Props) => {
-  const { control, register, handleSubmit, errors, formState } = useForm({
+  const { register, handleSubmit, errors, formState } = useForm({
     mode: 'onChange',
   });
   const classes = useStyles();
@@ -91,29 +88,6 @@ export const RegisterComponentForm = ({ onSubmit, submitting }: Props) => {
         )}
       </FormControl>
 
-      <FormControl variant="outlined" className={classes.select}>
-        <InputLabel id="scmLabel">Host type</InputLabel>
-        <Controller
-          control={control}
-          name="scmType"
-          defaultValue="AUTO"
-          render={({ onChange, onBlur, value }) => (
-            <Select
-              labelId="scmLabel"
-              id="scmSelect"
-              label="scmLabel"
-              value={value}
-              onChange={onChange}
-              onBlur={onBlur}
-            >
-              <MenuItem value="AUTO">Auto-detect</MenuItem>
-              <MenuItem value="gitlab">GitLab</MenuItem>
-              <MenuItem value="bitbucket/api">Bitbucket</MenuItem>
-              <MenuItem value="azure/api">Azure</MenuItem>
-            </Select>
-          )}
-        />
-      </FormControl>
       <Button
         variant="contained"
         color="primary"

--- a/plugins/register-component/src/components/RegisterComponentPage/RegisterComponentPage.tsx
+++ b/plugins/register-component/src/components/RegisterComponentPage/RegisterComponentPage.tsx
@@ -82,20 +82,9 @@ export const RegisterComponentPage = ({
 
   const handleSubmit = async (formData: Record<string, string>) => {
     setFormState(FormStates.Submitting);
-    const { scmType, componentLocation: target } = formData;
+    const { componentLocation: target } = formData;
     try {
-      const typeMapping = [
-        { url: /^https:\/\/gitlab\.com\/.*/, type: 'gitlab/api' },
-        { url: /^https:\/\/bitbucket\.org\/.*/, type: 'bitbucket/api' },
-        { url: /^https:\/\/dev\.azure\.com\/.*/, type: 'azure/api' },
-        { url: /.*/, type: 'github' },
-      ];
-
-      const type =
-        scmType === 'AUTO'
-          ? typeMapping.filter(item => item.url.test(target))[0].type
-          : scmType;
-      const data = await catalogApi.addLocation(type, target);
+      const data = await catalogApi.addLocation('url', target);
 
       if (!isMounted()) return;
 


### PR DESCRIPTION
I'm not 100% sure if we are ready for this change. The auto detection of the target was still in place, this PR removes it and always creates locations with the target type "url". The catalog backend is now intelligent enough to choose the right integration.

![image](https://user-images.githubusercontent.com/648527/96446772-c1cb4400-1211-11eb-85cb-1b6d664d2eb0.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
