### PR TITLE
feat(catalog-backend): permit entity field subselection

### DIFF
--- a/.changeset/alchemists-on-ice.md
+++ b/.changeset/alchemists-on-ice.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add support for `fields` sub-selection of just parts of an entity when listing
+entities in the catalog backend.
+
+Example: `.../entities?fields=metadata.name,spec.type` will return partial
+entity objects with only those exact fields present and the rest cut out.
+Fields do not have to be simple scalars - you can for example do
+`fields=metadata`.

--- a/plugins/catalog-backend/src/service/router.test.ts
+++ b/plugins/catalog-backend/src/service/router.test.ts
@@ -76,6 +76,7 @@ describe('createRouter', () => {
     });
 
     it('parses single and multiple request parameters and passes them down', async () => {
+      entitiesCatalog.entities.mockResolvedValueOnce([]);
       const response = await request(app).get(
         '/entities?filter=a=1,a=,a=3,b=4&filter=c=',
       );

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -22,7 +22,10 @@ import Router from 'express-promise-router';
 import { Logger } from 'winston';
 import { EntitiesCatalog, LocationsCatalog } from '../catalog';
 import { HigherOrderOperation } from '../ingestion/types';
-import { translateQueryToEntityFilters } from './filterQuery';
+import {
+  translateQueryToEntityFilters,
+  translateQueryToFieldMapper,
+} from './filterQuery';
 import { requireRequestBody, validateRequestBody } from './util';
 
 export interface RouterOptions {
@@ -44,8 +47,9 @@ export async function createRouter(
     router
       .get('/entities', async (req, res) => {
         const filters = translateQueryToEntityFilters(req.query);
+        const fieldMapper = translateQueryToFieldMapper(req.query);
         const entities = await entitiesCatalog.entities(filters);
-        res.status(200).send(entities);
+        res.status(200).send(entities.map(fieldMapper));
       })
       .post('/entities', async (req, res) => {
         const body = await requireRequestBody(req);


### PR DESCRIPTION
Ran into the `set` lodash function while looking into something else, and got inspired.