### PR TITLE
Improve styling of outlined chips in dark mode

### DIFF
--- a/.changeset/strong-moose-cough.md
+++ b/.changeset/strong-moose-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+Improve styling of outlined chips in dark mode.

--- a/packages/core/src/components/Chip/Chip.stories.tsx
+++ b/packages/core/src/components/Chip/Chip.stories.tsx
@@ -39,3 +39,5 @@ export const SmallDeletable = () => (
 export const SmallNotDeletable = () => (
   <Chip label="Small not deletable" size="small" />
 );
+
+export const Outline = () => <Chip label="Outline" variant="outlined" />;

--- a/packages/theme/src/baseTheme.ts
+++ b/packages/theme/src/baseTheme.ts
@@ -209,9 +209,12 @@ export function createThemeOverrides(theme: BackstageTheme): Overrides {
         // By default there's no margin, but it's usually wanted, so we add some trailing margin
         marginRight: theme.spacing(1),
         marginBottom: theme.spacing(1),
+        color: theme.palette.grey[900],
+      },
+      outlined: {
+        color: theme.palette.text.primary,
       },
       label: {
-        color: theme.palette.grey[900],
         lineHeight: `${theme.spacing(2.5)}px`,
         fontWeight: theme.typography.fontWeightMedium,
         fontSize: `${theme.spacing(1.75)}px`,


### PR DESCRIPTION
#3224 introduced using outlined chips that weren't available in our storybook. However they look wrong in dark mode. I added a story and fixed the theming. 

**Before**
![image](https://user-images.githubusercontent.com/648527/98271498-49de7700-1f90-11eb-96c3-c4a9c18a2464.png)
![image](https://user-images.githubusercontent.com/648527/98271476-4519c300-1f90-11eb-8c75-f13a88647bdb.png)

**After**
![image](https://user-images.githubusercontent.com/648527/98271537-5531a280-1f90-11eb-8667-86c956161aac.png)
![image](https://user-images.githubusercontent.com/648527/98271545-56fb6600-1f90-11eb-84fb-8ac85252da2b.png)

Here is how it looks in the table now:

<img width="480" alt="Bildschirmfoto 2020-11-05 um 17 52 02" src="https://user-images.githubusercontent.com/648527/98271428-3af7c480-1f90-11eb-8195-c22f835e2183.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
