### PR TITLE
fix: update the ItemCard component and it's story

### DIFF
--- a/.changeset/polite-moose-cough.md
+++ b/.changeset/polite-moose-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+update ItemCard component and it's story

--- a/packages/core/src/layout/ItemCard/ItemCard.stories.tsx
+++ b/packages/core/src/layout/ItemCard/ItemCard.stories.tsx
@@ -24,7 +24,7 @@ export default {
 
 export const Default = () => (
   <Grid container spacing={4}>
-    <Grid item xs={3}>
+    <Grid item xs={12} md={3}>
       <ItemCard
         title="Item Card"
         description="This is the description of an Item Card"
@@ -33,7 +33,7 @@ export const Default = () => (
         onClick={() => {}}
       />
     </Grid>
-    <Grid item xs={3}>
+    <Grid item xs={12} md={3}>
       <ItemCard
         title="Item Card"
         description="This is the description of an Item Card"
@@ -47,18 +47,18 @@ export const Default = () => (
 
 export const Tags = () => (
   <Grid container spacing={4}>
-    <Grid item xs={3}>
+    <Grid item xs={12} md={3}>
       <ItemCard
         title="Item Card"
-        description="This is a Item Card"
-        tags={['one tag', 'two tag']}
+        description="This is the description of an Item Card with Tags"
+        tags={['one tag', 'one tag']}
         label="Button"
       />
     </Grid>
-    <Grid item xs={3}>
+    <Grid item xs={12} md={3}>
       <ItemCard
         title="Item Card"
-        description="This is a Item Card"
+        description="This is the description of an Item Card with Tags"
         tags={['one tag', 'two tag']}
         label="Button"
       />

--- a/packages/core/src/layout/ItemCard/ItemCard.test.tsx
+++ b/packages/core/src/layout/ItemCard/ItemCard.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { ItemCard } from './ItemCard';
+
+const minProps = {
+  description: 'This is the description of an Item Card',
+  label: 'Button',
+  title: 'Item Card',
+  type: 'Pretitle',
+};
+
+describe('<InfoCard />', () => {
+  it('renders default without exploding', async () => {
+    const { description, label, title, type } = minProps;
+    const { getByText } = await renderInTestApp(<ItemCard {...minProps} />);
+    expect(getByText(description)).toBeInTheDocument();
+    expect(getByText(title)).toBeInTheDocument();
+    expect(getByText(label)).toBeInTheDocument();
+    expect(getByText(type)).toBeInTheDocument();
+  });
+
+  it('renders with tags without exploding', async () => {
+    const { description, label, title } = minProps;
+    const tags = ['tag one', 'tag two'];
+    const { getByText } = await renderInTestApp(
+      <ItemCard {...minProps} tags={tags} />,
+    );
+    expect(getByText(description)).toBeInTheDocument();
+    expect(getByText(title)).toBeInTheDocument();
+    expect(getByText(label)).toBeInTheDocument();
+    tags.forEach(tag => {
+      expect(getByText(tag)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/core/src/layout/ItemCard/ItemCard.tsx
+++ b/packages/core/src/layout/ItemCard/ItemCard.tsx
@@ -61,8 +61,8 @@ export const ItemCard: FC<ItemCardProps> = ({
         <Typography variant="h6">{title}</Typography>
       </div>
       <div className={classes.content}>
-        {tags?.map(tag => (
-          <Chip label={tag} key={tag} />
+        {tags?.map((tag, i) => (
+          <Chip label={tag} key={`tag-${i}`} />
         ))}
         <Typography variant="body2" paragraph className={classes.description}>
           {description}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Update the ItemCard story to show responsive version properly
- Update the key prop when using tags in ItemCard component, because using only value of tag as key will throw warning on console when the value of two or more tags are same in array of tags. Now the key prop value is coupled with the index of map method
- Adds test case for ItemCard component

### Screenshots

#### Before

<img width="960" alt="item-card-story-before" src="https://user-images.githubusercontent.com/19193724/96641881-fdb1f680-1342-11eb-9a86-c34d31845e68.png">

#### After

<img width="960" alt="item-card-story-after" src="https://user-images.githubusercontent.com/19193724/96641863-f7237f00-1342-11eb-8c94-da3aa5bbda6d.png">




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
