### PR TITLE
core: let Link accept any element type as component

### DIFF
--- a/.changeset/eighty-queens-explode.md
+++ b/.changeset/eighty-queens-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Link `component` prop now accepts any element type.

--- a/packages/core/src/components/Link/Link.tsx
+++ b/packages/core/src/components/Link/Link.tsx
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 
-import React, { ComponentProps } from 'react';
-import { Link as MaterialLink } from '@material-ui/core';
-import { Link as RouterLink } from 'react-router-dom';
+import React, { ElementType } from 'react';
+import {
+  Link as MaterialLink,
+  LinkProps as MaterialLinkProps,
+} from '@material-ui/core';
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+} from 'react-router-dom';
 
-type Props = ComponentProps<typeof MaterialLink> &
-  ComponentProps<typeof RouterLink> & { component?: React.ReactNode };
+type Props = MaterialLinkProps &
+  RouterLinkProps & {
+    component?: ElementType<any>;
+  };
 
 /**
  * Thin wrapper on top of material-ui's Link component


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup for https://github.com/backstage/backstage/pull/3527#discussion_r538795854

I reverted back from `ReactNode` to the full `ComponentType<any>` + intrinsic elements

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
