### PR TITLE
core-api: rename BackstageRoutes to FlatRoutes

### DIFF
--- a/.changeset/dull-seals-march.md
+++ b/.changeset/dull-seals-march.md
@@ -3,4 +3,4 @@
 '@backstage/core': patch
 ---
 
-Add `BackstageRoutes` component to replace the top-level `Routes` component from `react-router` within apps, removing the need for manually appending `/*` to paths or sorting routes.
+Add `FlatRoutes` component to replace the top-level `Routes` component from `react-router` within apps, removing the need for manually appending `/*` to paths or sorting routes.

--- a/packages/core-api/src/routing/FlatRoutes.tsx
+++ b/packages/core-api/src/routing/FlatRoutes.tsx
@@ -66,13 +66,11 @@ function createRoutesFromChildren(children: ReactNode): RouteObject[] {
     });
 }
 
-type BackstageRoutesProps = {
+type FlatRoutesProps = {
   children: ReactNode;
 };
 
-export const BackstageRoutes = (
-  props: BackstageRoutesProps,
-): JSX.Element | null => {
+export const FlatRoutes = (props: FlatRoutesProps): JSX.Element | null => {
   const routes = createRoutesFromChildren(props.children);
   return useRoutes(routes);
 };

--- a/packages/core-api/src/routing/index.ts
+++ b/packages/core-api/src/routing/index.ts
@@ -21,6 +21,6 @@ export type {
   ConcreteRoute,
   MutableRouteRef,
 } from './types';
-export { BackstageRoutes } from './BackstageRoutes';
+export { FlatRoutes } from './FlatRoutes';
 export { createRouteRef } from './RouteRef';
 export { useRouteRef } from './hooks';

--- a/packages/dev-utils/src/devApp/render.tsx
+++ b/packages/dev-utils/src/devApp/render.tsx
@@ -30,7 +30,7 @@ import {
   OAuthRequestDialog,
   AnyApiFactory,
   IconComponent,
-  BackstageRoutes,
+  FlatRoutes,
   attachComponentData,
 } from '@backstage/core';
 import SentimentDissatisfiedIcon from '@material-ui/icons/SentimentDissatisfied';
@@ -133,10 +133,10 @@ class DevAppBuilder {
           <AppRouter>
             <SidebarPage>
               {sidebar}
-              <BackstageRoutes>
+              <FlatRoutes>
                 {this.routes}
                 {deprecatedAppRoutes}
-              </BackstageRoutes>
+              </FlatRoutes>
             </SidebarPage>
           </AppRouter>
         </AppProvider>


### PR DESCRIPTION
Feeling that `FlatRoutes` is a lot more descriptive and captures all that we want to do with this component atm