### PR TITLE
backend-common: remove deprecated HTTPS config

### DIFF
--- a/.changeset/wise-mice-invite.md
+++ b/.changeset/wise-mice-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': minor
+---
+
+Remove support for HTTPS certificate generation parameters. Use `backend.https = true` instead.

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -41,31 +41,16 @@ export interface Config {
     https?:
       | true
       | {
-          /**
-           * Certificate configuration or parameters for generating a self-signed certificate
-           *
-           * Setting parameters for self-signed certificates is deprecated and will be removed in
-           * the future, set `backend.https = true` instead.
-           */
-          certificate?:
-            | {
-                /** Algorithm to use to generate a self-signed certificate */
-                algorithm?: string;
-                keySize?: number;
-                days?: number;
-                attributes: {
-                  commonName: string;
-                };
-              }
-            | {
-                /** PEM encoded certificate. Use $file to load in a file */
-                cert: string;
-                /**
-                 * PEM encoded certificate key. Use $file to load in a file.
-                 * @visibility secret
-                 */
-                key: string;
-              };
+          /** Certificate configuration */
+          certificate?: {
+            /** PEM encoded certificate. Use $file to load in a file */
+            cert: string;
+            /**
+             * PEM encoded certificate key. Use $file to load in a file.
+             * @visibility secret
+             */
+            key: string;
+          };
         };
 
     /** Database connection configuration, select database type using the `client` field */

--- a/packages/backend-common/src/service/lib/config.ts
+++ b/packages/backend-common/src/service/lib/config.ts
@@ -22,23 +22,8 @@ export type BaseOptions = {
   listenHost?: string;
 };
 
-export type CertificateOptions = {
-  key?: CertificateKeyOptions;
-  attributes?: CertificateAttributeOptions;
-};
-
-export type CertificateKeyOptions = {
-  size?: number;
-  algorithm?: string;
-  days?: number;
-};
-
-export type CertificateAttributeOptions = {
-  commonName?: string;
-};
-
 export type HttpsSettings = {
-  certificate: CertificateSigningOptions | CertificateReferenceOptions;
+  certificate: CertificateGenerationOptions | CertificateReferenceOptions;
 };
 
 export type CertificateReferenceOptions = {
@@ -46,11 +31,8 @@ export type CertificateReferenceOptions = {
   cert: string;
 };
 
-export type CertificateSigningOptions = {
-  algorithm?: string;
-  size?: number;
-  days?: number;
-  attributes: CertificateAttributes;
+export type CertificateGenerationOptions = {
+  hostname: string;
 };
 
 export type CertificateAttributes = {
@@ -196,20 +178,14 @@ export function readHttpsSettings(config: Config): HttpsSettings | undefined {
   const https = config.get('https');
   if (https === true) {
     const baseUrl = config.getString('baseUrl');
-    let commonName;
+    let hostname;
     try {
-      commonName = new URL(baseUrl).hostname;
+      hostname = new URL(baseUrl).hostname;
     } catch (error) {
       throw new Error(`Invalid backend.baseUrl "${baseUrl}"`);
     }
 
-    return {
-      certificate: {
-        attributes: {
-          commonName,
-        },
-      },
-    };
+    return { certificate: { hostname } };
   }
 
   const cc = config.getOptionalConfig('https');


### PR DESCRIPTION
Followup for #3885, removing the deprecated config format

Not too picky as stability index is at 1, but let's still merge on Jan 20th to avoid breakages.