### PR TITLE
Fix broken link from Docs site to Code of Conduct

### DIFF
--- a/docs/support/support.md
+++ b/docs/support/support.md
@@ -5,16 +5,16 @@ description: Support and Community Details and Links
 ---
 
 - [Discord chatroom](https://discord.gg/MUpMjP2) - Get support or discuss the
-  project
+  project.
 - [Good First Issues](https://github.com/backstage/backstage/contribute) - Start
-  here if you want to contribute
+  here if you want to contribute.
 - [RFCs](https://github.com/backstage/backstage/labels/rfc) - Help shape the
-  technical direction
-- [FAQ](../FAQ.md) - Frequently Asked Questions
+  technical direction by reviewing _Request for Comments_ issues.
+- [FAQ](../FAQ.md) - Frequently Asked Questions.
 - [Code of Conduct](https://github.com/backstage/backstage/blob/master/CODE_OF_CONDUCT.md) -
-  This is how we roll
-- [Blog](https://backstage.io/blog/) - Announcements and updates
+  This is how we roll.
+- [Blog](https://backstage.io/blog/) - Announcements and updates.
 - [Newsletter](https://mailchi.mp/spotify/backstage-community) - Subscribe to
-  our email newsletter
+  our email newsletter.
 - Give us a star ⭐️ - If you are using Backstage or think it is an interesting
-  project, we would love a star ❤️
+  project, we would love a star! ❤️

--- a/docs/support/support.md
+++ b/docs/support/support.md
@@ -11,7 +11,8 @@ description: Support and Community Details and Links
 - [RFCs](https://github.com/backstage/backstage/labels/rfc) - Help shape the
   technical direction
 - [FAQ](../FAQ.md) - Frequently Asked Questions
-- [Code of Conduct](../../CODE_OF_CONDUCT.md) - This is how we roll
+- [Code of Conduct](https://github.com/backstage/backstage/blob/master/CODE_OF_CONDUCT.md) -
+  This is how we roll
 - [Blog](https://backstage.io/blog/) - Announcements and updates
 - [Newsletter](https://mailchi.mp/spotify/backstage-community) - Subscribe to
   our email newsletter


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

In the published documentation site, the link to the Code of Conduct is broken. This PR fixes it. The link works fine if just browsing in the GitHub code content itself.

Also threw in some minor clarifications.

![image](https://user-images.githubusercontent.com/33203301/99031006-fd70d980-2543-11eb-874b-885f8e273175.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
