### PR TITLE
feat: add internal routing to BottomLink

### DIFF
--- a/.changeset/dry-pillows-carry.md
+++ b/.changeset/dry-pillows-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+The BottomLink is now able to handle with internal routes.

--- a/.changeset/dry-pillows-carry.md
+++ b/.changeset/dry-pillows-carry.md
@@ -2,4 +2,5 @@
 '@backstage/core': patch
 ---
 
-The BottomLink is now able to handle with internal routes.
+- The BottomLink is now able to handle with internal routes.
+- @backstage/core Link component detect whether it's an external link or not, and render accordingly

--- a/packages/core/src/components/Link/Link.test.tsx
+++ b/packages/core/src/components/Link/Link.test.tsx
@@ -34,9 +34,43 @@ describe('<Link />', () => {
       ),
     );
     expect(() => getByText(testString)).toThrow();
+    expect(getByText(linkText, { selector: 'a' })).not.toHaveAttribute(
+      'to',
+      'test',
+    );
     await act(async () => {
       fireEvent.click(getByText(linkText));
     });
     expect(getByText(testString)).toBeInTheDocument();
+  });
+
+  it('navigates external href with external https link', async () => {
+    const linkText = 'Navigate!';
+    const { getByText } = render(
+      <Link to="https://backstage.io">{linkText}</Link>,
+    );
+    expect(getByText(linkText, { selector: 'a' })).toHaveAttribute(
+      'href',
+      'https://backstage.io',
+    );
+    expect(getByText(linkText, { selector: 'a' })).toHaveAttribute(
+      'to',
+      'https://backstage.io',
+    );
+  });
+
+  it('navigates external href with external http link', async () => {
+    const linkText = 'Navigate!';
+    const { getByText } = render(
+      <Link to="http://backstage.io">{linkText}</Link>,
+    );
+    expect(getByText(linkText, { selector: 'a' })).toHaveAttribute(
+      'href',
+      'http://backstage.io',
+    );
+    expect(getByText(linkText, { selector: 'a' })).toHaveAttribute(
+      'to',
+      'http://backstage.io',
+    );
   });
 });

--- a/packages/core/src/components/Link/Link.test.tsx
+++ b/packages/core/src/components/Link/Link.test.tsx
@@ -34,43 +34,9 @@ describe('<Link />', () => {
       ),
     );
     expect(() => getByText(testString)).toThrow();
-    expect(getByText(linkText, { selector: 'a' })).not.toHaveAttribute(
-      'to',
-      'test',
-    );
     await act(async () => {
       fireEvent.click(getByText(linkText));
     });
     expect(getByText(testString)).toBeInTheDocument();
-  });
-
-  it('navigates external href with external https link', async () => {
-    const linkText = 'Navigate!';
-    const { getByText } = render(
-      <Link to="https://backstage.io">{linkText}</Link>,
-    );
-    expect(getByText(linkText, { selector: 'a' })).toHaveAttribute(
-      'href',
-      'https://backstage.io',
-    );
-    expect(getByText(linkText, { selector: 'a' })).toHaveAttribute(
-      'to',
-      'https://backstage.io',
-    );
-  });
-
-  it('navigates external href with external http link', async () => {
-    const linkText = 'Navigate!';
-    const { getByText } = render(
-      <Link to="http://backstage.io">{linkText}</Link>,
-    );
-    expect(getByText(linkText, { selector: 'a' })).toHaveAttribute(
-      'href',
-      'http://backstage.io',
-    );
-    expect(getByText(linkText, { selector: 'a' })).toHaveAttribute(
-      'to',
-      'http://backstage.io',
-    );
   });
 });

--- a/packages/core/src/components/Link/Link.tsx
+++ b/packages/core/src/components/Link/Link.tsx
@@ -25,6 +25,12 @@ type Props = ComponentProps<typeof MaterialLink> &
  * Thin wrapper on top of material-ui's Link component
  * Makes the Link to utilise react-router
  */
