### PR TITLE
feat: Move the params of the CatalogApi Client to be an options object

### DIFF
--- a/.changeset/popular-parrots-beam.md
+++ b/.changeset/popular-parrots-beam.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-api-docs': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Added an options parameter to the CatalogApi Client so filter is keyed off

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
@@ -26,7 +26,7 @@ import { ApiExplorerLayout } from './ApiExplorerLayout';
 export const ApiExplorerPage = () => {
   const catalogApi = useApi(catalogApiRef);
   const { loading, error, value: matchingEntities } = useAsync(() => {
-    return catalogApi.getEntities({ kind: 'API' });
+    return catalogApi.getEntities({ filter: { kind: 'API' }});
   }, [catalogApi]);
 
   return (

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
@@ -26,7 +26,7 @@ import { ApiExplorerLayout } from './ApiExplorerLayout';
 export const ApiExplorerPage = () => {
   const catalogApi = useApi(catalogApiRef);
   const { loading, error, value: matchingEntities } = useAsync(() => {
-    return catalogApi.getEntities({ filter: { kind: 'API' }});
+    return catalogApi.getEntities({ filter: { kind: 'API' } });
   }, [catalogApi]);
 
   return (

--- a/plugins/catalog/src/api/CatalogClient.test.ts
+++ b/plugins/catalog/src/api/CatalogClient.test.ts
@@ -77,9 +77,11 @@ describe('CatalogClient', () => {
       );
 
       const entities = await client.getEntities({
-        a: '1',
-        b: ['2', '3'],
-        ö: '=',
+        filter: {
+          a: '1',
+          b: ['2', '3'],
+          ö: '=',
+        },
       });
 
       expect(entities).toEqual([]);

--- a/plugins/catalog/src/api/CatalogClient.ts
+++ b/plugins/catalog/src/api/CatalogClient.ts
@@ -63,17 +63,21 @@ export class CatalogClient implements CatalogApi {
     return await this.getOptional(`/locations/${id}`);
   }
 
-  async getEntities(
-    filter?: Record<string, string | string[]>,
-  ): Promise<Entity[]> {
+  async getEntities(opts?: {
+    filter?: Record<string, string | string[]>;
+  }): Promise<Entity[]> {
+    // todo(blam): maybe we should move this to return a URL instead
+    // and use URLSearchParams rather than building a string for stricter
+    // types and cleaner code?
     let path = `/entities`;
-    if (filter) {
+    if (opts?.filter) {
       const parts: string[] = [];
-      for (const [key, value] of Object.entries(filter)) {
+      for (const [key, value] of Object.entries(opts.filter)) {
         for (const v of [value].flat()) {
           parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(v)}`);
         }
       }
+
       path += `?filter=${parts.join(',')}`;
     }
 

--- a/plugins/catalog/src/api/types.ts
+++ b/plugins/catalog/src/api/types.ts
@@ -34,7 +34,9 @@ export interface CatalogApi {
   getEntityByName(
     compoundName: EntityCompoundName,
   ): Promise<Entity | undefined>;
-  getEntities(filter?: Record<string, string | string[]>): Promise<Entity[]>;
+  getEntities(opts?: {
+    filter?: Record<string, string | string[]>;
+  }): Promise<Entity[]>;
   addLocation(type: string, target: string): Promise<AddLocationResponse>;
   getLocationByEntity(entity: Entity): Promise<Location | undefined>;
   removeEntityByUid(uid: string): Promise<void>;

--- a/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -45,7 +45,7 @@ function useColocatedEntities(entity: Entity): AsyncState<Entity[]> {
   return useAsync(async () => {
     const myLocation = entity.metadata.annotations?.[LOCATION_ANNOTATION];
     return myLocation
-      ? await catalogApi.getEntities({ [LOCATION_ANNOTATION]: myLocation })
+      ? await catalogApi.getEntities({ filter: {[LOCATION_ANNOTATION]: myLocation }})
       : [];
   }, [catalogApi, entity]);
 }

--- a/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -45,7 +45,9 @@ function useColocatedEntities(entity: Entity): AsyncState<Entity[]> {
   return useAsync(async () => {
     const myLocation = entity.metadata.annotations?.[LOCATION_ANNOTATION];
     return myLocation
-      ? await catalogApi.getEntities({ filter: {[LOCATION_ANNOTATION]: myLocation }})
+      ? await catalogApi.getEntities({
+          filter: { [LOCATION_ANNOTATION]: myLocation },
+        })
       : [];
   }, [catalogApi, entity]);
 }

--- a/plugins/catalog/src/filter/EntityFilterGroupsProvider.tsx
+++ b/plugins/catalog/src/filter/EntityFilterGroupsProvider.tsx
@@ -47,7 +47,7 @@ export const EntityFilterGroupsProvider = ({
 function useProvideEntityFilters(): FilterGroupsContext {
   const catalogApi = useApi(catalogApiRef);
   const [{ value: entities, error }, doReload] = useAsyncFn(() =>
-    catalogApi.getEntities({ filter: { kind: 'Component' }}),
+    catalogApi.getEntities({ filter: { kind: 'Component' } }),
   );
 
   const filterGroups = useRef<{

--- a/plugins/catalog/src/filter/EntityFilterGroupsProvider.tsx
+++ b/plugins/catalog/src/filter/EntityFilterGroupsProvider.tsx
@@ -47,7 +47,7 @@ export const EntityFilterGroupsProvider = ({
 function useProvideEntityFilters(): FilterGroupsContext {
   const catalogApi = useApi(catalogApiRef);
   const [{ value: entities, error }, doReload] = useAsyncFn(() =>
-    catalogApi.getEntities({ kind: 'Component' }),
+    catalogApi.getEntities({ filter: { kind: 'Component' }}),
   );
 
   const filterGroups = useRef<{

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -54,7 +54,7 @@ export const ScaffolderPage = () => {
   const { data: templates, isValidating, error } = useStaleWhileRevalidate(
     'templates/all',
     async () =>
-      catalogApi.getEntities({ kind: 'Template' }) as Promise<
+      catalogApi.getEntities({ filter: {kind: 'Template' }}) as Promise<
         TemplateEntityV1alpha1[]
       >,
   );

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -54,7 +54,7 @@ export const ScaffolderPage = () => {
   const { data: templates, isValidating, error } = useStaleWhileRevalidate(
     'templates/all',
     async () =>
-      catalogApi.getEntities({ filter: {kind: 'Template' }}) as Promise<
+      catalogApi.getEntities({ filter: { kind: 'Template' } }) as Promise<
         TemplateEntityV1alpha1[]
       >,
   );

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -44,8 +44,10 @@ const useTemplate = (
     `templates/${templateName}`,
     async () =>
       catalogApi.getEntities({
-        kind: 'Template',
-        'metadata.name': templateName,
+        filter: {
+          kind: 'Template',
+          'metadata.name': templateName,
+        },
       }) as Promise<TemplateEntityV1alpha1[]>,
   );
   return { template: data?.[0], loading: !error && !data, error };


### PR DESCRIPTION
## Hey, I just made a Pull Request!
- Implementing some of the feedback from @freben's earlier PR
- Adding the ability to support an options object to be passed to the `CatalogApi` `getEntities` call


Thought it better to do this sooner rather than later as it's let typescript problems when it's an object if we were planning on doing that sooner rather than later.

#### :heavy_check_mark: Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
