### PR TITLE
Add pagerduty config to helm chart

### DIFF
--- a/contrib/chart/backstage/templates/backend-secret.yaml
+++ b/contrib/chart/backstage/templates/backend-secret.yaml
@@ -20,4 +20,5 @@ stringData:
   AZURE_TOKEN: {{ .Values.auth.azure.api.token }}
   NEW_RELIC_REST_API_KEY: {{ .Values.auth.newRelicRestApiKey }}
   TRAVISCI_AUTH_TOKEN: {{ .Values.auth.travisciAuthToken }}
+  PAGERDUTY_TOKEN: {{ .Values.auth.pagerdutyToken }}
 {{- end }}

--- a/contrib/chart/backstage/values.yaml
+++ b/contrib/chart/backstage/values.yaml
@@ -250,3 +250,4 @@ auth:
   gitlabToken: g
   newRelicRestApiKey: r
   travisciAuthToken: fake-travis-ci-auth-token
+  pagerdutyToken: h


### PR DESCRIPTION
This allows Helm chart users to set the `PAGERDUTY_TOKEN` via the `values.yaml` file.