### PR TITLE
Fixes when referring to entity YAML filename to use new standard catalog-info.yaml

### DIFF
--- a/.changeset/tidy-brooms-look.md
+++ b/.changeset/tidy-brooms-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix React entity YAML filename to new standard

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -43,7 +43,7 @@ software catalog API.
   "kind": "Component",
   "metadata": {
     "annotations": {
-      "backstage.io/managed-by-location": "file:/tmp/component-info.yaml",
+      "backstage.io/managed-by-location": "file:/tmp/catalog-info.yaml",
       "example.com/service-discovery": "artistweb",
       "circleci.com/project-slug": "github/example-org/artist-website"
     },

--- a/plugins/circleci/README.md
+++ b/plugins/circleci/README.md
@@ -88,4 +88,4 @@ spec:
 ## Limitations
 
 - CircleCI has pretty strict rate limits per token, be careful with opened tabs
-- CircelCI doesn't provide a way to auth by 3rd party (e.g. GitHub) token, nor by calling their OAuth endpoints, which currently stands in the way of better auth integration with Backstage (https://discuss.circleci.com/t/circleci-api-authorization-with-github-token/5356)
+- CircleCI doesn't provide a way to auth by 3rd party (e.g. GitHub) token, nor by calling their OAuth endpoints, which currently stands in the way of better auth integration with Backstage (https://discuss.circleci.com/t/circleci-api-authorization-with-github-token/5356)

--- a/plugins/circleci/README.md
+++ b/plugins/circleci/README.md
@@ -61,7 +61,7 @@ proxy:
 ```
 
 5. Get and provide `CIRCLECI_AUTH_TOKEN` as env variable (https://circleci.com/docs/api/#add-an-api-token)
-6. Add `circleci.com/project-slug` annotation to your component-info.yaml file in format <git-provider>/<owner>/<project> (https://backstage.io/docs/architecture-decisions/adrs-adr002#format)
+6. Add `circleci.com/project-slug` annotation to your catalog-info.yaml file in format <git-provider>/<owner>/<project> (https://backstage.io/docs/architecture-decisions/adrs-adr002#format)
 
 ```yaml
 apiVersion: backstage.io/v1alpha1

--- a/plugins/jenkins/README.md
+++ b/plugins/jenkins/README.md
@@ -41,7 +41,7 @@ export JENKINS_BASIC_AUTH_HEADER="Basic $HEADER"
 ```
 
 5. Run app with `yarn start`
-6. Add the Jenkins folder annotation to your `component-info.yaml`, (note: currently this plugin only supports folders and Git SCM)
+6. Add the Jenkins folder annotation to your `catalog-info.yaml`, (note: currently this plugin only supports folders and Git SCM)
 
 ```yaml
 apiVersion: backstage.io/v1alpha1

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cra.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cra.ts
@@ -48,7 +48,7 @@ export class CreateReactAppTemplater implements TemplaterBase {
       },
     });
 
-    // Need to also make a component-info.yaml to store the data about the service.
+    // Need to also make a catalog-info.yaml to store the data about the service.
     const componentInfo = {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'Component',
@@ -69,7 +69,7 @@ export class CreateReactAppTemplater implements TemplaterBase {
     );
 
     await fs.promises.writeFile(
-      `${finalDir}/component-info.yaml`,
+      `${finalDir}/catalog-info.yaml`,
       yaml.stringify(componentInfo),
     );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
* Fixes a few legacy references in doco of `component-info.yaml` to use the new `catalog-info.yaml`
* Patch to the `scaffolder-backend` so React templates get the proper entity YAML file name
* Fixed a minor typo in CircleCI doco which skips through the Vale checks

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