-export const Link = React.forwardRef<any, Props>((props, ref) => (
-  <MaterialLink ref={ref} component={RouterLink} {...props} />
-));
+export const Link = React.forwardRef<any, Props>((props, ref) => {
+  const to = props.to.toString();
+  const external = /^https?:\/\//.test(to);
+  return !external ? (
+    <MaterialLink ref={ref} component={RouterLink} {...props} />
+  ) : (
+    <MaterialLink href={to} {...props} />
+  );
+});

--- a/packages/core/src/components/Link/Link.tsx
+++ b/packages/core/src/components/Link/Link.tsx
@@ -26,11 +26,12 @@ type Props = ComponentProps<typeof MaterialLink> &
  * Makes the Link to utilise react-router
  */
 export const Link = React.forwardRef<any, Props>((props, ref) => {
-  const to = props.to.toString();
-  const external = /^https?:\/\//.test(to);
-  return !external ? (
-    <MaterialLink ref={ref} component={RouterLink} {...props} />
+  const to = String(props.to);
+  return /^https?:\/\//.test(to) ? (
+    // External links
+    <MaterialLink ref={ref} href={to} {...props} />
   ) : (
-    <MaterialLink href={to} {...props} />
+    // Interact with React Router for internal links
+    <MaterialLink ref={ref} component={RouterLink} {...props} />
   );
 });

--- a/packages/core/src/layout/BottomLink/BottomLink.test.tsx
+++ b/packages/core/src/layout/BottomLink/BottomLink.test.tsx
@@ -22,23 +22,9 @@ const minProps = {
   title: 'A deepLink title',
   link: '/mocked',
 };
-
-const internalLinkProps = {
-  title: 'A deepLink internal',
-  link: '/mocked',
-  internal: true,
-};
-
 describe('<BottomLink />', () => {
   it('renders without exploding', async () => {
     const rendered = await renderInTestApp(<BottomLink {...minProps} />);
     expect(rendered.getByText('A deepLink title')).toBeInTheDocument();
-  });
-
-  it('renders with backstage Link', async () => {
-    const rendered = await renderInTestApp(
-      <BottomLink {...internalLinkProps} />,
-    );
-    expect(rendered.getByText('A deepLink internal')).toBeInTheDocument();
   });
 });

--- a/packages/core/src/layout/BottomLink/BottomLink.test.tsx
+++ b/packages/core/src/layout/BottomLink/BottomLink.test.tsx
@@ -23,9 +23,22 @@ const minProps = {
   link: '/mocked',
 };
 
+const internalLinkProps = {
+  title: 'A deepLink internal',
+  link: '/mocked',
+  internal: true,
+};
+
 describe('<BottomLink />', () => {
   it('renders without exploding', async () => {
     const rendered = await renderInTestApp(<BottomLink {...minProps} />);
     expect(rendered.getByText('A deepLink title')).toBeInTheDocument();
+  });
+
+  it('renders with backstage Link', async () => {
+    const rendered = await renderInTestApp(
+      <BottomLink {...internalLinkProps} />,
+    );
+    expect(rendered.getByText('A deepLink internal')).toBeInTheDocument();
   });
 });

