### PR TITLE
TechDocs: Remove failing TechDocs project board workflow for some PRs

### DIFF
--- a/.github/workflows/techdocs-project-board.yml
+++ b/.github/workflows/techdocs-project-board.yml
@@ -16,6 +16,7 @@ jobs:
   assign_issue_or_pr_to_project:
     runs-on: ubuntu-latest
     name: Triage
+    if: ${{ env.MY_GITHUB_TOKEN }} != null
     steps:
       - name: Assign new issue to Incoming based on its title.
         uses: srggrs/assign-one-project-github-action@1.2.0


### PR DESCRIPTION
The TechDocs project board auto-assign workflow can not run on Pull Requests created from a fork because secrets are not shared in GitHub actions with forks. To avoid having a failed workflow in some PRs, the job should be run conditionally.

Just an example: https://github.com/backstage/backstage/pull/3939

![Screenshot 2021-01-06 at 15 10 23](https://user-images.githubusercontent.com/8065913/103777556-5be0a280-5031-11eb-9a50-cb12375c13e5.png)
---
(This current PR is created from a fork to test the implementation.)