### PR TITLE
cli: add experimental backend:bundle command

### DIFF
--- a/.changeset/orange-cherries-run.md
+++ b/.changeset/orange-cherries-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add experimental backend:bundle command

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ typings/
 .nuxt
 dist
 dist-types
+dist-workspace
 
 # Gatsby files
 .cache/

--- a/packages/cli/src/commands/backend/bundle.ts
+++ b/packages/cli/src/commands/backend/bundle.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Command } from 'commander';
+import fs from 'fs-extra';
+import { createDistWorkspace } from '../../lib/packager';
+import { paths } from '../../lib/paths';
+import { parseParallel, PARALLEL_ENV_VAR } from '../../lib/parallel';
+
+const PKG_PATH = 'package.json';
+const TARGET_DIR = 'dist-workspace';
+
+export default async (cmd: Command) => {
+  const targetDir = paths.resolveTarget(TARGET_DIR);
+  const pkgPath = paths.resolveTarget(PKG_PATH);
+  const pkg = await fs.readJson(pkgPath);
+
+  await fs.remove(targetDir);
+  await fs.mkdir(targetDir);
+  await createDistWorkspace([pkg.name], {
+    targetDir: targetDir,
+    buildDependencies: Boolean(cmd.build),
+    parallel: parseParallel(process.env[PARALLEL_ENV_VAR]),
+    skeleton: 'skeleton.tar',
+  });
+};

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -45,6 +45,11 @@ export function registerCommands(program: CommanderStatic) {
     .action(lazy(() => import('./backend/build').then(m => m.default)));
 
   program
+    .command('backend:__experimental__bundle__', { hidden: true })
+    .description('Bundle all backend packages into dist-workspace')
+    .action(lazy(() => import('./backend/bundle').then(m => m.default)));
+
+  program
     .command('backend:build-image')
     .allowUnknownOption(true)
     .helpOption(', --backstage-cli-help') // Let docker handle --help


### PR DESCRIPTION
Work towards #3347, don't use this yet :grin:, want to try this out in a nightly release.

Figured out two different possible approaches for using this with multi-stage docker builds. First option is to use 3 stages, where stage one creates a repo skeleton with only yarn.lock + all package.json, stage two does a cached install and build, and stage 3 builds the actual backend image. This method would be required for when the frontend is bundled with the backend.

Second approach would be to just use two stages and never run a full `yarn install`, but instead only install `@backstage/cli` globally in the first stage and run the `backend:bundle` command. This won't be able to build the frontend, but may be a significant shortcut to getting the backend shipped.