### PR TITLE
Cleanup after refactoring of plugins

### DIFF
--- a/.changeset/sweet-bikes-battle.md
+++ b/.changeset/sweet-bikes-battle.md
@@ -1,0 +1,5 @@
+---
+'example-app': patch
+---
+
+cleaning up because external plugins have already implemented new api for creating

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -36,7 +36,7 @@
     "@octokit/rest": "^18.0.0",
     "@roadiehq/backstage-plugin-github-insights": "^0.2.7",
     "@roadiehq/backstage-plugin-github-pull-requests": "^0.5.2",
-    "@roadiehq/backstage-plugin-travis-ci": "^0.2.3",
+    "@roadiehq/backstage-plugin-travis-ci": "^0.2.5",
     "dayjs": "^1.9.1",
     "history": "^5.0.0",
     "prop-types": "^15.7.2",

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -25,16 +25,6 @@ import {
   GraphQLEndpoints,
 } from '@backstage/plugin-graphiql';
 
-import {
-  TravisCIApi,
-  travisCIApiRef,
-} from '@roadiehq/backstage-plugin-travis-ci';
-
-import {
-  GithubPullRequestsClient,
-  githubPullRequestsApiRef,
-} from '@roadiehq/backstage-plugin-github-pull-requests';
-
 import { costInsightsApiRef } from '@backstage/plugin-cost-insights';
 import { ExampleCostInsightsClient } from './plugins/cost-insights';
 
@@ -59,8 +49,4 @@ export const apis = [
   }),
 
   createApiFactory(costInsightsApiRef, new ExampleCostInsightsClient()),
-
-  // TODO: move to plugins
-  createApiFactory(travisCIApiRef, new TravisCIApi()),
-  createApiFactory(githubPullRequestsApiRef, new GithubPullRequestsClient()),
 ];


### PR DESCRIPTION
## Cleanup after refactoring of plugins

Just cleaning up because plugins have already implemented new api for creating.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
