### PR TITLE
scaffolder-backend: switch location type of example templates to url

### DIFF
--- a/plugins/scaffolder-backend/sample-templates/all-templates.yaml
+++ b/plugins/scaffolder-backend/sample-templates/all-templates.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-templates
   description: A collection of all Backstage example templates
 spec:
-  type: github
+  type: url
   targets:
     - https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml
     - https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/template.yaml


### PR DESCRIPTION
Scaffolder has supported url type detection for close to two months, so expecting this to be safe to remove