### PR TITLE
fix(cost-insights): More exports to help custom alerting

### DIFF
--- a/plugins/cost-insights/src/components/BarChart/BarChart.tsx
+++ b/plugins/cost-insights/src/components/BarChart/BarChart.tsx
@@ -30,7 +30,7 @@ import {
 import { Box, useTheme } from '@material-ui/core';
 import BarChartTick from './BarChartTick';
 import BarChartStepper from './BarChartStepper';
-import Tooltip, { TooltipItemProps } from '../Tooltip';
+import { Tooltip, TooltipItemProps } from '../Tooltip';
 
 import { currencyFormatter } from '../../utils/formatters';
 import {

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewTooltip.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewTooltip.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import moment from 'moment';
 import { TooltipPayload, TooltipProps } from 'recharts';
-import Tooltip, { TooltipItemProps } from '../../components/Tooltip';
+import { Tooltip, TooltipItemProps } from '../../components/Tooltip';
 import { DEFAULT_DATE_FORMAT } from '../../types';
 
 export type CostOverviewTooltipProps = TooltipProps & {

--- a/plugins/cost-insights/src/components/Tooltip/index.ts
+++ b/plugins/cost-insights/src/components/Tooltip/index.ts
@@ -14,5 +14,7 @@
  * limitations under the License.
  */
 
-export { default } from './Tooltip';
-export * from './TooltipItem';
+export { default as Tooltip } from './Tooltip';
+export type { TooltipProps } from './Tooltip';
+export { default as TooltipItem } from './TooltipItem';
+export type { TooltipItemProps } from './TooltipItem';

--- a/plugins/cost-insights/src/components/index.ts
+++ b/plugins/cost-insights/src/components/index.ts
@@ -16,3 +16,4 @@
 
 export { default as BarChart } from './BarChart';
 export { default as LegendItem } from './LegendItem';
+export * from './Tooltip';

--- a/plugins/cost-insights/src/index.ts
+++ b/plugins/cost-insights/src/index.ts
@@ -17,4 +17,5 @@
 export { plugin } from './plugin';
 export * from './api';
 export * from './components';
+export { useCurrency } from './hooks';
 export * from './types';


### PR DESCRIPTION
Exports Tooltip types and the `useCurrency` hook from cost-insights to use in custom alerts.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
