### PR TITLE
docs: How to configure CI/CD to generate and publish TechDocs sites

### DIFF
--- a/docs/features/techdocs/architecture.md
+++ b/docs/features/techdocs/architecture.md
@@ -142,11 +142,10 @@ Status of all the features mentioned above.
 
 - Basic setup with techdocs-backend file server as storage.
 - Basic setup with cloud storage solution.
-
-**Work in progress 🚧**
-
 - `techdocs-cli` is able to generate docs in CI/CD environment.
 - `techdocs-cli` is able to publish docs site to any storage.
+
+**Work in progress 🚧**
 
 **Not implemented yet ❌**
 

--- a/docs/features/techdocs/configuring-ci-cd.md
+++ b/docs/features/techdocs/configuring-ci-cd.md
@@ -1,0 +1,87 @@
+---
+id: configuring-ci-cd
+title: Configuring CI/CD to generate and publish TechDocs sites
+description:
+  Configuring CI/CD to generate and publish TechDocs sites to cloud storage
+---
+
+In the [Recommended deployment setup](./architecture.md#recommended-deployment),
+TechDocs reads the static generated documentation files from a cloud storage
+bucket (GCS, AWS S3, etc.). The documentation site is generated on the CI/CD
+workflow associated with the repository containing the documentation files. This
+document explains the steps needed to generate docs on CI and publish to a cloud
+storage using [`techdocs-cli`](https://github.com/backstage/techdocs-cli).
+
+The steps here target all kinds of CI providers (GitHub actions, Circle CI,
+Jenkins, etc.) Specific tools for individual providers will also be made
+available here for simplicity (e.g. A GitHub Actions runner, CircleCI orb, etc.)
+
+A summary of the instructions below looks like this -
+
+```sh
+# Prepare
+REPOSITORY_URL='https://github.com/org/repo'
+git clone $REPOSITORY_URL
+
+# Generate
+npx techdocs-cli generate --source-dir ./repo --output-dir ./site
+
+# Publish
+npx techdocs-cli publish --directory ./site --publisher-type awsS3 --bucket-name <bucket> --entity <Namespace/Kind/Name>
+
+# That's it!
+```
+
+## 1. Setup a workflow
+
+The TechDocs workflow should trigger on CI when any changes are made in the
+repository containing the documentation files. You can be specific and trigger
+the workflow only on changes to files inside the `docs/` directory or
+`mkdocs.yml`.
+
+## 2. Prepare step
+
+The first step on the CI is to clone the repository in a working directory. This
+is almost always the first step in most CI workflows.
+
+On GitHub actions, you can add a step
+
+[`- uses: actions@checkout@v2`](https://github.com/actions/checkout).
+
+On CircleCI, you can add a special
+[`checkout`](https://circleci.com/docs/2.0/configuration-reference/#checkout)
+step.
+
+Eventually we are trying to do a `git clone <https://path/to/docs-repository/>`.
+
+## 3. Generate step
+
+Install [`npx`](https://www.npmjs.com/package/npx) to use it for running
+`techdocs-cli`. We are going to use the `techdocs-cli generate` command here.
+
+Take a look at
+[`techdocs-cli` README](https://github.com/backstage/techdocs-cli) for the
+complete command reference, details, and options.
+
+```
+npx techdocs-cli generate --no-docker --source-dir PATH_TO_REPO --output-dir ./site
+```
+
+`PATH_TO_REPO` should be the location where the prepare step above clones the
+repository.
+
+## 4. Publish step
+
+Take a look at
+[`techdocs-cli` README](https://github.com/backstage/techdocs-cli) for the
+complete command reference, details, and options.
+
+Depending on your cloud storage provider (AWS or Google Cloud), set the
+necessary authentication environment variables.
+
+- [Google Cloud authentication](https://cloud.google.com/storage/docs/authentication#libauth)
+- [AWS authentication](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html)
+
+```
+techdocs-cli publish --directory ./site --publisher-type <awsS3|googleGcs> --bucket-name <bucket> --entity <namespace/kind/name>
+```

--- a/docs/features/techdocs/configuring-ci-cd.md
+++ b/docs/features/techdocs/configuring-ci-cd.md
@@ -24,10 +24,10 @@ REPOSITORY_URL='https://github.com/org/repo'
 git clone $REPOSITORY_URL
 
 # Generate
-npx techdocs-cli generate --source-dir ./repo --output-dir ./site
+npx @techdocs/cli generate --source-dir ./repo --output-dir ./site
 
 # Publish
-npx techdocs-cli publish --directory ./site --publisher-type awsS3 --bucket-name <bucket> --entity <Namespace/Kind/Name>
+npx @techdocs/cli publish --directory ./site --publisher-type awsS3 --bucket-name <bucket> --entity <Namespace/Kind/Name>
 
 # That's it!
 ```
@@ -64,7 +64,7 @@ Take a look at
 complete command reference, details, and options.
 
 ```
-npx techdocs-cli generate --no-docker --source-dir PATH_TO_REPO --output-dir ./site
+npx @techdocs/cli generate --no-docker --source-dir PATH_TO_REPO --output-dir ./site
 ```
 
 `PATH_TO_REPO` should be the location where the prepare step above clones the
@@ -83,5 +83,5 @@ necessary authentication environment variables.
 - [AWS authentication](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html)
 
 ```
-techdocs-cli publish --directory ./site --publisher-type <awsS3|googleGcs> --bucket-name <bucket> --entity <namespace/kind/name>
+npx @techdocs/cli publish --directory ./site --publisher-type <awsS3|googleGcs> --bucket-name <bucket> --entity <namespace/kind/name>
 ```

--- a/docs/features/techdocs/configuring-ci-cd.md
+++ b/docs/features/techdocs/configuring-ci-cd.md
@@ -13,8 +13,8 @@ document explains the steps needed to generate docs on CI and publish to a cloud
 storage using [`techdocs-cli`](https://github.com/backstage/techdocs-cli).
 
 The steps here target all kinds of CI providers (GitHub Actions, CircleCI,
-Jenkins, etc.) Specific tools for individual providers will also be made
-available here for simplicity (e.g. A GitHub Actions runner, CircleCI orb, etc.)
+Jenkins, etc.). Specific tools for individual providers will also be made
+available here for simplicity (e.g. a GitHub Actions runner, CircleCI orb, etc.).
 
 A summary of the instructions below looks like this -
 

--- a/docs/features/techdocs/configuring-ci-cd.md
+++ b/docs/features/techdocs/configuring-ci-cd.md
@@ -12,7 +12,7 @@ workflow associated with the repository containing the documentation files. This
 document explains the steps needed to generate docs on CI and publish to a cloud
 storage using [`techdocs-cli`](https://github.com/backstage/techdocs-cli).
 
-The steps here target all kinds of CI providers (GitHub actions, Circle CI,
+The steps here target all kinds of CI providers (GitHub Actions, CircleCI,
 Jenkins, etc.) Specific tools for individual providers will also be made
 available here for simplicity (e.g. A GitHub Actions runner, CircleCI orb, etc.)
 
@@ -44,7 +44,7 @@ the workflow only on changes to files inside the `docs/` directory or
 The first step on the CI is to clone the repository in a working directory. This
 is almost always the first step in most CI workflows.
 
-On GitHub actions, you can add a step
+On GitHub Actions, you can add a step
 
 [`- uses: actions@checkout@v2`](https://github.com/actions/checkout).
 
@@ -67,7 +67,7 @@ complete command reference, details, and options.
 npx @techdocs/cli generate --no-docker --source-dir PATH_TO_REPO --output-dir ./site
 ```
 
-`PATH_TO_REPO` should be the location where the prepare step above clones the
+`PATH_TO_REPO` should be the location in the file path where the prepare step above clones the
 repository.
 
 ## 4. Publish step
@@ -76,7 +76,7 @@ Take a look at
 [`techdocs-cli` README](https://github.com/backstage/techdocs-cli) for the
 complete command reference, details, and options.
 
-Depending on your cloud storage provider (AWS or Google Cloud), set the
+Depending on your cloud storage provider (AWS, Google Cloud, or Azure), set the
 necessary authentication environment variables.
 
 - [Google Cloud authentication](https://cloud.google.com/storage/docs/authentication#libauth)

--- a/docs/features/techdocs/configuring-ci-cd.md
+++ b/docs/features/techdocs/configuring-ci-cd.md
@@ -14,7 +14,8 @@ storage using [`techdocs-cli`](https://github.com/backstage/techdocs-cli).
 
 The steps here target all kinds of CI providers (GitHub Actions, CircleCI,
 Jenkins, etc.). Specific tools for individual providers will also be made
-available here for simplicity (e.g. a GitHub Actions runner, CircleCI orb, etc.).
+available here for simplicity (e.g. a GitHub Actions runner, CircleCI orb,
+etc.).
 
 A summary of the instructions below looks like this -
 

--- a/docs/features/techdocs/configuring-ci-cd.md
+++ b/docs/features/techdocs/configuring-ci-cd.md
@@ -1,8 +1,8 @@
 ---
 id: configuring-ci-cd
 title: Configuring CI/CD to generate and publish TechDocs sites
-description:
-  Configuring CI/CD to generate and publish TechDocs sites to cloud storage
+# prettier-ignore
+description: Configuring CI/CD to generate and publish TechDocs sites to cloud storage
 ---
 
 In the [Recommended deployment setup](./architecture.md#recommended-deployment),
@@ -19,30 +19,37 @@ available here for simplicity (e.g. A GitHub Actions runner, CircleCI orb, etc.)
 A summary of the instructions below looks like this -
 
 ```sh
+# This is an example script
+
 # Prepare
 REPOSITORY_URL='https://github.com/org/repo'
 git clone $REPOSITORY_URL
+cd repo
 
 # Generate
-npx @techdocs/cli generate --source-dir ./repo --output-dir ./site
+npx @techdocs/cli generate
 
 # Publish
-npx @techdocs/cli publish --directory ./site --publisher-type awsS3 --bucket-name <bucket> --entity <Namespace/Kind/Name>
-
-# That's it!
+npx @techdocs/cli publish --publisher-type awsS3 --storage-name <bucket/container> --entity <Namespace/Kind/Name>
 ```
+
+That's it!
+
+Take a look at
+[`techdocs-cli` README](https://github.com/backstage/techdocs-cli) for the
+complete command reference, details, and options.
 
 ## 1. Setup a workflow
 
 The TechDocs workflow should trigger on CI when any changes are made in the
-repository containing the documentation files. You can be specific and trigger
-the workflow only on changes to files inside the `docs/` directory or
-`mkdocs.yml`.
+repository containing the documentation files. You can be specific and configure
+the workflow to be triggered only when files inside the `docs/` directory or
+`mkdocs.yml` are changed.
 
 ## 2. Prepare step
 
-The first step on the CI is to clone the repository in a working directory. This
-is almost always the first step in most CI workflows.
+The first step on the CI is to clone your documentation source repository in a
+working directory. This is almost always the first step in most CI workflows.
 
 On GitHub Actions, you can add a step
 
@@ -57,24 +64,20 @@ Eventually we are trying to do a `git clone <https://path/to/docs-repository/>`.
 ## 3. Generate step
 
 Install [`npx`](https://www.npmjs.com/package/npx) to use it for running
-`techdocs-cli`. We are going to use the `techdocs-cli generate` command here.
+`techdocs-cli`. Or you can install using `npm install -g @techdocs/cli`.
 
-Take a look at
-[`techdocs-cli` README](https://github.com/backstage/techdocs-cli) for the
-complete command reference, details, and options.
+We are going to use the
+[`techdocs-cli generate`](https://github.com/backstage/techdocs-cli#generate-techdocs-site-from-a-documentation-project)
+command in this step.
 
-```
+```sh
 npx @techdocs/cli generate --no-docker --source-dir PATH_TO_REPO --output-dir ./site
 ```
 
-`PATH_TO_REPO` should be the location in the file path where the prepare step above clones the
-repository.
+`PATH_TO_REPO` should be the location in the file path where the prepare step
+above clones the repository.
 
 ## 4. Publish step
-
-Take a look at
-[`techdocs-cli` README](https://github.com/backstage/techdocs-cli) for the
-complete command reference, details, and options.
 
 Depending on your cloud storage provider (AWS, Google Cloud, or Azure), set the
 necessary authentication environment variables.
@@ -82,6 +85,13 @@ necessary authentication environment variables.
 - [Google Cloud authentication](https://cloud.google.com/storage/docs/authentication#libauth)
 - [AWS authentication](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html)
 
+And then run the
+[`techdocs-cli publish`](https://github.com/backstage/techdocs-cli#publish-generated-techdocs-sites)
+command.
+
+```sh
+npx @techdocs/cli publish --publisher-type <awsS3|googleGcs> --storage-name <bucket/container> --entity <namespace/kind/name> --directory ./site
 ```
-npx @techdocs/cli publish --directory ./site --publisher-type <awsS3|googleGcs> --bucket-name <bucket> --entity <namespace/kind/name>
-```
+
+The updated TechDocs site built in this workflow is now ready to be served by
+the TechDocs plugin in your Backstage app.

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -91,6 +91,7 @@
           "features/techdocs/creating-and-publishing",
           "features/techdocs/configuration",
           "features/techdocs/using-cloud-storage",
+          "features/techdocs/configuring-ci-cd",
           "features/techdocs/how-to-guides",
           "features/techdocs/troubleshooting",
           "features/techdocs/faqs"


### PR DESCRIPTION
[`techdocs-cli`](https://github.com/backstage/techdocs-cli) is now ready to be used in a CI environment for generating docs and publishing to a cloud storage. [Features added in this PR](https://github.com/backstage/techdocs-cli/pull/20). TechDocs plugin is already able to read from an external cloud storage (GCS/AWS). [Docs](https://backstage.io/docs/features/techdocs/using-cloud-storage).

Merging this PR signifies that the [Recommended deployment setup of TechDocs](https://backstage.io/docs/features/techdocs/architecture) is now ready to use. 🎉 

Closes #3097 