### PR TITLE
truncate large percentages

### DIFF
--- a/.changeset/cost-insights-tiny-llamas-perform.md
+++ b/.changeset/cost-insights-tiny-llamas-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+truncate large percentages > 1000%

--- a/plugins/cost-insights/src/components/BarChart/BarChartTooltip.tsx
+++ b/plugins/cost-insights/src/components/BarChart/BarChartTooltip.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { ReactNode, PropsWithChildren } from 'react';
+import classnames from 'classnames';
 import { Box, Divider, Typography } from '@material-ui/core';
 import { useTooltipStyles as useStyles } from '../../utils/styles';
 
@@ -35,6 +36,10 @@ export const BarChartTooltip = ({
   children,
 }: PropsWithChildren<BarChartTooltipProps>) => {
   const classes = useStyles();
+  const titleClassName = classnames(classes.truncate, {
+    [classes.maxWidth]: topRight === undefined,
+  });
+
   return (
     <Box className={classes.tooltip} display="flex" flexDirection="column">
       <Box
@@ -46,7 +51,7 @@ export const BarChartTooltip = ({
         pt={2}
       >
         <Box display="flex" flexDirection="column">
-          <Typography className={classes.truncate} variant="h6">
+          <Typography className={titleClassName} variant="h6">
             {title}
           </Typography>
           {subtitle && (
@@ -55,10 +60,10 @@ export const BarChartTooltip = ({
             </Typography>
           )}
         </Box>
-        {topRight && <Box ml={1}>{topRight}</Box>}
+        {topRight && <Box ml={2}>{topRight}</Box>}
       </Box>
       {content && (
-        <Box px={2} pt={2}>
+        <Box px={2} pt={2} className={classes.maxWidth}>
           <Typography variant="body1" paragraph>
             {content}
           </Typography>

--- a/plugins/cost-insights/src/utils/formatters.test.ts
+++ b/plugins/cost-insights/src/utils/formatters.test.ts
@@ -16,6 +16,7 @@
 
 import {
   formatPeriod,
+  formatPercent,
   lengthyCurrencyFormatter,
   quarterOf,
 } from './formatters';
@@ -67,5 +68,19 @@ describe.each`
 `('formatPeriod', ({ duration, date, isEndDate, output }) => {
   it(`Correctly formats ${duration} with date ${date}`, async () => {
     expect(formatPeriod(duration, date, isEndDate)).toBe(output);
+  });
+});
+
+describe.each`
+  ratio             | expected
+  ${0.0}            | ${'0%'}
+  ${0.000000000001} | ${'0%'}
+  ${-0.00000000001} | ${'0%'}
+  ${0.123123}       | ${'12%'}
+  ${1.123}          | ${'112%'}
+  ${10.123}         | ${'>1000%'}
+`('formatPercent', ({ ratio, expected }) => {
+  it(`correctly formats ${ratio} as ${expected}`, () => {
+    expect(formatPercent(ratio)).toBe(expected);
   });
 });

--- a/plugins/cost-insights/src/utils/formatters.ts
+++ b/plugins/cost-insights/src/utils/formatters.ts
@@ -88,10 +88,6 @@ export function formatPercent(n: number): string {
     return `>1000%`;
   }
 
-  if (Math.abs(n) >= 1e19) {
-    return '∞%';
-  }
-
   return `${(n * 100).toFixed(0)}%`;
 }
 

--- a/plugins/cost-insights/src/utils/formatters.ts
+++ b/plugins/cost-insights/src/utils/formatters.ts
@@ -83,9 +83,15 @@ export function formatPercent(n: number): string {
   if (isNaN(n) || Math.abs(n) < 0.01) {
     return '0%';
   }
+
+  if (Math.abs(n) > 10) {
+    return `>1000%`;
+  }
+
   if (Math.abs(n) >= 1e19) {
     return '∞%';
   }
+
   return `${(n * 100).toFixed(0)}%`;
 }
 

--- a/plugins/cost-insights/src/utils/styles.ts
+++ b/plugins/cost-insights/src/utils/styles.ts
@@ -386,6 +386,9 @@ export const useTooltipStyles = makeStyles<CostInsightsTheme>(
         boxShadow: theme.shadows[1],
         color: theme.palette.tooltip.color,
         fontSize: theme.typography.fontSize,
+        minWidth: 300,
+      },
+      maxWidth: {
         maxWidth: 300,
       },
       actions: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Like extremely small percentages, extremely large percentages are relatively insignificant. 

This typically happens when  a service did not generate any significant cost in one period but generate cost in another, resulting in technically correct but visually jarring percentages in excess of thousands.

As these extremely large changes are not meaningful, they are truncated at 1000%. Extremely small percentage changes are already truncated to 0%.

This change affects all components that format percentages using the `formatPercent` util

### Bar Chart Legend
<img width="555" alt="Screen Shot 2020-11-20 at 10 48 09 AM" src="https://user-images.githubusercontent.com/3030003/99819801-eae73900-2b1d-11eb-811e-8939806606e9.png">

### Product Insights Tooltip
<img width="654" alt="Screen Shot 2020-11-20 at 10 21 03 AM" src="https://user-images.githubusercontent.com/3030003/99818155-da35c380-2b1b-11eb-87e6-e60e943c1e05.png">

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
