### PR TITLE
Remove the dependency from the catalog plugin to techdocs

### DIFF
--- a/.changeset/large-guests-compete.md
+++ b/.changeset/large-guests-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Remove the unused dependency to `@backstage/plugin-techdocs`.

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -34,7 +34,6 @@
     "@backstage/catalog-model": "^0.6.0",
     "@backstage/core": "^0.4.3",
     "@backstage/plugin-scaffolder": "^0.3.5",
-    "@backstage/plugin-techdocs": "^0.5.2",
     "@backstage/theme": "^0.2.2",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
This dependency forces us to comply to the config schema that was added in #3799 even though we don't use techdocs yet.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
