### PR TITLE
Fix cleaning of the prom-client metrics registry on hot reloads

### DIFF
--- a/.changeset/happy-parents-shout.md
+++ b/.changeset/happy-parents-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fix cleaning of the prom-client metrics registry on hot reloads.

--- a/packages/backend-common/src/service/lib/metrics.ts
+++ b/packages/backend-common/src/service/lib/metrics.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import prom from 'prom-client';
-import promBundle from 'express-prom-bundle';
 import { RequestHandler } from 'express';
+import promBundle from 'express-prom-bundle';
+import prom from 'prom-client';
 import * as url from 'url';
+import { useHotCleanup } from '../..';
 
 const rootRegEx = new RegExp('^/([^/]*)/.*');
 const apiRegEx = new RegExp('^/api/([^/]*)/.*');
@@ -38,7 +39,7 @@ export function normalizePath(req: any): string {
  */
 export function metricsHandler(): RequestHandler {
   // We can only initialize the metrics once and have to clean them up between hot reloads
-  prom.register.clear();
+  useHotCleanup(module, () => prom.register.clear());
 
   return promBundle({
     includeMethod: true,


### PR DESCRIPTION
As #3512 will not be merged, this extracts a small fixes for hot reloading from the PR.

Even though prom-client might be removed in the future, we should resolve this issue right now. Otherwise hot reloading is not useable for teams that plan to use prom-client for their metric integration.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
