### PR TITLE
Introduce slight bias towards positive trend in cost insights mock data

### DIFF
--- a/plugins/cost-insights/src/utils/mockData.ts
+++ b/plugins/cost-insights/src/utils/mockData.ts
@@ -234,14 +234,24 @@ export function aggregationFor(
     'day',
   );
 
+  function nextDelta(): number {
+    const varianceFromBaseline = 0.15;
+    // Let's give positive vibes in trendlines - higher change for positive delta with >0.5 value
+    const positiveTrendChance = 0.55;
+    const normalization = positiveTrendChance - 1;
+    return baseline * (Math.random() + normalization) * varianceFromBaseline;
+  }
+
   return [...Array(days).keys()].reduce(
     (values: DateAggregation[], i: number): DateAggregation[] => {
       const last = values.length ? values[values.length - 1].amount : baseline;
+      const date = dayjs(inclusiveStartDateOf(duration, endDate))
+        .add(i, 'day')
+        .format(DEFAULT_DATE_FORMAT);
+      const amount = Math.max(0, last + nextDelta());
       values.push({
-        date: dayjs(inclusiveStartDateOf(duration, endDate))
-          .add(i, 'day')
-          .format(DEFAULT_DATE_FORMAT),
-        amount: Math.max(0, last + (baseline / 20) * (Math.random() * 2 - 1)),
+        date: date,
+        amount: amount,
       });
       return values;
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR will make Cost Insights plugin graphs to have slight positive trend instead of complete random.
It also extracts inline constants and adds self-documenting names to them for better readability.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~

This change is probabilistic, so making stable tests are not easy. I'm open for suggestion.

- [ ] Screenshots attached (for UI changes)

![image](https://user-images.githubusercontent.com/3862294/103208849-ed4d6780-4901-11eb-8708-516e3e47b2e2.png)

