### PR TITLE
fix: id token expiration in s, not ms

### DIFF
--- a/.changeset/warm-pets-sin.md
+++ b/.changeset/warm-pets-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+fix bug in token expiration date

--- a/plugins/auth-backend/src/identity/TokenFactory.test.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.test.ts
@@ -87,7 +87,7 @@ describe('TokenFactory', () => {
       iat: expect.any(Number),
       exp: expect.any(Number),
     });
-    expect(payload.exp).toBe(payload.iat + keyDurationSeconds * 1000);
+    expect(payload.exp).toBe(payload.iat + keyDurationSeconds);
   });
 
   it('should generate new signing keys when the current one expires', async () => {

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -69,7 +69,7 @@ export class TokenFactory implements TokenIssuer {
     const sub = params.claims.sub;
     const aud = 'backstage';
     const iat = Math.floor(Date.now() / MS_IN_S);
-    const exp = iat + this.keyDurationSeconds * MS_IN_S;
+    const exp = iat + this.keyDurationSeconds;
 
     this.logger.info(`Issuing token for ${sub}`);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `idToken` created by `auth-backend` mistakenly sets the expiration date to milliseconds instead of seconds. Default key duration is 3600 seconds (one hour) - but the bug causes token expiration to be a thousand times longer, ie 42 days. As the backend will remove keys when all tokens should have expired, the bug would cause users to still be logged in, but with tokens no longer accepted by the backend (signed by a key no longer stored in the backend)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
