### PR TITLE
bug(scaffolder): Ignore the .git folder

### DIFF
--- a/.changeset/nervous-mirrors-cough.md
+++ b/.changeset/nervous-mirrors-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+bug(scaffolder): Ignore the .git folder when adding dotfiles to the index

--- a/.changeset/nervous-mirrors-cough.md
+++ b/.changeset/nervous-mirrors-cough.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-bug(scaffolder): Ignore the .git folder when adding dotfiles to the index
+bug(scaffolder): Ignore the .git folder when adding dot-files to the index

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
@@ -39,7 +39,7 @@ export async function initRepoAndPush({
     dir,
   });
 
-  const paths = await globby(['./**', './**/.*'], {
+  const paths = await globby(['./**', './**/.*', '!.git'], {
     cwd: dir,
     gitignore: true,
     dot: true,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Woop's we add the git folder to the repo when we add dotfiles too. they're not automatically excluded by the index in `isomorphic-git`

