### PR TITLE
TechDocs: Improve Google Cloud authentication

### DIFF
--- a/.changeset/heavy-owls-float.md
+++ b/.changeset/heavy-owls-float.md
@@ -5,6 +5,8 @@
 
 Google Cloud authentication in TechDocs has been improved.
 
-`techdocs.publisher.googleGcs.credentials` is now optional. If it is missing, `GOOGLE_APPLICATION_CREDENTIALS`
-environment variable (and some other methods) will be used to authenticate.
-Read more here https://cloud.google.com/docs/authentication/production
+1. `techdocs.publisher.googleGcs.credentials` is now optional. If it is missing, `GOOGLE_APPLICATION_CREDENTIALS`
+   environment variable (and some other methods) will be used to authenticate.
+   Read more here https://cloud.google.com/docs/authentication/production
+
+2. `techdocs.publisher.googleGcs.projectId` is no longer used. You can remove it from your `app-config.yaml`.

--- a/.changeset/heavy-owls-float.md
+++ b/.changeset/heavy-owls-float.md
@@ -1,0 +1,10 @@
+---
+'@backstage/techdocs-common': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Google Cloud authentication in TechDocs has been improved. https://github.com/backstage/backstage/pull/3981
+
+`techdocs.publisher.googleGcs.credentials` is now optional. If it is missing, `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable (and some other methods) will be used to authenticate.
+Read more here https://cloud.google.com/docs/authentication/production

--- a/.changeset/heavy-owls-float.md
+++ b/.changeset/heavy-owls-float.md
@@ -3,7 +3,7 @@
 '@backstage/plugin-techdocs': patch
 ---
 
-Google Cloud authentication in TechDocs has been improved. https://github.com/backstage/backstage/pull/3981
+Google Cloud authentication in TechDocs has been improved.
 
 `techdocs.publisher.googleGcs.credentials` is now optional. If it is missing, `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable (and some other methods) will be used to authenticate.

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -54,15 +54,14 @@ techdocs:
     # Required when techdocs.publisher.type is set to 'googleGcs'. Skip otherwise.
 
     googleGcs:
-      # An API key is required to write to a storage bucket.
+      # (Required) Cloud Storage Bucket Name
+      bucketName: 'techdocs-storage'
+
+      # (Optional) An API key is required to write to a storage bucket.
+      # If missing, GOOGLE_APPLICATION_CREDENTIALS environment variable will be used.
+      # https://cloud.google.com/docs/authentication/production
       credentials:
         $file: '/path/to/google_application_credentials.json'
-
-      # Your GCP Project ID where the Cloud Storage Bucket is hosted.
-      projectId: 'gcp-project-id'
-
-      # Cloud Storage Bucket Name
-      bucketName: 'techdocs-storage'
 
     # Required when techdocs.publisher.type is set to 'awsS3'. Skip otherwise.
 

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -30,20 +30,34 @@ techdocs:
     type: 'googleGcs'
 ```
 
-**2. GCP (Google Cloud Platform) Project**
+**2. GCS Bucket**
 
-Create or choose a dedicated GCP project. Set
-`techdocs.publisher.googleGcs.projectId` to the project ID.
+Create a dedicated Google Cloud Storage bucket for TechDocs sites.
+techdocs-backend will publish documentation to this bucket. TechDocs will fetch
+files from here to serve documentation in Backstage. Note that the bucket names
+are globally unique.
+
+Set the name of the bucket to `techdocs.publisher.googleGcs.bucketName`.
 
 ```yaml
 techdocs:
   publisher:
     type: 'googleGcs'
