### PR TITLE
fix(lighthouse plugin): Remove trailing slash from lighthouse audit urls

### DIFF
--- a/.changeset/brave-boats-greet.md
+++ b/.changeset/brave-boats-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-lighthouse': patch
+---
+
+Strip trailing slash from urls when creating a new audit. This change prevents duplicate audits from being displayed in the audit list.

--- a/.changeset/brave-boats-greet.md
+++ b/.changeset/brave-boats-greet.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-lighthouse': patch
 ---
 
-Strip trailing slash from urls when creating a new audit. This change prevents duplicate audits from being displayed in the audit list.
+Strip trailing slash from url when creating a new audit. This change prevents duplicate audits from being displayed in the audit list.

--- a/plugins/lighthouse/src/components/CreateAudit/index.tsx
+++ b/plugins/lighthouse/src/components/CreateAudit/index.tsx
@@ -79,7 +79,7 @@ export const CreateAuditContent = () => {
       // TODO use the id from the response to redirect to the audit page for that id when
       // FAILED and RUNNING audits are supported
       await lighthouseApi.triggerAudit({
-        url,
+        url: url.replace(/\/$/, ''),
         options: {
           lighthouseConfig: {
             settings: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR removes trailing slashes from Lighthouse audit urls. Prevents duplicate audits of the same url.

Resolves [3783](https://github.com/backstage/backstage/issues/3783)

## Steps to reproduce
1. Go to the Lighthouse plugin
2. Audit a public web site that just is a pure domain name
3. Run that same audit, providing the same domain name, but add a trailing slash.
4. See that you've created two different audit records, rather than now having a history of running two audits against the same site.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
