### PR TITLE
fix(cost-insights): Disable animation for product breakdown chart

### DIFF
--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewByProductChart.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewByProductChart.tsx
@@ -130,6 +130,7 @@ export const CostOverviewByProductChart = ({
     return ['Other', ...sortedProducts].map((product, i) => (
       <Area
         dataKey={product}
+        isAnimationActive={false}
         stackId="1"
         stroke={theme.palette.dataViz[sortedProducts.length - i]}
         fill={theme.palette.dataViz[sortedProducts.length - i]}


### PR DESCRIPTION
Disable animation when switching to the product breakdown chart. Most noticeable when switching back and forth.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
