### PR TITLE
fix(techdocs): Handle images and other binaries correctly in aws/gcs publishers

### DIFF
--- a/.changeset/grumpy-trains-juggle.md
+++ b/.changeset/grumpy-trains-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Fix bug where binary files (`png`, etc.) could not load when using AWS or GCS publisher.

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -186,7 +186,7 @@ export class AwsS3Publish implements PublisherBase {
           fileStreamChunks.push(chunk);
         })
         .on('end', () => {
-          const fileContent = Buffer.concat(fileStreamChunks).toString();
+          const fileContent = Buffer.concat(fileStreamChunks);
           // Inject response headers
           for (const [headerKey, headerValue] of Object.entries(
             responseHeaders,

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -184,7 +184,7 @@ export class GoogleGCSPublish implements PublisherBase {
           fileStreamChunks.push(chunk);
         })
         .on('end', () => {
-          const fileContent = Buffer.concat(fileStreamChunks).toString();
+          const fileContent = Buffer.concat(fileStreamChunks);
           // Inject response headers
           for (const [headerKey, headerValue] of Object.entries(
             responseHeaders,


### PR DESCRIPTION
Closes https://github.com/backstage/backstage/issues/3990

Thanks to @jizg for reporting and proposing the solution!

Since we set the MIME type of each file in the response headers `Content-Type`, the browser will be able to understand the Buffer, and we don't need to convert it to a string.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
