### PR TITLE
Fix Link Icon Visibility on Hover

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -48,6 +48,13 @@ h6 {
   color: $textColor;
 }
 
+h2:hover .hash-link{
+  opacity: 1
+}
+
+.hash-link {
+  fill:white;
+}
 /* body elements  */
 p,
 ul,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added some CSS in main.css, to fix the color of the anchor on hover effect of each H2.
`h2:hover .hash-link{
  opacity: 1
}

.hash-link {
  fill:white;
}`

#### :heavy_check_mark: Checklist

![scst1](https://user-images.githubusercontent.com/20237313/102113994-06521500-3e3a-11eb-900b-753cac26d4f0.png)
![scst2](https://user-images.githubusercontent.com/20237313/102113999-06eaab80-3e3a-11eb-98cd-10e44545cfcc.png)
