### PR TITLE
Add window config loader and allow composition of loaders

### DIFF
--- a/.changeset/3194.md
+++ b/.changeset/3194.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core': patch
+---
+
+Extend default config loader to read config from the window object.
+
+Config will be read from `window.__APP_CONFIG__` which should be an object.

--- a/packages/core/src/api-wrappers/createApp.tsx
+++ b/packages/core/src/api-wrappers/createApp.tsx
@@ -67,6 +67,13 @@ export const defaultConfigLoader: AppConfigLoader = async (
     }
   }
 
+  const windowAppConfig = (window as any).__APP_CONFIG__;
+  if (windowAppConfig) {
+    configs.push({
+      context: 'window',
+      data: windowAppConfig,
+    });
+  }
   return configs;
 };
 


### PR DESCRIPTION
I think this should resolve #3194. Updates the default config loader to read a config object from `window.__APP_CONFIG__`


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
