### PR TITLE
fix: accordion details design for job stage failure 

### DIFF
--- a/.changeset/flat-yaks-march.md
+++ b/.changeset/flat-yaks-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+fix the accordion details design when job stage fail

--- a/plugins/scaffolder/src/components/JobStage/JobStage.tsx
+++ b/plugins/scaffolder/src/components/JobStage/JobStage.tsx
@@ -125,7 +125,9 @@ export const JobStage = ({ endedAt, startedAt, name, log, status }: Props) => {
       </AccordionSummary>
       <AccordionDetails className={classes.accordionDetails}>
         {log.length === 0 ? (
-          <Box px={4}>No logs available for this step</Box>
+          <Box px={9} pb={2} width="100%">
+            No logs available for this step
+          </Box>
         ) : (
           <Suspense fallback={<LinearProgress />}>
             <div style={{ height: '20vh', width: '100%' }}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The accordion details where we show the content was having no room and was stuck to the text for the case when we show job stage failure text message. 

Now, breathing space have been provided and text telling `No logs available for this step` have been aligned. 

### Screenshots

#### Before

<img width="960" alt="job-stage-fail-bug-1" src="https://user-images.githubusercontent.com/19193724/96690095-e43f9780-13a0-11eb-89db-59f0a9812102.png">

<img width="1440" alt="job-stage-fail-bug-2" src="https://user-images.githubusercontent.com/19193724/96690114-ea357880-13a0-11eb-8b47-629e4afad0bd.png">

<img width="960" alt="jog-stage-fail-bug-3" src="https://user-images.githubusercontent.com/19193724/96690286-1a7d1700-13a1-11eb-9212-1202d9909bbf.png">

#### After

<img width="960" alt="job-stage-fail-fix-1" src="https://user-images.githubusercontent.com/19193724/96690214-03d6c000-13a1-11eb-942b-54995e74948d.png">

<img width="960" alt="job-stage-fail-fix-2" src="https://user-images.githubusercontent.com/19193724/96690243-0fc28200-13a1-11eb-8e9a-73921d830525.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
