### PR TITLE
catalog-backend: get rid of winston warnings

### DIFF
--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import { getVoidLogger } from '@backstage/backend-common';
 import { LocationSpec } from '@backstage/catalog-model';
 import { CodeOwnersEntry } from 'codeowners-utils';
-import { createLogger } from 'winston';
 import {
   buildCodeOwnerUrl,
   buildUrl,
@@ -28,7 +28,7 @@ import {
   resolveCodeOwner,
 } from './CodeOwnersProcessor';
 
-const logger = createLogger();
+const logger = getVoidLogger();
 
 describe('CodeOwnersProcessor', () => {
   const mockUrl = ({ basePath = '' } = {}): string =>


### PR DESCRIPTION
Using a winston logger with no sink leads to huge warnings in the test output