### PR TITLE
Filter the response headers in the proxy backend

### DIFF
--- a/.changeset/new-nails-thank.md
+++ b/.changeset/new-nails-thank.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Filter the headers that are sent from the proxied-targed back to the frontend to not forwarded unwanted authentication or
+monitoring contexts from other origins (like `Set-Cookie` with e.g. a google analytics context). The implementation reuses
+the `allowedHeaders` configuration that now controls both directions `frontend->target` and `target->frontend`.

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -78,7 +78,8 @@ There are also additional settings:
 
 - `allowedMethods`: Limit the forwarded HTTP methods. For example
   `allowedMethods: ['GET']` enforces read-only access.
-- `allowedHeaders`: A list of headers that should be forwarded to the target.
+- `allowedHeaders`: A list of headers that should be forwarded to and received
+  from the target.
 
 By default, the proxy will only forward safe HTTP request headers to the target.
 Those are based on the headers that are considered safe for CORS and includes
@@ -88,3 +89,6 @@ set by the proxy. If the proxy should forward other headers like
 example `allowedHeaders: ['Authorization']`. This should help to not
 accidentally forward confidential headers (`cookie`, `X-Auth-Request-User`) to
 third-parties.
+
+The same logic applies to headers that are sent from the target back to the
+frontend.

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -198,4 +198,74 @@ describe('buildMiddleware', () => {
       'X-Auth-Request-User',
     );
   });
+
+  it('responds default headers', async () => {
+    buildMiddleware('/api/', logger, 'test', {
+      target: 'http://mocked',
+    });
+
+    expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
+
+    const config = mockCreateProxyMiddleware.mock
+      .calls[0][1] as ProxyMiddlewareConfig;
+
+    const testClientResponse = {
+      headers: {
+        'cache-control': 'value',
+        'content-language': 'value',
+        'content-length': 'value',
+        'content-type': 'value',
+        expires: 'value',
+        'last-modified': 'value',
+        pragma: 'value',
+        'set-cookie': ['value'],
+      },
+    } as Partial<http.IncomingMessage>;
+
+    expect(config).toBeDefined();
+    expect(config.onProxyReq).toBeDefined();
+
+    config.onProxyRes!(
+      testClientResponse as http.IncomingMessage,
+      {} as http.IncomingMessage,
+      {} as http.ServerResponse,
+    );
+
+    expect(Object.keys(testClientResponse.headers!)).toEqual([
+      'cache-control',
+      'content-language',
+      'content-length',
+      'content-type',
+      'expires',
+      'last-modified',
+      'pragma',
+    ]);
+  });
+
+  it('responds configured headers', async () => {
+    buildMiddleware('/api/', logger, 'test', {
+      target: 'http://mocked',
+      allowedHeaders: ['set-cookie'],
+    });
+
+    expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
+
+    const config = mockCreateProxyMiddleware.mock
+      .calls[0][1] as ProxyMiddlewareConfig;
+
+    const testClientResponse = {
+      headers: {
+        'set-cookie': [],
+        'x-auth-request-user': 'asd',
+      },
+    } as Partial<http.IncomingMessage>;
+
+    config.onProxyRes!(
+      testClientResponse as http.IncomingMessage,
+      {} as http.IncomingMessage,
+      {} as http.ServerResponse,
+    );
+
+    expect(Object.keys(testClientResponse.headers!)).toEqual(['set-cookie']);
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Filter the headers that are sent from the proxied-targed back to the frontend to not forwarded unwanted authentication or
monitoring contexts from other origins (like `Set-Cookie` with e.g. a google analytics context). The implementation reuses
the `allowedHeaders` configuration that now controls both directions `frontend->target` and `target->frontend`.

What do you think about this solution? An alternative would be to rename the existing config to `allowedRequestHeaders` and add a second `allowedResponseHeaders` option.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
