### PR TITLE
backend-common: allow port in config to be both a number or a string

### DIFF
--- a/.changeset/light-bulldogs-guess.md
+++ b/.changeset/light-bulldogs-guess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Allow the `backend.listen.port` config to be both a number or a string.

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -29,7 +29,7 @@ export interface Config {
           /** Address of the interface that the backend should bind to. */
           address?: string;
           /** Port that the backend should listen to. */
-          port?: number;
+          port?: string | number;
         };
 
     /** HTTPS configuration for the backend. If omitted the backend will serve HTTP */

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -85,7 +85,10 @@ export class ServiceBuilderImpl implements ServiceBuilder {
 
     const baseOptions = readBaseOptions(backendConfig);
     if (baseOptions.listenPort) {
-      this.port = baseOptions.listenPort;
+      this.port =
+        typeof baseOptions.listenPort === 'string'
+          ? parseInt(baseOptions.listenPort, 10)
+          : baseOptions.listenPort;
     }
     if (baseOptions.listenHost) {
       this.host = baseOptions.listenHost;

--- a/packages/backend-common/src/service/lib/config.ts
+++ b/packages/backend-common/src/service/lib/config.ts
@@ -18,7 +18,7 @@ import { Config } from '@backstage/config';
 import { CorsOptions } from 'cors';
 
 export type BaseOptions = {
-  listenPort?: number;
+  listenPort?: string | number;
   listenHost?: string;
 };
 
@@ -89,8 +89,19 @@ export function readBaseOptions(config: Config): BaseOptions {
     });
   }
 
+  const port = config.getOptional('listen.port');
+  if (
+    typeof port !== 'undefined' &&
+    typeof port !== 'number' &&
+    typeof port !== 'string'
+  ) {
+    throw new Error(
+      `Invalid type in config for key 'backend.listen.post', got ${typeof port}, wanted string or number`,
+    );
+  }
+
   return removeUnknown({
-    listenPort: config.getOptionalNumber('listen.port'),
+    listenPort: port,
     listenHost: config.getOptionalString('listen.host'),
     baseUrl: config.getOptionalString('baseUrl'),
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Having the port be string is generally fine, and not allowing it causes headaches in some deployment environments.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
