### PR TITLE
register-component: Remove link to catalog item on validation popup

### DIFF
--- a/.changeset/empty-kids-look.md
+++ b/.changeset/empty-kids-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-register-component': patch
+---
+
+Remove catalog link on validate popup

--- a/plugins/register-component/src/components/RegisterComponentResultDialog/RegisterComponentResultDialog.tsx
+++ b/plugins/register-component/src/components/RegisterComponentResultDialog/RegisterComponentResultDialog.tsx
@@ -100,7 +100,9 @@ export const RegisterComponentResultDialog = ({
                     metadata={{
                       name: entity.metadata.name,
                       type: entity.spec.type,
-                      link: (
+                      link: dryRun ? (
+                        entityPath
+                      ) : (
                         <Link component={RouterLink} to={entityPath}>
                           {entityPath}
                         </Link>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When validating a component entity file, the validation popup provides a link to a phantom catalog entity which if clicked is broken. This PR simply makes it non-clickable.

| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/33203301/99752285-07e62280-2ab2-11eb-8411-c5dfbe0f0a89.png) |  ![image](https://user-images.githubusercontent.com/33203301/99752248-f43abc00-2ab1-11eb-98d1-e81c9a4baf0c.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