--- a/packages/core/src/layout/BottomLink/BottomLink.tsx
+++ b/packages/core/src/layout/BottomLink/BottomLink.tsx
@@ -16,7 +16,6 @@
 
 import React, { FC } from 'react';
 import {
-  Link as ExternalLink,
   ListItem,
   ListItemIcon,
   Divider,
@@ -26,7 +25,7 @@ import {
 import ArrowIcon from '@material-ui/icons/ArrowForward';
 import { BackstageTheme } from '@backstage/theme';
 import Box from '@material-ui/core/Box';
-import { Link as InternalLink } from '../../components/Link';
+import { Link } from '../../components/Link';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   root: {
@@ -44,49 +43,28 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 
 export type BottomLinkProps = {
   link: string;
-  internal?: boolean;
   title: string;
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
-export const BottomLink: FC<BottomLinkProps> = ({
-  link,
-  title,
-  onClick,
-  internal = false,
-}) => {
+export const BottomLink: FC<BottomLinkProps> = ({ link, title, onClick }) => {
   const classes = useStyles();
 
-  const bottomLinkChildren = (
-    <ListItem className={classes.root}>
-      <ListItemText>
-        <Box className={classes.boxTitle} fontWeight="fontWeightBold" m={1}>
-          {title}
-        </Box>
-      </ListItemText>
-      <ListItemIcon>
-        <ArrowIcon className={classes.arrow} />
-      </ListItemIcon>
-    </ListItem>
-  );
   return (
     <div>
       <Divider />
-      {!internal ? (
-        <ExternalLink
-          href={link}
-          onClick={onClick}
-          underline="none"
-          children={bottomLinkChildren}
-        />
-      ) : (
-        <InternalLink
-          to={link}
-          onClick={onClick}
-          underline="none"
-          children={bottomLinkChildren}
-        />
-      )}
+      <Link to={link} onClick={onClick} underline="none">
+        <ListItem className={classes.root}>
+          <ListItemText>
+            <Box className={classes.boxTitle} fontWeight="fontWeightBold" m={1}>
+              {title}
+            </Box>
+          </ListItemText>
+          <ListItemIcon>
+            <ArrowIcon className={classes.arrow} />
+          </ListItemIcon>
+        </ListItem>
+      </Link>
     </div>
   );
 };

--- a/packages/core/src/layout/BottomLink/BottomLink.tsx
+++ b/packages/core/src/layout/BottomLink/BottomLink.tsx
@@ -16,7 +16,7 @@
 
 import React, { FC } from 'react';
 import {
-  Link,
+  Link as ExternalLink,
   ListItem,
   ListItemIcon,
   Divider,
@@ -26,6 +26,7 @@ import {
 import ArrowIcon from '@material-ui/icons/ArrowForward';
 import { BackstageTheme } from '@backstage/theme';
 import Box from '@material-ui/core/Box';
+import { Link as InternalLink } from '../../components/Link';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   root: {
@@ -43,28 +44,49 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 
 export type BottomLinkProps = {
   link: string;
+  internal?: boolean;
   title: string;
   onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
-export const BottomLink: FC<BottomLinkProps> = ({ link, title, onClick }) => {
+export const BottomLink: FC<BottomLinkProps> = ({
+  link,
+  title,
+  onClick,
+  internal = false,
+}) => {
   const classes = useStyles();
 
+  const bottomLinkChildren = (
+    <ListItem className={classes.root}>
+      <ListItemText>
+        <Box className={classes.boxTitle} fontWeight="fontWeightBold" m={1}>
+          {title}
+        </Box>
+      </ListItemText>
+      <ListItemIcon>
+        <ArrowIcon className={classes.arrow} />
+      </ListItemIcon>
+    </ListItem>
+  );
   return (
     <div>
       <Divider />
-      <Link href={link} onClick={onClick} underline="none">
-        <ListItem className={classes.root}>
-          <ListItemText>
-            <Box className={classes.boxTitle} fontWeight="fontWeightBold" m={1}>
-              {title}
-            </Box>
-          </ListItemText>
-          <ListItemIcon>
-            <ArrowIcon className={classes.arrow} />
-          </ListItemIcon>
-        </ListItem>
-      </Link>
+      {!internal ? (
+        <ExternalLink
+          href={link}
+          onClick={onClick}
+          underline="none"
+          children={bottomLinkChildren}
+        />
+      ) : (
+        <InternalLink
+          to={link}
+          onClick={onClick}
+          underline="none"
+          children={bottomLinkChildren}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Enable internal routing for BottomLink
For one of our internal plugins we want to route to an internal component without reloading the entire app. 
So adding the possibility to use the `@backstage/core/Link ` instead. 

![Nov-06-2020 12-13-22](https://user-images.githubusercontent.com/61695677/98361286-8c08c680-202b-11eb-8398-e9c6e021a718.gif)
