### PR TITLE
backend-common: make loadBackendConfig return config directly and log all resolved app-configs

### DIFF
--- a/.changeset/weak-ducks-tan.md
+++ b/.changeset/weak-ducks-tan.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-common': minor
+'example-backend': patch
+'@backstage/cli': patch
+'@backstage/create-app': patch
+---
+
+Change loadBackendConfig to return the config directly

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -15,12 +15,18 @@
  */
 
 import { findPaths } from '@backstage/cli-common';
+import { Config, ConfigReader } from '@backstage/config';
 import { loadConfig } from '@backstage/config-loader';
+import { Logger } from 'winston';
+
+type Options = {
+  logger: Logger;
+};
 
 /**
  * Load configuration for a Backend
  */
-export async function loadBackendConfig() {
+export async function loadBackendConfig(options: Options): Promise<Config> {
   /* eslint-disable-next-line no-restricted-syntax */
   const paths = findPaths(__dirname);
   const configs = await loadConfig({
@@ -28,5 +34,10 @@ export async function loadBackendConfig() {
     rootPaths: [paths.targetRoot, paths.targetDir],
     shouldReadSecrets: true,
   });
-  return configs;
+
+  options.logger.info(
+    `Loaded config from ${configs.map(c => c.context).join(', ')}`,
+  );
+
+  return ConfigReader.fromConfigs(configs);
 }

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ConfigReader } from '@backstage/config';
+import { Config } from '@backstage/config';
 import compression from 'compression';
 import cors from 'cors';
 import express, { Router } from 'express';
@@ -77,7 +77,7 @@ export class ServiceBuilderImpl implements ServiceBuilder {
     this.module = moduleRef;
   }
 
-  loadConfig(config: ConfigReader): ServiceBuilder {
+  loadConfig(config: Config): ServiceBuilder {
     const backendConfig = config.getOptionalConfig('backend');
     if (!backendConfig) {
       return this;

--- a/packages/cli/src/commands/app/build.ts
+++ b/packages/cli/src/commands/app/build.ts
@@ -26,6 +26,11 @@ export default async (cmd: Command) => {
     env: process.env.APP_ENV ?? process.env.NODE_ENV ?? 'production',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
+
+  console.log(
+    `Loaded config from ${appConfigs.map(c => c.context).join(', ')}`,
+  );
+
   await buildBundle({
     entry: 'src/index',
     parallel: parseParallel(process.env[PARALLEL_ENV_VAR]),

--- a/packages/cli/src/commands/app/serve.ts
+++ b/packages/cli/src/commands/app/serve.ts
@@ -25,6 +25,11 @@ export default async (cmd: Command) => {
     env: process.env.APP_ENV ?? process.env.NODE_ENV ?? 'development',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
+
+  console.log(
+    `Loaded config from ${appConfigs.map(c => c.context).join(', ')}`,
+  );
+
   const waitForExit = await serveBundle({
     entry: 'src/index',
     checksEnabled: cmd.check,

--- a/packages/cli/src/commands/backend/dev.ts
+++ b/packages/cli/src/commands/backend/dev.ts
@@ -26,6 +26,10 @@ export default async (cmd: Command) => {
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
 
+  console.log(
+    `Loaded config from ${appConfigs.map(c => c.context).join(', ')}`,
+  );
+
   const waitForExit = await serveBackend({
     entry: 'src/index',
     checksEnabled: cmd.check,

--- a/packages/cli/src/commands/config/print.ts
+++ b/packages/cli/src/commands/config/print.ts
@@ -28,6 +28,10 @@ export default async (cmd: Command) => {
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
 
+  console.log(
+    `Loaded config from ${appConfigs.map(c => c.context).join(', ')}`,
+  );
+
   const flatConfig = ConfigReader.fromConfigs(appConfigs).get();
 
   if (cmd.format === 'json') {

--- a/packages/cli/src/commands/plugin/export.ts
+++ b/packages/cli/src/commands/plugin/export.ts
@@ -25,6 +25,11 @@ export default async (cmd: Command) => {
     env: process.env.APP_ENV ?? process.env.NODE_ENV ?? 'production',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
+
+  console.log(
+    `Loaded config from ${appConfigs.map(c => c.context).join(', ')}`,
+  );
+
   await buildBundle({
     entry: 'dev/index',
     statsJsonEnabled: cmd.stats,

--- a/packages/cli/src/commands/plugin/serve.ts
+++ b/packages/cli/src/commands/plugin/serve.ts
@@ -25,6 +25,11 @@ export default async (cmd: Command) => {
     env: process.env.APP_ENV ?? process.env.NODE_ENV ?? 'development',
     rootPaths: [paths.targetRoot, paths.targetDir],
   });
+
+  console.log(
+    `Loaded config from ${appConfigs.map(c => c.context).join(', ')}`,
+  );
+
   const waitForExit = await serveBundle({
     entry: 'dev/index',
     checksEnabled: cmd.check,

--- a/plugins/auth-backend/src/service/standaloneServer.ts
+++ b/plugins/auth-backend/src/service/standaloneServer.ts
@@ -17,7 +17,6 @@
 import Knex from 'knex';
 import { Server } from 'http';
 import { Logger } from 'winston';
-import { ConfigReader } from '@backstage/config';
 import { createRouter } from './router';
 import {
   createServiceBuilder,
@@ -34,7 +33,7 @@ export async function startStandaloneServer(
   options: ServerOptions,
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'auth-backend' });
-  const config = ConfigReader.fromConfigs(await loadBackendConfig());
+  const config = await loadBackendConfig({ logger });
   const discovery = SingleHostDiscovery.fromConfig(config);
 
   const database = useHotMemoize(module, () => {

--- a/plugins/catalog-backend/src/service/standaloneServer.ts
+++ b/plugins/catalog-backend/src/service/standaloneServer.ts
@@ -20,7 +20,6 @@ import {
   UrlReaders,
   useHotMemoize,
 } from '@backstage/backend-common';
-import { ConfigReader } from '@backstage/config';
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { DatabaseManager } from '../database';
@@ -37,7 +36,7 @@ export async function startStandaloneServer(
   options: ServerOptions,
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'catalog-backend' });
-  const config = ConfigReader.fromConfigs(await loadBackendConfig());
+  const config = await loadBackendConfig({ logger });
   const reader = UrlReaders.default({ logger, config });
   const db = useHotMemoize(module, () =>
     DatabaseManager.createInMemoryDatabaseConnection(),

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -16,7 +16,6 @@
 
 import { buildMiddleware, createRouter } from './router';
 import * as winston from 'winston';
-import { ConfigReader } from '@backstage/config';
 import {
   loadBackendConfig,
   SingleHostDiscovery,
@@ -42,7 +41,7 @@ const mockCreateProxyMiddleware = createProxyMiddleware as jest.MockedFunction<
 describe('createRouter', () => {
   it('works', async () => {
     const logger = winston.createLogger();
-    const config = ConfigReader.fromConfigs(await loadBackendConfig());
+    const config = await loadBackendConfig({ logger });
     const discovery = SingleHostDiscovery.fromConfig(config);
     const router = await createRouter({
       config,

--- a/plugins/proxy-backend/src/service/standaloneServer.ts
+++ b/plugins/proxy-backend/src/service/standaloneServer.ts
@@ -22,7 +22,6 @@ import {
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { createRouter } from './router';
-import { ConfigReader } from '@backstage/config';
 
 export interface ServerOptions {
   port: number;
@@ -37,7 +36,7 @@ export async function startStandaloneServer(
 
   logger.debug('Creating application...');
 
-  const config = ConfigReader.fromConfigs(await loadBackendConfig());
+  const config = await loadBackendConfig({ logger });
   const discovery = SingleHostDiscovery.fromConfig(config);
   const router = await createRouter({
     config,

--- a/plugins/rollbar-backend/src/service/standaloneServer.ts
+++ b/plugins/rollbar-backend/src/service/standaloneServer.ts
@@ -20,7 +20,6 @@ import {
   createServiceBuilder,
   loadBackendConfig,
 } from '@backstage/backend-common';
-import { ConfigReader } from '@backstage/config';
 import { createRouter } from './router';
 
 export interface ServerOptions {
@@ -33,7 +32,7 @@ export async function startStandaloneServer(
   options: ServerOptions,
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'rollbar-backend' });
-  const config = ConfigReader.fromConfigs(await loadBackendConfig());
+  const config = await loadBackendConfig({ logger });
 
   logger.debug('Creating application...');
 

--- a/plugins/techdocs-backend/src/default-branch.ts
+++ b/plugins/techdocs-backend/src/default-branch.ts
@@ -15,8 +15,8 @@
  */
 import fetch, { RequestInit } from 'node-fetch';
 import parseGitUrl from 'git-url-parse';
-import { ConfigReader, Config } from '@backstage/config';
-import { loadBackendConfig } from '@backstage/backend-common';
+import { Config } from '@backstage/config';
+import { getRootLogger, loadBackendConfig } from '@backstage/backend-common';
 
 interface IGitlabBranch {
   name: string;
@@ -228,7 +228,8 @@ async function getAzureDefaultBranch(
 export const getDefaultBranch = async (
   repositoryUrl: string,
 ): Promise<string> => {
-  const config = ConfigReader.fromConfigs(await loadBackendConfig());
+  // TODO(Rugvip): Config should not be loaded here, pass it in instead
+  const config = await loadBackendConfig({ logger: getRootLogger() });
   const typeMapping = [
     { url: /github*/g, type: 'github' },
     { url: /gitlab*/g, type: 'gitlab' },


### PR DESCRIPTION
Partial fix for #2889

When loading the config on backends or when building the frontend, it now logs something like this:

```
Loaded config from app-config.yaml, app-config.local.yaml, app-config.development.yaml
```

I also changed `loadBackendConfig` to return the config directly while at it, since the split doesn't make sense anymore, and we'll be needing that if we want to add config watching in the future as discussed in #2397