### PR TITLE
chore: Add standard NPM metadata to plugins

### DIFF
--- a/plugins/app-backend/package.json
+++ b/plugins/app-backend/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/app-backend"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "start": "backstage-cli backend:dev",
     "build": "backstage-cli backend:build",

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/auth-backend"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "start": "backstage-cli backend:dev",
     "build": "backstage-cli backend:build",

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/catalog-backend"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "start": "backstage-cli backend:dev",
     "build": "backstage-cli backend:build",

--- a/plugins/catalog-graphql/package.json
+++ b/plugins/catalog-graphql/package.json
@@ -9,6 +9,16 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/catalog-graphql"
+  },
+  "keywords": [
+    "backstage",
+    "graphql"
+  ],
   "scripts": {
     "start": "backstage-cli backend:dev",
     "build": "backstage-cli backend:build",

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/catalog-import"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/catalog"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/circleci"
+  },
+  "keywords": [
+    "backstage",
+    "circleci"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",

--- a/plugins/cloudbuild/package.json
+++ b/plugins/cloudbuild/package.json
@@ -9,6 +9,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/cloudbuild"
+  },
+  "keywords": [
+    "backstage",
+    "google cloud"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/cost-insights"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/explore"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",

--- a/plugins/gcp-projects/package.json
+++ b/plugins/gcp-projects/package.json
@@ -9,6 +9,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/gcp-projects"
+  },
+  "keywords": [
+    "backstage",
+    "google cloud"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/github-actions/package.json
+++ b/plugins/github-actions/package.json
@@ -10,6 +10,17 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/github-actions"
+  },
+  "keywords": [
+    "backstage",
+    "github",
+    "github actions"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/gitops-profiles/package.json
+++ b/plugins/gitops-profiles/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/gitops-profiles"
+  },
+  "keywords": [
+    "backstage",
+    "gitops"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/graphql/package.json
+++ b/plugins/graphql/package.json
@@ -9,6 +9,16 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/graphql-backend"
+  },
+  "keywords": [
+    "backstage",
+    "graphql"
+  ],
   "scripts": {
     "start": "backstage-cli backend:dev",
     "build": "backstage-cli backend:build",

--- a/plugins/jenkins/package.json
+++ b/plugins/jenkins/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/jenkins"
+  },
+  "keywords": [
+    "backstage",
+    "jenkins"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/kubernetes-backend"
+  },
+  "keywords": [
+    "backstage",
+    "kubernetes"
+  ],
   "configSchema": "schema.d.ts",
   "scripts": {
     "start": "backstage-cli backend:dev",

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -9,6 +9,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/kubernetes"
+  },
+  "keywords": [
+    "backstage",
+    "kubernetes"
+  ],
   "configSchema": "schema.d.ts",
   "scripts": {
     "build": "backstage-cli plugin:build",

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/lighthouse"
+  },
+  "keywords": [
+    "backstage",
+    "lighthouse"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",

--- a/plugins/newrelic/package.json
+++ b/plugins/newrelic/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/newrelic"
+  },
+  "keywords": [
+    "backstage",
+    "newrelic"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/pagerduty/package.json
+++ b/plugins/pagerduty/package.json
@@ -9,6 +9,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/pagerduty"
+  },
+  "keywords": [
+    "backstage",
+    "pagerduty"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/proxy-backend/package.json
+++ b/plugins/proxy-backend/package.json
@@ -9,6 +9,15 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/proxy-backend"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "start": "backstage-cli backend:dev",
     "build": "backstage-cli backend:build",

--- a/plugins/register-component/package.json
+++ b/plugins/register-component/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/register-component"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/rollbar-backend/package.json
+++ b/plugins/rollbar-backend/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/rollbar-backend"
+  },
+  "keywords": [
+    "backstage",
+    "rollbar"
+  ],
   "scripts": {
     "start": "backstage-cli backend:dev",
     "build": "backstage-cli backend:build",

--- a/plugins/rollbar/package.json
+++ b/plugins/rollbar/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/rollbar"
+  },
+  "keywords": [
+    "backstage",
+    "rollbar"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/scaffolder-backend"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "start": "backstage-cli backend:dev",
     "build": "backstage-cli backend:build",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/scaffolder"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -9,6 +9,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/search"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/sentry"
+  },
+  "keywords": [
+    "backstage",
+    "sentry"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -10,6 +10,17 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/sonarqube"
+  },
+  "keywords": [
+    "backstage",
+    "sonarqube",
+    "sonarcloud"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/tech-radar"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/techdocs-backend"
+  },
+  "keywords": [
+    "backstage",
+    "techdocs"
+  ],
   "scripts": {
     "start": "backstage-cli backend:dev",
     "build": "backstage-cli backend:build",

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/techdocs"
+  },
+  "keywords": [
+    "backstage",
+    "techdocs"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/user-settings"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -10,6 +10,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/welcome"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "lint": "backstage-cli lint",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Follow-up to #3585 , adding standard NPM metadata fields so NPM will pick up more info on the plugins.  No changeset, as it's not a code change, but the next patch to the plugin will push the metadata to NPM.

| With Homepage / Repo and Keywords Defined | When not defined |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/33203301/101270377-78de3900-3746-11eb-8c19-a08c2720ab16.png) | ![image](https://user-images.githubusercontent.com/33203301/101270383-84316480-3746-11eb-8593-36ed72cc9247.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
