### PR TITLE
Add tooltips on About card

### DIFF
--- a/.changeset/friendly-dodos-remember.md
+++ b/.changeset/friendly-dodos-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Add About Card tooltips

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -192,6 +192,7 @@ tolerations
 Tolerations
 toolsets
 tooltip
+tooltips
 touchpoints
 ui
 upvote

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -119,6 +119,7 @@ export function AboutCard({ entity, variant }: AboutCardProps) {
         action={
           <IconButton
             aria-label="Edit"
+            title="Edit Metadata"
             onClick={() => {
               window.open(codeLink.edithref || '#', '_blank');
             }}
@@ -133,7 +134,12 @@ export function AboutCard({ entity, variant }: AboutCardProps) {
               disabled={
                 !entity.metadata.annotations?.['backstage.io/techdocs-ref']
               }
-              label="View Techdocs"
+              label="View TechDocs"
+              title={
+                !entity.metadata.annotations?.['backstage.io/techdocs-ref']
+                  ? 'No TechDocs available'
+                  : ''
+              }
               icon={<DocsIcon />}
               href={`/docs/${
                 entity.metadata.namespace || ENTITY_DEFAULT_NAMESPACE
@@ -142,6 +148,7 @@ export function AboutCard({ entity, variant }: AboutCardProps) {
             <IconLinkVertical
               disabled={!entity.spec?.implementsApis}
               label="View API"
+              title={!entity.spec?.implementsApis ? 'No APIs available' : ''}
               icon={<ExtensionIcon />}
               href="api"
             />

--- a/plugins/catalog/src/components/AboutCard/IconLinkVertical/IconLinkVertical.tsx
+++ b/plugins/catalog/src/components/AboutCard/IconLinkVertical/IconLinkVertical.tsx
@@ -23,6 +23,7 @@ export type IconLinkVerticalProps = {
   icon?: React.ReactNode;
   href?: string;
   disabled?: boolean;
+  title?: string;
   label: string;
 };
 
@@ -57,6 +58,7 @@ export function IconLinkVertical({
       <Link
         className={classnames(classes.link, classes.disabled)}
         underline="none"
+        title={props.title}
         {...props}
       >
         {icon}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR adds tool tips to the About card, specifically:

* Edit Metadata over the pencil
  ![image](https://user-images.githubusercontent.com/33203301/99426923-c0557000-28d2-11eb-94b6-c615c14c11ff.png)
* When the View TechDocs or View APIs cards are disabled, a relevant tool tip so user knows why the buttons are disabled (e.g., "No TechDocs available" to re-enforce it).
  ![image](https://user-images.githubusercontent.com/33203301/99427008-da8f4e00-28d2-11eb-9121-db415fbe6593.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
