### PR TITLE
fix(catalog-backend): fix codeowners processor to handle users

### DIFF
--- a/.changeset/great-apples-flash.md
+++ b/.changeset/great-apples-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix CodeOwnersProcessor to handle non team users

--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
@@ -123,6 +123,10 @@ describe('CodeOwnersProcessor', () => {
   });
 
   describe('normalizeCodeOwner', () => {
+    it('should remove the @ symbol', () => {
+      expect(normalizeCodeOwner('@yoda')).toBe('yoda');
+    });
+
     it('should remove org from org/team format', () => {
       expect(normalizeCodeOwner('@acme/foo')).toBe('foo');
     });

--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
@@ -127,6 +127,8 @@ export function findPrimaryCodeOwner(
 export function normalizeCodeOwner(owner: string) {
   if (owner.match(/^@.*\/.*/)) {
     return owner.split('/')[1];
+  } else if (owner.match(/^@.*/)) {
+    return owner.substring(1);
   } else if (owner.match(/^.*@.*\..*$/)) {
     return owner.split('@')[0];
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ensure the `CodeOwnersProcessor` handles non team users (e.g. `@yoda` vs `@jedi/yoda`)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
