### PR TITLE
Fix another Windows test issue

### DIFF
--- a/packages/cli/src/lib/versioning/packages.test.ts
+++ b/packages/cli/src/lib/versioning/packages.test.ts
@@ -15,6 +15,7 @@
  */
 
 import mockFs from 'mock-fs';
+import path from 'path';
 import * as runObj from '../run';
 import { paths } from '../paths';
 import { fetchPackageInfo, mapDependencies } from './packages';
@@ -54,16 +55,16 @@ describe('mapDependencies', () => {
     await project.getPackages();
 
     mockFs({
-      '/lerna.json': JSON.stringify({
+      'lerna.json': JSON.stringify({
         packages: ['pkgs/*'],
       }),
-      '/pkgs/a/package.json': JSON.stringify({
+      'pkgs/a/package.json': JSON.stringify({
         name: 'a',
         dependencies: {
           '@backstage/core': '1 || 2',
         },
       }),
-      '/pkgs/b/package.json': JSON.stringify({
+      'pkgs/b/package.json': JSON.stringify({
         name: 'b',
         dependencies: {
           '@backstage/core': '3',
@@ -71,9 +72,6 @@ describe('mapDependencies', () => {
         },
       }),
     });
-
-    const oldDir = paths.targetDir;
-    paths.targetDir = '/';
 
     const dependencyMap = await mapDependencies(paths.targetDir);
     expect(Array.from(dependencyMap)).toEqual([
@@ -83,12 +81,12 @@ describe('mapDependencies', () => {
           {
             name: 'a',
             range: '1 || 2',
-            location: '/pkgs/a',
+            location: path.resolve('pkgs', 'a'),
           },
           {
             name: 'b',
             range: '3',
-            location: '/pkgs/b',
+            location: path.resolve('pkgs', 'b'),
           },
         ],
       ],
@@ -98,12 +96,10 @@ describe('mapDependencies', () => {
           {
             name: 'b',
             range: '^0',
-            location: '/pkgs/b',
+            location: path.resolve('pkgs', 'b'),
           },
         ],
       ],
     ]);
-
-    paths.targetDir = oldDir;
   });
 });


### PR DESCRIPTION
This one is a bit tricky. Instead of testing at the root folder of the drive, this test is now relative to the current directory. This resolves the difference between "/pkgs/a" and "d:\pkgs\a"

Still haven't run all tests on Windows, maybe we need another PR...

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
