### PR TITLE
Add a configuration schema for the proxy plugin

### DIFF
--- a/.changeset/weak-roses-search.md
+++ b/.changeset/weak-roses-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Add configuration schema for the commonly used properties

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -38,7 +38,7 @@ proxy:
     headers:
       Authorization:
         $env: TRAVISCI_AUTH_TOKEN
-      travis-api-version: 3
+      travis-api-version: '3'
 
   '/newrelic/apm/api':
     target: https://api.newrelic.com/v2

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -52,19 +52,7 @@ configuration will lead to the proxy acting on backend requests to
 
 The value inside each route is either a simple URL string, or an object on the
 format accepted by
-[http-proxy-middleware](https://www.npmjs.com/package/http-proxy-middleware). It
-is also possible to limit the forwarded HTTP methods with the configuration
-`allowedMethods`, for example `allowedMethods: ['GET']` to enforce read-only
-access.
-
-By default, the proxy will only forward safe HTTP request headers to the target.
-Those are based on the headers that are considered safe for CORS and includes
-headers like `content-type` or `last-modified`, as well as all headers that are
-set by the proxy. If the proxy should forward other headers like
-`authorization`, this must be enabled by the `allowedHeaders` config, for
-example `allowedHeaders: ['Authorization']`. This should help to not
-accidentally forward confidential headers (`cookie`, `X-Auth-Request-User`) to
-third-parties.
+[http-proxy-middleware](https://www.npmjs.com/package/http-proxy-middleware).
 
 If the value is a string, it is assumed to correspond to:
 
@@ -85,3 +73,18 @@ except with the following caveats for convenience:
   `'^/api/proxy/larger-example/v1/': '/'` is added. That means that a request to
   `/api/proxy/larger-example/v1/some/path` will be translated to a request to
   `http://larger.example.com:8080/svc.v1/some/path`.
+
+There are also additional settings:
+
+- `allowedMethods`: Limit the forwarded HTTP methods. For example
+  `allowedMethods: ['GET']` enforces read-only access.
+- `allowedHeaders`: A list of headers that should be forwarded to the target.
+
+By default, the proxy will only forward safe HTTP request headers to the target.
+Those are based on the headers that are considered safe for CORS and includes
+headers like `content-type` or `last-modified`, as well as all headers that are
+set by the proxy. If the proxy should forward other headers like
+`authorization`, this must be enabled by the `allowedHeaders` config, for
+example `allowedHeaders: ['Authorization']`. This should help to not
+accidentally forward confidential headers (`cookie`, `X-Auth-Request-User`) to
+third-parties.

--- a/plugins/proxy-backend/config.d.ts
+++ b/plugins/proxy-backend/config.d.ts
@@ -20,34 +20,36 @@ export interface Config {
    * below the prefix that the proxy plugin is mounted on. It must
    * start with a '/'.
    */
-  proxy: { [key: string]: string | ProxyConfig };
-}
-
-interface ProxyConfig {
-  /**
-   * Target of the proxy. Url string to be parsed with the url module.
-   */
-  target: string;
-  /**
-   * Object with extra headers to be added to target requests.
-   */
-  headers?: { [key: string]: string };
-  /**
-   * Changes the origin of the host header to the target URL. Default: true.
-   */
-  changeOrigin?: boolean;
-  /**
-   * Rewrite target's url path. Object-keys will be used as RegExp to match paths.
-   * If pathRewrite is not specified, it is set to a single rewrite that removes the entire prefix and route.
-   */
-  pathRewrite?: { [regexp: string]: string };
-  /**
-   * Limit the forwarded HTTP methods, for example allowedMethods: ['GET'] to enforce read-only access.
-   */
-  allowedMethods?: string[];
-  /**
-   * Limit the forwarded HTTP methods. By default, only the headers that are considered safe for CORS
-   * and headers that are set by the proxy will be forwarded.
-   */
-  allowedHeaders?: string[];
+  proxy: {
+    [key: string]:
+      | string
+      | {
+          /**
+           * Target of the proxy. Url string to be parsed with the url module.
+           */
+          target: string;
+          /**
+           * Object with extra headers to be added to target requests.
+           */
+          headers?: { [key: string]: string };
+          /**
+           * Changes the origin of the host header to the target URL. Default: true.
+           */
+          changeOrigin?: boolean;
+          /**
+           * Rewrite target's url path. Object-keys will be used as RegExp to match paths.
+           * If pathRewrite is not specified, it is set to a single rewrite that removes the entire prefix and route.
+           */
+          pathRewrite?: { [regexp: string]: string };
+          /**
+           * Limit the forwarded HTTP methods, for example allowedMethods: ['GET'] to enforce read-only access.
+           */
+          allowedMethods?: string[];
+          /**
+           * Limit the forwarded HTTP methods. By default, only the headers that are considered safe for CORS
+           * and headers that are set by the proxy will be forwarded.
+           */
+          allowedHeaders?: string[];
+        };
+  };
 }

--- a/plugins/proxy-backend/config.d.ts
+++ b/plugins/proxy-backend/config.d.ts
@@ -20,7 +20,7 @@ export interface Config {
    * below the prefix that the proxy plugin is mounted on. It must
    * start with a '/'.
    */
-  proxy: {
+  proxy?: {
     [key: string]:
       | string
       | {

--- a/plugins/proxy-backend/config.d.ts
+++ b/plugins/proxy-backend/config.d.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  /**
+   * A list of forwarding-proxies. Each key is a route to match,
+   * below the prefix that the proxy plugin is mounted on. I must
+   * start with a '/'.
+   */
+  proxy: { [key: string]: string | ProxyConfig };
+}
+
+interface ProxyConfig {
+  /**
+   * Target of the proxy. Url string to be parsed with the url module.
+   */
+  target: string;
+  /**
+   * Object with extra headers to be added to target requests.
+   */
+  headers?: { [key: string]: string };
+  /**
+   * Changes the origin of the host header to the target URL. Default: true.
+   */
+  changeOrigin?: boolean;
+  /**
+   * Rewrite target's url path. Object-keys will be used as RegExp to match paths.
+   * If pathRewrite is not specified, it is set to a single rewrite that removes the entire prefix and route.
+   */
+  pathRewrite?: { [regexp: string]: string };
+  /**
+   * Limit the forwarded HTTP methods, for example allowedMethods: ['GET'] to enforce read-only access.
+   */
+  allowedMethods?: string[];
+  /**
+   * Limit the forwarded HTTP methods. By default, only the headers that are considered safe for CORS
+   * and headers that are set by the proxy will be forwarded.
+   */
+  allowedHeaders?: string[];
+}

--- a/plugins/proxy-backend/config.d.ts
+++ b/plugins/proxy-backend/config.d.ts
@@ -17,7 +17,7 @@
 export interface Config {
   /**
    * A list of forwarding-proxies. Each key is a route to match,
-   * below the prefix that the proxy plugin is mounted on. I must
+   * below the prefix that the proxy plugin is mounted on. It must
    * start with a '/'.
    */
   proxy: { [key: string]: string | ProxyConfig };

--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -41,6 +41,8 @@
     "supertest": "^4.0.2"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }


### PR DESCRIPTION
Part of #3364.

This pr adds the schema for the proxy-backend. I only added the minimal config settings that are also mentioned in the docs and not all settings from the upstream [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware#http-proxy-options). Is this a good approach?

I also found the proxy doc a bit confusing since the description of the `allowedMethods` and `allowedHeaders` fields that I added in the past splitted the content too much.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
