### PR TITLE
Fix entity model and validation

### DIFF
--- a/.changeset/tender-nails-decide.md
+++ b/.changeset/tender-nails-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Fix entity model and validation

--- a/packages/catalog-model/src/kinds/ApiEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ApiEntityV1alpha1.ts
@@ -28,7 +28,7 @@ const schema = yup.object<Partial<ApiEntityV1alpha1>>({
     .object({
       type: yup.string().required().min(1),
       lifecycle: yup.string().required().min(1),
-      owner: yup.string().required().min(1),
+      owner: yup.string().notRequired().min(1),
       definition: yup.string().required().min(1),
     })
     .required(),
@@ -40,7 +40,7 @@ export interface ApiEntityV1alpha1 extends Entity {
   spec: {
     type: string;
     lifecycle: string;
-    owner: string;
+    owner?: string;
     definition: string;
   };
 }

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
@@ -28,7 +28,7 @@ const schema = yup.object<Partial<ComponentEntityV1alpha1>>({
     .object({
       type: yup.string().required().min(1),
       lifecycle: yup.string().required().min(1),
-      owner: yup.string().required().min(1),
+      owner: yup.string().notRequired().min(1),
       implementsApis: yup.array(yup.string().required()).notRequired(),
       providesApis: yup.array(yup.string().required()).notRequired(),
       consumesApis: yup.array(yup.string().required()).notRequired(),
@@ -42,7 +42,7 @@ export interface ComponentEntityV1alpha1 extends Entity {
   spec: {
     type: string;
     lifecycle: string;
-    owner: string;
+    owner?: string;
     /**
      * @deprecated This field will disappear on Dec 14th, 2020. Please remove
      *             any consuming code. The new field providesApis provides the


### PR DESCRIPTION
## Fix entity model and validation

Interface `ApiEntityV1alpha1` was containing wrong type definition, which was causing bug  #3678.

Since owner property should be optional (to allow reading it from rhe CODEOWNERS file), i'm changing the model and validation accordingly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
