### PR TITLE
techdocs-backend: update Gitlab clone auth

### DIFF
--- a/.changeset/famous-items-travel.md
+++ b/.changeset/famous-items-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Update URL auth format for Gitlab clone

--- a/plugins/techdocs-backend/src/helpers.ts
+++ b/plugins/techdocs-backend/src/helpers.ts
@@ -146,8 +146,18 @@ export const checkoutGitRepository = async (
 
   if (token) {
     const type = getGitRepoType(repoUrl);
-    const auth = type === 'github' ? `${token}:x-oauth-basic` : `:${token}`;
-    parsedGitLocation.token = auth;
+    switch (type) {
+      case 'gitlab':
+        // Personal Access Token
+        parsedGitLocation.token = `dummyUsername:${token}`;
+        parsedGitLocation.git_suffix = true;
+        break;
+      case 'github':
+        parsedGitLocation.token = `${token}:x-oauth-basic`;
+        break;
+      default:
+        parsedGitLocation.token = `:${token}`;
+    }
   }
 
   const repositoryCheckoutUrl = parsedGitLocation.toString('https');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A recent update in our Gitlab server from 13.3.8 to 13.4.6 seems to require this more specific URL format for cloning with a token. Would be good if anyone else with private Gitlab could test this out as well.

#### :heavy_check_mark: Checklist

- [✔️ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
