### PR TITLE
feat(catalog-import): Add instructions to Pull Request description when registering a new component

### DIFF
--- a/.changeset/loud-icons-itch.md
+++ b/.changeset/loud-icons-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Add description to Pull Request when registering a new component

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -15,7 +15,7 @@
  */
 
 import { Octokit } from '@octokit/rest';
-import { DiscoveryApi, OAuthApi } from '@backstage/core';
+import { DiscoveryApi, OAuthApi, ConfigApi } from '@backstage/core';
 import { CatalogImportApi } from './CatalogImportApi';
 import { AnalyzeLocationResponse } from '@backstage/plugin-catalog-backend';
 import { PartialEntity } from '../util/types';
@@ -24,13 +24,16 @@ import { GitHubIntegrationConfig } from '@backstage/integration';
 export class CatalogImportClient implements CatalogImportApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly githubAuthApi: OAuthApi;
+  private readonly configApi: ConfigApi;
 
   constructor(options: {
     discoveryApi: DiscoveryApi;
     githubAuthApi: OAuthApi;
+    configApi: ConfigApi;
   }) {
     this.discoveryApi = options.discoveryApi;
     this.githubAuthApi = options.githubAuthApi;
+    this.configApi = options.configApi;
   }
 
   async generateEntityDefinitions({
@@ -164,12 +167,22 @@ export class CatalogImportClient implements CatalogImportApi {
         );
       });
 
+    const appTitle = this.configApi.getString('app.title');
+    const appBaseUrl = this.configApi.getString('app.baseUrl');
+
+    const prBody = `This pull request adds a **Backstage entity metadata file** \
+to this repository so that the component can be added to the \
+${appTitle} software catalog.\n\nAfter you merge this pull request, \
+you can [return to Backstage](${appBaseUrl}/catalog-import) \
+to register the component with the direct URL to the ${fileName} file.`;
+
     const pullRequestResponse = await octo.pulls
       .create({
         owner,
         repo,
         title: `Add ${fileName} config file`,
         head: branchName,
+        body: prBody,
         base: repoData.data.default_branch,
       })
       .catch(e => {

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -173,9 +173,9 @@ export class CatalogImportClient implements CatalogImportApi {
 
     const prBody = `This pull request adds a **Backstage entity metadata file** \
 to this repository so that the component can be added to the \
-${appTitle} software catalog.\n\nAfter you merge this pull request, \
-you can [return to Backstage](${appBaseUrl}/catalog-import) \
-to register the component with the direct URL to the \`${fileName}\` file.`;
+[${appTitle} software catalog](${appBaseUrl}).\n\nAfter this pull request is merged, \
+the component will become available.\n\nFor more information, read an \
+[overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).`;
 
     const pullRequestResponse = await octo.pulls
       .create({

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -167,7 +167,8 @@ export class CatalogImportClient implements CatalogImportApi {
         );
       });
 
-    const appTitle = this.configApi.getString('app.title');
+    const appTitle =
+      this.configApi.getOptionalString('app.title') ?? 'Backstage';
     const appBaseUrl = this.configApi.getString('app.baseUrl');
 
     const prBody = `This pull request adds a **Backstage entity metadata file** \

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -174,7 +174,7 @@ export class CatalogImportClient implements CatalogImportApi {
 to this repository so that the component can be added to the \
 ${appTitle} software catalog.\n\nAfter you merge this pull request, \
 you can [return to Backstage](${appBaseUrl}/catalog-import) \
-to register the component with the direct URL to the ${fileName} file.`;
+to register the component with the direct URL to the \`${fileName}\` file.`;
 
     const pullRequestResponse = await octo.pulls
       .create({

--- a/plugins/catalog-import/src/plugin.ts
+++ b/plugins/catalog-import/src/plugin.ts
@@ -20,6 +20,7 @@ import {
   createRouteRef,
   discoveryApiRef,
   githubAuthApiRef,
+  configApiRef,
 } from '@backstage/core';
 import { catalogImportApiRef } from './api/CatalogImportApi';
 import { CatalogImportClient } from './api/CatalogImportClient';
@@ -34,9 +35,13 @@ export const plugin = createPlugin({
   apis: [
     createApiFactory({
       api: catalogImportApiRef,
-      deps: { discoveryApi: discoveryApiRef, githubAuthApi: githubAuthApiRef },
-      factory: ({ discoveryApi, githubAuthApi }) =>
-        new CatalogImportClient({ discoveryApi, githubAuthApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        githubAuthApi: githubAuthApiRef,
+        configApi: configApiRef,
+      },
+      factory: ({ discoveryApi, githubAuthApi, configApi }) =>
+        new CatalogImportClient({ discoveryApi, githubAuthApi, configApi }),
     }),
   ],
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Enhances the pull request description to guide the recipient for when a new pull request is added to GitHub.

![image](https://user-images.githubusercontent.com/33203301/101824277-fc5aaa00-3af9-11eb-84b4-82726ccded7f.png)

NB: I added the name of their backstage instance and a link to get straight to the Backstage Base URL. When using GitHub.com, I suppose there could be a scenario where users might not want to expose the name of their catalog even if their components are open source, but I'd consider that an edge case because if their code is truly open source, the info about them having a named catalog or it's URL may be as well? I believe having that info would make it a lot easier to proceed with the next step. Open to opinions on it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
