### PR TITLE
Remove the plugin-catalog-backend dependency from the catalog-import

### DIFF
--- a/.changeset/rare-paws-listen.md
+++ b/.changeset/rare-paws-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Remove dependency to `@backstage/plugin-catalog-backend`.

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -33,7 +33,6 @@
     "@backstage/catalog-model": "^0.6.0",
     "@backstage/core": "^0.4.3",
     "@backstage/plugin-catalog": "^0.2.10",
-    "@backstage/plugin-catalog-backend": "^0.5.2",
     "@backstage/integration": "^0.1.5",
     "@backstage/theme": "^0.2.2",
     "@material-ui/core": "^4.11.0",

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -17,7 +17,6 @@
 import { Octokit } from '@octokit/rest';
 import { DiscoveryApi, OAuthApi, ConfigApi } from '@backstage/core';
 import { CatalogImportApi } from './CatalogImportApi';
-import { AnalyzeLocationResponse } from '@backstage/plugin-catalog-backend';
 import { PartialEntity } from '../util/types';
 import { GitHubIntegrationConfig } from '@backstage/integration';
 
@@ -61,8 +60,8 @@ export class CatalogImportClient implements CatalogImportApi {
       );
     }
 
-    const payload = (await response.json()) as AnalyzeLocationResponse;
-    return payload.generateEntities.map(x => x.entity);
+    const payload = await response.json();
+    return payload.generateEntities.map((x: any) => x.entity);
   }
 
   async createRepositoryLocation({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Frontend plugins should not depend on backend packages. In the future, all calls to the backend should be replaced by the `CatalogApi`, which then needs to be extended by the `/analyze-location` endpoint (or that is moved to another API/backend service).
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
