### PR TITLE
catalog-backend: read all relations at once

### DIFF
--- a/.changeset/fluffy-pillows-smile.md
+++ b/.changeset/fluffy-pillows-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Batch the fetching of relations

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
@@ -85,7 +85,7 @@ export class HigherOrderOperations implements HigherOrderOperation {
     // Write
     if (!previousLocation && !dryRun) {
       // TODO: We do not include location operations in the dryRun. We might perform
-      // this operation as a seperate dry run.
+      // this operation as a separate dry run.
       await this.locationsCatalog.addLocation(location);
     }
     if (readerOutput.entities.length === 0) {


### PR DESCRIPTION
Make sure to batch read relations instead of one by one.

This is not addressing the heart of the issue of #3534, but is a related improvement nonetheless.