### PR TITLE
Register Existing Component: Add GitHub to host type dropdown

### DIFF
--- a/plugins/register-component/src/components/RegisterComponentForm/RegisterComponentForm.tsx
+++ b/plugins/register-component/src/components/RegisterComponentForm/RegisterComponentForm.tsx
@@ -107,9 +107,10 @@ export const RegisterComponentForm = ({ onSubmit, submitting }: Props) => {
               onBlur={onBlur}
             >
               <MenuItem value="AUTO">Auto-detect</MenuItem>
-              <MenuItem value="gitlab">GitLab</MenuItem>
-              <MenuItem value="bitbucket/api">Bitbucket</MenuItem>
               <MenuItem value="azure/api">Azure</MenuItem>
+              <MenuItem value="bitbucket/api">Bitbucket</MenuItem>
+              <MenuItem value="github">GitHub</MenuItem>
+              <MenuItem value="gitlab">GitLab</MenuItem>
             </Select>
           )}
         />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When registering an existing component, it auto detects but also has a drop down to select your provider.  GitHub was missing from the drop down, though the note under the URL box suggested it would be available _and_ the code does support it. For now, add this to the static drop down.

I also alphabetized the list so as to avoid preference. 😁 

![image](https://user-images.githubusercontent.com/33203301/97356492-b958b600-186e-11eb-8091-70ced3359a2b.png)

Where it currently is used as the default scm provider:

https://github.com/spotify/backstage/blob/5ff5b1325d671de166ca2f5284cdd141ac68d120/plugins/register-component/src/components/RegisterComponentPage/RegisterComponentPage.tsx#L83-L92

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
