### PR TITLE
fix(kubernetes-backend): Fix Typescript error stopping backend to start

### DIFF
--- a/.changeset/new-ladybugs-nail.md
+++ b/.changeset/new-ladybugs-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+New lint rule to disallow <type> assertions and promote `as` assertions. - @typescript-eslint/consistent-type-assertions

--- a/packages/cli/config/eslint.js
+++ b/packages/cli/config/eslint.js
@@ -58,6 +58,7 @@ module.exports = {
     ],
     'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions': 'error',
+    '@typescript-eslint/consistent-type-assertions': 'error',
     '@typescript-eslint/no-unused-vars': [
       'warn',
       {

--- a/plugins/kubernetes-backend/src/service/getKubernetesObjectsForServiceHandler.ts
+++ b/plugins/kubernetes-backend/src/service/getKubernetesObjectsForServiceHandler.ts
@@ -97,12 +97,12 @@ export const handleGetKubernetesObjectsForService: GetKubernetesObjectsForServic
   return Promise.all(
     clusterDetailsDecoratedForAuth.map(clusterDetails => {
       return fetcher
-        .fetchObjectsForService(<ObjectFetchParams>{
+        .fetchObjectsForService({
           serviceId,
           clusterDetails,
           objectTypesToFetch,
           labelSelector,
-        })
+        } as ObjectFetchParams)
         .then(result => {
           return {
             cluster: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Closes #3403 

As seen in #3404, Backstage Backend is unable to start due to an `unexpected token` error coming from the Kubernetes backend plugin.

Turns out doing type assertions using `as` instead of `<type>` fixes the issue. 🤷‍♂️ 😅 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
