### PR TITLE
enable sku breakdowns for unlabeled entities

### DIFF
--- a/.changeset/cost-insights-calm-bikes-prove.md
+++ b/.changeset/cost-insights-calm-bikes-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+enable SKU breakdown for unlabeled entities

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityDialog.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityDialog.tsx
@@ -176,7 +176,7 @@ export const ProductEntityDialog = ({
       <Table
         columns={columns}
         data={rowData}
-        title={entity.id || 'Unknown'}
+        title={entity.id || 'Unlabeled'}
         subtitle="Resource breakdown"
         options={{
           paging: false,

--- a/plugins/cost-insights/src/utils/assert.ts
+++ b/plugins/cost-insights/src/utils/assert.ts
@@ -17,7 +17,15 @@
 export function notEmpty<TValue>(
   value: TValue | null | undefined,
 ): value is TValue {
-  return value !== null && value !== undefined;
+  return !isNull(value) && !isUndefined(value);
+}
+
+export function isUndefined(value: any): boolean {
+  return value === undefined;
+}
+
+export function isNull(value: any): boolean {
+  return value === null;
 }
 
 // Utility for exhaustiveness checking in switch statements

--- a/plugins/cost-insights/src/utils/graphs.ts
+++ b/plugins/cost-insights/src/utils/graphs.ts
@@ -72,8 +72,12 @@ export const isInvalid = ({ label, payload }: TooltipProps) => {
   return label === undefined || !payload || !payload.length;
 };
 
-export const isActiveLabel = (
+export const isLabeled = (data?: Record<'activeLabel', string | undefined>) => {
+  return data?.activeLabel && data?.activeLabel !== '';
+};
+
+export const isUnlabeled = (
   data?: Record<'activeLabel', string | undefined>,
 ) => {
-  return data?.activeLabel && data.activeLabel !== '';
+  return data?.activeLabel === '';
 };

--- a/plugins/cost-insights/src/utils/mockData.ts
+++ b/plugins/cost-insights/src/utils/mockData.ts
@@ -563,7 +563,26 @@ export const SampleCloudDataflowInsights: Entity = {
         ratio: 0.2,
         amount: 2_000,
       },
-      entities: [],
+      entities: [
+        {
+          id: 'Sample SKU A',
+          aggregation: [3_000, 4_000],
+          change: {
+            ratio: 0.333333,
+            amount: 1_000,
+          },
+          entities: [],
+        },
+        {
+          id: 'Sample SKU B',
+          aggregation: [7_000, 8_000],
+          change: {
+            ratio: 0.14285714,
+            amount: 1_000,
+          },
+          entities: [],
+        },
+      ],
     },
     {
       id: 'entity-a',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

![unlabeled-skus](https://user-images.githubusercontent.com/3030003/100790762-48b13600-33e6-11eb-8874-d505f1402f89.gif)

Enables sku breakdowns for unlabeled entities.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
