### PR TITLE
[Search] Fix highlighted SearchQuery in dark mode

### DIFF
--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -31,8 +31,9 @@ import { FiltersButton, Filters, FiltersState } from '../Filters';
 import SearchApi, { Result, SearchResults } from '../../apis';
 
 const useStyles = makeStyles(theme => ({
-  searchTerm: {
-    background: '#eee',
+  searchQuery: {
+    color: theme.palette.text.primary,
+    background: theme.palette.background.default,
     borderRadius: '10%',
   },
   tableHeader: {
@@ -107,7 +108,7 @@ const TableHeader = ({
           <Typography variant="h6">
             {`${numberOfResults} `}
             {numberOfResults > 1 ? `results for ` : `result for `}
-            <span className={classes.searchTerm}>"{searchQuery}"</span>{' '}
+            <span className={classes.searchQuery}>"{searchQuery}"</span>{' '}
           </Typography>
         ) : (
           <Typography variant="h6">{`${numberOfResults} results`}</Typography>


### PR DESCRIPTION
closes: #3377

Result of using the colors that currently exist from the palette, maybe want to add another alternative for light mode in the future to improve the color contrast. 
<img width="925" alt="Screen Shot 2020-11-20 at 6 15 44 PM" src="https://user-images.githubusercontent.com/25153114/99829788-0a518680-2b5d-11eb-8478-ed1251cbba85.png">
<img width="900" alt="Screen Shot 2020-11-20 at 6 15 35 PM" src="https://user-images.githubusercontent.com/25153114/99829795-0cb3e080-2b5d-11eb-9a8b-40f26c0c16bc.png">


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
