### PR TITLE
Independently release cost insights 

### DIFF
--- a/.changeset/cost-insights-pink-boats-exercise.md
+++ b/.changeset/cost-insights-pink-boats-exercise.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-cost-insights': patch
----
-
-fix breakdown sorting

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -42,6 +42,7 @@ const
 cookiecutter
 css
 dariddler
+dataflow
 deadnaming
 destructured
 dev

--- a/plugins/cost-insights/CHANGELOG.md
+++ b/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage/plugin-cost-insights
 
+## 0.5.1
+
+### Patch Changes
+
+- 64c9fd84c: fix breakdown sorting
+- Fix bar chart legend label bug for unlabeled dataflow alerts
+
 ## 0.5.0
 
 ### Minor Changes

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-cost-insights",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/cost-insights/src/components/UnlabeledDataflowAlertCard/UnlabeledDataflowAlertCard.tsx
+++ b/plugins/cost-insights/src/components/UnlabeledDataflowAlertCard/UnlabeledDataflowAlertCard.tsx
@@ -49,8 +49,8 @@ export const UnlabeledDataflowAlertCard = ({
     <InfoCard title="Label Dataflow" subheader={subheader}>
       <Box className={classes.wrapper}>
         <BarChartLegend
-          costStart={alert.labeledCost}
-          costEnd={alert.unlabeledCost}
+          costStart={alert.unlabeledCost}
+          costEnd={alert.labeledCost}
           options={options}
         />
         <BarChart resources={resources} options={options} />


### PR DESCRIPTION
## Hey, I just made a Pull Request!
- Bump the Cost Insights plugin to `0.5.1` independently. Includes two small bug fixes, for breakdown sorting as well as for the bar chart legend for unlabeled dataflow alerts

### Releases

## @backstage/cost-insights@0.5.1

### Patch Changes

- 64c9fd84c: fix breakdown sorting
- Fix bar chart legend label bug for unlabeled dataflow alerts


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
