### PR TITLE
Fix cost excess amount calculation

### DIFF
--- a/.changeset/cost-insights-wild-cars-wait.md
+++ b/.changeset/cost-insights-wild-cars-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Fix savings/excess display calculation

--- a/plugins/cost-insights/src/client.ts
+++ b/plugins/cost-insights/src/client.ts
@@ -42,7 +42,7 @@ type IntervalFields = {
   endDate: string;
 };
 
-export function parseIntervals(intervals: string): IntervalFields {
+function parseIntervals(intervals: string): IntervalFields {
   const match = intervals.match(
     /\/(?<duration>P\d+[DM])\/(?<date>\d{4}-\d{2}-\d{2})/,
   );

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
@@ -22,7 +22,12 @@ import { CostOverviewHeader } from './CostOverviewHeader';
 import { LegendItem } from '../LegendItem';
 import { MetricSelect } from '../MetricSelect';
 import { PeriodSelect } from '../PeriodSelect';
-import { useScroll, useFilters, useConfig } from '../../hooks';
+import {
+  useScroll,
+  useFilters,
+  useConfig,
+  useLastCompleteBillingDate,
+} from '../../hooks';
 import { mapFiltersToProps } from './selector';
 import { DefaultNavigation } from '../../utils/navigation';
 import { formatPercent } from '../../utils/formatters';
@@ -41,6 +46,7 @@ export const CostOverviewCard = ({
 }: CostOverviewCardProps) => {
   const theme = useTheme<CostInsightsTheme>();
   const config = useConfig();
+  const lastCompleteBillingDate = useLastCompleteBillingDate();
   const { ScrollAnchor } = useScroll(DefaultNavigation.CostOverviewCard);
   const { setDuration, setProject, setMetric, ...filters } = useFilters(
     mapFiltersToProps,
@@ -50,7 +56,12 @@ export const CostOverviewCard = ({
     ? findAlways(config.metrics, m => m.kind === filters.metric)
     : null;
   const comparedChange = metricData
-    ? getComparedChange(dailyCostData, metricData, filters.duration)
+    ? getComparedChange(
+        dailyCostData,
+        metricData,
+        filters.duration,
+        lastCompleteBillingDate,
+      )
     : null;
 
   return (

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
@@ -50,7 +50,7 @@ export const CostOverviewCard = ({
     ? findAlways(config.metrics, m => m.kind === filters.metric)
     : null;
   const comparedChange = metricData
-    ? getComparedChange(dailyCostData, metricData)
+    ? getComparedChange(dailyCostData, metricData, filters.duration)
     : null;
 
   return (

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewChart.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewChart.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import React from 'react';
-import moment from 'moment';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import { useTheme } from '@material-ui/core';
 import {
   ComposedChart,
@@ -49,6 +50,8 @@ import {
 import { useCostOverviewStyles as useStyles } from '../../utils/styles';
 import { groupByDate, toDataMax, trendFrom } from '../../utils/charts';
 import { aggregationSort } from '../../utils/sort';
+
+dayjs.extend(utc);
 
 type CostOverviewChartProps = {
   metric: Maybe<Metric>;
@@ -104,7 +107,7 @@ export const CostOverviewChart = ({
     if (isInvalid({ label, payload })) return null;
 
     const dataKeys = [data.dailyCost.dataKey, data.metric.dataKey];
-    const title = moment(label).format(DEFAULT_DATE_FORMAT);
+    const title = dayjs(label).utc().format(DEFAULT_DATE_FORMAT);
     const items = payload
       .filter(p => dataKeys.includes(p.dataKey as string))
       .map(p => ({

--- a/plugins/cost-insights/src/utils/change.test.ts
+++ b/plugins/cost-insights/src/utils/change.test.ts
@@ -14,8 +14,15 @@
  * limitations under the License.
  */
 
-import { growthOf } from './change';
-import { GrowthType, ChangeThreshold, EngineerThreshold } from '../types';
+import { growthOf, getPreviousPeriodTotalCost } from './change';
+import {
+  GrowthType,
+  ChangeThreshold,
+  EngineerThreshold,
+  Duration,
+  Cost,
+} from '../types';
+import { MockAggregatedDailyCosts, trendlineOf, changeOf } from './mockData';
 
 const GrowthMap = {
   [GrowthType.Negligible]: 'negligible growth',
@@ -60,3 +67,17 @@ describe.each`
     });
   },
 );
+
+describe('getPreviousPeriodTotalCost', () => {
+  it('Correctly returns the total cost for the previous period given daily costs', () => {
+    const mockGroupDailyCost: Cost = {
+      id: 'test-group',
+      aggregation: MockAggregatedDailyCosts,
+      change: changeOf(MockAggregatedDailyCosts),
+      trendline: trendlineOf(MockAggregatedDailyCosts),
+    };
+    expect(
+      getPreviousPeriodTotalCost(mockGroupDailyCost, Duration.P1M),
+    ).toEqual(100_000);
+  });
+});

--- a/plugins/cost-insights/src/utils/change.test.ts
+++ b/plugins/cost-insights/src/utils/change.test.ts
@@ -76,8 +76,13 @@ describe('getPreviousPeriodTotalCost', () => {
       change: changeOf(MockAggregatedDailyCosts),
       trendline: trendlineOf(MockAggregatedDailyCosts),
     };
+    const exclusiveEndDate = '2020-10-01';
     expect(
-      getPreviousPeriodTotalCost(mockGroupDailyCost, Duration.P1M),
+      getPreviousPeriodTotalCost(
+        mockGroupDailyCost,
+        Duration.P1M,
+        exclusiveEndDate,
+      ),
     ).toEqual(100_000);
   });
 });

--- a/plugins/cost-insights/src/utils/change.test.ts
+++ b/plugins/cost-insights/src/utils/change.test.ts
@@ -76,7 +76,7 @@ describe('getPreviousPeriodTotalCost', () => {
       change: changeOf(MockAggregatedDailyCosts),
       trendline: trendlineOf(MockAggregatedDailyCosts),
     };
-    const exclusiveEndDate = '2020-10-01';
+    const exclusiveEndDate = '2020-09-30';
     expect(
       getPreviousPeriodTotalCost(
         mockGroupDailyCost,

--- a/plugins/cost-insights/src/utils/change.ts
+++ b/plugins/cost-insights/src/utils/change.ts
@@ -23,10 +23,8 @@ import {
   MetricData,
   Duration,
 } from '../types';
-import { aggregationSort } from '../utils/sort';
-import moment from 'moment';
 import dayjs, { OpUnitType } from 'dayjs';
-import duration, { DurationInputType } from 'dayjs/plugin/duration';
+import duration from 'dayjs/plugin/duration';
 import { inclusiveStartDateOf } from './duration';
 
 dayjs.extend(duration);

--- a/plugins/cost-insights/src/utils/change.ts
+++ b/plugins/cost-insights/src/utils/change.ts
@@ -22,6 +22,7 @@ import {
   GrowthType,
   MetricData,
   Duration,
+  DEFAULT_DATE_FORMAT,
 } from '../types';
 import dayjs, { OpUnitType } from 'dayjs';
 import duration from 'dayjs/plugin/duration';
@@ -68,13 +69,17 @@ export function getComparedChange(
 export function getPreviousPeriodTotalCost(
   dailyCost: Cost,
   duration: Duration,
-  endDate: string,
+  inclusiveEndDate: string,
 ): number {
   const dayjsDuration = dayjs.duration(duration);
-  const startDate = inclusiveStartDateOf(duration, endDate);
+  const startDate = inclusiveStartDateOf(
+    duration,
+    dayjs(inclusiveEndDate).add(1, 'day').format(DEFAULT_DATE_FORMAT),
+  );
+  // dayjs doesn't allow adding an ISO 8601 period to dates.
   const [amount, type]: [number, OpUnitType] = dayjsDuration.days()
-    ? [dayjsDuration.days(), 'days' as OpUnitType]
-    : [dayjsDuration.months(), 'months' as OpUnitType];
+    ? [dayjsDuration.days(), 'day']
+    : [dayjsDuration.months(), 'month'];
   const nextPeriodStart = dayjs(startDate).add(amount, type);
 
   // Add up costs that incurred before the start of the next period.

--- a/plugins/cost-insights/src/utils/duration.ts
+++ b/plugins/cost-insights/src/utils/duration.ts
@@ -22,27 +22,27 @@ import { assertNever } from './assert';
  * Derive the start date of a given period, assuming two repeating intervals.
  *
  * @param duration see comment on Duration enum
- * @param endDate from CostInsightsApi.getLastCompleteBillingDate
+ * @param endDate from CostInsightsApi.getLastCompleteBillingDate + 1 day
  */
 export function inclusiveStartDateOf(
   duration: Duration,
-  endDate: string,
+  exclusiveEndDate: string,
 ): string {
   switch (duration) {
     case Duration.P30D:
     case Duration.P90D:
-      return moment(endDate)
+      return moment(exclusiveEndDate)
         .utc()
         .subtract(moment.duration(duration).add(moment.duration(duration)))
         .format(DEFAULT_DATE_FORMAT);
     case Duration.P1M:
-      return moment(endDate)
+      return moment(exclusiveEndDate)
         .utc()
         .startOf('month')
         .subtract(moment.duration(duration).add(moment.duration(duration)))
         .format(DEFAULT_DATE_FORMAT);
     case Duration.P3M:
-      return moment(endDate)
+      return moment(exclusiveEndDate)
         .utc()
         .startOf('quarter')
         .subtract(moment.duration(duration).add(moment.duration(duration)))
@@ -54,16 +54,22 @@ export function inclusiveStartDateOf(
 
 export function exclusiveEndDateOf(
   duration: Duration,
-  endDate: string,
+  inclusiveEndDate: string,
 ): string {
   switch (duration) {
     case Duration.P30D:
     case Duration.P90D:
-      return moment(endDate).utc().add(1, 'day').format(DEFAULT_DATE_FORMAT);
+      return moment(inclusiveEndDate)
+        .utc()
+        .add(1, 'day')
+        .format(DEFAULT_DATE_FORMAT);
     case Duration.P1M:
-      return moment(endDate).utc().startOf('month').format(DEFAULT_DATE_FORMAT);
+      return moment(inclusiveEndDate)
+        .utc()
+        .startOf('month')
+        .format(DEFAULT_DATE_FORMAT);
     case Duration.P3M:
-      return moment(endDate)
+      return moment(inclusiveEndDate)
         .utc()
         .startOf('quarter')
         .format(DEFAULT_DATE_FORMAT);
@@ -74,15 +80,15 @@ export function exclusiveEndDateOf(
 
 export function inclusiveEndDateOf(
   duration: Duration,
-  endDate: string,
+  inclusiveEndDate: string,
 ): string {
-  return moment(exclusiveEndDateOf(duration, endDate))
+  return moment(exclusiveEndDateOf(duration, inclusiveEndDate))
     .utc()
     .subtract(1, 'day')
     .format(DEFAULT_DATE_FORMAT);
 }
 
 // https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals
-export function intervalsOf(duration: Duration, endDate: string) {
-  return `R2/${duration}/${exclusiveEndDateOf(duration, endDate)}`;
+export function intervalsOf(duration: Duration, inclusiveEndDate: string) {
+  return `R2/${duration}/${exclusiveEndDateOf(duration, inclusiveEndDate)}`;
 }

--- a/plugins/cost-insights/src/utils/formatters.ts
+++ b/plugins/cost-insights/src/utils/formatters.ts
@@ -15,7 +15,7 @@
  */
 
 import moment from 'moment';
-import { Duration } from '../types';
+import { Duration, DEFAULT_DATE_FORMAT } from '../types';
 import { inclusiveEndDateOf, inclusiveStartDateOf } from '../utils/duration';
 import { pluralOf } from '../utils/grammar';
 
@@ -84,21 +84,27 @@ export function formatPercent(n: number): string {
   return `${(n * 100).toFixed(0)}%`;
 }
 
-export function formatLastTwoLookaheadQuarters(endDate: string) {
-  const start = moment(inclusiveStartDateOf(Duration.P3M, endDate)).format(
-    '[Q]Q YYYY',
-  );
-  const end = moment(inclusiveEndDateOf(Duration.P3M, endDate)).format(
+export function formatLastTwoLookaheadQuarters(inclusiveEndDate: string) {
+  const exclusiveEndDate = moment(inclusiveEndDate)
+    .add(1, 'day')
+    .format(DEFAULT_DATE_FORMAT);
+  const start = moment(
+    inclusiveStartDateOf(Duration.P3M, exclusiveEndDate),
+  ).format('[Q]Q YYYY');
+  const end = moment(inclusiveEndDateOf(Duration.P3M, inclusiveEndDate)).format(
     '[Q]Q YYYY',
   );
   return `${start} vs ${end}`;
 }
 
-export function formatLastTwoMonths(endDate: string) {
-  const start = moment(inclusiveStartDateOf(Duration.P1M, endDate))
+export function formatLastTwoMonths(inclusiveEndDate: string) {
+  const exclusiveEndDate = moment(inclusiveEndDate)
+    .add(1, 'day')
+    .format(DEFAULT_DATE_FORMAT);
+  const start = moment(inclusiveStartDateOf(Duration.P1M, exclusiveEndDate))
     .utc()
     .format('MMMM');
-  const end = moment(inclusiveEndDateOf(Duration.P1M, endDate))
+  const end = moment(inclusiveEndDateOf(Duration.P1M, inclusiveEndDate))
     .utc()
     .format('MMMM');
   return `${start} vs ${end}`;

--- a/plugins/cost-insights/src/utils/mockData.ts
+++ b/plugins/cost-insights/src/utils/mockData.ts
@@ -215,3 +215,250 @@ export function changeOf(aggregation: DateAggregation[]): ChangeStatistic {
     amount: after - before,
   };
 }
+
+export const MockAggregatedDailyCosts: DateAggregation[] = [
+  {
+    date: '2020-08-07',
+    amount: 3500,
+  },
+  {
+    date: '2020-08-06',
+    amount: 2500,
+  },
+  {
+    date: '2020-08-05',
+    amount: 1400,
+  },
+  {
+    date: '2020-08-04',
+    amount: 3800,
+  },
+  {
+    date: '2020-08-09',
+    amount: 1900,
+  },
+  {
+    date: '2020-08-08',
+    amount: 2400,
+  },
+  {
+    date: '2020-08-03',
+    amount: 4000,
+  },
+  {
+    date: '2020-08-02',
+    amount: 3700,
+  },
+  {
+    date: '2020-08-01',
+    amount: 2500,
+  },
+  {
+    date: '2020-08-18',
+    amount: 4300,
+  },
+  {
+    date: '2020-08-17',
+    amount: 1500,
+  },
+  {
+    date: '2020-08-16',
+    amount: 3600,
+  },
+  {
+    date: '2020-08-15',
+    amount: 2200,
+  },
+  {
+    date: '2020-08-19',
+    amount: 3900,
+  },
+  {
+    date: '2020-08-10',
+    amount: 4100,
+  },
+  {
+    date: '2020-08-14',
+    amount: 3600,
+  },
+  {
+    date: '2020-08-13',
+    amount: 2900,
+  },
+  {
+    date: '2020-08-12',
+    amount: 2700,
+  },
+  {
+    date: '2020-08-11',
+    amount: 5100,
+  },
+  {
+    date: '2020-09-19',
+    amount: 1200,
+  },
+  {
+    date: '2020-09-18',
+    amount: 6500,
+  },
+  {
+    date: '2020-09-17',
+    amount: 2500,
+  },
+  {
+    date: '2020-09-16',
+    amount: 1400,
+  },
+  {
+    date: '2020-09-11',
+    amount: 2300,
+  },
+  {
+    date: '2020-09-10',
+    amount: 1900,
+  },
+  {
+    date: '2020-09-15',
+    amount: 3100,
+  },
+  {
+    date: '2020-09-14',
+    amount: 4500,
+  },
+  {
+    date: '2020-09-13',
+    amount: 3300,
+  },
+  {
+    date: '2020-09-12',
+    amount: 2800,
+  },
+  {
+    date: '2020-09-29',
+    amount: 2600,
+  },
+  {
+    date: '2020-09-28',
+    amount: 4100,
+  },
+  {
+    date: '2020-09-27',
+    amount: 3800,
+  },
+  {
+    date: '2020-09-22',
+    amount: 3700,
+  },
+  {
+    date: '2020-09-21',
+    amount: 2700,
+  },
+  {
+    date: '2020-09-20',
+    amount: 2200,
+  },
+  {
+    date: '2020-09-26',
+    amount: 3300,
+  },
+  {
+    date: '2020-09-25',
+    amount: 4000,
+  },
+  {
+    date: '2020-09-24',
+    amount: 3800,
+  },
+  {
+    date: '2020-09-23',
+    amount: 4100,
+  },
+  {
+    date: '2020-08-29',
+    amount: 4400,
+  },
+  {
+    date: '2020-08-28',
+    amount: 5000,
+  },
+  {
+    date: '2020-08-27',
+    amount: 4900,
+  },
+  {
+    date: '2020-08-26',
+    amount: 4100,
+  },
+  {
+    date: '2020-08-21',
+    amount: 3700,
+  },
+  {
+    date: '2020-08-20',
+    amount: 2200,
+  },
+  {
+    date: '2020-08-25',
+    amount: 1700,
+  },
+  {
+    date: '2020-08-24',
+    amount: 2100,
+  },
+  {
+    date: '2020-08-23',
+    amount: 3100,
+  },
+  {
+    date: '2020-08-22',
+    amount: 1500,
+  },
+  {
+    date: '2020-09-08',
+    amount: 2900,
+  },
+  {
+    date: '2020-09-07',
+    amount: 4100,
+  },
+  {
+    date: '2020-09-06',
+    amount: 3600,
+  },
+  {
+    date: '2020-09-05',
+    amount: 3300,
+  },
+  {
+    date: '2020-09-09',
+    amount: 2800,
+  },
+  {
+    date: '2020-08-31',
+    amount: 3400,
+  },
+  {
+    date: '2020-08-30',
+    amount: 4300,
+  },
+  {
+    date: '2020-09-04',
+    amount: 6100,
+  },
+  {
+    date: '2020-09-03',
+    amount: 2500,
+  },
+  {
+    date: '2020-09-02',
+    amount: 4900,
+  },
+  {
+    date: '2020-09-01',
+    amount: 6100,
+  },
+  {
+    date: '2020-09-30',
+    amount: 5500,
+  },
+];


### PR DESCRIPTION
## Hey, I just made a Pull Request!
- Fixes calculation of `comparedChange` between the comparison metric and daily cost data. This was causing incorrect excess/savings amounts in the daily cost panel. The savings/excess amount is based on the amount difference between the actual cost incurred during the current period vs the expected cost if costs had grown at the same rate as the comparison metric.  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
