### PR TITLE
fix(microsite): plugins page, plugins card and plugins header

### DIFF
--- a/microsite/pages/en/plugins.js
+++ b/microsite/pages/en/plugins.js
@@ -44,7 +44,7 @@ const Plugins = () => (
         </span>
       </div>
       <BulletLine style={{ width: '100% ' }} />
-      <Container wrapped className="grid">
+      <Container wrapped className="PluginGrid">
         {pluginMetadata.map(
           ({
             iconUrl,

--- a/microsite/pages/en/plugins.js
+++ b/microsite/pages/en/plugins.js
@@ -57,26 +57,25 @@ const Plugins = () => (
           }) => (
             <div className="PluginCard">
               <div className="PluginCardHeader">
-                <img src={iconUrl || defaultIconUrl} alt={title} />
-                <h2 className="PluginCardTitle">{title}</h2>
-                <p className="Author">
-                  by <a href={authorUrl}>{author}</a>
-                </p>
-                <span className="ChipOutlined">{category}</span>
+                <div className="PluginCardImage">
+                  <img src={iconUrl || defaultIconUrl} alt={title} />
+                </div>
+                <div className="PluginCardInfo">
+                  <h3 className="PluginCardTitle">{title}</h3>
+                  <p className="PluginCardAuthor">
+                    by <a href={authorUrl}>{author}</a>
+                  </p>
+                  <span className="PluginCardChipOutlined">{category}</span>
+                </div>
               </div>
               <div className="PluginCardBody">
                 <p>{truncate(description)}</p>
               </div>
-              <Container className="PluginCardFooter">
-                <span>
-                  <a
-                    className="PluginCardLink ButtonFilled"
-                    href={documentation}
-                  >
-                    Explore
-                  </a>
-                </span>
-              </Container>
+              <div className="PluginCardFooter">
+                <a className="ButtonFilled" href={documentation}>
+                  Explore
+                </a>
+              </div>
             </div>
           ),
         )}

--- a/microsite/static/css/plugins.css
+++ b/microsite/static/css/plugins.css
@@ -6,7 +6,7 @@
   flex-direction: column;
 }
 
-.grid {
+.PluginGrid {
   display: grid;
   grid-gap: 1rem;
   grid-template-columns: repeat(4, 1fr);
@@ -15,14 +15,20 @@
 }
 
 @media (max-width: 1200px) {
-  .grid {
+  .PluginGrid {
     grid-template-columns: repeat(3, 1fr);
   }
 }
 
 @media only screen and (max-width: 815px) {
-  .grid {
+  .PluginGrid {
     grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media only screen and (max-width: 485px) {
+  .PluginGrid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/microsite/static/css/plugins.css
+++ b/microsite/static/css/plugins.css
@@ -56,6 +56,12 @@
   right: 0px;
 }
 
+@media only screen and (max-width: 485px) {
+  .PluginAddNewButton {
+    bottom: -4px;
+  }
+}
+
 .ButtonFilled {
   padding: 4px 8px;
   border-radius: 4px;

--- a/microsite/static/css/plugins.css
+++ b/microsite/static/css/plugins.css
@@ -40,14 +40,32 @@
 }
 
 .PluginCardHeader {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   max-height: fit-content;
   min-height: fit-content;
+}
+
+.PluginCardImage {
+  width: 80px;
+  height: 80px;
+  margin-right: 16px;
+}
+
+.PluginCardImage img {
+  width: 100%;
+  max-width: 100%;
 }
 
 .PluginCardTitle {
   color: white;
   vertical-align: top;
-  margin: 8px 0px 0px 16px;
+  margin: 8px 0 0;
+}
+
+.PluginCardInfo {
+  flex: 1;
 }
 
 .PluginAddNewButton {
@@ -66,7 +84,6 @@
   padding: 4px 8px;
   border-radius: 4px;
   color: #69ddc7;
-  margin-top: 36px;
 }
 
 .ButtonFilled:hover {
@@ -74,7 +91,7 @@
   background-color: transparent;
 }
 
-.ChipOutlined {
+.PluginCardChipOutlined {
   font-size: small;
   border-radius: 16px;
   padding: 2px 8px;
@@ -82,11 +99,16 @@
   color: #69ddc7;
 }
 
-.PluginCardLink {
+.PluginCardFooter {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  margin-top: auto;
+  min-height: 2em;
+}
+
+.PluginCardFooter a {
   padding: 2px 8px;
-  position: absolute;
-  bottom: 0;
-  right: 0;
 }
 
 .PluginPageLayout {
@@ -107,18 +129,13 @@
   padding-top: 8px;
 }
 
-.PluginCardFooter {
-  position: relative;
-  min-height: 2em;
-}
-
-.Author,
-.Author a {
+.PluginCardAuthor,
+.PluginCardAuthor a {
   margin-bottom: 0.25em;
   color: rgba(255, 255, 255, 0.6);
 }
 
-.Author a:hover {
+.PluginCardAuthor a:hover {
   color: white;
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes the following things:

- align 'Add to Marketplace' button on plugins page header on mobile screen sizes
- layout of plugins page on mobile screen sizes, now we are showing only 1 plugin card in 1 row
- the chip inside plugin card was going below the image for lots of cards, it is now consistent and will always come below name of Author

### Screenshots

### Plugins page and header

##### Bug
<img width="960" alt="plugins-bug" src="https://user-images.githubusercontent.com/19193724/96448112-8c821e80-1230-11eb-9cd8-cc3fc9d0083f.png">

##### Fix
<img width="960" alt="plugins-fix" src="https://user-images.githubusercontent.com/19193724/96448185-a1f74880-1230-11eb-9b98-ea35fa29cab5.png">

### Plugin card

##### Bug
<img width="960" alt="plugins-card-bug" src="https://user-images.githubusercontent.com/19193724/96448123-9277ff80-1230-11eb-9029-98e1cdf99ca7.png">

<img width="960" alt="plugins-desktop-bug" src="https://user-images.githubusercontent.com/19193724/96448149-986de080-1230-11eb-81ad-26a836437636.png">

##### Fix
<img width="960" alt="plugins-card-fix" src="https://user-images.githubusercontent.com/19193724/96448127-93109600-1230-11eb-97d0-ddec5b17cde6.png">

<img width="960" alt="plugins-desktop-fix" src="https://user-images.githubusercontent.com/19193724/96448170-9efc5800-1230-11eb-9c55-082bebd0cece.png">

### After

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
