### PR TITLE
TechDocs: create type for TechDocs metadata

### DIFF
--- a/.changeset/techdocs-healthy-kiwis-mix.md
+++ b/.changeset/techdocs-healthy-kiwis-mix.md
@@ -1,0 +1,9 @@
+---
+'@backstage/techdocs-common': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Create type for TechDocsMetadata (#3716)
+
+This change introduces a new type (TechDocsMetadata) in packages/techdocs-common. This type is then introduced in the endpoint response in techdocs-backend and in the api interface in techdocs (frontend).

--- a/packages/techdocs-common/package.json
+++ b/packages/techdocs-common/package.json
@@ -50,6 +50,7 @@
     "fs-extra": "^9.0.1",
     "git-url-parse": "^11.4.3",
     "js-yaml": "^4.0.0",
+    "json5": "^2.1.3",
     "mime-types": "^2.1.27",
     "mock-fs": "^4.13.0",
     "recursive-readdir": "^2.2.2",

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -24,7 +24,8 @@ import { Logger } from 'winston';
 import { Entity, EntityName } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { getHeadersForFileExtension, getFileTreeRecursively } from './helpers';
-import { PublisherBase, PublishRequest } from './types';
+import { PublisherBase, PublishRequest, TechDocsMetadata } from './types';
+import JSON5 from 'json5';
 
 export class GoogleGCSPublish implements PublisherBase {
   static async fromConfig(
@@ -132,7 +133,7 @@ export class GoogleGCSPublish implements PublisherBase {
     });
   }
 
-  fetchTechDocsMetadata(entityName: EntityName): Promise<string> {
+  fetchTechDocsMetadata(entityName: EntityName): Promise<TechDocsMetadata> {
     return new Promise((resolve, reject) => {
       const entityRootDir = `${entityName.namespace}/${entityName.kind}/${entityName.name}`;
 
@@ -152,7 +153,7 @@ export class GoogleGCSPublish implements PublisherBase {
           const techdocsMetadataJson = Buffer.concat(
             fileStreamChunks,
           ).toString();
-          resolve(techdocsMetadataJson);
+          resolve(JSON5.parse(techdocsMetadataJson));
         });
     });
   }

--- a/packages/techdocs-common/src/stages/publish/local.ts
+++ b/packages/techdocs-common/src/stages/publish/local.ts
@@ -25,7 +25,12 @@ import {
   PluginEndpointDiscovery,
 } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
-import { PublisherBase, PublishRequest, PublishResponse } from './types';
+import {
+  PublisherBase,
+  PublishRequest,
+  PublishResponse,
+  TechDocsMetadata,
+} from './types';
 
 // TODO: Use a more persistent storage than node_modules or /tmp directory.
 // Make it configurable with techdocs.publisher.local.publishDirectory
@@ -102,7 +107,7 @@ export class LocalPublish implements PublisherBase {
     });
   }
 
