### PR TITLE
Fix for integration.github.apiBaseUrl configuration not properly overriding apiBaseUrl used by techdocs

### DIFF
--- a/.changeset/fifty-yaks-behave.md
+++ b/.changeset/fifty-yaks-behave.md
@@ -1,5 +1,4 @@
 ---
-'example-app': patch
 '@backstage/techdocs-common': patch
 ---
 

--- a/.changeset/fifty-yaks-behave.md
+++ b/.changeset/fifty-yaks-behave.md
@@ -1,0 +1,6 @@
+---
+'example-app': patch
+'@backstage/techdocs-common': patch
+---
+
+Fix for `integration.github.apiBaseUrl` configuration not properly overriding apiBaseUrl used by techdocs

--- a/packages/techdocs-common/src/default-branch.ts
+++ b/packages/techdocs-common/src/default-branch.ts
@@ -50,19 +50,19 @@ interface IGitlabBranch {
 }
 
 function getGithubApiUrl(config: Config, url: string): URL {
-  const { protocol, owner, name } = parseGitUrl(url);
+  const { resource, owner, name } = parseGitUrl(url);
   const providerConfigs =
     config.getOptionalConfigArray('integrations.github') ?? [];
 
-  // TODO: Maybe we need to filter by host in the array, not sure about GHE
-  const targetProviderConfig = providerConfigs[0];
+  const hostConfig = providerConfigs.filter(
+    providerConfig => providerConfig.getOptionalString('host') === resource,
+  );
 
   const apiBaseUrl =
-    targetProviderConfig?.getOptionalString('integrations.github.apiBaseUrl') ??
-    'api.github.com';
+    hostConfig[0]?.getOptionalString('apiBaseUrl') ?? 'https://api.github.com';
   const apiRepos = 'repos';
 
-  return new URL(`${protocol}://${apiBaseUrl}/${apiRepos}/${owner}/${name}`);
+  return new URL(`${apiBaseUrl}/${apiRepos}/${owner}/${name}`);
 }
 
 function getGitlabApiUrl(url: string): URL {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `getGithubApiUrl` function in techdocs-common (1) always choses the first entry in the `integrations.github` configuration array and (2) uses an incorrect path to retrieve the apiBaseUrl property. This causes a 401 when asking techdocs for a GHE location.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
