### PR TITLE
Fix techdocs for url locations

### DIFF
--- a/plugins/techdocs-backend/src/techdocs/stages/prepare/dir.ts
+++ b/plugins/techdocs-backend/src/techdocs/stages/prepare/dir.ts
@@ -43,6 +43,7 @@ export class DirectoryPreparer implements PreparerBase {
     switch (type) {
       case 'github':
       case 'gitlab':
+      case 'url':
       case 'azure/api': {
         const parsedGitLocation = parseGitUrl(target);
         const repoLocation = await checkoutGitRepository(target, this.logger);


### PR DESCRIPTION
Pasting a URL like `https://github.com/RoadieHQ/sample-service/blob/master/catalog-info-1.yaml`
into the Register Existing Component input creates an Entity with the
the `backstage.io/managed-by-location` annotation set to the `type` of
`url`.

The TechDocs perparer does not handle this type.

```ts
    switch (type) {
      case 'github':
      case 'gitlab':
      case 'azure/api': {
        // ...
      }

      case 'file':
        // ...
      default:
        throw new InputError(`Unable to resolve location type ${type}`);
    }
  }
```

Thus, docs are never generated and we see the following error when
trying to view then in Backstage.

```
InputError: Unable to resolve location type url at DirectoryPreparer.resolveManagedByLocationToDir (webpack-internal:///../../node_modules/@backstage/plugin-techdocs-backend/src/techdocs/stages/prepare/dir.ts:63:15) at DirectoryPreparer.prepare (webpack-internal:///../../node_modules/@backstage/plugin-techdocs-backend/src/techdocs/stages/prepare/dir.ts:73:51) at DocsBuilder.build (webpack-internal:///../../node_modules/@backstage/plugin-techdocs-backend/src/service/helpers.ts:74:45) at eval (webpack-internal:///../../node_modules/@backstage/plugin-techdocs-backend/src/service/router.ts:141:25) at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

This may not be the correct solution. An alternative solution would be
to ensure that pasted URLs end up with the `type` of `github` rather
than `url`.

