### PR TITLE
docgen: add support for picking up the type from the declaration instead of initialization

### DIFF
--- a/docs/reference/utility-apis/AlertApi.md
+++ b/docs/reference/utility-apis/AlertApi.md
@@ -1,7 +1,7 @@
 # AlertApi
 
 The AlertApi type is defined at
-[packages/core-api/src/apis/definitions/AlertApi.ts:29](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/AlertApi.ts#L29).
+[packages/core-api/src/apis/definitions/AlertApi.ts:29](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/AlertApi.ts#L29).
 
 The following Utility API implements this type: [alertApiRef](./README.md#alert)
 
@@ -38,7 +38,7 @@ export type AlertMessage = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/AlertApi.ts:19](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/AlertApi.ts#L19).
+[packages/core-api/src/apis/definitions/AlertApi.ts:19](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/AlertApi.ts#L19).
 
 Referenced by: [post](#post), [alert\$](#alert).
 
@@ -67,13 +67,13 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L53).
 
 Referenced by: [alert\$](#alert).
 
 ### Observer
 
-This file contains non-react related core types used through Backstage.
+This file contains non-react related core types used throughout Backstage.
 
 Observer interface for consuming an Observer, see TC39.
 
@@ -86,7 +86,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -109,6 +109,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/AppThemeApi.md
+++ b/docs/reference/utility-apis/AppThemeApi.md
@@ -1,7 +1,7 @@
 # AppThemeApi
 
 The AppThemeApi type is defined at
-[packages/core-api/src/apis/definitions/AppThemeApi.ts:50](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/AppThemeApi.ts#L50).
+[packages/core-api/src/apis/definitions/AppThemeApi.ts:56](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/AppThemeApi.ts#L56).
 
 The following Utility API implements this type:
 [appThemeApiRef](./README.md#apptheme)
@@ -72,11 +72,16 @@ export type AppTheme = {
    * The specialized MaterialUI theme instance.
    */
   theme: <a href="#backstagetheme">BackstageTheme</a>;
+
+  /**
+   * An Icon for the theme mode setting.
+   */
+  icon?: React.ReactElement&lt;SvgIconProps&gt;;
 }
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/AppThemeApi.ts:24](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/AppThemeApi.ts#L24).
+[packages/core-api/src/apis/definitions/AppThemeApi.ts:25](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/AppThemeApi.ts#L25).
 
 Referenced by: [getInstalledThemes](#getinstalledthemes).
 
@@ -87,7 +92,7 @@ export type BackstagePalette = Palette &amp; <a href="#paletteadditions">Palette
 </pre>
 
 Defined at
-[packages/theme/src/types.ts:70](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/theme/src/types.ts#L70).
+[packages/theme/src/types.ts:74](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/theme/src/types.ts#L74).
 
 Referenced by: [BackstageTheme](#backstagetheme).
 
@@ -96,11 +101,13 @@ Referenced by: [BackstageTheme](#backstagetheme).
 <pre>
 export interface BackstageTheme extends Theme {
   palette: <a href="#backstagepalette">BackstagePalette</a>;
+  page: <a href="#pagetheme">PageTheme</a>;
+  getPageTheme: ({ themeId }: <a href="#pagethemeselector">PageThemeSelector</a>) =&gt; <a href="#pagetheme">PageTheme</a>;
 }
 </pre>
 
 Defined at
-[packages/theme/src/types.ts:73](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/theme/src/types.ts#L73).
+[packages/theme/src/types.ts:81](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/theme/src/types.ts#L81).
 
 Referenced by: [AppTheme](#apptheme).
 
@@ -129,13 +136,13 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L53).
 
 Referenced by: [activeThemeId\$](#activethemeid).
 
 ### Observer
 
-This file contains non-react related core types used through Backstage.
+This file contains non-react related core types used throughout Backstage.
 
 Observer interface for consuming an Observer, see TC39.
 
@@ -148,9 +155,37 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
+
+### PageTheme
+
+<pre>
+export type PageTheme = {
+  colors: string[];
+  shape: string;
+  backgroundImage: string;
+}
+</pre>
+
+Defined at
+[packages/theme/src/types.ts:103](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/theme/src/types.ts#L103).
+
+Referenced by: [BackstageTheme](#backstagetheme).
+
+### PageThemeSelector
+
+<pre>
+export type PageThemeSelector = {
+  themeId: string;
+}
+</pre>
+
+Defined at
+[packages/theme/src/types.ts:77](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/theme/src/types.ts#L77).
+
+Referenced by: [BackstageTheme](#backstagetheme).
 
 ### PaletteAdditions
 
@@ -181,6 +216,8 @@ type PaletteAdditions = {
   navigation: {
     background: string;
     indicator: string;
+    color: string;
+    selectedColor: string;
   };
   tabbar: {
     indicator: string;
@@ -199,12 +236,14 @@ type PaletteAdditions = {
   banner: {
     info: string;
     error: string;
+    text: string;
+    link: string;
   };
 }
 </pre>
 
 Defined at
-[packages/theme/src/types.ts:23](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/theme/src/types.ts#L23).
+[packages/theme/src/types.ts:23](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/theme/src/types.ts#L23).
 
 Referenced by: [BackstagePalette](#backstagepalette).
 
@@ -227,6 +266,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/BackstageIdentityApi.md
+++ b/docs/reference/utility-apis/BackstageIdentityApi.md
@@ -1,7 +1,7 @@
 # BackstageIdentityApi
 
 The BackstageIdentityApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:134](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L134).
+[packages/core-api/src/apis/definitions/auth.ts:134](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L134).
 
 The following Utility APIs implement this type:
 
@@ -18,6 +18,8 @@ The following Utility APIs implement this type:
 - [oauth2ApiRef](./README.md#oauth2)
 
 - [oktaAuthApiRef](./README.md#oktaauth)
+
+- [samlAuthApiRef](./README.md#samlauth)
 
 ## Members
 
@@ -68,7 +70,7 @@ export type AuthRequestOptions = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L40).
+[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L40).
 
 Referenced by: [getBackstageIdentity](#getbackstageidentity).
 
@@ -89,6 +91,6 @@ export type BackstageIdentity = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:147](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L147).
+[packages/core-api/src/apis/definitions/auth.ts:147](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L147).
 
 Referenced by: [getBackstageIdentity](#getbackstageidentity).

--- a/docs/reference/utility-apis/Config.md
+++ b/docs/reference/utility-apis/Config.md
@@ -1,7 +1,7 @@
 # Config
 
 The Config type is defined at
-[packages/config/src/types.ts:32](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/config/src/types.ts#L32).
+[packages/config/src/types.ts:32](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/config/src/types.ts#L32).
 
 The following Utility API implements this type:
 [configApiRef](./README.md#config)
@@ -140,7 +140,7 @@ export type Config = {
 </pre>
 
 Defined at
-[packages/config/src/types.ts:32](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/config/src/types.ts#L32).
+[packages/config/src/types.ts:32](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/config/src/types.ts#L32).
 
 Referenced by: [getConfig](#getconfig), [getOptionalConfig](#getoptionalconfig),
 [getConfigArray](#getconfigarray),
@@ -153,7 +153,7 @@ export type JsonArray = <a href="#jsonvalue">JsonValue</a>[]
 </pre>
 
 Defined at
-[packages/config/src/types.ts:18](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/config/src/types.ts#L18).
+[packages/config/src/types.ts:18](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/config/src/types.ts#L18).
 
 Referenced by: [JsonValue](#jsonvalue).
 
@@ -164,7 +164,7 @@ export type JsonObject = { [key in string]?: <a href="#jsonvalue">JsonValue</a> 
 </pre>
 
 Defined at
-[packages/config/src/types.ts:17](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/config/src/types.ts#L17).
+[packages/config/src/types.ts:17](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/config/src/types.ts#L17).
 
 Referenced by: [JsonValue](#jsonvalue).
 
@@ -181,7 +181,7 @@ export type JsonValue =
 </pre>
 
 Defined at
-[packages/config/src/types.ts:19](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/config/src/types.ts#L19).
+[packages/config/src/types.ts:19](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/config/src/types.ts#L19).
 
 Referenced by: [get](#get), [getOptional](#getoptional),
 [JsonObject](#jsonobject), [JsonArray](#jsonarray), [Config](#config).

--- a/docs/reference/utility-apis/DiscoveryApi.md
+++ b/docs/reference/utility-apis/DiscoveryApi.md
@@ -1,7 +1,7 @@
 # DiscoveryApi
 
 The DiscoveryApi type is defined at
-[packages/core-api/src/apis/definitions/DiscoveryApi.ts:30](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/DiscoveryApi.ts#L30).
+[packages/core-api/src/apis/definitions/DiscoveryApi.ts:30](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/DiscoveryApi.ts#L30).
 
 The following Utility API implements this type:
 [discoveryApiRef](./README.md#discovery)

--- a/docs/reference/utility-apis/ErrorApi.md
+++ b/docs/reference/utility-apis/ErrorApi.md
@@ -1,7 +1,7 @@
 # ErrorApi
 
 The ErrorApi type is defined at
-[packages/core-api/src/apis/definitions/ErrorApi.ts:53](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/ErrorApi.ts#L53).
+[packages/core-api/src/apis/definitions/ErrorApi.ts:53](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/ErrorApi.ts#L53).
 
 The following Utility API implements this type: [errorApiRef](./README.md#error)
 
@@ -41,7 +41,7 @@ type Error = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/ErrorApi.ts:24](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/ErrorApi.ts#L24).
+[packages/core-api/src/apis/definitions/ErrorApi.ts:24](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/ErrorApi.ts#L24).
 
 Referenced by: [post](#post), [error\$](#error).
 
@@ -58,7 +58,7 @@ export type ErrorContext = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/ErrorApi.ts:33](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/ErrorApi.ts#L33).
+[packages/core-api/src/apis/definitions/ErrorApi.ts:33](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/ErrorApi.ts#L33).
 
 Referenced by: [post](#post), [error\$](#error).
 
@@ -87,13 +87,13 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L53).
 
 Referenced by: [error\$](#error).
 
 ### Observer
 
-This file contains non-react related core types used through Backstage.
+This file contains non-react related core types used throughout Backstage.
 
 Observer interface for consuming an Observer, see TC39.
 
@@ -106,7 +106,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -129,6 +129,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/FeatureFlagsApi.md
+++ b/docs/reference/utility-apis/FeatureFlagsApi.md
@@ -1,27 +1,20 @@
 # FeatureFlagsApi
 
 The FeatureFlagsApi type is defined at
-[packages/core-api/src/apis/definitions/FeatureFlagsApi.ts:41](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L41).
+[packages/core-api/src/apis/definitions/FeatureFlagsApi.ts:60](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L60).
 
 The following Utility API implements this type:
 [featureFlagsApiRef](./README.md#featureflags)
 
 ## Members
 
-### registeredFeatureFlags
+### registerFlag()
 
-Store a list of registered feature flags.
-
-<pre>
-registeredFeatureFlags: FeatureFlagsRegistryItem[]
-</pre>
-
-### getFlags()
-
-Get a list of all feature flags from the current user.
+Registers a new feature flag. Once a feature flag has been registered it can be
+toggled by users, and read back to enable or disable features.
 
 <pre>
-getFlags(): UserFlags
+registerFlag(flag: <a href="#featureflag">FeatureFlag</a>): void
 </pre>
 
 ### getRegisteredFlags()
@@ -29,5 +22,92 @@ getFlags(): UserFlags
 Get a list of all registered flags.
 
 <pre>
-getRegisteredFlags(): FeatureFlagsRegistry
+getRegisteredFlags(): <a href="#featureflag">FeatureFlag</a>[]
 </pre>
+
+### isActive()
+
+Whether the feature flag with the given name is currently activated for the
+user.
+
+<pre>
+isActive(name: string): boolean
+</pre>
+
+### save()
+
+Save the user's choice of feature flag states.
+
+<pre>
+save(options: <a href="#featureflagssaveoptions">FeatureFlagsSaveOptions</a>): void
+</pre>
+
+## Supporting types
+
+These types are part of the API declaration, but may not be unique to this API.
+
+### FeatureFlag
+
+The feature flags API is used to toggle functionality to users across plugins
+and Backstage.
+
+Plugins can use this API to register feature flags that they have available for
+users to enable/disable, and this API will centralize the current user's state
+of which feature flags they would like to enable.
+
+This is ideal for Backstage plugins, as well as your own App, to trial
+incomplete or unstable upcoming features. Although there will be a common
+interface for users to enable and disable feature flags, this API acts as
+another way to enable/disable.
+
+<pre>
+export type FeatureFlag = {
+  name: string;
+  pluginId: string;
+}
+</pre>
+
+Defined at
+[packages/core-api/src/apis/definitions/FeatureFlagsApi.ts:31](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L31).
+
+Referenced by: [registerFlag](#registerflag),
+[getRegisteredFlags](#getregisteredflags).
+
+### FeatureFlagState
+
+<pre>
+export enum FeatureFlagState {
+  None = 0,
+  Active = 1,
+}
+</pre>
+
+Defined at
+[packages/core-api/src/apis/definitions/FeatureFlagsApi.ts:36](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L36).
+
+Referenced by: [FeatureFlagsSaveOptions](#featureflagssaveoptions).
+
+### FeatureFlagsSaveOptions
+
+Options to use when saving feature flags.
+
+<pre>
+export type FeatureFlagsSaveOptions = {
+  /**
+   * The new feature flag states to save.
+   */
+  states: Record&lt;string, <a href="#featureflagstate">FeatureFlagState</a>&gt;;
+
+  /**
+   * Whether the saves states should be merged into the existing ones, or replace them.
+   *
+   * Defaults to false.
+   */
+  merge?: boolean;
+}
+</pre>
+
+Defined at
+[packages/core-api/src/apis/definitions/FeatureFlagsApi.ts:44](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L44).
+
+Referenced by: [save](#save).

--- a/docs/reference/utility-apis/IdentityApi.md
+++ b/docs/reference/utility-apis/IdentityApi.md
@@ -1,7 +1,7 @@
 # IdentityApi
 
 The IdentityApi type is defined at
-[packages/core-api/src/apis/definitions/IdentityApi.ts:22](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/IdentityApi.ts#L22).
+[packages/core-api/src/apis/definitions/IdentityApi.ts:22](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/IdentityApi.ts#L22).
 
 The following Utility API implements this type:
 [identityApiRef](./README.md#identity)
@@ -76,6 +76,6 @@ export type ProfileInfo = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:162](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L162).
+[packages/core-api/src/apis/definitions/auth.ts:162](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L162).
 
 Referenced by: [getProfile](#getprofile).

--- a/docs/reference/utility-apis/OAuthApi.md
+++ b/docs/reference/utility-apis/OAuthApi.md
@@ -1,7 +1,7 @@
 # OAuthApi
 
 The OAuthApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:67](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L67).
+[packages/core-api/src/apis/definitions/auth.ts:67](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L67).
 
 The following Utility APIs implement this type:
 
@@ -82,7 +82,7 @@ export type AuthRequestOptions = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L40).
+[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L40).
 
 Referenced by: [getAccessToken](#getaccesstoken).
 
@@ -108,6 +108,6 @@ export type OAuthScope = string | string[]
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:38](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L38).
+[packages/core-api/src/apis/definitions/auth.ts:38](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L38).
 
 Referenced by: [getAccessToken](#getaccesstoken).

--- a/docs/reference/utility-apis/OAuthRequestApi.md
+++ b/docs/reference/utility-apis/OAuthRequestApi.md
@@ -1,7 +1,7 @@
 # OAuthRequestApi
 
 The OAuthRequestApi type is defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:99](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L99).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:99](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L99).
 
 The following Utility API implements this type:
 [oauthRequestApiRef](./README.md#oauthrequest)
@@ -73,7 +73,7 @@ export type AuthProvider = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:27](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L27).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:27](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L27).
 
 Referenced by: [AuthRequesterOptions](#authrequesteroptions),
 [PendingAuthRequest](#pendingauthrequest).
@@ -97,7 +97,7 @@ export type AuthRequester&lt;AuthResponse&gt; = (
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:66](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L66).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:66](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L66).
 
 Referenced by: [createAuthRequester](#createauthrequester).
 
@@ -122,7 +122,7 @@ export type AuthRequesterOptions&lt;AuthResponse&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:43](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L43).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:43](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L43).
 
 Referenced by: [createAuthRequester](#createauthrequester).
 
@@ -151,13 +151,13 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L53).
 
 Referenced by: [authRequest\$](#authrequest).
 
 ### Observer
 
-This file contains non-react related core types used through Backstage.
+This file contains non-react related core types used throughout Backstage.
 
 Observer interface for consuming an Observer, see TC39.
 
@@ -170,7 +170,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -205,7 +205,7 @@ export type PendingAuthRequest = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:77](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L77).
+[packages/core-api/src/apis/definitions/OAuthRequestApi.ts:77](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L77).
 
 Referenced by: [authRequest\$](#authrequest).
 
@@ -228,6 +228,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/OpenIdConnectApi.md
+++ b/docs/reference/utility-apis/OpenIdConnectApi.md
@@ -1,7 +1,7 @@
 # OpenIdConnectApi
 
 The OpenIdConnectApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:99](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L99).
+[packages/core-api/src/apis/definitions/auth.ts:99](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L99).
 
 The following Utility APIs implement this type:
 
@@ -66,6 +66,6 @@ export type AuthRequestOptions = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L40).
+[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L40).
 
 Referenced by: [getIdToken](#getidtoken).

--- a/docs/reference/utility-apis/ProfileInfoApi.md
+++ b/docs/reference/utility-apis/ProfileInfoApi.md
@@ -1,7 +1,7 @@
 # ProfileInfoApi
 
 The ProfileInfoApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:117](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L117).
+[packages/core-api/src/apis/definitions/auth.ts:117](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L117).
 
 The following Utility APIs implement this type:
 
@@ -18,6 +18,8 @@ The following Utility APIs implement this type:
 - [oauth2ApiRef](./README.md#oauth2)
 
 - [oktaAuthApiRef](./README.md#oktaauth)
+
+- [samlAuthApiRef](./README.md#samlauth)
 
 ## Members
 
@@ -65,7 +67,7 @@ export type AuthRequestOptions = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L40).
+[packages/core-api/src/apis/definitions/auth.ts:40](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L40).
 
 Referenced by: [getProfile](#getprofile).
 
@@ -93,6 +95,6 @@ export type ProfileInfo = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:162](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L162).
+[packages/core-api/src/apis/definitions/auth.ts:162](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L162).
 
 Referenced by: [getProfile](#getprofile).

--- a/docs/reference/utility-apis/README.md
+++ b/docs/reference/utility-apis/README.md
@@ -12,7 +12,7 @@ Used to report alerts and forward them to the app
 Implemented type: [AlertApi](./AlertApi.md)
 
 ApiRef:
-[alertApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/AlertApi.ts#L41)
+[alertApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/AlertApi.ts#L41)
 
 ### appTheme
 
@@ -21,7 +21,7 @@ API Used to configure the app theme, and enumerate options
 Implemented type: [AppThemeApi](./AppThemeApi.md)
 
 ApiRef:
-[appThemeApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/AppThemeApi.ts#L74)
+[appThemeApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/AppThemeApi.ts#L80)
 
 ### auth0Auth
 
@@ -32,7 +32,7 @@ Implemented types: [OpenIdConnectApi](./OpenIdConnectApi.md),
 [BackstageIdentityApi](./BackstageIdentityApi.md), [SessionApi](./SessionApi.md)
 
 ApiRef:
-[auth0AuthApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L275)
+[auth0AuthApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L275)
 
 ### config
 
@@ -41,7 +41,7 @@ Used to access runtime configuration
 Implemented type: [Config](./Config.md)
 
 ApiRef:
-[configApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/ConfigApi.ts#L22)
+[configApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/ConfigApi.ts#L22)
 
 ### discovery
 
@@ -50,7 +50,7 @@ Provides service discovery of backend plugins
 Implemented type: [DiscoveryApi](./DiscoveryApi.md)
 
 ApiRef:
-[discoveryApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/DiscoveryApi.ts#L44)
+[discoveryApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/DiscoveryApi.ts#L44)
 
 ### error
 
@@ -59,7 +59,7 @@ Used to report errors and forward them to the app
 Implemented type: [ErrorApi](./ErrorApi.md)
 
 ApiRef:
-[errorApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/ErrorApi.ts#L65)
+[errorApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/ErrorApi.ts#L65)
 
 ### featureFlags
 
@@ -68,7 +68,7 @@ Used to toggle functionality in features across Backstage
 Implemented type: [FeatureFlagsApi](./FeatureFlagsApi.md)
 
 ApiRef:
-[featureFlagsApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L58)
+[featureFlagsApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/FeatureFlagsApi.ts#L83)
 
 ### githubAuth
 
@@ -79,7 +79,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [BackstageIdentityApi](./BackstageIdentityApi.md), [SessionApi](./SessionApi.md)
 
 ApiRef:
-[githubAuthApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L232)
+[githubAuthApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L232)
 
 ### gitlabAuth
 
@@ -90,7 +90,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [BackstageIdentityApi](./BackstageIdentityApi.md), [SessionApi](./SessionApi.md)
 
 ApiRef:
-[gitlabAuthApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L262)
+[gitlabAuthApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L262)
 
 ### googleAuth
 
@@ -102,7 +102,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [BackstageIdentityApi](./BackstageIdentityApi.md), [SessionApi](./SessionApi.md)
 
 ApiRef:
-[googleAuthApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L215)
+[googleAuthApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L215)
 
 ### identity
 
@@ -111,7 +111,7 @@ Provides access to the identity of the signed in user
 Implemented type: [IdentityApi](./IdentityApi.md)
 
 ApiRef:
-[identityApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/IdentityApi.ts#L54)
+[identityApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/IdentityApi.ts#L54)
 
 ### microsoftAuth
 
@@ -123,7 +123,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [BackstageIdentityApi](./BackstageIdentityApi.md), [SessionApi](./SessionApi.md)
 
 ApiRef:
-[microsoftAuthApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L289)
+[microsoftAuthApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L289)
 
 ### oauth2
 
@@ -135,7 +135,7 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [BackstageIdentityApi](./BackstageIdentityApi.md), [SessionApi](./SessionApi.md)
 
 ApiRef:
-[oauth2ApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L303)
+[oauth2ApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L303)
 
 ### oauthRequest
 
@@ -144,7 +144,7 @@ An API for implementing unified OAuth flows in Backstage
 Implemented type: [OAuthRequestApi](./OAuthRequestApi.md)
 
 ApiRef:
-[oauthRequestApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L130)
+[oauthRequestApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/OAuthRequestApi.ts#L130)
 
 ### oktaAuth
 
@@ -156,7 +156,17 @@ Implemented types: [OAuthApi](./OAuthApi.md),
 [BackstageIdentityApi](./BackstageIdentityApi.md), [SessionApi](./SessionApi.md)
 
 ApiRef:
-[oktaAuthApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L245)
+[oktaAuthApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L245)
+
+### samlAuth
+
+Example of how to use SAML custom provider
+
+Implemented types: [ProfileInfoApi](./ProfileInfoApi.md),
+[BackstageIdentityApi](./BackstageIdentityApi.md), [SessionApi](./SessionApi.md)
+
+ApiRef:
+[samlAuthApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L317)
 
 ### storage
 
@@ -165,4 +175,4 @@ Provides the ability to store data which is unique to the user
 Implemented type: [StorageApi](./StorageApi.md)
 
 ApiRef:
-[storageApiRef](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/StorageApi.ts#L68)
+[storageApiRef](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/StorageApi.ts#L68)

--- a/docs/reference/utility-apis/SessionApi.md
+++ b/docs/reference/utility-apis/SessionApi.md
@@ -1,7 +1,7 @@
 # SessionApi
 
 The SessionApi type is defined at
-[packages/core-api/src/apis/definitions/auth.ts:190](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L190).
+[packages/core-api/src/apis/definitions/auth.ts:190](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L190).
 
 The following Utility APIs implement this type:
 
@@ -18,6 +18,8 @@ The following Utility APIs implement this type:
 - [oauth2ApiRef](./README.md#oauth2)
 
 - [oktaAuthApiRef](./README.md#oktaauth)
+
+- [samlAuthApiRef](./README.md#samlauth)
 
 ## Members
 
@@ -75,13 +77,13 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L53).
 
 Referenced by: [sessionState\$](#sessionstate).
 
 ### Observer
 
-This file contains non-react related core types used through Backstage.
+This file contains non-react related core types used throughout Backstage.
 
 Observer interface for consuming an Observer, see TC39.
 
@@ -94,7 +96,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -110,7 +112,7 @@ export enum SessionState {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/auth.ts:182](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/auth.ts#L182).
+[packages/core-api/src/apis/definitions/auth.ts:182](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/auth.ts#L182).
 
 Referenced by: [sessionState\$](#sessionstate).
 
@@ -133,6 +135,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/docs/reference/utility-apis/StorageApi.md
+++ b/docs/reference/utility-apis/StorageApi.md
@@ -1,7 +1,7 @@
 # StorageApi
 
 The StorageApi type is defined at
-[packages/core-api/src/apis/definitions/StorageApi.ts:31](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/StorageApi.ts#L31).
+[packages/core-api/src/apis/definitions/StorageApi.ts:31](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/StorageApi.ts#L31).
 
 The following Utility API implements this type:
 [storageApiRef](./README.md#storage)
@@ -79,13 +79,13 @@ export type Observable&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L53).
+[packages/core-api/src/types.ts:53](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L53).
 
 Referenced by: [observe\$](#observe), [StorageApi](#storageapi).
 
 ### Observer
 
-This file contains non-react related core types used through Backstage.
+This file contains non-react related core types used throughout Backstage.
 
 Observer interface for consuming an Observer, see TC39.
 
@@ -98,7 +98,7 @@ export type Observer&lt;T&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L24).
+[packages/core-api/src/types.ts:24](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L24).
 
 Referenced by: [Observable](#observable).
 
@@ -144,7 +144,7 @@ export interface StorageApi {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/StorageApi.ts:31](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/StorageApi.ts#L31).
+[packages/core-api/src/apis/definitions/StorageApi.ts:31](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/StorageApi.ts#L31).
 
 Referenced by: [forBucket](#forbucket).
 
@@ -158,7 +158,7 @@ export type StorageValueChange&lt;T = any&gt; = {
 </pre>
 
 Defined at
-[packages/core-api/src/apis/definitions/StorageApi.ts:21](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/apis/definitions/StorageApi.ts#L21).
+[packages/core-api/src/apis/definitions/StorageApi.ts:21](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/apis/definitions/StorageApi.ts#L21).
 
 Referenced by: [observe\$](#observe), [StorageApi](#storageapi).
 
@@ -181,6 +181,6 @@ export type Subscription = {
 </pre>
 
 Defined at
-[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/0406ace29aba7332a98ff9ef9feedd65adc75223/packages/core-api/src/types.ts#L33).
+[packages/core-api/src/types.ts:33](https://github.com/spotify/backstage/blob/ca535f2f66c3a4980c80f4b1a049dfd07569010e/packages/core-api/src/types.ts#L33).
 
 Referenced by: [Observable](#observable).

--- a/packages/core-api/src/apis/definitions/OAuthRequestApi.ts
+++ b/packages/core-api/src/apis/definitions/OAuthRequestApi.ts
@@ -99,7 +99,7 @@ export type PendingAuthRequest = {
 export type OAuthRequestApi = {
   /**
    * A utility for showing login popups or similar things, and merging together multiple requests for
-   * different scopes into one request that inclues all scopes.
+   * different scopes into one request that includes all scopes.
    *
    * The passed in options provide information about the login provider, and how to handle auth requests.
    *
@@ -114,7 +114,7 @@ export type OAuthRequestApi = {
   ): AuthRequester<AuthResponse>;
 
   /**
-   * Observers panding auth requests. The returned observable will emit all
+   * Observers pending auth requests. The returned observable will emit all
    * current active auth request, at most one for each created auth requester.
    *
    * Each request has its own info about the login provider, forwarded from the auth requester options.

--- a/packages/core-api/src/apis/definitions/StorageApi.ts
+++ b/packages/core-api/src/apis/definitions/StorageApi.ts
@@ -52,7 +52,7 @@ export interface StorageApi {
   remove(key: string): Promise<void>;
 
   /**
-   * Save persistant data, and emit messages to anyone that is using observe$ for this key
+   * Save persistent data, and emit messages to anyone that is using observe$ for this key
    *
    * @param {String} key Unique key associated with the data.
    */

--- a/packages/core-api/src/types.ts
+++ b/packages/core-api/src/types.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * This file contains non-react related core types used throught Backstage.
+ * This file contains non-react related core types used throughout Backstage.
  */
 
 /**

--- a/packages/docgen/src/docgen/TypeLocator.ts
+++ b/packages/docgen/src/docgen/TypeLocator.ts
@@ -76,13 +76,7 @@ export default class TypeLocator {
           return;
         }
 
-        docMap.get(decl.constructorType)!.push({
-          node,
-          name: decl.name,
-          source,
-          args: Array.from(decl.initializer.arguments || []),
-          typeArgs: Array.from(decl.initializer.typeArguments || []),
-        });
+        docMap.get(decl.constructorType)!.push({ node, source, ...decl });
       });
     });
 
@@ -103,7 +97,8 @@ export default class TypeLocator {
   ):
     | {
         constructorType: ts.Type;
-        initializer: ts.CallExpression | ts.NewExpression;
+        args: ts.Expression[];
+        typeArgs: ts.TypeNode[];
         name: string;
       }
     | undefined {
@@ -137,6 +132,14 @@ export default class TypeLocator {
     const constructorType = this.checker.getTypeAtLocation(
       initializer.expression,
     );
-    return { constructorType, initializer, name: name.text };
+    const args = Array.from(initializer.arguments ?? []);
+    const typeNode = declaration.type;
+    const typeArgs = Array.from(
+      (typeNode && ts.isTypeReferenceNode(typeNode)
+        ? typeNode.typeArguments
+        : initializer.typeArguments) ?? [],
+    );
+
+    return { constructorType, args, typeArgs, name: name.text };
   }
 }


### PR DESCRIPTION
\+ regenerate docs