### PR TITLE
Replace broken icon for the api-docs plugin

### DIFF
--- a/microsite/data/plugins/api-docs.yaml
+++ b/microsite/data/plugins/api-docs.yaml
@@ -5,5 +5,5 @@ authorUrl: https://sda.se/
 category: Discovery
 description: Components to discover and display API entities as an extension to the catalog plugin.
 documentation: https://github.com/backstage/backstage/blob/master/plugins/api-docs/README.md
-iconUrl: https://thecoders.io/wp-content/uploads/2019/11/tech-swagger.svg
+iconUrl: https://raw.githubusercontent.com/vscode-icons/vscode-icons/master/icons/file_type_swagger.svg
 npmPackageName: '@backstage/plugin-api-docs'


### PR DESCRIPTION
Closes #3330

I would guess that https://github.com/vscode-icons/vscode-icons is a more stable location for an icon.

![image](https://user-images.githubusercontent.com/648527/99655313-de9aa780-2a5b-11eb-8c2a-62c0718e998d.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
