### PR TITLE
fix(core): React descendant P tag warning

### DIFF
--- a/.changeset/rare-cooks-tan.md
+++ b/.changeset/rare-cooks-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Fix React warning of descendant paragraph tag

--- a/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -20,8 +20,7 @@ import { BackstageTheme } from '@backstage/theme';
 import { EmptyState } from './EmptyState';
 import { CodeSnippet } from '../CodeSnippet';
 
-const COMPONENT_YAML = `# Example
-apiVersion: backstage.io/v1alpha1
+const COMPONENT_YAML = `apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: example
@@ -49,10 +48,10 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 export const MissingAnnotationEmptyState = ({ annotation }: Props) => {
   const classes = useStyles();
   const description = (
-    <Typography>
+    <>
       The <code>{annotation}</code> annotation is missing. You need to add the
       annotation to your component if you want to enable this tool.
-    </Typography>
+    </>
   );
   return (
     <EmptyState
@@ -70,7 +69,7 @@ export const MissingAnnotationEmptyState = ({ annotation }: Props) => {
               text={COMPONENT_YAML.replace('ANNOTATION', annotation)}
               language="yaml"
               showLineNumbers
-              highlightedNumbers={[7, 8]}
+              highlightedNumbers={[6, 7]}
               customStyle={{ background: 'inherit', fontSize: '115%' }}
             />
           </div>

--- a/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -30,8 +30,7 @@ metadata:
 spec:
   type: website
   lifecycle: production
-  owner: guest
-`;
+  owner: guest`;
 
 type Props = {
   annotation: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The _Missing Annotation_ page passed a `<Typography>` element for a description into _another_ `<Typography>` element, and threw this warning in React DevTools.  Just converted the tag to empty to remove the warning. There may be smoother ways to do this, so welcome feedback.

Also removed the "Example" code tag header in the YAML to simplify it, since the YAML already is the example, and trailing whitespace for the YAML example in this case.

### Before

![image](https://user-images.githubusercontent.com/33203301/101583988-a4615d80-39aa-11eb-8789-920428e78381.png)

### After

![image](https://user-images.githubusercontent.com/33203301/101584154-ff935000-39aa-11eb-9042-f9e54ae1eb3a.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