-  googleGcs:
-    projectId: 'gcp-project-id'
+    googleGcs:
+      bucketName: 'name-of-techdocs-storage-bucket'
 ```
 
-**3. Service account API key**
+**3a. (Recommended) Authentication using environment variable**
+
+The GCS Node.js client will automatically use the environment variable
+`GOOGLE_APPLICATION_CREDENTIALS` to authenticate with Google Cloud. It might
+already be set in Compute Engine, Google Kubernetes Engine, etc. Read
+https://cloud.google.com/docs/authentication/production for more details.
+
+**3b. Authentication using app-config.yaml**
+
+If you do not prefer (3a) and optionally like to use a service account, you can
+follow these steps.
 
 Create a new Service Account and a key associated with it. In roles of the
 service account, use "Storage Admin".
@@ -65,34 +79,29 @@ techdocs:
   publisher:
     type: 'googleGcs'
     googleGcs:
-      projectId: 'gcp-project-id'
+      bucketName: 'name-of-techdocs-storage-bucket'
       credentials:
         $file: '/path/to/google_application_credentials.json'
 ```
 
-**4. GCS Bucket**
-
-Create a dedicated bucket for TechDocs sites. techdocs-backend will publish
-documentation to this bucket. TechDocs will fetch files from here to serve
-documentation in Backstage.
-
-Set the name of the bucket to `techdocs.publisher.googleGcs.bucketName`.
+Note: If you are finding it difficult to make the file
+`google_application_credentials.json` available on a server, you could use the
+file's content and set as an environment variable. And then use
 
 ```yaml
 techdocs:
   publisher:
     type: 'googleGcs'
     googleGcs:
-      projectId: 'gcp-project-id'
-      credentials:
-        $file: '/path/to/google_application_credentials.json'
       bucketName: 'name-of-techdocs-storage-bucket'
+      credentials:
+        $env: TECHDOCS_GCS_CREDENTIALS
 ```
 
-**5. That's it!**
+**4. That's it!**
 
 Your Backstage app is now ready to use Google Cloud Storage for TechDocs, to
-store the static generated documentation files.
+store and read the static generated documentation files.
 
 ## Configuring AWS S3 Bucket with TechDocs
 
@@ -113,9 +122,8 @@ techdocs:
 **2. AWS Policies**
 
 AWS Policies lets you **control access** to Amazon Web Services (AWS) products
-and resources.  
-Here we will use a user policy **and** a bucket policy to show you the different
-possibilities you have but you can use only one.
+and resources. Here we will use a user policy **and** a bucket policy to show
+you the different possibilities you have but you can use only one.
 
 <img data-zoomable src="../../assets/techdocs/aws-s3.drawio.svg" alt="AWS S3" width="500" />
 
