### PR TITLE
Derive the owned entities in the catalog from group memberships

### DIFF
--- a/.changeset/twenty-trees-travel.md
+++ b/.changeset/twenty-trees-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Use the OWNED_BY relation and compare it to the users MEMBER_OF relation. The user entity is searched by name, based on the userId of the identity.

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
@@ -15,7 +15,11 @@
  */
 
 import { CatalogApi } from '@backstage/catalog-client';
-import { Entity } from '@backstage/catalog-model';
+import {
+  Entity,
+  RELATION_MEMBER_OF,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
 import {
   ApiProvider,
   ApiRegistry,
@@ -46,6 +50,12 @@ describe('CatalogPage', () => {
               owner: 'tools@example.com',
               type: 'service',
             },
+            relations: [
+              {
+                type: RELATION_OWNED_BY,
+                target: { kind: 'Group', name: 'tools', namespace: 'default' },
+              },
+            ],
           },
           {
             apiVersion: 'backstage.io/v1alpha1',
@@ -57,11 +67,34 @@ describe('CatalogPage', () => {
               owner: 'not-tools@example.com',
               type: 'service',
             },
+            relations: [
+              {
+                type: RELATION_OWNED_BY,
+                target: {
+                  kind: 'Group',
+                  name: 'not-tools',
+                  namespace: 'default',
+                },
+              },
+            ],
           },
         ] as Entity[],
       }),
     getLocationByEntity: () =>
       Promise.resolve({ id: 'id', type: 'github', target: 'url' }),
