### PR TITLE
chore: remove the usage of SFC in Error component

### DIFF
--- a/packages/core/src/layout/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/core/src/layout/ErrorBoundary/ErrorBoundary.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { ComponentClass, Component, SFC, ErrorInfo } from 'react';
+import React, { ComponentClass, Component, ErrorInfo } from 'react';
 
 type Props = {
   slackChannel?: string;
@@ -60,9 +60,10 @@ export const ErrorBoundary: ComponentClass<
 type EProps = {
   error?: Error;
   slackChannel?: string;
+  children?: React.ReactNode;
 };
 
-const Error: SFC<EProps> = ({ slackChannel }) => {
+const Error = ({ slackChannel }: EProps) => {
   return (
     <div>
       Something went wrong here.{' '}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The SFC is deprecated after the introduction of React hooks, because function components can no longer be considered stateless.

We should either import FC or FunctionComponent from react.

```
import React, { FC } from 'react';
```
OR
```
import React, { FunctionComponent } from 'react';
```

This PR replaces SFC with FC.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
