### PR TITLE
Export the defaultConfigLoader

### DIFF
--- a/.changeset/tall-hairs-switch.md
+++ b/.changeset/tall-hairs-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Export the `defaultConfigLoader` implementation

--- a/packages/core/src/api-wrappers/index.ts
+++ b/packages/core/src/api-wrappers/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { createApp } from './createApp';
+export { createApp, defaultConfigLoader } from './createApp';


### PR DESCRIPTION
The `createApp(…)` can be configured with a custom `configLoader` but the default one is not exported.

Why would someone need that? Maybe one wants to add an additional config loader beside the defaults, or one needs wants to have the result of `defaultConfigLoader()` output even before an actual app has been started.

We use this for example to read some settings for sentry, which is initialized even before React (like described in their docs https://docs.sentry.io/platforms/javascript/guides/react/#configure). Though this is technically _after_ the call for the config loader, but the config system makes it very convenient to manage configs and inject different configs at deploy-time.

Is there a good reason to not export it?

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
