### PR TITLE
Avoid "Each child in a list should have a unique "key" prop." Warning

### DIFF
--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -184,7 +184,13 @@ export class PrivateAppImpl implements BackstageApp {
       }
     }
 
-    routes.push(<Route path="/*" element={<NotFoundErrorPage />} />);
+    routes.push(
+      <Route
+        key="not-found-error-page"
+        path="/*"
+        element={<NotFoundErrorPage />}
+      />,
+    );
 
     return routes;
   }


### PR DESCRIPTION
Route for `NotFoundErrorPage` did not contain a key prop. Added the `key` prop using `NotFoundErrorPage` in kebab case.

Avoids:
```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `App`. See https://fb.me/react-warning-keys for more information.
    in Route
    in App (at src/index.tsx:6)
```

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
