### PR TITLE
Increase pageSize for search result view

### DIFF
--- a/.changeset/purple-ghosts-attack.md
+++ b/.changeset/purple-ghosts-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+change default size for pageSize in search result view

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -251,7 +251,7 @@ export const SearchResult = ({ searchQuery }: SearchResultProps) => {
         )}
         <Grid item xs={showFilters ? 9 : 12}>
           <Table
-            options={{ paging: true, search: false }}
+            options={{ paging: true, pageSize: 20, search: false }}
             data={filteredResults}
             columns={columns}
             title={


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Increases the defaultPage size value from `5` to `20` for the search result page.

<img width="413" alt="image" src="https://user-images.githubusercontent.com/46317312/101151262-ac737300-3621-11eb-96dd-22c0692a8135.png">

<img width="1678" alt="image" src="https://user-images.githubusercontent.com/46317312/101151304-bdbc7f80-3621-11eb-856e-8bfb0e2ae583.png">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
