### PR TITLE
core-api: refactor and slim down the FeatureFlagsApi

### DIFF
--- a/.changeset/swift-emus-mate.md
+++ b/.changeset/swift-emus-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-api': minor
+---
+
+Refactored the FeatureFlagsApi to make it easier to re-implement. Existing usage of particularly getUserFlags can be replaced with isActive() or save().

--- a/docs/reference/createPlugin-feature-flags.md
+++ b/docs/reference/createPlugin-feature-flags.md
@@ -10,7 +10,7 @@ can use this to split out logic in your code for manual A/B testing, etc.
 
 ```typescript
 export type FeatureFlagsHooks = {
-  register(name: FeatureFlagName): void;
+  register(name: string): void;
 };
 ```
 

--- a/docs/reference/createPlugin-feature-flags.md
+++ b/docs/reference/createPlugin-feature-flags.md
@@ -24,14 +24,14 @@ export default createPlugin({
 ## Using with useApi
 
 To inspect the state of a feature flag inside your plugin, you can use the
-`FeatureFlagsApi`, accessed via the `FeatureFlagsApiRef`. For example:
+`FeatureFlagsApi`, accessed via the `featureFlagsApiRef`. For example:
 
 ```tsx
 import React, { FC } from 'react';
 import { Button } from '@material-ui/core';
 import { featureFlagsApiRef, useApi } from '@backstage/core';
 
-const ExamplePage: FC<{}> = () => {
+const ExamplePage = () => {
   const featureFlags = useApi(featureFlagsApiRef);
 
   return (

--- a/docs/reference/createPlugin-feature-flags.md
+++ b/docs/reference/createPlugin-feature-flags.md
@@ -8,12 +8,6 @@ The `featureFlags` object passed to the `register` function makes it possible
 for plugins to register Feature Flags in Backstage for users to opt into. You
 can use this to split out logic in your code for manual A/B testing, etc.
 
-```typescript
-export type FeatureFlagsHooks = {
-  register(name: string): void;
-};
-```
-
 Here's a code sample:
 
 ```typescript
@@ -21,8 +15,7 @@ import { createPlugin } from '@backstage/core';
 
 export default createPlugin({
   id: 'welcome',
-  register({ router, featureFlags }) {
-    // router.registerRoute('/', Component);
+  register({ featureFlags }) {
     featureFlags.register('enable-example-feature');
   },
 });
@@ -30,41 +23,22 @@ export default createPlugin({
 
 ## Using with useApi
 
-To use it, you'll first need to register the `FeatureFlags` API via
-`ApiRegistry` in your `apis.ts` in your App:
-
-```tsx
-import {
-  ApiHolder,
-  ApiRegistry,
-  featureFlagsApiRef,
-  FeatureFlags,
-} from '@backstage/core';
-
-const builder = ApiRegistry.builder();
-builder.add(featureFlagsApiRef, new FeatureFlags());
-
-export default builder.build() as ApiHolder;
-```
-
-Then, later, you can directly use it via `useApi`:
+To inspect the state of a feature flag inside your plugin, you can use the
+`FeatureFlagsApi`, accessed via the `FeatureFlagsApiRef`. For example:
 
 ```tsx
 import React, { FC } from 'react';
 import { Button } from '@material-ui/core';
-import { FeatureFlagState, featureFlagsApiRef, useApi } from '@backstage/core';
+import { featureFlagsApiRef, useApi } from '@backstage/core';
 
-const ExampleButton: FC<{}> = () => {
-  const flags = useApi(featureFlagsApiRef).getFlags();
-
-  const handleClick = () => {
-    flags.set('enable-example-feature', FeatureFlagState.On);
-  };
+const ExamplePage: FC<{}> = () => {
+  const featureFlags = useApi(featureFlagsApiRef);
 
   return (
-    <Button variant="contained" color="primary" onClick={handleClick}>
-      Enable the 'enable-example-feature' feature flag
-    </Button>
+    <div>
+      <MyPluginWidget>
+      { featureFlags.isActive('enable-example-feature') && <ExperimentalPluginWidget> }
+    </div>
   );
 };
 ```

--- a/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts
+++ b/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts
@@ -16,7 +16,6 @@
 
 import { ApiRef, createApiRef } from '../system';
 import { UserFlags, FeatureFlagsRegistry } from '../../app/FeatureFlags';
-import { FeatureFlagName } from '../../plugin';
 
 /**
  * The feature flags API is used to toggle functionality to users across plugins and Backstage.
@@ -54,7 +53,7 @@ export interface FeatureFlagsApi {
 
 export interface FeatureFlagsRegistryItem {
   pluginId: string;
-  name: FeatureFlagName;
+  name: string;
 }
 
 export const featureFlagsApiRef: ApiRef<FeatureFlagsApi> = createApiRef({

--- a/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts
+++ b/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts
@@ -34,11 +34,17 @@ export enum FeatureFlagState {
   On = 1,
 }
 
+export interface FeatureFlag {
+  name: string;
+  pluginId: string;
+}
+
 export interface FeatureFlagsApi {
   /**
-   * Store a list of registered feature flags.
+   * Registers a new feature flag. Once a feature flag has been registered it
+   * can be toggled by users, and read back to enable or disable features.
    */
-  registeredFeatureFlags: FeatureFlagsRegistryItem[];
+  registerFlag(flag: FeatureFlag): void;
 
   /**
    * Get a list of all feature flags from the current user.
@@ -49,11 +55,6 @@ export interface FeatureFlagsApi {
    * Get a list of all registered flags.
    */
   getRegisteredFlags(): FeatureFlagsRegistry;
-}
-
-export interface FeatureFlagsRegistryItem {
-  pluginId: string;
-  name: string;
 }
 
 export const featureFlagsApiRef: ApiRef<FeatureFlagsApi> = createApiRef({

--- a/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts
+++ b/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts
@@ -15,7 +15,7 @@
  */
 
 import { ApiRef, createApiRef } from '../system';
-import { UserFlags, FeatureFlagsRegistry } from '../../app/FeatureFlags';
+import { UserFlags } from '../../app/FeatureFlags';
 
 /**
  * The feature flags API is used to toggle functionality to users across plugins and Backstage.
@@ -47,14 +47,14 @@ export interface FeatureFlagsApi {
   registerFlag(flag: FeatureFlag): void;
 
   /**
+   * Get a list of all registered flags.
+   */
+  getRegisteredFlags(): FeatureFlag[];
+
+  /**
    * Get a list of all feature flags from the current user.
    */
   getFlags(): UserFlags;
-
-  /**
-   * Get a list of all registered flags.
-   */
-  getRegisteredFlags(): FeatureFlagsRegistry;
 }
 
 export const featureFlagsApiRef: ApiRef<FeatureFlagsApi> = createApiRef({

--- a/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts
+++ b/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts
@@ -15,7 +15,6 @@
  */
 
 import { ApiRef, createApiRef } from '../system';
-import { UserFlags } from '../../app/FeatureFlags';
 
 /**
  * The feature flags API is used to toggle functionality to users across plugins and Backstage.
@@ -29,15 +28,34 @@ import { UserFlags } from '../../app/FeatureFlags';
  * to enable and disable feature flags, this API acts as another way to enable/disable.
  */
 
-export enum FeatureFlagState {
-  Off = 0,
-  On = 1,
-}
-
-export interface FeatureFlag {
+export type FeatureFlag = {
   name: string;
   pluginId: string;
+};
+
+export enum FeatureFlagState {
+  None = 0,
+  Active = 1,
 }
+
+/**
+ * Options to use when saving feature flags.
+ */
+export type FeatureFlagsSaveOptions = {
+  /**
+   * The new feature flag states to save.
+   */
+  states: Record<string, FeatureFlagState>;
+
+  /**
+   * Whether the saves states should be merged into the existing ones, or replace them.
+   *
+   * Defaults to false.
+   */
+  merge?: boolean;
+};
+
+export type UserFlags = {};
 
 export interface FeatureFlagsApi {
   /**
@@ -52,9 +70,14 @@ export interface FeatureFlagsApi {
   getRegisteredFlags(): FeatureFlag[];
 
   /**
-   * Get a list of all feature flags from the current user.
+   * Whether the feature flag with the given name is currently activated for the user.
    */
-  getFlags(): UserFlags;
+  isActive(name: string): boolean;
+
+  /**
+   * Save the user's choice of feature flag states.
+   */
+  save(options: FeatureFlagsSaveOptions): void;
 }
 
 export const featureFlagsApiRef: ApiRef<FeatureFlagsApi> = createApiRef({

--- a/packages/core-api/src/apis/implementations/FeatureFlagsApi/LocalStorageFeatureFlags.test.tsx
+++ b/packages/core-api/src/apis/implementations/FeatureFlagsApi/LocalStorageFeatureFlags.test.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { LocalStorageFeatureFlags } from './FeatureFlags';
-import { FeatureFlagState, FeatureFlagsApi } from '../apis/definitions';
+import { LocalStorageFeatureFlags } from './LocalStorageFeatureFlags';
+import { FeatureFlagState, FeatureFlagsApi } from '../../definitions';
 
 describe('FeatureFlags', () => {
   beforeEach(() => {

--- a/packages/core-api/src/apis/implementations/FeatureFlagsApi/LocalStorageFeatureFlags.tsx
+++ b/packages/core-api/src/apis/implementations/FeatureFlagsApi/LocalStorageFeatureFlags.tsx
@@ -19,7 +19,7 @@ import {
   FeatureFlagsApi,
   FeatureFlag,
   FeatureFlagsSaveOptions,
-} from '../apis/definitions';
+} from '../../definitions';
 
 export function validateFlagName(name: string): void {
   if (name.length < 3) {

--- a/packages/core-api/src/apis/implementations/FeatureFlagsApi/index.ts
+++ b/packages/core-api/src/apis/implementations/FeatureFlagsApi/index.ts
@@ -14,17 +14,4 @@
  * limitations under the License.
  */
 
-// This folder contains implementations for all core APIs.
-//
-// Plugins should rely on these APIs for functionality as much as possible.
-
-export * from './auth';
-
-export * from './AlertApi';
-export * from './AppThemeApi';
-export * from './ConfigApi';
-export * from './DiscoveryApi';
-export * from './ErrorApi';
-export * from './FeatureFlagsApi';
-export * from './OAuthRequestApi';
-export * from './StorageApi';
+export { LocalStorageFeatureFlags } from './LocalStorageFeatureFlags';

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -50,11 +50,11 @@ import {
   useApi,
   AnyApiFactory,
   ApiHolder,
+  LocalStorageFeatureFlags,
 } from '../apis';
 import { useAsync } from 'react-use';
 import { AppIdentity } from './AppIdentity';
 import { ApiResolver, ApiFactoryRegistry } from '../apis/system';
-import { LocalStorageFeatureFlags } from './FeatureFlags';
 
 type FullAppOptions = {
   apis: Iterable<AnyApiFactory>;

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -35,7 +35,6 @@ import {
   AppThemeApi,
   ConfigApi,
   identityApiRef,
-  FeatureFlagsRegistryItem,
 } from '../apis/definitions';
 import { AppThemeProvider } from './AppThemeProvider';
 
@@ -55,6 +54,7 @@ import {
 import { useAsync } from 'react-use';
 import { AppIdentity } from './AppIdentity';
 import { ApiResolver, ApiFactoryRegistry } from '../apis/system';
+import { FeatureFlags } from './FeatureFlags';
 
 type FullAppOptions = {
   apis: Iterable<AnyApiFactory>;
@@ -135,7 +135,8 @@ export class PrivateAppImpl implements BackstageApp {
 
   getRoutes(): JSX.Element[] {
     const routes = new Array<JSX.Element>();
-    const registeredFeatureFlags = new Array<FeatureFlagsRegistryItem>();
+
+    const featureFlagsApi = this.getApiHolder().get(featureFlagsApiRef)!;
 
     const { NotFoundErrorPage } = this.components;
 
@@ -171,9 +172,9 @@ export class PrivateAppImpl implements BackstageApp {
             break;
           }
           case 'feature-flag': {
-            registeredFeatureFlags.push({
-              pluginId: plugin.getId(),
+            featureFlagsApi.registerFlag({
               name: output.name,
+              pluginId: plugin.getId(),
             });
             break;
           }
@@ -181,11 +182,6 @@ export class PrivateAppImpl implements BackstageApp {
             break;
         }
       }
-    }
-
-    const featureFlags = this.getApiHolder().get(featureFlagsApiRef);
-    if (featureFlags) {
-      featureFlags.registeredFeatureFlags = registeredFeatureFlags;
     }
 
     routes.push(<Route path="/*" element={<NotFoundErrorPage />} />);
@@ -319,6 +315,13 @@ export class PrivateAppImpl implements BackstageApp {
       factory: () => this.identityApi,
     });
 
+    // It's possible to replace the feature flag API, but since we must have at least
+    // one implementation we add it here directly instead of through the defaultApis.
+    registry.register('default', {
+      api: featureFlagsApiRef,
+      deps: {},
+      factory: () => new FeatureFlags(),
+    });
     for (const factory of this.defaultApis) {
       registry.register('default', factory);
     }

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -54,7 +54,7 @@ import {
 import { useAsync } from 'react-use';
 import { AppIdentity } from './AppIdentity';
 import { ApiResolver, ApiFactoryRegistry } from '../apis/system';
-import { FeatureFlags } from './FeatureFlags';
+import { LocalStorageFeatureFlags } from './FeatureFlags';
 
 type FullAppOptions = {
   apis: Iterable<AnyApiFactory>;
@@ -320,7 +320,7 @@ export class PrivateAppImpl implements BackstageApp {
     registry.register('default', {
       api: featureFlagsApiRef,
       deps: {},
-      factory: () => new FeatureFlags(),
+      factory: () => new LocalStorageFeatureFlags(),
     });
     for (const factory of this.defaultApis) {
       registry.register('default', factory);

--- a/packages/core-api/src/app/FeatureFlags.test.tsx
+++ b/packages/core-api/src/app/FeatureFlags.test.tsx
@@ -125,15 +125,22 @@ describe('FeatureFlags', () => {
 
     beforeEach(() => {
       featureFlags = new FeatureFlagsImpl();
-      featureFlags.registeredFeatureFlags = [
-        { name: 'registered-flag-1', pluginId: 'plugin-one' },
-        { name: 'registered-flag-2', pluginId: 'plugin-one' },
-        { name: 'registered-flag-3', pluginId: 'plugin-two' },
-      ];
+      featureFlags.registerFlag({
+        name: 'registered-flag-1',
+        pluginId: 'plugin-one',
+      });
+      featureFlags.registerFlag({
+        name: 'registered-flag-2',
+        pluginId: 'plugin-one',
+      });
+      featureFlags.registerFlag({
+        name: 'registered-flag-3',
+        pluginId: 'plugin-two',
+      });
     });
 
     it('should return an empty list', () => {
-      featureFlags.registeredFeatureFlags = [];
+      featureFlags = new FeatureFlagsImpl();
       expect(featureFlags.getRegisteredFlags().toObject()).toEqual([]);
     });
 
@@ -203,9 +210,8 @@ describe('FeatureFlags', () => {
     });
 
     it('throws an error if length is less than three characters', () => {
-      const flags = featureFlags.getRegisteredFlags();
       expect(() =>
-        flags.push({
+        featureFlags.registerFlag({
           name: 'ab',
           pluginId: 'plugin-three',
         }),
@@ -213,9 +219,8 @@ describe('FeatureFlags', () => {
     });
 
     it('throws an error if length is greater than 150 characters', () => {
-      const flags = featureFlags.getRegisteredFlags();
       expect(() =>
-        flags.push({
+        featureFlags.registerFlag({
           name:
             'loremipsumdolorsitametconsecteturadipiscingelitnuncvitaeportaexaullamcorperturpismaurisutmattisnequemorbisediaculisauguevivamuspulvinarcursuseratblandithendreritquisqueuttinciduntmagnavestibulumblanditaugueat',
           pluginId: 'plugin-three',
@@ -224,9 +229,8 @@ describe('FeatureFlags', () => {
     });
 
     it('throws an error if name does not start with a lowercase letter', () => {
-      const flags = featureFlags.getRegisteredFlags();
       expect(() =>
-        flags.push({
+        featureFlags.registerFlag({
           name: '123456789',
           pluginId: 'plugin-three',
         }),
@@ -234,9 +238,8 @@ describe('FeatureFlags', () => {
     });
 
     it('throws an error if name contains characters other than lowercase letters, numbers and hyphens', () => {
-      const flags = featureFlags.getRegisteredFlags();
       expect(() =>
-        flags.push({
+        featureFlags.registerFlag({
           name: 'Invalid_Feature_Flag',
           pluginId: 'plugin-three',
         }),

--- a/packages/core-api/src/app/FeatureFlags.test.tsx
+++ b/packages/core-api/src/app/FeatureFlags.test.tsx
@@ -141,11 +141,11 @@ describe('FeatureFlags', () => {
 
     it('should return an empty list', () => {
       featureFlags = new FeatureFlagsImpl();
-      expect(featureFlags.getRegisteredFlags().toObject()).toEqual([]);
+      expect(featureFlags.getRegisteredFlags()).toEqual([]);
     });
 
     it('should return an valid list', () => {
-      expect(featureFlags.getRegisteredFlags().toObject()).toMatchObject([
+      expect(featureFlags.getRegisteredFlags()).toEqual([
         { name: 'registered-flag-1', pluginId: 'plugin-one' },
         { name: 'registered-flag-2', pluginId: 'plugin-one' },
         { name: 'registered-flag-3', pluginId: 'plugin-two' },
@@ -179,7 +179,7 @@ describe('FeatureFlags', () => {
         pluginId: 'plugin-three',
       });
 
-      expect(flags.toObject()).toMatchObject([
+      expect(flags).toEqual([
         { name: 'registered-flag-1', pluginId: 'plugin-one' },
         { name: 'registered-flag-2', pluginId: 'plugin-one' },
         { name: 'registered-flag-3', pluginId: 'plugin-two' },

--- a/packages/core-api/src/app/FeatureFlags.tsx
+++ b/packages/core-api/src/app/FeatureFlags.tsx
@@ -127,45 +127,6 @@ export class UserFlags extends Map<string, FeatureFlagState> {
 }
 
 /**
- * The FeatureFlagsRegistry class.
- *
- * This acts as a holding data structure for feature flags
- * that plugins wish to register for use in Backstage.
- */
-
-export class FeatureFlagsRegistry extends Array<FeatureFlag> {
-  static from(entries: FeatureFlag[]) {
-    Array.from(entries).forEach(entry => validateFlagName(entry.name));
-    return new FeatureFlagsRegistry(...entries);
-  }
-
-  push(...entries: FeatureFlag[]): number {
-    Array.from(entries).forEach(entry => validateFlagName(entry.name));
-    return super.push(...entries);
-  }
-
-  concat(
-    ...entries: (FeatureFlag | ConcatArray<FeatureFlag>)[]
-  ): FeatureFlag[] {
-    const _concat = super.concat(...entries);
-    Array.from(_concat).forEach(entry => validateFlagName(entry.name));
-    return _concat;
-  }
-
-  toObject() {
-    return [...this.values()];
-  }
-
-  toJSON() {
-    return JSON.stringify(this.toObject());
-  }
-
-  toString() {
-    return this.toJSON();
-  }
-}
-
-/**
  * Create the FeatureFlags implementation based on the API.
  */
 export class FeatureFlags implements FeatureFlagsApi {
@@ -177,12 +138,12 @@ export class FeatureFlags implements FeatureFlagsApi {
     this.registeredFeatureFlags.push(flag);
   }
 
+  getRegisteredFlags(): FeatureFlag[] {
+    return this.registeredFeatureFlags.slice();
+  }
+
   getFlags(): UserFlags {
     if (!this.userFlags) this.userFlags = UserFlags.load();
     return this.userFlags;
-  }
-
-  getRegisteredFlags(): FeatureFlagsRegistry {
-    return FeatureFlagsRegistry.from(this.registeredFeatureFlags);
   }
 }

--- a/packages/core-api/src/app/FeatureFlags.tsx
+++ b/packages/core-api/src/app/FeatureFlags.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { FeatureFlagName } from '../plugin/types';
 import {
   FeatureFlagState,
   FeatureFlagsApi,
@@ -32,7 +31,7 @@ export function validateBrowserCompat(): void {
   }
 }
 
-export function validateFlagName(name: FeatureFlagName): void {
+export function validateFlagName(name: string): void {
   if (name.length < 3) {
     throw new Error(
       `The '${name}' feature flag must have a minimum length of three characters.`,
@@ -60,7 +59,7 @@ export function validateFlagName(name: FeatureFlagName): void {
  * can use this to retrieve, add, edit, delete, clear and save the user's
  * feature flags to the local browser for persisted storage.
  */
-export class UserFlags extends Map<FeatureFlagName, FeatureFlagState> {
+export class UserFlags extends Map<string, FeatureFlagState> {
   static load(): UserFlags {
     validateBrowserCompat();
 
@@ -73,18 +72,18 @@ export class UserFlags extends Map<FeatureFlagName, FeatureFlagState> {
     }
   }
 
-  get(name: FeatureFlagName): FeatureFlagState {
+  get(name: string): FeatureFlagState {
     return super.get(name) || FeatureFlagState.Off;
   }
 
-  set(name: FeatureFlagName, state: FeatureFlagState): this {
+  set(name: string, state: FeatureFlagState): this {
     validateFlagName(name);
     const output = super.set(name, state);
     this.save();
     return output;
   }
 
-  toggle(name: FeatureFlagName): FeatureFlagState {
+  toggle(name: string): FeatureFlagState {
     if (super.get(name) === FeatureFlagState.On) {
       super.set(name, FeatureFlagState.Off);
     } else {
@@ -93,7 +92,7 @@ export class UserFlags extends Map<FeatureFlagName, FeatureFlagState> {
     return super.get(name) || FeatureFlagState.Off;
   }
 
-  delete(name: FeatureFlagName): boolean {
+  delete(name: string): boolean {
     const output = super.delete(name);
     this.save();
     return output;

--- a/packages/core-api/src/app/FeatureFlags.tsx
+++ b/packages/core-api/src/app/FeatureFlags.tsx
@@ -17,7 +17,7 @@
 import {
   FeatureFlagState,
   FeatureFlagsApi,
-  FeatureFlagsRegistryItem,
+  FeatureFlag,
 } from '../apis/definitions';
 
 /**
@@ -133,23 +133,20 @@ export class UserFlags extends Map<string, FeatureFlagState> {
  * that plugins wish to register for use in Backstage.
  */
 
-export class FeatureFlagsRegistry extends Array<FeatureFlagsRegistryItem> {
-  static from(entries: FeatureFlagsRegistryItem[]) {
+export class FeatureFlagsRegistry extends Array<FeatureFlag> {
+  static from(entries: FeatureFlag[]) {
     Array.from(entries).forEach(entry => validateFlagName(entry.name));
     return new FeatureFlagsRegistry(...entries);
   }
 
-  push(...entries: FeatureFlagsRegistryItem[]): number {
+  push(...entries: FeatureFlag[]): number {
     Array.from(entries).forEach(entry => validateFlagName(entry.name));
     return super.push(...entries);
   }
 
   concat(
-    ...entries: (
-      | FeatureFlagsRegistryItem
-      | ConcatArray<FeatureFlagsRegistryItem>
-    )[]
-  ): FeatureFlagsRegistryItem[] {
+    ...entries: (FeatureFlag | ConcatArray<FeatureFlag>)[]
+  ): FeatureFlag[] {
     const _concat = super.concat(...entries);
     Array.from(_concat).forEach(entry => validateFlagName(entry.name));
     return _concat;
@@ -172,8 +169,13 @@ export class FeatureFlagsRegistry extends Array<FeatureFlagsRegistryItem> {
  * Create the FeatureFlags implementation based on the API.
  */
 export class FeatureFlags implements FeatureFlagsApi {
-  public registeredFeatureFlags: FeatureFlagsRegistryItem[] = [];
+  private registeredFeatureFlags: FeatureFlag[] = [];
   private userFlags: UserFlags | undefined;
+
+  registerFlag(flag: FeatureFlag) {
+    validateFlagName(flag.name);
+    this.registeredFeatureFlags.push(flag);
+  }
 
   getFlags(): UserFlags {
     if (!this.userFlags) this.userFlags = UserFlags.load();

--- a/packages/core-api/src/app/index.ts
+++ b/packages/core-api/src/app/index.ts
@@ -14,6 +14,5 @@
  * limitations under the License.
  */
 
-export { FeatureFlags } from './FeatureFlags';
 export { useApp } from './AppContext';
 export * from './types';

--- a/packages/core-api/src/plugin/Plugin.tsx
+++ b/packages/core-api/src/plugin/Plugin.tsx
@@ -15,7 +15,6 @@
  */
 
 import { PluginConfig, PluginOutput, BackstagePlugin } from './types';
-import { validateBrowserCompat, validateFlagName } from '../app/FeatureFlags';
 import { AnyApiFactory } from '../apis';
 
 export class PluginImpl {
@@ -57,8 +56,6 @@ export class PluginImpl {
       },
       featureFlags: {
         register(name) {
-          validateBrowserCompat();
-          validateFlagName(name);
           outputs.push({ type: 'feature-flag', name });
         },
       },

--- a/packages/core-api/src/plugin/types.ts
+++ b/packages/core-api/src/plugin/types.ts
@@ -54,11 +54,9 @@ export type LegacyRedirectRouteOutput = {
   options?: RouteOptions;
 };
 
-export type FeatureFlagName = string;
-
 export type FeatureFlagOutput = {
   type: 'feature-flag';
-  name: FeatureFlagName;
+  name: string;
 };
 
 export type PluginOutput =
@@ -103,5 +101,5 @@ export type RouterHooks = {
 };
 
 export type FeatureFlagsHooks = {
-  register(name: FeatureFlagName): void;
+  register(name: string): void;
 };

--- a/packages/core/src/api-wrappers/defaultApis.ts
+++ b/packages/core/src/api-wrappers/defaultApis.ts
@@ -20,8 +20,6 @@ import {
   AlertApiForwarder,
   ErrorApiForwarder,
   ErrorAlerter,
-  featureFlagsApiRef,
-  FeatureFlags,
   discoveryApiRef,
   GoogleAuth,
   GithubAuth,
@@ -69,7 +67,6 @@ export const defaultApis = [
     deps: { errorApi: errorApiRef },
     factory: ({ errorApi }) => WebStorage.create({ errorApi }),
   }),
-  createApiFactory(featureFlagsApiRef, new FeatureFlags()),
   createApiFactory(oauthRequestApiRef, new OAuthRequestManager()),
   createApiFactory({
     api: googleAuthApiRef,

--- a/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPage.tsx
+++ b/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPage.tsx
@@ -55,9 +55,7 @@ import { useSubtleTypographyStyles } from '../../utils/styles';
 
 export const CostInsightsPage = () => {
   const classes = useSubtleTypographyStyles();
-  const flags = useApi(featureFlagsApiRef).getFlags();
-  // There is not currently a UI to set feature flags
-  // flags.set('cost-insights-currencies', FeatureFlagState.On);
+  const featureFlags = useApi(featureFlagsApiRef);
   const client = useApi(costInsightsApiRef);
   const config = useConfig();
   const groups = useGroups();
@@ -211,7 +209,7 @@ export const CostInsightsPage = () => {
         </Typography>
       </Box>
       <Box minHeight={40} maxHeight={60} display="flex">
-        {!!flags.get('cost-insights-currencies') && (
+        {featureFlags.isActive('cost-insights-currencies') && (
           <Box mr={1}>
             <CurrencySelect
               currency={currency}

--- a/plugins/user-settings/src/components/FeatureFlags/FeatureFlags.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/FeatureFlags.tsx
@@ -17,7 +17,7 @@
 import React, { useCallback, useState } from 'react';
 import {
   featureFlagsApiRef,
-  FeatureFlagsRegistryItem,
+  FeatureFlag,
   FeatureFlagState,
   InfoCard,
   useApi,
@@ -30,7 +30,7 @@ export const FeatureFlags = () => {
   const featureFlagsApi = useApi(featureFlagsApiRef);
   const featureFlags = featureFlagsApi.getRegisteredFlags();
   const initialFlagState = featureFlags.reduce(
-    (result, featureFlag: FeatureFlagsRegistryItem) => {
+    (result, featureFlag: FeatureFlag) => {
       const state = featureFlagsApi.getFlags().get(featureFlag.name);
 
       result[featureFlag.name] = state;

--- a/plugins/user-settings/src/components/FeatureFlags/FeatureFlags.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/FeatureFlags.tsx
@@ -16,7 +16,6 @@
 
 import React, { useCallback, useState } from 'react';
 import {
-  FeatureFlagName,
   featureFlagsApiRef,
   FeatureFlagsRegistryItem,
   FeatureFlagState,
@@ -37,15 +36,15 @@ export const FeatureFlags = () => {
       result[featureFlag.name] = state;
       return result;
     },
-    {} as Record<FeatureFlagName, FeatureFlagState>,
+    {} as Record<string, FeatureFlagState>,
   );
 
-  const [state, setState] = useState<Record<FeatureFlagName, FeatureFlagState>>(
+  const [state, setState] = useState<Record<string, FeatureFlagState>>(
     initialFlagState,
   );
 
   const toggleFlag = useCallback(
-    (flagName: FeatureFlagName) => {
+    (flagName: string) => {
       const newState = featureFlagsApi.getFlags().toggle(flagName);
 
       setState(prevState => ({

--- a/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
@@ -22,10 +22,10 @@ import {
   Switch,
   Tooltip,
 } from '@material-ui/core';
-import { FeatureFlagsRegistryItem } from '@backstage/core';
+import { FeatureFlag } from '@backstage/core';
 
 type Props = {
-  flag: FeatureFlagsRegistryItem;
+  flag: FeatureFlag;
   enabled: boolean;
   toggleHandler: Function;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The current feature flags API had a lot of concrete types mixed in, as well as a couple of layers making it awkward to use and implement. This distills the API down into 4 methods that covers all the existing use-cases, while leaving room for further evolving it in the future. For example adding another state is now possible, and it's still straight-forward to add observability.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
