### PR TITLE
[Scaffolder] Add workdir config support to scaffolder

### DIFF
--- a/.changeset/spicy-rockets-ring.md
+++ b/.changeset/spicy-rockets-ring.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Added support for configuring the working directory of the Scaffolder:
+
+```yaml
+backend:
+  workingDirectory: /some-dir # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
+```

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -16,6 +16,7 @@ backend:
     credentials: true
   csp:
     connect-src: ["'self'", 'http:', 'https:']
+  # workingDirectory: /tmp # Use this to configure a working direcotry for the scaffolder, defaults to the OS temp-dir
 
 # See README.md in the proxy-backend plugin for information on the configuration format
 proxy:
@@ -155,7 +156,6 @@ catalog:
       target: https://github.com/spotify/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
 
 scaffolder:
-  # workingDirectory: /tmp # Use this to configure a working direcotry for the scaffolder, defaults to the OS temp-dir
   github:
     token:
       $env: GITHUB_TOKEN

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -155,6 +155,7 @@ catalog:
       target: https://github.com/spotify/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
 
 scaffolder:
+  # workingDirectory: /tmp # Use this to configure a working direcotry for the scaffolder, defaults to the OS temp-dir
   github:
     token:
       $env: GITHUB_TOKEN

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -45,6 +45,7 @@ export default async function createPlugin({
     templaters,
     publishers,
     logger,
+    config,
     dockerClient,
   });
 }

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -69,6 +69,7 @@ auth:
   providers: {}
 
 scaffolder:
+  # workingDirectory: /tmp # Use this to configure a working direcotry for the scaffolder, defaults to the OS temp-dir
   github:
     token:
       $env: GITHUB_TOKEN

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -38,6 +38,7 @@ backend:
         #ca: # if you have a CA file and want to verify it you can uncomment this section
         #  $file: <file-path>/ca/server.crt
   {{/if}}
+  # workingDirectory: /tmp # Use this to configure a working direcotry for the scaffolder, defaults to the OS temp-dir
 
 integrations:
   github:
@@ -69,7 +70,6 @@ auth:
   providers: {}
 
 scaffolder:
