### PR TITLE
plugins,packages: replace usages of ConfigReader.fromConfigs

### DIFF
--- a/packages/backend-common/src/database/SingleConnection.test.ts
+++ b/packages/backend-common/src/database/SingleConnection.test.ts
@@ -21,14 +21,6 @@ import { SingleConnectionDatabaseManager } from './SingleConnection';
 jest.mock('./connection');
 
 describe('SingleConnectionDatabaseManager', () => {
-  const createConfig = (data: any) =>
-    ConfigReader.fromConfigs([
-      {
-        context: '',
-        data,
-      },
-    ]);
-
   const defaultConfigOptions = {
     backend: {
       database: {
@@ -42,7 +34,7 @@ describe('SingleConnectionDatabaseManager', () => {
       },
     },
   };
-  const defaultConfig = () => createConfig(defaultConfigOptions);
+  const defaultConfig = () => new ConfigReader(defaultConfigOptions);
 
   // This is similar to the ts-jest `mocked` helper.
   const mocked = (f: Function) => f as jest.Mock;

--- a/packages/backend-common/src/database/connection.test.ts
+++ b/packages/backend-common/src/database/connection.test.ts
@@ -18,19 +18,11 @@ import { ConfigReader } from '@backstage/config';
 import { createDatabaseClient } from './connection';
 
 describe('database connection', () => {
-  const createConfig = (data: any) =>
-    ConfigReader.fromConfigs([
-      {
-        context: '',
-        data,
-      },
-    ]);
-
   describe('createDatabaseClient', () => {
     it('returns a postgres connection', () => {
       expect(
         createDatabaseClient(
-          createConfig({
+          new ConfigReader({
             client: 'pg',
             connection: {
               host: 'acme',
@@ -46,7 +38,7 @@ describe('database connection', () => {
     it('returns an sqlite connection', () => {
       expect(
         createDatabaseClient(
-          createConfig({
+          new ConfigReader({
             client: 'sqlite3',
             connection: ':memory:',
           }),
@@ -57,7 +49,7 @@ describe('database connection', () => {
     it('tries to create a mysql connection as a passthrough', () => {
       expect(() =>
         createDatabaseClient(
-          createConfig({
+          new ConfigReader({
             client: 'mysql',
             connection: {
               host: '127.0.0.1',
@@ -73,7 +65,7 @@ describe('database connection', () => {
     it('accepts overrides', () => {
       expect(
         createDatabaseClient(
-          createConfig({
+          new ConfigReader({
             client: 'pg',
             connection: {
               host: 'acme',
@@ -94,7 +86,7 @@ describe('database connection', () => {
     it('throws an error without a client', () => {
       expect(() =>
         createDatabaseClient(
-          createConfig({
+          new ConfigReader({
             connection: '',
           }),
         ),
@@ -104,7 +96,7 @@ describe('database connection', () => {
     it('throws an error without a connection', () => {
       expect(() =>
         createDatabaseClient(
-          createConfig({
+          new ConfigReader({
             client: 'pg',
           }),
         ),

--- a/packages/backend-common/src/database/postgres.test.ts
+++ b/packages/backend-common/src/database/postgres.test.ts
@@ -34,15 +34,7 @@ describe('postgres', () => {
     'postgresql://foo:bar@acme:5432/foodb';
 
   const createConfig = (connection: any): Config =>
-    ConfigReader.fromConfigs([
-      {
-        context: '',
-        data: {
-          client: 'pg',
-          connection,
-        },
-      },
-    ]);
+    new ConfigReader({ client: 'pg', connection });
 
   describe('buildPgDatabaseConfig', () => {
     it('builds a postgres config', () => {

--- a/packages/backend-common/src/database/sqlite3.test.ts
+++ b/packages/backend-common/src/database/sqlite3.test.ts
@@ -22,15 +22,7 @@ import {
 
 describe('sqlite3', () => {
   const createConfig = (connection: any) =>
-    ConfigReader.fromConfigs([
-      {
-        context: '',
-        data: {
-          client: 'sqlite3',
-          connection,
-        },
-      },
-    ]);
+    new ConfigReader({ client: 'sqlite3', connection });
 
   describe('buildSqliteDatabaseConfig', () => {
     it('buidls a string connection', () => {

--- a/packages/backend-common/src/service/lib/config.test.ts
+++ b/packages/backend-common/src/service/lib/config.test.ts
@@ -20,9 +20,7 @@ import { readCspOptions } from './config';
 describe('config', () => {
   describe('readCspOptions', () => {
     it('reads valid values', () => {
-      const config = ConfigReader.fromConfigs([
-        { context: '', data: { csp: { key: ['value'] } } },
-      ]);
+      const config = new ConfigReader({ csp: { key: ['value'] } });
       expect(readCspOptions(config)).toEqual(
         expect.objectContaining({
           key: ['value'],
@@ -31,9 +29,7 @@ describe('config', () => {
     });
 
     it('accepts false', () => {
-      const config = ConfigReader.fromConfigs([
-        { context: '', data: { csp: { key: false } } },
-      ]);
+      const config = new ConfigReader({ csp: { key: false } });
       expect(readCspOptions(config)).toEqual(
         expect.objectContaining({
           key: false,
@@ -42,9 +38,7 @@ describe('config', () => {
     });
 
     it('rejects invalid value types', () => {
-      const config = ConfigReader.fromConfigs([
-        { context: '', data: { csp: { key: [4] } } },
-      ]);
+      const config = new ConfigReader({ csp: { key: [4] } });
       expect(() => readCspOptions(config)).toThrow(/wanted string-array/);
     });
   });

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -69,7 +69,7 @@ export class ConfigReader implements Config {
 
   constructor(
     private readonly data: JsonObject | undefined,
-    private readonly context: string = 'empty-config',
+    private readonly context: string = 'mock-config',
     private readonly fallback?: ConfigReader,
     private readonly prefix: string = '',
   ) {}

--- a/packages/integration/src/azure/AzureIntegration.test.ts
+++ b/packages/integration/src/azure/AzureIntegration.test.ts
@@ -20,21 +20,16 @@ import { AzureIntegration } from './AzureIntegration';
 describe('AzureIntegration', () => {
   it('has a working factory', () => {
     const integrations = AzureIntegration.factory({
-      config: ConfigReader.fromConfigs([
-        {
-          context: '',
-          data: {
-            integrations: {
-              azure: [
-                {
-                  host: 'h.com',
-                  token: 'token',
-                },
-              ],
+      config: new ConfigReader({
+        integrations: {
+          azure: [
+            {
+              host: 'h.com',
+              token: 'token',
             },
-          },
+          ],
         },
-      ]),
+      }),
     });
     expect(integrations.length).toBe(2); // including default
     expect(integrations[0].predicate(new URL('https://h.com/a'))).toBe(true);

--- a/packages/integration/src/azure/config.test.ts
+++ b/packages/integration/src/azure/config.test.ts
@@ -23,7 +23,7 @@ import {
 
 describe('readAzureIntegrationConfig', () => {
   function buildConfig(data: Partial<AzureIntegrationConfig>): Config {
-    return ConfigReader.fromConfigs([{ context: '', data }]);
+    return new ConfigReader(data);
   }
 
   it('reads all values', () => {
@@ -60,9 +60,7 @@ describe('readAzureIntegrationConfig', () => {
 
 describe('readAzureIntegrationConfigs', () => {
   function buildConfig(data: Partial<AzureIntegrationConfig>[]): Config[] {
-    return data.map(item =>
-      ConfigReader.fromConfigs([{ context: '', data: item }]),
-    );
+    return data.map(item => new ConfigReader(item));
   }
 
   it('reads all values', () => {

--- a/packages/integration/src/bitbucket/BitbucketIntegration.test.ts
+++ b/packages/integration/src/bitbucket/BitbucketIntegration.test.ts
@@ -20,24 +20,19 @@ import { BitbucketIntegration } from './BitbucketIntegration';
 describe('BitbucketIntegration', () => {
   it('has a working factory', () => {
     const integrations = BitbucketIntegration.factory({
-      config: ConfigReader.fromConfigs([
-        {
-          context: '',
-          data: {
-            integrations: {
-              bitbucket: [
-                {
-                  host: 'h.com',
-                  apiBaseUrl: 'a',
-                  token: 't',
-                  username: 'u',
-                  appPassword: 'p',
-                },
-              ],
+      config: new ConfigReader({
+        integrations: {
+          bitbucket: [
+            {
+              host: 'h.com',
+              apiBaseUrl: 'a',
+              token: 't',
+              username: 'u',
+              appPassword: 'p',
             },
-          },
+          ],
         },
-      ]),
+      }),
     });
     expect(integrations.length).toBe(2); // including default
     expect(integrations[0].predicate(new URL('https://h.com/a'))).toBe(true);

--- a/packages/integration/src/bitbucket/config.test.ts
+++ b/packages/integration/src/bitbucket/config.test.ts
@@ -23,7 +23,7 @@ import {
 
 describe('readBitbucketIntegrationConfig', () => {
   function buildConfig(data: Partial<BitbucketIntegrationConfig>): Config {
-    return ConfigReader.fromConfigs([{ context: '', data }]);
+    return new ConfigReader(data);
   }
 
   it('reads all values', () => {
@@ -83,9 +83,7 @@ describe('readBitbucketIntegrationConfig', () => {
 
 describe('readBitbucketIntegrationConfigs', () => {
   function buildConfig(data: Partial<BitbucketIntegrationConfig>[]): Config[] {
-    return data.map(item =>
-      ConfigReader.fromConfigs([{ context: '', data: item }]),
-    );
+    return data.map(item => new ConfigReader(item));
   }
 
   it('reads all values', () => {

--- a/packages/integration/src/github/GitHubIntegration.test.ts
+++ b/packages/integration/src/github/GitHubIntegration.test.ts
@@ -20,23 +20,18 @@ import { GitHubIntegration } from './GitHubIntegration';
 describe('GitHubIntegration', () => {
   it('has a working factory', () => {
     const integrations = GitHubIntegration.factory({
-      config: ConfigReader.fromConfigs([
-        {
-          context: '',
-          data: {
-            integrations: {
-              github: [
-                {
-                  host: 'h.com',
-                  apiBaseUrl: 'a',
-                  rawBaseUrl: 'r',
-                  token: 't',
-                },
-              ],
+      config: new ConfigReader({
+        integrations: {
+          github: [
+            {
+              host: 'h.com',
+              apiBaseUrl: 'a',
+              rawBaseUrl: 'r',
+              token: 't',
             },
-          },
+          ],
         },
-      ]),
+      }),
     });
     expect(integrations.length).toBe(2); // including default
     expect(integrations[0].predicate(new URL('https://h.com/a'))).toBe(true);

--- a/packages/integration/src/github/config.test.ts
+++ b/packages/integration/src/github/config.test.ts
@@ -23,7 +23,7 @@ import {
 
 describe('readGitHubIntegrationConfig', () => {
   function buildConfig(provider: Partial<GitHubIntegrationConfig>) {
-    return ConfigReader.fromConfigs([{ context: '', data: provider }]);
+    return new ConfigReader(provider);
   }
 
   it('reads all values', () => {
@@ -80,9 +80,7 @@ describe('readGitHubIntegrationConfigs', () => {
   function buildConfig(
     providers: Partial<GitHubIntegrationConfig>[],
   ): Config[] {
-    return providers.map(provider =>
-      ConfigReader.fromConfigs([{ context: '', data: provider }]),
-    );
+    return providers.map(provider => new ConfigReader(provider));
   }
 
   it('reads all values', () => {

--- a/packages/integration/src/gitlab/GitLabIntegration.test.ts
+++ b/packages/integration/src/gitlab/GitLabIntegration.test.ts
@@ -20,21 +20,16 @@ import { GitLabIntegration } from './GitLabIntegration';
 describe('GitLabIntegration', () => {
   it('has a working factory', () => {
     const integrations = GitLabIntegration.factory({
-      config: ConfigReader.fromConfigs([
-        {
-          context: '',
-          data: {
-            integrations: {
-              gitlab: [
-                {
-                  host: 'h.com',
-                  token: 't',
-                },
-              ],
+      config: new ConfigReader({
+        integrations: {
+          gitlab: [
+            {
+              host: 'h.com',
+              token: 't',
             },
-          },
+          ],
         },
-      ]),
+      }),
     });
     expect(integrations.length).toBe(2); // including default
     expect(integrations[0].predicate(new URL('https://h.com/a'))).toBe(true);

--- a/packages/integration/src/gitlab/config.test.ts
+++ b/packages/integration/src/gitlab/config.test.ts
@@ -23,7 +23,7 @@ import {
 
 describe('readGitLabIntegrationConfig', () => {
   function buildConfig(data: Partial<GitLabIntegrationConfig>): Config {
-    return ConfigReader.fromConfigs([{ context: '', data }]);
+    return new ConfigReader(data);
   }
 
   it('reads all values', () => {
@@ -60,9 +60,7 @@ describe('readGitLabIntegrationConfig', () => {
 
 describe('readGitLabIntegrationConfigs', () => {
   function buildConfig(data: Partial<GitLabIntegrationConfig>[]): Config[] {
-    return data.map(item =>
-      ConfigReader.fromConfigs([{ context: '', data: item }]),
-    );
+    return data.map(item => new ConfigReader(item));
   }
 
   it('reads all values', () => {

--- a/packages/storybook/.storybook/apis.js
+++ b/packages/storybook/.storybook/apis.js
@@ -26,7 +26,7 @@ import {
 
 const builder = ApiRegistry.builder();
 
-builder.add(configApiRef, ConfigReader.fromConfigs([]));
+builder.add(configApiRef, new ConfigReader({}));
 
 const alertApi = builder.add(alertApiRef, new AlertApiForwarder());
 

--- a/packages/techdocs-common/src/stages/generate/generators.test.ts
+++ b/packages/techdocs-common/src/stages/generate/generators.test.ts
@@ -39,10 +39,7 @@ describe('generators', () => {
 
   it('should return correct registered generator', async () => {
     const generators = new Generators();
-    const techdocs = new TechdocsGenerator(
-      logger,
-      ConfigReader.fromConfigs([]),
-    );
+    const techdocs = new TechdocsGenerator(logger, new ConfigReader({}));
 
     generators.register('techdocs', techdocs);
 

--- a/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
@@ -38,24 +38,19 @@ jest.spyOn(logger, 'info').mockReturnValue(logger);
 let publisher: PublisherBase;
 
 beforeEach(() => {
-  const mockConfig = ConfigReader.fromConfigs([
-    {
-      context: '',
-      data: {
-        techdocs: {
-          requestUrl: 'http://localhost:7000',
-          publisher: {
-            type: 'googleGcs',
-            googleGcs: {
-              credentials: '{}',
-              projectId: 'gcp-project-id',
-              bucketName: 'bucketName',
-            },
-          },
+  const mockConfig = new ConfigReader({
+    techdocs: {
+      requestUrl: 'http://localhost:7000',
+      publisher: {
+        type: 'googleGcs',
+        googleGcs: {
+          credentials: '{}',
+          projectId: 'gcp-project-id',
+          bucketName: 'bucketName',
         },
       },
     },
-  ]);
+  });
 
   publisher = GoogleGCSPublish.fromConfig(mockConfig, logger);
 });

--- a/packages/techdocs-common/src/stages/publish/local.test.ts
+++ b/packages/techdocs-common/src/stages/publish/local.test.ts
@@ -63,17 +63,12 @@ describe('local publisher', () => {
       getExternalBaseUrl: jest.fn(),
     };
 
-    const mockConfig = ConfigReader.fromConfigs([
-      {
-        context: '',
-        data: {
-          techdocs: {
-            requestUrl: 'http://localhost:7000',
-            storageUrl: 'http://localhost:7000/static/docs',
-          },
-        },
+    const mockConfig = new ConfigReader({
+      techdocs: {
+        requestUrl: 'http://localhost:7000',
+        storageUrl: 'http://localhost:7000/static/docs',
       },
-    ]);
+    });
 
     const publisher = new LocalPublish(mockConfig, logger, testDiscovery);
     const mockEntity = createMockEntity();

--- a/packages/techdocs-common/src/stages/publish/publish.test.ts
+++ b/packages/techdocs-common/src/stages/publish/publish.test.ts
@@ -30,59 +30,44 @@ const testDiscovery: jest.Mocked<PluginEndpointDiscovery> = {
 
 describe('Publisher', () => {
   it('should create local publisher by default', () => {
-    const mockConfig = ConfigReader.fromConfigs([
-      {
-        context: '',
-        data: {
-          techdocs: {
-            requestUrl: 'http://localhost:7000',
-          },
-        },
+    const mockConfig = new ConfigReader({
+      techdocs: {
+        requestUrl: 'http://localhost:7000',
       },
-    ]);
+    });
 
     const publisher = Publisher.fromConfig(mockConfig, logger, testDiscovery);
     expect(publisher).toBeInstanceOf(LocalPublish);
   });
 
   it('should create local publisher from config', () => {
-    const mockConfig = ConfigReader.fromConfigs([
-      {
-        context: '',
-        data: {
-          techdocs: {
-            requestUrl: 'http://localhost:7000',
-            publisher: {
-              type: 'local',
-            },
-          },
+    const mockConfig = new ConfigReader({
+      techdocs: {
+        requestUrl: 'http://localhost:7000',
+        publisher: {
+          type: 'local',
         },
       },
-    ]);
+    });
 
     const publisher = Publisher.fromConfig(mockConfig, logger, testDiscovery);
     expect(publisher).toBeInstanceOf(LocalPublish);
   });
 
   it('should create google gcs publisher from config', () => {
-    const mockConfig = ConfigReader.fromConfigs([
-      {
-        context: '',
-        data: {
-          techdocs: {
-            requestUrl: 'http://localhost:7000',
-            publisher: {
-              type: 'googleGcs',
-              googleGcs: {
-                credentials: '{}',
-                projectId: 'gcp-project-id',
-                bucketName: 'bucketName',
-              },
-            },
+    const mockConfig = new ConfigReader({
+      techdocs: {
+        requestUrl: 'http://localhost:7000',
+        publisher: {
+          type: 'googleGcs',
+          googleGcs: {
+            credentials: '{}',
+            projectId: 'gcp-project-id',
+            bucketName: 'bucketName',
           },
         },
       },
-    ]);
+    });
 
     const publisher = Publisher.fromConfig(mockConfig, logger, testDiscovery);
     expect(publisher).toBeInstanceOf(GoogleGCSPublish);

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
@@ -28,14 +28,9 @@ describe('GithubOrgReaderProcessor', () => {
     function config(
       providers: { target: string; apiBaseUrl?: string; token?: string }[],
     ) {
-      return ConfigReader.fromConfigs([
-        {
-          context: '',
-          data: {
-            catalog: { processors: { githubOrg: { providers } } },
-          },
-        },
-      ]);
+      return new ConfigReader({
+        catalog: { processors: { githubOrg: { providers } } },
+      });
     }
 
     it('adds a default GitHub entry when missing', () => {

--- a/plugins/catalog-backend/src/ingestion/processors/ldap/config.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/ldap/config.test.ts
@@ -32,9 +32,7 @@ describe('readLdapConfig', () => {
         },
       ],
     };
-    const actual = readLdapConfig(
-      ConfigReader.fromConfigs([{ context: '', data: config }]),
-    );
+    const actual = readLdapConfig(new ConfigReader(config));
     const expected = [
       {
         target: 'target',
@@ -125,9 +123,7 @@ describe('readLdapConfig', () => {
         },
       ],
     };
-    const actual = readLdapConfig(
-      ConfigReader.fromConfigs([{ context: '', data: config }]),
-    );
+    const actual = readLdapConfig(new ConfigReader(config));
     const expected = [
       {
         target: 'target',

--- a/plugins/catalog-backend/src/ingestion/processors/microsoftGraph/config.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/microsoftGraph/config.test.ts
@@ -29,9 +29,7 @@ describe('readMicrosoftGraphConfig', () => {
         },
       ],
     };
-    const actual = readMicrosoftGraphConfig(
-      ConfigReader.fromConfigs([{ context: '', data: config }]),
-    );
+    const actual = readMicrosoftGraphConfig(new ConfigReader(config));
     const expected = [
       {
         target: 'target',
@@ -60,9 +58,7 @@ describe('readMicrosoftGraphConfig', () => {
         },
       ],
     };
-    const actual = readMicrosoftGraphConfig(
-      ConfigReader.fromConfigs([{ context: '', data: config }]),
-    );
+    const actual = readMicrosoftGraphConfig(new ConfigReader(config));
     const expected = [
       {
         target: 'target',

--- a/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
@@ -47,7 +47,7 @@ describe('CatalogBuilder', () => {
   const env: CatalogEnvironment = {
     logger: getVoidLogger(),
     database: { getClient: async () => db },
-    config: ConfigReader.fromConfigs([]),
+    config: new ConfigReader({}),
     reader,
   };
 

--- a/plugins/catalog-graphql/src/graphql/module.test.ts
+++ b/plugins/catalog-graphql/src/graphql/module.test.ts
@@ -27,16 +27,11 @@ import { gql } from 'apollo-server';
 describe('Catalog Module', () => {
   const worker = setupServer();
   const mockCatalogBaseUrl = 'http://im.mock';
-  const mockConfig = ConfigReader.fromConfigs([
-    {
-      context: '',
-      data: {
-        backend: {
-          baseUrl: mockCatalogBaseUrl,
-        },
-      },
+  const mockConfig = new ConfigReader({
+    backend: {
+      baseUrl: mockCatalogBaseUrl,
     },
-  ]);
+  });
 
   msw.setupDefaultHandlers(worker);
 

--- a/plugins/graphql/src/service/router.test.ts
+++ b/plugins/graphql/src/service/router.test.ts
@@ -22,9 +22,7 @@ import express from 'express';
 describe('Router', () => {
   describe('/health', () => {
     it('should return ok', async () => {
-      const config = ConfigReader.fromConfigs([
-        { data: { backend: { baseUrl: 'lol' } }, context: 'something' },
-      ]);
+      const config = new ConfigReader({ backend: { baseUrl: 'lol' } });
 
       const router = await createRouter({ config, logger: createLogger() });
       const app = express().use(router);

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
@@ -20,12 +20,9 @@ import { ConfigClusterLocator } from './ConfigClusterLocator';
 
 describe('ConfigClusterLocator', () => {
   it('empty clusters returns empty cluster details', async () => {
-    const config: Config = new ConfigReader(
-      {
-        clusters: [],
-      },
-      'ctx',
-    );
+    const config: Config = new ConfigReader({
+      clusters: [],
+    });
 
     const sut = ConfigClusterLocator.fromConfig(
       config.getConfigArray('clusters'),
@@ -37,18 +34,15 @@ describe('ConfigClusterLocator', () => {
   });
 
   it('one clusters returns one cluster details', async () => {
-    const config: Config = new ConfigReader(
-      {
-        clusters: [
-          {
-            name: 'cluster1',
-            url: 'http://localhost:8080',
-            authProvider: 'serviceAccount',
-          },
-        ],
-      },
-      'ctx',
-    );
+    const config: Config = new ConfigReader({
+      clusters: [
+        {
+          name: 'cluster1',
+          url: 'http://localhost:8080',
+          authProvider: 'serviceAccount',
+        },
+      ],
+    });
 
     const sut = ConfigClusterLocator.fromConfig(
       config.getConfigArray('clusters'),
@@ -67,24 +61,21 @@ describe('ConfigClusterLocator', () => {
   });
 
   it('two clusters returns two cluster details', async () => {
-    const config: Config = new ConfigReader(
-      {
-        clusters: [
-          {
-            name: 'cluster1',
-            serviceAccountToken: 'token',
-            url: 'http://localhost:8080',
-            authProvider: 'serviceAccount',
-          },
-          {
-            name: 'cluster2',
-            url: 'http://localhost:8081',
-            authProvider: 'google',
-          },
-        ],
-      },
-      'ctx',
-    );
+    const config: Config = new ConfigReader({
+      clusters: [
+        {
+          name: 'cluster1',
+          serviceAccountToken: 'token',
+          url: 'http://localhost:8080',
+          authProvider: 'serviceAccount',
+        },
+        {
+          name: 'cluster2',
+          url: 'http://localhost:8081',
+          authProvider: 'google',
+        },
+      ],
+    });
 
     const sut = ConfigClusterLocator.fromConfig(
       config.getConfigArray('clusters'),

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -60,7 +60,7 @@ describe('getCombinedClusterDetails', () => {
 
   it('throws an error when using an unsupported cluster locator', async () => {
     await expect(
-      getCombinedClusterDetails(['magic' as any], new ConfigReader({}, 'ctx')),
+      getCombinedClusterDetails(['magic' as any], new ConfigReader({})),
     ).rejects.toStrictEqual(
       new Error('Unsupported kubernetes.clusterLocatorMethods: "magic"'),
     );

--- a/plugins/kubernetes-backend/src/service/standaloneApplication.ts
+++ b/plugins/kubernetes-backend/src/service/standaloneApplication.ts
@@ -36,7 +36,7 @@ export async function createStandaloneApplication(
   options: ApplicationOptions,
 ): Promise<express.Application> {
   const { enableCors, logger } = options;
-  const config = ConfigReader.fromConfigs([]);
+  const config = new ConfigReader({});
   const app = express();
 
   app.use(helmet());

--- a/plugins/rollbar-backend/src/service/router.test.ts
+++ b/plugins/rollbar-backend/src/service/router.test.ts
@@ -38,9 +38,7 @@ describe('createRouter', () => {
     const router = await createRouter({
       rollbarApi,
       logger: getVoidLogger(),
-      config: ConfigReader.fromConfigs([
-        { context: 'abc', data: { rollbar: { accountToken: 'foo' } } },
-      ]),
+      config: new ConfigReader({ rollbar: { accountToken: 'foo' } }),
     });
     app = express().use(router);
   });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/azure.test.ts
@@ -78,7 +78,7 @@ describe('AzurePreparer', () => {
   });
 
   it('calls the clone command with the correct arguments for a repository', async () => {
-    const preparer = new AzurePreparer(ConfigReader.fromConfigs([]));
+    const preparer = new AzurePreparer(new ConfigReader({}));
     await preparer.prepare(mockEntity, { logger: getVoidLogger() });
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
       1,
@@ -90,20 +90,15 @@ describe('AzurePreparer', () => {
 
   it('calls the clone command with the correct arguments if an access token is provided for a repository', async () => {
     const preparer = new AzurePreparer(
-      ConfigReader.fromConfigs([
-        {
-          context: '',
-          data: {
-            scaffolder: {
-              azure: {
-                api: {
-                  token: 'fake-token',
-                },
-              },
+      new ConfigReader({
+        scaffolder: {
+          azure: {
+            api: {
+              token: 'fake-token',
             },
           },
         },
-      ]),
+      }),
     );
     await preparer.prepare(mockEntity, { logger: getVoidLogger() });
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
@@ -121,7 +116,7 @@ describe('AzurePreparer', () => {
   });
 
   it('calls the clone command with the correct arguments for a repository when no path is provided', async () => {
-    const preparer = new AzurePreparer(ConfigReader.fromConfigs([]));
+    const preparer = new AzurePreparer(new ConfigReader({}));
     delete mockEntity.spec.path;
     await preparer.prepare(mockEntity, { logger: getVoidLogger() });
     expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
@@ -133,7 +128,7 @@ describe('AzurePreparer', () => {
   });
 
   it('return the temp directory with the path to the folder if it is specified', async () => {
-    const preparer = new AzurePreparer(ConfigReader.fromConfigs([]));
+    const preparer = new AzurePreparer(new ConfigReader({}));
     mockEntity.spec.path = './template/test/1/2/3';
     const response = await preparer.prepare(mockEntity, {
       logger: getVoidLogger(),
@@ -145,7 +140,7 @@ describe('AzurePreparer', () => {
   });
 
   it('return the working directory with the path to the folder if it is specified', async () => {
-    const preparer = new AzurePreparer(ConfigReader.fromConfigs([]));
+    const preparer = new AzurePreparer(new ConfigReader({}));
     mockEntity.spec.path = './template/test/1/2/3';
     const response = await preparer.prepare(mockEntity, {
       logger: getVoidLogger(),

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
@@ -78,7 +78,7 @@ describe('GitLabPreparer', () => {
 
   ['gitlab', 'gitlab/api'].forEach(protocol => {
     it(`calls the clone command with the correct arguments for a repository using the ${protocol} protocol`, async () => {
-      const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
+      const preparer = new GitlabPreparer(new ConfigReader({}));
       mockEntity = mockEntityWithProtocol(protocol);
       await preparer.prepare(mockEntity, { logger: getVoidLogger() });
       expect(mocks.Clone.clone).toHaveBeenNthCalledWith(
@@ -91,20 +91,15 @@ describe('GitLabPreparer', () => {
 
     it(`calls the clone command with the correct arguments if an access token is provided for a repository using the ${protocol} protocol`, async () => {
       const preparer = new GitlabPreparer(
-        ConfigReader.fromConfigs([
-          {
-            context: '',
-            data: {
-              catalog: {
-                processors: {
-                  gitlabApi: {
-                    privateToken: 'fake-token',
-                  },
-                },
+        new ConfigReader({
+          catalog: {
+            processors: {
+              gitlabApi: {
+                privateToken: 'fake-token',
               },
             },
           },
-        ]),
+        }),
       );
       mockEntity = mockEntityWithProtocol(protocol);
       await preparer.prepare(mockEntity, { logger: getVoidLogger() });
@@ -123,7 +118,7 @@ describe('GitLabPreparer', () => {
     });
 
     it(`calls the clone command with the correct arguments for a repository when no path is provided using the ${protocol} protocol`, async () => {
-      const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
+      const preparer = new GitlabPreparer(new ConfigReader({}));
       mockEntity = mockEntityWithProtocol(protocol);
       delete mockEntity.spec.path;
       await preparer.prepare(mockEntity, { logger: getVoidLogger() });
@@ -136,7 +131,7 @@ describe('GitLabPreparer', () => {
     });
 
     it(`return the temp directory with the path to the folder if it is specified using the ${protocol} protocol`, async () => {
-      const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
+      const preparer = new GitlabPreparer(new ConfigReader({}));
       mockEntity = mockEntityWithProtocol(protocol);
       mockEntity.spec.path = './template/test/1/2/3';
       const response = await preparer.prepare(mockEntity, {
@@ -149,7 +144,7 @@ describe('GitLabPreparer', () => {
     });
 
     it('return the working directory with the path to the folder if it is specified', async () => {
-      const preparer = new GitlabPreparer(ConfigReader.fromConfigs([]));
+      const preparer = new GitlabPreparer(new ConfigReader({}));
       mockEntity.spec.path = './template/test/1/2/3';
       const response = await preparer.prepare(mockEntity, {
         logger: getVoidLogger(),

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -55,11 +55,8 @@ describe('createRouter - working directory', () => {
   });
 
   const workDirConfig = (path: string) => ({
-    context: '',
-    data: {
-      backend: {
-        workingDirectory: path,
-      },
+    backend: {
+      workingDirectory: path,
     },
   });
 
@@ -91,7 +88,7 @@ describe('createRouter - working directory', () => {
         preparers: new Preparers(),
         templaters: new Templaters(),
         publishers: new Publishers(),
-        config: ConfigReader.fromConfigs([workDirConfig('/path')]),
+        config: new ConfigReader(workDirConfig('/path')),
         dockerClient: new Docker(),
         entityClient: mockedEntityClient,
       }),
@@ -104,7 +101,7 @@ describe('createRouter - working directory', () => {
       preparers: mockPreparers,
       templaters: new Templaters(),
       publishers: new Publishers(),
-      config: ConfigReader.fromConfigs([workDirConfig('/path')]),
+      config: new ConfigReader(workDirConfig('/path')),
       dockerClient: new Docker(),
       entityClient: mockedEntityClient,
     });
@@ -127,7 +124,7 @@ describe('createRouter - working directory', () => {
       preparers: mockPreparers,
       templaters: new Templaters(),
       publishers: new Publishers(),
-      config: ConfigReader.fromConfigs([]),
+      config: new ConfigReader({}),
       dockerClient: new Docker(),
       entityClient: mockedEntityClient,
     });
@@ -190,7 +187,7 @@ describe('createRouter', () => {
       preparers: new Preparers(),
       templaters: new Templaters(),
       publishers: new Publishers(),
-      config: ConfigReader.fromConfigs([]),
+      config: new ConfigReader({}),
       dockerClient: new Docker(),
       entityClient: generateEntityClient(template),
     });

--- a/plugins/techdocs-backend/src/service/standaloneServer.ts
+++ b/plugins/techdocs-backend/src/service/standaloneServer.ts
@@ -41,18 +41,13 @@ export async function startStandaloneServer(
   options: ServerOptions,
 ): Promise<Server> {
   const logger = options.logger.child({ service: 'techdocs-backend' });
-  const config = ConfigReader.fromConfigs([
-    {
-      context: '',
-      data: {
-        techdocs: {
-          publisher: {
-            type: 'local',
-          },
-        },
+  const config = new ConfigReader({
+    techdocs: {
+      publisher: {
+        type: 'local',
       },
     },
-  ]);
+  });
   const discovery = SingleHostDiscovery.fromConfig(config);
 
   logger.debug('Creating application...');

--- a/plugins/user-settings/src/components/AuthProviders/AuthProviders.test.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/AuthProviders.test.tsx
@@ -37,18 +37,13 @@ const mockGoogleAuth = {
 };
 
 const createConfig = () =>
-  ConfigReader.fromConfigs([
-    {
-      context: '',
-      data: {
-        auth: {
-          providers: {
-            google: { development: {} },
-          },
-        },
+  new ConfigReader({
+    auth: {
+      providers: {
+        google: { development: {} },
       },
     },
-  ]);
+  });
 
 const config = createConfig();
 


### PR DESCRIPTION
`ConfigReader.fromConfigs` is a more advanced usage which helps merge together configuration from multiple different contexts. In tests on other placer where you want some static config it's simpler to just use `new ConfigReader(data)` instead. By replacing the usage everywhere I'm hoping the more simple pattern can be encouraged :grin: