### PR TITLE
create-app: removed lighthouse plugin from default template

### DIFF
--- a/.changeset/twenty-llamas-sin.md
+++ b/.changeset/twenty-llamas-sin.md
@@ -1,0 +1,12 @@
+---
+'@backstage/create-app': patch
+---
+
+Removed lighthouse plugin from the default set up plugins, as it requires a separate Backend to function.
+
+To apply this change to an existing app, remove the following:
+
+1. The `lighthouse` block from `app-config.yaml`.
+2. The `@backstage/plugin-lighthouse` dependency from `packages/app/package.json`.
+3. The `@backstage/plugin-lighthouse` re-export from `packages/app/src/plugins.ts`.
+4. The Lighthouse sidebar item from `packages/app/src/sidebar.tsx`, and the `RuleIcon` import if it is unused.

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -65,9 +65,6 @@ techdocs:
   publisher:
     type: 'local'
 
-lighthouse:
-  baseUrl: http://localhost:3003
-
 auth:
   # see https://backstage.io/docs/tutorials/quickstart-app-auth to know more about enabling auth providers
   providers: {}

--- a/packages/create-app/templates/default-app/packages/app/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/app/package.json.hbs
@@ -15,7 +15,6 @@
     "@backstage/plugin-techdocs": "^{{version '@backstage/plugin-techdocs'}}",
     "@backstage/catalog-model": "^{{version '@backstage/catalog-model'}}",
     "@backstage/plugin-circleci": "^{{version '@backstage/plugin-circleci'}}",
-    "@backstage/plugin-lighthouse": "^{{version '@backstage/plugin-lighthouse'}}",
     "@backstage/plugin-tech-radar": "^{{version '@backstage/plugin-tech-radar'}}",
     "@backstage/plugin-github-actions": "^{{version '@backstage/plugin-github-actions'}}",
     "@backstage/plugin-user-settings": "^{{version '@backstage/plugin-user-settings'}}",

--- a/packages/create-app/templates/default-app/packages/app/src/plugins.ts
+++ b/packages/create-app/templates/default-app/packages/app/src/plugins.ts
@@ -3,7 +3,6 @@ export { plugin as CatalogPlugin } from '@backstage/plugin-catalog';
 export { plugin as CatalogImport } from '@backstage/plugin-catalog-import';
 export { plugin as Circleci } from '@backstage/plugin-circleci';
 export { plugin as GithubActions } from '@backstage/plugin-github-actions';
-export { plugin as LighthousePlugin } from '@backstage/plugin-lighthouse';
 export { plugin as ScaffolderPlugin } from '@backstage/plugin-scaffolder';
 export { plugin as TechDocsPlugin } from '@backstage/plugin-techdocs';
 export { plugin as TechRadar } from '@backstage/plugin-tech-radar';

--- a/packages/create-app/templates/default-app/packages/app/src/sidebar.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/sidebar.tsx
@@ -4,7 +4,6 @@ import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import ExtensionIcon from '@material-ui/icons/Extension';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import BuildIcon from '@material-ui/icons/BuildRounded';
-import RuleIcon from '@material-ui/icons/AssignmentTurnedIn';
 import MapIcon from '@material-ui/icons/MyLocation';
 import { Link, makeStyles } from '@material-ui/core';
 import { NavLink } from 'react-router-dom';
@@ -34,7 +33,6 @@ export const AppSidebar = () => (
     <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
     <SidebarDivider />
     <SidebarItem icon={MapIcon} to="tech-radar" text="Tech Radar" />
-    <SidebarItem icon={RuleIcon} to="lighthouse" text="Lighthouse" />
     <SidebarItem icon={BuildIcon} to="circleci" text="CircleCI" />
     {/* End global nav */}
     <SidebarDivider />


### PR DESCRIPTION
Worth having the lighthouse plugin in the default set since it requires a separate backend to be spun up? :grin: