### PR TITLE
Update Node LTS in Getting Started docs

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -24,7 +24,7 @@ Requests towards this repo.
 Backstage provides the `@backstage/create-app` package to scaffold standalone
 instances of Backstage. You will need to have
 [Node.js](https://nodejs.org/en/download/) Active LTS Release installed
-(currently v12), [Yarn](https://classic.yarnpkg.com/en/docs/install) and
+(currently v14), [Yarn](https://classic.yarnpkg.com/en/docs/install) and
 [Python](https://www.python.org/downloads/) (although you likely have it
 already). You will also need to have
 [Docker](https://docs.docker.com/engine/install/) installed to use some features


### PR DESCRIPTION
I've tested and the v14 [Fermium LTS](https://nodejs.org/en/about/releases/) works fine.