### PR TITLE
Add NPM metadata to the create-plugin template

### DIFF
--- a/.changeset/dull-hairs-unite.md
+++ b/.changeset/dull-hairs-unite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add NPM metadata to create-plugin template

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -13,6 +13,15 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/{{id}}"
+  },
+  "keywords": [
+    "backstage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Subsequent to #3585 and #3624, update the create-plugin template to properly add the NPM meta data.

Obviously, if a user were to want to use a plugin locally or seprately from the app at whole, they would modify this metadata, so I figured it was better to template it than not and have the users change it if they need to, than leave it empty.  Happy w/ alternate opinions on it. In future, could even have the cli ask a question about the URL if not defaulted, that sort of thing. For now, fired a patch to the cli for it.

![image](https://user-images.githubusercontent.com/33203301/101539065-ed45f180-396b-11eb-925b-136ea4695e02.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
