### PR TITLE
backend-common: add support for passing false as a CSP field value, to drop it from the defaults

### DIFF
--- a/.changeset/few-kings-agree.md
+++ b/.changeset/few-kings-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added support for passing false as a CSP field value, to drop it from the defaults in the backend

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -79,8 +79,15 @@ export interface Config {
       optionsSuccessStatus?: number;
     };
 
-    /**  */
-    csp?: object;
+    /**
+     * Content Security Policy options.
+     *
+     * The keys are the plain policy ID, e.g. "upgrade-insecure-requests". The
+     * values are on the format that the helmet library expects them, as an
+     * array of strings. There is also the special value false, which means to
+     * remove the default value that Backstage puts in place for that policy.
+     */
+    csp?: { [policyId: string]: string[] | false };
   };
 
   /** Configuration for integrations towards various external repository provider systems */

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { applyCspDirectives } from './ServiceBuilderImpl';
+
+describe('ServiceBuilderImpl', () => {
+  describe('applyCspDirectives', () => {
+    it('copies actual values', () => {
+      const result = applyCspDirectives({ key: ['value'] });
+      expect(result).toEqual(
+        expect.objectContaining({
+          'default-src': ["'self'"],
+          key: ['value'],
+        }),
+      );
+    });
+
+    it('removes false value keys', () => {
+      const result = applyCspDirectives({ 'upgrade-insecure-requests': false });
+      expect(result!['upgrade-insecure-requests']).toBeUndefined();
+    });
+  });
+});

--- a/packages/backend-common/src/service/lib/config.test.ts
+++ b/packages/backend-common/src/service/lib/config.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { readCspOptions } from './config';
+
+describe('config', () => {
+  describe('readCspOptions', () => {
+    it('reads valid values', () => {
+      const config = ConfigReader.fromConfigs([
+        { context: '', data: { csp: { key: ['value'] } } },
+      ]);
+      expect(readCspOptions(config)).toEqual(
+        expect.objectContaining({
+          key: ['value'],
+        }),
+      );
+    });
+
+    it('accepts false', () => {
+      const config = ConfigReader.fromConfigs([
+        { context: '', data: { csp: { key: false } } },
+      ]);
+      expect(readCspOptions(config)).toEqual(
+        expect.objectContaining({
+          key: false,
+        }),
+      );
+    });
+
+    it('rejects invalid value types', () => {
+      const config = ConfigReader.fromConfigs([
+        { context: '', data: { csp: { key: [4] } } },
+      ]);
+      expect(() => readCspOptions(config)).toThrow(/wanted string-array/);
+    });
+  });
+});

--- a/packages/backend-common/src/service/lib/config.ts
+++ b/packages/backend-common/src/service/lib/config.ts
@@ -134,24 +134,33 @@ export function readCorsOptions(config: Config): CorsOptions | undefined {
  * Attempts to read a CSP options object from the root of a config object.
  *
  * @param config The root of a backend config object
- * @returns A CSP options object, or undefined if not specified
+ * @returns A CSP options object, or undefined if not specified. Values can be
+ *          false as well, which means to remove the default behavior for that
+ *          key.
  *
  * @example
  * ```yaml
  * backend:
  *   csp:
  *     connect-src: ["'self'", 'http:', 'https:']
+ *     upgrade-insecure-requests: false
  * ```
  */
-export function readCspOptions(config: Config): CspOptions | undefined {
+export function readCspOptions(
+  config: Config,
+): Record<string, string[] | false> | undefined {
   const cc = config.getOptionalConfig('csp');
   if (!cc) {
     return undefined;
   }
 
-  const result: CspOptions = {};
+  const result: Record<string, string[] | false> = {};
   for (const key of cc.keys()) {
-    result[key] = cc.getStringArray(key);
+    if (cc.get(key) === false) {
+      result[key] = false;
+    } else {
+      result[key] = cc.getStringArray(key);
+    }
   }
 
   return result;


### PR DESCRIPTION
Context: Questions on Discord, where users were seeing problems caused by Helmet giving a CSP response header that forced the browser to redirect to https, which wasn't available