### PR TITLE
feat: improve circleci builds table

### DIFF
--- a/.changeset/mighty-cycles-impress.md
+++ b/.changeset/mighty-cycles-impress.md
@@ -1,0 +1,6 @@
+---
+'example-app': minor
+'@backstage/plugin-circleci': minor
+---
+
+Improved CircleCI builds table to show more information and relevant links

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -79,10 +79,10 @@ export const CICDSwitcher = ({ entity }: { entity: Entity }) => {
       return <JenkinsRouter entity={entity} />;
     case isBuildkiteAvailable(entity):
       return <BuildkiteRouter entity={entity} />;
-    case isGitHubActionsAvailable(entity):
-      return <GitHubActionsRouter entity={entity} />;
     case isCircleCIAvailable(entity):
       return <CircleCIRouter entity={entity} />;
+    case isGitHubActionsAvailable(entity):
+      return <GitHubActionsRouter entity={entity} />;
     case isCloudbuildAvailable(entity):
       return <CloudbuildRouter entity={entity} />;
     case isTravisCIAvailable(entity):

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -29,6 +29,8 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
     "circleci-api": "^4.0.0",
+    "dayjs": "^1.9.4",
+    "lodash": "^4.17.15",
     "moment": "^2.25.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/circleci/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
+++ b/plugins/circleci/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { FC, useEffect } from 'react';
+
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { InfoCard, Progress, Link } from '@backstage/core';
 import { BuildWithSteps, BuildStepAction } from '../../api';
@@ -31,7 +32,8 @@ import LaunchIcon from '@material-ui/icons/Launch';
 import { useBuildWithSteps } from '../../state/useBuildWithSteps';
 
 const IconLink = (IconButton as any) as typeof MaterialLink;
-const BuildName: FC<{ build?: BuildWithSteps }> = ({ build }) => (
+
+const BuildName = ({ build }: { build?: BuildWithSteps }) => (
   <Box display="flex" alignItems="center">
     #{build?.build_num} - {build?.subject}
     <IconLink href={build?.build_url} target="_blank">
@@ -39,6 +41,7 @@ const BuildName: FC<{ build?: BuildWithSteps }> = ({ build }) => (
     </IconLink>
   </Box>
 );
+
 const useStyles = makeStyles(theme => ({
   neutral: {},
   failed: {
@@ -96,7 +99,7 @@ const pickClassName = (
   return classes.neutral;
 };
 
-const BuildsList: FC<{ build?: BuildWithSteps }> = ({ build }) => (
+const BuildsList = ({ build }: { build?: BuildWithSteps }) => (
   <Box>
     {build &&
       build.steps &&
@@ -108,8 +111,11 @@ const BuildsList: FC<{ build?: BuildWithSteps }> = ({ build }) => (
   </Box>
 );
 
-const ActionsList: FC<{ actions: BuildStepAction[]; name: string }> = ({
+const ActionsList = ({
   actions,
+}: {
+  actions: BuildStepAction[];
+  name: string;
 }) => {
   const classes = useStyles();
   return (

--- a/plugins/circleci/src/state/useBuilds.ts
+++ b/plugins/circleci/src/state/useBuilds.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { errorApiRef, useApi } from '@backstage/core';
 import { BuildSummary, GitType } from 'circleci-api';
 import { useCallback, useEffect, useState } from 'react';
@@ -21,6 +22,7 @@ import { circleCIApiRef } from '../api/index';
 import type { CITableBuildInfo } from '../components/BuildsPage/lib/CITable';
 import { useEntity } from '@backstage/plugin-catalog';
 import { CIRCLECI_ANNOTATION } from '../constants';
+import { getOr } from 'lodash/fp';
 
 const makeReadableStatus = (status: string | undefined) => {
   if (!status) return '';
@@ -41,6 +43,39 @@ const makeReadableStatus = (status: string | undefined) => {
   } as Record<string, string>)[status];
 };
 
+const mapWorkflowDetails = (buildData: BuildSummary) => {
+  // Workflows should be an object: fixed in https://github.com/worldturtlemedia/circleci-api/pull/787
+  const { workflows } = (buildData as any) ?? {};
+
+  return {
+    id: workflows?.workflow_id,
+    url: `${buildData.build_url}/workflows/${workflows?.workflow_id}`,
+    jobName: workflows?.job_name,
+    name: workflows?.workflow_name,
+  };
+};
+
+const mapSourceDetails = (buildData: BuildSummary) => {
+  const commitDetails = getOr({}, 'all_commit_details[0]', buildData);
+
+  return {
+    branchName: String(buildData.branch),
+    commit: {
+      hash: String(buildData.vcs_revision),
+      shortHash: String(buildData.vcs_revision).substr(0, 7),
+      committerName: buildData.committer_name,
+      url: commitDetails.commit_url,
+    },
+  };
+};
+
+const mapUser = (buildData: BuildSummary) => ({
+  isUser: buildData?.user?.is_user || false,
+  login: buildData?.user?.login || 'none',
+  name: (buildData?.user as any)?.name,
+  avatarUrl: (buildData?.user as any)?.avatar_url,
+});
+
 export const transform = (
   buildsData: BuildSummary[],
   restartBuild: { (buildId: number): Promise<void> },
@@ -52,16 +87,14 @@ export const transform = (
         ? buildData.subject +
           (buildData.retry_of ? ` (retry of #${buildData.retry_of})` : '')
         : '',
+      startTime: buildData.start_time,
+      stopTime: buildData.stop_time,
       onRestartClick: () =>
         typeof buildData.build_num !== 'undefined' &&
         restartBuild(buildData.build_num),
-      source: {
-        branchName: String(buildData.branch),
-        commit: {
-          hash: String(buildData.vcs_revision),
-          url: 'todo',
-        },
-      },
+      source: mapSourceDetails(buildData),
+      workflow: mapWorkflowDetails(buildData),
+      user: mapUser(buildData),
       status: makeReadableStatus(buildData.status),
       buildUrl: buildData.build_url,
     };
@@ -79,6 +112,7 @@ export const useProjectSlugFromEntity = () => {
 
 export function mapVcsType(vcs: string): GitType {
   switch (vcs) {
+    case 'gh':
     case 'github':
       return GitType.GITHUB;
     default:
@@ -93,7 +127,7 @@ export function useBuilds() {
 
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(5);
+  const [pageSize, setPageSize] = useState(10);
 
   const getBuilds = useCallback(
     async ({ limit, offset }: { limit: number; offset: number }) => {

--- a/plugins/circleci/src/util/index.ts
+++ b/plugins/circleci/src/util/index.ts
@@ -13,26 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { CITable } from '../CITable';
-import { useBuilds } from '../../../../state';
 
-export const Builds = () => {
-  const [
-    { total, loading, value, projectName, page, pageSize },
-    { setPage, retry, setPageSize },
-  ] = useBuilds();
-  return (
-    <CITable
-      total={total}
-      loading={loading}
-      retry={retry}
-      builds={value ?? []}
-      projectName={projectName}
-      page={page}
-      onChangePage={setPage}
-      pageSize={pageSize}
-      onChangePageSize={setPageSize}
-    />
-  );
-};
+export * from './time';

--- a/plugins/circleci/src/util/time.test.ts
+++ b/plugins/circleci/src/util/time.test.ts
@@ -13,26 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { CITable } from '../CITable';
-import { useBuilds } from '../../../../state';
 
-export const Builds = () => {
-  const [
-    { total, loading, value, projectName, page, pageSize },
-    { setPage, retry, setPageSize },
-  ] = useBuilds();
-  return (
-    <CITable
-      total={total}
-      loading={loading}
-      retry={retry}
-      builds={value ?? []}
-      projectName={projectName}
-      page={page}
-      onChangePage={setPage}
-      pageSize={pageSize}
-      onChangePageSize={setPageSize}
-    />
-  );
-};
+import { durationHumanized, relativeTimeTo } from './time';
+
+describe('times utils', () => {
+  describe('toRelativeTime', () => {
+    it('should give a relative time of x from today', () => {
+      expect(relativeTimeTo('2020-01-01')).toEqual(expect.any(String));
+    });
+  });
+
+  describe('durationHumanized', () => {
+    it('should give a humanized duration', () => {
+      expect(durationHumanized('2020-11-01', '2020-11-03')).toBe('2 days');
+    });
+  });
+});

--- a/plugins/circleci/src/util/time.ts
+++ b/plugins/circleci/src/util/time.ts
@@ -13,26 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { CITable } from '../CITable';
-import { useBuilds } from '../../../../state';
 
-export const Builds = () => {
-  const [
-    { total, loading, value, projectName, page, pageSize },
-    { setPage, retry, setPageSize },
-  ] = useBuilds();
-  return (
-    <CITable
-      total={total}
-      loading={loading}
-      retry={retry}
-      builds={value ?? []}
-      projectName={projectName}
-      page={page}
-      onChangePage={setPage}
-      pageSize={pageSize}
-      onChangePageSize={setPageSize}
-    />
-  );
-};
+import dayjs from 'dayjs';
+import durationPlugin from 'dayjs/plugin/duration';
+import relativeTimePlugin from 'dayjs/plugin/relativeTime';
+
+dayjs.extend(durationPlugin);
+dayjs.extend(relativeTimePlugin);
+
+type DateTimeObject = Date | string | number | undefined;
+
+export function relativeTimeTo(time: DateTimeObject, withoutSuffix = false) {
+  return dayjs().to(dayjs(time), withoutSuffix);
+}
+
+export function durationHumanized(
+  startTime: DateTimeObject,
+  endTime: DateTimeObject,
+) {
+  return dayjs.duration(dayjs(startTime).diff(dayjs(endTime))).humanize();
+}

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -31,8 +31,9 @@ import { FiltersButton, Filters, FiltersState } from '../Filters';
 import SearchApi, { Result, SearchResults } from '../../apis';
 
 const useStyles = makeStyles(theme => ({
-  searchTerm: {
-    background: '#eee',
+  searchQuery: {
+    color: theme.palette.text.primary,
+    background: theme.palette.background.default,
     borderRadius: '10%',
   },
   tableHeader: {
@@ -107,7 +108,7 @@ const TableHeader = ({
           <Typography variant="h6">
             {`${numberOfResults} `}
             {numberOfResults > 1 ? `results for ` : `result for `}
-            <span className={classes.searchTerm}>"{searchQuery}"</span>{' '}
+            <span className={classes.searchQuery}>"{searchQuery}"</span>{' '}
           </Typography>
         ) : (
           <Typography variant="h6">{`${numberOfResults} results`}</Typography>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Some improvements to the CircleCI builds table:

- The `Build` column now shows the `jobName` if the `buildName` is not present (which can be the case when builds are scheduled) 
- Added a `Job` column which links to the external job
- Updated the `Source` column to show the users avatar and a short hash instead of the full sha. It also has a link to the source control commit
- Added a `Time` column which displays the start time and duration (humanized)
- Added a `Workflow` column to indicate which workflow the `job` is from.
- Some other minor refactoring changes (e.g. removed usage of react FC).

NOTE: Also moved the `CircleCI` above `GH Actions` in the `CICDSwitcher` in the example app. This ensures the CircleCI annotation is used rather then the common `github/project-slug` key first.

<img width="1583" alt="image" src="https://user-images.githubusercontent.com/6507159/99885290-d0868b80-2c01-11eb-9c36-da11f4816d8c.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
