### PR TITLE
Use `yarn --cwd` parameter instead of `cd` pattern for exampls in documentation

### DIFF
--- a/docs/auth/add-auth-provider.md
+++ b/docs/auth/add-auth-provider.md
@@ -27,9 +27,8 @@ suitable framework if needed.
 ### Installing the dependencies:
 
 ```bash
-cd plugins/auth-backend
-yarn add passport-provider-a
-yarn add @types/passport-provider-a
+yarn --cwd plugins/auth-backend add passport-provider-a
+yarn --cwd plugins/auth-backend add @types/passport-provider-a
 ```
 
 ### Create implementation

--- a/docs/features/software-catalog/installation.md
+++ b/docs/features/software-catalog/installation.md
@@ -17,8 +17,7 @@ The catalog frontend plugin should be installed in your `app` package, which is
 created as a part of `@backstage/create-app`. To install the package, run:
 
 ```bash
-cd packages/app
-yarn add @backstage/plugin-catalog
+yarn --cwd packages/app add @backstage/plugin-catalog
 ```
 
 Make sure the version of `@backstage/plugin-catalog` matches the version of
@@ -82,8 +81,7 @@ The catalog backend should be installed in your `backend` package, which is
 created as a part of `@backstage/create-app`. To install the package, run:
 
 ```bash
-cd packages/backend
-yarn add @backstage/plugin-catalog-backend
+yarn --cwd packages/backend add @backstage/plugin-catalog-backend
 ```
 
 Make sure the version of `@backstage/plugin-catalog-backend` matches the version
@@ -190,8 +188,7 @@ catalog:
 Finally, start up the backend with the new configuration:
 
 ```bash
-cd packages/backend
-yarn start
+yarn --cwd packages/backend start
 ```
 
 If you've also set up the frontend plugin, so you should be ready to go browse

--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -20,8 +20,7 @@ The scaffolder frontend plugin should be installed in your `app` package, which
 is created as a part of `@backstage/create-app`. To install the package, run:
 
 ```bash
-cd packages/app
-yarn add @backstage/plugin-scaffolder
+yarn --cwd packages/app add @backstage/plugin-scaffolder
 ```
 
 Make sure the version of `@backstage/plugin-scaffolder` matches the version of
@@ -67,8 +66,7 @@ The scaffolder backend should be installed in your `backend` package, which is
 created as a part of `@backstage/create-app`. To install the package, run:
 
 ```bash
-cd packages/backend
-yarn add @backstage/plugin-scaffolder-backend
+yarn --cwd packages/backend add @backstage/plugin-scaffolder-backend
 ```
 
 Make sure the version of `@backstage/plugin-scaffolder-backend` matches the
@@ -232,8 +230,7 @@ Finally, make sure you have a local Docker daemon running, and start up the
 backend with the new configuration:
 
 ```bash
-cd packages/backend
-GITHUB_TOKEN=<token> yarn start
+GITHUB_TOKEN=<token> yarn --cwd packages/backend start
 ```
 
 If you've also set up the frontend plugin, so you should be ready to go browse

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -23,8 +23,7 @@ Navigate to your new Backstage application directory. And then to your
 
 ```bash
 cd my-backstage-app/
-cd packages/app
-yarn add @backstage/plugin-techdocs
+yarn --cwd packages/app add @backstage/plugin-techdocs
 ```
 
 Once the package has been installed, you need to import the plugin in your app.
@@ -62,8 +61,7 @@ Navigate to `packages/backend` of your Backstage app, and install the
 
 ```bash
 cd my-backstage-app/
-cd packages/backend
-yarn add @backstage/plugin-techdocs-backend
+yarn --cwd packages/backend add @backstage/plugin-techdocs-backend
 ```
 
 Create a file called `techdocs.ts` inside `packages/backend/src/plugins/` and

--- a/docs/getting-started/running-backstage-locally.md
+++ b/docs/getting-started/running-backstage-locally.md
@@ -61,8 +61,7 @@ terminal windows, both starting from the Backstage project root.
 In the first window, run
 
 ```bash
-cd packages/backend
-yarn start
+yarn --cwd packages/backend start
 ```
 
 That starts up a backend instance on port 7000.

--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -131,11 +131,10 @@ The secret value will then be displayed on the screen. **You will not be able to
 #### Starting the Auth Backend
 
 ```bash
-cd packages/backend
 export AUTH_MICROSOFT_CLIENT_ID=x
 export AUTH_MICROSOFT_CLIENT_SECRET=x
 export AUTH_MICROSOFT_TENANT_ID=x
-yarn start
+yarn --cwd packages/backend start
 ```
 
 ### SAML

--- a/plugins/catalog-backend/README.md
+++ b/plugins/catalog-backend/README.md
@@ -18,9 +18,8 @@ most convenient when developing the catalog backend plugin itself.
 To evaluate the catalog and have a greater amount of functionality available, instead do
 
 ```bash
-# in one terminal window, run this from from the very root of the Backstage project
-cd packages/backend
-yarn start
+# in one terminal window, run this from the very root of the Backstage project
+yarn --cwd packages/backend start
 ```
 
 This will launch the full example backend, populated some example entities.

--- a/plugins/techdocs-backend/README.md
+++ b/plugins/techdocs-backend/README.md
@@ -11,9 +11,8 @@ most convenient when developing the techdocs backend plugin itself.
 To evaluate TechDocs and have a greater amount of functionality available, instead do
 
 ```bash
-# in one terminal window, run this from from the very root of the Backstage project
-cd packages/backend
-yarn start
+# in one terminal window, run this from the very root of the Backstage project
+yarn --cwd packages/backend start
 ```
 
 ## What techdocs-backend does


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I think it is considered a good practice to use --cwd parameter and staying in project root, instead of changing working directory.
If this is not the case, we can close PR... :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [x] Added or updated documentation
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
