### PR TITLE
backend-common: refactor readTree to only accept URL and options + add response helper

### DIFF
--- a/.changeset/odd-camels-begin.md
+++ b/.changeset/odd-camels-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': minor
+---
+
+Refactored UrlReader.readTree to be required and accept (url, options)

--- a/packages/backend-common/src/reading/AzureUrlReader.test.ts
+++ b/packages/backend-common/src/reading/AzureUrlReader.test.ts
@@ -20,8 +20,13 @@ import { ConfigReader } from '@backstage/config';
 import { getVoidLogger } from '../logging';
 import { AzureUrlReader } from './AzureUrlReader';
 import { msw } from '@backstage/test-utils';
+import { ReadTreeResponseFactory } from './tree';
 
 const logger = getVoidLogger();
+
+const treeResponseFactory = ReadTreeResponseFactory.create({
+  config: new ConfigReader({}),
+});
 
 describe('AzureUrlReader', () => {
   const worker = setupServer();
@@ -87,7 +92,11 @@ describe('AzureUrlReader', () => {
       }),
     },
   ])('should handle happy path %#', async ({ url, config, response }) => {
-    const [{ reader }] = AzureUrlReader.factory({ config, logger });
+    const [{ reader }] = AzureUrlReader.factory({
+      config,
+      logger,
+      treeResponseFactory,
+    });
 
     const data = await reader.read(url);
     const res = await JSON.parse(data.toString('utf-8'));
@@ -115,7 +124,11 @@ describe('AzureUrlReader', () => {
     },
   ])('should handle error path %#', async ({ url, config, error }) => {
     await expect(async () => {
-      const [{ reader }] = AzureUrlReader.factory({ config, logger });
+      const [{ reader }] = AzureUrlReader.factory({
+        config,
+        logger,
+        treeResponseFactory,
+      });
       await reader.read(url);
     }).rejects.toThrow(error);
   });

--- a/packages/backend-common/src/reading/AzureUrlReader.ts
+++ b/packages/backend-common/src/reading/AzureUrlReader.ts
@@ -17,7 +17,7 @@
 import fetch from 'cross-fetch';
 import { Config } from '@backstage/config';
 import { NotFoundError } from '../errors';
-import { ReaderFactory, UrlReader } from './types';
+import { ReaderFactory, ReadTreeResponse, UrlReader } from './types';
 
 type Options = {
   // TODO: added here for future support, but we only allow dev.azure.com for now
@@ -84,6 +84,10 @@ export class AzureUrlReader implements UrlReader {
       throw new NotFoundError(message);
     }
     throw new Error(message);
+  }
+
+  readTree(): Promise<ReadTreeResponse> {
+    throw new Error('AzureUrlReader does not implement readTree');
   }
 
   // Converts

--- a/packages/backend-common/src/reading/BitbucketUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.ts
@@ -18,7 +18,7 @@ import { Config } from '@backstage/config';
 import parseGitUri from 'git-url-parse';
 import fetch from 'cross-fetch';
 import { NotFoundError } from '../errors';
-import { ReaderFactory, UrlReader } from './types';
+import { ReaderFactory, ReadTreeResponse, UrlReader } from './types';
 
 const DEFAULT_BASE_URL = 'https://api.bitbucket.org/2.0';
 
@@ -207,6 +207,10 @@ export class BitbucketUrlReader implements UrlReader {
       throw new NotFoundError(message);
     }
     throw new Error(message);
+  }
+
+  readTree(): Promise<ReadTreeResponse> {
+    throw new Error('BitbucketUrlReader does not implement readTree');
   }
 
   toString() {

--- a/packages/backend-common/src/reading/FetchUrlReader.ts
+++ b/packages/backend-common/src/reading/FetchUrlReader.ts
@@ -16,7 +16,7 @@
 
 import fetch from 'cross-fetch';
 import { NotFoundError } from '../errors';
-import { UrlReader } from './types';
+import { ReadTreeResponse, UrlReader } from './types';
 
 /**
  * A UrlReader that does a plain fetch of the URL.
@@ -39,6 +39,10 @@ export class FetchUrlReader implements UrlReader {
       throw new NotFoundError(message);
     }
     throw new Error(message);
+  }
+
+  readTree(): Promise<ReadTreeResponse> {
+    throw new Error('FetchUrlReader does not implement readTree');
   }
 
   toString() {

--- a/packages/backend-common/src/reading/GithubUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.test.ts
@@ -293,7 +293,7 @@ describe('GithubUrlReader', () => {
       );
 
       mockfs();
-      const directory = await response.dir('/tmp/fs');
+      const directory = await response.dir({ targetDir: '/tmp/fs' });
 
       const writtenToDirectory = fs.existsSync(directory);
       const paths = await recursive(directory);

--- a/packages/backend-common/src/reading/GithubUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.test.ts
@@ -29,8 +29,11 @@ import {
 } from './GithubUrlReader';
 import fs from 'fs';
 import path from 'path';
-import mockfs from 'mock-fs';
-import recursive from 'recursive-readdir';
+import { ReadTreeResponseFactory } from './tree';
+
+const treeResponseFactory = ReadTreeResponseFactory.create({
+  config: new ConfigReader({}),
+});
 
 describe('GithubUrlReader', () => {
   describe('getApiRequestOptions', () => {
@@ -226,10 +229,13 @@ describe('GithubUrlReader', () => {
 
   describe('implementation', () => {
     it('rejects unknown targets', async () => {
-      const processor = new GithubUrlReader({
-        host: 'github.com',
-        apiBaseUrl: 'https://api.github.com',
-      });
+      const processor = new GithubUrlReader(
+        {
+          host: 'github.com',
+          apiBaseUrl: 'https://api.github.com',
+        },
+        { treeResponseFactory },
+      );
       await expect(
         processor.read('https://not.github.com/apa'),
       ).rejects.toThrow(
@@ -250,7 +256,7 @@ describe('GithubUrlReader', () => {
     beforeEach(() => {
       worker.use(
         rest.get(
-          'https://github.com/spotify/mock/archive/repo.tar.gz',
+          'https://github.com/backstage/mock/archive/repo.tar.gz',
           (_, res, ctx) =>
             res(
               ctx.status(200),
@@ -262,18 +268,20 @@ describe('GithubUrlReader', () => {
     });
 
     it('returns the wanted files from an archive', async () => {
-      const processor = new GithubUrlReader({
-        host: 'github.com',
-      });
+      const processor = new GithubUrlReader(
+        {
+          host: 'github.com',
+        },
+        { treeResponseFactory },
+      );
 
       const response = await processor.readTree(
-        'https://github.com/spotify/mock',
-        'repo',
-        ['mkdocs.yml', 'docs'],
+        'https://github.com/backstage/mock/tree/repo',
       );
 
       const files = await response.files();
 
+      expect(files.length).toBe(2);
       const mkDocsFile = await files[0].content();
       const indexMarkdownFile = await files[1].content();
 
@@ -281,33 +289,39 @@ describe('GithubUrlReader', () => {
       expect(indexMarkdownFile.toString()).toBe('# Test\n');
     });
 
-    it('returns a folder path from an archive', async () => {
-      const processor = new GithubUrlReader({
-        host: 'github.com',
-      });
+    it('must specify a branch', async () => {
+      const processor = new GithubUrlReader(
+        {
+          host: 'github.com',
+        },
+        { treeResponseFactory },
+      );
+
+      await expect(
+        processor.readTree('https://github.com/backstage/mock'),
+      ).rejects.toThrow(
+        'GitHub URL must contain branch to be able to fetch tree',
+      );
+    });
+
+    it('returns the wanted files from an archive with a subpath', async () => {
+      const processor = new GithubUrlReader(
+        {
+          host: 'github.com',
+        },
+        { treeResponseFactory },
+      );
 
       const response = await processor.readTree(
-        'https://github.com/spotify/mock',
-        'repo',
-        ['mkdocs.yml', 'docs'],
+        'https://github.com/backstage/mock/tree/repo/docs',
       );
 
-      mockfs();
-      const directory = await response.dir({ targetDir: '/tmp/fs' });
+      const files = await response.files();
 
-      const writtenToDirectory = fs.existsSync(directory);
-      const paths = await recursive(directory);
-      mockfs.restore();
+      expect(files.length).toBe(1);
+      const indexMarkdownFile = await files[0].content();
 
-      expect(writtenToDirectory).toBe(true);
-      expect(paths.sort()).toEqual(
-        [
-          '/tmp/fs/mock-repo/docs/index.md',
-          '/tmp/fs/mock-repo/mkdocs.yml',
-        ].sort(),
-      );
-
-      worker.resetHandlers();
+      expect(indexMarkdownFile.toString()).toBe('# Test\n');
     });
   });
 });

--- a/packages/backend-common/src/reading/GithubUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.test.ts
@@ -272,7 +272,7 @@ describe('GithubUrlReader', () => {
         ['mkdocs.yml', 'docs'],
       );
 
-      const files = response.files();
+      const files = await response.files();
 
       const mkDocsFile = await files[0].content();
       const indexMarkdownFile = await files[1].content();

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -286,7 +286,7 @@ export class GithubUrlReader implements UrlReader {
       // @ts-ignore Typescript doesn't consider .pipe a method on ReadableStream. Don't know why.
       repoArchive.body?.pipe(parser).on('finish', () => {
         resolve({
-          files: () => {
+          files: async () => {
             return files;
           },
           archive: () => {

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -18,7 +18,13 @@ import { Config } from '@backstage/config';
 import parseGitUri from 'git-url-parse';
 import fetch from 'cross-fetch';
 import { NotFoundError } from '../errors';
-import { ReaderFactory, ReadTreeResponse, UrlReader, File } from './types';
+import {
+  ReaderFactory,
+  ReadTreeResponse,
+  UrlReader,
+  File,
+  ReadTreeResponseDirOptions,
+} from './types';
 import tar from 'tar';
 import fs from 'fs-extra';
 import concatStream from 'concat-stream';
@@ -294,9 +300,10 @@ export class GithubUrlReader implements UrlReader {
               resolve(Buffer.from('Archive is not yet implemented')),
             );
           },
-          dir: (outDir: string | undefined) => {
+          dir: (options?: ReadTreeResponseDirOptions) => {
             const targetDirectory =
-              outDir || fs.mkdtempSync(path.join(os.tmpdir(), 'backstage-'));
+              options?.targetDir ||
+              fs.mkdtempSync(path.join(os.tmpdir(), 'backstage-'));
 
             return new Promise((res, rej) => {
               Promise.all(

--- a/packages/backend-common/src/reading/GitlabUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.test.ts
@@ -20,8 +20,13 @@ import { ConfigReader } from '@backstage/config';
 import { getVoidLogger } from '../logging';
 import { GitlabUrlReader } from './GitlabUrlReader';
 import { msw } from '@backstage/test-utils';
+import { ReadTreeResponseFactory } from './tree';
 
 const logger = getVoidLogger();
+
+const treeResponseFactory = ReadTreeResponseFactory.create({
+  config: new ConfigReader({}),
+});
 
 describe('GitlabUrlReader', () => {
   const worker = setupServer();
@@ -98,7 +103,11 @@ describe('GitlabUrlReader', () => {
       }),
     },
   ])('should handle happy path %#', async ({ url, config, response }) => {
-    const [{ reader }] = GitlabUrlReader.factory({ config, logger });
+    const [{ reader }] = GitlabUrlReader.factory({
+      config,
+      logger,
+      treeResponseFactory,
+    });
 
     const data = await reader.read(url);
     const res = await JSON.parse(data.toString('utf-8'));
@@ -114,7 +123,11 @@ describe('GitlabUrlReader', () => {
     },
   ])('should handle error path %#', async ({ url, config, error }) => {
     await expect(async () => {
-      const [{ reader }] = GitlabUrlReader.factory({ config, logger });
+      const [{ reader }] = GitlabUrlReader.factory({
+        config,
+        logger,
+        treeResponseFactory,
+      });
       await reader.read(url);
     }).rejects.toThrow(error);
   });

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -17,7 +17,7 @@
 import fetch from 'cross-fetch';
 import { Config } from '@backstage/config';
 import { NotFoundError } from '../errors';
-import { ReaderFactory, UrlReader } from './types';
+import { ReaderFactory, ReadTreeResponse, UrlReader } from './types';
 
 type Options = {
   host: string;
@@ -85,6 +85,10 @@ export class GitlabUrlReader implements UrlReader {
       throw new NotFoundError(message);
     }
     throw new Error(message);
+  }
+
+  readTree(): Promise<ReadTreeResponse> {
+    throw new Error('GitlabUrlReader does not implement readTree');
   }
 
   // Converts

--- a/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
+++ b/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
@@ -58,23 +58,20 @@ export class UrlReaderPredicateMux implements UrlReader {
     throw new Error(`No reader found that could handle '${url}'`);
   }
 
-  readTree(
-    repoUrl: string,
-    options?: ReadTreeOptions,
-  ): Promise<ReadTreeResponse> {
-    const parsed = new URL(repoUrl);
+  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse> {
+    const parsed = new URL(url);
 
     for (const { predicate, reader } of this.readers) {
       if (predicate(parsed)) {
-        return reader.readTree(repoUrl, options);
+        return reader.readTree(url, options);
       }
     }
 
     if (this.fallback) {
-      return this.fallback.readTree(repoUrl, options);
+      return this.fallback.readTree(url, options);
     }
 
-    throw new Error(`No reader found that could handle '${repoUrl}'`);
+    throw new Error(`No reader found that could handle '${url}'`);
   }
 
   toString() {

--- a/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
+++ b/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { ReadTreeResponse, UrlReader, UrlReaderPredicateTuple } from './types';
+import {
+  ReadTreeOptions,
+  ReadTreeResponse,
+  UrlReader,
+  UrlReaderPredicateTuple,
+} from './types';
 
 type Options = {
   // UrlReader to fall back to if no other reader is matched
@@ -55,14 +60,13 @@ export class UrlReaderPredicateMux implements UrlReader {
 
   readTree(
     repoUrl: string,
-    branchName: string,
-    paths: Array<string>,
+    options?: ReadTreeOptions,
   ): Promise<ReadTreeResponse> {
     const parsed = new URL(repoUrl);
 
     for (const { predicate, reader } of this.readers) {
       if (predicate(parsed)) {
-        if (reader.readTree) return reader.readTree(repoUrl, branchName, paths);
+        if (reader.readTree) return reader.readTree(repoUrl, options);
         throw new Error(
           `Trying to call readTree on UrlReader which does not support the feature.`,
         );
@@ -71,7 +75,7 @@ export class UrlReaderPredicateMux implements UrlReader {
 
     if (this.fallback) {
       if (this.fallback.readTree)
-        return this.fallback.readTree(repoUrl, branchName, paths);
+        return this.fallback.readTree(repoUrl, options);
       throw new Error(
         `Trying to call readTree on UrlReader which does not support the feature.`,
       );

--- a/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
+++ b/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
@@ -66,19 +66,12 @@ export class UrlReaderPredicateMux implements UrlReader {
 
     for (const { predicate, reader } of this.readers) {
       if (predicate(parsed)) {
-        if (reader.readTree) return reader.readTree(repoUrl, options);
-        throw new Error(
-          `Trying to call readTree on UrlReader which does not support the feature.`,
-        );
+        return reader.readTree(repoUrl, options);
       }
     }
 
     if (this.fallback) {
-      if (this.fallback.readTree)
-        return this.fallback.readTree(repoUrl, options);
-      throw new Error(
-        `Trying to call readTree on UrlReader which does not support the feature.`,
-      );
+      return this.fallback.readTree(repoUrl, options);
     }
 
     throw new Error(`No reader found that could handle '${repoUrl}'`);

--- a/packages/backend-common/src/reading/UrlReaders.ts
+++ b/packages/backend-common/src/reading/UrlReaders.ts
@@ -23,6 +23,7 @@ import { BitbucketUrlReader } from './BitbucketUrlReader';
 import { GithubUrlReader } from './GithubUrlReader';
 import { GitlabUrlReader } from './GitlabUrlReader';
 import { FetchUrlReader } from './FetchUrlReader';
+import { ReadTreeResponseFactory } from './tree';
 
 type CreateOptions = {
   /** Root config object */
@@ -49,9 +50,10 @@ export class UrlReaders {
     fallback,
   }: CreateOptions): UrlReader {
     const mux = new UrlReaderPredicateMux({ fallback: fallback });
+    const treeResponseFactory = ReadTreeResponseFactory.create({ config });
 
     for (const factory of factories ?? []) {
-      const tuples = factory({ config, logger: logger });
+      const tuples = factory({ config, logger: logger, treeResponseFactory });
 
       for (const tuple of tuples) {
         mux.register(tuple);

--- a/packages/backend-common/src/reading/tree/ArchiveResponse.test.ts
+++ b/packages/backend-common/src/reading/tree/ArchiveResponse.test.ts
@@ -16,7 +16,6 @@
 
 import fs from 'fs-extra';
 import mockFs from 'mock-fs';
-import { Readable } from 'stream';
 import { resolve as resolvePath } from 'path';
 import { ArchiveResponse } from './ArchiveResponse';
 
@@ -87,7 +86,7 @@ describe('ArchiveResponse', () => {
       'Response has already been read',
     );
 
-    const res2 = new ArchiveResponse(Readable.from(buffer), '', '/tmp');
+    const res2 = new ArchiveResponse(buffer, '', '/tmp');
     const files = await res2.files();
 
     expect(files).toEqual([

--- a/packages/backend-common/src/reading/tree/ArchiveResponse.test.ts
+++ b/packages/backend-common/src/reading/tree/ArchiveResponse.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import mockFs from 'mock-fs';
+import { Readable } from 'stream';
+import { resolve as resolvePath } from 'path';
+import { ArchiveResponse } from './ArchiveResponse';
+
+const archiveData = fs.readFileSync(
+  resolvePath(__filename, '../../__fixtures__/repo.tar.gz'),
+);
+
+describe('ArchiveResponse', () => {
+  beforeEach(() => {
+    mockFs({
+      '/test-archive.tar.gz': archiveData,
+      '/tmp': mockFs.directory(),
+    });
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+  });
+
+  it('should read as archive and files', async () => {
+    const stream = fs.createReadStream('/test-archive.tar.gz');
+
+    const res = new ArchiveResponse(stream, 'mock-repo', '/tmp');
+    const buffer = await res.archive();
+
+    await expect(res.archive()).rejects.toThrow(
+      'Response has already been read',
+    );
+
+    const res2 = new ArchiveResponse(Readable.from(buffer), '', '/tmp');
+    const files = await res2.files();
+
+    expect(files).toEqual([
+      {
+        path: './mkdocs.yml',
+        content: expect.any(Function),
+      },
+      {
+        path: './docs/index.md',
+        content: expect.any(Function),
+      },
+    ]);
+    const contents = await Promise.all(files.map(f => f.content()));
+    expect(contents.map(c => c.toString('utf8').trim())).toEqual([
+      'site_name: Test',
+      '# Test',
+    ]);
+  });
+
+  it('should extract entire archive into directory', async () => {
+    const stream = fs.createReadStream('/test-archive.tar.gz');
+
+    const res = new ArchiveResponse(stream, '', '/tmp');
+    const dir = await res.dir();
+
+    await expect(
+      fs.readFile(resolvePath(dir, 'mock-repo/mkdocs.yml'), 'utf8'),
+    ).resolves.toBe('site_name: Test\n');
+    await expect(
+      fs.readFile(resolvePath(dir, 'mock-repo/docs/index.md'), 'utf8'),
+    ).resolves.toBe('# Test\n');
+  });
+
+  it('should extract archive into directory with a subpath', async () => {
+    const stream = fs.createReadStream('/test-archive.tar.gz');
+
+    const res = new ArchiveResponse(stream, 'mock-repo/docs', '/tmp');
+    const dir = await res.dir();
+
+    await expect(
+      fs.readFile(resolvePath(dir, 'index.md'), 'utf8'),
+    ).resolves.toBe('# Test\n');
+  });
+});

--- a/packages/backend-common/src/reading/tree/ArchiveResponse.ts
+++ b/packages/backend-common/src/reading/tree/ArchiveResponse.ts
@@ -42,10 +42,12 @@ export class ArchiveResponse implements ReadTreeResponse {
   ) {
     if (subPath) {
       if (!subPath.endsWith('/')) {
-        throw new TypeError('ArchiveResponse subPath must end with a /');
+        this.subPath += '/';
       }
       if (subPath.startsWith('/')) {
-        throw new TypeError('ArchiveResponse subPath must not start with a /');
+        throw new TypeError(
+          `ArchiveResponse subPath must not start with a /, got '${subPath}'`,
+        );
       }
     }
   }

--- a/packages/backend-common/src/reading/tree/ReadTreeResponseFactory.ts
+++ b/packages/backend-common/src/reading/tree/ReadTreeResponseFactory.ts
@@ -23,7 +23,7 @@ import { ArchiveResponse } from './ArchiveResponse';
 type FromArchiveOptions = {
   // A binary stream of a tar archive.
   stream: Readable;
-  // If set, root of the tree will be set to the given path. Should not have a trailing `/`.
+  // If set, the root of the tree will be set to the given directory path.
   path?: string;
   // Filter passed on from the ReadTreeOptions
   filter?: (path: string) => boolean;

--- a/packages/backend-common/src/reading/tree/ReadTreeResponseFactory.ts
+++ b/packages/backend-common/src/reading/tree/ReadTreeResponseFactory.ts
@@ -25,6 +25,8 @@ type FromArchiveOptions = {
   stream: Readable;
   // If set, root of the tree will be set to the given path. Should not have a trailing `/`.
   path?: string;
+  // Filter passed on from the ReadTreeOptions
+  filter?: (path: string) => boolean;
 };
 
 export class ReadTreeResponseFactory {
@@ -42,6 +44,7 @@ export class ReadTreeResponseFactory {
       options.stream,
       options.path ?? '',
       this.workDir,
+      options.filter,
     );
   }
 }

--- a/packages/backend-common/src/reading/tree/ReadTreeResponseFactory.ts
+++ b/packages/backend-common/src/reading/tree/ReadTreeResponseFactory.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import os from 'os';
+import { Readable } from 'stream';
+import { Config } from '@backstage/config';
+import { ReadTreeResponse } from '../types';
+import { ArchiveResponse } from './ArchiveResponse';
+
+type FromArchiveOptions = {
+  // A binary stream of a tar archive.
+  stream: Readable;
+  // If set, root of the tree will be set to the given path. Should not have a trailing `/`.
+  path?: string;
+};
+
+export class ReadTreeResponseFactory {
+  static create(options: { config: Config }): ReadTreeResponseFactory {
+    return new ReadTreeResponseFactory(
+      options.config.getOptionalString('backend.workingDirectory') ??
+        os.tmpdir(),
+    );
+  }
+
+  constructor(private readonly workDir: string) {}
+
+  async fromArchive(options: FromArchiveOptions): Promise<ReadTreeResponse> {
+    return new ArchiveResponse(
+      options.stream,
+      options.path ?? '',
+      this.workDir,
+    );
+  }
+}

--- a/packages/backend-common/src/reading/tree/index.ts
+++ b/packages/backend-common/src/reading/tree/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { ReadTreeResponseFactory } from './ReadTreeResponseFactory';

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -28,7 +28,7 @@ export type ReadTreeOptions = {
  */
 export type UrlReader = {
   read(url: string): Promise<Buffer>;
-  readTree?(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
 };
 
 export type UrlReaderPredicateTuple = {

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -16,6 +16,7 @@
 
 import { Logger } from 'winston';
 import { Config } from '@backstage/config';
+import { ReadTreeResponseFactory } from './tree';
 
 export type ReadTreeOptions = {
   /** A filter that can be used to select which files should be extracted. By default all files are extracted */
@@ -46,6 +47,7 @@ export type UrlReaderPredicateTuple = {
 export type ReaderFactory = (options: {
   config: Config;
   logger: Logger;
+  treeResponseFactory: ReadTreeResponseFactory;
 }) => UrlReaderPredicateTuple[];
 
 export type File = {

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -28,11 +28,7 @@ export type ReadTreeOptions = {
  */
 export type UrlReader = {
   read(url: string): Promise<Buffer>;
-  readTree?(
-    repoUrl: string,
-    branchName: string,
-    paths: Array<string>,
-  ): Promise<ReadTreeResponse>;
+  readTree?(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
 };
 
 export type UrlReaderPredicateTuple = {

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -49,7 +49,7 @@ export type File = {
 };
 
 export type ReadTreeResponse = {
-  files(): File[];
+  files(): Promise<File[]>;
   archive(): Promise<Buffer>;
   dir(outDir?: string): Promise<string>;
 };

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -19,7 +19,18 @@ import { Config } from '@backstage/config';
 import { ReadTreeResponseFactory } from './tree';
 
 export type ReadTreeOptions = {
-  /** A filter that can be used to select which files should be extracted. By default all files are extracted */
+  /**
+   * A filter that can be used to select which files should be included.
+   *
+   * The path passed to the filter function is the relative path from the URL
+   * that the file tree is fetched from, without any leading '/'.
+   *
+   * For example, given the URL https://github.com/my/repo/tree/master/my-dir, a file
+   * at https://github.com/my/repo/blob/master/my-dir/my-subdir/my-file.txt will
+   * be represented as my-subdir/my-file.txt
+   *
+   * If no filter is provided all files are extracted.
+   */
   filter?(path: string): boolean;
 };
 
@@ -46,7 +57,7 @@ export type ReaderFactory = (options: {
   treeResponseFactory: ReadTreeResponseFactory;
 }) => UrlReaderPredicateTuple[];
 
-export type File = {
+export type ReadTreeResponseFile = {
   path: string;
   content(): Promise<Buffer>;
 };
@@ -57,7 +68,7 @@ export type ReadTreeResponseDirOptions = {
 };
 
 export type ReadTreeResponse = {
-  files(): Promise<File[]>;
-  archive(): Promise<Buffer>;
+  files(): Promise<ReadTreeResponseFile[]>;
+  archive(): Promise<NodeJS.ReadableStream>;
   dir(options?: ReadTreeResponseDirOptions): Promise<string>;
 };

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -17,6 +17,11 @@
 import { Logger } from 'winston';
 import { Config } from '@backstage/config';
 
+export type ReadTreeOptions = {
+  /** A filter that can be used to select which files should be extracted. By default all files are extracted */
+  filter?(path: string): boolean;
+};
+
 /**
  * A generic interface for fetching plain data from URLs.
  */
@@ -48,8 +53,13 @@ export type File = {
   content(): Promise<Buffer>;
 };
 
+export type ReadTreeResponseDirOptions = {
+  /** The directory to write files to. Defaults to the OS tmpdir or `backend.workingDirectory` if set in config */
+  targetDir?: string;
+};
+
 export type ReadTreeResponse = {
   files(): Promise<File[]>;
   archive(): Promise<Buffer>;
-  dir(outDir?: string): Promise<string>;
+  dir(options?: ReadTreeResponseDirOptions): Promise<string>;
 };

--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
@@ -157,14 +157,14 @@ describe('CodeOwnersProcessor', () => {
       const read = jest
         .fn()
         .mockResolvedValue(mockReadResult({ data: ownersText }));
-      const reader = { read };
+      const reader = { read, readTree: jest.fn() };
       const result = await findRawCodeOwners(mockLocation(), reader);
       expect(result).toEqual(ownersText);
     });
 
     it('should raise error when no codeowner', async () => {
       const read = jest.fn().mockRejectedValue(mockReadResult());
-      const reader = { read };
+      const reader = { read, readTree: jest.fn() };
 
       await expect(
         findRawCodeOwners(mockLocation(), reader),
@@ -178,7 +178,7 @@ describe('CodeOwnersProcessor', () => {
         .mockImplementationOnce(() => mockReadResult({ error: 'foo' }))
         .mockImplementationOnce(() => mockReadResult({ error: 'bar' }))
         .mockResolvedValue(mockReadResult({ data: ownersText }));
-      const reader = { read };
+      const reader = { read, readTree: jest.fn() };
 
       const result = await findRawCodeOwners(mockLocation(), reader);
 
@@ -197,7 +197,7 @@ describe('CodeOwnersProcessor', () => {
       const read = jest
         .fn()
         .mockResolvedValue(mockReadResult({ data: mockCodeOwnersText() }));
-      const reader = { read };
+      const reader = { read, readTree: jest.fn() };
 
       const owner = await resolveCodeOwner(mockLocation(), reader);
       expect(owner).toBe('backstage-core');
@@ -207,7 +207,7 @@ describe('CodeOwnersProcessor', () => {
       const read = jest
         .fn()
         .mockImplementation(() => mockReadResult({ error: 'error: foo' }));
-      const reader = { read };
+      const reader = { read, readTree: jest.fn() };
 
       await expect(
         resolveCodeOwner(mockLocation(), reader),
@@ -221,7 +221,7 @@ describe('CodeOwnersProcessor', () => {
       const read = jest
         .fn()
         .mockResolvedValue(mockReadResult({ data: mockCodeOwnersText() }));
-      const reader = { read };
+      const reader = { read, readTree: jest.fn() };
       const processor = new CodeOwnersProcessor({ reader });
 
       return { entity, processor, read };

--- a/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.test.ts
@@ -27,7 +27,7 @@ import {
 
 describe('PlaceholderProcessor', () => {
   const read: jest.MockedFunction<ResolverRead> = jest.fn();
-  const reader: UrlReader = { read };
+  const reader: UrlReader = { read, readTree: jest.fn() };
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
@@ -40,7 +40,10 @@ const dummyEntityYaml = yaml.stringify(dummyEntity);
 
 describe('CatalogBuilder', () => {
   let db: Knex<any, unknown[]>;
-  const reader: jest.Mocked<UrlReader> = { read: jest.fn() };
+  const reader: jest.Mocked<UrlReader> = {
+    read: jest.fn(),
+    readTree: jest.fn(),
+  };
   const env: CatalogEnvironment = {
     logger: getVoidLogger(),
     database: { getClient: async () => db },

--- a/plugins/techdocs-backend/src/helpers.test.ts
+++ b/plugins/techdocs-backend/src/helpers.test.ts
@@ -30,7 +30,7 @@ describe('getDocFilesFromRepository', () => {
           dir: async () => {
             return '/tmp/testfolder';
           },
-          files: () => {
+          files: async () => {
             return [];
           },
           archive: async () => {
@@ -78,7 +78,7 @@ describe('getDocFilesFromRepository', () => {
           dir: async () => {
             return '/tmp/testfolder';
           },
-          files: () => {
+          files: async () => {
             return [];
           },
           archive: async () => {

--- a/plugins/techdocs-backend/src/helpers.test.ts
+++ b/plugins/techdocs-backend/src/helpers.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Readable } from 'stream';
 import { getDocFilesFromRepository } from './helpers';
 import { UrlReader, ReadTreeResponse } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
@@ -34,7 +35,7 @@ describe('getDocFilesFromRepository', () => {
             return [];
           },
           archive: async () => {
-            return Buffer.from('');
+            return Readable.from('');
           },
         };
       }

--- a/plugins/techdocs-backend/src/helpers.test.ts
+++ b/plugins/techdocs-backend/src/helpers.test.ts
@@ -19,7 +19,7 @@ import { UrlReader, ReadTreeResponse } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 
 describe('getDocFilesFromRepository', () => {
-  it('should take the directory from UrlReader.readTree and add the docs path when mkdocs.yml is in root', async () => {
+  it('should read a remote directory using UrlReader.readTree', async () => {
     class MockUrlReader implements UrlReader {
       async read() {
         return Buffer.from('mock');
@@ -45,7 +45,7 @@ describe('getDocFilesFromRepository', () => {
         namespace: 'default',
         annotations: {
           'backstage.io/techdocs-ref':
-            'url:https://github.com/backstage/backstage/blob/master/mkdocs.yml',
+            'url:https://github.com/backstage/backstage/blob/master/subfolder/',
         },
         name: 'mytestcomponent',
         description: 'A component for testing',
@@ -64,54 +64,6 @@ describe('getDocFilesFromRepository', () => {
       mockEntity,
     );
 
-    expect(output).toBe('/tmp/testfolder/.');
-  });
-
-  it('should take the directory from UrlReader.readTree and add the docs path when mkdocs.yml is in a subfolder', async () => {
-    class MockUrlReader implements UrlReader {
-      async read() {
-        return Buffer.from('mock');
-      }
-
-      async readTree(): Promise<ReadTreeResponse> {
-        return {
-          dir: async () => {
-            return '/tmp/testfolder';
-          },
-          files: async () => {
-            return [];
-          },
-          archive: async () => {
-            return Buffer.from('');
-          },
-        };
-      }
-    }
-
-    const mockEntity: Entity = {
-      metadata: {
-        namespace: 'default',
-        annotations: {
-          'backstage.io/techdocs-ref':
-            'url:https://github.com/backstage/backstage/blob/master/subfolder/mkdocs.yml',
-        },
-        name: 'mytestcomponent',
-        description: 'A component for testing',
-      },
-      apiVersion: 'backstage.io/v1alpha1',
-      kind: 'Component',
-      spec: {
-        type: 'documentation',
-        lifecycle: 'experimental',
-        owner: 'testuser',
-      },
-    };
-
-    const output = await getDocFilesFromRepository(
-      new MockUrlReader(),
-      mockEntity,
-    );
-
-    expect(output).toBe('/tmp/testfolder/subfolder');
+    expect(output).toBe('/tmp/testfolder');
   });
 });

--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -179,13 +179,7 @@ export const getDocFilesFromRepository = async (
     entity,
   );
 
-  if (reader.readTree) {
-    const response = await reader.readTree(target);
+  const response = await reader.readTree(target);
 
-    return response.dir();
-  }
-
-  throw new Error(
-    `No readTree method available on the UrlReader for ${target}`,
-  );
+  return await response.dir();
 };

--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -179,21 +179,10 @@ export const getDocFilesFromRepository = async (
     entity,
   );
 
-  const { ref, filepath: mkdocsPath } = parseGitUrl(target);
-
-  const docsRootPath = path.dirname(mkdocsPath);
-  const docsFolderPath = path.join(docsRootPath, 'docs');
-
   if (reader.readTree) {
-    const readTreeResponse = await reader.readTree(
-      parseGitUrl(target).toString(),
-      ref,
-      [mkdocsPath, docsFolderPath],
-    );
+    const response = await reader.readTree(target);
 
-    const tmpDir = await readTreeResponse.dir();
-
-    return `${tmpDir}/${docsRootPath}`;
+    return response.dir();
   }
 
   throw new Error(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`.readTree` now handles sub-paths within the git repo automatically, and the added utilities defers fs operations until read time. The `dir()` method of the response now skips over the intermediate file list representation, making it possible to handle much larger archives.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
