### PR TITLE
fix: fix edge case of sonarqube plugin if no quality gate was computed

### DIFF
--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -51,6 +51,9 @@ const useStyles = makeStyles(theme => ({
     margin: 0,
     backgroundColor: theme.palette.success.main,
   },
+  badgeUnknown: {
+    backgroundColor: theme.palette.grey[500],
+  },
   header: {
     padding: theme.spacing(2, 2, 2, 2.5),
   },
@@ -104,17 +107,20 @@ export const SonarQubeCard = ({
         }
       : undefined;
 
-  const gatePassed = value && value.metrics.alert_status === 'OK';
-
   const classes = useStyles();
+  let gateLabel = 'Not computed';
+  let gateColor = classes.badgeUnknown;
+
+  if (value?.metrics.alert_status) {
+    const gatePassed = value.metrics.alert_status === 'OK';
+    gateLabel = gatePassed ? 'Gate passed' : 'Gate failed';
+    gateColor = gatePassed ? classes.badgeSuccess : classes.badgeError;
+  }
 
   const qualityBadge = !loading && value && (
     <Chip
-      label={gatePassed ? 'Gate Passed' : 'Gate Failed'}
-      classes={{
-        root: gatePassed ? classes.badgeSuccess : classes.badgeError,
-        label: classes.badgeLabel,
-      }}
+      label={gateLabel}
+      classes={{ root: gateColor, label: classes.badgeLabel }}
     />
   );
 


### PR DESCRIPTION
Initially no quality gate is available, till the first analysis. Previously this was handled as "failed". Now it has its own state.

![image](https://user-images.githubusercontent.com/648527/97904260-8320a800-1d40-11eb-90c0-a6b89ae2c869.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
