### PR TITLE
docs: Add a table of visibility values in our JSON Schema

### DIFF
--- a/docs/conf/defining.md
+++ b/docs/conf/defining.md
@@ -83,6 +83,12 @@ object will be available in the frontend. The full ancestry does not need to
 have correctly defined visibilities however, so it is enough to only for example
 declare the visibility of a leaf node of `type: "string"`.
 
+| `visibility` |                                                                    |
+| ------------ | ------------------------------------------------------------------ |
+| `frontend`   | Visible in frontend and backend                                    |
+| `backend`    | (Default) Only in backend                                          |
+| `secret`     | Only in backend and may be excluded from logs for security reasons |
+
 ## Validation
 
 Schemas can be validated using the `backstage-cli config:check` command. If you


### PR DESCRIPTION

I found it inexplicit that setting visibility to `frontend` makes the config available in both frontend and backend.

Added a little table 

![Screenshot 2020-12-11 at 10 49 21](https://user-images.githubusercontent.com/8065913/101888626-a855d100-3b9e-11eb-9b47-19391607acdd.png)

Discussion https://discord.com/channels/687207715902193673/687235481154617364/784555643960688660
