### PR TITLE
chore: remove obsolete circleci proxy config

### DIFF
--- a/.changeset/loud-pets-clap.md
+++ b/.changeset/loud-pets-clap.md
@@ -1,0 +1,5 @@
+---
+'example-app': patch
+---
+
+Removed obsolete CircleCI proxy config from example-app

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -86,14 +86,5 @@
       "last 1 safari version"
     ]
   },
-  "license": "Apache-2.0",
-  "proxy": {
-    "/circleci/api": {
-      "target": "https://circleci.com/api/v1.1",
-      "changeOrigin": true,
-      "pathRewrite": {
-        "^/circleci/api/": "/"
-      }
-    }
-  }
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The CircleCI proxy config was moved to the `app-config.yaml` a while back so it is not longer needed in the package.json file of the example-app.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
