### PR TITLE
Use discovery api to build URLs in techdocs

### DIFF
--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -62,7 +62,13 @@ export async function createRouter({
   const router = Router();
 
   router.get('/metadata/mkdocs/*', async (req, res) => {
-    const storageUrl = config.getString('techdocs.storageUrl');
+    let storageUrl = config.getString('techdocs.storageUrl');
+    if (publisher instanceof LocalPublish) {
+      storageUrl = new URL(
+        new URL(storageUrl).pathname,
+        await discovery.getBaseUrl('techdocs'),
+      ).toString();
+    }
     const { '0': path } = req.params;
 
     const metadataURL = `${storageUrl}/${path}/techdocs_metadata.json`;
@@ -77,13 +83,14 @@ export async function createRouter({
   });
 
   router.get('/metadata/entity/:namespace/:kind/:name', async (req, res) => {
-    const baseUrl = config.getString('backend.baseUrl');
+    const catalogUrl = await discovery.getBaseUrl('catalog');
+
     const { kind, namespace, name } = req.params;
 
     try {
       const entity = (await (
         await fetch(
-          `${baseUrl}/api/catalog/entities/by-name/${kind}/${namespace}/${name}`,
+          `${catalogUrl}/entities/by-name/${kind}/${namespace}/${name}`,
         )
       ).json()) as Entity;
 


### PR DESCRIPTION
Use the discovery api to build catalog API URLs and URLs to locally published metadata. We're hitting an issue where the techdocs backend is using a public (external) url to fetch data. This causes us issues as we've put an authentication layer between the API and the client (at the kubernetes ingress) so the backend can't make calls using the public URL (as this resolves to the ingress). 



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
