### PR TITLE
Fix GitHub OAuth format

### DIFF
--- a/plugins/techdocs-backend/src/default-branch.ts
+++ b/plugins/techdocs-backend/src/default-branch.ts
@@ -51,8 +51,14 @@ interface IGitlabBranch {
 
 function getGithubApiUrl(config: Config, url: string): URL {
   const { protocol, owner, name } = parseGitUrl(url);
+  const providerConfigs =
+    config.getOptionalConfigArray('integrations.github') ?? [];
+
+  // TODO: Maybe we need to filter by host in the array, not sure about GHE
+  const targetProviderConfig = providerConfigs[0];
+
   const apiBaseUrl =
-    config.getOptionalString('integrations.github.apiBaseUrl') ||
+    targetProviderConfig?.getOptionalString('integrations.github.apiBaseUrl') ??
     'api.github.com';
   const apiRepos = 'repos';
 

--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -145,7 +145,7 @@ export const checkoutGitRepository = async (
 
   if (token) {
     const type = getGitRepoType(repoUrl);
-    const auth = type === 'github' ? `${token}` : `:${token}`;
+    const auth = type === 'github' ? `${token}:x-oauth-basic` : `:${token}`;
     parsedGitLocation.token = auth;
   }
 

--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -20,7 +20,7 @@ import parseGitUrl from 'git-url-parse';
 import NodeGit, { Clone, Repository } from 'nodegit';
 import fs from 'fs-extra';
 import { getDefaultBranch } from './default-branch';
-import { getTokenForGitRepo } from './git-auth';
+import { getGitRepoType, getTokenForGitRepo } from './git-auth';
 import { Entity } from '@backstage/catalog-model';
 import { InputError } from '@backstage/backend-common';
 import { RemoteProtocol } from './techdocs/stages/prepare/types';
@@ -121,14 +121,6 @@ export const checkoutGitRepository = async (
 ): Promise<string> => {
   const parsedGitLocation = parseGitUrl(repoUrl);
   const repositoryTmpPath = await getGitRepositoryTempFolder(repoUrl);
-
-  // TODO: Should propably not be hardcoded names of env variables, but seems too hard to access config down here
-  const user =
-    process.env.GITHUB_PRIVATE_TOKEN_USER ||
-    process.env.GITLAB_PRIVATE_TOKEN_USER ||
-    process.env.AZURE_PRIVATE_TOKEN_USER ||
-    '';
-
   const token = await getTokenForGitRepo(repoUrl);
 
   if (fs.existsSync(repositoryTmpPath)) {
@@ -152,7 +144,9 @@ export const checkoutGitRepository = async (
   }
 
   if (token) {
-    parsedGitLocation.token = `${user}:${token}`;
+    const type = getGitRepoType(repoUrl);
+    const auth = type === 'github' ? `${token}` : `:${token}`;
+    parsedGitLocation.token = auth;
   }
 
   const repositoryCheckoutUrl = parsedGitLocation.toString('https');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

GitHub expects the OAuth token to be used, in the repo url, in a slightly different manner from GitLab and Azure.
[GitHub expects just the token](https://github.blog/2012-09-21-easier-builds-and-deployments-using-git-over-https-and-oauth/#using-oauth-with-git), whereas GitLab and [Azure](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page#use-a-pat) expect a colon before the token.

Fixes #2964 

#### Points to note
- If someone can verify this with GitHub and/or Azure, it would be great. I have tested it only on GitLab and it works.
- I noticed that code to support BitBucket integration is missing. That will need to be added in future.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
