### PR TITLE
fix(cli): Fix Config Schema for `app.listen`

### DIFF
--- a/.changeset/perfect-donkeys-hope.md
+++ b/.changeset/perfect-donkeys-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix config schema for `.app.listen`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -178,7 +178,7 @@
             "description": "Listening configuration for local development",
             "properties": {
               "host": {
-                "type": "number",
+                "type": "string",
                 "visibility": "frontend",
                 "description": "The host that the frontend should be bound to. Only used for local development."
               },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The app.listen config type declaration introduced in #3264 erroneously marks app.list.host as a number (it should be string)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
