### PR TITLE
Document adding a custom catalog type

### DIFF
--- a/docs/features/software-catalog/extending-the-model.md
+++ b/docs/features/software-catalog/extending-the-model.md
@@ -24,8 +24,14 @@ the years, and now includes ML models, Apps, data pipelines and many more.
 
 To add a new type to the catalog, you need to:
 
-1. Modify the component interface
+1. Modify the tabs in the component page
 2. Set the new type in your component (e.g., modify your `catalog-info.yaml`)
+
+You can also optionally modify the page to display different information when
+the component is displayed (see
+[`EntityPage.tsx`](https://github.com/spotify/backstage/blob/master/packages/app/src/components/catalog/EntityPage.tsx)),
+but this example will use the `DefaultEntityPage` with the Overview and Docs
+tabs.
 
 For example, to add a new type of iOS Application, first modify the `const tabs`
 variable in `plugins/catalog/src/components/CatalogPage/CatalogPage.tsx` like

--- a/docs/features/software-catalog/extending-the-model.md
+++ b/docs/features/software-catalog/extending-the-model.md
@@ -22,8 +22,53 @@ the years, and now includes ML models, Apps, data pipelines and many more.
 
 ## Adding a new type
 
-TODO: Describe what changes are needed to add a new type that shows up in the
-catalog.
+To add a new type to the catalog, you need to:
+
+1. Modify the component interface
+2. Set the new type in your component (e.g., modify your `catalog-info.yaml`)
+
+For example, to add a new type of iOS Application, first modify the `const tabs`
+variable in `plugins/catalog/src/components/CatalogPage/CatalogPage.tsx` like
+so:
+
+```js
+const tabs = useMemo<LabeledComponentType[]>(
+    () => [
+      {
+        id: 'service',
+        label: 'Services',
+      },
+      {
+        id: 'website',
+        label: 'Websites',
+      },
+      {
+        id: 'library',
+        label: 'Libraries',
+      },
+      {
+        id: 'documentation',
+        label: 'Documentation',
+      },
+      {
+        id: 'other',
+        label: 'Other',
+      },
+      {
+        id: 'ios',
+        label: 'iOS Applications'
+      },
+    ],
+    [],
+  );
+```
+
+Then in your `catalog-info.yaml`, you will define your type:
+
+```yaml
+spec:
+  type: ios
+```
 
 ## The Other type
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Adds instructions in the documentation for how to extend the catalog model to support a new type.

I tested this in my local installation, and I believe this is the extent of the customization needed, though there may be more I've missed so welcome edits.

Addition of "iOS Applications" custom type:

![image](https://user-images.githubusercontent.com/33203301/97042914-c197b500-153f-11eb-8700-50a591ada4f3.png)

Default EntityPage:

![image](https://user-images.githubusercontent.com/33203301/97043788-0112d100-1541-11eb-9392-bca72b2854de.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
