### PR TITLE
catalog-backend: fix bug where all entities got read back from the catalog

### DIFF
--- a/.changeset/early-spies-grow.md
+++ b/.changeset/early-spies-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed a bug where the catalog would read back all entities when adding a location that already exists.

--- a/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
@@ -205,7 +205,7 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
         }
       }
 
-      if (options?.outputEntities) {
+      if (options?.outputEntities && responses.length > 0) {
         const writtenEntities = await this.database.entities(
           tx,
           EntityFilters.ofMatchers({
@@ -285,7 +285,8 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
         // instead and call a dedicated batch update database method
         toUpdate.push(request);
       } else {
-        toIgnore.push(request);
+        // Use the existing entity to ensure that we're able to read it back by uid if needed
+        toIgnore.push({ ...request, entity: oldEntity });
       }
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Filtering by `[]` ends up returning everything 😅 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
