### PR TITLE
catalog-backend: gracefully handle missing codeowners

### DIFF
--- a/.changeset/sour-eels-dream.md
+++ b/.changeset/sour-eels-dream.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Gracefully handle missing codeowners.
+
+The CodeOwnersProcessor now also takes a logger as a parameter.

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -280,7 +280,7 @@ export class CatalogBuilder {
         LdapOrgReaderProcessor.fromConfig(config, { logger }),
         MicrosoftGraphOrgReaderProcessor.fromConfig(config, { logger }),
         new UrlReaderProcessor({ reader, logger }),
-        new CodeOwnersProcessor({ reader }),
+        new CodeOwnersProcessor({ reader, logger }),
         new LocationRefProcessor(),
         new AnnotateLocationEntityProcessor(),
       );


### PR DESCRIPTION
`Promise.all` throws if none of the candidate locations could be read. Now, when that happens, undefined is returned instead of throwing an error. Since the processor installation is site wide, but maybe not all repos make use of codeowners, we should not throw a hard error. It's better to have the later kind validation step saying that the user has not filled in the owner.

This is a candidate fix for https://discord.com/channels/687207715902193673/687235481154617364/781899726421229618