### PR TITLE
[Search] name in search result clickable

### DIFF
--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@backstage/core": "^0.3.1",
     "@backstage/plugin-catalog": "^0.2.2",
+    "@backstage/catalog-model": "^0.2.0",
     "@backstage/theme": "^0.2.1",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/plugins/search/src/apis.ts
+++ b/plugins/search/src/apis.ts
@@ -18,11 +18,11 @@ import { CatalogApi } from '@backstage/plugin-catalog';
 
 export type Result = {
   name: string;
-  namespace: string;
   description: string;
   owner: string;
   kind: string;
   lifecycle: string;
+  url: string;
 };
 
 export type SearchResults = Array<Result>;
@@ -38,11 +38,13 @@ class SearchApi {
     const entities = await this.catalogApi.getEntities();
     return entities.items.map((result: any) => ({
       name: result.metadata.name,
-      namespace: result.metadata.namespace,
       description: result.metadata.description,
       owner: result.spec.owner,
       kind: result.kind,
       lifecycle: result.spec.lifecycle,
+      url: `/catalog/${result.metadata.namespace || 'default'}/${result.kind}/${
+        result.metadata.name
+      }`,
     }));
   }
 

--- a/plugins/search/src/apis.ts
+++ b/plugins/search/src/apis.ts
@@ -18,6 +18,7 @@ import { CatalogApi } from '@backstage/plugin-catalog';
 
 export type Result = {
   name: string;
+  namespace: string;
   description: string;
   owner: string;
   kind: string;
@@ -37,6 +38,7 @@ class SearchApi {
     const entities = await this.catalogApi.getEntities();
     return entities.items.map((result: any) => ({
       name: result.metadata.name,
+      namespace: result.metadata.namespace,
       description: result.metadata.description,
       owner: result.spec.owner,
       kind: result.kind,

--- a/plugins/search/src/apis.ts
+++ b/plugins/search/src/apis.ts
@@ -15,6 +15,7 @@
  */
 
 import { CatalogApi } from '@backstage/plugin-catalog';
+import { Entity, ENTITY_DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 
 export type Result = {
   name: string;
@@ -36,15 +37,19 @@ class SearchApi {
 
   private async entities() {
     const entities = await this.catalogApi.getEntities();
-    return entities.items.map((result: any) => ({
-      name: result.metadata.name,
-      description: result.metadata.description,
-      owner: result.spec.owner,
-      kind: result.kind,
-      lifecycle: result.spec.lifecycle,
-      url: `/catalog/${result.metadata.namespace || 'default'}/${result.kind}/${
-        result.metadata.name
-      }`,
+    return entities.items.map((entity: Entity) => ({
+      name: entity.metadata.name,
+      description: entity.metadata.description || 'No description',
+      owner:
+        typeof entity.spec?.owner === 'string' ? entity.spec?.owner : 'unknown',
+      kind: entity.kind,
+      lifecycle:
+        typeof entity.spec?.lifecycle === 'string'
+          ? entity.spec?.lifecycle
+          : 'unknown',
+      url: `/catalog/${entity.metadata.namespace || ENTITY_DEFAULT_NAMESPACE}/${
+        entity.kind
+      }/${entity.metadata.name}`,
     }));
   }
 

--- a/plugins/search/src/apis.ts
+++ b/plugins/search/src/apis.ts
@@ -20,9 +20,9 @@ import { Entity, ENTITY_DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 export type Result = {
   name: string;
   description: string;
-  owner: string;
+  owner: string | undefined;
   kind: string;
-  lifecycle: string;
+  lifecycle: string | undefined;
   url: string;
 };
 
@@ -40,16 +40,15 @@ class SearchApi {
     return entities.items.map((entity: Entity) => ({
       name: entity.metadata.name,
       description: entity.metadata.description || 'No description',
-      owner:
-        typeof entity.spec?.owner === 'string' ? entity.spec?.owner : 'unknown',
+      owner: typeof entity.spec?.owner ?? undefined,
       kind: entity.kind,
       lifecycle:
         typeof entity.spec?.lifecycle === 'string'
           ? entity.spec?.lifecycle
-          : 'unknown',
-      url: `/catalog/${entity.metadata.namespace || ENTITY_DEFAULT_NAMESPACE}/${
-        entity.kind
-      }/${entity.metadata.name}`,
+          : undefined,
+      url: `/catalog/${
+        entity.metadata.namespace?.toLowerCase() || ENTITY_DEFAULT_NAMESPACE
+      }/${entity.kind.toLowerCase()}/${entity.metadata.name}`,
     }));
   }
 

--- a/plugins/search/src/apis.ts
+++ b/plugins/search/src/apis.ts
@@ -19,7 +19,7 @@ import { Entity, ENTITY_DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 
 export type Result = {
   name: string;
-  description: string;
+  description: string | undefined;
   owner: string | undefined;
   kind: string;
   lifecycle: string | undefined;
@@ -39,8 +39,9 @@ class SearchApi {
     const entities = await this.catalogApi.getEntities();
     return entities.items.map((entity: Entity) => ({
       name: entity.metadata.name,
-      description: entity.metadata.description || 'No description',
-      owner: typeof entity.spec?.owner ?? undefined,
+      description: entity.metadata.description,
+      owner:
+        typeof entity.spec?.owner === 'string' ? entity.spec?.owner : undefined,
       kind: entity.kind,
       lifecycle:
         typeof entity.spec?.lifecycle === 'string'

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -19,6 +19,7 @@ import { useAsync } from 'react-use';
 import { makeStyles, Typography, Grid, Divider } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import {
+  Link,
   EmptyState,
   Progress,
   Table,
@@ -68,6 +69,11 @@ const columns: TableColumn[] = [
     title: 'Component Id',
     field: 'name',
     highlight: true,
+    render: (entity: Partial<Result>) => (
+      <Link to={`/catalog/${entity.namespace}/${entity.kind}/${entity.name}`}>
+        {entity.name}
+      </Link>
+    ),
   },
   {
     title: 'Description',

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -66,7 +66,7 @@ type Filters = {
 // TODO: move out column to make the search result component more generic
 const columns: TableColumn[] = [
   {
-    title: 'Component Id',
+    title: 'Name',
     field: 'name',
     highlight: true,
     render: (entity: Partial<Result>) => (

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -69,10 +69,8 @@ const columns: TableColumn[] = [
     title: 'Name',
     field: 'name',
     highlight: true,
-    render: (entity: Partial<Result>) => (
-      <Link to={`/catalog/${entity.namespace}/${entity.kind}/${entity.name}`}>
-        {entity.name}
-      </Link>
+    render: (result: Partial<Result>) => (
+      <Link to={result.url || ''}>{result.name}</Link>
     ),
   },
   {

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -153,8 +153,9 @@ export const SearchResult = ({ searchQuery }: SearchResultProps) => {
 
       // filter on checked
       if (filters.checked.length > 0) {
-        withFilters = withFilters.filter((result: Result) =>
-          filters.checked.includes(result.lifecycle),
+        withFilters = withFilters.filter(
+          (result: Result) =>
+            result.lifecycle && filters.checked.includes(result.lifecycle),
         );
       }
 


### PR DESCRIPTION
This PR makes it possible to navigate to the service catalog page of an entity by clicking on the name. It also changes the column name from "component id" to "name" to be more consistent in terminology across Backstage. 

closes: #3345

Before: 
<img width="1440" alt="Screen Shot 2020-11-19 at 12 49 54 PM" src="https://user-images.githubusercontent.com/25153114/99662581-bdd74f80-2a65-11eb-9a66-1a83137de946.png">

After:
<img width="1440" alt="Screen Shot 2020-11-19 at 12 48 29 PM" src="https://user-images.githubusercontent.com/25153114/99662479-97b1af80-2a65-11eb-8285-6ec6f62beede.png">


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
