### PR TITLE
chore(sentry,welcome): Refactor route registration to remove deprecating code

### DIFF
--- a/.changeset/four-plants-happen.md
+++ b/.changeset/four-plants-happen.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-sentry': patch
+'@backstage/plugin-welcome': patch
+---
+
+Refactor route registration to remove deprecating code

--- a/docs/reference/createPlugin.md
+++ b/docs/reference/createPlugin.md
@@ -4,7 +4,7 @@ title: createPlugin
 description: Documentation on createPlugin
 ---
 
-Taking a plugin config as argument and returns a new plugin.
+Takes a plugin config as an argument and returns a new plugin.
 
 ## Plugin Config
 
@@ -28,18 +28,22 @@ type PluginHooks = {
 
 ### Creating a basic plugin
 
-Showcasing adding multiple routes, a feature flag and a redirect.
+Showcasing adding a route and a feature flag.
 
 ```jsx
-import { createPlugin } from '@backstage/core';
+import { createPlugin, createRouteRef } from '@backstage/core';
 import ExampleComponent from './components/ExampleComponent';
+
+export const rootRouteRef = createRouteRef({
+  path: '/new-plugin',
+  title: 'New Plugin',
+});
 
 export default createPlugin({
   id: 'new-plugin',
   register({ router, featureFlags }) {
+    router.addRoute(rootRouteRef, ExampleComponent);
     featureFlags.register('enable-example-component');
-
-    router.registerRoute('/new-plugin', ExampleComponent);
   },
 });
 ```

--- a/packages/core-api/src/plugin/types.ts
+++ b/packages/core-api/src/plugin/types.ts
@@ -92,6 +92,7 @@ export type RouterHooks = {
 
   /**
    * @deprecated See the `addRoute` method
+   * @see https://github.com/backstage/backstage/issues/418
    */
   registerRoute(
     path: RoutePath,

--- a/plugins/sentry/src/plugin.ts
+++ b/plugins/sentry/src/plugin.ts
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
-import { createPlugin } from '@backstage/core';
+import { createPlugin, createRouteRef } from '@backstage/core';
 import SentryPluginPage from './components/SentryPluginPage';
+
+export const rootRouteRef = createRouteRef({
+  path: '/sentry',
+  title: 'Sentry',
+});
 
 export const plugin = createPlugin({
   id: 'sentry',
   register({ router }) {
-    router.registerRoute('/sentry', SentryPluginPage);
+    router.addRoute(rootRouteRef, SentryPluginPage);
   },
 });

--- a/plugins/welcome/src/plugin.ts
+++ b/plugins/welcome/src/plugin.ts
@@ -24,7 +24,8 @@ export const rootRouteRef = createRouteRef({
 
 export const plugin = createPlugin({
   id: 'welcome',
-  register({ router }) {
+  register({ router, featureFlags }) {
     router.addRoute(rootRouteRef, WelcomePage);
+    featureFlags.register('enable-welcome-box');
   },
 });

--- a/plugins/welcome/src/plugin.ts
+++ b/plugins/welcome/src/plugin.ts
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-import { createPlugin } from '@backstage/core';
+import { createPlugin, createRouteRef } from '@backstage/core';
 import WelcomePage from './components/WelcomePage';
+
+export const rootRouteRef = createRouteRef({
+  path: '/welcome',
+  title: 'Welcome',
+});
 
 export const plugin = createPlugin({
   id: 'welcome',
-  register({ router, featureFlags }) {
-    router.registerRoute('/welcome', WelcomePage);
-
-    featureFlags.register('enable-welcome-box');
+  register({ router }) {
+    router.addRoute(rootRouteRef, WelcomePage);
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

In support of https://github.com/backstage/backstage/issues/418, refactor the route registration in the `welcome` and `sentry`  plugins. Also tags the RFC issue for context in JSDoc, and updates an example in the docs site which is out of date.

Note the Sentry plugin also has a deeper route which I did not touch or really even review. This chore work is to help me understand the routing mechanisms better, so stopped a bit short.

Moves the deprecation of `registerRoute()` ever so slightly forward, but not totally complete yet.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
