### PR TITLE
Second take on improving the performance of the Jenkins Plugin

### DIFF
--- a/.changeset/purple-radios-complain.md
+++ b/.changeset/purple-radios-complain.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-jenkins': patch
+---
+
+Improve loading speed of the CI/CD page.
+Only request the necessary fields from Jenkins to keep the request size low.
+In addition everything is loaded in a single request, instead of requesting
+each job and build individually. As this (and also the previous behavior) can
+lead to a big amount of data, this limits the amount of jobs to 50.
+For each job, only the latest build is loaded. Loading the full build history
+of a job can lead to excessive load on the Jenkins instance.

--- a/plugins/jenkins/src/api/JenkinsApi.ts
+++ b/plugins/jenkins/src/api/JenkinsApi.ts
@@ -107,26 +107,48 @@ export class JenkinsApi {
 
   async getFolder(folderName: string) {
     const client = await this.getClient();
-    const folder = await client.job.get(folderName);
+    const folder = await client.job.get({
+      name: folderName,
+      // Filter only be the information we need, instead of loading all fields.
+      // Limit to only show the latest build for each job and only load 50 jobs
+      // at all.
+      // Whitespaces are only included for readablity here and stripped out
+      // before sending to Jenkins
+      tree: `jobs[
+               actions[*],
+               builds[
+                number,
+                url,
+                fullDisplayName,
+                building,
+                result,
+                actions[
+                  *[
+                    *[
+                      *[
+                        *
+                      ]
+                    ]
+                  ]
+                ]
+              ]{0,1},
+              jobs{0,1},
+              name
+            ]{0,50}
+            `.replace(/\s/g, ''),
+    });
     const results = [];
-    for (const jobSummary of folder.jobs) {
-      const jobDetails = await client.job.get({
-        name: `${folderName}/${jobSummary.name}`,
-        depth: 1,
-      });
 
+    for (const jobDetails of folder.jobs) {
       const jobScmInfo = this.extractScmDetailsFromJob(jobDetails);
       if (jobDetails.jobs) {
         // skipping folders inside folders for now
       } else {
         for (const buildDetails of jobDetails.builds) {
-          const build = await client.build.get({
-            name: `${folderName}/${jobSummary.name}`,
-            number: buildDetails.number,
-            depth: 1,
-          });
-
-          const ciTable = this.mapJenkinsBuildToCITable(build, jobScmInfo);
+          const ciTable = this.mapJenkinsBuildToCITable(
+            buildDetails,
+            jobScmInfo,
+          );
           results.push(ciTable);
         }
       }


### PR DESCRIPTION
Improve loading speed of the CI/CD page.
Only request the necessary fields from Jenkins to keep the request size low.
In addition everything is loaded in a single request, instead of requesting
each job and build individually. As this (and also the previous behavior) can
lead to a big amount of data, this limits the amount of jobs to 50.
For each job, only the latest build is loaded. Loading the full build history
of a job can lead to excessive load on the Jenkins instance.

Related to #3300, but I'm not sure if I would call it a fix. In the long term paging on the server side would be useful, but I couldn't find a way to move sorting there.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
