### PR TITLE
Fix typo in Kubernetes contrib folder name

### DIFF
--- a/contrib/kubernetes/plain_single_backend_deployment/README.md
+++ b/contrib/kubernetes/plain_single_backend_deployment/README.md
@@ -13,7 +13,7 @@ yarn install
 
 yarn docker-build
 
-kubectl apply -f contrib/kubernetes/plain_single_backend_deplyoment/deployment.yaml
+kubectl apply -f contrib/kubernetes/plain_single_backend_deployment/deployment.yaml
 ```
 
 You can use the following commands to monitor the deployment:

--- a/contrib/kubernetes/plain_single_backend_deployment/deployment.yaml
+++ b/contrib/kubernetes/plain_single_backend_deployment/deployment.yaml
@@ -38,12 +38,12 @@ spec:
             - name: NODE_ENV
               value: development
 
-              # This makes it possible for the app to reach the backend when serving through `kubectl proxy`
-              # If you expose the service using for example an ingress controller, you should
-              # switch this out or remove it.
-              #
-              # Note that we're not setting app.baseUrl here, as setting the base path is not working at the moment.
-              # Further work is needed around the routing in the frontend or react-router before we can support that.
+            # This makes it possible for the app to reach the backend when serving through `kubectl proxy`
+            # If you expose the service using for example an ingress controller, you should
+            # switch this out or remove it.
+            #
+            # Note that we're not setting app.baseUrl here, as setting the base path is not working at the moment.
+            # Further work is needed around the routing in the frontend or react-router before we can support that.
             - name: APP_CONFIG_backend_baseUrl
               value: http://localhost:8001/api/v1/namespaces/backstage/services/backstage-backend:http/proxy
 

--- a/docs/getting-started/deployment-k8s.md
+++ b/docs/getting-started/deployment-k8s.md
@@ -9,5 +9,5 @@ Beyond that point we do not have an opinionated way to deploy Backstage within
 Kubernetes, as each cluster has its own unique set of tooling and patterns.
 
 We do provide examples to help you get started though. Check out
-[this example](https://github.com/backstage/backstage/tree/master/contrib/kubernetes/plain_single_backend_deplyoment/)
+[this example](https://github.com/backstage/backstage/tree/master/contrib/kubernetes/plain_single_backend_deployment/)
 for a basic single-deployment setup.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes a minor typo in a folder name for the contributed Kubernetes example:

```
plain_single_backend_deplyoment -> plain_single_backend_deployment
                        ^^^                                ^^^
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
