### PR TITLE
fix(catalog-import): Catalog import internal variable typo and update plugin ID

### DIFF
--- a/.changeset/grumpy-meals-wink.md
+++ b/.changeset/grumpy-meals-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Align plugin ID and fix variable typo

--- a/plugins/catalog-import/src/api/CatalogImportApi.ts
+++ b/plugins/catalog-import/src/api/CatalogImportApi.ts
@@ -18,7 +18,7 @@ import { createApiRef } from '@backstage/core';
 import { PartialEntity } from '../util/types';
 
 export const catalogImportApiRef = createApiRef<CatalogImportApi>({
-  id: 'plugin.catalogimport.service',
+  id: 'plugin.catalog-import.service',
   description: 'Used by the catalog import plugin to make requests',
 });
 

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -160,7 +160,7 @@ export class CatalogImportClient implements CatalogImportApi {
         );
       });
 
-    const pullRequestRespone = await octo.pulls
+    const pullRequestResponse = await octo.pulls
       .create({
         owner,
         repo,
@@ -178,7 +178,7 @@ export class CatalogImportClient implements CatalogImportApi {
       });
 
     return {
-      link: pullRequestRespone.data.html_url,
+      link: pullRequestResponse.data.html_url,
       location: `https://github.com/${owner}/${repo}/blob/${repoData.data.default_branch}/${fileName}`,
     };
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixed a typo in an internal plugin variable.

Also, the plugin ID for `catalog-import` lacked a dash, so updated it. (which I believe is as of now non-breaking)  Since the plugin contains a dash, it makes sense to align that the ID would also.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
