### PR TITLE
docs: Align Docusaurus for fixed SEO output and "prettier" happiness

### DIFF
--- a/docs/auth/oauth.md
+++ b/docs/auth/oauth.md
@@ -1,9 +1,8 @@
 ---
 id: oauth
 title: OAuth and OpenID Connect
-description: This section describes how Backstage allows plugins to request
-OAuth Access Tokens and OpenID Connect ID Tokens on behalf of the user, to be
-used for auth to various third party APIs
+# prettier-ignore
+description: This section describes how Backstage allows plugins to request OAuth Access Tokens and OpenID Connect ID Tokens on behalf of the user, to be used for auth to various third party APIs
 ---
 
 This section describes how Backstage allows plugins to request OAuth Access

--- a/docs/dls/figma.md
+++ b/docs/dls/figma.md
@@ -1,8 +1,8 @@
 ---
 id: figma
 title: Figma
-description: Documentation on using Figma to build your own plugins for
-Backstage
+# prettier-ignore
+description: Documentation on using Figma to build your own plugins for Backstage
 ---
 
 We have a [Figma component library](https://www.figma.com/@backstage) that you

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -268,7 +268,7 @@ identical in use to
 
 Their purpose is mainly, but not limited, to reference into external systems.
 This could for example be a reference to the git ref the entity was ingested
-from, to monitoring and logging systems, to pagerduty schedules, etc. Users may
+from, to monitoring and logging systems, to PagerDuty schedules, etc. Users may
 add these to descriptor YAML files, but in addition to this automated systems
 may also add annotations, either during ingestion into the catalog, or at a
 later time.

--- a/docs/features/software-templates/index.md
+++ b/docs/features/software-templates/index.md
@@ -2,8 +2,8 @@
 id: software-templates-index
 title: Backstage Software Templates
 sidebar_label: Overview
-description: The Software Templates part of Backstage is a tool that can help
-you create Components inside Backstage
+# prettier-ignore
+description: The Software Templates part of Backstage is a tool that can help you create Components inside Backstage
 ---
 
 The Software Templates part of Backstage is a tool that can help you create

--- a/docs/features/techdocs/README.md
+++ b/docs/features/techdocs/README.md
@@ -2,8 +2,8 @@
 id: techdocs-overview
 title: TechDocs Documentation
 sidebar_label: Overview
-description: TechDocs is Spotify’s homegrown docs-like-code solution built
-directly into Backstage
+# prettier-ignore
+description: TechDocs is Spotify’s homegrown docs-like-code solution built directly into Backstage
 ---
 
 ## What is it?

--- a/docs/features/techdocs/concepts.md
+++ b/docs/features/techdocs/concepts.md
@@ -1,8 +1,8 @@
 ---
 id: concepts
 title: Concepts
-description: Documentation on concepts that are introduced with
-Spotify's docs-like-code solution in Backstage
+# prettier-ignore
+description: Documentation on concepts that are introduced with Spotify's docs-like-code solution in Backstage
 ---
 
 This page describes concepts that are introduced with Spotify's docs-like-code

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -1,8 +1,8 @@
 ---
 id: configuration
 title: TechDocs Configuration Options
-description:
-  Reference documentation for configuring TechDocs using app-config.yaml
+# prettier-ignore
+description: Reference documentation for configuring TechDocs using app-config.yaml
 ---
 
 Using the `app-config.yaml` in the Backstage app, you can configure TechDocs

--- a/docs/getting-started/development-environment.md
+++ b/docs/getting-started/development-environment.md
@@ -1,8 +1,8 @@
 ---
 id: development-environment
 title: Development Environment
-description: Documentation on how to get set up for doing development on
-the Backstage repository
+# prettier-ignore
+description: Documentation on how to get set up for doing development on the Backstage repository
 ---
 
 This section describes how to get set up for doing development on the Backstage

--- a/docs/overview/adopting.md
+++ b/docs/overview/adopting.md
@@ -1,8 +1,8 @@
 ---
 id: adopting
 title: Strategies for adopting
-description: Documentation on some general best practices that have been key
-to Backstage's success inside Spotify
+# prettier-ignore
+description: Documentation on some general best practices that have been key to Backstage's success inside Spotify
 ---
 
 This document outlines some general best practices that have been key to

--- a/docs/overview/background.md
+++ b/docs/overview/background.md
@@ -1,8 +1,8 @@
 ---
 id: background
 title: The Spotify Story
-description: Backstage was born out of necessity at Spotify. We found that as we grew, our
-infrastructure was becoming more fragmented, our engineers less productive.
+# prettier-ignore
+description: Backstage was born out of necessity at Spotify. We found that as we grew, our infrastructure was becoming more fragmented, our engineers less productive.
 ---
 
 Backstage was born out of necessity at Spotify. We found that as we grew, our

--- a/docs/overview/roadmap.md
+++ b/docs/overview/roadmap.md
@@ -8,9 +8,9 @@ description: Roadmap of Backstage Project
 
 > Backstage is currently under rapid development. This means that you can expect
 > APIs and features to evolve. It is also recommended that teams who adopt
-> Backstage today upgrade their installation as new
-> [releases](https://github.com/backstage/backstage/releases) become available,
-> as Backwards compatibility is not yet guaranteed.
+> Backstage today [upgrade their installation](../cli/commands.md#versionsbump)
+> as new [releases](https://github.com/backstage/backstage/releases) become
+> available, as Backwards compatibility is not yet guaranteed.
 
 ## Phases
 

--- a/docs/overview/stability-index.md
+++ b/docs/overview/stability-index.md
@@ -1,9 +1,8 @@
 ---
 id: stability-index
 title: Stability Index
-description:
-  An overview of the commitment to stability for different parts of the
-  Backstage codebase.
+# prettier-ignore
+description: An overview of the commitment to stability for different parts of the Backstage codebase.
 ---
 
 ## Overview

--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -1,8 +1,8 @@
 ---
 id: vision
 title: Vision
-description: Goal is to provide engineers with the best developer experience in
-the world
+# prettier-ignore
+description: Goal is to provide engineers with the best developer experience in the world
 ---
 
 Our goal is to provide engineers with the best developer experience in the

--- a/docs/overview/what-is-backstage.md
+++ b/docs/overview/what-is-backstage.md
@@ -1,8 +1,8 @@
 ---
 id: what-is-backstage
 title: What is Backstage?
-description: Backstage is an open platform for building developer portals.
-Powered by a centralized service catalog, Backstage restores order to your microservices and infrastructure
+# prettier-ignore
+description: Backstage is an open platform for building developer portals. Powered by a centralized service catalog, Backstage restores order to your microservices and infrastructure
 ---
 
 ![service-catalog](https://backstage.io/blog/assets/6/header.png)

--- a/docs/plugins/call-existing-api.md
+++ b/docs/plugins/call-existing-api.md
@@ -1,8 +1,8 @@
 ---
 id: call-existing-api
 title: Call Existing API
-description: Describes the various options that Backstage frontend plugins have,
-in communicating with service APIs that already exist
+# prettier-ignore
+description: Describes the various options that Backstage frontend plugins have, in communicating with service APIs that already exist
 ---
 
 This article describes the various options that Backstage frontend plugins have,

--- a/docs/support/project-structure.md
+++ b/docs/support/project-structure.md
@@ -1,8 +1,8 @@
 ---
 id: project-structure
 title: Backstage Project Structure
-description:
-  Introduction to files and folders in the Backstage Project repository
+# prettier-ignore
+description: Introduction to files and folders in the Backstage Project repository
 ---
 
 Backstage is a complex project, and the GitHub repository contains many


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

There's a bit of a conflict between,
* Docusaurus which does not support true YAML Front Matter, it's code just tries to parse name/value pairs per line; when starting the site, it spits out lots of header errors
    ```
    Header field "An overview of the commitment to stability for different parts of the" in /home/user/github/backstage/docs/overview/stability-index.md is not supported.
    Header field "Backstage codebase." in /home/user/github/backstage/docs/overview/stability-index.md is not supported.
    Header field "the world" in /home/user/github/backstage/docs/overview/vision.md is not supported.
    Header field "Powered by a centralized service catalog, Backstage restores order to your microservices and infrastructure" in /home/user/github/backstage/docs/overview/what-is-backstage.md is not supported.
    ````
    * I validated both via their code base but also tested various permutations of `|-` and `>-`, etc.
* Prettier ignores added to the non-YAML Front Matter spit out errors in Docusaurus also, but are ignored
* Prettier itself which will prevent descriptions in YAML Front Matter that are too long, effectively chopping them off since Docusaurus only supports single line vars
* And the resulting SEO of the HTML site output where descriptions are broken

Many of the metadata descriptions for pages in backstage.io/docs/ are broken or partial, e.g.,

![image](https://user-images.githubusercontent.com/33203301/103686057-3afa4d80-4f5c-11eb-825d-ce7136b84d98.png)

This PR makes all descriptions one line (even if they are long), required for Docusaurus (at least v1) and the SEO output to be good, and adds the prettier ignores so the linting passes green. _However_, it will mean Docusaurus startup will spit out a dozen or more prettier errors, but those can be ignored so long as the SEO output is accurate.  i.e.,

```
Header field "# prettier-ignore" in /home/user/github/backstage/docs/overview/stability-index.md is not supported.
Header field "# prettier-ignore" in /home/user/github/backstage/docs/overview/vision.md is not supported.
Header field "# prettier-ignore" in /home/user/github/backstage/docs/overview/what-is-backstage.md is not supported.
Header field "# prettier-ignore" in /home/user/github/backstage/docs/plugins/call-existing-api.md is not supported.
Header field "# prettier-ignore" in /home/user/github/backstage/docs/support/project-structure.md is not supported.
```

✨ Also snuck in a link to the CLI `version:bump` command on the roadmap page and two typo fixes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
