### PR TITLE
Proper render boolean values on StructuredMetadataTable component

### DIFF
--- a/.changeset/popular-ghosts-remain.md
+++ b/.changeset/popular-ghosts-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Proper render boolean values on StructuredMetadataTable component

--- a/packages/core/src/components/StructuredMetadataTable/StructuredMetadataTable.stories.tsx
+++ b/packages/core/src/components/StructuredMetadataTable/StructuredMetadataTable.stories.tsx
@@ -24,6 +24,8 @@ const metadata = {
   description:
     'This is a long description of what this is doing (and some additional info too). \n It has new lines and extra text to make it especially annoying to render. But it just ignores them.',
   something: 'Yes',
+  'true value': true,
+  'false value': false,
   owner: 'squad',
   'longer key name': ['v1', 'v2', 'v3'],
   rules: {

--- a/packages/core/src/components/StructuredMetadataTable/StructuredMetadataTable.test.tsx
+++ b/packages/core/src/components/StructuredMetadataTable/StructuredMetadataTable.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import { startCase } from 'lodash';
 import React from 'react';
 import { StructuredMetadataTable } from './StructuredMetadataTable';
@@ -67,6 +67,26 @@ describe('<StructuredMetadataTable />', () => {
       });
       metadata.arrayField.forEach(value => {
         expect(getByText(value)).toBeInTheDocument();
+      });
+    });
+
+    it('Supports boolean values', () => {
+      const metadata = { foo: true, bar: false };
+      const expectedValues = [
+        ['Foo', '✅'],
+        ['Bar', '❌'],
+      ];
+
+      const { getAllByRole } = render(
+        <StructuredMetadataTable metadata={metadata} />,
+      );
+
+      getAllByRole('row').forEach((row, index) => {
+        const [firstCell, secondCell] = within(row).getAllByRole('cell');
+        const [expectedKey, expectedValue] = expectedValues[index];
+
+        expect(firstCell).toHaveTextContent(expectedKey);
+        expect(secondCell).toHaveTextContent(expectedValue);
       });
     });
 

--- a/packages/core/src/components/StructuredMetadataTable/StructuredMetadataTable.tsx
+++ b/packages/core/src/components/StructuredMetadataTable/StructuredMetadataTable.tsx
@@ -78,7 +78,7 @@ function renderMap(
 }
 
 function toValue(
-  value: ReactElement | object | Array<any>,
+  value: ReactElement | object | Array<any> | boolean,
   options?: any,
   nested?: boolean,
 ) {
@@ -92,6 +92,10 @@ function toValue(
 
   if (Array.isArray(value)) {
     return renderList(value, nested);
+  }
+
+  if (typeof value === 'boolean') {
+    return <Fragment>{value ? '✅' : '❌'}</Fragment>;
   }
 
   return <Fragment>{value}</Fragment>;


### PR DESCRIPTION
The StructuredMetadataTable was not rendering boolean values.
This change checks if the value is boolean and converts it to ✅   or ❌  when being rendered.

Closes https://github.com/spotify/backstage/issues/3073

### Before
![Screenshot 2020-10-29 at 18 28 09](https://user-images.githubusercontent.com/3709948/97609919-87815400-1a14-11eb-9d2b-c4ea2cf86e00.png)

### After
![Screenshot 2020-10-29 at 18 25 22](https://user-images.githubusercontent.com/3709948/97609971-97009d00-1a14-11eb-8737-3df282ab81a3.png)
