### PR TITLE
Fix reference to Catalog path in overview docs

### DIFF
--- a/docs/features/software-catalog/index.md
+++ b/docs/features/software-catalog/index.md
@@ -33,10 +33,10 @@ More specifically, the Service Catalog enables two main use-cases:
 
 ## Getting Started
 
-The Software Catalog is available to browse on the start page at `/`. If you've
-followed [Installing in your Backstage App](./installation.md) in your separate
-App or [Getting Started with Backstage](../../getting-started) for this repo,
-you should be able to browse the catalog at `http://localhost:3000`.
+The Software Catalog is available to browse at `/catalog`. If you've followed
+[Installing in your Backstage App](./installation.md) in your separate App or
+[Getting Started with Backstage](../../getting-started) for this repo, you
+should be able to browse the catalog at `http://localhost:3000`.
 
 ![](../../assets/software-catalog/service-catalog-home.png)
 


### PR DESCRIPTION
While you do end up on the catalog if you visit `/`, the browser URL is actually `/catalog`.