### PR TITLE
fix: text flowing out of unregister entity dialog

### DIFF
--- a/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -101,7 +101,7 @@ export const UnregisterEntityDialog: FC<Props> = ({
               That are located at the following location:
             </DialogContentText>
             <Typography component="div">
-              <ul>
+              <ul style={{ wordBreak: 'break-word' }}>
                 <li>
                   {entities[0]?.metadata.annotations?.[LOCATION_ANNOTATION]}
                 </li>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The text in UnregisterEntityDialog component was flowing out of the modal, the text was telling about the location of entities which were going to be unregistered.

The text is flowing out in both mobile and desktop.

### Screenshots

#### Before

<img width="640" alt="unregister-entity-before-mobile-1" src="https://user-images.githubusercontent.com/19193724/97201655-b317fa80-17d8-11eb-9865-47fbd5b565c7.png">

<img width="640" alt="unregister-entity-before-mobile-2" src="https://user-images.githubusercontent.com/19193724/97201663-b6ab8180-17d8-11eb-8852-8abebff797d7.png">

<img width="640" alt="unregister-entity-before-desktop" src="https://user-images.githubusercontent.com/19193724/97201650-b14e3700-17d8-11eb-8f15-1e4129e40f05.png">

#### After

<img width="640" alt="unregister-entity-after-desktop" src="https://user-images.githubusercontent.com/19193724/97201622-a8f5fc00-17d8-11eb-90b0-1b2b4d83f9ce.png">

<img width="640" alt="unregister-entity-after-mobile" src="https://user-images.githubusercontent.com/19193724/97201644-af847380-17d8-11eb-9d79-75593b146118.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
