### PR TITLE
create-app: removed the CircleCI sidebar item, since the target page doesn't exist

### DIFF
--- a/.changeset/short-ravens-complain.md
+++ b/.changeset/short-ravens-complain.md
@@ -1,0 +1,7 @@
+---
+'@backstage/create-app': patch
+---
+
+Removed the Circle CI sidebar item, since the target page does not exist.
+
+To apply this change to an existing app, remove `"CircleCI"` sidebar item from `packages/app/src/sidebar.tsx`, and the `BuildIcon` import if it is unused.

--- a/packages/create-app/templates/default-app/packages/app/src/sidebar.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/sidebar.tsx
@@ -3,7 +3,6 @@ import HomeIcon from '@material-ui/icons/Home';
 import LibraryBooks from '@material-ui/icons/LibraryBooks';
 import ExtensionIcon from '@material-ui/icons/Extension';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
-import BuildIcon from '@material-ui/icons/BuildRounded';
 import MapIcon from '@material-ui/icons/MyLocation';
 import { Link, makeStyles } from '@material-ui/core';
 import { NavLink } from 'react-router-dom';
@@ -33,7 +32,6 @@ export const AppSidebar = () => (
     <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
     <SidebarDivider />
     <SidebarItem icon={MapIcon} to="tech-radar" text="Tech Radar" />
-    <SidebarItem icon={BuildIcon} to="circleci" text="CircleCI" />
     {/* End global nav */}
     <SidebarDivider />
     <SidebarSpace />


### PR DESCRIPTION
There's no top-level CircleCI page anymore right? Just the entity page content