### PR TITLE
[TechDocs] Fix broken graphviz

### DIFF
--- a/packages/techdocs-container/techdocs-core/README.md
+++ b/packages/techdocs-container/techdocs-core/README.md
@@ -82,6 +82,10 @@ Extensions:
 
 ## Changelog
 
+### 0.0.10
+
+- Pin Markdown version to fix issue with Graphviz
+
 ### 0.0.9
 
 - Change development status to 3 - Alpha

--- a/packages/techdocs-container/techdocs-core/requirements.txt
+++ b/packages/techdocs-container/techdocs-core/requirements.txt
@@ -8,6 +8,7 @@ plantuml-markdown==3.1.2
 markdown_inline_graphviz_extension==1.1
 pygments==2.6.1
 pymdown-extensions==7.1
+Markdown==3.2.2
 
 # The linter using for Python
 # Note: This requires Python 3.6+ to run, but can format Python 2 code too.

--- a/packages/techdocs-container/techdocs-core/setup.py
+++ b/packages/techdocs-container/techdocs-core/setup.py
@@ -23,7 +23,7 @@ with open(path.join(this_dir, "README.md"), encoding="utf-8") as file:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.0.9",
+    version="0.0.10",
     description="A Mkdocs package that contains TechDocs defaults",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/packages/techdocs-container/techdocs-core/setup.py
+++ b/packages/techdocs-container/techdocs-core/setup.py
@@ -41,6 +41,7 @@ setup(
         "markdown_inline_graphviz_extension==1.1",
         "pygments==2.6.1",
         "pymdown-extensions==7.1",
+        "Markdown==3.2.2",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
One of our Python dependencies `mkdocs` does not have a pinned version of Python `Markdown` dependency. Pinning `Markdown` to a version is a good idea to make sure we don't get unexpected changes.

Also, this fixes the issue of Graphviz graphs not rendering in techdocs.