### PR TITLE
fix(create-app): Add missing `yarn clean` for frontend

### DIFF
--- a/.changeset/eight-experts-visit.md
+++ b/.changeset/eight-experts-visit.md
@@ -1,0 +1,13 @@
+---
+'@backstage/create-app': patch
+---
+
+Add missing `yarn clean` for app.
+
+For users with existing Backstage installations, add the following under the `scripts` section in `packages/app/package.json`, after the "lint" entry:
+
+```json
+"clean": "backstage-cli clean",
+```
+
+This will add the missing `yarn clean` for the generated frontend.

--- a/packages/create-app/templates/default-app/packages/app/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/app/package.json.hbs
@@ -46,6 +46,7 @@
     "build": "backstage-cli app:build",
     "test": "backstage-cli test",
     "lint": "backstage-cli lint",
+    "clean": "backstage-cli clean",
     "test:e2e": "cross-env PORT=3001 start-server-and-test start http://localhost:3001 cy:dev",
     "test:e2e:ci": "cross-env PORT=3001 start-server-and-test start http://localhost:3001 cy:run",
     "cy:dev": "cypress open",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The `yarn clean` for the generated Backstage app omits cleaning the frontend app.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
