### PR TITLE
fix(app): listen to app.listen.host

### DIFF
--- a/.changeset/fuzzy-windows-cry.md
+++ b/.changeset/fuzzy-windows-cry.md
@@ -1,5 +1,0 @@
----
-'@backstage/cli': patch
----
-
-Use app.listen.host configuration when starting dev server

--- a/.changeset/fuzzy-windows-cry.md
+++ b/.changeset/fuzzy-windows-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Use app.listen.host configuration when starting dev server

--- a/.changeset/violet-sloths-reply.md
+++ b/.changeset/violet-sloths-reply.md
@@ -1,5 +1,5 @@
 ---
-"@backstage/cli": patch
+'@backstage/cli': patch
 ---
 
 Fix for `app.listen.host` configuration not properly overriding listening host.

--- a/.changeset/violet-sloths-reply.md
+++ b/.changeset/violet-sloths-reply.md
@@ -1,0 +1,5 @@
+---
+"@backstage/cli": patch
+---
+
+Fix for `app.listen.host` configuration not properly overriding listening host.

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -61,7 +61,7 @@ export async function serveBundle(options: ServeOptions) {
   });
 
   await new Promise<void>((resolve, reject) => {
-    server.listen(port, url.hostname, (err?: Error) => {
+    server.listen(port, host, (err?: Error) => {
       if (err) {
         reject(err);
         return;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When running the backstage frontend app in a Docker container, e.g. when using docker-compose for local development of app, backend, database and lighthouse, the frontend app by default refuses to accept connections, the container giving empty responses. The reason seems to be that the webpack dev server is started with localhost as host, which in turn is interpreted as do not accept connections from other than localhost. This PR allows overriding this behaviour by setting the `app.listen.host` configuration parameter to `0.0.0.0` (allow incoming connections on all network interfaces). The current code instead uses the host from the URL configuration, but it is inconvenient to remember to browse to http://0.0.0.0:3000 when developing (and modify CORS etc from default configuration)

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

A bit lazy, but ☝️ is not super-relevant to this little change I think.