### PR TITLE
github/workdflows: bump setup-msbuild to fix windows builds

### DIFF
--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
       - name: yarn install
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
Due to https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w