### PR TITLE
TechDocs: mkdocs.yml config override

### DIFF
--- a/packages/techdocs-container/techdocs-core/requirements.txt
+++ b/packages/techdocs-container/techdocs-core/requirements.txt
@@ -13,4 +13,4 @@ Markdown==3.2.2
 # The linter using for Python
 # Note: This requires Python 3.6+ to run, but can format Python 2 code too.
 # https://github.com/psf/black
-black==20.8b1
+black==19.10b0

--- a/packages/techdocs-container/techdocs-core/requirements.txt
+++ b/packages/techdocs-container/techdocs-core/requirements.txt
@@ -13,4 +13,4 @@ Markdown==3.2.2
 # The linter using for Python
 # Note: This requires Python 3.6+ to run, but can format Python 2 code too.
 # https://github.com/psf/black
-black==19.10b0
+black==20.8b1

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -36,7 +36,10 @@ class TechDocsCore(BasePlugin):
 
         # Theme
         config["theme"] = Theme(
-            name="material", static_templates=["techdocs_metadata.json",],
+            name="material",
+            static_templates=[
+                "techdocs_metadata.json",
+            ],
         )
         config["theme"].dirs.append(tempfile.gettempdir())
 

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -36,10 +36,7 @@ class TechDocsCore(BasePlugin):
 
         # Theme
         config["theme"] = Theme(
-            name="material",
-            static_templates=[
-                "techdocs_metadata.json",
-            ],
+            name="material", static_templates=["techdocs_metadata.json",],
         )
         config["theme"].dirs.append(tempfile.gettempdir())
 

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -96,10 +96,8 @@ class TechDocsCore(BasePlugin):
         config["markdown_extensions"].append("plantuml_markdown")
 
         # merge config supplied by user in the mkdocs.yml
-        mdx_configs_keys = config["mdx_configs"].keys()
-        mdx_configs_override_keys = mdx_configs_override.keys()
-        for key in mdx_configs_override_keys:
-            if key in mdx_configs_keys:
+        for key in mdx_configs_override:
+            if key in config["mdx_configs"]:
                 default_config = config["mdx_configs"][key]
                 override_config = mdx_configs_override[key]
                 default_config.update(override_config)

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -31,7 +31,7 @@ class TechDocsCore(BasePlugin):
         )
 
         mdx_configs_override = {}
-        if "mdx_configs" in config.keys():
+        if "mdx_configs" in config:
             mdx_configs_override = config["mdx_configs"].copy()
 
         # Theme
@@ -52,10 +52,10 @@ class TechDocsCore(BasePlugin):
         config["plugins"]["monorepo"] = monorepo_plugin
 
         # Markdown Extensions
-        if "markdown_extensions" not in config.keys():
+        if "markdown_extensions" not in config:
             config["markdown_extensions"] = []
 
-        if "mdx_configs" not in config.keys():
+        if "mdx_configs" not in config:
             config["mdx_configs"] = {}
 
         config["markdown_extensions"].append("admonition")

--- a/packages/techdocs-container/techdocs-core/src/core.py
+++ b/packages/techdocs-container/techdocs-core/src/core.py
@@ -95,7 +95,7 @@ class TechDocsCore(BasePlugin):
         config["markdown_extensions"].append("markdown_inline_graphviz")
         config["markdown_extensions"].append("plantuml_markdown")
 
-        # merge or add config supplied by user in the mkdocs.yml
+        # merge config supplied by user in the mkdocs.yml
         mdx_configs_keys = config["mdx_configs"].keys()
         mdx_configs_override_keys = mdx_configs_override.keys()
         for key in mdx_configs_override_keys:
@@ -103,9 +103,5 @@ class TechDocsCore(BasePlugin):
                 default_config = config["mdx_configs"][key]
                 override_config = mdx_configs_override[key]
                 default_config.update(override_config)
-                config["mdx_configs"][key] = default_config
-            else:
-                config["mdx_configs"].append(key)
-                config["mdx_configs"][key] = mdx_configs_override[key]
 
         return config

--- a/packages/techdocs-container/techdocs-core/src/test_core.py
+++ b/packages/techdocs-container/techdocs-core/src/test_core.py
@@ -3,15 +3,17 @@ import mkdocs.config as config
 import mkdocs.plugins as plugins
 from .core import TechDocsCore
 
+
 class DummyTechDocsCorePlugin(plugins.BasePlugin):
     pass
+
 
 class TestTechDocsCoreConfig(unittest.TestCase):
     def setUp(self):
         self.techdocscore = TechDocsCore()
         self.plugin_collection = plugins.PluginCollection()
         plugin = DummyTechDocsCorePlugin()
-        self.plugin_collection['techdocs-core'] = plugin
+        self.plugin_collection["techdocs-core"] = plugin
         self.mkdocs_yaml_config = {"plugins": self.plugin_collection}
 
     def test_removes_techdocs_core_plugin_from_config(self):
@@ -24,9 +26,9 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.mkdocs_yaml_config["markdown_extension"].append(["toc"])
         self.mkdocs_yaml_config["mdx_configs"]["toc"] = {"toc_depth": 3}
         final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
