### PR TITLE
fix(auth-backend/saml): Add checks for blank cert and implement logout configs

### DIFF
--- a/.changeset/smooth-pigs-deny.md
+++ b/.changeset/smooth-pigs-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Allow blank certificates and support logout URLs in the SAML provider.

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -46,6 +46,7 @@ export interface Config {
       };
       saml?: {
         entryPoint: string;
+        logoutUrl?: string;
         issuer: string;
         cert?: string;
         privateKey?: string;

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -129,6 +129,7 @@ export const createSamlProvider: AuthProviderFactory = ({
   const opts = {
     callbackUrl: `${globalConfig.baseUrl}/${providerId}/handler/frame`,
     entryPoint: config.getString('entryPoint'),
+    logoutUrl: config.getOptionalString('logoutUrl'),
     issuer: config.getString('issuer'),
     cert: config.getOptionalString('cert'),
     privateCert: config.getOptionalString('privateKey'),
@@ -142,5 +143,10 @@ export const createSamlProvider: AuthProviderFactory = ({
     appUrl: globalConfig.appUrl,
   };
 
+  // passport-saml will return an error if the `cert` key is set, and the value is empty.
+  // Since we read from config (such as environment variables) an empty string should be equal to being unset.
+  if (!opts.cert) {
+    delete opts.cert;
+  }
   return new SamlAuthProvider(opts);
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Add configs for logout URLs, as well as allow the SAML provider to be used without a IdP certificate.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
