### PR TITLE
failed attempt to add pkce option for OAuth2 provider

### DIFF
--- a/.changeset/olive-steaks-obey.md
+++ b/.changeset/olive-steaks-obey.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Add PKCE option for OAuth2

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -255,7 +255,7 @@ auth:
           $env: AUTH_OAUTH2_AUTH_URL
         tokenUrl:
           $env: AUTH_OAUTH2_TOKEN_URL
-        pkce: false
+        pkce: 'false'
     oidc:
       development:
         metadataUrl:

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -255,6 +255,7 @@ auth:
           $env: AUTH_OAUTH2_AUTH_URL
         tokenUrl:
           $env: AUTH_OAUTH2_TOKEN_URL
+        pkce: false
     oidc:
       development:
         metadataUrl:

--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -103,6 +103,17 @@ export AUTH_AUTH0_CLIENT_ID=x
 export AUTH_AUTH0_CLIENT_SECRET=x
 ```
 
+### OAuth2
+
+PKCE can be enabled by setting `pkce: true` and providing a value for `auth.session.secret` in `app-config.yaml`.
+
+```bash
+export AUTH_OAUTH2_CLIENT_ID=x
+export AUTH_OAUTH2_CLIENT_SECRET=x
+export AUTH_OAUTH2_AUTH_URL=x
+export AUTH_OAUTH2_TOKEN_URL=x
+```
+
 ### Microsoft
 
 #### Creating an Azure AD App Registration

--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -105,7 +105,7 @@ export AUTH_AUTH0_CLIENT_SECRET=x
 
 ### OAuth2
 
-PKCE can be enabled by setting `pkce: true` and providing a value for `auth.session.secret` in `app-config.yaml`.
+PKCE can be enabled by setting `auth.providers.oauth2.development.pkce: 'true'` and providing a value for `auth.session.secret` in `app-config.yaml`.
 
 ```bash
 export AUTH_OAUTH2_CLIENT_ID=x

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -171,7 +171,7 @@ export const createOAuth2Provider: AuthProviderFactory = ({
     const callbackUrl = `${globalConfig.baseUrl}/${providerId}/handler/frame`;
     const authorizationUrl = envConfig.getString('authorizationUrl');
     const tokenUrl = envConfig.getString('tokenUrl');
-    const pkce = envConfig.getOptionalBoolean('pkce');
+    const pkce = envConfig.getOptionalString('pkce') === 'true';
 
     const provider = new OAuth2AuthProvider({
       clientId,

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -44,6 +44,7 @@ type PrivateInfo = {
 export type OAuth2AuthProviderOptions = OAuthProviderOptions & {
   authorizationUrl: string;
   tokenUrl: string;
+  pkce?: boolean;
 };
 
 export class OAuth2AuthProvider implements OAuthHandlers {
@@ -58,6 +59,8 @@ export class OAuth2AuthProvider implements OAuthHandlers {
         authorizationURL: options.authorizationUrl,
         tokenURL: options.tokenUrl,
         passReqToCallback: false as true,
+        pkce: options.pkce,
+        state: options.pkce, // needed for pkce; enable session with app-config.yaml auth.session.secret
       },
       (
         accessToken: any,
@@ -168,6 +171,7 @@ export const createOAuth2Provider: AuthProviderFactory = ({
     const callbackUrl = `${globalConfig.baseUrl}/${providerId}/handler/frame`;
     const authorizationUrl = envConfig.getString('authorizationUrl');
     const tokenUrl = envConfig.getString('tokenUrl');
+    const pkce = envConfig.getOptionalBoolean('pkce');
 
     const provider = new OAuth2AuthProvider({
       clientId,
@@ -175,6 +179,7 @@ export const createOAuth2Provider: AuthProviderFactory = ({
       callbackUrl,
       authorizationUrl,
       tokenUrl,
+      pkce,
     });
 
     return OAuthAdapter.fromConfig(globalConfig, provider, {


### PR DESCRIPTION
OAuth2 providers sometimes require PKCE. this makes it possible to enable it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
