### PR TITLE
Export the schemaValidator helper function

### DIFF
--- a/.changeset/friendly-masks-dress.md
+++ b/.changeset/friendly-masks-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Export the `schemaValidator` helper function.

--- a/packages/catalog-model/src/kinds/index.ts
+++ b/packages/catalog-model/src/kinds/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export { schemaValidator } from './util';
+export type { KindValidator } from './types';
 export { apiEntityV1alpha1Validator } from './ApiEntityV1alpha1';
 export type {
   ApiEntityV1alpha1 as ApiEntity,
@@ -40,7 +42,6 @@ export type {
   TemplateEntityV1alpha1 as TemplateEntity,
   TemplateEntityV1alpha1,
 } from './TemplateEntityV1alpha1';
-export type { KindValidator } from './types';
 export { userEntityV1alpha1Validator } from './UserEntityV1alpha1';
 export type {
   UserEntityV1alpha1 as UserEntity,


### PR DESCRIPTION
I tried to follow the guide to [add a new Entity kind](https://backstage.io/docs/features/software-catalog/extending-the-model#adding-a-new-kind) and found that the convenient `schemaValidator` util hasn't been exported. Is this on purpose or can we also export it?

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
