### PR TITLE
[CLI - refactor]: Temporary files use inside tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -114,6 +114,7 @@
     "@types/http-proxy": "^1.17.4",
     "@types/inquirer": "^7.3.1",
     "@types/mini-css-extract-plugin": "^0.9.1",
+    "@types/mock-fs": "^4.13.0",
     "@types/node": "^13.7.2",
     "@types/ora": "^3.2.0",
     "@types/react-dev-utils": "^9.0.4",

--- a/packages/cli/src/commands/create-plugin/createPlugin.test.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.test.ts
@@ -16,11 +16,25 @@
 
 import fs from 'fs-extra';
 import path from 'path';
+import mockFs from 'mock-fs';
 import os from 'os';
 import del from 'del';
 import { createTemporaryPluginFolder, movePlugin } from './createPlugin';
 
 describe('createPlugin', () => {
+  beforeEach(() => {
+    mockFs({
+      '/testPluginMock': {},
+      'test-temp': {
+        plugins: {
+          testPluginMock: {},
+        },
+      },
+    });
+  });
+  afterEach(() => {
+    mockFs.restore();
+  });
   describe('createPluginFolder', () => {
     it('should create a temporary plugin directory in the correct place', async () => {
       const id = 'testPlugin';
@@ -35,35 +49,22 @@ describe('createPlugin', () => {
     });
 
     it('should not create a temporary plugin directory if it already exists', async () => {
-      const id = 'testPlugin';
-      const tempDir = path.join(os.tmpdir(), id);
-      try {
-        await createTemporaryPluginFolder(tempDir);
-        await expect(fs.pathExists(tempDir)).resolves.toBe(true);
-        await expect(createTemporaryPluginFolder(tempDir)).rejects.toThrow(
-          /Failed to create temporary plugin directory/,
-        );
-      } finally {
-        await del(tempDir, { force: true });
-      }
+      const id = '/testPluginMock';
+      await expect(createTemporaryPluginFolder(id)).rejects.toThrow(
+        /Failed to create temporary plugin directory/,
+      );
     });
   });
 
   describe('movePlugin', () => {
     it('should move the temporary plugin directory to its final place', async () => {
-      const id = 'testPlugin';
-      const tempDir = path.join(os.tmpdir(), id);
-      const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'test-'));
-      const pluginDir = path.join(rootDir, 'plugins', id);
-      try {
-        await createTemporaryPluginFolder(tempDir);
-        await movePlugin(tempDir, pluginDir, id);
-        await expect(fs.pathExists(pluginDir)).resolves.toBe(true);
-        expect(pluginDir).toMatch(path.join('', 'plugins', id));
-      } finally {
-        await del(tempDir, { force: true });
-        await del(rootDir, { force: true });
-      }
+      const id = 'testPluginMock';
+      const tempDir = `/${id}`;
+      const pluginDir = `/test-temp/plugins/${id}`;
+
+      await movePlugin(tempDir, pluginDir, id);
+      await expect(fs.pathExists(pluginDir)).resolves.toBe(true);
+      expect(pluginDir).toMatch(path.join('', 'plugins', id));
     });
   });
 });