-  fetchTechDocsMetadata(entityName: EntityName): Promise<string> {
+  fetchTechDocsMetadata(entityName: EntityName): Promise<TechDocsMetadata> {
     return new Promise((resolve, reject) => {
       this.discovery.getBaseUrl('techdocs').then(techdocsApiUrl => {
         const storageUrl = new URL(
@@ -116,7 +121,7 @@ export class LocalPublish implements PublisherBase {
           .then(response =>
             response
               .json()
-              .then(techdocsMetadataJson => resolve(techdocsMetadataJson))
+              .then(techdocsMetadata => resolve(techdocsMetadata))
               .catch(err => {
                 reject(
                   `Unable to parse metadata JSON for ${entityRootDir}. Error: ${err}`,

--- a/packages/techdocs-common/src/stages/publish/types.ts
+++ b/packages/techdocs-common/src/stages/publish/types.ts
@@ -33,6 +33,14 @@ export type PublishResponse = {
 } | void;
 
 /**
+ * Type to hold metadata found in techdocs_metadata.json and associated with each site
+ */
+export type TechDocsMetadata = {
+  site_name: string;
+  site_description: string;
+};
+
+/**
  * Base class for a TechDocs publisher (e.g. Local, Google GCS Bucket, AWS S3, etc.)
  * The publisher handles publishing of the generated static files after the prepare and generate steps of TechDocs.
  * It also provides APIs to communicate with the storage service.
@@ -50,7 +58,7 @@ export interface PublisherBase {
    * Retrieve TechDocs Metadata about a site e.g. name, contributors, last updated, etc.
    * This API uses the techdocs_metadata.json file that co-exists along with the generated docs.
    */
-  fetchTechDocsMetadata(entityName: EntityName): Promise<string>;
+  fetchTechDocsMetadata(entityName: EntityName): Promise<TechDocsMetadata>;
 
   /**
    * Route middleware to serve static documentation files for an entity.

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -58,14 +58,22 @@ export async function createRouter({
     const { '0': path } = req.params;
     const entityName = getEntityNameFromUrlPath(path);
 
-    publisher
-      .fetchTechDocsMetadata(entityName)
-      .then(techdocsMetadataJson => {
-        res.send(techdocsMetadataJson);
-      })
-      .catch(reason => {
-        res.status(500).send(`Unable to get Metadata. Reason: ${reason}`);
-      });
+    try {
+      const techdocsMetadata = await publisher.fetchTechDocsMetadata(
+        entityName,
+      );
+
+      res.send(techdocsMetadata);
+    } catch (err) {
+      logger.error(
+        `Unable to get metadata for ${entityName.namespace}/${entityName.name} with error ${err}`,
+      );
+      res
+        .status(500)
+        .send(
+          `Unable to get metadata for $${entityName.namespace}/${entityName.name}, reason: ${err}`,
+        );
+    }
   });
 
   router.get('/metadata/entity/:namespace/:kind/:name', async (req, res) => {

--- a/plugins/techdocs/src/api.ts
+++ b/plugins/techdocs/src/api.ts
@@ -16,6 +16,7 @@
 
 import { createApiRef } from '@backstage/core';
 import { EntityName } from '@backstage/catalog-model';
+import { TechDocsMetadata } from './types';
 
 export const techdocsStorageApiRef = createApiRef<TechDocsStorageApi>({
   id: 'plugin.techdocs.storageservice',
@@ -33,7 +34,7 @@ export interface TechDocsStorage {
 }
 
 export interface TechDocs {
-  getTechDocsMetadata(entityId: EntityName): Promise<string>;
+  getTechDocsMetadata(entityId: EntityName): Promise<TechDocsMetadata>;
   getEntityMetadata(entityId: EntityName): Promise<string>;
 }
 

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
@@ -19,12 +19,13 @@ import { AsyncState } from 'react-use/lib/useAsync';
 import CodeIcon from '@material-ui/icons/Code';
 import { EntityName } from '@backstage/catalog-model';
 import { Header, HeaderLabel, Link } from '@backstage/core';
+import { TechDocsMetadata } from '../../types';
 
 type TechDocsPageHeaderProps = {
   entityId: EntityName;
   metadataRequest: {
     entity: AsyncState<any>;
-    techdocs: AsyncState<any>;
+    techdocs: AsyncState<TechDocsMetadata>;
   };
 };
 

--- a/plugins/techdocs/src/types.ts
+++ b/plugins/techdocs/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Spotify AB
+ * Copyright 2021 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { Publisher } from './publish';
-export type { PublisherBase, PublisherType, TechDocsMetadata } from './types';
+
+export type TechDocsMetadata = {
+  site_name: string;
+  site_description: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -16734,7 +16734,7 @@ json3@^3.3.2:
   resolved "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
-json5@2.x, json5@^2.1.1, json5@^2.1.2:
+json5@2.x, json5@^2.1.1, json5@^2.1.2, json5@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### What
---

This change introduces a new type `TechDocsMetadata` in `packages/techdocs-common`. As requested in #3716 this new type has the following fields:
```js
export type TechDocsMetadata = {
site_name: string
site_description: string
}
```

* Apart from introducing this new type in `techdocs-common`, this change also modifies the techdocs publishers to make use of the new type instead of simply returning a string to represent the metadata. The publishers changed are:
   - `local`;
   - `googleStorage`;
   - `awsS3` (including tests).
   
* In `plugins/techdocs-backend` the type is used in the endpoint.
* In `plugins/techdocs` it is used in the api interface as well as in (some) components.


#### How
---

`techdocs-common`. 
   * For the three publishers I have changed the function signatures to include the new type. Additionally, for `awsS3` I have changed the test fixtures to reflect the new changes. Because of a mismatch caused by the tests (e.g when checking for an error), I have also tried my best at changing the error handling to conform to the existing test suite.
   * Exported the type to make it available in the respective plugins.

`techdocs-backend`.
   * The only change I have made here has been in the endpoint response; a quick `grep` in the root of the plugin shows the metadata used only in the endpoint response. _I am unsure if this is what has been requested_ so please do let me know if I need to make changes. I have sought here to be more rigorous in type checking so I switched the logic to `async/await` with explicit type annotations. I have also added in a try/catch to be in tune with the rest of the endpoints.

`techdocs`.
  * This is the one I'm most uncertain of, I feel like I missed a few things;
  * The most noticeable change comes from the api interface modification; the signature of the function now has a return type of `Promise<TechDocsMetadata>`, in the method implementation we parse the JSON into an actual object of the type.
  * Modified the header props to have an explicit `AnyState<E>` type (where E is TechdocsMetadata) instead of a more generic any.
 

Created a `PATCH` changeset. Please let me know if I have missed anything! Feedback is greatly appreciated in terms of code quality, stylistic choices and of course how well this fixes the issue.

_Fixes #3716_

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
