### PR TITLE
catalog-backend: start warning about usage of deprecated location types

### DIFF
--- a/.changeset/shaggy-candles-rush.md
+++ b/.changeset/shaggy-candles-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Start warning about usage of deprecated location types, such as `github`

--- a/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
@@ -45,11 +45,11 @@ export class UrlReaderProcessor implements CatalogProcessor {
     emit: CatalogProcessorEmit,
   ): Promise<boolean> {
     if (deprecatedTypes.includes(location.type)) {
-      // TODO(Rugvip): Let's not enable this warning yet, as we want to move over the example YAMLs
-      //               in this repo to use the 'url' type first.
-      // this.options.logger.warn(
-      //   `Using deprecated location type '${location.type}' for '${location.target}', use 'url' instead`,
-      // );
+      // TODO(Rugvip): Remove this warning a month or two into 2021, and remove support for the deprecated types.
+      this.options.logger.warn(
+        `Location '${location.target}' uses deprecated location type '${location.type}', use 'url' instead. ` +
+          'Use "scripts/migrate-location-types.js" in the Backstage repo to migrate existing locations.',
+      );
     } else if (location.type !== 'url') {
       return false;
     }


### PR DESCRIPTION
Let's get warning going so that we eventually can remove the deprecated types.

We should merge this after ~#3732~ and #3524, or we'll be getting warnings in master