### PR TITLE
core-api: gather all relevant route refs into each route object

### DIFF
--- a/packages/core-api/src/routing/hooks.tsx
+++ b/packages/core-api/src/routing/hooks.tsx
@@ -60,8 +60,8 @@ class RouteResolver {
       currentRouteRef;
       currentRouteRef = this.routeParents.get(currentRouteRef)
     ) {
-      matchIndex = match.findIndex(
-        m => (m.route as BackstageRouteObject).routeRef === currentRouteRef,
+      matchIndex = match.findIndex(m =>
+        (m.route as BackstageRouteObject).routeRefs.has(currentRouteRef!),
       );
       if (matchIndex !== -1) {
         break;

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -62,5 +62,5 @@ export interface BackstageRouteObject {
   children?: BackstageRouteObject[];
   element: React.ReactNode;
   path: string;
-  routeRef: AnyRouteRef;
+  routeRefs: Set<AnyRouteRef>;
 }


### PR DESCRIPTION
Co-authored-by: blam <ben@blam.sh>

## Hey, I just made a Pull Request!

Fix on top of #3808 to fix the route object matching. The `matchRoute` function only matches a single leaf object so we gather up all relevant route refs in each object instead of leaving multiple objects.

Again piggybacking on the changeset for the other core-api changes

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
