### PR TITLE
catalog-backend: make CodeOwnersProcessor handle url locations

### DIFF
--- a/.changeset/old-jeans-dance.md
+++ b/.changeset/old-jeans-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+The CodeOwnersProcessor now handles 'url' locations

--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
@@ -180,10 +180,12 @@ describe('CodeOwnersProcessor', () => {
 
       const result = await findRawCodeOwners(mockLocation(), reader);
 
-      expect(read.mock.calls.length).toBe(3);
-      expect(read.mock.calls[0]).toEqual([mockReadUrl('.github/')]);
-      expect(read.mock.calls[1]).toEqual([mockReadUrl('')]);
-      expect(read.mock.calls[2]).toEqual([mockReadUrl('docs/')]);
+      expect(read.mock.calls.length).toBe(5);
+      expect(read.mock.calls[0]).toEqual([mockReadUrl('')]);
+      expect(read.mock.calls[1]).toEqual([mockReadUrl('docs/')]);
+      expect(read.mock.calls[2]).toEqual([mockReadUrl('.bitbucket/')]);
+      expect(read.mock.calls[3]).toEqual([mockReadUrl('.github/')]);
+      expect(read.mock.calls[4]).toEqual([mockReadUrl('.gitlab/')]);
       expect(result).toEqual(ownersText);
     });
   });
@@ -236,7 +238,7 @@ describe('CodeOwnersProcessor', () => {
       expect(result).toEqual(entity);
     });
 
-    it('should ignore url locations', async () => {
+    it('should handle url locations', async () => {
       const { entity, processor } = setupTest();
 
       const result = await processor.preProcessEntity(
@@ -244,7 +246,10 @@ describe('CodeOwnersProcessor', () => {
         mockLocation({ type: 'url' }),
       );
 
-      expect(result).toEqual(entity);
+      expect(result).toEqual({
+        ...entity,
+        spec: { owner: 'backstage-core' },
+      });
     });
 
     it('should ignore invalid kinds', async () => {

--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
@@ -25,6 +25,7 @@ import { filter, get, head, pipe, reverse } from 'lodash/fp';
 import { CatalogProcessor } from './types';
 
 const ALLOWED_LOCATION_TYPES = [
+  'url',
   'azure/api',
   'bitbucket/api',
   'github',
@@ -32,6 +33,11 @@ const ALLOWED_LOCATION_TYPES = [
   'gitlab',
   'gitlab/api',
 ];
+
+// TODO(Rugvip): We want to properly detect out repo provider, but for now it's
+//               best to wait for GitHub Apps to be properly introduced and see
+//               what kind of APIs that integrations will expose.
+const KNOWN_LOCATIONS = ['', '/docs', '/.bitbucket', '/.github', '/.gitlab'];
 
 type Options = {
   reader: UrlReader;
@@ -91,13 +97,7 @@ export async function findRawCodeOwners(
     return data.toString();
   };
 
-  const gitProvider = location.type.split('/')[0];
-
-  return Promise.any([
-    readOwnerLocation(`/.${gitProvider}`),
-    readOwnerLocation(''),
-    readOwnerLocation('/docs'),
-  ]);
+  return Promise.any(KNOWN_LOCATIONS.map(readOwnerLocation));
 }
 
 export function buildCodeOwnerUrl(


### PR DESCRIPTION
@andrewthauer this is very much untested, but I'm assuming it will work since the target URLs are unchanged. Do you happen to have a good example laying around that it could be tested with?