### PR TITLE
TechDocs: Release new version of mkdocs-techdocs-core

### DIFF
--- a/packages/techdocs-container/techdocs-core/README.md
+++ b/packages/techdocs-container/techdocs-core/README.md
@@ -82,6 +82,10 @@ Extensions:
 
 ## Changelog
 
+### 0.0.11
+
+- Any MkDocs plugin configurations from mkdocs.yml will now work and override the default configuration. See https://github.com/spotify/backstage/issues/3017
+
 ### 0.0.10
 
 - Pin Markdown version to fix issue with Graphviz

--- a/packages/techdocs-container/techdocs-core/setup.py
+++ b/packages/techdocs-container/techdocs-core/setup.py
@@ -23,7 +23,7 @@ with open(path.join(this_dir, "README.md"), encoding="utf-8") as file:
 
 setup(
     name="mkdocs-techdocs-core",
-    version="0.0.10",
+    version="0.0.11",
     description="A Mkdocs package that contains TechDocs defaults",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The Python package needs to be released after
https://github.com/spotify/backstage/pull/3199
https://github.com/spotify/backstage/issues/3017