### PR TITLE
Remove tech-radar owner and lifecycle from header

### DIFF
--- a/plugins/tech-radar/src/components/RadarPage.tsx
+++ b/plugins/tech-radar/src/components/RadarPage.tsx
@@ -48,8 +48,7 @@ export const RadarPage = ({
   const classes = useStyles();
   return (
     <Page themeId="tool">
-      <Header title={title} subtitle={subtitle}>
-      </Header>
+      <Header title={title} subtitle={subtitle} />
       <Content className={classes.overflowXScroll}>
         <ContentHeader title={pageTitle}>
           <SupportButton>

--- a/plugins/tech-radar/src/components/RadarPage.tsx
+++ b/plugins/tech-radar/src/components/RadarPage.tsx
@@ -21,7 +21,6 @@ import {
   ContentHeader,
   Page,
   Header,
-  HeaderLabel,
   SupportButton,
 } from '@backstage/core';
 import RadarComponent from '../components/RadarComponent';

--- a/plugins/tech-radar/src/components/RadarPage.tsx
+++ b/plugins/tech-radar/src/components/RadarPage.tsx
@@ -49,8 +49,6 @@ export const RadarPage = ({
   return (
     <Page themeId="tool">
       <Header title={title} subtitle={subtitle}>
-        <HeaderLabel label="Owner" value="Spotify" />
-        <HeaderLabel label="Lifecycle" value="Beta" />
       </Header>
       <Content className={classes.overflowXScroll}>
         <ContentHeader title={pageTitle}>


### PR DESCRIPTION
Resolves #3059 

Removes the owner and lifecycle from the tech-radar plugin header

<img width="1119" alt="Screenshot 2020-10-23 at 6 51 07 PM" src="https://user-images.githubusercontent.com/8716693/96995543-f36d4380-1560-11eb-9e5b-b8d346e473b9.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
