### PR TITLE
catalog: more info about refresh errors

### DIFF
--- a/plugins/catalog-backend/src/ingestion/CatalogRules.ts
+++ b/plugins/catalog-backend/src/ingestion/CatalogRules.ts
@@ -147,10 +147,10 @@ export class CatalogRulesEnforcer {
     }
 
     for (const matcher of matchers) {
-      if (matcher.type !== location.type) {
+      if (matcher.type !== location?.type) {
         continue;
       }
-      if (matcher.target && matcher.target !== location.target) {
+      if (matcher.target && matcher.target !== location?.target) {
         continue;
       }
       return true;
@@ -165,7 +165,7 @@ export class CatalogRulesEnforcer {
     }
 
     for (const matcher of matchers) {
-      if (entity.kind.toLowerCase() !== matcher.kind.toLowerCase()) {
+      if (entity?.kind?.toLowerCase() !== matcher.kind.toLowerCase()) {
         continue;
       }
 

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
@@ -130,7 +130,7 @@ export class HigherOrderOperations implements HigherOrderOperation {
         await this.locationsCatalog.logUpdateSuccess(location.id, undefined);
       } catch (e) {
         this.logger.warn(
-          `Failed to refresh location ${location.type}:${location.target}, ${e}`,
+          `Failed to refresh location ${location.type}:${location.target}, ${e.stack}`,
         );
         await this.locationsCatalog.logUpdateFailure(location.id, e);
       }
@@ -152,7 +152,7 @@ export class HigherOrderOperations implements HigherOrderOperation {
 
     for (const item of readerOutput.errors) {
       this.logger.warn(
-        `Failed item in location ${item.location.type}:${item.location.target}, ${item.error}`,
+        `Failed item in location ${item.location.type}:${item.location.target}, ${item.error.stack}`,
       );
     }
 

--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -97,7 +97,7 @@ export class LocationReaders implements LocationReader {
             output.errors.push({
               location: item.location,
               error: new Error(
-                `Entity of kind ${item.entity.kind} is not allowed from location ${item.location.target}:${item.location.type}`,
+                `Entity of kind ${item.entity.kind} is not allowed from location ${item.location.type} ${item.location.target}`,
               ),
             });
           }
@@ -117,7 +117,7 @@ export class LocationReaders implements LocationReader {
       items = newItems;
     }
 
-    const message = `Max recursion depth ${MAX_DEPTH} reached for ${location.type} ${location.target}`;
+    const message = `Max recursion depth ${MAX_DEPTH} reached for location ${location.type} ${location.target}`;
     logger.warn(message);
     output.errors.push({ location, error: new Error(message) });
     return output;


### PR DESCRIPTION
We sometimes get errors like `Cannot read property 'toLowerCase' of undefined` which really doesn't help debugging. So log the error stack instead of just the message, and also make the rules enforcer (which is the very first code that's hit by newly read data) more defensive. The latter is needed because no validation has been performed on the entity data yet, so if the user mistakenly inserted bad data, the code will crash instead of just rejecting the data as invalid.

Context: https://discord.com/channels/687207715902193673/687207715902193679/775479178849288224