### PR TITLE
Feat: bump GitHub Insights Plugin version

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,7 +34,7 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@octokit/rest": "^18.0.0",
-    "@roadiehq/backstage-plugin-github-insights": "^0.2.12",
+    "@roadiehq/backstage-plugin-github-insights": "^0.2.14",
     "@roadiehq/backstage-plugin-github-pull-requests": "^0.6.2",
     "@roadiehq/backstage-plugin-travis-ci": "^0.2.7",
     "@roadiehq/backstage-plugin-buildkite": "^0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,10 +3706,10 @@
     react-router-dom "6.0.0-beta.0"
     react-use "^15.3.3"
 
-"@roadiehq/backstage-plugin-github-insights@^0.2.12":
-  version "0.2.12"
-  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-github-insights/-/backstage-plugin-github-insights-0.2.12.tgz#aeda6306769f376cf6b5b9d74268b060a0f4e764"
-  integrity sha512-f9g5ajVWQkywoYo0zDUZV3g0SPxOTi3MvMuhUvgaZ/XKJr9mBZTe5qHnEYBSHOCB88l0Y2g0qHNdbjXhbFpokQ==
+"@roadiehq/backstage-plugin-github-insights@^0.2.14":
+  version "0.2.14"
+  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-github-insights/-/backstage-plugin-github-insights-0.2.14.tgz#2e4bf61495e650bb2b7a1711f97c9c4995215588"
+  integrity sha512-xhzHAmmTu7op1V7K3ytomGlmzHMs9jnb2Lc2YTrU3ame4WZcrrMCrqi8X9v8B8VHfwMBrwa55tyxRYObXrPr7A==
   dependencies:
     "@backstage/catalog-model" "^0.2.0"
     "@backstage/core" "^0.2.0"
@@ -3722,10 +3722,8 @@
     history "^5.0.0"
     react "^16.13.1"
     react-dom "^16.13.1"
-    react-markdown "^5.0.0"
     react-router "^6.0.0-beta.0"
     react-use "^15.3.3"
-    remark-gfm "^1.0.0"
 
 "@roadiehq/backstage-plugin-github-pull-requests@^0.6.2":
   version "0.6.2"
@@ -19788,7 +19786,7 @@ react-markdown@^4.3.1:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
-react-markdown@^5.0.0, react-markdown@^5.0.2:
+react-markdown@^5.0.2:
   version "5.0.2"
   resolved "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.2.tgz#d15a8beb37b4ec34fc23dd892e7755eb7040b8db"
   integrity sha512-kmkB4JbV7LqkDAjvaKRKtodB3n3Id76/DalaDun1U8FuLB0SenPfvH+jAQ5Pcpo54cACRQc1LB1yXmuuuIVecw==


### PR DESCRIPTION
## GitHub Insights Plugin
Hello,
this PR bump plugin version to the latest one. Plugin is of course backward compatible.
 
Changes:
- replace ReactMarkdown component to the one from Backstage core adopting those changes https://github.com/backstage/backstage/pull/3157
- resolve issues with fetching contributors avatars for GitHub Enterprise setup

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
