### PR TITLE
chore: Align optional NPM fields for multiple packages

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,11 +3,20 @@
   "version": "0.2.5",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
-  "private": true,
   "license": "Apache-2.0",
+  "private": true,
   "engines": {
     "node": "12 || 14"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "packages/backend"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli backend:build",
     "build-image": "backstage-cli backend:build-image --build --tag example-backend",

--- a/packages/catalog-client/package.json
+++ b/packages/catalog-client/package.json
@@ -11,6 +11,15 @@
     "module": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "packages/catalog-client"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli build",
     "lint": "backstage-cli lint",

--- a/packages/catalog-model/package.json
+++ b/packages/catalog-model/package.json
@@ -11,6 +11,15 @@
     "module": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "packages/catalog-model"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli build",
     "lint": "backstage-cli lint",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -11,6 +11,15 @@
     "module": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "packages/integration"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli build",
     "lint": "backstage-cli lint",

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -9,6 +9,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/api-docs"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
In NPM, I noticed some inconsistencies with how packages in the monorepo showed up.  This is a chore pull to try to standardize these a bit.

I can have a larger one behind this for plugins, but before I do, thought I'd try this smaller one to work out:

* Opted for no changeset. Theoretically these change the package, but figured as metadata, better to let actual code changes trigger version bumps and next versions bumps will publish to NPM with this?
* Maybe there's a smarter way to manage this in monorepos, and/or another open source package to better align/standardize this than a few greps and a manual tweak or two?  happy to submit this brute force method, even if there might be a more elegant long term method.

In the right nav, NPM shows just more context for the elements of the monorepo.

| With Homepage / Repo and Keywords Defined | When not defined Changes |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/33203301/101270377-78de3900-3746-11eb-8c19-a08c2720ab16.png) | ![image](https://user-images.githubusercontent.com/33203301/101270383-84316480-3746-11eb-8593-36ed72cc9247.png) |

Ran this with a `yarn cache clean` and `yarn install`, and everything seemed ok locally (i.e., no JSON typos).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
