### PR TITLE
github/workflows: use service account auth for changeset

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -19,4 +19,4 @@ jobs:
           # Calls out to `changeset version`, but also runs prettier
           version: yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
By switching to using a service account instead of the regular token builds will be triggered in the created PR