### PR TITLE
build: Change Windows master build to use raw Discord webhook

### DIFF
--- a/.github/workflows/master-win.yml
+++ b/.github/workflows/master-win.yml
@@ -51,10 +51,13 @@ jobs:
       - name: test
         run: yarn lerna -- run test
 
+      # credit: https://github.com/appleboy/discord-action/issues/3#issuecomment-731426861
       - name: Discord notification
         if: ${{ failure() }}
-        uses: Ilshidur/action-discord@0.2.0
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        with:
-          args: 'Windows master build failed https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}'
+        run: |
+          $MESSAGE=@"
+          {\"content\": \"Windows master build failed https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}\"}
+          "@
+          C:\msys64\usr\bin\curl.exe -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST $env:DISCORD_WEBHOOK --data $MESSAGE


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Noticed the master builds were failing on the Windows step, like so:

![image](https://user-images.githubusercontent.com/33203301/102928268-6cf0b780-4466-11eb-9945-acfdffde46ac.png)
https://github.com/backstage/backstage/runs/1596622881

As a hack, this PR just converts it to use a raw string for posting the alerts out since most of the packaged Actions don't support Windows. Tested on my private repo and the mechanics worked, assuming the discord hook (same as used in Linux builds) is fine!

![image](https://user-images.githubusercontent.com/33203301/102928392-9f021980-4466-11eb-8678-ddeac42888e2.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