--- a/packages/cli/src/commands/create-plugin/createPlugin.test.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.test.ts
@@ -22,17 +22,7 @@ import del from 'del';
 import { createTemporaryPluginFolder, movePlugin } from './createPlugin';
 
 describe('createPlugin', () => {
-  beforeEach(() => {
-    mockFs({
-      '/testPluginMock': {},
-      'test-temp': {
-        plugins: {
-          testPluginMock: {},
-        },
-      },
-    });
-  });
-  afterEach(() => {
+  afterAll(() => {
     mockFs.restore();
   });
   describe('createPluginFolder', () => {
@@ -49,7 +39,12 @@ describe('createPlugin', () => {
     });
 
     it('should not create a temporary plugin directory if it already exists', async () => {
-      const id = '/testPluginMock';
+      const id = 'testPluginMock';
+
+      mockFs({
+        [id]: {},
+      });
+
       await expect(createTemporaryPluginFolder(id)).rejects.toThrow(
         /Failed to create temporary plugin directory/,
       );
@@ -59,8 +54,17 @@ describe('createPlugin', () => {
   describe('movePlugin', () => {
     it('should move the temporary plugin directory to its final place', async () => {
       const id = 'testPluginMock';
-      const tempDir = `/${id}`;
+      const tempDir = id;
       const pluginDir = `/test-temp/plugins/${id}`;
+
+      mockFs({
+        [id]: {},
+        'test-temp': {
+          plugins: {
+            testPluginMock: {},
+          },
+        },
+      });
 
       await movePlugin(tempDir, pluginDir, id);
       await expect(fs.pathExists(pluginDir)).resolves.toBe(true);

--- a/packages/cli/src/commands/create-plugin/createPlugin.test.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.test.ts
@@ -21,13 +21,15 @@ import os from 'os';
 import del from 'del';
 import { createTemporaryPluginFolder, movePlugin } from './createPlugin';
 
+const id = 'testPluginMock';
+
 describe('createPlugin', () => {
   afterAll(() => {
     mockFs.restore();
   });
+
   describe('createPluginFolder', () => {
     it('should create a temporary plugin directory in the correct place', async () => {
-      const id = 'testPlugin';
       const tempDir = path.join(os.tmpdir(), id);
       try {
         await createTemporaryPluginFolder(tempDir);
@@ -39,8 +41,6 @@ describe('createPlugin', () => {
     });
 
     it('should not create a temporary plugin directory if it already exists', async () => {
-      const id = 'testPluginMock';
-
       mockFs({
         [id]: {},
       });
@@ -53,18 +53,11 @@ describe('createPlugin', () => {
 
   describe('movePlugin', () => {
     it('should move the temporary plugin directory to its final place', async () => {
-      const id = 'testPluginMock';
-      const tempDir = id;
-      const pluginDir = `/test-temp/plugins/${id}`;
-
       mockFs({
         [id]: {},
-        'test-temp': {
-          plugins: {
-            testPluginMock: {},
-          },
-        },
       });
+      const tempDir = id;
+      const pluginDir = `/test-temp/plugins/${id}`;
 
       await movePlugin(tempDir, pluginDir, id);
       await expect(fs.pathExists(pluginDir)).resolves.toBe(true);

--- a/packages/cli/src/commands/remove-plugin/removePlugin.test.ts
+++ b/packages/cli/src/commands/remove-plugin/removePlugin.test.ts
@@ -16,6 +16,7 @@
 
 import fse from 'fs-extra';
 import path from 'path';
+import mockFs from 'mock-fs';
 import { paths } from '../../lib/paths';
 import { addExportStatement, capitalize } from '../create-plugin/createPlugin';
 import { addCodeownersEntry } from '../../lib/codeowners';
@@ -26,8 +27,6 @@ import {
   removeSymLink,
   removePluginFromCodeOwners,
 } from './removePlugin';
-
-const mockFs = require('mock-fs');
 
 const BACKSTAGE = `@backstage`;
 const testPluginName = 'yarn-test-package';
@@ -213,19 +212,22 @@ describe('removePlugin', () => {
       it('removes system link from @backstage', async () => {
         const symLink = `plugin-${testPluginName}`;
         const testSymLinkPath = `/node_modules/@backstage/${symLink}`;
-
-        mkTestPluginDir(testDirPath);
+        const mockedTestDirPath = path.join('/plugins', testPluginName);
 
         mockFs({
+          '/plugins': {
+            [testPluginName]: {},
+          },
           '/node_modules': {
             '@backstage': {
               [symLink]: mockFs.symlink({
-                path: testDirPath,
+                path: mockedTestDirPath,
               }),
             },
           },
         });
 
+        expect(fse.existsSync(testSymLinkPath)).toBeTruthy();
         await removeSymLink(testSymLinkPath);
         expect(fse.existsSync(testSymLinkPath)).toBeFalsy();
       });

--- a/packages/cli/src/commands/remove-plugin/removePlugin.test.ts
+++ b/packages/cli/src/commands/remove-plugin/removePlugin.test.ts
@@ -91,7 +91,7 @@ const createTestPluginFile = async (
     .map(name => capitalize(name))
     .join('');
   const exportStatement = `export { default as ${pluginNameCapitalized}} from @backstage/plugin-${testPluginName}`;
-  addExportStatement(`${tempDir}/${testFilePath}`, exportStatement);
+  await addExportStatement(path.join(tempDir, testFilePath), exportStatement);
 };
 
 const mkTestPluginDir = (testDirPath: string) => {
@@ -130,7 +130,7 @@ describe('removePlugin', () => {
 
     it('removes plugin references from /packages/app/package.json', async () => {
       // Set up test
-      const packageFilePath = `${tempDir}/package.json`;
+      const packageFilePath = path.join(tempDir, 'package.json');
       const testFilePath = 'test.json';
       createTestPackageFile(testFilePath, packageFilePath);
       await removeReferencesFromAppPackage(
@@ -148,7 +148,7 @@ describe('removePlugin', () => {
     });
     it('removes plugin exports from /packages/app/src/packacge.json', async () => {
       const testFilePath = 'test.ts';
-      const pluginsFilePaths = `${tempDir}/src/plugin.ts`;
+      const pluginsFilePaths = path.join(tempDir, 'src/plugin.ts');
       createTestPluginFile(testFilePath, pluginsFilePaths);
       await removeReferencesFromPluginsFile(
         path.join(tempDir, testFilePath),

--- a/packages/cli/src/lib/tasks.test.ts
+++ b/packages/cli/src/lib/tasks.test.ts
@@ -33,7 +33,7 @@ describe('templatingTask', () => {
 
     mockFs({
       [tmplDir]: {
-        'sub': {
+        sub: {
           'version.txt.hbs': 'version: {{version}}',
         },
         'test.txt': 'testing',

--- a/packages/cli/src/lib/tasks.test.ts
+++ b/packages/cli/src/lib/tasks.test.ts
@@ -15,39 +15,41 @@
  */
 
 import fs from 'fs-extra';
+import mockFs from 'mock-fs';
 import { resolve as resolvePath } from 'path';
-import os from 'os';
-import del from 'del';
 import { templatingTask } from './tasks';
 
 describe('templatingTask', () => {
+  afterEach(() => {
+    mockFs.restore();
+  });
+
   it('should template a directory with mix of regular files and templates', async () => {
-    // Set up a testing template directory
-    const tmplDir = await fs.mkdtemp(resolvePath(os.tmpdir(), 'test-'));
-    await fs.ensureDir(resolvePath(tmplDir, 'sub'));
-    await fs.writeFile(resolvePath(tmplDir, 'test.txt'), 'testing');
-    await fs.writeFile(
-      resolvePath(tmplDir, 'sub/version.txt.hbs'),
-      'version: {{version}}',
-    );
+    // Testing template directory
+    const tmplDir = 'test-tmpl';
 
-    // Set up a temporary dest dir to write the template to
-    const destDir = await fs.mkdtemp(resolvePath(os.tmpdir(), 'test-'));
+    // Temporary dest dir to write the template to
+    const destDir = 'test-dest';
 
-    try {
-      await templatingTask(tmplDir, destDir, {
-        version: '0.0.0',
-      });
+    mockFs({
+      [tmplDir]: {
+        'sub': {
+          'version.txt.hbs': 'version: {{version}}',
+        },
+        'test.txt': 'testing',
+      },
+      [destDir]: {},
+    });
 
-      await expect(
-        fs.readFile(resolvePath(destDir, 'test.txt'), 'utf8'),
-      ).resolves.toBe('testing');
-      await expect(
-        fs.readFile(resolvePath(destDir, 'sub/version.txt'), 'utf8'),
-      ).resolves.toBe('version: 0.0.0');
-    } finally {
-      await del(tmplDir, { force: true });
-      await del(destDir, { force: true });
-    }
+    await templatingTask(tmplDir, destDir, {
+      version: '0.0.0',
+    });
+
+    await expect(
+      fs.readFile(resolvePath(destDir, 'test.txt'), 'utf8'),
+    ).resolves.toBe('testing');
+    await expect(
+      fs.readFile(resolvePath(destDir, 'sub/version.txt'), 'utf8'),
+    ).resolves.toBe('version: 0.0.0');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5206,6 +5206,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/mock-fs@^4.13.0":
+  version "4.13.0"
+  resolved "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.0.tgz#b8b01cd2db588668b2532ecd21b1babd3fffb2c0"
+  integrity sha512-FUqxhURwqFtFBCuUj3uQMp7rPSQs//b3O9XecAVxhqS9y4/W8SIJEZFq2mmpnFVZBXwR/2OyPLE97CpyYiB8Mw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/morgan@^1.9.0":
   version "1.9.1"
   resolved "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.1.tgz#6457872df95647c1dbc6b3741e8146b71ece74bf"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #2926 

#### :heavy_check_mark: Checklist

This PR refactor the way temporary files were used inside CLI tests.
These tests are refactored to use [mock-fs](https://github.com/tschaub/mock-fs).

**NOTE:** I am still insightful about some of my changes and how I used `mock-fs` inside the tests. 
I will need some review/help on these changes 👍

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
