### PR TITLE
Fix missing authentication in GitHubUrlReader

### DIFF
--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -196,6 +196,7 @@ export class GithubUrlReader implements UrlReader {
       new URL(
         `${protocol}://${resource}/${full_name}/archive/${ref}.tar.gz`,
       ).toString(),
+      getApiRequestOptions(this.config)
     );
     if (!response.ok) {
       const message = `Failed to read tree from ${url}, ${response.status} ${response.statusText}`;

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -196,7 +196,7 @@ export class GithubUrlReader implements UrlReader {
       new URL(
         `${protocol}://${resource}/${full_name}/archive/${ref}.tar.gz`,
       ).toString(),
-      getApiRequestOptions(this.config)
+      getRawRequestOptions(this.config),
     );
     if (!response.ok) {
       const message = `Failed to read tree from ${url}, ${response.status} ${response.statusText}`;


### PR DESCRIPTION


## Hey, I just made a Pull Request!

An oversight that probably stems from that most repositories for tech-docs are public anyway. 
Ours are not, and are inside of a GitHub Enterprise, which is how i found this tiny bug. 

I wish i knew how to mock the cross-fetch in order to inspect the Authorization header of the request to test this fix. 
I can only confirm that it works on our backstage that targets GHE.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
