### PR TITLE
feat(plugin-auth-backend): Support core Passport-SAML configuration

### DIFF
--- a/.changeset/flat-suns-call.md
+++ b/.changeset/flat-suns-call.md
@@ -1,0 +1,17 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Add support for the majority of the Core configurations for Passport-SAML.
+
+These configuration keys are supported:
+
+- entryPoint
+- issuer
+- cert
+- privateKey
+- decryptionPvk
+- signatureAlgorithm
+- digestAlgorithm
+
+As part of this change, there is also a fix to the redirection behaviour when doing load balancing and HTTPS termination - the application's baseUrl is used to generate the callback URL. For properly configured Backstage installations, no changes are necessary, and the baseUrl is respected.

--- a/docs/auth/auth-backend-classes.md
+++ b/docs/auth/auth-backend-classes.md
@@ -61,6 +61,19 @@ If your authentication provider is any of the above mentioned providers, you can
 configure them by setting the right variables in `app-config.yaml` under the
 `auth` section.
 
+### SAML
+
+The SAML Provider is currently under development. Additional validation and
+profile handling is still required before use in production.
+
+To configure the SAML Auth provider, look at the configuration parameters
+supported by
+[Passport-SAML](https://github.com/node-saml/passport-saml#config-parameter-details)
+under the `auth.providers.saml` key
+
+For security reasons, validate that the response from the IdP is indeed signed
+by also providing the `cert` configuration.
+
 ### Configuration
 
 Each authentication provider (except SAML) needs five parameters: an OAuth
@@ -96,6 +109,11 @@ auth:
       development:
         clientId:
           $env:
+    saml:
+      entryPoint:
+        $env: AUTH_SAML_ENTRY_POINT
+      issuer:
+        $env: AUTH_SAML_ISSUER
             ...
 ```
 

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -47,6 +47,11 @@ export interface Config {
       saml?: {
         entryPoint: string;
         issuer: string;
+        cert?: string;
+        privateKey?: string;
+        decryptionPvk?: string;
+        signatureAlgorithm?: 'sha1' | 'sha256' | 'sha512';
+        digestAlgorithm?: string;
       };
       okta?: {
         development: { [key: string]: string };

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -58,7 +58,7 @@
     "passport-oauth2": "^1.5.0",
     "passport-okta-oauth": "^0.0.1",
     "passport-onelogin-oauth": "^0.0.1",
-    "passport-saml": "^1.3.3",
+    "passport-saml": "^1.3.5, <1.4.0",
     "uuid": "^8.0.0",
     "winston": "^3.2.1",
     "yn": "^4.0.0"

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -16,6 +16,7 @@
 
 import express from 'express';
 import {
+  SamlConfig,
   Strategy as SamlStrategy,
   Profile as SamlProfile,
   VerifyWithoutRequest,
@@ -112,13 +113,12 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
   }
 }
 
-type SAMLProviderOptions = {
-  entryPoint: string;
-  issuer: string;
-  path: string;
+type SAMLProviderOptions = SamlConfig & {
   tokenIssuer: TokenIssuer;
   appUrl: string;
 };
+
+type SignatureAlgorithm = 'sha1' | 'sha256' | 'sha512';
 
 export const createSamlProvider: AuthProviderFactory = ({
   providerId,
@@ -126,13 +126,18 @@ export const createSamlProvider: AuthProviderFactory = ({
   config,
   tokenIssuer,
 }) => {
-  const url = new URL(globalConfig.baseUrl);
-  const entryPoint = config.getString('entryPoint');
-  const issuer = config.getString('issuer');
   const opts = {
-    entryPoint,
-    issuer,
-    path: `${url.pathname}/${providerId}/handler/frame`,
+    callbackUrl: `${globalConfig.baseUrl}/${providerId}/handler/frame`,
+    entryPoint: config.getString('entryPoint'),
+    issuer: config.getString('issuer'),
+    cert: config.getOptionalString('cert'),
+    privateCert: config.getOptionalString('privateKey'),
+    decryptionPvk: config.getOptionalString('decryptionPvk'),
+    signatureAlgorithm: config.getOptionalString('signatureAlgorithm') as
+      | SignatureAlgorithm
+      | undefined,
+    digestAlgorithm: config.getOptionalString('digestAlgorithm'),
+
     tokenIssuer,
     appUrl: globalConfig.appUrl,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -19055,16 +19055,16 @@ passport-onelogin-oauth@^0.0.1:
     pkginfo "0.2.x"
     uid2 "0.0.3"
 
-passport-saml@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/passport-saml/-/passport-saml-1.3.3.tgz#cbea1a2b21ff32b3bc4bfd84dc39c3a370df9935"
-  integrity sha512-54ecY/A6UEsyCehJws6a+J6THvwtYnGl9cnAUxx5DjsuKgZrDs0tSy58K4hCk1XG/LOcdQSF1TR3xlRXgTULhA==
+"passport-saml@^1.3.5, <1.4.0":
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/passport-saml/-/passport-saml-1.3.5.tgz#747f2c8bb8b9fed41e8cd14586df5aa83e8a8996"
+  integrity sha512-HFamiqgGiMRCbUBm3wx02WYWKb6ojke0WJHrg4QXI8tx35HrTmDiY8MksUXhouJtEkfcRwXjBL2cSEpRQ6+PgQ==
   dependencies:
     debug "^3.1.0"
     passport-strategy "*"
     q "^1.5.0"
     xml-crypto "^1.4.0"
-    xml-encryption "^1.0.0"
+    xml-encryption "1.2.1"
     xml2js "0.4.x"
     xmlbuilder "^11.0.0"
     xmldom "0.1.x"
@@ -25236,7 +25236,7 @@ xml-crypto@^1.4.0:
     xmldom "0.1.27"
     xpath "0.0.27"
 
-xml-encryption@^1.0.0:
+xml-encryption@1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.2.1.tgz#e6d18817c4309fd07ca7793cca93c3fd06745baa"
   integrity sha512-hn5w3l5p2+nGjlmM0CAhMChDzVGhW+M37jH35Z+GJIipXbn9PUlAIRZ6I5Wm7ynlqZjFrMAr83d/CIp9VZJMTA==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes backstage/backstage#3326

This adds majority of the core [Passport-SAML configuration](https://github.com/node-saml/passport-saml#config-parameter-details) as well as a short note on how to use the (still not production-ready) SAML provider.

As part of this change, there is also a fix to the redirection behaviour when doing load balancing and HTTPS termination - the application's baseUrl is used to generate the callback URL. For properly configured Backstage installations, no changes are necessary, and the baseUrl is respected.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
