### PR TITLE
fix: favicon for Safari

### DIFF
--- a/microsite/siteConfig.js
+++ b/microsite/siteConfig.js
@@ -60,7 +60,7 @@ const siteConfig = {
   /* path to images for header/footer */
   // headerIcon: "img/android-chrome-192x192.png",
   footerIcon: 'img/android-chrome-192x192.png',
-  favicon: 'img/favicon.svg',
+  favicon: 'img/favicon.ico',
 
   /* Colors for website */
   colors: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Safari browser is having partial support for SVG favicons, due to which is is not showing up properly on Safari.

The favicon.svg has been replaced with favicon.ico

**Fixes:** https://github.com/spotify/backstage/issues/3012

#### Screenshots

The left tab is the website running locally and right tab is backstage.io running on production

<img width="960" alt="safari-favicon" src="https://user-images.githubusercontent.com/19193724/97138319-ec6f4c80-177d-11eb-853e-6d48a6c4db9e.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
