### PR TITLE
catalog: rename EntityProvider to EntityLoaderProvider, and add new EntityProvider

### DIFF
--- a/.changeset/polite-glasses-occur.md
+++ b/.changeset/polite-glasses-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Add new `EntityProvider` component, which can be used to provide an entity for the `useEntity` hook.

--- a/plugins/catalog/src/components/CatalogEntityPage/CatalogEntityPage.tsx
+++ b/plugins/catalog/src/components/CatalogEntityPage/CatalogEntityPage.tsx
@@ -16,12 +16,12 @@
 
 import React from 'react';
 import { Outlet } from 'react-router';
-import { EntityProvider } from '../EntityProvider';
+import { EntityLoaderProvider } from '../EntityLoaderProvider';
 
 export const CatalogEntityPage = () => {
   return (
-    <EntityProvider>
+    <EntityLoaderProvider>
       <Outlet />
-    </EntityProvider>
+    </EntityLoaderProvider>
   );
 };

--- a/plugins/catalog/src/components/EntityLoaderProvider/EntityLoaderProvider.tsx
+++ b/plugins/catalog/src/components/EntityLoaderProvider/EntityLoaderProvider.tsx
@@ -13,23 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Entity } from '@backstage/catalog-model';
 import React, { ReactNode } from 'react';
-import { EntityContext } from '../../hooks/useEntity';
+import { useEntityFromUrl, EntityContext } from '../../hooks/useEntity';
 
-type EntityProviderProps = {
-  entity: Entity;
-  children: ReactNode;
+export const EntityLoaderProvider = ({ children }: { children: ReactNode }) => {
+  const { entity, loading, error } = useEntityFromUrl();
+
+  return (
+    <EntityContext.Provider value={{ entity, loading, error }}>
+      {children}
+    </EntityContext.Provider>
+  );
 };
-
-export const EntityProvider = ({ entity, children }: EntityProviderProps) => (
-  <EntityContext.Provider
-    value={{
-      entity,
-      loading: Boolean(entity),
-      error: undefined,
-    }}
-  >
-    {children}
-  </EntityContext.Provider>
-);

--- a/plugins/catalog/src/components/EntityLoaderProvider/index.ts
+++ b/plugins/catalog/src/components/EntityLoaderProvider/index.ts
@@ -13,23 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Entity } from '@backstage/catalog-model';
-import React, { ReactNode } from 'react';
-import { EntityContext } from '../../hooks/useEntity';
-
-type EntityProviderProps = {
-  entity: Entity;
-  children: ReactNode;
-};
-
-export const EntityProvider = ({ entity, children }: EntityProviderProps) => (
-  <EntityContext.Provider
-    value={{
-      entity,
-      loading: Boolean(entity),
-      error: undefined,
-    }}
-  >
-    {children}
-  </EntityContext.Provider>
-);
+export { EntityLoaderProvider } from './EntityLoaderProvider';

--- a/plugins/catalog/src/components/Router.tsx
+++ b/plugins/catalog/src/components/Router.tsx
@@ -23,7 +23,7 @@ import { entityRoute, rootRoute } from '../routes';
 import { CatalogPage } from './CatalogPage';
 import { EntityNotFound } from './EntityNotFound';
 import { EntityPageLayout } from './EntityPageLayout';
-import { EntityProvider } from './EntityProvider';
+import { EntityLoaderProvider } from './EntityLoaderProvider';
 
 const DefaultEntityPage = () => (
   <EntityPageLayout>
@@ -79,9 +79,9 @@ export const Router = ({
     <Route
       path={`${entityRoute.path}`}
       element={
-        <EntityProvider>
+        <EntityLoaderProvider>
           <EntityPageSwitch EntityPage={EntityPage} />
-        </EntityProvider>
+        </EntityLoaderProvider>
       }
     />
     <Route

--- a/plugins/catalog/src/hooks/useEntity.ts
+++ b/plugins/catalog/src/hooks/useEntity.ts
@@ -55,7 +55,7 @@ export const useEntityFromUrl = (): EntityLoadingStatus => {
 };
 
 /**
- * Grab Entity from the context and it's current loading state.
+ * Grab Entity from the context and its current loading state.
  */
 export const useEntity = () => {
   const { entity, loading, error } = useContext<{

--- a/plugins/catalog/src/hooks/useEntity.ts
+++ b/plugins/catalog/src/hooks/useEntity.ts
@@ -55,7 +55,7 @@ export const useEntityFromUrl = (): EntityLoadingStatus => {
 };
 
 /**
- * Always going to return an entity, or throw an error if not a descendant of a EntityProvider.
+ * Grab Entity from the context and it's current loading state.
  */
 export const useEntity = () => {
   const { entity, loading, error } = useContext<{

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -18,6 +18,7 @@ export * from '@backstage/catalog-client';
 export { AboutCard } from './components/AboutCard';
 export { EntityPageLayout } from './components/EntityPageLayout';
 export { EntityLayout } from './components/EntityLayout';
+export { EntityProvider } from './components/EntityProvider';
 export * from './components/EntitySwitch';
 export { Router } from './components/Router';
 export { useEntityCompoundName } from './components/useEntityCompoundName';


### PR DESCRIPTION
Having an easy to use `EntityProvider` is gonna be important for creating test cases and overrides. These all deserve their own `@backstage/catalog-react` package or something of that sort, but keeping in the catalog for now.