### PR TITLE
Allow setting travis ci auth token via helm

### DIFF
--- a/contrib/chart/backstage/templates/backend-secret.yaml
+++ b/contrib/chart/backstage/templates/backend-secret.yaml
@@ -19,4 +19,5 @@ stringData:
   GITLAB_TOKEN: {{ .Values.auth.gitlabToken }}
   AZURE_TOKEN: {{ .Values.auth.azure.api.token }}
   NEW_RELIC_REST_API_KEY: {{ .Values.auth.newRelicRestApiKey }}
+  TRAVISCI_AUTH_TOKEN: {{ .Values.auth.travisciAuthToken }}
 {{- end }}

--- a/contrib/chart/backstage/values.yaml
+++ b/contrib/chart/backstage/values.yaml
@@ -249,3 +249,4 @@ auth:
   githubToken: g
   gitlabToken: g
   newRelicRestApiKey: r
+  travisciAuthToken: fake-travis-ci-auth-token


### PR DESCRIPTION
The auth token needs to be passed through into the environment variables via a kubernetes secret.