### PR TITLE
fix(scaffolder): Allow user to retry creating new component without having to reload the page

### DIFF
--- a/.changeset/famous-shrimps-double.md
+++ b/.changeset/famous-shrimps-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Bug fix: User can retry creating a new component if an error occurs, without having to reload the page.

--- a/plugins/scaffolder/src/components/JobStatusModal/JobStatusModal.tsx
+++ b/plugins/scaffolder/src/components/JobStatusModal/JobStatusModal.tsx
@@ -23,18 +23,23 @@ import {
   LinearProgress,
 } from '@material-ui/core';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { Job } from '../../types';
 import { JobStage } from '../JobStage/JobStage';
 
 type Props = {
   job: Job | null;
   toCatalogLink?: string;
+  open: boolean;
+  setOpen: (newState: boolean) => void;
 };
 
-export const JobStatusModal = ({ job, toCatalogLink }: Props) => {
-  const [isOpen, setOpen] = useState(true);
-
+export const JobStatusModal = ({
+  job,
+  toCatalogLink,
+  open,
+  setOpen,
+}: Props) => {
   const renderTitle = () => {
     switch (job?.status) {
       case 'COMPLETED':
@@ -47,16 +52,17 @@ export const JobStatusModal = ({ job, toCatalogLink }: Props) => {
   };
 
   const onClose = useCallback(() => {
+    setOpen(false);
     if (!job) {
       return;
     }
     if (job.status === 'COMPLETED' || job.status === 'FAILED') {
       setOpen(false);
     }
-  }, [job]);
+  }, [job, setOpen]);
 
   return (
-    <Dialog open={isOpen} onClose={onClose} fullWidth>
+    <Dialog open={open} onClose={onClose} fullWidth>
       <DialogTitle id="responsive-dialog-title">{renderTitle()}</DialogTitle>
       <DialogContent>
         {!job ? (

--- a/plugins/scaffolder/src/components/JobStatusModal/JobStatusModal.tsx
+++ b/plugins/scaffolder/src/components/JobStatusModal/JobStatusModal.tsx
@@ -31,14 +31,14 @@ type Props = {
   job: Job | null;
   toCatalogLink?: string;
   open: boolean;
-  setOpen: (newState: boolean) => void;
+  onModalClose: () => void;
 };
 
 export const JobStatusModal = ({
   job,
   toCatalogLink,
   open,
-  setOpen,
+  onModalClose,
 }: Props) => {
   const renderTitle = () => {
     switch (job?.status) {
@@ -52,14 +52,14 @@ export const JobStatusModal = ({
   };
 
   const onClose = useCallback(() => {
-    setOpen(false);
     if (!job) {
       return;
     }
+    // Disallow closing modal if the job is in progress.
     if (job.status === 'COMPLETED' || job.status === 'FAILED') {
-      setOpen(false);
+      onModalClose();
     }
-  }, [job, setOpen]);
+  }, [job, onModalClose]);
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth>
@@ -87,7 +87,7 @@ export const JobStatusModal = ({
       )}
       {job?.status === 'FAILED' && (
         <DialogActions>
-          <Action onClick={() => setOpen(false)}>Close</Action>
+          <Action onClick={onClose}>Close</Action>
         </DialogActions>
       )}
     </Dialog>

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -161,7 +161,12 @@ export const TemplatePage = () => {
       />
       <Content>
         {loading && <LinearProgress data-testid="loading-progress" />}
-        {modalOpen && <JobStatusModal job={job} toCatalogLink={catalogLink} />}
+        <JobStatusModal
+          job={job}
+          toCatalogLink={catalogLink}
+          open={modalOpen}
+          setOpen={setModalOpen}
+        />
         {template && (
           <InfoCard title={template.metadata.title} noPadding>
             <MultistepJsonForm

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -165,7 +165,7 @@ export const TemplatePage = () => {
           job={job}
           toCatalogLink={catalogLink}
           open={modalOpen}
-          setOpen={setModalOpen}
+          onModalClose={() => setModalOpen(false)}
         />
         {template && (
           <InfoCard title={template.metadata.title} noPadding>

--- a/plugins/scaffolder/src/components/hooks/useJobPolling.ts
+++ b/plugins/scaffolder/src/components/hooks/useJobPolling.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Job } from '../../types';
 import { useApi } from '@backstage/core';
 import { scaffolderApiRef } from '../../api';
@@ -28,10 +28,23 @@ export const useJobPolling = (
 ) => {
   const scaffolderApi = useApi(scaffolderApiRef);
   const [currentJob, setCurrentJob] = useState<Job | null>(null);
+
+  useEffect(() => {
+    const resetCurrentJob = async () => {
+      if (jobId) {
+        const job = await scaffolderApi.getJob(jobId);
+        setCurrentJob(job);
+      }
+    };
+
+    resetCurrentJob();
+  }, [jobId, scaffolderApi]);
+
   const shouldBeRunningInterval =
     jobId &&
     currentJob?.status !== 'COMPLETED' &&
     currentJob?.status !== 'FAILED';
+
   useInterval(
     async () => {
       if (jobId) {


### PR DESCRIPTION
# Problem

![output](https://user-images.githubusercontent.com/8065913/103248402-c24b2e00-496a-11eb-9cc7-a0cdea60447a.gif)

(30 seconds GIF)

If the job of creating a new component fails due to some reason and if the user wants to retry, the "Submit" button does not work. Even after doing a "Reset", the "Submit" button is unresponsive.

# How to Reproduce

A simple way to encounter a failed job scenario might be closing docker application and trying to create a new component.

# Technical issue (and fix)

Underneath the UI, the "Submit" button _does_ actually create a new job. There are two problems - New modal doesn't show up and the Polling mechanism doesn't pick up the new job ID.

1. When the user clicks the `Close` button on the `JobStatusModal`, it does not set the `modalOpen` state of its parent component. Thus, even after closing, `JobStatusModal` still persists in the DOM, and `modalOpen` is still set to `true`. That is why, retrying by clicking on "Submit" again does not reopen the modal.

2. The `useJobPolling` hook does not consider restarting the timer again when the `job` changes. Even if `jobId` is set to the new value, the logic to set `shouldBeRunningInterval` still uses a previous value of `currentJob` since it is not being reset after the timer stops. Using an effect hook and having `jobId` as a dependency to reset `currentJob` is the way to fix this.

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
