### PR TITLE
core-api: add BackstageRoutes

### DIFF
--- a/.changeset/dull-seals-march.md
+++ b/.changeset/dull-seals-march.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-api': patch
+'@backstage/core': patch
+---
+
+Add `BackstageRoutes` component to replace the top-level `Routes` component from `react-router` within apps, removing the need for manually appending `/*` to paths or sorting routes.

--- a/packages/core-api/src/routing/BackstageRoutes.tsx
+++ b/packages/core-api/src/routing/BackstageRoutes.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactNode, Children, isValidElement, Fragment } from 'react';
+import { useRoutes } from 'react-router-dom';
+
+type RouteObject = {
+  path: string;
+  element: JSX.Element;
+  children?: RouteObject[];
+};
+
+// Similar to the same function from react-router, this collects routes from the
+// children, but only the first level of routes
+function createRoutesFromChildren(children: ReactNode): RouteObject[] {
+  return Children.toArray(children)
+    .flatMap(child => {
+      if (!isValidElement(child)) {
+        return [];
+      }
+
+      const { children } = child.props;
+
+      if (child.type === Fragment) {
+        return createRoutesFromChildren(children);
+      }
+
+      let path = child.props.path as string | undefined;
+
+      // TODO(Rugvip): Work around plugins registering empty paths, remove once deprecated routes are gone
+      if (path === '') {
+        return [];
+      }
+      path = path?.replace(/\/\*$/, '') ?? '/';
+
+      return [
+        {
+          path,
+          element: child,
+          children: children && [
+            {
+              path: '/*',
+              element: children,
+            },
+          ],
+        },
+      ];
+    })
+    .sort((a, b) => b.path.localeCompare(a.path))
+    .map(obj => {
+      obj.path = obj.path === '/' ? '/' : `${obj.path}/*`;
+      return obj;
+    });
+}
+
+type BackstageRoutesProps = {
+  children: ReactNode;
+};
+
+export const BackstageRoutes = (
+  props: BackstageRoutesProps,
+): JSX.Element | null => {
+  const routes = createRoutesFromChildren(props.children);
+  return useRoutes(routes);
+};

--- a/packages/core-api/src/routing/index.ts
+++ b/packages/core-api/src/routing/index.ts
@@ -21,5 +21,6 @@ export type {
   ConcreteRoute,
   MutableRouteRef,
 } from './types';
+export { BackstageRoutes } from './BackstageRoutes';
 export { createRouteRef } from './RouteRef';
 export { useRouteRef } from './hooks';


### PR DESCRIPTION
Co-authored-by: blam <ben@blam.sh>

## Hey, I just made a Pull Request!

Adds a `BackstageRoutes` component that is similar to the `Routes` component from react-router, but tailored for top-level extension routes by only collecting routes from the immediate children. It also adds `/*` at the end of paths as well as sorts them, so that you don't need to do that manually in the app.

The main reason for the introduction of this is to be able to do the following:

```tsx
<Route path="/catalog/:namespace/:kind/:name" element={<CatalogEntityPage />} >
  <EntityLayout>
    ...
  </EntityLayout>
</Route>
```

instead of

```tsx
<Route path="/catalog/:namespace/:kind/:name/*" element={<CatalogEntityPage />} >
  <Route path="/*" element={
    <EntityLayout>
      ...
    </EntityLayout>
  }/>
</Route>
```

Fixes #3793

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
