### PR TITLE
catalog-backend: add index to foreign key columns

### DIFF
--- a/.changeset/rotten-pandas-draw.md
+++ b/.changeset/rotten-pandas-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add index to foreign key columns. Postgres (and others) do not do this on the "source" side of a foreign key relation, which was what led to the slowness on large datasets. The full LDAP dataset ingestion now takes two minutes, which is not optimal yet but still a huge improvement over before when it basically never finished :)

--- a/plugins/catalog-backend/migrations/20201210185851_fk_index.js
+++ b/plugins/catalog-backend/migrations/20201210185851_fk_index.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
+  if (knex.client.config.client !== 'sqlite3') {
+    await knex.schema.alterTable('entities_relations', table => {
+      table.index('originating_entity_id', 'originating_entity_id_idx');
+    });
+    await knex.schema.alterTable('entities_search', table => {
+      table.index('entity_id', 'entity_id_idx');
+    });
+  }
+};
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
+  if (knex.client.config.client !== 'sqlite3') {
+    await knex.schema.alterTable('entities_relations', table => {
+      table.dropIndex([], 'originating_entity_id_idx');
+    });
+    await knex.schema.alterTable('entities_relations', table => {
+      table.dropIndex([], 'entity_id_idx');
+    });
+  }
+};


### PR DESCRIPTION
See the changeset for details. This was an oversight on my part and explains why the database got slower as it grew.