### PR TITLE
bug(scaffolder): list the template entries correctly

### DIFF
--- a/.changeset/young-turtles-ring.md
+++ b/.changeset/young-turtles-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Update the frontend to use the new Catalog filter API

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -54,7 +54,7 @@ export const ScaffolderPage = () => {
   const { data: templates, isValidating, error } = useStaleWhileRevalidate(
     'templates/all',
     async () =>
-      catalogApi.getEntities({ kind: 'Template' }) as Promise<
+      catalogApi.getEntities({ filter: 'kind=Template' }) as Promise<
         TemplateEntityV1alpha1[]
       >,
   );

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -44,8 +44,7 @@ const useTemplate = (
     `templates/${templateName}`,
     async () =>
       catalogApi.getEntities({
-        kind: 'Template',
-        'metadata.name': templateName,
+        filter: `kind=Template,metadata.name=${templateName}`,
       }) as Promise<TemplateEntityV1alpha1[]>,
   );
   return { template: data?.[0], loading: !error && !data, error };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #3102. Use the new Catalog Filter API to get the templates and choose the correct one when selected.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
