### PR TITLE
TechDocs: Improve techdocs-common APIs for it to be used by techdocs-cli

### DIFF
--- a/.changeset/eleven-badgers-wink.md
+++ b/.changeset/eleven-badgers-wink.md
@@ -1,0 +1,6 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Improve techdocs-common Generator API for it to be used by techdocs-cli. No breaking changes.
+Generator can now accept an output directory.

--- a/.changeset/eleven-badgers-wink.md
+++ b/.changeset/eleven-badgers-wink.md
@@ -1,6 +1,9 @@
 ---
 '@backstage/techdocs-common': patch
+'@backstage/plugin-techdocs-backend': patch
 ---
 
-Improve techdocs-common Generator API for it to be used by techdocs-cli. No breaking changes.
-Generator can now accept an output directory.
+Improve techdocs-common Generator API for it to be used by techdocs-cli. TechDocs generator.run function now takes
+an input AND an output directory. Most probably you use techdocs-common via plugin-techdocs-backend, and so there
+is no breaking change for you.
+But if you use techdocs-common separately, you need to create an output directory and pass into the generator.

--- a/packages/techdocs-common/src/stages/generate/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.test.ts
@@ -80,14 +80,14 @@ describe('helpers', () => {
     const imageName = 'spotify/techdocs';
     const args = ['build', '-d', '/result'];
     const docsDir = os.tmpdir();
-    const resultDir = os.tmpdir();
+    const outputDir = os.tmpdir();
 
     it('should pull the techdocs docker container', async () => {
       await runDockerContainer({
         imageName,
         args,
         docsDir,
-        resultDir,
+        outputDir,
         dockerClient: mockDocker,
       });
 
@@ -103,7 +103,7 @@ describe('helpers', () => {
         imageName,
         args,
         docsDir,
-        resultDir,
+        outputDir,
         dockerClient: mockDocker,
       });
 
@@ -118,7 +118,7 @@ describe('helpers', () => {
           },
           WorkingDir: '/content',
           HostConfig: {
-            Binds: [`${docsDir}:/content`, `${resultDir}:/result`],
+            Binds: [`${docsDir}:/content`, `${outputDir}:/result`],
           },
         },
       );
@@ -129,7 +129,7 @@ describe('helpers', () => {
         imageName,
         args,
         docsDir,
-        resultDir,
+        outputDir,
         dockerClient: mockDocker,
       });
 
@@ -151,7 +151,7 @@ describe('helpers', () => {
             imageName,
             args,
             docsDir,
-            resultDir,
+            outputDir,
             dockerClient: mockDocker,
           }),
         ).rejects.toThrow(new RegExp(`.+: ${dockerError}`));

--- a/packages/techdocs-common/src/stages/generate/helpers.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.ts
@@ -39,7 +39,7 @@ type RunDockerContainerOptions = {
   args: string[];
   logStream?: Writable;
   docsDir: string;
-  resultDir: string;
+  outputDir: string;
   dockerClient: Docker;
   createOptions?: Docker.ContainerCreateOptions;
 };
@@ -56,7 +56,7 @@ export async function runDockerContainer({
   args,
   logStream = new PassThrough(),
   docsDir,
-  resultDir,
+  outputDir,
   dockerClient,
   createOptions,
 }: RunDockerContainerOptions) {
@@ -89,7 +89,7 @@ export async function runDockerContainer({
       },
       WorkingDir: '/content',
       HostConfig: {
-        Binds: [`${docsDir}:/content`, `${resultDir}:/result`],
+        Binds: [`${docsDir}:/content`, `${outputDir}:/result`],
       },
       ...createOptions,
     },

--- a/packages/techdocs-common/src/stages/generate/types.ts
+++ b/packages/techdocs-common/src/stages/generate/types.ts
@@ -31,13 +31,15 @@ export type GeneratorRunResult = {
  *
  * @param {string} directory The directory of the uncompiled documentation, with the values from the frontend
  * @param {Docker} dockerClient A docker client to run any generator on top of your directory
+ * @param {string} expectedResultDir Optional directory to store generated docs in. Default: A newly created temporary directory.
  * @param {ParsedLocationAnnotation} parsedLocationAnnotation backstage.io/techdocs-ref annotation of an entity
  * @param {Writable} [logStream] A dedicated log stream
  */
 export type GeneratorRunOptions = {
   directory: string;
   dockerClient: Docker;
-  parsedLocationAnnotation: ParsedLocationAnnotation;
+  expectedResultDir?: string;
+  parsedLocationAnnotation?: ParsedLocationAnnotation;
   logStream?: Writable;
 };
 

--- a/packages/techdocs-common/src/stages/generate/types.ts
+++ b/packages/techdocs-common/src/stages/generate/types.ts
@@ -19,33 +19,25 @@ import { Entity } from '@backstage/catalog-model';
 import { ParsedLocationAnnotation } from '../../helpers';
 
 /**
- * The returned directory from the generator which is ready
- * to pass to the next stage of the TechDocs which is publishing
- */
-export type GeneratorRunResult = {
-  resultDir: string;
-};
-
-/**
  * The values that the generator will receive.
  *
- * @param {string} directory The directory of the uncompiled documentation, with the values from the frontend
+ * @param {string} inputDir The directory of the uncompiled documentation, with the values from the frontend
+ * @param {string} outputDir Directory to store generated docs in. Usually - a newly created temporary directory.
  * @param {Docker} dockerClient A docker client to run any generator on top of your directory
- * @param {string} expectedResultDir Optional directory to store generated docs in. Default: A newly created temporary directory.
  * @param {ParsedLocationAnnotation} parsedLocationAnnotation backstage.io/techdocs-ref annotation of an entity
  * @param {Writable} [logStream] A dedicated log stream
  */
 export type GeneratorRunOptions = {
-  directory: string;
+  inputDir: string;
+  outputDir: string;
   dockerClient: Docker;
-  expectedResultDir?: string;
   parsedLocationAnnotation?: ParsedLocationAnnotation;
   logStream?: Writable;
 };
 
 export type GeneratorBase = {
-  // runs the generator with the values and returns the directory to be published
-  run(opts: GeneratorRunOptions): Promise<GeneratorRunResult>;
+  // Runs the generator with the values
+  run(opts: GeneratorRunOptions): Promise<void>;
 };
 
 /**

--- a/packages/techdocs-common/src/stages/prepare/index.ts
+++ b/packages/techdocs-common/src/stages/prepare/index.ts
@@ -17,4 +17,4 @@ export { DirectoryPreparer } from './dir';
 export { CommonGitPreparer } from './commonGit';
 export { UrlPreparer } from './url';
 export { Preparers } from './preparers';
-export type { PreparerBuilder, PreparerBase } from './types';
+export type { PreparerBuilder, PreparerBase, RemoteProtocol } from './types';

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -40,6 +40,7 @@
     "dockerode": "^3.2.1",
     "express": "^4.17.1",
     "express-promise-router": "^3.0.3",
+    "fs-extra": "^9.0.1",
     "knex": "^0.21.6",
     "winston": "^3.2.1"
   },


### PR DESCRIPTION
- Generator now takes an input and output directory as argument. It does not create those directories itself.
- Generator may not get techdocs-ref annotation since that is not critical for the step.

Needed for the incoming improvements in TechDocs CLI https://github.com/backstage/techdocs-cli/pull/20