@@ -135,9 +143,9 @@ and the **user** policy.
 **2.1.1 Create an Admin user** (if you don't have one yet)
 
 Create an **administrator user** account `ADMIN_USER` and grant it administrator
-privileges by attaching a user policy giving the account **full access**.  
-Note down the Admin User credentials and IAM User Sign-In URL as you will need
-to use this information in the next step.
+privileges by attaching a user policy giving the account **full access**. Note
+down the Admin User credentials and IAM User Sign-In URL as you will need to use
+this information in the next step.
 
 **2.1.2 Create an AWS S3 Bucket**
 
@@ -171,9 +179,9 @@ In the IAM console, do the following:
 
 **2.2 Attach policies**
 
-Remember that you can use Bucket policy **or** User policy.  
-Just make sure that you grant all the permissions to the TechDocs user:
-`3:PutObject`, `s3:GetObject`, `s3:ListBucket` and `s3:GetBucketLocation`.
+Remember that you can use Bucket policy **or** User policy. Just make sure that
+you grant all the permissions to the TechDocs user: `3:PutObject`,
+`s3:GetObject`, `s3:ListBucket` and `s3:GetBucketLocation`.
 
 **2.2.1 Create the bucket policy**
 
@@ -209,9 +217,9 @@ section:
 - The first statement grants **TechDocs User** the bucket operation permissions
   `s3:GetBucketLocation` and `s3:ListBucket` which are permissions required by
   the console.
-- The second statement grants the `s3:GetObject` permission.  
-  (**NOTE :** if you do not use the user policy defined below you must also add
-  the `s3:PutObject` permission to allow the TechDocs user to add objects.)
+- The second statement grants the `s3:GetObject` permission. (**NOTE :** if you
+  do not use the user policy defined below you must also add the `s3:PutObject`
+  permission to allow the TechDocs user to add objects.)
 
 **2.2.2 Create the user policy**
 

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -180,7 +180,7 @@ In the IAM console, do the following:
 **2.2 Attach policies**
 
 Remember that you can use Bucket policy **or** User policy. Just make sure that
-you grant all the permissions to the TechDocs user: `3:PutObject`,
+you grant all the permissions to the TechDocs user: `s3:PutObject`,
 `s3:GetObject`, `s3:ListBucket` and `s3:GetBucketLocation`.
 
 **2.2.1 Create the bucket policy**

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -95,7 +95,7 @@ techdocs:
     googleGcs:
       bucketName: 'name-of-techdocs-storage-bucket'
       credentials:
-        $env: TECHDOCS_GCS_CREDENTIALS
+        $env: GOOGLE_APPLICATION_CREDENTIALS
 ```
 
 **4. That's it!**

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -37,7 +37,8 @@ techdocs-backend will publish documentation to this bucket. TechDocs will fetch
 files from here to serve documentation in Backstage. Note that the bucket names
 are globally unique.
 
-Set the name of the bucket to `techdocs.publisher.googleGcs.bucketName`.
+Set the config `techdocs.publisher.googleGcs.bucketName` in your
+`app-config.yaml` to the name of the bucket you just created.
 
 ```yaml
 techdocs:

--- a/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
+++ b/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 type storageOptions = {
-  projectId?: string;
   keyFilename?: string;
 };
 
@@ -39,11 +38,9 @@ class Bucket {
 }
 
 export class Storage {
-  private readonly projectId;
   private readonly keyFilename;
 
   constructor(options: storageOptions) {
-    this.projectId = options.projectId;
     this.keyFilename = options.keyFilename;
   }
 

--- a/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
@@ -37,7 +37,7 @@ jest.spyOn(logger, 'info').mockReturnValue(logger);
 
 let publisher: PublisherBase;
 
-beforeEach(() => {
+beforeEach(async () => {
   const mockConfig = new ConfigReader({
     techdocs: {
       requestUrl: 'http://localhost:7000',
@@ -45,14 +45,13 @@ beforeEach(() => {
         type: 'googleGcs',
         googleGcs: {
           credentials: '{}',
-          projectId: 'gcp-project-id',
           bucketName: 'bucketName',
         },
       },
     },
   });
 
-  publisher = GoogleGCSPublish.fromConfig(mockConfig, logger);
+  publisher = await GoogleGCSPublish.fromConfig(mockConfig, logger);
 });
 
 describe('GoogleGCSPublish', () => {

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -72,7 +72,7 @@ export class GoogleGCSPublish implements PublisherBase {
       logger.error(
         `Could not retrieve metadata about the GCS bucket ${bucketName}. ` +
           'Make sure the bucket exists. Also make sure that authentication is setup either by explicitly defining ' +
-          'techdocs.publisher.googleGcs.credentials in app config or by using environment variables' +
+          'techdocs.publisher.googleGcs.credentials in app config or by using environment variables. ' +
           'Refer to https://backstage.io/docs/features/techdocs/using-cloud-storage',
       );
       throw new Error(err.message);

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -56,15 +56,11 @@ export class GoogleGCSPublish implements PublisherBase {
         );
       }
     }
-    const projectId = config.getOptionalString(
-      'techdocs.publisher.googleGcs.projectId',
-    );
 
     const storageClient = new Storage({
       ...(credentials && {
         credentials: credentialsJson,
       }),
-      ...(projectId && { projectId }),
     });
 
     // Check if the defined bucket exists. Being able to connect means the configuration is good

--- a/packages/techdocs-common/src/stages/publish/publish.test.ts
+++ b/packages/techdocs-common/src/stages/publish/publish.test.ts
@@ -69,7 +69,6 @@ describe('Publisher', () => {
           type: 'googleGcs',
           googleGcs: {
             credentials: '{}',
-            projectId: 'gcp-project-id',
             bucketName: 'bucketName',
           },
         },

--- a/packages/techdocs-common/src/stages/publish/publish.ts
+++ b/packages/techdocs-common/src/stages/publish/publish.ts
@@ -43,7 +43,7 @@ export class Publisher {
     switch (publisherType) {
       case 'googleGcs':
         logger.info('Creating Google Storage Bucket publisher for TechDocs');
-        return GoogleGCSPublish.fromConfig(config, logger);
+        return await GoogleGCSPublish.fromConfig(config, logger);
       case 'awsS3':
         logger.info('Creating AWS S3 Bucket publisher for TechDocs');
         return AwsS3Publish.fromConfig(config, logger);

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -123,7 +123,7 @@ export interface Config {
            */
           googleGcs?: {
             /**
-             * Cloud Storage Bucket Name
+             * (Required) Cloud Storage Bucket Name
              * attr: 'bucketName' - accepts a string value
              * @visibility secret
              */

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -123,17 +123,19 @@ export interface Config {
            */
           googleGcs?: {
             /**
-             * API key used to write to a storage bucket.
+             * (Optional) API key used to write to a storage bucket.
+             * If not set, environment variables will be used to authenticate.
+             * Read more: https://cloud.google.com/docs/authentication/production
              * attr: 'credentials' - accepts a string value
              * @visibility secret
              */
-            credentials: string;
+            credentials?: string;
             /**
              * GCP Project ID where the Cloud Storage Bucket is hosted.
              * attr: 'projectId' - accepts a string value
              * @visibility secret
              */
-            projectId: string;
+            projectId?: string;
             /**
              * Cloud Storage Bucket Name
              * attr: 'bucketName' - accepts a string value

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -123,6 +123,12 @@ export interface Config {
            */
           googleGcs?: {
             /**
+             * Cloud Storage Bucket Name
+             * attr: 'bucketName' - accepts a string value
+             * @visibility secret
+             */
+            bucketName: string;
+            /**
              * (Optional) API key used to write to a storage bucket.
              * If not set, environment variables will be used to authenticate.
              * Read more: https://cloud.google.com/docs/authentication/production
@@ -130,18 +136,6 @@ export interface Config {
              * @visibility secret
              */
             credentials?: string;
-            /**
-             * GCP Project ID where the Cloud Storage Bucket is hosted.
-             * attr: 'projectId' - accepts a string value
-             * @visibility secret
-             */
-            projectId?: string;
-            /**
-             * Cloud Storage Bucket Name
-             * attr: 'bucketName' - accepts a string value
-             * @visibility secret
-             */
-            bucketName: string;
           };
         };
   };


### PR DESCRIPTION
Closes #3947

In config language ->

```yaml
techdocs:
  publisher:
    type: 'googleGcs'
    googleGcs:
      bucketName: ''  # The only required config now.
      credentials: ''  # Now Optional. 
      projectId: ''  # Now Removed.
```

It is now possible to authenticate with Google Cloud without explicitly setting `techdocs.publisher.googleGcs.credentials`.

Arguably the most secure and simple way to authenticate with Google Cloud is to have the cloud set credentials on its own during deployment. Compute Engine, Google Kubernetes Engine, App Engine, (and more..) automatically provide a default service account and set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.

https://cloud.google.com/docs/authentication/production

This PR enables the client used by TechDocs to be configured using the environment variable `GOOGLE_APPLICATION_CREDENTIALS`. If it the environment variable is missing, the client can also read credentials from `~/.config/gcloud/*` if available.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
