### PR TITLE
Remove unnecessary dev dependencies

### DIFF
--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -82,7 +82,6 @@
     "@types/tar": "^4.0.3",
     "@types/unzipper": "^0.10.3",
     "@types/webpack-env": "^1.15.2",
-    "@types/yaml": "^1.9.7",
     "get-port": "^5.1.1",
     "http-errors": "^1.7.3",
     "jest": "^26.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -125,7 +125,6 @@
     "@types/mini-css-extract-plugin": "^0.9.1",
     "@types/mock-fs": "^4.13.0",
     "@types/node": "^13.7.2",
-    "@types/ora": "^3.2.0",
     "@types/react-dev-utils": "^9.0.4",
     "@types/recursive-readdir": "^2.2.0",
     "@types/rollup-plugin-peer-deps-external": "^2.2.0",

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -65,7 +65,6 @@
     "@backstage/theme": "^0.2.2",
     "@types/fs-extra": "^9.0.1",
     "@types/inquirer": "^7.3.1",
-    "@types/ora": "^3.2.0",
     "@types/react-dev-utils": "^9.0.4",
     "@types/recursive-readdir": "^2.2.0",
     "ts-node": "^8.6.2"

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -69,8 +69,6 @@
     "@types/cookie-parser": "^1.4.2",
     "@types/express-session": "^1.17.2",
     "@types/jwt-decode": "^3.1.0",
-    "@types/nock": "^11.1.0",
-    "@types/openid-client": "^3.7.0",
     "@types/passport": "^1.0.3",
     "@types/passport-github2": "^1.2.4",
     "@types/passport-google-oauth20": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5937,13 +5937,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/nock@^11.1.0":
-  version "11.1.0"
-  resolved "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz#0a8c1056a31ba32a959843abccf99626dd90a538"
-  integrity sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==
-  dependencies:
-    nock "*"
-
 "@types/node-fetch@2.5.7", "@types/node-fetch@^2.5.4":
   version "2.5.7"
   resolved "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
@@ -5988,20 +5981,6 @@
   integrity sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==
   dependencies:
     "@types/node" "*"
-
-"@types/openid-client@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.npmjs.org/@types/openid-client/-/openid-client-3.7.0.tgz#8406e12798d16083df09cc3625973f5a00dd57fa"
-  integrity sha512-hW+QbAeUyfUHABwUjUECOcv56Mf5tN29xK3GPN7wy3R3XfIQdkm37XELA4wbe2RNG9GYUpN8l2ytfoW05XmpgQ==
-  dependencies:
-    openid-client "*"
-
-"@types/ora@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/@types/ora/-/ora-3.2.0.tgz#b2f65d1283a8f36d8b0f9ee767e0732a2f429362"
-  integrity sha512-jll99xUKpiFbIFZSQcxm4numfsLaOWBzWNaRk3PvTSE7BPqTzzOCFmS0mQ7m8qkTfmYhuYbehTGsxkvRLPC++w==
-  dependencies:
-    ora "*"
 
 "@types/overlayscrollbars@^1.9.0":
   version "1.12.0"
@@ -6508,13 +6487,6 @@
   integrity sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==
   dependencies:
     "@types/node" "*"
-
-"@types/yaml@^1.9.7":
-  version "1.9.7"
-  resolved "https://registry.npmjs.org/@types/yaml/-/yaml-1.9.7.tgz#2331f36e0aac91311a63d33eb026c21687729679"
-  integrity sha512-8WMXRDD1D+wCohjfslHDgICd2JtMATZU8CkhH8LVJqcJs6dyYj5TGptzP8wApbmEullGBSsCEzzap73DQ1HJaA==
-  dependencies:
-    yaml "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -17905,7 +17877,7 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
-nock@*, nock@^13.0.5:
+nock@^13.0.5:
   version "13.0.5"
   resolved "https://registry.npmjs.org/nock/-/nock-13.0.5.tgz#a618c6f86372cb79fac04ca9a2d1e4baccdb2414"
   integrity sha512-1ILZl0zfFm2G4TIeJFW0iHknxr2NyA+aGCMTjDVUsBY4CkMRispF1pfIYkTRdAR/3Bg+UzdEuK0B6HczMQZcCg==
