### PR TITLE
techdocs-backend: remove duplicate log tagging

### DIFF
--- a/plugins/techdocs-backend/src/service/helpers.ts
+++ b/plugins/techdocs-backend/src/service/helpers.ts
@@ -66,22 +66,16 @@ export class DocsBuilder {
   }
 
   public async build() {
-    this.logger.info(
-      `[TechDocs] Running preparer on entity ${getEntityId(this.entity)}`,
-    );
+    this.logger.info(`Running preparer on entity ${getEntityId(this.entity)}`);
     const preparedDir = await this.preparer.prepare(this.entity);
 
-    this.logger.info(
-      `[TechDocs] Running generator on entity ${getEntityId(this.entity)}`,
-    );
+    this.logger.info(`Running generator on entity ${getEntityId(this.entity)}`);
     const { resultDir } = await this.generator.run({
       directory: preparedDir,
       dockerClient: this.dockerClient,
     });
 
-    this.logger.info(
-      `[TechDocs] Running publisher on entity ${getEntityId(this.entity)}`,
-    );
+    this.logger.info(`Running publisher on entity ${getEntityId(this.entity)}`);
     await this.publisher.publish({
       entity: this.entity,
       directory: resultDir,
@@ -117,16 +111,14 @@ export class DocsBuilder {
       // Check if documentation source is newer than what we have
       if (storageTimeStamp && storageTimeStamp >= lastCommit) {
         this.logger.debug(
-          `[TechDocs] Docs for entity ${getEntityId(
-            this.entity,
-          )} is up to date.`,
+          `Docs for entity ${getEntityId(this.entity)} is up to date.`,
         );
         return true;
       }
     }
 
     this.logger.debug(
-      `[TechDocs] Docs for entity ${getEntityId(this.entity)} was outdated.`,
+      `Docs for entity ${getEntityId(this.entity)} was outdated.`,
     );
     return false;
   }

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -71,9 +71,7 @@ export async function createRouter({
       const mkDocsMetadata = await (await fetch(metadataURL)).json();
       res.send(mkDocsMetadata);
     } catch (err) {
-      logger.info(
-        `[TechDocs] Unable to get metadata for ${path} with error ${err}`,
-      );
+      logger.info(`Unable to get metadata for ${path} with error ${err}`);
       throw new Error(`Unable to get metadata for ${path} with error ${err}`);
     }
   });
@@ -93,7 +91,7 @@ export async function createRouter({
       res.send({ ...entity, locationMetadata });
     } catch (err) {
       logger.info(
-        `[TechDocs] Unable to get metadata for ${kind}/${namespace}/${name} with error ${err}`,
+        `Unable to get metadata for ${kind}/${namespace}/${name} with error ${err}`,
       );
       throw new Error(
         `Unable to get metadata for ${kind}/${namespace}/${name} with error ${err}`,

--- a/plugins/techdocs-backend/src/techdocs/stages/generate/techdocs.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/generate/techdocs.ts
@@ -83,7 +83,7 @@ export class TechdocsGenerator implements GeneratorBase {
             logStream,
           });
           this.logger.info(
-            `[TechDocs]: Successfully generated docs from ${directory} into ${resultDir} using local mkdocs`,
+            `Successfully generated docs from ${directory} into ${resultDir} using local mkdocs`,
           );
           break;
         case 'docker':
@@ -96,7 +96,7 @@ export class TechdocsGenerator implements GeneratorBase {
             dockerClient,
           });
           this.logger.info(
-            `[TechDocs]: Successfully generated docs from ${directory} into ${resultDir} using techdocs-container`,
+            `Successfully generated docs from ${directory} into ${resultDir} using techdocs-container`,
           );
           break;
         default:
@@ -106,9 +106,9 @@ export class TechdocsGenerator implements GeneratorBase {
       }
     } catch (error) {
       this.logger.debug(
-        `[TechDocs]: Failed to generate docs from ${directory} into ${resultDir}`,
+        `Failed to generate docs from ${directory} into ${resultDir}`,
       );
-      this.logger.debug(`[TechDocs]: Build failed with error: ${log}`);
+      this.logger.debug(`Build failed with error: ${log}`);
       throw new Error(
         `Failed to generate docs from ${directory} into ${resultDir} with error ${error.message}`,
       );

--- a/plugins/techdocs-backend/src/techdocs/stages/prepare/dir.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/prepare/dir.ts
@@ -38,7 +38,7 @@ export class DirectoryPreparer implements PreparerBase {
     );
 
     this.logger.debug(
-      `[TechDocs] Building docs for entity with type 'dir' and managed-by-location '${type}'`,
+      `Building docs for entity with type 'dir' and managed-by-location '${type}'`,
     );
     switch (type) {
       case 'github':


### PR DESCRIPTION
Saw this while running the backend. All logs are already tagged with the plugin ID, so let's not duplicate it. This may provide a bit more visibility when 1 plugin does it, the same way that adding `#######` to the log does, but is gonna be a mess if all plugins start doing it 😅 

![image](https://user-images.githubusercontent.com/4984472/97281031-4e42bb80-183d-11eb-8d57-b265a81d1322.png)