-        self.assertTrue("toc"  in final_config["mdx_configs"])
-        self.assertTrue("permalink"  in final_config["mdx_configs"]["toc"])
-        self.assertTrue("toc_depth"  in final_config["mdx_configs"]["toc"])
+        self.assertTrue("toc" in final_config["mdx_configs"])
+        self.assertTrue("permalink" in final_config["mdx_configs"]["toc"])
+        self.assertTrue("toc_depth" in final_config["mdx_configs"]["toc"])
 
     def test_override_default_config_with_user_config(self):
         self.mkdocs_yaml_config["markdown_extension"] = []
@@ -34,6 +36,6 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.mkdocs_yaml_config["markdown_extension"].append(["toc"])
         self.mkdocs_yaml_config["mdx_configs"]["toc"] = {"permalink": False}
         final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
-        self.assertTrue("toc"  in final_config["mdx_configs"])
-        self.assertTrue("permalink"  in final_config["mdx_configs"]["toc"])
+        self.assertTrue("toc" in final_config["mdx_configs"])
+        self.assertTrue("permalink" in final_config["mdx_configs"]["toc"])
         self.assertFalse(final_config["mdx_configs"]["toc"]["permalink"])

--- a/packages/techdocs-container/techdocs-core/src/test_core.py
+++ b/packages/techdocs-container/techdocs-core/src/test_core.py
@@ -37,12 +37,3 @@ class TestTechDocsCoreConfig(unittest.TestCase):
         self.assertTrue("toc"  in final_config["mdx_configs"])
         self.assertTrue("permalink"  in final_config["mdx_configs"]["toc"])
         self.assertFalse(final_config["mdx_configs"]["toc"]["permalink"])
-
-    def test_add_user_config_to_default_config(self):
-        self.mkdocs_yaml_config["markdown_extension"] = []
-        self.mkdocs_yaml_config["mdx_configs"] = {}
-        self.mkdocs_yaml_config["markdown_extension"].append(["abc"])
-        self.mkdocs_yaml_config["mdx_configs"]["abc"] = {"testkey": "testvalue"}
-        final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
-        self.assertTrue("abc"  in final_config["mdx_configs"])
-        self.assertTrue("testkey"  in final_config["mdx_configs"]["abc"])

--- a/packages/techdocs-container/techdocs-core/src/test_core.py
+++ b/packages/techdocs-container/techdocs-core/src/test_core.py
@@ -1,0 +1,48 @@
+import unittest
+import mkdocs.config as config
+import mkdocs.plugins as plugins
+from .core import TechDocsCore
+
+class DummyTechDocsCorePlugin(plugins.BasePlugin):
+    pass
+
+class TestTechDocsCoreConfig(unittest.TestCase):
+    def setUp(self):
+        self.techdocscore = TechDocsCore()
+        self.plugin_collection = plugins.PluginCollection()
+        plugin = DummyTechDocsCorePlugin()
+        self.plugin_collection['techdocs-core'] = plugin
+        self.mkdocs_yaml_config = {"plugins": self.plugin_collection}
+
+    def test_removes_techdocs_core_plugin_from_config(self):
+        final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
+        self.assertTrue("techdocs-core" not in final_config["plugins"])
+
+    def test_merge_default_config_and_user_config(self):
+        self.mkdocs_yaml_config["markdown_extension"] = []
+        self.mkdocs_yaml_config["mdx_configs"] = {}
+        self.mkdocs_yaml_config["markdown_extension"].append(["toc"])
+        self.mkdocs_yaml_config["mdx_configs"]["toc"] = {"toc_depth": 3}
+        final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
+        self.assertTrue("toc"  in final_config["mdx_configs"])
+        self.assertTrue("permalink"  in final_config["mdx_configs"]["toc"])
+        self.assertTrue("toc_depth"  in final_config["mdx_configs"]["toc"])
+
+    def test_override_default_config_with_user_config(self):
+        self.mkdocs_yaml_config["markdown_extension"] = []
+        self.mkdocs_yaml_config["mdx_configs"] = {}
+        self.mkdocs_yaml_config["markdown_extension"].append(["toc"])
+        self.mkdocs_yaml_config["mdx_configs"]["toc"] = {"permalink": False}
+        final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
+        self.assertTrue("toc"  in final_config["mdx_configs"])
+        self.assertTrue("permalink"  in final_config["mdx_configs"]["toc"])
+        self.assertFalse(final_config["mdx_configs"]["toc"]["permalink"])
+
+    def test_add_user_config_to_default_config(self):
+        self.mkdocs_yaml_config["markdown_extension"] = []
+        self.mkdocs_yaml_config["mdx_configs"] = {}
+        self.mkdocs_yaml_config["markdown_extension"].append(["abc"])
+        self.mkdocs_yaml_config["mdx_configs"]["abc"] = {"testkey": "testvalue"}
+        final_config = self.techdocscore.on_config(self.mkdocs_yaml_config)
+        self.assertTrue("abc"  in final_config["mdx_configs"])
+        self.assertTrue("testkey"  in final_config["mdx_configs"]["abc"])


### PR DESCRIPTION
Fixes #3017 

In techdocs-core, we create a default config for mkdocs with plugins, extensions, and extension configs but any extension configs provided in the mkdocs yaml is ignored.

This PR merges or overrides the default configs with configs provided in the mkdocs.yml.

Added a test file to check a couple of use cases. To run the test
- Install pytest: pip install pytest
- Run the test: pytest test_core.py (from the packages/techdocs-container/techdocs-core/src folder)

Let me know if you have any inputs on how to make the tests setup better.

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
