### PR TITLE
Remove empty entity count; tweak mock data

### DIFF
--- a/.changeset/cost-insights-careless-coins-pretend
+++ b/.changeset/cost-insights-careless-coins-pretend
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+bug(cost-insights): Remove entity count when none present

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsCard.test.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsCard.test.tsx
@@ -117,6 +117,7 @@ describe('<ProductInsightsCard/>', () => {
     );
     const subheaderRgx = new RegExp(subheader);
     expect(rendered.getByText(subheaderRgx)).toBeInTheDocument();
+    expect(rendered.queryByText(/sorted by cost/)).not.toBeInTheDocument();
     expect(
       rendered.queryByTestId('.resource-growth-chart-legend'),
     ).not.toBeInTheDocument();

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsCard.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsCard.tsx
@@ -96,9 +96,10 @@ export const ProductInsightsCard = ({
   const entityKey = findAnyKey(entity?.entities);
   const entities = entityKey ? entity!.entities[entityKey] : [];
 
-  const subheader = entityKey
-    ? `${pluralize(entityKey, entities.length, true)}, sorted by cost`
-    : null;
+  const subheader =
+    entityKey && entities.length
+      ? `${pluralize(entityKey, entities.length, true)}, sorted by cost`
+      : null;
   const headerProps = {
     classes: classes,
     action: <PeriodSelect duration={duration} onSelect={setDuration} />,

--- a/plugins/cost-insights/src/utils/mockData.ts
+++ b/plugins/cost-insights/src/utils/mockData.ts
@@ -211,16 +211,15 @@ export function trendlineOf(aggregation: DateAggregation[]): Trendline {
 }
 
 export function changeOf(aggregation: DateAggregation[]): ChangeStatistic {
-  const half = Math.ceil(aggregation.length / 2);
-  const before = aggregation
-    .slice(0, half)
-    .reduce((sum, a) => sum + a.amount, 0);
-  const after = aggregation
-    .slice(half, aggregation.length)
-    .reduce((sum, a) => sum + a.amount, 0);
+  const firstAmount = aggregation.length ? aggregation[0].amount : 0;
+  const lastAmount = aggregation.length
+    ? aggregation[aggregation.length - 1].amount
+    : 0;
+  const ratio =
+    firstAmount !== 0 ? (lastAmount - firstAmount) / firstAmount : 0;
   return {
-    ratio: (after - before) / before,
-    amount: after - before,
+    ratio: ratio,
+    amount: lastAmount - firstAmount,
   };
 }
 
@@ -530,7 +529,7 @@ export const SampleBigQueryInsights: Entity = {
   entities: {
     dataset: [
       {
-        id: 'entity-a',
+        id: 'dataset-a',
         aggregation: [5_000, 10_000],
         change: {
           ratio: 1,
@@ -539,7 +538,7 @@ export const SampleBigQueryInsights: Entity = {
         entities: {},
       },
       {
-        id: 'entity-b',
+        id: 'dataset-b',
         aggregation: [5_000, 10_000],
         change: {
           ratio: 1,
@@ -548,7 +547,7 @@ export const SampleBigQueryInsights: Entity = {
         entities: {},
       },
       {
-        id: 'entity-c',
+        id: 'dataset-c',
         aggregation: [0, 10_000],
         change: {
           ratio: 10_000,
@@ -600,7 +599,7 @@ export const SampleCloudDataflowInsights: Entity = {
         },
       },
       {
-        id: 'entity-a',
+        id: 'pipeline-a',
         aggregation: [60_000, 70_000],
         change: {
           ratio: 0.16666666666666666,
@@ -639,7 +638,7 @@ export const SampleCloudDataflowInsights: Entity = {
         },
       },
       {
-        id: 'entity-b',
+        id: 'pipeline-b',
         aggregation: [12_000, 8_000],
         change: {
           ratio: -0.33333,
@@ -669,7 +668,7 @@ export const SampleCloudDataflowInsights: Entity = {
         },
       },
       {
-        id: 'entity-c',
+        id: 'pipeline-c',
         aggregation: [0, 10_000],
         change: {
           ratio: 10_000,
@@ -691,7 +690,7 @@ export const SampleCloudStorageInsights: Entity = {
   entities: {
     bucket: [
       {
-        id: 'entity-a',
+        id: 'bucket-a',
         aggregation: [15_000, 20_000],
         change: {
           ratio: 0.333,
@@ -730,7 +729,7 @@ export const SampleCloudStorageInsights: Entity = {
         },
       },
       {
-        id: 'entity-b',
+        id: 'bucket-b',
         aggregation: [30_000, 25_000],
         change: {
           ratio: -0.16666,
@@ -769,7 +768,7 @@ export const SampleCloudStorageInsights: Entity = {
         },
       },
       {
-        id: 'entity-c',
+        id: 'bucket-c',
         aggregation: [0, 0],
         change: {
           ratio: 0,
@@ -791,7 +790,7 @@ export const SampleComputeEngineInsights: Entity = {
   entities: {
     service: [
       {
-        id: 'entity-a',
+        id: 'service-a',
         aggregation: [20_000, 10_000],
         change: {
           ratio: -0.5,
@@ -850,7 +849,7 @@ export const SampleComputeEngineInsights: Entity = {
         },
       },
       {
-        id: 'entity-b',
+        id: 'service-b',
         aggregation: [10_000, 20_000],
         change: {
           ratio: 1,
@@ -909,7 +908,7 @@ export const SampleComputeEngineInsights: Entity = {
         },
       },
       {
-        id: 'entity-c',
+        id: 'service-c',
         aggregation: [0, 10_000],
         change: {
           ratio: 10_000,
@@ -931,7 +930,7 @@ export const SampleEventsInsights: Entity = {
   entities: {
     event: [
       {
-        id: 'entity-a',
+        id: 'event-a',
         aggregation: [15_000, 7_000],
         change: {
           ratio: -0.53333333333,
@@ -970,7 +969,7 @@ export const SampleEventsInsights: Entity = {
         },
       },
       {
-        id: 'entity-b',
+        id: 'event-b',
         aggregation: [5_000, 3_000],
         change: {
           ratio: -0.4,


### PR DESCRIPTION
Fixes a bug where Cost Insights product panels showed `0 entities, sorted by cost` in addition to the "no entities" verbiage already present.

I also updated mock data to have less-generic entity names, and switched the `changeOf` calculation to use first/last amount rather than sums.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
