### PR TITLE
fix text color of tech-radar footer

### DIFF
--- a/.changeset/smooth-hairs-breathe.md
+++ b/.changeset/smooth-hairs-breathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Make the footer color of the tech-radar work in both light and dark theme.

--- a/plugins/tech-radar/src/components/RadarFooter/RadarFooter.tsx
+++ b/plugins/tech-radar/src/components/RadarFooter/RadarFooter.tsx
@@ -15,19 +15,19 @@
  */
 
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core';
 
 export type Props = {
   x: number;
   y: number;
 };
 
-const useStyles = makeStyles<Theme>(() => ({
+const useStyles = makeStyles(theme => ({
   text: {
     pointerEvents: 'none',
     userSelect: 'none',
     fontSize: '10px',
-    fill: '#000',
+    fill: theme.palette.text.secondary,
   },
 }));
 


### PR DESCRIPTION
Uses the secondary text color.

<img width="268" alt="Bildschirmfoto 2020-11-05 um 08 53 57" src="https://user-images.githubusercontent.com/648527/98212846-7a002880-1f44-11eb-96ab-8da03dd0bbfb.png">
<img width="268" alt="Bildschirmfoto 2020-11-05 um 08 53 40" src="https://user-images.githubusercontent.com/648527/98212849-7a98bf00-1f44-11eb-99b9-f16aa16add1e.png">

Closes #3243

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
