### PR TITLE
Make backend-commons tests work on Windows

### DIFF
--- a/packages/backend-common/src/reading/tree/TarArchiveResponse.test.ts
+++ b/packages/backend-common/src/reading/tree/TarArchiveResponse.test.ts
@@ -126,7 +126,7 @@ describe('TarArchiveResponse', () => {
     const res = new TarArchiveResponse(stream, 'mock-repo/docs/', '/tmp');
     const dir = await res.dir();
 
-    expect(dir).toMatch(/^\/tmp\/.*$/);
+    expect(dir).toMatch(/^[\/\\]tmp[\/\\].*$/);
     await expect(
       fs.readFile(resolvePath(dir, 'index.md'), 'utf8'),
     ).resolves.toBe('# Test\n');

--- a/packages/backend-common/src/reading/tree/ZipArchiveResponse.test.ts
+++ b/packages/backend-common/src/reading/tree/ZipArchiveResponse.test.ts
@@ -126,7 +126,7 @@ describe('ZipArchiveResponse', () => {
     const res = new ZipArchiveResponse(stream, 'mock-repo/docs/', '/tmp');
     const dir = await res.dir();
 
-    expect(dir).toMatch(/^\/tmp\/.*$/);
+    expect(dir).toMatch(/^[\/\\]tmp[\/\\].*$/);
     await expect(
       fs.readFile(resolvePath(dir, 'index.md'), 'utf8'),
     ).resolves.toBe('# Test\n');


### PR DESCRIPTION
After this, there should still be two remaining errors:

``` 
FAIL database/connection.test.ts
  ● database connection › createDatabaseClient › returns an sqlite connection

    Knex: run
    $ npm install sqlite3 --save
    Cannot find module 'D:\a\backstage\backstage\node_modules\sqlite3\lib\binding\napi-v3-win32-x64\node_sqlite3.node' from '../../../node_modules/sqlite3/lib/sqlite3-binding.js'

    Require stack:
      D:/a/backstage/backstage/node_modules/sqlite3/lib/sqlite3-binding.js
      D:/a/backstage/backstage/node_modules/sqlite3/lib/sqlite3.js
      D:/a/backstage/backstage/node_modules/knex/lib/dialects/sqlite3/index.js
      D:/a/backstage/backstage/node_modules/knex/lib/knex.js
      D:/a/backstage/backstage/node_modules/knex/lib/index.js
      D:/a/backstage/backstage/node_modules/knex/knex.js
      database/connection.ts
      database/connection.test.ts

      30 | ) {
      31 |   const knexConfig = buildSqliteDatabaseConfig(dbConfig, overrides);
    > 32 |   const database = knex(knexConfig);
         |                        ^
      33 | 
      34 |   database.client.pool.on('createSuccess', (_eventId: any, resource: any) => {
      35 |     resource.run('PRAGMA foreign_keys = ON', () => {});

      at Client_SQLite3.initializeDriver (../../../node_modules/knex/lib/client.js:235:13)
      at Client_SQLite3.Client (../../../node_modules/knex/lib/client.js:69:10)
      at new Client_SQLite3 (../../../node_modules/knex/lib/dialects/sqlite3/index.js:17:10)
      at Object.Knex [as default] (../../../node_modules/knex/lib/knex.js:53:28)
      at Object.createSqliteDatabaseClient (database/sqlite3.ts:32:24)
      at Object.createDatabaseClient (database/connection.ts:40:12)
      at Object.<anonymous> (database/connection.test.ts:48:9)

FAIL database/sqlite3.test.ts
  ● sqlite3 › createSqliteDatabaseClient › creates an in memory knex instance

    Knex: run
    $ npm install sqlite3 --save
    Cannot find module 'D:\a\backstage\backstage\node_modules\sqlite3\lib\binding\napi-v3-win32-x64\node_sqlite3.node' from '../../../node_modules/sqlite3/lib/sqlite3-binding.js'

    Require stack:
      D:/a/backstage/backstage/node_modules/sqlite3/lib/sqlite3-binding.js
      D:/a/backstage/backstage/node_modules/sqlite3/lib/sqlite3.js
      D:/a/backstage/backstage/node_modules/knex/lib/dialects/sqlite3/index.js
      D:/a/backstage/backstage/node_modules/knex/lib/knex.js
      D:/a/backstage/backstage/node_modules/knex/lib/index.js
      D:/a/backstage/backstage/node_modules/knex/knex.js
      database/sqlite3.ts
      database/sqlite3.test.ts

      30 | ) {
      31 |   const knexConfig = buildSqliteDatabaseConfig(dbConfig, overrides);
    > 32 |   const database = knex(knexConfig);
         |                        ^
      33 | 
      34 |   database.client.pool.on('createSuccess', (_eventId: any, resource: any) => {
      35 |     resource.run('PRAGMA foreign_keys = ON', () => {});

      at Client_SQLite3.initializeDriver (../../../node_modules/knex/lib/client.js:235:13)
      at Client_SQLite3.Client (../../../node_modules/knex/lib/client.js:69:10)
      at new Client_SQLite3 (../../../node_modules/knex/lib/dialects/sqlite3/index.js:17:10)
      at Object.Knex [as default] (../../../node_modules/knex/lib/knex.js:53:28)
      at Object.createSqliteDatabaseClient (database/sqlite3.ts:32:24)
      at Object.<anonymous> (database/sqlite3.test.ts:78:9)
```

But they don't fail on my machine, any ideas?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
