### PR TITLE
Fix double divider on InfoCard

### DIFF
--- a/.changeset/silent-dodos-repeat.md
+++ b/.changeset/silent-dodos-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Fix divider prop not respected on InfoCard

--- a/packages/core/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.tsx
@@ -143,7 +143,7 @@ type Props = {
 export const InfoCard = ({
   title,
   subheader,
-  divider,
+  divider = true,
   deepLink,
   slackChannel = '#backstage',
   variant,
@@ -190,23 +190,20 @@ export const InfoCard = ({
     <Card style={calculatedStyle} className={className}>
       <ErrorBoundary slackChannel={slackChannel}>
         {title && (
-          <>
-            <CardHeader
-              classes={{
-                root: classes.header,
-                title: classes.headerTitle,
-                subheader: classes.headerSubheader,
-                avatar: classes.headerAvatar,
-                action: classes.headerAction,
-                content: classes.headerContent,
-              }}
-              title={title}
-              subheader={subheader}
-              style={{ ...headerStyle }}
-              {...headerProps}
-            />
-            <Divider />
-          </>
+          <CardHeader
+            classes={{
+              root: classes.header,
+              title: classes.headerTitle,
+              subheader: classes.headerSubheader,
+              avatar: classes.headerAvatar,
+              action: classes.headerAction,
+              content: classes.headerContent,
+            }}
+            title={title}
+            subheader={subheader}
+            style={{ ...headerStyle }}
+            {...headerProps}
+          />
         )}
         {actionsTopRight && (
           <CardActionsTopRight>{actionsTopRight}</CardActionsTopRight>


### PR DESCRIPTION
The `InfoCard` component has a divider prop that is not respected. Or rather, it is respected for one Divider but there's errantly two Dividers in the header (which one can see through DOM inspection or 1px-sensitive eyesight). See line 214 for the other. I removed the extraneous Divider in CardHeader and set the prop default to `true` to mimic the previous behavior.

![Screen Shot 2020-11-04 at 11 23 50](https://user-images.githubusercontent.com/556258/98153349-48c62080-1e90-11eb-82e4-79ad03018f69.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
