### PR TITLE
build: Fix devApp unit test

### DIFF
--- a/.changeset/twenty-squids-think.md
+++ b/.changeset/twenty-squids-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/dev-utils': patch
+---
+
+Fix render test

--- a/packages/dev-utils/src/devApp/render.test.tsx
+++ b/packages/dev-utils/src/devApp/render.test.tsx
@@ -33,7 +33,7 @@ describe('DevAppBuilder', () => {
     };
 
     const DevApp = createDevApp()
-      .addRootChild(<MyComponent />)
+      .addRootChild(<MyComponent key="uniqueKey" />)
       .build();
 
     const rendered = render(<DevApp />);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The `devapp` package tests only run when it's changed or against full master. It is currently broken against master due to a list-type element missing a key, and doesn't block PRs since non-changed packages don't run in PR CI/CD. This change hardcodes the a key to get the tests to pass, which should also clear up some distraction on the `master` branch.

![image](https://user-images.githubusercontent.com/33203301/102950010-a5f55000-4497-11eb-923b-d41613f636ff.png)

I was also able to reproduce it locally:

![image](https://user-images.githubusercontent.com/33203301/102950055-bd343d80-4497-11eb-92a8-7f8b20e5ccbd.png)

And this PR clears it up:

![image](https://user-images.githubusercontent.com/33203301/102950077-c91fff80-4497-11eb-8fe8-daabca6f1397.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
