### PR TITLE
Added validation for component id in the CRA template, fixed issue when job stages fail

### DIFF
--- a/plugins/scaffolder-backend/sample-templates/create-react-app/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/create-react-app/template.yaml
@@ -22,6 +22,7 @@ spec:
       component_id:
         title: Name
         type: string
+        pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
         description: Unique name of the component. Lowercase, URL-safe characters only.
       description:
         title: Description

--- a/plugins/scaffolder-backend/src/scaffolder/jobs/processor.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/jobs/processor.ts
@@ -118,8 +118,8 @@ export class JobProcessor implements Processor {
           stage.status = 'COMPLETED';
         } catch (error) {
           // Log to the current stage the error that occured and fail the stage.
-          logger.error(`Stage failed with error: ${error.message}`);
           stage.status = 'FAILED';
+          logger.error(`Stage failed with error: ${error.message}`);
 
           // Throw the error so the job can be failed too.
           throw error;

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -25,7 +25,7 @@ import {
   Stepper,
   Typography,
 } from '@material-ui/core';
-import { FormProps, IChangeEvent, withTheme } from '@rjsf/core';
+import { AjvError, FormProps, IChangeEvent, withTheme } from '@rjsf/core';
 import { Theme as MuiTheme } from '@rjsf/material-ui';
 import React, { useState } from 'react';
 
@@ -63,6 +63,15 @@ export const MultistepJsonForm = ({
     setActiveStep(Math.min(activeStep + 1, steps.length));
   const handleBack = () => setActiveStep(Math.max(activeStep - 1, 0));
 
+  const transformErrors = (errors: AjvError[]) =>
+    errors.map(error => {
+      if (error.name === 'pattern') {
+        error.message = 'does not match the required pattern';
+        error.stack = `${error.property} ${error.message}, see its description`;
+      }
+      return error;
+    });
+
   return (
     <>
       <Stepper activeStep={activeStep} orientation="vertical">
@@ -75,6 +84,7 @@ export const MultistepJsonForm = ({
                 formData={formData}
                 onChange={onChange}
                 schema={schema as FormProps<any>['schema']}
+                transformErrors={transformErrors}
                 onSubmit={e => {
                   if (e.errors.length === 0) handleNext();
                 }}

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -25,7 +25,7 @@ import {
   Stepper,
   Typography,
 } from '@material-ui/core';
-import { AjvError, FormProps, IChangeEvent, withTheme } from '@rjsf/core';
+import { FormProps, IChangeEvent, withTheme } from '@rjsf/core';
 import { Theme as MuiTheme } from '@rjsf/material-ui';
 import React, { useState } from 'react';
 
@@ -63,15 +63,6 @@ export const MultistepJsonForm = ({
     setActiveStep(Math.min(activeStep + 1, steps.length));
   const handleBack = () => setActiveStep(Math.max(activeStep - 1, 0));
 
-  const transformErrors = (errors: AjvError[]) =>
-    errors.map(error => {
-      if (error.name === 'pattern') {
-        error.message = 'does not match the required pattern';
-        error.stack = `${error.property} ${error.message}, see its description`;
-      }
-      return error;
-    });
-
   return (
     <>
       <Stepper activeStep={activeStep} orientation="vertical">
@@ -84,7 +75,6 @@ export const MultistepJsonForm = ({
                 formData={formData}
                 onChange={onChange}
                 schema={schema as FormProps<any>['schema']}
-                transformErrors={transformErrors}
                 onSubmit={e => {
                   if (e.errors.length === 0) handleNext();
                 }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Resolves #3077 and #3078 
For #3078, I've added validation to the component id in the CRA template using Json Schema validation's [_pattern_](https://json-schema.org/draft/2019-09/json-schema-validation.html#pattern). Also added a [custom error message](https://react-jsonschema-form.readthedocs.io/en/latest/usage/validation/#custom-error-messages) so it doesn't just say _".component-id does not match pattern "[ugly regex]""_. However, I've kept it fairly general for simplicity's sake. 

The new validation and message:
<img width="1168" alt="Screenshot 2020-10-26 at 20 59 47" src="https://user-images.githubusercontent.com/16206098/97232477-7ef30880-17dd-11eb-81a4-baecf2655d6a.png">

For #3077, I've just made the it so the stage's status is updated before the error is logged. 


#### :heavy_check_mark: Checklist
- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
