### PR TITLE
Change metadata buttons on component About widget

### DIFF
--- a/.changeset/witty-horses-deny.md
+++ b/.changeset/witty-horses-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Update About widget metadata buttons

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -119,6 +119,7 @@ export function AboutCard({ entity, variant }: AboutCardProps) {
         action={
           <IconButton
             aria-label="Edit"
+            title="Edit Metadata"
             onClick={() => {
               window.open(codeLink.edithref || '#', '_blank');
             }}
@@ -128,12 +129,11 @@ export function AboutCard({ entity, variant }: AboutCardProps) {
         }
         subheader={
           <nav className={classes.links}>
-            <IconLinkVertical label="View Source" {...codeLink} />
             <IconLinkVertical
               disabled={
                 !entity.metadata.annotations?.['backstage.io/techdocs-ref']
               }
-              label="View Techdocs"
+              label="View TechDocs"
               icon={<DocsIcon />}
               href={`/docs/${
                 entity.metadata.namespace || ENTITY_DEFAULT_NAMESPACE


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR changes how the about widget supports viewing/modifying meta data.  With a view to user-centric design, most users who are viewing my component are interested in the component itself, not it's meta data. I believe the "View Source" button shouldn't be so prominent.  And in fact, it's not the source of the component, but the metadata ABOUT the component.

This PR,

* Adds a tool tip to the edit button to remind that it is to "Edit Metadata"
* Removes the "View Source" button

Thus, the only way to access the meta data itself is to click the edit button.

I believe this makes sense but open to feedback/opinions!

| Old | New |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33203301/99311242-49fd3300-282a-11eb-81c0-fca8e082ec9d.png) | ![image](https://user-images.githubusercontent.com/33203301/99311324-6ac58880-282a-11eb-8482-22d83995bc2d.png) |


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
