### PR TITLE
chore: reset fake timers in onCssReady test cases

### DIFF
--- a/plugins/techdocs/src/reader/transformers/onCssReady.test.ts
+++ b/plugins/techdocs/src/reader/transformers/onCssReady.test.ts
@@ -25,14 +25,20 @@ import { onCssReady } from '../transformers';
 const docStorageUrl: string =
   'https://techdocs-mock-sites.storage.googleapis.com';
 
-jest.useFakeTimers();
-
 const fixture = `
   <link rel="stylesheet" href="${docStorageUrl}/test.css" />
   <link rel="stylesheet" href="http://example.com/test.css" />
 `;
 
 describe('onCssReady', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(() => {
     mockStylesheetEventListener(100);
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Good practice to reset fake timers with the help of useRealTimers after the test case is completed, because if in future we have any test which does not want to use fakeTimers it would become problematic for that test case.

It is more of a cleanup thing that's why I have put it inside afterEach.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
