### PR TITLE
fix(microsite): Sort plugins by title

### DIFF
--- a/microsite/pages/en/plugins.js
+++ b/microsite/pages/en/plugins.js
@@ -16,9 +16,8 @@ const {
 const pluginsDirectory = require('path').join(process.cwd(), 'data/plugins');
 const pluginMetadata = fs
   .readdirSync(pluginsDirectory)
-  .map(file =>
-    yaml.safeLoad(fs.readFileSync(`./data/plugins/${file}`, 'utf8')),
-  );
+  .map(file => yaml.safeLoad(fs.readFileSync(`./data/plugins/${file}`, 'utf8')))
+  .sort((a, b) => a.title.toLowerCase().localeCompare(b.title.toLowerCase()));
 const truncate = text =>
   text.length > 170 ? text.substr(0, 170) + '...' : text;
 


### PR DESCRIPTION
The Google Cloud Build plugin is destroying the sanctity of alphabetical order on the microsite Plugins page:

![Screen Shot 2020-10-23 at 14 48 28](https://user-images.githubusercontent.com/556258/97052957-33bbca00-153f-11eb-8091-daaeb2c7740d.png)

This is due to the file being named `cloud-build.yaml` when then title is `Google Cloud Build`. This PR sorts the plugin metadata by title to fix the page sorting (another option would be to rename `cloud-build.yaml` to `google-cloud-build.yaml`, but sorting by what is displayed seems more stable).

![Screen Shot 2020-10-23 at 14 48 03](https://user-images.githubusercontent.com/556258/97053383-1affe400-1540-11eb-9c9a-9c2d94eb2109.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
