### PR TITLE
api-docs: Update register API link, deprecate register-component

### DIFF
--- a/.changeset/famous-eagles-swim.md
+++ b/.changeset/famous-eagles-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-register-component': patch
+---
+
+Register component plugin is deprecated in favor of @backstage/plugin-catalog-import

--- a/.changeset/gentle-dragons-marry.md
+++ b/.changeset/gentle-dragons-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Link register API to catalog-import plugin

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
@@ -37,7 +37,7 @@ export const ApiExplorerPage = () => {
             variant="contained"
             color="primary"
             component={RouterLink}
-            to="/register-component"
+            to="/catalog-import"
           >
             Register Existing API
           </Button>

--- a/plugins/register-component/README.md
+++ b/plugins/register-component/README.md
@@ -1,5 +1,7 @@
 # Register component plugin
 
+> This plugin is deprecated in favor of [`@backstage/catalog-import`](https://github.com/backstage/backstage/tree/master/plugins/catalog-import), and will be soon removed from the project.
+
 Welcome to the register-component plugin!
 
 This plugin allows you to submit your Backstage component using your software's YAML config.

--- a/plugins/register-component/src/components/Router.tsx
+++ b/plugins/register-component/src/components/Router.tsx
@@ -20,6 +20,13 @@ import { RouteRef } from '@backstage/core';
 
 // As we don't know which path the catalog's router mounted on
 // We need to inject this from the app
+
+/**
+ * Provides a router for registering a component.
+ *
+ * @deprecated The router for this component is deprecated and replaced with the `catalog-import` plugin.
+ * @see https://github.com/backstage/backstage/tree/master/plugins/catalog-import
+ */
 export const Router = ({ catalogRouteRef }: { catalogRouteRef: RouteRef }) => (
   <Routes>
     <Route


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The `register-component` isn't used in the project currently anywhere except in the API Docs register API link. This wires that link  instead back to the newer `catalog-import`.

This PR replaces PR #3782 to simply not use the `register-component` plugin, before some future pure decommission activity.

Tried to figure out how to do something smart with Winston to try warning if the register component is used (e.g., by an outside plugin, a la `logger.warn('This component is deprecated')`), but couldn't figure out how to inject it since this plugin lacks business logic (it's mostly entirely a React component). Welcome suggestion/advice!

Also figured a real `npm deprecate` wasn't appropriate here.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
