### PR TITLE
backend: remove yarn cache from built docker image

### DIFF
--- a/.changeset/beige-queens-crash.md
+++ b/.changeset/beige-queens-crash.md
@@ -1,0 +1,13 @@
+---
+'@backstage/create-app': patch
+---
+
+Optimized the `yarn install` step in the backend `Dockerfile`.
+
+To apply these changes to an existing app, make the following changes to `packages/backend/Dockerfile`:
+
+Replace the `RUN yarn install ...` line with the following:
+
+```bash
+RUN yarn install --frozen-lockfile --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"
+```

--- a/.changeset/beige-queens-crash.md
+++ b/.changeset/beige-queens-crash.md
@@ -9,5 +9,5 @@ To apply these changes to an existing app, make the following changes to `packag
 Replace the `RUN yarn install ...` line with the following:
 
 ```bash
-RUN yarn install --frozen-lockfile --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"
+RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
 ```

--- a/.yarnrc
+++ b/.yarnrc
@@ -6,4 +6,4 @@ registry "https://registry.npmjs.org/"
 disable-self-update-check true
 lastUpdateCheck 1580389148099
 yarn-path ".yarn/releases/yarn-1.22.1.js"
-network-timeout 600000
+network-timeout 300000

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 # and along with yarn.lock and the root package.json, that's enough to run yarn install.
 ADD yarn.lock package.json skeleton.tar ./
 
-RUN yarn install --frozen-lockfile --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"
+RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
 
 # This will copy the contents of the dist-workspace when running the build-image command.
 # Do not use this Dockerfile outside of that command, as it will copy in the source code instead.

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 # and along with yarn.lock and the root package.json, that's enough to run yarn install.
 ADD yarn.lock package.json skeleton.tar ./
 
-RUN yarn install --frozen-lockfile --production
+RUN yarn install --frozen-lockfile --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"
 
 # This will copy the contents of the dist-workspace when running the build-image command.
 # Do not use this Dockerfile outside of that command, as it will copy in the source code instead.

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 # and along with yarn.lock and the root package.json, that's enough to run yarn install.
 ADD yarn.lock package.json skeleton.tar ./
 
-RUN yarn install --frozen-lockfile --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"
+RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
 
 # This will copy the contents of the dist-workspace when running the build-image command.
 # Do not use this Dockerfile outside of that command, as it will copy in the source code instead.

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 # and along with yarn.lock and the root package.json, that's enough to run yarn install.
 ADD yarn.lock package.json skeleton.tar ./
 
-RUN yarn install --frozen-lockfile --production
+RUN yarn install --frozen-lockfile --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"
 
 # This will copy the contents of the dist-workspace when running the build-image command.
 # Do not use this Dockerfile outside of that command, as it will copy in the source code instead.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removing the yarn cache after `yarn install` brings the size of that layer from 716MB to 191MB.

Also tried using `buster-slim`, and it further brings total image size down from an initial 1.65GB to 422MB, but is missing some dynamic libraries depended on by `nodegit`, which I shall add to the ever-growing list of reasons to replace `nodegit` :grin:

Since we're running the install without `.yarnrc` I've added in `--network-timeout 600000` to make sure large packages don't cause issues. Adding the local yarn installation to the image is a bit more involved and requires changes to the CLI. I'm hoping we can avoid that in favor of a future #3347

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
