### PR TITLE
Remove MkDocs copyright from documentation pages

### DIFF
--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -30,6 +30,7 @@ import transformer, {
   rewriteDocLinks,
   addLinkClickListener,
   removeMkdocsHeader,
+  simplifyMkdocsFooter,
   modifyCss,
   onCssReady,
   sanitizeDOM,
@@ -81,6 +82,7 @@ export const Reader = ({ entityId, onReady }: Props) => {
         },
       }),
       removeMkdocsHeader(),
+      simplifyMkdocsFooter(),
       injectCss({
         css: `
         body {

--- a/plugins/techdocs/src/reader/transformers/index.ts
+++ b/plugins/techdocs/src/reader/transformers/index.ts
@@ -18,6 +18,7 @@ export * from './addBaseUrl';
 export * from './rewriteDocLinks';
 export * from './addLinkClickListener';
 export * from './removeMkdocsHeader';
+export * from './simplifyMkdocsFooter';
 export * from './modifyCss';
 export * from './onCssReady';
 export * from './sanitizeDOM';

--- a/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.test.ts
+++ b/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTestShadowDom, FIXTURES } from '../../test-utils';
+import { simplifyMkdocsFooter } from '.';
+
+describe('simplifyMkdocsFooter', () => {
+  it('does not remove mkdocs copyright', () => {
+    const shadowDom = createTestShadowDom(FIXTURES.FIXTURE_STANDARD_PAGE, {
+      preTransformers: [],
+      postTransformers: [],
+    });
+
+    expect(shadowDom.querySelector('.md-footer-copyright')).toBeTruthy();
+  });
+
+  it('does remove mkdocs copyright', () => {
+    const shadowDom = createTestShadowDom(FIXTURES.FIXTURE_STANDARD_PAGE, {
+      preTransformers: [simplifyMkdocsFooter()],
+      postTransformers: [],
+    });
+
+    expect(shadowDom.querySelector('.md-footer-copyright')).toBeFalsy();
+  });
+});

--- a/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.ts
+++ b/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Transformer } from './index';
+
+export const simplifyMkdocsFooter = (): Transformer => {
+  return dom => {
+    // Remove the header
+    dom.querySelector('.md-footer-copyright')?.remove();
+
+    return dom;
+  };
+};

--- a/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.ts
+++ b/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.ts
@@ -18,7 +18,7 @@ import type { Transformer } from './index';
 
 export const simplifyMkdocsFooter = (): Transformer => {
   return dom => {
-    // Remove the header
+    // Remove mkdocs copyright
     dom.querySelector('.md-footer-copyright')?.remove();
 
     return dom;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is fixing https://github.com/spotify/backstage/issues/2850.
It removes the copyright with a transformer similar to removeMkdocsHeader.

![image](https://user-images.githubusercontent.com/4560150/97059855-fb91a700-1591-11eb-90b9-fb30b3f5293c.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
