### PR TITLE
backend-common: include extra fields on dev log formatter

### DIFF
--- a/.changeset/mighty-plums-wave.md
+++ b/.changeset/mighty-plums-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Tweaked development log formatter to include extra fields at the end of each log line

--- a/packages/backend-common/src/logging/formats.ts
+++ b/packages/backend-common/src/logging/formats.ts
@@ -17,19 +17,23 @@ import * as winston from 'winston';
 import { TransformableInfo } from 'logform';
 
 const coloredTemplate = (info: TransformableInfo) => {
-  const { timestamp, level, message, plugin, service } = info;
+  const { timestamp, level, message, plugin, service, ...fields } = info;
   const colorizer = winston.format.colorize();
   const prefix = plugin || service;
   const timestampColor = colorizer.colorize('timestamp', timestamp);
   const prefixColor = colorizer.colorize('prefix', prefix);
 
-  return `${timestampColor} ${prefixColor} ${level} ${message}`;
+  const extraFields = Object.entries(fields)
+    .map(([key, value]) => `${colorizer.colorize('field', `${key}`)}=${value}`)
+    .join(' ');
+
+  return `${timestampColor} ${prefixColor} ${level} ${message} ${extraFields}`;
 };
 
 export const coloredFormat = winston.format.combine(
   winston.format.timestamp(),
   winston.format.colorize({
-    colors: { timestamp: 'dim', prefix: 'blue' },
+    colors: { timestamp: 'dim', prefix: 'blue', field: 'cyan' },
   }),
   winston.format.printf(coloredTemplate),
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Opening this up for debate. Any extra log fields are currently hidden in development, but adding them makes the log a bit more busy

![image](https://user-images.githubusercontent.com/4984472/103278805-a7a9a100-49cc-11eb-8647-21d721d93f52.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
