### PR TITLE
cli: Add backend:bundle

### DIFF
--- a/.changeset/nasty-colts-tell.md
+++ b/.changeset/nasty-colts-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add `backend:bundle` command for bundling a backend package with dependencies into a deployment archive.

--- a/packages/cli/src/commands/backend/bundle.ts
+++ b/packages/cli/src/commands/backend/bundle.ts
@@ -38,7 +38,7 @@ export default async (cmd: Command) => {
   try {
     await createDistWorkspace([pkg.name], {
       targetDir: tmpDir,
-      buildDependencies: Boolean(cmd.build),
+      buildDependencies: Boolean(cmd.buildDependencies),
       buildExcludes: [pkg.name],
       parallel: parseParallel(process.env[PARALLEL_ENV_VAR]),
       skeleton: SKELETON_FILE,

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -45,9 +45,12 @@ export function registerCommands(program: CommanderStatic) {
     .action(lazy(() => import('./backend/build').then(m => m.default)));
 
   program
-    .command('backend:__experimental__bundle__', { hidden: true })
-    .description('Bundle all backend packages into dist-workspace')
-    .option('--build', 'Build packages before packing them into the image')
+    .command('backend:bundle')
+    .description('Bundle the backend into a deployment archive')
+    .option(
+      '--build-dependencies',
+      'Build all local package dependencies before bundling the backend',
+    )
     .action(lazy(() => import('./backend/bundle').then(m => m.default)));
 
   program


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #3347

Have been experimenting with this command for a couple of releases, and feeling happy with this version of it :grin:

Added docs, but it doesn't deprecate the `backend:build-image` command yet, but that's the intention.

To replicate `backend:build-image`, you'd use `yarn workspace backend build --build dependencies && docker image build -f packages/backend/Dockerfile` in a root script, or the same in a backend package script, but with the docker build context set to the package root.

I'm thinking we'd ship this and gather feedback on the command before we go through and replace it in all templates etc.

There's a host-assisted Dockerfile example in the docs, but here's an example of a multi-stage builds that executes all steps within docker and caches both `yarn install` steps:

```Dockerfile
# Stage 1 - Create yarn install skeleton layer
FROM node:14-buster AS packages

WORKDIR /app
COPY package.json yarn.lock ./
COPY packages packages
COPY plugins plugins

RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf

# Stage 2 - Install dependencies and build packages
FROM node:14-buster AS build

WORKDIR /app
COPY --from=packages /app .

RUN yarn install --network-timeout 600000 && rm -rf "$(yarn cache dir)"

COPY . .

RUN yarn tsc
RUN yarn --cwd packages/backend backstage-cli backend:bundle --build-dependencies

# Stage 3 - Build the actual backend image and install production dependencies
FROM node:14-buster

WORKDIR /app

# Copy from build stage
COPY --from=build /app/yarn.lock /app/package.json /app/packages/backend/dist/skeleton.tar.gz ./
RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz

RUN yarn install --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"

COPY --from=build /app/packages/backend/dist/bundle.tar.gz .
RUN tar xzf bundle.tar.gz && rm bundle.tar.gz

COPY app-config.yaml app-config.production.yaml ./

CMD ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.production.yaml"]
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
