### PR TITLE
chore(core-api,cost-insights,tech-radar): Removes @backstage/test-utils from being production dependencies

### DIFF
--- a/.changeset/angry-avocados-hope.md
+++ b/.changeset/angry-avocados-hope.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-api': patch
+'@backstage/plugin-cost-insights': patch
+'@backstage/plugin-tech-radar': patch
+---
+
+Remove test deps from production package list

--- a/.changeset/angry-avocados-hope.md
+++ b/.changeset/angry-avocados-hope.md
@@ -4,4 +4,4 @@
 '@backstage/plugin-tech-radar': patch
 ---
 
-Remove test deps from production package list
+Remove test dependencies from production package list

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -33,7 +33,6 @@
     "@backstage/plugin-techdocs": "^0.5.1",
     "@backstage/plugin-user-settings": "^0.2.3",
     "@backstage/plugin-welcome": "^0.2.3",
-    "@backstage/test-utils": "^0.1.6",
     "@backstage/theme": "^0.2.2",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
@@ -53,6 +52,7 @@
     "zen-observable": "^0.8.15"
   },
   "devDependencies": {
+    "@backstage/test-utils": "^0.1.6",
     "@testing-library/cypress": "^7.0.1",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.4.1",

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@backstage/config": "^0.1.2",
-    "@backstage/test-utils": "^0.1.6",
     "@backstage/theme": "^0.2.2",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
@@ -44,6 +43,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.4.4",
+    "@backstage/test-utils": "^0.1.6",
     "@backstage/test-utils-core": "^0.1.1",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.4.1",

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@backstage/config": "^0.1.2",
     "@backstage/core": "^0.4.3",
-    "@backstage/test-utils": "^0.1.5",
     "@backstage/theme": "^0.2.2",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@backstage/core": "^0.4.3",
-    "@backstage/test-utils": "^0.1.5",
     "@backstage/theme": "^0.2.2",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Removes `@backstage/test-utils` from being production dependencies and ensures they are clearly aligned only to the devDependencies. Patch bump for each affected product.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
