### PR TITLE
TechDocs: Release new version of techdocs-container

### DIFF
--- a/packages/techdocs-container/Dockerfile
+++ b/packages/techdocs-container/Dockerfile
@@ -18,7 +18,7 @@ FROM python:3.8-alpine
 RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz ttf-dejavu fontconfig
 
 RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2020.16.jar/download && echo "c789ace48347c43073232b1458badc5810c01fe8  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
-RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.0.10
+RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.0.11
 
 # Create script to call plantuml.jar from a location in path
 


### PR DESCRIPTION
Includes upgrade of mkdocs-techdocs-core package from 0.0.10 to 0.0.11

Merge only when https://github.com/spotify/backstage/pull/3207 has released the 0.0.11 version of the package on pypi https://pypi.org/project/mkdocs-techdocs-core/.