### PR TITLE
feat(cli): Support specifying listen host/port for frontend

### DIFF
--- a/.changeset/modern-boats-knock.md
+++ b/.changeset/modern-boats-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Support specifying listen host/port for frontend

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -25,7 +25,12 @@ import { resolveBundlingPaths } from './paths';
 export async function serveBundle(options: ServeOptions) {
   const url = resolveBaseUrl(options.config);
 
-  const port = Number(url.port) || (url.protocol === 'https:' ? 443 : 80);
+  const host =
+    options.config.getOptionalString('app.listen.host') || url.hostname;
+  const port =
+    options.config.getOptionalNumber('app.listen.port') ||
+    Number(url.port) ||
+    (url.protocol === 'https:' ? 443 : 80);
 
   const paths = resolveBundlingPaths(options);
   const pkgPath = paths.targetPackageJson;
@@ -50,7 +55,7 @@ export async function serveBundle(options: ServeOptions) {
     clientLogLevel: 'warning',
     stats: 'errors-warnings',
     https: url.protocol === 'https:',
-    host: url.hostname,
+    host,
     port,
     proxy: pkg.proxy,
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Supersedes #3211.

This extends the `app` config to have `app.listen` just like `backend.listen`. However, because the key did not exist before, only the hash form of `listen` is supported.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
