### PR TITLE
[plugin-jenkins] Add tooltip to Jenkins build rerun

### DIFF
--- a/.changeset/calm-emus-push.md
+++ b/.changeset/calm-emus-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins': minor
+---
+
+Add tooltip for Jenkins rerun button

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -191,6 +191,7 @@ toc
 tolerations
 Tolerations
 toolsets
+tooltip
 touchpoints
 ui
 upvote

--- a/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { FC } from 'react';
-import { Box, IconButton, Link, Typography } from '@material-ui/core';
+import { Box, IconButton, Link, Typography, Tooltip } from '@material-ui/core';
 import RetryIcon from '@material-ui/icons/Replay';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
@@ -179,9 +179,11 @@ const generatedColumns: TableColumn[] = [
     title: 'Actions',
     sorting: false,
     render: (row: Partial<CITableBuildInfo>) => (
-      <IconButton onClick={row.onRestartClick}>
-        <RetryIcon />
-      </IconButton>
+      <Tooltip title="Rerun build">
+        <IconButton onClick={row.onRestartClick}>
+          <RetryIcon />
+        </IconButton>
+      </Tooltip>
     ),
     width: '10%',
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Adds a tool tip when highlighting over the Jenkins rerun button on the CI/CD page.

![image](https://user-images.githubusercontent.com/33203301/98267390-55fb1200-1f59-11eb-848a-8c87e7327fb5.png)

Marked as minor, under the guise that _pure semver_ would suggest patches should only be for bugfixes?  But happy to change back to a patch as this is really small.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
