### PR TITLE
Use dense table style and outlined chips in the API Explorer

### DIFF
--- a/.changeset/perfect-boats-attack.md
+++ b/.changeset/perfect-boats-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Use dense table style and outlined chips in the API Explorer.

--- a/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
@@ -90,7 +90,13 @@ const columns: TableColumn<Entity>[] = [
       <>
         {entity.metadata.tags &&
           entity.metadata.tags.map(t => (
-            <Chip key={t} label={t} style={{ marginBottom: '0px' }} />
+            <Chip
+              key={t}
+              label={t}
+              size="small"
+              variant="outlined"
+              style={{ marginBottom: '0px' }}
+            />
           ))}
       </>
     ),
@@ -149,6 +155,7 @@ export const ApiExplorerTable = ({
         paging: false,
         actionsColumnIndex: -1,
         loadingType: 'linear',
+        padding: 'dense',
         showEmptyDataSourceMessage: !loading,
       }}
       data={entities}


### PR DESCRIPTION
This matches the styling of the catalog.

![image](https://user-images.githubusercontent.com/648527/98798989-cf3dad80-240e-11eb-85e0-324a1d99f2b9.png)

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
