### PR TITLE
feat: add security insights plugin to marketplace

### DIFF
--- a/microsite/data/plugins/security-insights.yaml
+++ b/microsite/data/plugins/security-insights.yaml
@@ -2,7 +2,7 @@
 title: Security Insights
 author: roadie.io
 authorUrl: https://roadie.io/
-category: Monitoring
+category: Security
 description: View Security Insights for your components in Backstage.
 documentation: https://roadie.io/backstage/plugins/security-insights
 iconUrl: https://roadie.io/static/7f13bb8d861d8dedc5112fb939d215f9/351f2/GitHub-Mark-Light-120px-plus.png

--- a/microsite/data/plugins/security-insights.yaml
+++ b/microsite/data/plugins/security-insights.yaml
@@ -1,0 +1,9 @@
+---
+title: Security Insights
+author: roadie.io
+authorUrl: https://roadie.io/
+category: Monitoring
+description: View Security Insights for your components in Backstage.
+documentation: https://roadie.io/backstage/plugins/security-insights
+iconUrl: https://roadie.io/static/7f13bb8d861d8dedc5112fb939d215f9/351f2/GitHub-Mark-Light-120px-plus.png
+npmPackageName: '@roadiehq/backstage-plugin-security-insights'


### PR DESCRIPTION
## Security Insights Plugin

Hello,
I would like to add new plugin to the marketplace. 
This plugin shows insights from GitHub Code Scanning inside Backstage app. 
Right now plugin could work as a standalone tab and widget placed in Overview page. 
Plugin also supports dismissing open security alerts directly from Backstage. 

Plugin repository: [Security Insights](https://github.com/RoadieHQ/backstage-plugin-security-insights)

Any suggestions and feedback how can the plugin could be improved would be more than welcome.

**Screenshots:**

**Tab:**
![chrome_9VKuKYrIVw](https://user-images.githubusercontent.com/36006588/96895308-9607c280-148c-11eb-978f-86234415234e.png)

**Widget:**
![chrome_wIlofLHL5t](https://user-images.githubusercontent.com/36006588/96895326-9902b300-148c-11eb-9906-01c75e560fae.png)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
