### PR TITLE
fix: 404 error page responsive and test case

### DIFF
--- a/.changeset/spicy-moles-yell.md
+++ b/.changeset/spicy-moles-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+make ErrorPage responsive + fix the test case

--- a/packages/core/src/layout/ErrorPage/ErrorPage.test.tsx
+++ b/packages/core/src/layout/ErrorPage/ErrorPage.test.tsx
@@ -20,12 +20,14 @@ import { renderInTestApp } from '@backstage/test-utils';
 
 describe('<ErrorPage/>', () => {
   it('should render with status code, status message and go back link', async () => {
-    const rendered = await renderInTestApp(
+    const { getByText, getByTestId } = await renderInTestApp(
       <ErrorPage status="404" statusMessage="PAGE NOT FOUND" />,
     );
-    rendered.getByText(/page not found/i);
-    rendered.getByText(/404/i);
-    rendered.getByText(/Looks like someone dropped the mic!/i);
-    expect(rendered.getByTestId('go-back-link')).toBeDefined();
+    expect(getByText(/page not found/i)).toBeInTheDocument();
+    expect(getByText(/404/i)).toBeInTheDocument();
+    expect(
+      getByText(/looks like someone dropped the mic!/i),
+    ).toBeInTheDocument();
+    expect(getByTestId('go-back-link')).toBeInTheDocument();
   });
 });

--- a/packages/core/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core/src/layout/ErrorPage/ErrorPage.tsx
@@ -30,9 +30,16 @@ interface IErrorPageProps {
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   container: {
     padding: theme.spacing(8),
+    [theme.breakpoints.down('xs')]: {
+      padding: theme.spacing(2),
+    },
   },
   title: {
     paddingBottom: theme.spacing(5),
+    [theme.breakpoints.down('xs')]: {
+      paddingBottom: theme.spacing(4),
+      fontSize: 32,
+    },
   },
   subtitle: {
     color: theme.palette.textSubtle,
@@ -48,9 +55,9 @@ export const ErrorPage = ({
   const navigate = useNavigate();
 
   return (
-    <Grid container className={classes.container}>
+    <Grid className={classes.container}>
       <MicDrop />
-      <Grid item xs={12} sm={4}>
+      <Grid item xs={12} sm={8} md={4}>
         <Typography variant="body1" className={classes.subtitle}>
           ERROR {status}: {statusMessage}
         </Typography>

--- a/packages/core/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core/src/layout/ErrorPage/ErrorPage.tsx
@@ -55,7 +55,7 @@ export const ErrorPage = ({
   const navigate = useNavigate();
 
   return (
-    <Grid className={classes.container}>
+    <Grid container spacing={0} className={classes.container}>
       <MicDrop />
       <Grid item xs={12} sm={8} md={4}>
         <Typography variant="body1" className={classes.subtitle}>

--- a/packages/core/src/layout/ErrorPage/MicDrop.tsx
+++ b/packages/core/src/layout/ErrorPage/MicDrop.tsx
@@ -36,5 +36,11 @@ const useStyles = makeStyles(theme => ({
 
 export const MicDrop = () => {
   const classes = useStyles();
-  return <img src={MicDropSvgUrl} className={classes.micDrop} alt="" />;
+  return (
+    <img
+      src={MicDropSvgUrl}
+      className={classes.micDrop}
+      alt="Girl dropping mic from her hands"
+    />
+  );
 };

--- a/packages/core/src/layout/ErrorPage/MicDrop.tsx
+++ b/packages/core/src/layout/ErrorPage/MicDrop.tsx
@@ -21,14 +21,14 @@ import MicDropSvgUrl from './mic-drop.svg';
 const useStyles = makeStyles(theme => ({
   micDrop: {
     maxWidth: '60%',
-    bottom: 16,
-    right: 16,
     position: 'absolute',
+    bottom: theme.spacing(2),
+    right: theme.spacing(2),
     [theme.breakpoints.down('xs')]: {
       maxWidth: '96%',
+      position: 'relative',
       bottom: 'unset',
       right: 'unset',
-      position: 'relative',
       margin: `${theme.spacing(10)}px auto ${theme.spacing(4)}px`,
     },
   },

--- a/packages/core/src/layout/ErrorPage/MicDrop.tsx
+++ b/packages/core/src/layout/ErrorPage/MicDrop.tsx
@@ -18,14 +18,21 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core';
 import MicDropSvgUrl from './mic-drop.svg';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   micDrop: {
     maxWidth: '60%',
-    bottom: 10,
-    right: 10,
+    bottom: 16,
+    right: 16,
     position: 'absolute',
+    [theme.breakpoints.down('xs')]: {
+      maxWidth: '96%',
+      bottom: 'unset',
+      right: 'unset',
+      position: 'relative',
+      margin: `${theme.spacing(10)}px auto ${theme.spacing(4)}px`,
+    },
   },
-});
+}));
 
 export const MicDrop = () => {
   const classes = useStyles();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Improve the responsive version of 404 Error page
- There were no assertions in test cases
- Unnecessary scroll bar was coming on desktop and mobile, that has been fixed
- Mic drop image was having alt attribute but there was no value given to it, that has been given

### Screenshots

##### Before

<img width="960" alt="error-page-before" src="https://user-images.githubusercontent.com/19193724/96918380-d59fd000-14c7-11eb-8fe7-7cdf32782538.png">

##### After

<img width="960" alt="error-page-after" src="https://user-images.githubusercontent.com/19193724/96918338-ca4ca480-14c7-11eb-917c-f5e046ec833a.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
