### PR TITLE
Handle empty YAML documents

### DIFF
--- a/.changeset/five-dryers-shout.md
+++ b/.changeset/five-dryers-shout.md
@@ -1,0 +1,18 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Ignore empty YAML documents. Having a YAML file like this is now ingested without an error:
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: web
+spec:
+  type: website
+---
+
+```
+
+This behaves now the same way as Kubernetes handles multiple documents in a single YAML file.

--- a/plugins/catalog-backend/src/ingestion/processors/util/parse.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/util/parse.test.ts
@@ -115,6 +115,41 @@ describe('parseEntityYaml', () => {
     ]);
   });
 
+  it('should handle empty yaml documents', () => {
+    // This happens if the user accidentially adds a "---"
+    // at the end of a file
+    const results = Array.from(
+      parseEntityYaml(
+        Buffer.from(
+          `
+      apiVersion: backstage.io/v1alpha1
+      kind: Component
+      metadata:
+        name: web
+      spec:
+        type: website
+---
+    `,
+          'utf8',
+        ),
+        testLoc,
+      ),
+    );
+
+    expect(results).toEqual([
+      result.entity(testLoc, {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'web',
+        },
+        spec: {
+          type: 'website',
+        },
+      }),
+    ]);
+  });
+
   it('should emit parsing errors', () => {
     const results = Array.from(
       parseEntityYaml(Buffer.from('`', 'utf8'), testLoc),

--- a/plugins/catalog-backend/src/ingestion/processors/util/parse.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/util/parse.ts
@@ -40,6 +40,9 @@ export function* parseEntityYaml(
       const json = document.toJSON();
       if (lodash.isPlainObject(json)) {
         yield result.entity(location, json as Entity);
+      } else if (json === null) {
+        // Ignore null values, these happen if there is an empty document in the
+        // YAML file, for example if --- is added to the end of the file.
       } else {
         const message = `Expected object at root, got ${typeof json}`;
         yield result.generalError(location, message);


### PR DESCRIPTION
One of our users just run into this. Kubernetes has the same behavior and doesn't complain about an empty document.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
