### PR TITLE
fix(search): return EmptyState/Progress bar/Alert depending on result of api call

### DIFF
--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -17,7 +17,14 @@ import React, { useState, useEffect } from 'react';
 import { useAsync } from 'react-use';
 
 import { makeStyles, Typography, Grid, Divider } from '@material-ui/core';
-import { Table, TableColumn, useApi } from '@backstage/core';
+import { Alert } from '@material-ui/lab';
+import {
+  EmptyState,
+  Progress,
+  Table,
+  TableColumn,
+  useApi,
+} from '@backstage/core';
 import { catalogApiRef } from '@backstage/plugin-catalog';
 
 import { FiltersButton, Filters, FiltersState } from '../Filters';
@@ -159,8 +166,19 @@ export const SearchResult = ({ searchQuery }: SearchResultProps) => {
       setFilteredResults(withFilters);
     }
   }, [filters, searchQuery, results]);
-
-  if (loading || error || !results) return null;
+  if (loading) {
+    return <Progress />;
+  }
+  if (error) {
+    return (
+      <Alert severity="error">
+        Error encountered while fetching search results. {error.toString()}
+      </Alert>
+    );
+  }
+  if (!results || results.length === 0) {
+    return <EmptyState missing="info" title="Sorry, no results were found" />;
+  }
 
   const resetFilters = () => {
     setFilters({

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -177,7 +177,7 @@ export const SearchResult = ({ searchQuery }: SearchResultProps) => {
     );
   }
   if (!results || results.length === 0) {
-    return <EmptyState missing="info" title="Sorry, no results were found" />;
+    return <EmptyState missing="data" title="Sorry, no results were found" />;
   }
 
   const resetFilters = () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request! 

Fixes #3342 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
On Search Result page, depending on the result of the api call display different component.

When `loading`, `Progress` component is shown
<img width="1440" alt="Screenshot 2020-11-19 at 13 03 06" src="https://user-images.githubusercontent.com/968005/99664451-7d2d0580-2a68-11eb-80ac-9aa71a424c1a.png">

When call to api fails with an error, `Alert` component is shown
<img width="1440" alt="Screenshot 2020-11-19 at 13 04 17" src="https://user-images.githubusercontent.com/968005/99664551-a0f04b80-2a68-11eb-8f5d-0b2b01c39553.png">

When call is finished with empty result, `EmptyState` component is shown
<img width="1440" alt="Screenshot 2020-11-19 at 13 04 46" src="https://user-images.githubusercontent.com/968005/99664637-c67d5500-2a68-11eb-87ca-45b55af897db.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
