### PR TITLE
fix: responsive of page example in storybook

### DIFF
--- a/.changeset/tough-weeks-pull.md
+++ b/.changeset/tough-weeks-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+fix the responsive of page story

--- a/packages/core/src/layout/Page/Page.stories.tsx
+++ b/packages/core/src/layout/Page/Page.stories.tsx
@@ -174,7 +174,7 @@ const DataGrid = () => (
 );
 
 const ExampleHeader = () => (
-  <Header title="Example" subtitle="This an example plugin">
+  <Header title="Example" subtitle="This is an example plugin">
     <HeaderLabel label="Owner" value="Owner" />
     <HeaderLabel label="Lifecycle" value="Lifecycle" />
   </Header>

--- a/packages/core/src/layout/Page/Page.stories.tsx
+++ b/packages/core/src/layout/Page/Page.stories.tsx
@@ -118,14 +118,14 @@ const DataGrid = () => (
         justify="space-between"
         direction="row"
       >
-        <Grid item xs={6}>
+        <Grid item xs={12} md={6}>
           <GaugeCard
             title="GKE Usage Score"
             subheader="This should be above 75%"
             progress={0.87}
           />
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={12} md={6}>
           <GaugeCard
             title="Deployment Score"
             subheader="This should be above 40%"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- fix the responsive version in examples page of storybook
- fix the typo in examples page of storybook

### Screenshots

#### iPhone

##### Before

<img width="960" alt="example-iphone-before" src="https://user-images.githubusercontent.com/19193724/96620766-7c983680-1325-11eb-8014-8135ecf34c2f.png">

##### After

<img width="960" alt="example-iphone-after" src="https://user-images.githubusercontent.com/19193724/96620748-7904af80-1325-11eb-89d1-a9872ce5819e.png">

#### iPad

##### Before

<img width="960" alt="example-ipad-before" src="https://user-images.githubusercontent.com/19193724/96620740-76a25580-1325-11eb-928c-290a3dff9d5b.png">

##### After

<img width="960" alt="example-ipad-after" src="https://user-images.githubusercontent.com/19193724/96620730-74d89200-1325-11eb-9970-d68357a1adb3.png">


#### Desktop

##### Before

<img width="960" alt="desktop-before" src="https://user-images.githubusercontent.com/19193724/96620721-72763800-1325-11eb-9620-d811868032ae.png">

##### After

<img width="960" alt="desktop-after" src="https://user-images.githubusercontent.com/19193724/96620678-62f6ef00-1325-11eb-847a-5fba51f39982.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
