### PR TITLE
auth-backend: Encode the OAuth state param using URL safe chars

### DIFF
--- a/.changeset/tidy-bobcats-prove.md
+++ b/.changeset/tidy-bobcats-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Encode the OAuth state parameter using URL safe chars only, so that providers have an easier time forming the callback URL.

--- a/plugins/auth-backend/src/lib/oauth/helpers.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.ts
@@ -19,7 +19,7 @@ import { OAuthState } from './types';
 
 export const readState = (stateString: string): OAuthState => {
   const state = Object.fromEntries(
-    new URLSearchParams(decodeURIComponent(stateString)),
+    new URLSearchParams(Buffer.from(stateString, 'hex').toString('utf-8')),
   );
   if (
     !state.nonce ||
@@ -40,7 +40,7 @@ export const encodeState = (state: OAuthState): string => {
   searchParams.append('nonce', state.nonce);
   searchParams.append('env', state.env);
 
-  return encodeURIComponent(searchParams.toString());
+  return Buffer.from(searchParams.toString(), 'utf-8').toString('hex');
 };
 
 export const verifyNonce = (req: express.Request, providerId: string) => {


### PR DESCRIPTION
Chose hex over URL safe base64 purely based on it being a builtin encoding of Buffer :) Output is a bit longer but whatever.

Context: At least one provider accidentally formed the callback URL incorrectly, likely by assuming that the state didn't contain any unsafe characters. https://discord.com/channels/687207715902193673/687235481154617364/776163750104530994