### PR TITLE
Fix styling issue on Cost Insights product panels with no cost

### DIFF
--- a/.changeset/cost-insights-quick-suits-brake.md
+++ b/.changeset/cost-insights-quick-suits-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Fix styling issue on Cost Insights product panels with no cost

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -253,7 +253,7 @@ costInsights:
       name: Cloud Storage
       icon: storage
     bigQuery:
-      name: Big Query
+      name: BigQuery
       icon: search
   metrics:
     DAU:

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsCard.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsCard.tsx
@@ -16,7 +16,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { InfoCard, useApi } from '@backstage/core';
-import { Box } from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import { costInsightsApiRef } from '../../api';
 import { PeriodSelect } from '../PeriodSelect';
@@ -58,7 +58,7 @@ export const ProductInsightsCard = ({ product }: ProductInsightsCardProps) => {
   const dispatchLoadingProduct = useCallback(dispatchLoading, [product.kind]);
 
   const amount = resource?.entities?.length || 0;
-  const hasCostsWithinTimeframe = resource?.change && !!amount;
+  const hasCostsWithinTimeframe = !!(resource?.change && amount);
 
   const previousName = formatPeriod(
     productFilter.duration,
@@ -71,9 +71,9 @@ export const ProductInsightsCard = ({ product }: ProductInsightsCardProps) => {
     true,
   );
 
-  const subheader = amount
+  const subheader = hasCostsWithinTimeframe
     ? `${amount} ${pluralOf(amount, 'entity', 'entities')}, sorted by cost`
-    : `There are no ${product.name} costs within this timeframe for your team's projects.`;
+    : null;
 
   const costStart = resource?.aggregation[0] || 0;
   const costEnd = resource?.aggregation[1] || 0;
@@ -144,26 +144,29 @@ export const ProductInsightsCard = ({ product }: ProductInsightsCardProps) => {
   return (
     <InfoCard title={product.name} subheader={subheader} {...infoCardProps}>
       <ScrollAnchor behavior="smooth" top={-12} />
-      {hasCostsWithinTimeframe && (
-        <>
-          <Box display="flex" flexDirection="column">
-            <Box pb={2}>
-              <ResourceGrowthBarChartLegend
-                duration={productFilter.duration}
-                change={resource.change!}
-                previousName={previousName}
-                currentName={currentName}
-                costStart={costStart}
-                costEnd={costEnd}
-              />
-            </Box>
-            <ResourceGrowthBarChart
+      {hasCostsWithinTimeframe ? (
+        <Box display="flex" flexDirection="column">
+          <Box pb={2}>
+            <ResourceGrowthBarChartLegend
+              duration={productFilter.duration}
+              change={resource.change!}
               previousName={previousName}
               currentName={currentName}
-              resources={resource.entities || []}
+              costStart={costStart}
+              costEnd={costEnd}
             />
           </Box>
-        </>
+          <ResourceGrowthBarChart
+            previousName={previousName}
+            currentName={currentName}
+            resources={resource.entities || []}
+          />
+        </Box>
+      ) : (
+        <Typography>
+          There are no {product.name} costs within this timeframe for your
+          team's projects.
+        </Typography>
       )}
     </InfoCard>
   );


### PR DESCRIPTION
Fixes a styling issue when no costs exist for a given product:

![Screen Shot 2020-11-04 at 10 29 07](https://user-images.githubusercontent.com/556258/98150710-54afe380-1e8c-11eb-82b8-b789709ea94b.png)

Moves the empty state message to the CardContent area instead of the CardHeader:

![Screen Shot 2020-11-04 at 10 26 33](https://user-images.githubusercontent.com/556258/98150815-76a96600-1e8c-11eb-90c1-b7a7ca88284f.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
