### PR TITLE
changeset: switch GitHubOrgReaderProcessor GHE support change to patch bump

### DIFF
--- a/.changeset/calm-scissors-jam.md
+++ b/.changeset/calm-scissors-jam.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend': minor
+'@backstage/plugin-catalog-backend': patch
 ---
 
 Add support for Github Enterprise in GitHubOrgReaderProcessor so you can properly ingest users of a GHE organization.


### PR DESCRIPTION
Small tweak for #3647, since it's not a breaking change.