### PR TITLE
Implement readTree for GitlabReader (#3547)

### DIFF
--- a/.changeset/pink-ravens-destroy.md
+++ b/.changeset/pink-ravens-destroy.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-common': minor
+'@backstage/integration': minor
+---
+
+Introduce readTree method for GitLab URL Reader

--- a/.changeset/pink-ravens-destroy.md
+++ b/.changeset/pink-ravens-destroy.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/backend-common': minor
-'@backstage/integration': minor
+'@backstage/backend-common': patch
+'@backstage/integration': patch
 ---
 
 Introduce readTree method for GitLab URL Reader

--- a/packages/backend-common/src/reading/GitlabUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.test.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
+import { ConfigReader } from '@backstage/config';
+import { msw } from '@backstage/test-utils';
+import fs from 'fs';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { ConfigReader } from '@backstage/config';
+import path from 'path';
 import { getVoidLogger } from '../logging';
 import { GitlabUrlReader } from './GitlabUrlReader';
-import { msw } from '@backstage/test-utils';
 import { ReadTreeResponseFactory } from './tree';
 
 const logger = getVoidLogger();
@@ -30,105 +32,207 @@ const treeResponseFactory = ReadTreeResponseFactory.create({
 
 describe('GitlabUrlReader', () => {
   const worker = setupServer();
-
   msw.setupDefaultHandlers(worker);
 
-  beforeEach(() => {
-    worker.use(
-      rest.get('*/api/v4/projects/:name', (_, res, ctx) =>
-        res(ctx.status(200), ctx.json({ id: 12345 })),
-      ),
-      rest.get('*', (req, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            url: req.url.toString(),
-            headers: req.headers.getAllHeaders(),
-          }),
+  describe('implementation', () => {
+    beforeEach(() => {
+      worker.use(
+        rest.get('*/api/v4/projects/:name', (_, res, ctx) =>
+          res(ctx.status(200), ctx.json({ id: 12345 })),
         ),
-      ),
-    );
-  });
-
-  const createConfig = (token?: string) =>
-    new ConfigReader(
-      {
-        integrations: { gitlab: [{ host: 'gitlab.com', token }] },
-      },
-      'test-config',
-    );
-
-  it.each([
-    // Project URLs
-    {
-      url:
-        'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
-      config: createConfig(),
-      response: expect.objectContaining({
-        url:
-          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
-        headers: expect.objectContaining({
-          'private-token': '',
-        }),
-      }),
-    },
-    {
-      url:
-        'https://gitlab.example.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
-      config: createConfig('0123456789'),
-      response: expect.objectContaining({
-        url:
-          'https://gitlab.example.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
-        headers: expect.objectContaining({
-          'private-token': '0123456789',
-        }),
-      }),
-    },
-    {
-      url:
-        'https://gitlab.com/groupA/teams/teamA/repoA/-/blob/branch/my/path/to/file.yaml', // Repo not in subgroup
-      config: createConfig(),
-      response: expect.objectContaining({
-        url:
-          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
-      }),
-    },
-
-    // Raw URLs
-    {
-      url: 'https://gitlab.example.com/a/b/blob/master/c.yaml',
-      config: createConfig(),
-      response: expect.objectContaining({
-        url: 'https://gitlab.example.com/a/b/raw/master/c.yaml',
-      }),
-    },
-  ])('should handle happy path %#', async ({ url, config, response }) => {
-    const [{ reader }] = GitlabUrlReader.factory({
-      config,
-      logger,
-      treeResponseFactory,
+        rest.get('*', (req, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.json({
+              url: req.url.toString(),
+              headers: req.headers.getAllHeaders(),
+            }),
+          ),
+        ),
+      );
     });
 
-    const data = await reader.read(url);
-    const res = await JSON.parse(data.toString('utf-8'));
-    expect(res).toEqual(response);
-  });
+    const createConfig = (token?: string) =>
+      new ConfigReader(
+        {
+          integrations: { gitlab: [{ host: 'gitlab.com', token }] },
+        },
+        'test-config',
+      );
 
-  it.each([
-    {
-      url: '',
-      config: createConfig(''),
-      error:
-        "Invalid type in config for key 'integrations.gitlab[0].token' in 'test-config', got empty-string, wanted string",
-    },
-  ])('should handle error path %#', async ({ url, config, error }) => {
-    await expect(async () => {
+    it.each([
+      // Project URLs
+      {
+        url:
+          'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
+        config: createConfig(),
+        response: expect.objectContaining({
+          url:
+            'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+          headers: expect.objectContaining({
+            'private-token': '',
+          }),
+        }),
+      },
+      {
+        url:
+          'https://gitlab.example.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
+        config: createConfig('0123456789'),
+        response: expect.objectContaining({
+          url:
+            'https://gitlab.example.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+          headers: expect.objectContaining({
+            'private-token': '0123456789',
+          }),
+        }),
+      },
+      {
+        url:
+          'https://gitlab.com/groupA/teams/teamA/repoA/-/blob/branch/my/path/to/file.yaml', // Repo not in subgroup
+        config: createConfig(),
+        response: expect.objectContaining({
+          url:
+            'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+        }),
+      },
+
+      // Raw URLs
+      {
+        url: 'https://gitlab.example.com/a/b/blob/master/c.yaml',
+        config: createConfig(),
+        response: expect.objectContaining({
+          url: 'https://gitlab.example.com/a/b/raw/master/c.yaml',
+        }),
+      },
+    ])('should handle happy path %#', async ({ url, config, response }) => {
       const [{ reader }] = GitlabUrlReader.factory({
         config,
         logger,
         treeResponseFactory,
       });
-      await reader.read(url);
-    }).rejects.toThrow(error);
+
+      const data = await reader.read(url);
+      const res = await JSON.parse(data.toString('utf-8'));
+      expect(res).toEqual(response);
+    });
+
+    it.each([
+      {
+        url: '',
+        config: createConfig(''),
+        error:
+          "Invalid type in config for key 'integrations.gitlab[0].token' in 'test-config', got empty-string, wanted string",
+      },
+    ])('should handle error path %#', async ({ url, config, error }) => {
+      await expect(async () => {
+        const [{ reader }] = GitlabUrlReader.factory({
+          config,
+          logger,
+          treeResponseFactory,
+        });
+        await reader.read(url);
+      }).rejects.toThrow(error);
+    });
+  });
+
+  describe('readTree', () => {
+    const repoBuffer = fs.readFileSync(
+      path.resolve('src', 'reading', '__fixtures__', 'repo.zip'),
+    );
+
+    beforeEach(() => {
+      worker.use(
+        rest.get(
+          'https://gitlab.com/backstage/mock/-/archive/repo/mock-repo.zip',
+          (_, res, ctx) =>
+            res(
+              ctx.status(200),
+              ctx.set('Content-Type', 'application/zip'),
+              ctx.body(repoBuffer),
+            ),
+        ),
+      );
+    });
+
+    it('returns the wanted files from an archive', async () => {
+      const processor = new GitlabUrlReader(
+        { host: 'gitlab.com' },
+        { treeResponseFactory },
+      );
+
+      const response = await processor.readTree(
+        'https://gitlab.com/backstage/mock/tree/repo',
+      );
+
+      const files = await response.files();
+      expect(files.length).toBe(2);
+
+      const indexMarkdownFile = await files[0].content();
+      const mkDocsFile = await files[1].content();
+
+      expect(mkDocsFile.toString()).toBe('site_name: Test\n');
+      expect(indexMarkdownFile.toString()).toBe('# Test\n');
+    });
+
+    it('returns the wanted files from hosted gitlab', async () => {
+      worker.use(
+        rest.get(
+          'https://git.mycompany.com/backstage/mock/-/archive/repo/mock-repo.zip',
+          (_, res, ctx) =>
+            res(
+              ctx.status(200),
+              ctx.set('Content-Type', 'application/zip'),
+              ctx.body(repoBuffer),
+            ),
+        ),
+      );
+
+      const processor = new GitlabUrlReader(
+        { host: 'git.mycompany.com' },
+        { treeResponseFactory },
+      );
+
+      const response = await processor.readTree(
+        'https://git.mycompany.com/backstage/mock/tree/repo/docs',
+      );
+
+      const files = await response.files();
+
+      expect(files.length).toBe(1);
+      const indexMarkdownFile = await files[0].content();
+
+      expect(indexMarkdownFile.toString()).toBe('# Test\n');
+    });
+
+    it('throws an error when branch is not specified', async () => {
+      const processor = new GitlabUrlReader(
+        { host: 'gitlab.com' },
+        { treeResponseFactory },
+      );
+
+      await expect(
+        processor.readTree('https://gitlab.com/backstage/mock'),
+      ).rejects.toThrow(
+        'GitLab URL must contain a branch to be able to fetch its tree',
+      );
+    });
+
+    it('returns the wanted files from an archive with a subpath', async () => {
+      const processor = new GitlabUrlReader(
+        { host: 'gitlab.com' },
+        { treeResponseFactory },
+      );
+
+      const response = await processor.readTree(
+        'https://gitlab.com/backstage/mock/tree/repo/docs',
+      );
+
+      const files = await response.files();
+
+      expect(files.length).toBe(1);
+      const indexMarkdownFile = await files[0].content();
+
+      expect(indexMarkdownFile.toString()).toBe('# Test\n');
+    });
   });
 });

--- a/packages/integration/src/gitlab/config.test.ts
+++ b/packages/integration/src/gitlab/config.test.ts
@@ -41,7 +41,10 @@ describe('readGitLabIntegrationConfig', () => {
 
   it('inserts the defaults if missing', () => {
     const output = readGitLabIntegrationConfig(buildConfig({}));
-    expect(output).toEqual({ host: 'gitlab.com' });
+    expect(output).toEqual({
+      host: 'gitlab.com',
+      apiBaseUrl: 'gitlab.com/api/v4',
+    });
   });
 
   it('rejects funky configs', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
~- [ ] Screenshots attached (for UI changes)~

#### What
---

Based on #3547 this PR adds an implementation for `readTree` in `GitlabUrlReader`. As part of this change, I have also added a new field to `GitlabIntegrationConfig` for `apiUrl` -- the field was present in both Bitbucket and Github configurations, so I thought it would make sense as part of this change to add it in Gitlab too.

The changes are quite straightforward, other than providing the implementation in the reader and touching the config, I have added in tests (with the same scenarios found in GH/Bitbucket readers) and made some smaller changes in the class, such as adding the TreeResponseFactory as a private field.

#### How
---

* The implementation is similar to the one in the Github reader (and Bitbucket reader branch suggested in #3547). The main distinctions are around the url for the archive and the archive format. From what I have noticed, Gitlab download urls (regardless of whether it is hosted) follow the same pattern: `<protocol>://<host>/<org>/<repo>/-/archive/<branch-ref>/<repo>-<branch-ref>.<zip-fmt>`.

* When it comes to the format of the archive I have chosen to go with `.zip`. I'm not sure what the general consensus around this is; the Bitbucket example used zip and GH unpacks tarballs. I have added in a `TODO` to keep track of this -- I can remove it or make the change directly based on feedback received.

* The final difference is in the path, Gitlab archives are named as `repo-branch` and contain the project tree, contrastingly, Github archives are named after a branch and have another directory inside with the repo name and the branch. Thought I'd put this in so it makes more sense when looking at the tests and the path.

Let me know of any feedback in terms of implementation details and code style. :) 

I am also unsure if this should contain a `changeset` would appreciate any info related to it.

Signed-off-by: Matei David <madavid@expediagroup.com>