### PR TITLE
cost-insights: refactor plugin creation to call createPlugin directly

### DIFF
--- a/plugins/cost-insights/dev/index.tsx
+++ b/plugins/cost-insights/dev/index.tsx
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 import { createDevApp } from '@backstage/dev-utils';
-import { createPlugin, createApiFactory } from '@backstage/core';
 import { costInsightsApiRef } from '../src/api';
 import { ExampleCostInsightsClient } from '../src/client';
-import { pluginConfig } from '../src/plugin';
+import { plugin } from '../src/plugin';
 
-const devPlugin = createPlugin({
-  ...pluginConfig,
-  apis: [
-    createApiFactory({
-      api: costInsightsApiRef,
-      deps: {},
-      factory: () => new ExampleCostInsightsClient(),
-    }),
-  ],
-});
-
-createDevApp().registerPlugin(devPlugin).render();
+createDevApp()
+  .registerPlugin(plugin)
+  .registerApi({
+    api: costInsightsApiRef,
+    deps: {},
+    factory: () => new ExampleCostInsightsClient(),
+  })
+  .render();

--- a/plugins/cost-insights/src/plugin.ts
+++ b/plugins/cost-insights/src/plugin.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createPlugin, createRouteRef, PluginConfig } from '@backstage/core';
+import { createPlugin, createRouteRef } from '@backstage/core';
 import { CostInsightsPage } from './components/CostInsightsPage';
 import { ProjectGrowthInstructionsPage } from './components/ProjectGrowthInstructionsPage';
 import { LabelDataflowInstructionsPage } from './components/LabelDataflowInstructionsPage';
@@ -34,7 +34,7 @@ export const unlabeledDataflowAlertRef = createRouteRef({
   title: 'Labeling Dataflow Jobs',
 });
 
-export const pluginConfig: PluginConfig = {
+export const plugin = createPlugin({
   id: 'cost-insights',
   register({ router, featureFlags }) {
     router.addRoute(rootRouteRef, CostInsightsPage);
@@ -42,6 +42,4 @@ export const pluginConfig: PluginConfig = {
     router.addRoute(unlabeledDataflowAlertRef, LabelDataflowInstructionsPage);
     featureFlags.register('cost-insights-currencies');
   },
-};
-
-export const plugin = createPlugin(pluginConfig);
+});


### PR DESCRIPTION
The call to `createPlugin` will be needed to infer types in some upcoming additions to the API. This is also kinda nicer :grin: