### PR TITLE
Export `AuthProviders`, `DefaultProviderSettings` and `ProviderSettingsItem`

### DIFF
--- a/.changeset/moody-pugs-smoke.md
+++ b/.changeset/moody-pugs-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Export `AuthProviders`, `DefaultProviderSettings` and `ProviderSettingsItem`.

--- a/plugins/user-settings/src/components/AuthProviders/index.ts
+++ b/plugins/user-settings/src/components/AuthProviders/index.ts
@@ -16,3 +16,4 @@
 
 export { AuthProviders } from './AuthProviders';
 export { DefaultProviderSettings } from './DefaultProviderSettings';
+export { ProviderSettingsItem } from './ProviderSettingsItem';

--- a/plugins/user-settings/src/components/index.ts
+++ b/plugins/user-settings/src/components/index.ts
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { plugin } from './plugin';
-export * from './components/';
+export { Settings } from './Settings';
+export { SettingsPage as Router } from './SettingsPage';
+export * from './AuthProviders';


### PR DESCRIPTION
`Settings` allows to pass `providerSettings`, but right now there isn't a way to constuct them out of the existing components as they aren't exported.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
