### PR TITLE
cli: update experimental backend:bundle command to output archives to dist/

### DIFF
--- a/.changeset/dull-dingos-dream.md
+++ b/.changeset/dull-dingos-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Update experimental backend bundle command to only output archives to `dist/` instead of a full workspace mirror in `dist-workspace/`.

--- a/packages/cli/src/lib/packager/index.ts
+++ b/packages/cli/src/lib/packager/index.ts
@@ -68,6 +68,11 @@ type Options = {
   buildDependencies?: boolean;
 
   /**
+   * When `buildDependencies` is set, this list of packages will not be built even if they are dependencies.
+   */
+  buildExcludes?: string[];
+
+  /**
    * Enable (true/false) or control amount of (number) parallelism in some build steps.
    */
   parallel?: ParallelOption;
@@ -76,7 +81,7 @@ type Options = {
    * If set, creates a skeleton tarball that contains all package.json files
    * with the same structure as the workspace dir.
    */
-  skeleton?: 'skeleton.tar';
+  skeleton?: 'skeleton.tar' | 'skeleton.tar.gz';
 };
 
 /**
@@ -98,7 +103,11 @@ export async function createDistWorkspace(
   const targets = await findTargetPackages(packageNames);
 
   if (options.buildDependencies) {
-    const scopeArgs = targets.flatMap(target => ['--scope', target.name]);
+    const exclude = options.buildExcludes ?? [];
+    const scopeArgs = targets
+      .filter(target => !exclude.includes(target.name))
+      .flatMap(target => ['--scope', target.name]);
+
     const lernaArgs =
       options.parallel && Number.isInteger(options.parallel)
         ? ['--concurrency', options.parallel.toString()]
@@ -131,6 +140,7 @@ export async function createDistWorkspace(
         cwd: targetDir,
         portable: true,
         noMtime: true,
+        gzip: options.skeleton.endsWith('.gz'),
       } as CreateOptions & { noMtime: boolean },
       skeletonFiles,
     );


### PR DESCRIPTION

## Hey, I just made a Pull Request!

More work towards #3347

This changes the output of the `backend:__experimental__bundle__` command to be two archives, `dist/bundle.tar.gz` and `dist/skeleton.tar.gz`. The skeleton serves the same purpose as it does when using `backend:build-image`, which is to allow for cached `yarn install`s in Dockerfiles. The bundle contains the rest of all the package files, which is the target backend packages itself, along with all local dependencies and transitive dependencies of it.

This also changes the command to build the packages that it is called from, so that we can skip the `dist` + `dist-workspace` combo and only have a single `dist` folder.

This allows for the following Dockerfile, called with `docker build -f packages/backend/Dockerfile` from the repo root, or directly in the package dir if all files are available there.

```Dockerfile
FROM node:14-buster

WORKDIR /usr/src/app

# Cached install of all dependencies
ADD yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"

# Extract the backend bundle into the workspace
ADD packages/backend/dist/bundle.tar.gz ./

# Copy any extra files
COPY app-config.yaml ./

CMD ["node", "packages/backend", "--config", "app-config.yaml"]
```

The rationale for using archives as the output units is that they're hopefully easier to reason about as build artifacts, compared to the monorepo directory structure with a bunch of packages. It's also real simple to bridge over to a containerized deployment, and also hopefully makes the `bundle`/`skeleton` relationship a bit more clear. If this is the way forward I could still see us adding an `--output tar|dir` option, similar to the build command.

Looking for feedback on this solution, and for people to try it out in their deployments once it's been released next Thursday :grin:

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
