### PR TITLE
Apply development config in Helm charts

### DIFF
--- a/contrib/docker/kubernetes-example-backend/Dockerfile
+++ b/contrib/docker/kubernetes-example-backend/Dockerfile
@@ -30,6 +30,4 @@ RUN yarn install --frozen-lockfile --production
 # Do not use this Dockerfile outside of that command, as it will copy in the source code instead.
 COPY . .
 
-CMD ["node", "packages/backend"]
-
-
+CMD ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.development.yaml"]


### PR DESCRIPTION
This isn't the best fix because we're still using `NODE_ENV=development` in a "production" environment. Ideally we would stop doing this.

Right now, the Helm charts are broken because they deploy the backend straight into Error state.. This change will unbreak them for the moment.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
