### PR TITLE
Read git auth token from backend config

### DIFF
--- a/plugins/techdocs-backend/src/git-auth.ts
+++ b/plugins/techdocs-backend/src/git-auth.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import parseGitUrl from 'git-url-parse';
+import { Config } from '@backstage/config';
+import { getRootLogger, loadBackendConfig } from '@backstage/backend-common';
+
+export function getGitHost(url: string): string {
+  const { resource } = parseGitUrl(url);
+  return resource;
+}
+
+export function getGitRepoType(url: string): string {
+  const typeMapping = [
+    { url: /github*/g, type: 'github' },
+    { url: /gitlab*/g, type: 'gitlab' },
+    { url: /azure*/g, type: 'azure/api' },
+  ];
+
+  const type = typeMapping.filter(item => item.url.test(url))[0]?.type;
+
+  return type;
+}
+
+export function getGithubHostToken(
+  config: Config,
+  host: string,
+): string | undefined {
+  const providerConfigs =
+    config.getOptionalConfigArray('integrations.github') ?? [];
+
+  const hostConfig = providerConfigs.filter(
+    providerConfig => providerConfig.getOptionalString('host') === host,
+  );
+  const token =
+    hostConfig[0]?.getOptionalString('token') ??
+    config.getOptionalString('catalog.processors.github.privateToken') ??
+    config.getOptionalString('catalog.processors.githubApi.privateToken') ??
+    process.env.GITHUB_TOKEN;
+
+  return token;
+}
+
+export function getGitlabHostToken(
+  config: Config,
+  host: string,
+): string | undefined {
+  const providerConfigs =
+    config.getOptionalConfigArray('integrations.gitlab') ?? [];
+
+  const hostConfig = providerConfigs.filter(
+    providerConfig => providerConfig.getOptionalString('host') === host,
+  );
+  const token =
+    hostConfig[0]?.getOptionalString('token') ??
+    config.getOptionalString('catalog.processors.gitlab.privateToken') ??
+    config.getOptionalString('catalog.processors.gitlabApi.privateToken') ??
+    process.env.GITLAB_TOKEN;
+
+  return token;
+}
+
+export function getAzureHostToken(
+  config: Config,
+  host: string,
+): string | undefined {
+  const providerConfigs =
+    config.getOptionalConfigArray('integrations.azure') ?? [];
+
+  const hostConfig = providerConfigs.filter(
+    providerConfig => providerConfig.getOptionalString('host') === host,
+  );
+  const token =
+    hostConfig[0]?.getOptionalString('token') ??
+    config.getOptionalString('catalog.processors.azureApi.privateToken') ??
+    process.env.AZURE_TOKEN;
+
+  return token;
+}
+
+export const getTokenForGitRepo = async (
+  repositoryUrl: string,
+): Promise<string | undefined> => {
+  const config = await loadBackendConfig({ logger: getRootLogger() });
+
+  const host = getGitHost(repositoryUrl);
+  const type = getGitRepoType(repositoryUrl);
+
+  try {
+    switch (type) {
+      case 'github':
+        return getGithubHostToken(config, host);
+      case 'gitlab':
+        return getGitlabHostToken(config, host);
+      case 'azure/api':
+        return getAzureHostToken(config, host);
+
+      default:
+        throw new Error('Failed to get repository type');
+    }
+  } catch (error) {
+    throw error;
+  }
+};

--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -20,6 +20,7 @@ import parseGitUrl from 'git-url-parse';
 import NodeGit, { Clone, Repository } from 'nodegit';
 import fs from 'fs-extra';
 import { getDefaultBranch } from './default-branch';
+import { getTokenForGitRepo } from './git-auth';
 import { Entity } from '@backstage/catalog-model';
 import { InputError } from '@backstage/backend-common';
 import { RemoteProtocol } from './techdocs/stages/prepare/types';
@@ -127,11 +128,8 @@ export const checkoutGitRepository = async (
     process.env.GITLAB_PRIVATE_TOKEN_USER ||
     process.env.AZURE_PRIVATE_TOKEN_USER ||
     '';
-  const token =
-    process.env.GITHUB_TOKEN ||
-    process.env.GITLAB_PRIVATE_TOKEN_USER ||
-    process.env.AZURE_TOKEN ||
-    '';
+
+  const token = await getTokenForGitRepo(repoUrl);
 
   if (fs.existsSync(repositoryTmpPath)) {
     try {
@@ -153,7 +151,7 @@ export const checkoutGitRepository = async (
     }
   }
 
-  if (user && token) {
+  if (token) {
     parsedGitLocation.token = `${user}:${token}`;
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While testing TechDocs from an internal GitLab repo, we found that the auth mechanism is not working properly and we were getting `Error: remote authentication required but no callback set`. Turned out that the token provided under `integrations.gitlab` wasn't being used and instead the GitlabPreparer was dependent on `catalog.processors.gitlab.privateToken` or the env var `process.env.GITLAB_TOKEN`. This PR adds support to check for the token first in the `integrations` config and then falls back to old behaviour. We have tested this with our internal GitLab.

#### Points to note
1. I am not sure of how GitHub or Azure auth logic is yet. If someone can verify it, that would be great.
2. It's my first major contribution here and first time working with TypeScript (or JavaScript). So please forgive my mistakes. Give me feedback and I will incorporate it :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
