### PR TITLE
fix: export currencies from useConfig hook

### DIFF
--- a/plugins/cost-insights/src/hooks/useConfig.tsx
+++ b/plugins/cost-insights/src/hooks/useConfig.tsx
@@ -109,11 +109,16 @@ export const ConfigProvider = ({ children }: PropsWithChildren<{}>) => {
       return c.getNumber('costInsights.engineerCost');
     }
 
+    function getCurrencies(): Currency[] {
+      return defaultCurrencies;
+    }
+
     function getConfig() {
       const products = getProducts();
       const metrics = getMetrics();
       const engineerCost = getEngineerCost();
       const icons = getIcons();
+      const currencies = getCurrencies();
 
       validateMetrics(metrics);
 
@@ -123,6 +128,7 @@ export const ConfigProvider = ({ children }: PropsWithChildren<{}>) => {
         products,
         engineerCost,
         icons,
+        currencies,
       }));
 
       setLoading(false);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Fixes:** https://github.com/spotify/backstage/issues/3134

The cost insights page is not loading because we are getting currencies as undefined and we are trying to loop over the undefined using map method in CurrencySelect component, now we will only show CurrencySelect component if currencies area available from config.

### Screenshots

#### Before

<img width="960" alt="cost-insights-page-bug" src="https://user-images.githubusercontent.com/19193724/97385333-8575a300-18f7-11eb-9f1d-31b671a045bd.png">

#### After

<img width="960" alt="cost-insights-page-fix" src="https://user-images.githubusercontent.com/19193724/97385342-89092a00-18f7-11eb-86a6-46c3265b94ec.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
