### PR TITLE
[Search] feat: improve search match

### DIFF
--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -159,6 +159,9 @@ export const SearchResult = ({ searchQuery }: SearchResultProps) => {
         withFilters = withFilters.filter(
           (result: Result) =>
             result.name?.toLowerCase().includes(searchQuery) ||
+            result.name
+              ?.toLowerCase()
+              .includes(searchQuery.split(' ').join('-')) ||
             result.description?.toLowerCase().includes(searchQuery),
         );
       }


### PR DESCRIPTION
Addresses #3340 

This PR helps search entities in search plugin when `searchQuery` contains entity name separated by spaces instead of hyphen.

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
