### PR TITLE
fix(cost-insights-plugin): fix tooltip title for very long period separated titles

### DIFF
--- a/plugins/cost-insights/src/components/BarChart/BarChartTooltip.tsx
+++ b/plugins/cost-insights/src/components/BarChart/BarChartTooltip.tsx
@@ -35,7 +35,6 @@ export const BarChartTooltip = ({
   children,
 }: PropsWithChildren<BarChartTooltipProps>) => {
   const classes = useStyles();
-
   return (
     <Box className={classes.tooltip} display="flex" flexDirection="column">
       <Box
@@ -47,14 +46,16 @@ export const BarChartTooltip = ({
         pt={2}
       >
         <Box display="flex" flexDirection="column">
-          <Typography variant="h6">{title}</Typography>
+          <Typography className={classes.truncate} variant="h6">
+            {title}
+          </Typography>
           {subtitle && (
             <Typography className={classes.subtitle} variant="subtitle1">
               {subtitle}
             </Typography>
           )}
         </Box>
-        {topRight}
+        {topRight && <Box ml={1}>{topRight}</Box>}
       </Box>
       {content && (
         <Box px={2} pt={2}>

--- a/plugins/cost-insights/src/utils/styles.ts
+++ b/plugins/cost-insights/src/utils/styles.ts
@@ -386,7 +386,7 @@ export const useTooltipStyles = makeStyles<CostInsightsTheme>(
         boxShadow: theme.shadows[1],
         color: theme.palette.tooltip.color,
         fontSize: theme.typography.fontSize,
-        width: 250,
+        maxWidth: 300,
       },
       actions: {
         padding: theme.spacing(2),
@@ -402,6 +402,12 @@ export const useTooltipStyles = makeStyles<CostInsightsTheme>(
       },
       divider: {
         backgroundColor: emphasize(theme.palette.divider, 1),
+      },
+      truncate: {
+        maxWidth: 200,
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
       },
       subtitle: {
         fontStyle: 'italic',


### PR DESCRIPTION
Long tooltip titles normally wrap around to a new line, which currently work as intended for space and hyphen separated title strings but the layout breaks for continuous, period separated titles.

<img width="561" alt="Screen Shot 2020-11-17 at 5 44 20 PM" src="https://user-images.githubusercontent.com/3030003/99459740-93b64e00-28fc-11eb-8507-c497a3a2834b.png">

Bumps the width of the tooltip slightly and truncates titles to a fixed width. 

### Long title with cost indicator
<img width="488" alt="Screen Shot 2020-11-17 at 5 23 32 PM" src="https://user-images.githubusercontent.com/3030003/99459205-b7c55f80-28fb-11eb-8b6a-94bc85e9e9ce.png">

### Long title without cost indicator
<img width="492" alt="Screen Shot 2020-11-17 at 5 23 18 PM" src="https://user-images.githubusercontent.com/3030003/99459246-c9a70280-28fb-11eb-9844-c1c0c094eb09.png">

### Normal length title with content
<img width="439" alt="Screen Shot 2020-11-17 at 5 25 11 PM" src="https://user-images.githubusercontent.com/3030003/99459385-ffe48200-28fb-11eb-83ab-769d1b09acfd.png">

### Normal length title without content
<img width="538" alt="Screen Shot 2020-11-17 at 5 22 57 PM" src="https://user-images.githubusercontent.com/3030003/99459479-2b676c80-28fc-11eb-9d1d-484d45174562.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
