### PR TITLE
docs/api: fix link in utility APIs

### DIFF
--- a/docs/api/utility-apis.md
+++ b/docs/api/utility-apis.md
@@ -160,7 +160,8 @@ const app = createApp({
 ```
 
 A common pattern is to export a list of all APIs from `apis.ts`, next to
-`App.tsx`. See the [example app in this repo](../../packages/app/src/apis.ts)
+`App.tsx`. See the
+[example app in this repo](https://github.com/backstage/backstage/blob/master/packages/app/src/apis.ts)
 for an example.
 
 ## Custom implementations of Utility APIs


### PR DESCRIPTION
Can't use relative links to code in docs. Quick fix for now but should add this to the link verification script 😅 