-  # workingDirectory: /tmp # Use this to configure a working direcotry for the scaffolder, defaults to the OS temp-dir
   github:
     token:
       $env: GITHUB_TOKEN

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/scaffolder.ts
@@ -102,6 +102,7 @@ export default async function createPlugin({
     templaters,
     publishers,
     logger,
+    config,
     dockerClient,
   });
 }

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.test.ts
@@ -134,12 +134,22 @@ describe('AzurePreparer', () => {
   it('return the temp directory with the path to the folder if it is specified', async () => {
     const preparer = new AzurePreparer(ConfigReader.fromConfigs([]));
     mockEntity.spec.path = './template/test/1/2/3';
+    const response = await preparer.prepare(mockEntity, {});
+
+    expect(response.split('\\').join('/')).toMatch(
+      /\/template\/test\/1\/2\/3$/,
+    );
+  });
+
+  it('return the working directory with the path to the folder if it is specified', async () => {
+    const preparer = new AzurePreparer(ConfigReader.fromConfigs([]));
+    mockEntity.spec.path = './template/test/1/2/3';
     const response = await preparer.prepare(mockEntity, {
       workingDirectory: '/workDir',
     });
 
     expect(response).toBe(
-      `/workDir/graphql-starter-static/template/test/1/2/3`,
+      '/workDir/graphql-starter-static/template/test/1/2/3',
     );
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.test.ts
@@ -78,7 +78,7 @@ describe('AzurePreparer', () => {
 
   it('calls the clone command with the correct arguments for a repository', async () => {
     const preparer = new AzurePreparer(ConfigReader.fromConfigs([]));
-    await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
+    await preparer.prepare(mockEntity);
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
       'https://dev.azure.com/backstage-org/backstage-project/_git/template-repo',
@@ -104,7 +104,7 @@ describe('AzurePreparer', () => {
         },
       ]),
     );
-    await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
+    await preparer.prepare(mockEntity);
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
       'https://dev.azure.com/backstage-org/backstage-project/_git/template-repo',
@@ -122,7 +122,7 @@ describe('AzurePreparer', () => {
   it('calls the clone command with the correct arguments for a repository when no path is provided', async () => {
     const preparer = new AzurePreparer(ConfigReader.fromConfigs([]));
     delete mockEntity.spec.path;
-    await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
+    await preparer.prepare(mockEntity);
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
       'https://dev.azure.com/backstage-org/backstage-project/_git/template-repo',
@@ -134,7 +134,7 @@ describe('AzurePreparer', () => {
   it('return the temp directory with the path to the folder if it is specified', async () => {
     const preparer = new AzurePreparer(ConfigReader.fromConfigs([]));
     mockEntity.spec.path = './template/test/1/2/3';
-    const response = await preparer.prepare(mockEntity, {});
+    const response = await preparer.prepare(mockEntity);
 
     expect(response.split('\\').join('/')).toMatch(
       /\/template\/test\/1\/2\/3$/,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import os from 'os';
 import fs from 'fs-extra';
 import path from 'path';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
@@ -33,10 +34,10 @@ export class AzurePreparer implements PreparerBase {
 
   async prepare(
     template: TemplateEntityV1alpha1,
-    opts: { workingDirectory: string },
+    opts: { workingDirectory?: string },
   ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
-    const { workingDirectory } = opts;
+    const workingDirectory = opts.workingDirectory ?? os.tmpdir();
 
     if (!['azure/api', 'url'].includes(protocol)) {
       throw new InputError(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.ts
@@ -34,10 +34,10 @@ export class AzurePreparer implements PreparerBase {
 
   async prepare(
     template: TemplateEntityV1alpha1,
-    opts: { workingDirectory?: string },
+    opts?: { workingDirectory?: string },
   ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
-    const workingDirectory = opts.workingDirectory ?? os.tmpdir();
+    const workingDirectory = opts?.workingDirectory ?? os.tmpdir();
 
     if (!['azure/api', 'url'].includes(protocol)) {
       throw new InputError(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.ts
@@ -15,7 +15,6 @@
  */
 import fs from 'fs-extra';
 import path from 'path';
-import os from 'os';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 import { parseLocationAnnotation } from '../helpers';
 import { InputError } from '@backstage/backend-common';
@@ -32,8 +31,12 @@ export class AzurePreparer implements PreparerBase {
       config.getOptionalString('scaffolder.azure.api.token') ?? '';
   }
 
-  async prepare(template: TemplateEntityV1alpha1): Promise<string> {
+  async prepare(
+    template: TemplateEntityV1alpha1,
+    opts: { workingDirectory: string },
+  ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
+    const { workingDirectory } = opts;
 
     if (!['azure/api', 'url'].includes(protocol)) {
       throw new InputError(
@@ -42,18 +45,14 @@ export class AzurePreparer implements PreparerBase {
     }
     const templateId = template.metadata.name;
 
-    const url = new URL(location); // Need to extract filepath from search parameter
     const parsedGitLocation = GitUriParser(location);
     const repositoryCheckoutUrl = parsedGitLocation.toString('https');
-
     const tempDir = await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), templateId),
+      path.join(workingDirectory, templateId),
     );
 
     const templateDirectory = path.join(
-      `${path
-        .dirname(url.searchParams.get('path') || '')
-        .replace(/^\/+/g, '')}`, // Strip leading slash
+      `${path.dirname(parsedGitLocation.filepath)}`,
       template.spec.path ?? '.',
     );
 

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import os from 'os';
 import fs from 'fs-extra';
 import YAML from 'yaml';
 import { FilePreparer } from './file';
@@ -42,7 +43,9 @@ const setupTest = async (fixturePath: string) => {
   };
 
   const filePreparer = new FilePreparer();
-  const resultDir = await filePreparer.prepare(template);
+  const resultDir = await filePreparer.prepare(template, {
+    workingDirectory: os.tmpdir(),
+  });
 
   return { filePreparer, template, resultDir };
 };

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
@@ -15,15 +15,18 @@
  */
 import fs from 'fs-extra';
 import path from 'path';
-import os from 'os';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 import { parseLocationAnnotation } from '../helpers';
 import { InputError } from '@backstage/backend-common';
 import { PreparerBase } from './types';
 
 export class FilePreparer implements PreparerBase {
-  async prepare(template: TemplateEntityV1alpha1): Promise<string> {
+  async prepare(
+    template: TemplateEntityV1alpha1,
+    opts: { workingDirectory: string },
+  ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
+    const { workingDirectory } = opts;
 
     if (protocol !== 'file') {
       throw new InputError(
@@ -33,7 +36,7 @@ export class FilePreparer implements PreparerBase {
     const templateId = template.metadata.name;
 
     const tempDir = await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), templateId),
+      path.join(workingDirectory, templateId),
     );
 
     const parentDirectory = path.resolve(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
@@ -24,10 +24,10 @@ import { PreparerBase } from './types';
 export class FilePreparer implements PreparerBase {
   async prepare(
     template: TemplateEntityV1alpha1,
-    opts: { workingDirectory?: string },
+    opts?: { workingDirectory?: string },
   ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
-    const workingDirectory = opts.workingDirectory ?? os.tmpdir();
+    const workingDirectory = opts?.workingDirectory ?? os.tmpdir();
 
     if (protocol !== 'file') {
       throw new InputError(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import os from 'os';
 import fs from 'fs-extra';
 import path from 'path';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
@@ -23,10 +24,10 @@ import { PreparerBase } from './types';
 export class FilePreparer implements PreparerBase {
   async prepare(
     template: TemplateEntityV1alpha1,
-    opts: { workingDirectory: string },
+    opts: { workingDirectory?: string },
   ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
-    const { workingDirectory } = opts;
+    const workingDirectory = opts.workingDirectory ?? os.tmpdir();
 
     if (protocol !== 'file') {
       throw new InputError(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
@@ -76,7 +76,7 @@ describe('GitHubPreparer', () => {
   });
   it('calls the clone command with the correct arguments for a repository', async () => {
     const preparer = new GithubPreparer();
-    await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
+    await preparer.prepare(mockEntity);
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
       'https://github.com/benjdlambert/backstage-graphql-template',
@@ -89,7 +89,7 @@ describe('GitHubPreparer', () => {
   it('calls the clone command with the correct arguments for a repository when no path is provided', async () => {
     const preparer = new GithubPreparer();
     delete mockEntity.spec.path;
-    await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
+    await preparer.prepare(mockEntity);
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
       'https://github.com/benjdlambert/backstage-graphql-template',
@@ -103,7 +103,7 @@ describe('GitHubPreparer', () => {
   it('return the temp directory with the path to the folder if it is specified', async () => {
     const preparer = new GithubPreparer();
     mockEntity.spec.path = './template/test/1/2/3';
-    const response = await preparer.prepare(mockEntity, {});
+    const response = await preparer.prepare(mockEntity);
 
     expect(response.split('\\').join('/')).toMatch(
       /\/template\/test\/1\/2\/3$/,
@@ -124,7 +124,7 @@ describe('GitHubPreparer', () => {
 
   it('calls the clone command with the token when provided', async () => {
     const preparer = new GithubPreparer({ token: 'abc' });
-    await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
+    await preparer.prepare(mockEntity);
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
       'https://github.com/benjdlambert/backstage-graphql-template',

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
@@ -99,7 +99,18 @@ describe('GitHubPreparer', () => {
       },
     );
   });
+
   it('return the temp directory with the path to the folder if it is specified', async () => {
+    const preparer = new GithubPreparer();
+    mockEntity.spec.path = './template/test/1/2/3';
+    const response = await preparer.prepare(mockEntity, {});
+
+    expect(response.split('\\').join('/')).toMatch(
+      /\/template\/test\/1\/2\/3$/,
+    );
+  });
+
+  it('return the working directory with the path to the folder if it is specified', async () => {
     const preparer = new GithubPreparer();
     mockEntity.spec.path = './template/test/1/2/3';
     const response = await preparer.prepare(mockEntity, {
@@ -107,7 +118,7 @@ describe('GitHubPreparer', () => {
     });
 
     expect(response).toBe(
-      `/workDir/graphql-starter-static/template/test/1/2/3`,
+      '/workDir/graphql-starter-static/template/test/1/2/3',
     );
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
@@ -19,6 +19,11 @@ const mocks = {
   CheckoutOptions: jest.fn(() => {}),
 };
 jest.doMock('nodegit', () => mocks);
+jest.doMock('fs-extra', () => ({
+  promises: {
+    mkdtemp: jest.fn(dir => `${dir}-static`),
+  },
+}));
 
 import { GithubPreparer } from './github';
 import {
@@ -71,7 +76,7 @@ describe('GitHubPreparer', () => {
   });
   it('calls the clone command with the correct arguments for a repository', async () => {
     const preparer = new GithubPreparer();
-    await preparer.prepare(mockEntity);
+    await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
       'https://github.com/benjdlambert/backstage-graphql-template',
@@ -84,7 +89,7 @@ describe('GitHubPreparer', () => {
   it('calls the clone command with the correct arguments for a repository when no path is provided', async () => {
     const preparer = new GithubPreparer();
     delete mockEntity.spec.path;
-    await preparer.prepare(mockEntity);
+    await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
       'https://github.com/benjdlambert/backstage-graphql-template',
@@ -97,15 +102,18 @@ describe('GitHubPreparer', () => {
   it('return the temp directory with the path to the folder if it is specified', async () => {
     const preparer = new GithubPreparer();
     mockEntity.spec.path = './template/test/1/2/3';
-    const response = await preparer.prepare(mockEntity);
+    const response = await preparer.prepare(mockEntity, {
+      workingDirectory: '/workDir',
+    });
 
-    expect(response.split('\\').join('/')).toMatch(
-      /\/template\/test\/1\/2\/3$/,
+    expect(response).toBe(
+      `/workDir/graphql-starter-static/template/test/1/2/3`,
     );
   });
+
   it('calls the clone command with the token when provided', async () => {
     const preparer = new GithubPreparer({ token: 'abc' });
-    await preparer.prepare(mockEntity);
+    await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
       'https://github.com/benjdlambert/backstage-graphql-template',

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import os from 'os';
 import fs from 'fs-extra';
 import path from 'path';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
@@ -31,10 +32,10 @@ export class GithubPreparer implements PreparerBase {
 
   async prepare(
     template: TemplateEntityV1alpha1,
-    opts: { workingDirectory: string },
+    opts: { workingDirectory?: string },
   ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
-    const { workingDirectory } = opts;
+    const workingDirectory = opts.workingDirectory ?? os.tmpdir();
     const { token } = this;
 
     if (!['github', 'url'].includes(protocol)) {

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
@@ -32,10 +32,10 @@ export class GithubPreparer implements PreparerBase {
 
   async prepare(
     template: TemplateEntityV1alpha1,
-    opts: { workingDirectory?: string },
+    opts?: { workingDirectory?: string },
   ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
-    const workingDirectory = opts.workingDirectory ?? os.tmpdir();
+    const workingDirectory = opts?.workingDirectory ?? os.tmpdir();
     const { token } = this;
 
     if (!['github', 'url'].includes(protocol)) {

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
@@ -15,7 +15,6 @@
  */
 import fs from 'fs-extra';
 import path from 'path';
-import os from 'os';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 import { parseLocationAnnotation } from '../helpers';
 import { InputError } from '@backstage/backend-common';
@@ -30,8 +29,12 @@ export class GithubPreparer implements PreparerBase {
     this.token = params.token;
   }
 
-  async prepare(template: TemplateEntityV1alpha1): Promise<string> {
+  async prepare(
+    template: TemplateEntityV1alpha1,
+    opts: { workingDirectory: string },
+  ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
+    const { workingDirectory } = opts;
     const { token } = this;
 
     if (!['github', 'url'].includes(protocol)) {
@@ -44,7 +47,7 @@ export class GithubPreparer implements PreparerBase {
     const parsedGitLocation = GitUriParser(location);
     const repositoryCheckoutUrl = parsedGitLocation.toString('https');
     const tempDir = await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), templateId),
+      path.join(workingDirectory, templateId),
     );
 
     const templateDirectory = path.join(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
@@ -18,6 +18,11 @@ const mocks = {
   CheckoutOptions: jest.fn(() => {}),
 };
 jest.doMock('nodegit', () => mocks);
+jest.doMock('fs-extra', () => ({
+  promises: {
+    mkdtemp: jest.fn(dir => `${dir}-static`),
+  },
+}));
 
 import { GitlabPreparer } from './gitlab';
 import {
@@ -74,7 +79,7 @@ describe('GitLabPreparer', () => {
     it(`calls the clone command with the correct arguments for a repository using the ${protocol} protocol`, async () => {
       const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
       mockEntity = mockEntityWithProtocol(protocol);
-      await preparer.prepare(mockEntity);
+      await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
       expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
         1,
         'https://gitlab.com/benjdlambert/backstage-graphql-template',
@@ -101,7 +106,7 @@ describe('GitLabPreparer', () => {
         ]),
       );
       mockEntity = mockEntityWithProtocol(protocol);
-      await preparer.prepare(mockEntity);
+      await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
       expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
         1,
         'https://gitlab.com/benjdlambert/backstage-graphql-template',
@@ -120,7 +125,7 @@ describe('GitLabPreparer', () => {
       const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
       mockEntity = mockEntityWithProtocol(protocol);
       delete mockEntity.spec.path;
-      await preparer.prepare(mockEntity);
+      await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
       expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
         1,
         'https://gitlab.com/benjdlambert/backstage-graphql-template',
@@ -133,10 +138,12 @@ describe('GitLabPreparer', () => {
       const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
       mockEntity = mockEntityWithProtocol(protocol);
       mockEntity.spec.path = './template/test/1/2/3';
-      const response = await preparer.prepare(mockEntity);
+      const response = await preparer.prepare(mockEntity, {
+        workingDirectory: '/workDir',
+      });
 
-      expect(response.split('\\').join('/')).toMatch(
-        /\/template\/test\/1\/2\/3$/,
+      expect(response).toBe(
+        `/workDir/graphql-starter-static/template/test/1/2/3`,
       );
     });
   });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
@@ -138,12 +138,22 @@ describe('GitLabPreparer', () => {
       const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
       mockEntity = mockEntityWithProtocol(protocol);
       mockEntity.spec.path = './template/test/1/2/3';
+      const response = await preparer.prepare(mockEntity, {});
+
+      expect(response.split('\\').join('/')).toMatch(
+        /\/template\/test\/1\/2\/3$/,
+      );
+    });
+
+    it('return the working directory with the path to the folder if it is specified', async () => {
+      const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
+      mockEntity.spec.path = './template/test/1/2/3';
       const response = await preparer.prepare(mockEntity, {
         workingDirectory: '/workDir',
       });
 
       expect(response).toBe(
-        `/workDir/graphql-starter-static/template/test/1/2/3`,
+        '/workDir/graphql-starter-static/template/test/1/2/3',
       );
     });
   });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
@@ -79,7 +79,7 @@ describe('GitLabPreparer', () => {
     it(`calls the clone command with the correct arguments for a repository using the ${protocol} protocol`, async () => {
       const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
       mockEntity = mockEntityWithProtocol(protocol);
-      await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
+      await preparer.prepare(mockEntity);
       expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
         1,
         'https://gitlab.com/benjdlambert/backstage-graphql-template',
@@ -106,7 +106,7 @@ describe('GitLabPreparer', () => {
         ]),
       );
       mockEntity = mockEntityWithProtocol(protocol);
-      await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
+      await preparer.prepare(mockEntity);
       expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
         1,
         'https://gitlab.com/benjdlambert/backstage-graphql-template',
@@ -125,7 +125,7 @@ describe('GitLabPreparer', () => {
       const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
       mockEntity = mockEntityWithProtocol(protocol);
       delete mockEntity.spec.path;
-      await preparer.prepare(mockEntity, { workingDirectory: '/workDir' });
+      await preparer.prepare(mockEntity);
       expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
         1,
         'https://gitlab.com/benjdlambert/backstage-graphql-template',
@@ -138,7 +138,7 @@ describe('GitLabPreparer', () => {
       const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
       mockEntity = mockEntityWithProtocol(protocol);
       mockEntity.spec.path = './template/test/1/2/3';
-      const response = await preparer.prepare(mockEntity, {});
+      const response = await preparer.prepare(mockEntity);
 
       expect(response.split('\\').join('/')).toMatch(
         /\/template\/test\/1\/2\/3$/,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.ts
@@ -35,10 +35,10 @@ export class GitlabPreparer implements PreparerBase {
 
   async prepare(
     template: TemplateEntityV1alpha1,
-    opts: { workingDirectory?: string },
+    opts?: { workingDirectory?: string },
   ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
-    const workingDirectory = opts.workingDirectory ?? os.tmpdir();
+    const workingDirectory = opts?.workingDirectory ?? os.tmpdir();
 
     if (!['gitlab', 'gitlab/api', 'url'].includes(protocol)) {
       throw new InputError(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import os from 'os';
 import fs from 'fs-extra';
 import path from 'path';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
@@ -34,10 +35,10 @@ export class GitlabPreparer implements PreparerBase {
 
   async prepare(
     template: TemplateEntityV1alpha1,
-    opts: { workingDirectory: string },
+    opts: { workingDirectory?: string },
   ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
-    const { workingDirectory } = opts;
+    const workingDirectory = opts.workingDirectory ?? os.tmpdir();
 
     if (!['gitlab', 'gitlab/api', 'url'].includes(protocol)) {
       throw new InputError(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.ts
@@ -15,7 +15,6 @@
  */
 import fs from 'fs-extra';
 import path from 'path';
-import os from 'os';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 import { parseLocationAnnotation } from '../helpers';
 import { InputError } from '@backstage/backend-common';
@@ -33,8 +32,12 @@ export class GitlabPreparer implements PreparerBase {
       '';
   }
 
-  async prepare(template: TemplateEntityV1alpha1): Promise<string> {
+  async prepare(
+    template: TemplateEntityV1alpha1,
+    opts: { workingDirectory: string },
+  ): Promise<string> {
     const { protocol, location } = parseLocationAnnotation(template);
+    const { workingDirectory } = opts;
 
     if (!['gitlab', 'gitlab/api', 'url'].includes(protocol)) {
       throw new InputError(
@@ -45,9 +48,8 @@ export class GitlabPreparer implements PreparerBase {
 
     const parsedGitLocation = GitUriParser(location);
     const repositoryCheckoutUrl = parsedGitLocation.toString('https');
-
     const tempDir = await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), templateId),
+      path.join(workingDirectory, templateId),
     );
 
     const templateDirectory = path.join(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/types.ts
@@ -25,7 +25,7 @@ export type PreparerBase = {
    */
   prepare(
     template: TemplateEntityV1alpha1,
-    opts: { logger: Logger; workingDirectory?: string },
+    opts?: { logger: Logger; workingDirectory?: string },
   ): Promise<string>;
 };
 

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/types.ts
@@ -25,7 +25,7 @@ export type PreparerBase = {
    */
   prepare(
     template: TemplateEntityV1alpha1,
-    opts: { logger: Logger },
+    opts: { logger: Logger; workingDirectory: string },
   ): Promise<string>;
 };
 

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/types.ts
@@ -25,7 +25,7 @@ export type PreparerBase = {
    */
   prepare(
     template: TemplateEntityV1alpha1,
-    opts: { logger: Logger; workingDirectory: string },
+    opts: { logger: Logger; workingDirectory?: string },
   ): Promise<string>;
 };
 

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -25,7 +25,6 @@ jest.doMock('fs-extra', () => ({
   },
 }));
 
-import os from 'os';
 import { getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import express from 'express';
@@ -114,7 +113,7 @@ describe('createRouter - working directory', () => {
     });
   });
 
-  it('should default to OS temp-dir when no working directory is configured', async () => {
+  it('should not pass along anything when no working directory is configured', async () => {
     const router = await createRouter({
       logger: getVoidLogger(),
       preparers: mockPreparers,
@@ -132,7 +131,6 @@ describe('createRouter - working directory', () => {
 
     expect(mockPrepare).toBeCalledWith(expect.anything(), {
       logger: expect.anything(),
-      workingDirectory: os.tmpdir(),
     });
   });
 });

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
 import express from 'express';
 import request from 'supertest';
 import { createRouter } from './router';
@@ -32,6 +33,7 @@ describe('createRouter', () => {
       preparers: new Preparers(),
       templaters: new Templaters(),
       publishers: new Publishers(),
+      config: ConfigReader.fromConfigs([]),
       dockerClient: new Docker(),
     });
     app = express().use(router);

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -14,6 +14,18 @@
  * limitations under the License.
  */
 
+const mockAccess = jest.fn();
+jest.doMock('fs-extra', () => ({
+  promises: {
+    access: mockAccess,
+  },
+  constants: {
+    F_OK: 0,
+    W_OK: 1,
+  },
+}));
+
+import os from 'os';
 import { getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import express from 'express';
@@ -23,6 +35,107 @@ import { Templaters, Preparers, Publishers } from '../scaffolder';
 import Docker from 'dockerode';
 
 jest.mock('dockerode');
+
+describe('createRouter - working directory', () => {
+  const mockPrepare = jest.fn();
+  const mockPreparers = new Preparers();
+
+  beforeAll(() => {
+    const mockPreparer = {
+      prepare: mockPrepare,
+    };
+    mockPreparers.register('azure/api', mockPreparer);
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const workDirConfig = (path: string) => ({
+    context: '',
+    data: {
+      scaffolder: {
+        workingDirectory: path,
+      },
+    },
+  });
+
+  const template = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Template',
+    metadata: {
+      annotations: {
+        'backstage.io/managed-by-location': 'azure/api:dev.azure.com',
+      },
+    },
+    spec: {
+      owner: 'template@backstage.io',
+      path: '.',
+      schema: {},
+    },
+  };
+
+  it('should throw an error when working directory does not exist or is not writable', async () => {
+    mockAccess.mockImplementation(() => {
+      throw new Error('access error');
+    });
+
+    await expect(
+      createRouter({
+        logger: getVoidLogger(),
+        preparers: new Preparers(),
+        templaters: new Templaters(),
+        publishers: new Publishers(),
+        config: ConfigReader.fromConfigs([workDirConfig('/path')]),
+        dockerClient: new Docker(),
+      }),
+    ).rejects.toThrow('access error');
+  });
+
+  it('should use the working directory when configured', async () => {
+    const router = await createRouter({
+      logger: getVoidLogger(),
+      preparers: mockPreparers,
+      templaters: new Templaters(),
+      publishers: new Publishers(),
+      config: ConfigReader.fromConfigs([workDirConfig('/path')]),
+      dockerClient: new Docker(),
+    });
+
+    const app = express().use(router);
+    await request(app).post('/v1/jobs').send({
+      template,
+      values: {},
+    });
+
+    expect(mockPrepare).toBeCalledWith(expect.anything(), {
+      logger: expect.anything(),
+      workingDirectory: '/path',
+    });
+  });
+
+  it('should default to OS temp-dir when no working directory is configured', async () => {
+    const router = await createRouter({
+      logger: getVoidLogger(),
+      preparers: mockPreparers,
+      templaters: new Templaters(),
+      publishers: new Publishers(),
+      config: ConfigReader.fromConfigs([]),
+      dockerClient: new Docker(),
+    });
+
+    const app = express().use(router);
+    await request(app).post('/v1/jobs').send({
+      template,
+      values: {},
+    });
+
+    expect(mockPrepare).toBeCalledWith(expect.anything(), {
+      logger: expect.anything(),
+      workingDirectory: os.tmpdir(),
+    });
+  });
+});
 
 describe('createRouter', () => {
   let app: express.Express;

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -54,7 +54,7 @@ describe('createRouter - working directory', () => {
   const workDirConfig = (path: string) => ({
     context: '',
     data: {
-      scaffolder: {
+      backend: {
         workingDirectory: path,
       },
     },

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -16,7 +16,6 @@
 
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 import { Config, JsonValue } from '@backstage/config';
-import os from 'os';
 import fs from 'fs-extra';
 import Docker from 'dockerode';
 import express from 'express';

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -60,22 +60,24 @@ export async function createRouter(
   const logger = parentLogger.child({ plugin: 'scaffolder' });
   const jobProcessor = new JobProcessor();
 
-  const workingDirectory =
-    config.getOptionalString('backend.workingDirectory') ?? os.tmpdir();
-  try {
-    // Check if working directory exists and is writable
-    await fs.promises.access(
-      workingDirectory,
-      fs.constants.F_OK | fs.constants.W_OK,
-    );
-    logger.info(`using working directory: ${workingDirectory}`);
-  } catch (err) {
-    logger.error(
-      `working directory ${workingDirectory} ${
-        err.code === 'ENOENT' ? 'does not exist' : 'is not writable'
-      }`,
-    );
-    throw err;
+  let workingDirectory: string;
+  if (config.has('backend.workingDirectory')) {
+    workingDirectory = config.getString('backend.workingDirectory');
+    try {
+      // Check if working directory exists and is writable
+      await fs.promises.access(
+        workingDirectory,
+        fs.constants.F_OK | fs.constants.W_OK,
+      );
+      logger.info(`using working directory: ${workingDirectory}`);
+    } catch (err) {
+      logger.error(
+        `working directory ${workingDirectory} ${
+          err.code === 'ENOENT' ? 'does not exist' : 'is not writable'
+        }`,
+      );
+      throw err;
+    }
   }
 
   router

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -61,7 +61,7 @@ export async function createRouter(
   const jobProcessor = new JobProcessor();
 
   const workingDirectory =
-    config.getOptionalString('scaffolder.workingDirectory') ?? os.tmpdir();
+    config.getOptionalString('backend.workingDirectory') ?? os.tmpdir();
   try {
     // Check if working directory exists and is writable
     await fs.promises.access(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added support for configuring the working directory of the Scaffolder. This will allow us to mount a shared filesystem and use that when running the templaters in another container. This resolves #2998

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
