### PR TITLE
Rework the search field behavior in the sidebar

### DIFF
--- a/packages/core/src/layout/Sidebar/Items.tsx
+++ b/packages/core/src/layout/Sidebar/Items.tsx
@@ -26,7 +26,6 @@ import { IconComponent } from '@backstage/core-api';
 import SearchIcon from '@material-ui/icons/Search';
 import clsx from 'clsx';
 import React, {
-  FC,
   useContext,
   useState,
   KeyboardEventHandler,
@@ -212,9 +211,10 @@ export const SidebarItem = forwardRef<any, SidebarItemProps>(
 
 type SidebarSearchFieldProps = {
   onSearch: (input: string) => void;
+  to?: string;
 };
 
-export const SidebarSearchField: FC<SidebarSearchFieldProps> = props => {
+export const SidebarSearchField = (props: SidebarSearchFieldProps) => {
   const [input, setInput] = useState('');
   const classes = useStyles();
 
@@ -229,12 +229,18 @@ export const SidebarSearchField: FC<SidebarSearchFieldProps> = props => {
     setInput(ev.target.value);
   };
 
+  const handleClick = (ev: React.MouseEvent<HTMLInputElement>) => {
+    // Clicking into the search fields shouldn't navigate to the search page
+    ev.preventDefault();
+  };
+
   return (
     <div className={classes.searchRoot}>
-      <SidebarItem icon={SearchIcon}>
+      <SidebarItem icon={SearchIcon} to={props.to}>
         <TextField
           placeholder="Search"
           value={input}
+          onClick={handleClick}
           onChange={handleInput}
           onKeyDown={handleEnter}
           className={classes.searchContainer}

--- a/packages/core/src/layout/Sidebar/Items.tsx
+++ b/packages/core/src/layout/Sidebar/Items.tsx
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
+import { IconComponent } from '@backstage/core-api';
+import { BackstageTheme } from '@backstage/theme';
 import {
+  Badge,
   makeStyles,
   styled,
   TextField,
   Typography,
-  Badge,
 } from '@material-ui/core';
-import { BackstageTheme } from '@backstage/theme';
-import { IconComponent } from '@backstage/core-api';
 import SearchIcon from '@material-ui/icons/Search';
 import clsx from 'clsx';
 import React, {
+  forwardRef,
+  KeyboardEventHandler,
+  ReactNode,
   useContext,
   useState,
-  KeyboardEventHandler,
-  forwardRef,
-  ReactNode,
 } from 'react';
 import { NavLink } from 'react-router-dom';
 import { sidebarConfig, SidebarContext } from './config';
@@ -120,7 +120,7 @@ type SidebarItemProps = {
   // If 'to' is set the item will act as a nav link with highlight, otherwise it's just a button
   to?: string;
   hasNotifications?: boolean;
-  onClick?: () => void;
+  onClick?: (ev: React.MouseEvent) => void;
   children?: ReactNode;
 };
 
@@ -218,10 +218,14 @@ export const SidebarSearchField = (props: SidebarSearchFieldProps) => {
   const [input, setInput] = useState('');
   const classes = useStyles();
 
+  const search = () => {
+    props.onSearch(input);
+    setInput('');
+  };
+
   const handleEnter: KeyboardEventHandler = ev => {
     if (ev.key === 'Enter') {
-      props.onSearch(input);
-      setInput('');
+      search();
     }
   };
 
@@ -229,18 +233,25 @@ export const SidebarSearchField = (props: SidebarSearchFieldProps) => {
     setInput(ev.target.value);
   };
 
-  const handleClick = (ev: React.MouseEvent<HTMLInputElement>) => {
+  const handleInputClick = (ev: React.MouseEvent<HTMLInputElement>) => {
     // Clicking into the search fields shouldn't navigate to the search page
+    ev.preventDefault();
+    ev.stopPropagation();
+  };
+
+  const handleItemClick = (ev: React.MouseEvent) => {
+    // Clicking on the search icon while should execute a query with the current field content
+    search();
     ev.preventDefault();
   };
 
   return (
     <div className={classes.searchRoot}>
-      <SidebarItem icon={SearchIcon} to={props.to}>
+      <SidebarItem icon={SearchIcon} to={props.to} onClick={handleItemClick}>
         <TextField
           placeholder="Search"
           value={input}
-          onClick={handleClick}
+          onClick={handleInputClick}
           onChange={handleInput}
           onKeyDown={handleEnter}
           className={classes.searchContainer}

--- a/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
+++ b/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
@@ -31,5 +31,5 @@ export const SidebarSearch = () => {
     [navigate],
   );
 
-  return <SidebarSearchField onSearch={handleSearch} />;
+  return <SidebarSearchField onSearch={handleSearch} to="/search" />;
 };


### PR DESCRIPTION
We just tested it with another user an noticed some more issues:
* If the user is on the search route it should be reflected in the sidebar ![image](https://user-images.githubusercontent.com/648527/99816784-65c74880-2b4c-11eb-8290-496d32b3860c.png)
* Clicking on the search icon alone should lead to the search page. Feels more natural now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
