### PR TITLE
plugin-org: Wrap Entity Counter widgets on Ownership Card

### DIFF
--- a/.changeset/chilly-pumpkins-retire.md
+++ b/.changeset/chilly-pumpkins-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Wrap entity cards on smaller screens

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -179,7 +179,7 @@ export const OwnershipCard = ({
     <InfoCard title="Ownership" variant={variant}>
       <Grid container>
         {componentsWithCounters?.map(c => (
-          <Grid item xs={12} md={6} lg={4} key={c.name}>
+          <Grid item xs={6} md={6} lg={4} key={c.name}>
             <EntityCountTile
               counter={c.counter}
               className={c.className}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Improve the entity counters wrapping on the Ownership card for non-full screen browsers and smaller screens. Some text overlap at the absolute smallest, but I'm opting as an edge case that is OK for future refactoring.

| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/33203301/102297657-9f0d9100-3f1d-11eb-8c26-ec283e0aae97.png) |  ![image](https://user-images.githubusercontent.com/33203301/102297590-856c4980-3f1d-11eb-8550-cfe515c8c303.png)  |

Even down to iPad, iPhone X, and Galaxy S5, the 2x2 table still fits quite well (though a bit of word wrapping on the absolute smallest):

![image](https://user-images.githubusercontent.com/33203301/102297845-fca1dd80-3f1d-11eb-9835-f871d1dddb27.png)
(i'm going to suggest this edge case could be addressed separately, and potentially by naming that panel on the smallest screens as just "Docs" but I couldn't figure out to change words to suit sizing :) )

![image](https://user-images.githubusercontent.com/33203301/102297828-f3b10c00-3f1d-11eb-9afd-175669e28241.png)

At larger size, the screen retains its nice 2x3 table:

![image](https://user-images.githubusercontent.com/33203301/102297522-6a99d500-3f1d-11eb-8d0a-59252044e264.png) 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
