### PR TITLE
Added 'owner' propoerty to the LocationAnalyzer

### DIFF
--- a/.changeset/blue-turtles-collect.md
+++ b/.changeset/blue-turtles-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added 'owner' propoerty to the config generated in LocationAnalyzer

--- a/.changeset/blue-turtles-collect.md
+++ b/.changeset/blue-turtles-collect.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Added 'owner' propoerty to the config generated in LocationAnalyzer
+Added 'owner' property to the config generated in LocationAnalyzer

--- a/plugins/catalog-backend/src/ingestion/LocationAnalyzer.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationAnalyzer.ts
@@ -40,7 +40,7 @@ export class RepoLocationAnalyzer implements LocationAnalyzer {
         // Probably won't handle properly self-hosted git providers with custom url
         annotations: { [`${source}/project-slug`]: `${owner}/${name}` },
       },
-      spec: { type: 'other', lifecycle: 'unknown' },
+      spec: { type: 'other', lifecycle: 'unknown', owner: 'guest' },
     };
 
     this.logger.debug(`entity created for ${request.location.target}`);


### PR DESCRIPTION
## Added 'owner' propoerty to the config generated in LocationAnalyzer

Due to recent change, 'owner' property is now a required field for the component config files. To maintain correctness of the files, I'm adding a placeholder "guest" property for the generated config files.

This should solve https://github.com/backstage/backstage/issues/3678

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
