### PR TITLE
[CLI - tests]: Fix path delimiters

### DIFF
--- a/packages/cli/src/commands/create-plugin/createPlugin.test.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.test.ts
@@ -57,7 +57,7 @@ describe('createPlugin', () => {
         [id]: {},
       });
       const tempDir = id;
-      const pluginDir = `/test-temp/plugins/${id}`;
+      const pluginDir = path.join('test-temp', 'plugins', id);
 
       await movePlugin(tempDir, pluginDir, id);
       await expect(fs.pathExists(pluginDir)).resolves.toBe(true);

--- a/packages/cli/src/commands/remove-plugin/removePlugin.test.ts
+++ b/packages/cli/src/commands/remove-plugin/removePlugin.test.ts
@@ -51,7 +51,7 @@ const createTestPackageFile = async (testFilePath: string) => {
   };
 
   mockFs({
-    '/packages': {
+    packages: {
       app: {
         'package.json': `${JSON.stringify(packageFileContent, null, 2)}\n`,
       },
@@ -72,7 +72,7 @@ const createTestPluginFile = async (
       [testFileName]: `${pluginsFileContent}\n`,
       [pluginsFileName]: `${pluginsFileContent}\n`,
     },
-    '/packages': {
+    packages: {
       app: {
         src: {
           'plugin.ts': `${pluginsFileContent}\n`,
@@ -90,15 +90,13 @@ const createTestPluginFile = async (
 };
 
 const mkTestPluginDir = (testDirPath: string) => {
-  const dirPath = `/${testDirPath}`;
-
-  const pluginFiles: { [index: number]: string } = {};
+  const pluginFiles: { [index: string]: string } = {};
   for (let i = 0; i < 50; i++) {
-    pluginFiles[i] = '';
+    pluginFiles[`testFile${i}.ts`] = '';
   }
 
   mockFs({
-    [dirPath]: pluginFiles,
+    [testDirPath]: pluginFiles,
   });
 };
 
@@ -133,7 +131,7 @@ describe('removePlugin', () => {
       );
 
       const mockedPackageFileContent = removeEmptyLines(
-        fse.readFileSync('/packages/app/package.json', 'utf8'),
+        fse.readFileSync(path.join('packages', 'app', 'package.json'), 'utf8'),
       );
       expect(testFileContent).toBe(mockedPackageFileContent);
     });
@@ -150,7 +148,7 @@ describe('removePlugin', () => {
       );
       const mockedPluginsFileContent = removeEmptyLines(
         fse.readFileSync(
-          path.join('/packages', 'app', 'src', pluginsFileName),
+          path.join('packages', 'app', 'src', pluginsFileName),
           'utf8',
         ),
       );
@@ -161,13 +159,13 @@ describe('removePlugin', () => {
       const testFileName = 'test';
       const testFilePath = path.join(tempDir, testFileName);
 
-      const mockedCodeownersPath = '/.github/CODEOWNERS';
+      const mockedCodeownersPath = path.join('.github', 'CODEOWNERS');
 
       mockFs({
         [tempDir]: {
           [testFileName]: '',
         },
-        '/.github': {
+        '.github': {
           CODEOWNERS: codeownersFileContent,
         },
       });
@@ -178,10 +176,11 @@ describe('removePlugin', () => {
       const codeOwnersFileContent = removeEmptyLines(
         fse.readFileSync(mockedCodeownersPath, 'utf8'),
       );
-      await addCodeownersEntry(testFilePath!, `/plugins/${testPluginName}`, [
-        '@thisIsAtestTeam',
-        'test@gmail.com',
-      ]);
+      await addCodeownersEntry(
+        testFilePath!,
+        path.join('plugins', testPluginName),
+        ['@thisIsAtestTeam', 'test@gmail.com'],
+      );
       await removePluginFromCodeOwners(testFilePath, testPluginName);
       expect(testFileContent).toBe(codeOwnersFileContent);
     });
@@ -206,8 +205,13 @@ describe('removePlugin', () => {
     describe('Removes System Link', () => {
       it('removes system link from @backstage', async () => {
         const symLink = `plugin-${testPluginName}`;
-        const testSymLinkPath = `/node_modules/@backstage/${symLink}`;
-        const mockedTestDirPath = path.join('/plugins', testPluginName);
+        const testSymLinkPath = path.join(
+          '/',
+          'node_modules',
+          '@backstage',
+          symLink,
+        );
+        const mockedTestDirPath = path.join('/', 'plugins', testPluginName);
 
         mockFs({
           '/plugins': {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix the [broken Windows build](https://github.com/spotify/backstage/runs/1299824817) introduced by using some static paths like `/my_dir/my_file` instead of building them using `path.join` which joins the given path segments together using the platform specific separator as delimiter: [discord link](https://discord.com/channels/687207715902193673/687235481154617364/769294207331729458).

It also removes some absolute paths which was causing the bug in `removePlugin.test.ts` where we had an absolute path instead of a relative path.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
