### PR TITLE
Ryanv/product entity dialog improvements

### DIFF
--- a/.changeset/cost-insights-wet-plants-glow.md
+++ b/.changeset/cost-insights-wet-plants-glow.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+UI improvements: Increase width of first column in product entity dialog table
+UI improvement: Display full cost amount in product entity dialog table

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityDialog.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityDialog.tsx
@@ -122,6 +122,7 @@ export const ProductEntityDialog = ({
       title: <Typography className={firstColClasses}>SKU</Typography>,
       render: createRenderer('sku', classes),
       customSort: createSorter('sku'),
+      width: '33.33%',
     },
     {
       field: 'previous',

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityDialog.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityDialog.tsx
@@ -20,7 +20,7 @@ import { Table, TableColumn } from '@backstage/core';
 import { Dialog, IconButton, Typography } from '@material-ui/core';
 import { default as CloseButton } from '@material-ui/icons/Close';
 import { CostGrowthIndicator } from '../CostGrowth';
-import { currencyFormatter, formatPercent } from '../../utils/formatters';
+import { costFormatter, formatPercent } from '../../utils/formatters';
 import { useEntityDialogStyles as useStyles } from '../../utils/styles';
 import { BarChartOptions, Entity } from '../../types';
 
@@ -38,7 +38,7 @@ function createRenderer(col: keyof RowData, classes: Record<string, string>) {
       case 'current':
         return (
           <Typography className={rowStyles}>
-            {currencyFormatter.format(row[col])}
+            {costFormatter.format(row[col])}
           </Typography>
         );
       case 'ratio':

--- a/plugins/cost-insights/src/utils/formatters.ts
+++ b/plugins/cost-insights/src/utils/formatters.ts
@@ -24,6 +24,11 @@ export type Period = {
   periodEnd: string;
 };
 
+export const costFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
 export const currencyFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some small UI improvements to the product entity dialog

<img width="1289" alt="Screen Shot 2020-11-18 at 3 20 33 PM" src="https://user-images.githubusercontent.com/3030003/99584575-231e3880-29b3-11eb-8a5c-669418c4a284.png">

### Increase width of SKU column
The first column in the table displays text content, which may run long. Current behavior is to wrap around but there is enough horizontal real estate to give it some extra width. Relative to a third of the container.

### Show full dollar amounts 
We normally round to the nearest dollar to prevent the visual bloat of insignificant costs but for the product entity breakdown, it's likely the user will want to see these raw costs in more granularity, however negligible they may be. This can also potentially reduce confusion around the bottom row `Total` calculation.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