+    getEntityByName: async entityName => {
+      return {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        metadata: { name: entityName.name },
+        relations: [
+          {
+            type: RELATION_MEMBER_OF,
+            target: { namespace: 'default', kind: 'Group', name: 'tools' },
+          },
+        ],
+      };
+    },
   };
   const testProfile: Partial<ProfileInfo> = {
     displayName: 'Display Name',

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -37,8 +37,8 @@ import { ResultsFilter } from '../ResultsFilter/ResultsFilter';
 import CatalogLayout from './CatalogLayout';
 import { CatalogTabs, LabeledComponentType } from './CatalogTabs';
 import { WelcomeBanner } from './WelcomeBanner';
-import { useUserGroups } from '../useUserGroups';
-import { RELATION_OWNED_BY } from '@backstage/catalog-model';
+import { useOwnUser } from '../useOwnUser';
+import { isOwnerOf } from '../isOwnerOf';
 
 const useStyles = makeStyles(theme => ({
   contentWrapper: {
@@ -112,7 +112,7 @@ const CatalogPageContents = () => {
     [],
   );
 
-  const { groups } = useUserGroups();
+  const { value: user } = useOwnUser();
 
   const filterGroups = useMemo<ButtonGroup[]>(
     () => [
@@ -123,16 +123,7 @@ const CatalogPageContents = () => {
             id: 'owned',
             label: 'Owned',
             icon: SettingsIcon,
-            filterFn: entity => {
-              const ownerRelation = entity.relations?.find(
-                r =>
-                  r.type === RELATION_OWNED_BY &&
-                  r.target.kind.toLowerCase() === 'group',
-              );
-              return (
-                !!ownerRelation && groups.includes(ownerRelation.target.name)
-              );
-            },
+            filterFn: entity => user !== undefined && isOwnerOf(user, entity),
           },
           {
             id: 'starred',
@@ -153,7 +144,7 @@ const CatalogPageContents = () => {
         ],
       },
     ],
-    [isStarredEntity, orgName, groups],
+    [isStarredEntity, orgName, user],
   );
 
   const showAddExampleEntities =

--- a/plugins/catalog/src/components/getEntityRelations.test.ts
+++ b/plugins/catalog/src/components/getEntityRelations.test.ts
@@ -60,7 +60,7 @@ describe('getEntityRelations', () => {
     } as Entity;
 
     expect(
-      getEntityRelations(entity, RELATION_MEMBER_OF, { kind: 'group' }),
+      getEntityRelations(entity, RELATION_MEMBER_OF, { kind: 'Group' }),
     ).toEqual([{ kind: 'group', name: 'member' }]);
   });
 });

--- a/plugins/catalog/src/components/getEntityRelations.test.ts
+++ b/plugins/catalog/src/components/getEntityRelations.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getEntityRelations } from './getEntityRelations';
+import {
+  Entity,
+  RELATION_CHILD_OF,
+  RELATION_MEMBER_OF,
+} from '@backstage/catalog-model';
+
+describe('getEntityRelations', () => {
+  it('should handle undefined value', () => {
+    expect(getEntityRelations(undefined, RELATION_MEMBER_OF)).toEqual([]);
+  });
+
+  it('should extract correct relation', () => {
+    const entity = {
+      relations: [
+        {
+          type: RELATION_MEMBER_OF,
+          target: { kind: 'group', name: 'member' },
+        },
+        {
+          type: RELATION_CHILD_OF,
+          target: { kind: 'group', name: 'child' },
+        },
+      ],
+    } as Entity;
+
+    expect(getEntityRelations(entity, RELATION_MEMBER_OF)).toEqual([
+      { kind: 'group', name: 'member' },
+    ]);
+  });
+
+  it('should filter relation by type', () => {
+    const entity = {
+      relations: [
+        {
+          type: RELATION_MEMBER_OF,
+          target: { kind: 'group', name: 'member' },
+        },
+        {
+          type: RELATION_MEMBER_OF,
+          target: { kind: 'user', name: 'child' },
+        },
+      ],
+    } as Entity;
+
+    expect(
+      getEntityRelations(entity, RELATION_MEMBER_OF, { kind: 'group' }),
+    ).toEqual([{ kind: 'group', name: 'member' }]);
+  });
+});

--- a/plugins/catalog/src/components/getEntityRelations.ts
+++ b/plugins/catalog/src/components/getEntityRelations.ts
@@ -31,7 +31,7 @@ export function getEntityRelations(
 
   if (filter?.kind) {
     entityNames = entityNames?.filter(
-      e => e.kind.toLowerCase() === filter.kind,
+      e => e.kind.toLowerCase() === filter.kind.toLowerCase(),
     );
   }
 

--- a/plugins/catalog/src/components/getEntityRelations.ts
+++ b/plugins/catalog/src/components/getEntityRelations.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity, EntityName } from '@backstage/catalog-model';
+
+/**
+ * Get the related entity references.
+ */
+export function getEntityRelations(
+  entity: Entity | undefined,
+  relationType: string,
+  filter?: { kind: string },
+): EntityName[] {
+  let entityNames =
+    entity?.relations
+      ?.filter(r => r.type === relationType)
+      ?.map(r => r.target) || [];
+
+  if (filter?.kind) {
+    entityNames = entityNames?.filter(
+      e => e.kind.toLowerCase() === filter.kind,
+    );
+  }
+
+  return entityNames;
+}

--- a/plugins/catalog/src/components/isOwnerOf.test.ts
+++ b/plugins/catalog/src/components/isOwnerOf.test.ts
@@ -25,7 +25,7 @@ describe('isOwnerOf', () => {
   it('should be owned by user', () => {
     const ownerEntity = {
       kind: 'User',
-      metadata: { name: 'user' },
+      metadata: { name: 'User', namespace: 'Default' },
     } as Entity;
     const ownedEntity = {
       relations: [

--- a/plugins/catalog/src/components/isOwnerOf.test.ts
+++ b/plugins/catalog/src/components/isOwnerOf.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  RELATION_MEMBER_OF,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
+import { isOwnerOf } from './isOwnerOf';
+
+describe('isOwnerOf', () => {
+  it('should be owned by user', () => {
+    const ownerEntity = {
+      kind: 'User',
+      metadata: { name: 'user' },
+    } as Entity;
+    const ownedEntity = {
+      relations: [
+        {
+          type: RELATION_OWNED_BY,
+          target: { kind: 'user', namespace: 'default', name: 'user' },
+        },
+      ],
+    } as Entity;
+
+    expect(isOwnerOf(ownerEntity, ownedEntity)).toBe(true);
+  });
+
+  it('should be owned by group', () => {
+    const ownerEntity = {
+      kind: 'User',
+      metadata: { name: 'user' },
+      relations: [
+        {
+          type: RELATION_MEMBER_OF,
+          target: { kind: 'group', namespace: 'default', name: 'group' },
+        },
+      ],
+    } as Entity;
+    const ownedEntity = {
+      relations: [
+        {
+          type: RELATION_OWNED_BY,
+          target: { kind: 'group', namespace: 'default', name: 'group' },
+        },
+      ],
+    } as Entity;
+
+    expect(isOwnerOf(ownerEntity, ownedEntity)).toBe(true);
+  });
+});

--- a/plugins/catalog/src/components/isOwnerOf.ts
+++ b/plugins/catalog/src/components/isOwnerOf.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  EntityName,
+  getEntityName,
+  RELATION_MEMBER_OF,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
+import { getEntityRelations } from './getEntityRelations';
+
+/**
+ * Get the related entity references.
+ */
+export function isOwnerOf(owner: Entity, owned: Entity) {
+  const possibleOwners: EntityName[] = [
+    ...getEntityRelations(owner, RELATION_MEMBER_OF, { kind: 'group' }),
+    ...(owner ? [getEntityName(owner)] : []),
+  ];
+
+  const owners = getEntityRelations(owned, RELATION_OWNED_BY);
+
+  for (const owner of owners) {
+    if (
+      possibleOwners.find(
+        o =>
+          owner.kind.toLowerCase() === o.kind.toLowerCase() &&
+          owner.namespace === o.namespace &&
+          owner.name === o.name,
+      ) !== undefined
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/plugins/catalog/src/components/isOwnerOf.ts
+++ b/plugins/catalog/src/components/isOwnerOf.ts
@@ -39,8 +39,8 @@ export function isOwnerOf(owner: Entity, owned: Entity) {
       possibleOwners.find(
         o =>
           owner.kind.toLowerCase() === o.kind.toLowerCase() &&
-          owner.namespace === o.namespace &&
-          owner.name === o.name,
+          owner.namespace.toLowerCase() === o.namespace.toLowerCase() &&
+          owner.name.toLowerCase() === o.name.toLowerCase(),
       ) !== undefined
     ) {
       return true;

--- a/plugins/catalog/src/components/useOwnUser.ts
+++ b/plugins/catalog/src/components/useOwnUser.ts
@@ -16,26 +16,25 @@
 
 import { UserEntity } from '@backstage/catalog-model';
 import { useAsync } from 'react-use';
+import { AsyncState } from 'react-use/lib/useAsync';
 import { identityApiRef, useApi } from '@backstage/core';
 import { catalogApiRef } from '../plugin';
 
 /**
  * Get the group memberships of the logged-in user.
  */
-export function useOwnUser(): {
-  value?: UserEntity;
-  loading: boolean;
-  error?: Error;
-} {
+export function useOwnUser(): AsyncState<UserEntity> {
   const catalogApi = useApi(catalogApiRef);
   const identityApi = useApi(identityApiRef);
 
   // TODO: get the full entity (or at least the full entity name) from the identityApi
-  return useAsync(async () => {
-    return (await catalogApi.getEntityByName({
-      kind: 'User',
-      namespace: 'default',
-      name: identityApi.getUserId(),
-    })) as UserEntity;
-  }, [catalogApi, identityApi]);
+  return useAsync(
+    () =>
+      catalogApi.getEntityByName({
+        kind: 'User',
+        namespace: 'default',
+        name: identityApi.getUserId(),
+      }) as Promise<UserEntity>,
+    [catalogApi, identityApi],
+  );
 }

--- a/plugins/catalog/src/components/useUserGroups.ts
+++ b/plugins/catalog/src/components/useUserGroups.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAsync } from 'react-use';
+import { useMemo } from 'react';
+import { RELATION_MEMBER_OF } from '@backstage/catalog-model';
+import { identityApiRef, useApi } from '@backstage/core';
+import { catalogApiRef } from '../plugin';
+
+/**
+ * Get the group memberships of the logged-in user.
+ */
+export const useUserGroups: () => {
+  groups: string[];
+  loading: boolean;
+  error?: Error;
+} = () => {
+  const catalogApi = useApi(catalogApiRef);
+  const userId = useApi(identityApiRef).getUserId();
+
+  // TODO: should the identityApiRef already include the entity? or at least a full EntityName?
+  const { value: user, loading, error } = useAsync(async () => {
+    return await catalogApi.getEntityByName({
+      kind: 'User',
+      namespace: 'default',
+      name: userId,
+    });
+  }, [catalogApi, userId]);
+
+  // calculate the group memberships
+  const groups = useMemo<string[]>(() => {
+    if (user && user.relations) {
+      return user.relations
+        .filter(
+          r =>
+            r.type === RELATION_MEMBER_OF &&
+            r.target.kind.toLowerCase() === 'group',
+        )
+        .map(r => r.target.name);
+    }
+
+    return [];
+  }, [user]);
+
+  return { groups, loading, error };
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I updated the catalog table to no longer derive the ownership from `userId == entity.spec.owner` but instead from `entity.relations(type=owned_by) ∈ user.relations(type=member_of)`. I use a trivial approach to fetch the user entity that assumes that the userId refers to a name of a `User` entity in the `default` namespace. I think this could be improved in the future. We should especially make sure that the user-ids that are created by the user-catalog-processors match those from the login providers.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
