### PR TITLE
Add config schema for the sonarqube plugin

### DIFF
--- a/.changeset/long-flowers-wink.md
+++ b/.changeset/long-flowers-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': patch
+---
+
+Add configuration schema

--- a/plugins/sonarqube/config.d.ts
+++ b/plugins/sonarqube/config.d.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  /** Optional configurations for the SonarQube plugin */
+  sonarQube?: {
+    /**
+     * The base url of the sonarqube installation. Defaults to https://sonarcloud.io.
+     * @visibility frontend
+     */
+    baseUrl: string;
+  };
+}

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -47,6 +47,8 @@
     "msw": "^0.21.2"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }


### PR DESCRIPTION
Ref https://github.com/backstage/backstage/issues/3364

Am I supposed to use the config also in code? `configApi.getOptionalString('sonarQube.baseUrl')` makes it hard to use the typing.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
