### PR TITLE
Use resource instead of source when building github repo tar url

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -173,6 +173,8 @@ catalog:
     # Backstage example groups and users
     - type: url
       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
+    - type: url
+      target: https://github.com/hooloovooo/some-old-docs/blob/master/catalog-info.yaml
 
 scaffolder:
   github:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -173,8 +173,6 @@ catalog:
     # Backstage example groups and users
     - type: url
       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
-    - type: url
-      target: https://github.com/hooloovooo/some-old-docs/blob/master/catalog-info.yaml
 
 scaffolder:
   github:

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -178,8 +178,8 @@ export class GithubUrlReader implements UrlReader {
     const {
       name: repoName,
       ref,
+      protocol,
       resource,
-      source,
       full_name,
       filepath,
     } = parseGitUri(url);
@@ -194,7 +194,7 @@ export class GithubUrlReader implements UrlReader {
     // TODO(Rugvip): use API to fetch URL instead
     const response = await fetch(
       new URL(
-        `${resource}://${source}/${full_name}/archive/${ref}.tar.gz`,
+        `${protocol}://${resource}/${full_name}/archive/${ref}.tar.gz`,
       ).toString(),
     );
     if (!response.ok) {

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -178,7 +178,7 @@ export class GithubUrlReader implements UrlReader {
     const {
       name: repoName,
       ref,
-      protocol,
+      resource,
       source,
       full_name,
       filepath,
@@ -194,7 +194,7 @@ export class GithubUrlReader implements UrlReader {
     // TODO(Rugvip): use API to fetch URL instead
     const response = await fetch(
       new URL(
-        `${protocol}://${source}/${full_name}/archive/${ref}.tar.gz`,
+        `${resource}://${source}/${full_name}/archive/${ref}.tar.gz`,
       ).toString(),
     );
     if (!response.ok) {


### PR DESCRIPTION
Source only contains the provider of the github host. If we have a GHE at  `ghe.example.com` source would be  `example.com`. Resouce contains the entire domain includign subdomains.