### PR TITLE
chore: remove redundant functions from microsite footer

### DIFF
--- a/microsite/core/Footer.js
+++ b/microsite/core/Footer.js
@@ -17,19 +17,6 @@
 const React = require('react');
 
 class Footer extends React.Component {
-  docUrl(doc, language) {
-    const baseUrl = this.props.config.baseUrl;
-    const docsUrl = this.props.config.docsUrl;
-    const docsPart = `${docsUrl ? `${docsUrl}/` : ''}`;
-    const langPart = `${language ? `${language}/` : ''}`;
-    return `${baseUrl}${docsPart}${langPart}${doc}`;
-  }
-
-  pageUrl(doc, language) {
-    const baseUrl = this.props.config.baseUrl;
-    return baseUrl + (language ? `${language}/` : '') + doc;
-  }
-
   render() {
     return (
       <footer className="nav-footer" id="footer">


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The docUrl and pageUrl functions are defined inside the Footer component of microsite, but they are not getting called anywhere. It is safe to remove them.

I encountered them while doing the Docusaurus migration, I am trying to keep less git diffs when I raise the migration PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
 