### PR TITLE
SAML origin url option

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -198,6 +198,7 @@ auth:
     saml:
       entryPoint: 'http://localhost:7001/'
       issuer: 'passport-saml'
+      origin: 'http://localhost:3000'
     okta:
       development:
         clientId:

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -42,12 +42,10 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
   private readonly strategy: SamlStrategy;
   private readonly tokenIssuer: TokenIssuer;
   private readonly appUrl: string;
-  private readonly origin: string;
 
   constructor(options: SAMLProviderOptions) {
     this.appUrl = options.appUrl;
     this.tokenIssuer = options.tokenIssuer;
-    this.origin = options.origin;
     this.strategy = new SamlStrategy({ ...options }, ((
       profile: SamlProfile,
       done: PassportDoneCallback<SamlInfo>,
@@ -86,7 +84,7 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
         claims: { sub: id },
       });
 
-      return postMessageResponse(res, this.origin, {
+      return postMessageResponse(res, this.appUrl, {
         type: 'authorization_response',
         response: {
           providerInfo: {},
@@ -95,7 +93,7 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
         },
       });
     } catch (error) {
-      return postMessageResponse(res, this.origin, {
+      return postMessageResponse(res, this.appUrl, {
         type: 'authorization_response',
         error: {
           name: error.name,
@@ -120,7 +118,6 @@ type SAMLProviderOptions = {
   path: string;
   tokenIssuer: TokenIssuer;
   appUrl: string;
-  origin: string;
 };
 
 export const createSamlProvider: AuthProviderFactory = ({
@@ -138,8 +135,7 @@ export const createSamlProvider: AuthProviderFactory = ({
     issuer,
     path: `${url.pathname}/${providerId}/handler/frame`,
     tokenIssuer,
-    appUrl: globalConfig.appUrl,
-    origin: origin ? origin : globalConfig.appUrl,
+    appUrl: origin ? origin : globalConfig.appUrl,
   };
 
   return new SamlAuthProvider(opts);

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -42,10 +42,12 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
   private readonly strategy: SamlStrategy;
   private readonly tokenIssuer: TokenIssuer;
   private readonly appUrl: string;
+  private readonly origin: string;
 
   constructor(options: SAMLProviderOptions) {
     this.appUrl = options.appUrl;
     this.tokenIssuer = options.tokenIssuer;
+    this.origin = options.origin;
     this.strategy = new SamlStrategy({ ...options }, ((
       profile: SamlProfile,
       done: PassportDoneCallback<SamlInfo>,
@@ -84,7 +86,7 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
         claims: { sub: id },
       });
 
-      return postMessageResponse(res, this.appUrl, {
+      return postMessageResponse(res, this.origin, {
         type: 'authorization_response',
         response: {
           providerInfo: {},
@@ -93,7 +95,7 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
         },
       });
     } catch (error) {
-      return postMessageResponse(res, this.appUrl, {
+      return postMessageResponse(res, this.origin, {
         type: 'authorization_response',
         error: {
           name: error.name,
@@ -118,6 +120,7 @@ type SAMLProviderOptions = {
   path: string;
   tokenIssuer: TokenIssuer;
   appUrl: string;
+  origin: string;
 };
 
 export const createSamlProvider: AuthProviderFactory = ({
@@ -129,12 +132,14 @@ export const createSamlProvider: AuthProviderFactory = ({
   const providerId = 'saml';
   const entryPoint = config.getString('entryPoint');
   const issuer = config.getString('issuer');
+  const origin = config.getString('origin');
   const opts = {
     entryPoint,
     issuer,
     path: `${url.pathname}/${providerId}/handler/frame`,
     tokenIssuer,
     appUrl: globalConfig.appUrl,
+    origin: origin ? origin : globalConfig.appUrl,
   };
 
   return new SamlAuthProvider(opts);


### PR DESCRIPTION
added option to set custom SAML `postMessage` origin URL. 

Context: Setting appUrl to localhost in docker container will restrict external traffic. Setting it to `0.0.0.0` will cause `postMessage` origin not match.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/spotify/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