@@ -18507,20 +18479,6 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
   integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
 
-openid-client@*, openid-client@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/openid-client/-/openid-client-4.2.1.tgz#8200c0ab6a3b8e954727dfa790847dc5cb8999c2"
-  integrity sha512-07eOcJeMH3ZHNvx5DVMZQmy3vZSTQqKSSunbtM1pXb+k5LBPi5hMum1vJCFReXlo4wuLEqZ/OgbsZvXPhbGRtA==
-  dependencies:
-    base64url "^3.0.1"
-    got "^11.8.0"
-    jose "^2.0.2"
-    lru-cache "^6.0.0"
-    make-error "^1.3.6"
-    object-hash "^2.0.1"
-    oidc-token-hash "^5.0.0"
-    p-any "^3.0.0"
-
 openid-client@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/openid-client/-/openid-client-4.1.1.tgz#3e8a25584c4292e9b9b03e60358f5549fb85197a"
@@ -18528,6 +18486,20 @@ openid-client@^4.1.1:
   dependencies:
     base64url "^3.0.1"
     got "^11.6.2"
+    jose "^2.0.2"
+    lru-cache "^6.0.0"
+    make-error "^1.3.6"
+    object-hash "^2.0.1"
+    oidc-token-hash "^5.0.0"
+    p-any "^3.0.0"
+
+openid-client@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/openid-client/-/openid-client-4.2.1.tgz#8200c0ab6a3b8e954727dfa790847dc5cb8999c2"
+  integrity sha512-07eOcJeMH3ZHNvx5DVMZQmy3vZSTQqKSSunbtM1pXb+k5LBPi5hMum1vJCFReXlo4wuLEqZ/OgbsZvXPhbGRtA==
+  dependencies:
+    base64url "^3.0.1"
+    got "^11.8.0"
     jose "^2.0.2"
     lru-cache "^6.0.0"
     make-error "^1.3.6"
@@ -18566,7 +18538,7 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-ora@*, ora@^4.0.3:
+ora@^4.0.3:
   version "4.0.4"
   resolved "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz#e8da697cc5b6a47266655bf68e0fb588d29a545d"
   integrity sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==
@@ -25410,7 +25382,7 @@ yaml-ast-parser@0.0.43, yaml-ast-parser@^0.0.43:
   resolved "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
   integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
 
-yaml@*, yaml@^1.10.0, yaml@^1.7.2, yaml@^1.9.2:
+yaml@^1.10.0, yaml@^1.7.2, yaml@^1.9.2:
   version "1.10.0"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==


### PR DESCRIPTION
The removes some warnings when installing packages:

```
[2/5] 🔍  Resolving packages...
warning workspace-aggregator-cd437b57-77f1-4e59-9273-ee4cd0659f97 > @backstage/backend-common > @types/yaml@1.9.7: This is a stub types definition. yaml provides its own type definitions, so you do not need this installed.
warning workspace-aggregator-cd437b57-77f1-4e59-9273-ee4cd0659f97 > @backstage/cli > @types/ora@3.2.0: This is a stub types definition. ora provides its own type definitions, so you do not need this installed.
warning workspace-aggregator-cd437b57-77f1-4e59-9273-ee4cd0659f97 > @backstage/create-app > @types/ora@3.2.0: This is a stub types definition. ora provides its own type definitions, so you do not need this installed.
warning workspace-aggregator-cd437b57-77f1-4e59-9273-ee4cd0659f97 > @backstage/plugin-auth-backend > @types/nock@11.1.0: This is a stub types definition. nock provides its own type definitions, so you do not need this installed.
warning workspace-aggregator-cd437b57-77f1-4e59-9273-ee4cd0659f97 > @backstage/plugin-auth-backend > @types/openid-client@3.7.0: This is a stub types definition. openid-client provides its own type definitions, so you do not need this installed.
...
```

These packages now come with typings out of the box, so we don't need the separate typings \o/

The lock file update around openid-client is a bit strange, but I think it's fine. No changeset I guess?


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
