### PR TITLE
cli: Handle no npm info

### DIFF
--- a/.changeset/quote-plastic-monk.md
+++ b/.changeset/quote-plastic-monk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Handle no npm info

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -98,7 +98,7 @@ export default async () => {
     try {
       target = await findTargetVersion(name);
     } catch (error) {
-      if (error instanceof NotFoundError) {
+      if (error.name === 'NotFoundError') {
         console.log(`Package info not found, ignoring package ${name}`);
         return;
       }

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -26,7 +26,6 @@ import {
   Lockfile,
 } from '../../lib/versioning';
 import { includedFilter, forbiddenDuplicatesFilter } from './lint';
-import { NotFoundError } from '../../lib/errors';
 
 const DEP_TYPES = [
   'dependencies',
@@ -60,7 +59,7 @@ export default async () => {
     try {
       target = await findTargetVersion(name);
     } catch (error) {
-      if (error instanceof NotFoundError) {
+      if (error.name === 'NotFoundError') {
         console.log(`Package info not found, ignoring package ${name}`);
         return;
       }

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -44,3 +44,5 @@ export function exitWithError(error: Error): never {
     process.exit(1);
   }
 }
+
+export class NotFoundError extends CustomError {}

--- a/packages/cli/src/lib/versioning/packages.test.ts
+++ b/packages/cli/src/lib/versioning/packages.test.ts
@@ -19,6 +19,7 @@ import path from 'path';
 import * as runObj from '../run';
 import { paths } from '../paths';
 import { fetchPackageInfo, mapDependencies } from './packages';
+import { NotFoundError } from '@backstage/backend-common';
 
 describe('fetchPackageInfo', () => {
   afterEach(() => {
@@ -38,6 +39,14 @@ describe('fetchPackageInfo', () => {
       'info',
       '--json',
       'my-package',
+    );
+  });
+
+  it('should throw if no info', async () => {
+    jest.spyOn(runObj, 'runPlain').mockResolvedValue('');
+
+    await expect(fetchPackageInfo('my-package')).rejects.toThrow(
+      new NotFoundError(`No package information found for package my-package`),
     );
   });
 });

--- a/packages/cli/src/lib/versioning/packages.test.ts
+++ b/packages/cli/src/lib/versioning/packages.test.ts
@@ -19,7 +19,7 @@ import path from 'path';
 import * as runObj from '../run';
 import { paths } from '../paths';
 import { fetchPackageInfo, mapDependencies } from './packages';
-import { NotFoundError } from '@backstage/backend-common';
+import { NotFoundError } from '../errors';
 
 describe('fetchPackageInfo', () => {
   afterEach(() => {

--- a/packages/cli/src/lib/versioning/packages.ts
+++ b/packages/cli/src/lib/versioning/packages.ts
@@ -15,6 +15,7 @@
  */
 
 import { runPlain } from '../../lib/run';
+import { NotFoundError } from '../errors';
 
 const PREFIX = '@backstage';
 
@@ -49,6 +50,11 @@ export async function fetchPackageInfo(
   name: string,
 ): Promise<YarnInfoInspectData> {
   const output = await runPlain('yarn', 'info', '--json', name);
+
+  if (!output) {
+    throw new NotFoundError(`No package information found for package ${name}`);
+  }
+
   const info = JSON.parse(output) as YarnInfo;
   if (info.type !== 'inspect') {
     throw new Error(`Received unknown yarn info for ${name}, ${output}`);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Solves the [problem](https://github.com/backstage/backstage/pull/3391#issuecomment-757926299) when no npm package info is found during `backstage-cli versions:bump`.

**How**
This PR handles empty response from `yarn info` used by `backstage-cli versions:bump`. Empty responses now throws a not found exception and is handled by ignoring the package bump and prints a message that the package is ignored due to package info not found. 
  
Note that all empty `stdout` from `yarn info` will be handled the same way regardless of `stderr`. Please feedback if this is ok or not.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
