### PR TITLE
backend-common: make test-utils a dev dep

### DIFF
--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -33,7 +33,6 @@
     "@backstage/config": "^0.1.1",
     "@backstage/config-loader": "^0.3.0",
     "@backstage/integration": "^0.1.1",
-    "@backstage/test-utils": "^0.1.3",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.6",
     "archiver": "^5.0.2",
@@ -69,6 +68,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.3.0",
+    "@backstage/test-utils": "^0.1.3",
     "@types/archiver": "^3.1.1",
     "@types/compression": "^1.7.0",
     "@types/concat-stream": "^1.6.0",


### PR DESCRIPTION
This causes `test-utils` and some other packages like `theme` and `core-api` to be included in the backend bundle 😅 