### PR TITLE
Add an authentication middleware to the set of common backend middlewares

### DIFF
--- a/packages/backend-common/src/middleware/authenticationHandler.test.ts
+++ b/packages/backend-common/src/middleware/authenticationHandler.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import express from 'express';
+import request from 'supertest';
+import { authenticationHandler } from './authenticationHandler';
+
+describe('authenticationHandler', () => {
+  it('checks if a request is authenticated', async () => {
+    const requestAuthenticator = (req: express.Request): boolean => {
+      const authHeader = req.header?.('Authorization');
+      // This is just for unit-testing !
+      // Tokens are generally cryptographically signed and to implement something
+      // one needs to check the token using JWK's etc
+      if (!authHeader || authHeader !== 'Test Token') {
+        return false;
+      }
+      return true;
+    };
+
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    const logRequest = (_req: express.Request) => {};
+
+    const authenticator = {
+      authenticateRequest: requestAuthenticator,
+      logRequest: logRequest,
+    };
+
+    const app = express();
+    app.use(authenticationHandler(authenticator));
+    app.get('/exists', (_, res) => res.status(200).send('This page exists'));
+
+    const unauthorizedResponse = await request(app).get('/exists');
+    const authorizedResponse = await request(app)
+      .get('/exists')
+      .set('Authorization', 'Test Token');
+
+    expect(unauthorizedResponse.status).toBe(403);
+    expect(authorizedResponse.status).toBe(200);
+  });
+});

--- a/packages/backend-common/src/middleware/authenticationHandler.ts
+++ b/packages/backend-common/src/middleware/authenticationHandler.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+
+export interface Authenticator {
+  authenticateRequest: (request: Request) => boolean;
+
+  // log the failed request if needed
+  logRequest?: (request: Request) => void;
+}
+
+/**
+ * Express middleware to authenticate requests
+ *
+ * @returns An Express request handler
+ */
+export function authenticationHandler(
+  authenticator: Authenticator,
+): RequestHandler {
+  return (request: Request, response: Response, next: NextFunction) => {
+    try {
+      const validRequest = authenticator.authenticateRequest(request);
+      if (!validRequest) {
+        if (authenticator.logRequest) {
+          authenticator.logRequest(request);
+        }
+        response.sendStatus(403);
+      } else {
+        next();
+      }
+    } catch (e) {
+      // Reject request when authentication fails
+      response.sendStatus(403);
+    }
+  };
+}

--- a/packages/backend-common/src/middleware/index.ts
+++ b/packages/backend-common/src/middleware/index.ts
@@ -18,3 +18,4 @@ export * from './errorHandler';
 export * from './notFoundHandler';
 export * from './requestLoggingHandler';
 export * from './statusCheckHandler';
+export * from './authenticationHandler';


### PR DESCRIPTION
Refs #1435 
## Hey, I just made a Pull Request!
This PR adds a standardized `middleware` in the `backend-common` package, that can be used to authenticate requests to the backend. 

A middleware : `authenticationHandler` and an interface `Authenticator`, are introduced. 

`Authenticator` has 2 methods `authenticateRequest` and `logRequest` .
`authenticateRequest` takes a request as parameter and verifies if the request is `authenticated`. 
If so, control is transferred to the next middleware/handler in the chain. 
Else, if `logRequest` is set, the `logRequest(request)` is called, mostly to log the unauthenticated request and 
a `HTTP 403` is generated. 

The `authenticationHandler` takes as argument an instance of `Authenticator` and returns a `middleware` that
can be attached to an Express `App` or `Router` instance. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
