### PR TITLE
CLI: Bypass build error to complete plugin creation

### DIFF
--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -146,7 +146,7 @@ async function buildPlugin(pluginFolder: string) {
       await exec(command).catch(error => {
         process.stdout.write(error.stderr);
         process.stdout.write(error.stdout);
-        throw new Error(`Could not execute command ${chalk.cyan(command)}`);
+        Task.error(`Warning: Could not execute command ${chalk.cyan(command)}`);
       });
     });
   }

--- a/packages/cli/src/commands/create-plugin/createPlugin.ts
+++ b/packages/cli/src/commands/create-plugin/createPlugin.ts
@@ -140,15 +140,21 @@ async function buildPlugin(pluginFolder: string) {
     'yarn build',
   ];
   for (const command of commands) {
-    await Task.forItem('executing', command, async () => {
-      process.chdir(pluginFolder);
-
-      await exec(command).catch(error => {
+    try {
+      await Task.forItem('executing', command, async () => {
+        process.chdir(pluginFolder);
+        await exec(command);
+      }).catch(error => {
         process.stdout.write(error.stderr);
         process.stdout.write(error.stdout);
-        Task.error(`Warning: Could not execute command ${chalk.cyan(command)}`);
+        throw new Error(
+          `Warning: Could not execute command ${chalk.cyan(command)}`,
+        );
       });
-    });
+    } catch (error) {
+      Task.error(error.message);
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
With this pull request build errors of the new plugin will not stop the creation. There will appear a warning in the console and the occured error will also be printed out.

![Screenshot 2020-11-05 110354](https://user-images.githubusercontent.com/8904624/98227293-6dd19680-1f57-11eb-8550-47db5c987993.png)

This fixes the bug and should give the user enough information. Nevertheless it might be more elegant and longer lasting to add a `Task.warn(...)` to the class Task and use that instead.

Closes #3227 

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [x] Prettier run on changed files

Note: The force-pushed was due to a issue I had with a changed, forked master branch. Everything solved now - just looks a little weird in the history
