### PR TITLE
ISSUE 2850 Solved

### DIFF
--- a/plugins/techdocs/src/test-utils/fixtures/mkdocs-index.ts
+++ b/plugins/techdocs/src/test-utils/fixtures/mkdocs-index.ts
@@ -1528,15 +1528,6 @@ css    img    js          mkdocs   sitemap.xml
                 <a href="/about/release-notes/#maintenance-team">MkDocs Team</a
                 >.
               </div>
-
-              Made with
-              <a
-                href="https://squidfunk.github.io/mkdocs-material/"
-                target="_blank"
-                rel="noopener"
-              >
-                Material for MkDocs
-              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
[Fixes 2850#]
## About this PR:
I've Deleted "Made with Material for MkDocs" from the backstage/plugins/techdocs/src/test-utils/fixtures/mkdocs-index.ts

![Backstage](https://user-images.githubusercontent.com/54148351/96543463-0e6e5800-12c2-11eb-9bc8-54a608e0b4e5.png)

## This will solve the issue by not showing "Made with Material for MkDocs"