### PR TITLE
Consider group memberships in the OwnershipCard

### DIFF
--- a/.changeset/witty-rabbits-smell.md
+++ b/.changeset/witty-rabbits-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Support transitive ownerships of users and groups.

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { InfoCard, useApi, Progress } from '@backstage/core';
-import { Entity, RELATION_OWNED_BY } from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 import { catalogApiRef } from '@backstage/plugin-catalog';
 import { useAsync } from 'react-use';
 import Alert from '@material-ui/lab/Alert';
@@ -28,6 +29,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import { pageTheme } from '@backstage/theme';
+import { isOwnerOf } from '../../isOwnerOf';
 
 type EntitiesKinds = 'Component' | 'API';
 type EntitiesTypes =
@@ -118,9 +120,6 @@ export const OwnershipCard = ({
   entity: Entity;
   variant: string;
 }) => {
-  const {
-    metadata: { name: groupName },
-  } = entity;
   const catalogApi = useApi(catalogApiRef);
   const {
     loading,
@@ -129,10 +128,8 @@ export const OwnershipCard = ({
   } = useAsync(async () => {
     const entitiesList = await catalogApi.getEntities();
     const ownedEntitiesList = entitiesList.items.filter(component =>
-      component?.relations?.some(
-        r => r.type === RELATION_OWNED_BY && r.target.name === groupName,
-      ),
-    ) as Array<Entity>;
+      isOwnerOf(entity, component),
+    );
 
     return [
       {

--- a/plugins/org/src/components/getEntityRelations.ts
+++ b/plugins/org/src/components/getEntityRelations.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity, EntityName } from '@backstage/catalog-model';
+
+// TODO: this file is copied from /packages/app/catalog/src/components/getEntityRelations.ts and
+//       should be replaced once common relation-functions are introduced.
+
+/**
+ * Get the related entity references.
+ */
+export function getEntityRelations(
+  entity: Entity | undefined,
+  relationType: string,
+  filter?: { kind: string },
+): EntityName[] {
+  let entityNames =
+    entity?.relations
+      ?.filter(r => r.type === relationType)
+      ?.map(r => r.target) || [];
+
+  if (filter?.kind) {
+    entityNames = entityNames?.filter(
+      e => e.kind.toLowerCase() === filter.kind.toLowerCase(),
+    );
+  }
+
+  return entityNames;
+}

--- a/plugins/org/src/components/isOwnerOf.ts
+++ b/plugins/org/src/components/isOwnerOf.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  EntityName,
+  getEntityName,
+  RELATION_MEMBER_OF,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
+import { getEntityRelations } from './getEntityRelations';
+
+// TODO: this file is copied from /packages/app/catalog/src/components/isOwnerOf.ts and
+//       should be replaced once common relation-functions are introduced.
+
+/**
+ * Check if one entity is owned by another. Returns true, if the entity is owned by the
+ * owner directly, or if the entity is owned by a group that the owner is a member of.
+ */
+export function isOwnerOf(owner: Entity, owned: Entity) {
+  const possibleOwners: EntityName[] = [
+    ...getEntityRelations(owner, RELATION_MEMBER_OF, { kind: 'group' }),
+    ...(owner ? [getEntityName(owner)] : []),
+  ];
+
+  const owners = getEntityRelations(owned, RELATION_OWNED_BY);
+
+  for (const owner of owners) {
+    if (
+      possibleOwners.find(
+        o =>
+          owner.kind.toLowerCase() === o.kind.toLowerCase() &&
+          owner.namespace.toLowerCase() === o.namespace.toLowerCase() &&
+          owner.name.toLowerCase() === o.name.toLowerCase(),
+      ) !== undefined
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
We tried the org-plugin and mentioned that the owned entities are not complete. I ~~export~~copied the `isOwnerOf` function from the catalog plugin and reuse it to also count entities that are owned by all groups the user is a member of.

New behavior:
* **User**: Count all entities that the user owns + the entities that all his groups own.
* **Group**: Count all the entities that the group directly owns. No child-group-owned entities are counted.

| Before (user guest)        | After (user guest)           |
| ------------- |-------------|
| <img src="https://user-images.githubusercontent.com/720821/101523076-65baab80-3988-11eb-82c4-6e1fbe282e55.png">      | <img src="https://user-images.githubusercontent.com/720821/101522924-2c823b80-3988-11eb-9b39-00a6fed9582e.png"> |

The `isOwnerOf` hook only works correctly for `User` entities today since Group-to-Group relationships are not modelled via `memberOf` but with `parentOf` relationships. Since I am not completely sure whether a group transitively owns all components of its children, I leave that for another PR.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
