### PR TITLE
feat: enable catalog table actions for all location types

### DIFF
--- a/.changeset/red-baboons-rhyme.md
+++ b/.changeset/red-baboons-rhyme.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Enable catalog table actions for all location types.
+
+The edit button has had support for other providers for a while and there is
+no specific reason the View in GitHub cannot work for all locations. This
+change also replaces the GitHub icon with the OpenInNew icon.

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -17,7 +17,7 @@ import { Entity } from '@backstage/catalog-model';
 import { Table, TableColumn, TableProps } from '@backstage/core';
 import { Chip, Link } from '@material-ui/core';
 import Edit from '@material-ui/icons/Edit';
-import GitHub from '@material-ui/icons/GitHub';
+import OpenInNew from '@material-ui/icons/OpenInNew';
 import { Alert } from '@material-ui/lab';
 import React from 'react';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
@@ -111,13 +111,12 @@ export const CatalogTable = ({
     (rowData: Entity) => {
       const location = findLocationForEntityMeta(rowData.metadata);
       return {
-        icon: () => <GitHub fontSize="small" />,
-        tooltip: 'View on GitHub',
+        icon: () => <OpenInNew fontSize="small" />,
+        tooltip: 'View',
         onClick: () => {
           if (!location) return;
           window.open(location.target, '_blank');
         },
-        hidden: location?.type !== 'github',
       };
     },
     (rowData: Entity) => {
@@ -129,7 +128,6 @@ export const CatalogTable = ({
           if (!location) return;
           window.open(createEditLink(location), '_blank');
         },
-        hidden: location?.type !== 'github',
       };
     },
     (rowData: Entity) => {


### PR DESCRIPTION
The edit button has had support for other providers for a while and there is no specific reason the View in GitHub cannot work for all locations. This change also replaces the GitHub icon with the OpenInNew icon.

<img width="191" alt="image" src="https://user-images.githubusercontent.com/6507159/104244410-579cf680-5430-11eb-8e21-b43b06c445bf.png">

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
