### PR TITLE
scaffolder-backend: export all preparers properly

### DIFF
--- a/.changeset/wild-dolls-rest.md
+++ b/.changeset/wild-dolls-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Export all preparers and publishers properly

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/index.ts
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './preparers';
-export * from './types';
-export * from './file';
-export * from './github';
-export * from './gitlab';
-export * from './azure';
+
+export { AzurePreparer } from './azure';
+export { BitbucketPreparer } from './bitbucket';
+export { FilePreparer } from './file';
+export { GithubPreparer } from './github';
+export { GitlabPreparer } from './gitlab';
+export { Preparers } from './preparers';
+export type { PreparerBase, PreparerBuilder, PreparerOptions } from './types';

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/index.ts
@@ -13,8 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './publishers';
-export * from './github';
-export * from './gitlab';
-export * from './azure';
-export * from './types';
+export { AzurePublisher } from './azure';
+export { BitbucketPublisher } from './bitbucket';
+export { GithubPublisher } from './github';
+export type { RepoVisibilityOptions } from './github';
+export { GitlabPublisher } from './gitlab';
+export { Publishers } from './publishers';
+export type {
+  PublisherBase,
+  PublisherBuilder,
+  PublisherOptions,
+  PublisherResult,
+} from './types';


### PR DESCRIPTION
The actual change is to export `BitbucketPreparer` and `BitbucketPublisher`, the rest is just naming the exports that already existed