### PR TITLE
workflows: use service account for pushing tag in master build

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: Klemensas/action-autotag@1.2.3
         if: matrix.node-version == '12.x'
         with:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}'
           package_root: 'packages/core'
           tag_prefix: 'v'
 


### PR DESCRIPTION
The GitHub release workflow isn't being triggered because of the workflow recursion protection. Using an SA token should allow the release workflow to be triggered properly