### PR TITLE
feat(catalog): add simple client side paging

### DIFF
--- a/.changeset/blue-donkeys-exercise.md
+++ b/.changeset/blue-donkeys-exercise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Add client side paging for catalog table

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -155,7 +155,8 @@ export const CatalogTable = ({
       isLoading={loading}
       columns={columns}
       options={{
-        paging: false,
+        paging: true,
+        pageSize: 10,
         actionsColumnIndex: -1,
         loadingType: 'linear',
         showEmptyDataSourceMessage: !loading,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

There is currently no paging for the catalog table. This is a quick fix to make the UI more responsive for larger lists.

NOTE: This obviously should be followed up with proper server side paging.

<img width="1611" alt="image" src="https://user-images.githubusercontent.com/6507159/96745565-434adf80-1394-11eb-9a4f-633aeb3afb95.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
