### PR TITLE
Add API docs link to About card

### DIFF
--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -26,6 +26,7 @@ import {
   makeStyles,
   Typography,
 } from '@material-ui/core';
+import BrightnessAutoIcon from '@material-ui/icons/BrightnessAuto';
 import DocsIcon from '@material-ui/icons/Description';
 import EditIcon from '@material-ui/icons/Edit';
 import GitHubIcon from '@material-ui/icons/GitHub';
@@ -119,6 +120,14 @@ export function AboutCard({ entity, variant }: AboutCardProps) {
               href={`/docs/${
                 entity.metadata.namespace || ENTITY_DEFAULT_NAMESPACE
               }/${entity.kind}/${entity.metadata.name}`}
+            />
+            <IconLinkVertical
+              disabled={!entity.spec?.implementsApis}
+              label="View API"
+              icon={<BrightnessAutoIcon />}
+              href={`./${
+                entity.metadata.namespace || ENTITY_DEFAULT_NAMESPACE
+              }:${entity.metadata.name}/api`}
             />
           </nav>
         }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR implements the feature request described in https://github.com/spotify/backstage/issues/3010. I used the best icon I could find to represent API docs. Let me know if you prefer another one.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

Icon enable
![image](https://user-images.githubusercontent.com/4560150/96803131-ad529b80-140b-11eb-9ee2-6008a44aba81.png)

Icon disable
![image](https://user-images.githubusercontent.com/4560150/96803169-cbb89700-140b-11eb-8ba2-3c44749d43bb.png)
