### PR TITLE
fix(search): Material-UI warning when filtering "all"

### DIFF
--- a/.changeset/loud-vans-pretend.md
+++ b/.changeset/loud-vans-pretend.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search': patch
 ---
 
-Fix Material-UI error for search filtering
+Fix Material-UI warning for search filtering

--- a/.changeset/loud-vans-pretend.md
+++ b/.changeset/loud-vans-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Fix Material-UI error for search filtering

--- a/plugins/search/src/components/Filters/Filters.tsx
+++ b/plugins/search/src/components/Filters/Filters.tsx
@@ -103,7 +103,7 @@ export const Filters = ({
           >
             {filterOptions.kind.map(filter => (
               <MenuItem
-                selected={filter === 'All'}
+                selected={filter === ''}
                 dense
                 key={filter}
                 value={filter}

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -127,7 +127,7 @@ export const SearchResult = ({ searchQuery }: SearchResultProps) => {
 
   const [showFilters, toggleFilters] = useState(false);
   const [selectedFilters, setSelectedFilters] = useState<FiltersState>({
-    selected: 'All',
+    selected: '',
     checked: [],
   });
 
@@ -146,7 +146,7 @@ export const SearchResult = ({ searchQuery }: SearchResultProps) => {
       // apply filters
 
       // filter on selected
-      if (selectedFilters.selected !== 'All') {
+      if (selectedFilters.selected !== '') {
         withFilters = results.filter((result: Result) =>
           selectedFilters.selected.includes(result.kind),
         );
@@ -192,7 +192,7 @@ export const SearchResult = ({ searchQuery }: SearchResultProps) => {
 
   const resetFilters = () => {
     setSelectedFilters({
-      selected: 'All',
+      selected: '',
       checked: [],
     });
   };
@@ -259,7 +259,7 @@ export const SearchResult = ({ searchQuery }: SearchResultProps) => {
                 searchQuery={searchQuery}
                 numberOfResults={filteredResults.length}
                 numberOfSelectedFilters={
-                  (selectedFilters.selected !== 'All' ? 1 : 0) +
+                  (selectedFilters.selected !== '' ? 1 : 0) +
                   selectedFilters.checked.length
                 }
                 handleToggleFilters={() => toggleFilters(!showFilters)}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes a Material-UI front end warning when the search filter uses "all" (nothing filtered). The recommendation is to use blank instead.

This value is not (currently) used for displaying "All" anywhere to the user, so seems non-intrusive, and I don't believe it can be passed in from outside so should be encapsulated within the plugin itself.

To reproduce,
1. Off master/nightly, bring up the search page by just clicking the magnifying glass
2. Click the filter icon to open the filter
3. See msg.
    > Material-UI: You have provided an out-of-range value `All` for the select component.
    > Consider providing a value that matches one of the available options or ''.
    > The available values are `API`, `Component`, `Group`, `Location`, `Template`, `User`. 

![image](https://user-images.githubusercontent.com/33203301/103608129-9d196b00-4ee8-11eb-9c57-a47398ffd717.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
