### PR TITLE
Updating CSP for unsafe eval

### DIFF
--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -52,7 +52,7 @@ const DEFAULT_CSP = {
   'frame-ancestors': ["'self'"],
   'img-src': ["'self'", 'data:'],
   'object-src': ["'none'"],
-  'script-src': ["'self'"],
+  'script-src': ["'self'", "'unsafe-eval'"],
   'script-src-attr': ["'none'"],
   'style-src': ["'self'", 'https:', "'unsafe-inline'"],
   'upgrade-insecure-requests': [] as string[],


### PR DESCRIPTION
Opening this up as I'm not sure if this is the best way to do this and I don't know CSP so well, @freben little help here.

We need to allow eval for `ajv` dependency in the scaffolder forms. When using app backend it doesn't work, because of the CSP that it applies to the static frontend.