### PR TITLE
Ryanv/disable cost insights support button

### DIFF
--- a/.changeset/cost-insights-hungry-oranges-enjoy.md
+++ b/.changeset/cost-insights-hungry-oranges-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+disable support button

--- a/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPage.tsx
+++ b/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPage.tsx
@@ -32,7 +32,8 @@ import {
 import { CostInsightsNavigation } from '../CostInsightsNavigation';
 import { CostOverviewCard } from '../CostOverviewCard';
 import { ProductInsights } from '../ProductInsights';
-import { CostInsightsSupportButton } from '../CostInsightsSupportButton';
+/* https://github.com/backstage/backstage/issues/2574 */
+// import { CostInsightsSupportButton } from '../CostInsightsSupportButton';
 import {
   useConfig,
   useCurrency,
@@ -164,7 +165,7 @@ export const CostInsightsPage = () => {
       <CostInsightsLayout groups={groups}>
         <Box textAlign="right">
           <CopyUrlToClipboard />
-          <CostInsightsSupportButton />
+          {/* <CostInsightsSupportButton /> */}
         </Box>
         <Container maxWidth="lg">
           <CostInsightsHeaderNoGroups />
@@ -239,7 +240,7 @@ export const CostInsightsPage = () => {
             mb={2}
           >
             <CopyUrlToClipboard />
-            <CostInsightsSupportButton />
+            {/* <CostInsightsSupportButton /> */}
           </Box>
           <Container maxWidth="lg" disableGutters>
             <Grid container direction="column">


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Disables support button for the cost insights plugin. The underlying `SupportButton` component is being refactored and links are currently broken.

Addressed in https://github.com/backstage/backstage/issues/2574

<img width="492" alt="Screen Shot 2020-12-02 at 5 38 45 PM" src="https://user-images.githubusercontent.com/3030003/100940085-5689b880-34c5-11eb-9b06-12be1e79fa0b.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
