### PR TITLE
docs: update local install example for node v14

### DIFF
--- a/docs/getting-started/create-an-app.md
+++ b/docs/getting-started/create-an-app.md
@@ -14,7 +14,7 @@ need to run Backstage in your own environment.
 
 To create a Backstage app, you will need to have
 [Node.js](https://nodejs.org/en/download/) Active LTS Release installed
-(currently v12).
+(currently v14).
 
 Backstage provides a utility for creating new apps. It guides you through the
 initial setup of selecting the name of the app and a database for the backend.

--- a/docs/getting-started/running-backstage-locally.md
+++ b/docs/getting-started/running-backstage-locally.md
@@ -8,19 +8,19 @@ description: Documentation on How to run Backstage Locally
 
 - Node.js
 
-First make sure you are using Node.js with an Active LTS Release, currently v12.
+First make sure you are using Node.js with an Active LTS Release, currently v14.
 This is made easy with a version manager such as
 [nvm](https://github.com/nvm-sh/nvm) which allows for version switching.
 
 ```bash
 # Installing a new version
-nvm install 12
-> Downloading and installing node v12.18.3...
-> Now using node v12.18.3 (npm v6.14.6)
+nvm install 14
+> Downloading and installing node v14.15.1...
+> Now using node v14.15.1 (npm v6.14.8)
 
 # Checking your version
 node --version
-> v12.18.3
+> v14.15.1
 ```
 
 - Yarn


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updating getting started docs for node version consistency, [docs/getting-started/index.md](https://github.com/backstage/backstage/blob/031ead5f5a81a8004017327434ac44f4b3bc42bd/docs/getting-started/index.md) refers to v14, whereas `running-backstage-locally.md` referred to v12. 

v12 will leave Active LTS on 2020-11-30.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
