### PR TITLE
fix:(cost-insights-plugin): remove excessive header margin from cost overview banner

### DIFF
--- a/.changeset/cost-insights-strange-rings-smile.md
+++ b/.changeset/cost-insights-strange-rings-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+remove excessive margin from cost overview banner

--- a/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPage.tsx
+++ b/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPage.tsx
@@ -191,7 +191,7 @@ export const CostInsightsPage = () => {
   const CostOverviewBanner = () => (
     <Box
       px={3}
-      marginTop={10}
+      pt={6}
       display="flex"
       flexDirection="row"
       justifyContent="space-between"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<img width="1373" alt="Screen Shot 2020-11-16 at 9 41 20 AM" src="https://user-images.githubusercontent.com/3030003/99265947-4482f700-27f0-11eb-9c06-9ed174e54513.png">

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
