### PR TITLE
catalog-backend: unbreak sqlite in create-app repos

### DIFF
--- a/plugins/catalog-backend/migrations/20200702153613_entities.js
+++ b/plugins/catalog-backend/migrations/20200702153613_entities.js
@@ -20,16 +20,14 @@
  * @param {import('knex')} knex
  */
 exports.up = async function up(knex) {
-  // Drop constraints (Postgres)
-  try {
+  // SQLite does not support FK and PK
+  if (knex.client.config.client !== 'sqlite3') {
     await knex.schema.alterTable('entities_search', table => {
       table.dropForeign(['entity_id']);
     });
     await knex.schema.alterTable('entities', table => {
       table.dropPrimary('entities_pkey');
     });
-  } catch (e) {
-    // SQLite does not support FK and PK, carry on
   }
   await knex.schema.alterTable('entities', table => {
     table.dropUnique([], 'entities_unique_name');
@@ -131,16 +129,14 @@ exports.up = async function up(knex) {
  * @param {import('knex')} knex
  */
 exports.down = async function down(knex) {
-  // Drop constraints (Postgres)
-  try {
+  // SQLite does not support FK and PK
+  if (knex.client.config.client !== 'sqlite3') {
     await knex.schema.alterTable('entities_search', table => {
       table.dropForeign(['entity_id']);
     });
     await knex.schema.alterTable('entities', table => {
       table.dropPrimary('entities_pkey');
     });
-  } catch (e) {
-    // SQLite does not support FK and PK, carry on
   }
   await knex.schema.alterTable('entities', table => {
     table.dropUnique([], 'entities_unique_name');

--- a/plugins/catalog-backend/migrations/20200807120600_entitySearch.js
+++ b/plugins/catalog-backend/migrations/20200807120600_entitySearch.js
@@ -20,12 +20,11 @@
  * @param {import('knex')} knex
  */
 exports.up = async function up(knex) {
-  try {
+  // Sqlite does not support alter column.
+  if (knex.client.config.client !== 'sqlite3') {
     await knex.schema.alterTable('entities_search', table => {
       table.text('value').nullable().alter();
     });
-  } catch (e) {
-    // Sqlite does not support alter column.
   }
 };
 
@@ -33,11 +32,10 @@ exports.up = async function up(knex) {
  * @param {import('knex')} knex
  */
 exports.down = async function down(knex) {
-  try {
+  // Sqlite does not support alter column.
+  if (knex.client.config.client !== 'sqlite3') {
     await knex.schema.alterTable('entities_search', table => {
       table.string('value').nullable().alter();
     });
-  } catch (e) {
-    // Sqlite does not support alter column.
   }
 };

--- a/plugins/catalog-backend/migrations/20201005122705_add_entity_full_name.js
+++ b/plugins/catalog-backend/migrations/20201005122705_add_entity_full_name.js
@@ -30,12 +30,11 @@ exports.up = async function up(knex) {
     ),
   });
 
-  try {
+  // SQLite does not support alter column
+  if (knex.client.config.client !== 'sqlite3') {
     await knex.schema.alterTable('entities', table => {
       table.text('full_name').notNullable().alter();
     });
-  } catch (e) {
-    // SQLite does not support alter column, ignore
   }
 
   await knex.schema.alterTable('entities', table => {

--- a/plugins/catalog-backend/migrations/20201006130744_entity_data_column.js
+++ b/plugins/catalog-backend/migrations/20201006130744_entity_data_column.js
@@ -40,10 +40,7 @@ exports.up = async function up(knex) {
     table.dropColumn('spec');
   });
 
-  // SQLite does not support ALTER COLUMN. Note that we do not use the try/
-  // catch method as in other migrations, because if the transaction is
-  // partially failed, it will further mess up the already messed-up
-  // statement below this.
+  // SQLite does not support ALTER COLUMN.
   if (knex.client.config.client !== 'sqlite3') {
     await knex.schema.alterTable('entities', table => {
       table.text('data').notNullable().alter();


### PR DESCRIPTION
Fixes an issue where newly create-app created repos won't start up on the SQLite driver, because the migrations claim that an index unexpectedly does not exist.

```
migration file "20200702153613_entities.js" failed
migration failed with error: create unique index `entities_unique_name` on `entities` (`kind`, `name`, `namespace`) - SQLITE_ERROR: index entities_unique_name already exists
Backend failed to start up [Error: create unique index `entities_unique_name` on `entities` (`kind`, `name`, `namespace`) - SQLITE_ERROR: index entities_unique_name already exists] {
  errno: 1,
  code: 'SQLITE_ERROR'
}
```

I'm honestly still surprised that this occurred. The problem does not manifest itself in the core repo, only in newly created separate repos, and only since recently. The migration file in question is many months old and has always worked. What happens is, as sqlite issues a `dropPrimary('entities_pkey')`, the `entities_unique_name` index ALSO disappears. But only under some unknown circumstances. Maybe the transaction is somehow broken already since some earlier, silent error?

@Rugvip noted that the bindings chosen by the sqlite package changed compared to what the internal repo used, but that's as far as we got.

In any case, rewriting the migrations to use the explicit client check makes things both unbroken, as well as more sane.