### PR TITLE
chore(auth): customizable github auth storage key

### DIFF
--- a/.changeset/sour-badgers-cry.md
+++ b/.changeset/sour-badgers-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-api': patch
+---
+
+Add argument for storage key to GitHub Auth Api for customizing it's value.

--- a/.changeset/sour-badgers-cry.md
+++ b/.changeset/sour-badgers-cry.md
@@ -2,4 +2,4 @@
 '@backstage/core-api': patch
 ---
 
-Add argument for storage key to GitHub Auth Api for customizing it's value.
+GitHub Auth Api uses provider.id to build storage key name.

--- a/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
@@ -50,13 +50,16 @@ const DEFAULT_PROVIDER = {
 };
 
 class GithubAuth implements OAuthApi, SessionApi {
-  static create({
-    discoveryApi,
-    environment = 'development',
-    provider = DEFAULT_PROVIDER,
-    oauthRequestApi,
-    defaultScopes = ['read:user'],
-  }: OAuthApiCreateOptions) {
+  static create(
+    {
+      discoveryApi,
+      environment = 'development',
+      provider = DEFAULT_PROVIDER,
+      oauthRequestApi,
+      defaultScopes = ['read:user'],
+    }: OAuthApiCreateOptions,
+    storageKey = 'githubSession',
+  ) {
     const connector = new DefaultAuthConnector({
       discoveryApi,
       environment,
@@ -84,7 +87,7 @@ class GithubAuth implements OAuthApi, SessionApi {
 
     const authSessionStore = new AuthSessionStore<GithubSession>({
       manager: sessionManager,
-      storageKey: 'githubSession',
+      storageKey: storageKey,
       sessionScopes: (session: GithubSession) => session.providerInfo.scopes,
     });
 

--- a/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/github/GithubAuth.ts
@@ -50,16 +50,13 @@ const DEFAULT_PROVIDER = {
 };
 
 class GithubAuth implements OAuthApi, SessionApi {
-  static create(
-    {
-      discoveryApi,
-      environment = 'development',
-      provider = DEFAULT_PROVIDER,
-      oauthRequestApi,
-      defaultScopes = ['read:user'],
-    }: OAuthApiCreateOptions,
-    storageKey = 'githubSession',
-  ) {
+  static create({
+    discoveryApi,
+    environment = 'development',
+    provider = DEFAULT_PROVIDER,
+    oauthRequestApi,
+    defaultScopes = ['read:user'],
+  }: OAuthApiCreateOptions) {
     const connector = new DefaultAuthConnector({
       discoveryApi,
       environment,
@@ -87,7 +84,7 @@ class GithubAuth implements OAuthApi, SessionApi {
 
     const authSessionStore = new AuthSessionStore<GithubSession>({
       manager: sessionManager,
-      storageKey: storageKey,
+      storageKey: `${provider.id}Session`,
       sessionScopes: (session: GithubSession) => session.providerInfo.scopes,
     });
 


### PR DESCRIPTION
We have a really strange setup... We support two GitHub enterprises instances. to make this easier we had to modify the core-api. This is a backwards compatible change that makes it possible for use to set up multiple GitHub auth Providers. We really don't want to have a copy of core-api in our codebase...

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
