### PR TITLE
feat(catalog): Remove "in default" in component name

### DIFF
--- a/.changeset/little-wasps-pull.md
+++ b/.changeset/little-wasps-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Remove "in default" in component name

--- a/plugins/catalog/src/components/EntityPageLayout/EntityPageLayout.tsx
+++ b/plugins/catalog/src/components/EntityPageLayout/EntityPageLayout.tsx
@@ -18,7 +18,7 @@ import { useParams, useNavigate } from 'react-router';
 
 import { EntityContext } from '../../hooks/useEntity';
 import { Page, Header, HeaderLabel, Content, Progress } from '@backstage/core';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, ENTITY_DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 import { FavouriteEntity } from '../FavouriteEntity/FavouriteEntity';
 import { Box } from '@material-ui/core';
 import { EntityContextMenu } from '../EntityContextMenu/EntityContextMenu';
@@ -46,7 +46,11 @@ function headerProps(
   entity: Entity | undefined,
 ): { headerTitle: string; headerType: string } {
   return {
-    headerTitle: `${name}${namespace ? ` in ${namespace}` : ''}`,
+    headerTitle: `${name}${
+      namespace && namespace !== ENTITY_DEFAULT_NAMESPACE
+        ? ` in ${namespace}`
+        : ''
+    }`,
     headerType: (() => {
       let t = kind.toLowerCase();
       if (entity && entity.spec && 'type' in entity.spec) {


### PR DESCRIPTION
Closes #3011

## Remove "in default" in component name header for default namespace

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The catalog plugin does not display the "in default" in the page header for default namespace

<img width="378" alt="Bildschirmfoto 2020-10-21 um 21 56 15" src="https://user-images.githubusercontent.com/20122620/96775805-59828b00-13e8-11eb-9f98-b053bd824a1a.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
