### PR TITLE
Improve SEO of microsite title

### DIFF
--- a/microsite/siteConfig.js
+++ b/microsite/siteConfig.js
@@ -12,7 +12,7 @@
 const users = [];
 
 const siteConfig = {
-  title: 'Backstage', // Title for your website.
+  title: 'Backstage Service Catalog and Developer Platform', // Title for your website.
   tagline: 'An open platform for building developer portals',
   url: 'https://backstage.io', // Your website URL
   cname: 'backstage.io',


### PR DESCRIPTION
Many people will be searching for "service catalog" and "developer platform" when they are looking for something like Backstage. They may not have ever heard of Backstage before so they will not know to search for it.

A title which includes the keywords "Service Catalog" and "developer platform" will rank better for those queries. This increases the change of Backstage being found by people who could make good use of it.

[Standard advice](https://moz.com/learn/seo/title-tag) is to keep page titles under 60 chars. The proposed title is 49 chars.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
