### PR TITLE
Config: Add $include which replaces $data and can include any value

### DIFF
--- a/.changeset/friendly-numbers-accept.md
+++ b/.changeset/friendly-numbers-accept.md
@@ -1,0 +1,20 @@
+---
+'@backstage/config-loader': patch
+---
+
+Deprecate `$data` and replace it with `$include` which allows for any type of json value to be read from external files. In addition, `$include` can be used without a path, which causes the value at the root of the file to be loaded.
+
+Most usages of `$data` can be directly replaced with `$include`, expect for if the referenced value is not a string, in which case the value needs to be changed. For example:
+
+```yaml
+# app-config.yaml
+foo:
+  $data: foo.yaml#myValue # replacing with $include will turn the value into a number
+  $data: bar.yaml#myValue # replacing with $include is safe
+
+# foo.yaml
+myValue: 0xf00
+
+# bar.yaml
+myValue: bar
+```

--- a/.changeset/friendly-numbers-accept.md
+++ b/.changeset/friendly-numbers-accept.md
@@ -4,7 +4,7 @@
 
 Deprecate `$data` and replace it with `$include` which allows for any type of json value to be read from external files. In addition, `$include` can be used without a path, which causes the value at the root of the file to be loaded.
 
-Most usages of `$data` can be directly replaced with `$include`, expect for if the referenced value is not a string, in which case the value needs to be changed. For example:
+Most usages of `$data` can be directly replaced with `$include`, except if the referenced value is not a string, in which case the value needs to be changed. For example:
 
 ```yaml
 # app-config.yaml

--- a/docs/conf/writing.md
+++ b/docs/conf/writing.md
@@ -141,16 +141,17 @@ itself:
 $file: ./my-secret.txt
 ```
 
-### Data File Secrets
+### Including Files
 
-This reads secrets from a path within a JSON-like data file. The file path
-behaves similar to file secrets, but with the addition of a url fragment that is
-used to point to a specific value inside the file. Supported file extensions are
-`.json`, `.yaml`, and `.yml`. For example, the following would read out
-`my-secret-key` from `my-secrets.json`:
+The `$include` keyword can be used to load in JSON data from an external file.
+It's able to load and parse data from `.json`, `.yml`, and `.yaml` files. It's
+also possible to include a url fragment (`#`) to point to a value at the given
+path in the file.
+
+For example, the following would read `my-secret-key` from `my-secrets.json`:
 
 ```yaml
-$data: ./my-secrets.json#deployment.key
+$include: ./my-secrets.json#deployment.key
 ```
 
 Example `my-secrets.json` file:

--- a/packages/config-loader/src/lib/secrets.ts
+++ b/packages/config-loader/src/lib/secrets.ts
@@ -107,6 +107,9 @@ export async function readSecret(
     return ctx.env[secret.env];
   }
   if ('data' in secret) {
+    console.warn(
+      `Configuration uses deprecated $data key, use $include instead.`,
+    );
     const url =
       'path' in secret ? `${secret.data}#${secret.path}` : secret.data;
     const [filePath, dataPath] = url.split(/#(.*)/);

--- a/packages/config-loader/src/lib/secrets.ts
+++ b/packages/config-loader/src/lib/secrets.ts
@@ -42,7 +42,12 @@ type DataSecret = {
   path?: string;
 };
 
-type Secret = FileSecret | EnvSecret | DataSecret;
+// TODO(Rugvip): Move this out of secret reading when we remove the deprecated DataSecret and $secret format
+type IncludeSecret = {
+  include: string;
+};
+
+type Secret = FileSecret | EnvSecret | DataSecret | IncludeSecret;
 
 // Schema for each type of secret description
 const secretLoaderSchemas = {

--- a/packages/config-loader/src/lib/types.ts
+++ b/packages/config-loader/src/lib/types.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { JsonObject } from '@backstage/config';
+import { JsonObject, JsonValue } from '@backstage/config';
 
 export type ReadFileFunc = (path: string) => Promise<string>;
 export type ReadSecretFunc = (
   path: string,
   desc: JsonObject,
-) => Promise<string | undefined>;
+) => Promise<JsonValue | undefined>;
 export type SkipFunc = (path: string) => boolean;
 
 /**

--- a/packages/config-loader/src/loader.ts
+++ b/packages/config-loader/src/loader.ts
@@ -16,7 +16,7 @@
 
 import fs from 'fs-extra';
 import { resolve as resolvePath, dirname, isAbsolute } from 'path';
-import { AppConfig, JsonObject } from '@backstage/config';
+import { AppConfig, JsonObject, JsonValue } from '@backstage/config';
 import { readConfigFile, readEnvConfig, readSecret } from './lib';
 
 export type LoadConfigOptions = {
@@ -49,7 +49,7 @@ class Context {
   async readSecret(
     _path: string,
     desc: JsonObject,
-  ): Promise<string | undefined> {
+  ): Promise<JsonValue | undefined> {
     return readSecret(desc, this);
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds a new `$include` keyword to the config parser which replaces `$data` and allows for json objects and other structured data to be loaded in from external files.

We are planning to use this for the Github Apps integration which is going to require a collection of multiple secrets.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
