### PR TITLE
fix(config-loader,cli,example-app): Refactor visibility typo in vars/funcs across multiple packages

### DIFF
--- a/.changeset/grumpy-crews-build.md
+++ b/.changeset/grumpy-crews-build.md
@@ -1,7 +1,9 @@
 ---
-'example-app': patch
-'@backstage/cli': patch
-'@backstage/config-loader': patch
+'@backstage/config-loader': minor
 ---
 
-Fix typo of "visibility" in multiple references
+Fix typo of "visibility" in config schema reference
+
+If you have defined a config element named `visiblity`, you
+will need to fix the spelling to `visibility`. For more info,
+see https://backstage.io/docs/conf/defining#visibility.

--- a/.changeset/grumpy-crews-build.md
+++ b/.changeset/grumpy-crews-build.md
@@ -1,0 +1,7 @@
+---
+'example-app': patch
+'@backstage/cli': patch
+'@backstage/config-loader': patch
+---
+
+Fix typo of "visibility" in multiple references

--- a/packages/cli/src/commands/config/print.ts
+++ b/packages/cli/src/commands/config/print.ts
@@ -25,7 +25,7 @@ export default async (cmd: Command) => {
     args: cmd.config,
     fromPackage: cmd.package,
   });
-  const visibility = getVisiblityOption(cmd);
+  const visibility = getVisibilityOption(cmd);
   const data = serializeConfigData(appConfigs, schema, visibility);
 
   if (cmd.format === 'json') {
@@ -35,7 +35,7 @@ export default async (cmd: Command) => {
   }
 };
 
-function getVisiblityOption(cmd: Command): ConfigVisibility {
+function getVisibilityOption(cmd: Command): ConfigVisibility {
   if (cmd.frontend && cmd.withSecrets) {
     throw new Error('Not allowed to combine frontend and secret config');
   }
@@ -50,14 +50,14 @@ function getVisiblityOption(cmd: Command): ConfigVisibility {
 function serializeConfigData(
   appConfigs: AppConfig[],
   schema: ConfigSchema,
-  visiblity: ConfigVisibility,
+  visibility: ConfigVisibility,
 ) {
-  if (visiblity === 'frontend') {
+  if (visibility === 'frontend') {
     const frontendConfigs = schema.process(appConfigs, {
-      visiblity: ['frontend'],
+      visibility: ['frontend'],
     });
     return ConfigReader.fromConfigs(frontendConfigs).get();
-  } else if (visiblity === 'secret') {
+  } else if (visibility === 'secret') {
     return ConfigReader.fromConfigs(appConfigs).get();
   }
 

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -51,7 +51,7 @@ export async function loadCliConfig(options: Options) {
 
   try {
     const frontendAppConfigs = schema.process(appConfigs, {
-      visiblity: ['frontend'],
+      visibility: ['frontend'],
     });
     const frontendConfig = ConfigReader.fromConfigs(frontendAppConfigs);
 

--- a/packages/config-loader/src/lib/schema/compile.test.ts
+++ b/packages/config-loader/src/lib/schema/compile.test.ts
@@ -89,7 +89,7 @@ describe('compileConfigSchemas', () => {
     });
   });
 
-  it('should reject visiblity conflicts', () => {
+  it('should reject visibility conflicts', () => {
     expect(() =>
       compileConfigSchemas([
         {

--- a/packages/config-loader/src/lib/schema/filtering.test.ts
+++ b/packages/config-loader/src/lib/schema/filtering.test.ts
@@ -38,7 +38,7 @@ const data = {
   objS: { never: 'here' },
 };
 
-const visiblity = new Map<string, ConfigVisibility>(
+const visibility = new Map<string, ConfigVisibility>(
   Object.entries({
     '.arr.0': 'frontend',
     '.arr.1': 'backend',
@@ -100,6 +100,6 @@ describe('filterByVisibility', () => {
     ],
     [['frontend', 'backend', 'secret'], data],
   ])('should filter correctly with %p', (filter, expected) => {
-    expect(filterByVisibility(data, filter, visiblity)).toEqual(expected);
+    expect(filterByVisibility(data, filter, visibility)).toEqual(expected);
   });
 });

--- a/packages/config-loader/src/lib/schema/load.test.ts
+++ b/packages/config-loader/src/lib/schema/load.test.ts
@@ -61,12 +61,12 @@ describe('loadConfigSchema', () => {
     const configs = [{ data: { key1: 'a', key2: 2 }, context: 'test' }];
 
     expect(schema.process(configs)).toEqual(configs);
-    expect(schema.process(configs, { visiblity: ['frontend'] })).toEqual([
+    expect(schema.process(configs, { visibility: ['frontend'] })).toEqual([
       { data: { key1: 'a' }, context: 'test' },
     ]);
     expect(
       schema.process(configs, {
-        visiblity: ['frontend'],
+        visibility: ['frontend'],
         valueTransform: () => 'X',
       }),
     ).toEqual([{ data: { key1: 'X' }, context: 'test' }]);
@@ -79,7 +79,7 @@ describe('loadConfigSchema', () => {
     const serialized = schema.serialize();
 
     const schema2 = await loadConfigSchema({ serialized });
-    expect(schema2.process(configs, { visiblity: ['frontend'] })).toEqual([
+    expect(schema2.process(configs, { visibility: ['frontend'] })).toEqual([
       { data: { key1: 'a' }, context: 'test' },
     ]);
     expect(() =>

--- a/packages/config-loader/src/lib/schema/load.ts
+++ b/packages/config-loader/src/lib/schema/load.ts
@@ -57,7 +57,7 @@ export async function loadConfigSchema(
   return {
     process(
       configs: AppConfig[],
-      { visiblity, valueTransform } = {},
+      { visibility, valueTransform } = {},
     ): AppConfig[] {
       const result = validate(configs);
       if (result.errors) {
@@ -70,12 +70,12 @@ export async function loadConfigSchema(
 
       let processedConfigs = configs;
 
-      if (visiblity) {
+      if (visibility) {
         processedConfigs = processedConfigs.map(({ data, context }) => ({
           context,
           data: filterByVisibility(
             data,
-            visiblity,
+            visibility,
             result.visibilityByPath,
             valueTransform,
           ),

--- a/packages/config-loader/src/lib/schema/types.ts
+++ b/packages/config-loader/src/lib/schema/types.ts
@@ -87,7 +87,7 @@ type ConfigProcessingOptions = {
    * The visibilities that should be included in the output data.
    * If omitted, the data will not be filtered by visibility.
    */
-  visiblity?: ConfigVisibility[];
+  visibility?: ConfigVisibility[];
 
   /**
    * A transform function that can be used to transform primitive configuration values

--- a/plugins/app-backend/src/lib/config.ts
+++ b/plugins/app-backend/src/lib/config.ts
@@ -88,7 +88,7 @@ export async function readConfigs(options: ReadOptions): Promise<AppConfig[]> {
 
     const frontendConfigs = await schema.process(
       [{ data: config.get() as JsonObject, context: 'app' }],
-      { visiblity: ['frontend'] },
+      { visibility: ['frontend'] },
     );
     appConfigs.push(...frontendConfigs);
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Noticed multiple typo references to `visib(i)lity` in a few packages.  I patch bumped three packages, because my understanding is in fact these _could_ be breaking if a user had defined `visiblity` (lacking the i) in their say custom plugin schema?  If I'm wrong and these are all internal calls, can eliminate the changeset and/or reword it as necessary.

Local testing for me was clean for these changes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
