### PR TITLE
Fix missing baseUrl in graphql client for GHE

### DIFF
--- a/.changeset/calm-scissors-jam.md
+++ b/.changeset/calm-scissors-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Add support for Github Enterprise in GitHubOrgReaderProcessor so you can properly ingest users of a GHE organization.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -133,7 +133,7 @@ catalog:
             $env: GITHUB_TOKEN
         #### Example for how to add your GitHub Enterprise instance using the API:
         # - target: https://ghe.example.net
-        #   apiBaseUrl: https://ghe.example.net/api/v3
+        #   apiBaseUrl: https://ghe.example.net/api
         #   token:
         #     $env: GHE_TOKEN
     ldapOrg:

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
@@ -64,6 +64,7 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     const client = !provider.token
       ? graphql
       : graphql.defaults({
+          baseUrl: provider.apiBaseUrl,
           headers: {
             authorization: `token ${provider.token}`,
           },


### PR DESCRIPTION
`baseUrl: provider.apiBaseUrl` was missing from the graphql client, making it fail miserably against a GHE instance when ingesting users and groups. Also the docs and app-config.yaml sample are wrong on what `apiBaseUrl: 'https://ghe.company.com/api/v3'` should be used, so this resolves that too. 

Very small but potent fix. 