### PR TITLE
feat: lazy state initialization of isPinned state of sidebar

### DIFF
--- a/packages/core/src/layout/Sidebar/Page.tsx
+++ b/packages/core/src/layout/Sidebar/Page.tsx
@@ -45,7 +45,9 @@ export const SidebarPinStateContext = createContext<SidebarPinStateContextType>(
 );
 
 export const SidebarPage: FC<{}> = props => {
-  const [isPinned, setIsPinned] = useState(LocalStorage.getSidebarPinState());
+  const [isPinned, setIsPinned] = useState(() =>
+    LocalStorage.getSidebarPinState(),
+  );
 
   useEffect(() => {
     LocalStorage.setSidebarPinState(isPinned);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Every time our SidebarPage component runs the useState call is going to run and we are passing the initial value as `LocalStorage.getSidebarPinState()`, and getting something from localStorage can be kind of an expensive call, and we only need to make that call the first time our component renders.

We will take `LocalStorage.getSidebarPinState()` out of the render phase and put it into the lazy state initialization phase so that this function is defined every render but it is only called when we actually need that initial value which is only when the SidebarPage component is rendered first time.

In the after screenshot attached below you will see that how many times I click on the pin sidebar switch it will not make a call to localStorage. But, in the before screenshot it will make a call.

### Screenshots

#### Before

<img width="960" alt="lazy-state-before" src="https://user-images.githubusercontent.com/19193724/96902897-b8143b80-14b2-11eb-9340-88e8ef851e69.png">

#### After

<img width="960" alt="lazy-state-after" src="https://user-images.githubusercontent.com/19193724/96902877-b2b6f100-14b2-11eb-9cbc-8ecadd9e7221.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
