### PR TITLE
backstage.io/docs: Add meaningful URL redirects for core features

### DIFF
--- a/microsite/pages/en/docs/features/software-catalog/index.js
+++ b/microsite/pages/en/docs/features/software-catalog/index.js
@@ -5,7 +5,10 @@ const siteConfig = require(process.cwd() + '/siteConfig.js');
 
 function Docs() {
   return (
-    <Redirect redirect="/docs/features/software-catalog/software-catalog-overview" config={siteConfig} />
+    <Redirect
+      redirect="/docs/features/software-catalog/software-catalog-overview"
+      config={siteConfig}
+    />
   );
 }
 

--- a/microsite/pages/en/docs/features/software-catalog/index.js
+++ b/microsite/pages/en/docs/features/software-catalog/index.js
@@ -1,0 +1,12 @@
+const React = require('react');
+const Redirect = require('../../../../../core/Redirect.js');
+
+const siteConfig = require(process.cwd() + '/siteConfig.js');
+
+function Docs() {
+  return (
+    <Redirect redirect="/docs/features/software-catalog/software-catalog-overview" config={siteConfig} />
+  );
+}
+
+module.exports = Docs;

--- a/microsite/pages/en/docs/features/software-templates/index.js
+++ b/microsite/pages/en/docs/features/software-templates/index.js
@@ -5,7 +5,10 @@ const siteConfig = require(process.cwd() + '/siteConfig.js');
 
 function Docs() {
   return (
-    <Redirect redirect="/docs/features/software-templates/software-templates-index" config={siteConfig} />
+    <Redirect
+      redirect="/docs/features/software-templates/software-templates-index"
+      config={siteConfig}
+    />
   );
 }
 

--- a/microsite/pages/en/docs/features/software-templates/index.js
+++ b/microsite/pages/en/docs/features/software-templates/index.js
@@ -1,0 +1,12 @@
+const React = require('react');
+const Redirect = require('../../../../../core/Redirect.js');
+
+const siteConfig = require(process.cwd() + '/siteConfig.js');
+
+function Docs() {
+  return (
+    <Redirect redirect="/docs/features/software-templates/software-templates-index" config={siteConfig} />
+  );
+}
+
+module.exports = Docs;

--- a/microsite/pages/en/docs/features/techdocs/index.js
+++ b/microsite/pages/en/docs/features/techdocs/index.js
@@ -1,0 +1,12 @@
+const React = require('react');
+const Redirect = require('../../../../../core/Redirect.js');
+
+const siteConfig = require(process.cwd() + '/siteConfig.js');
+
+function Docs() {
+  return (
+    <Redirect redirect="/docs/features/techdocs/techdocs-overview" config={siteConfig} />
+  );
+}
+
+module.exports = Docs;

--- a/microsite/pages/en/docs/features/techdocs/index.js
+++ b/microsite/pages/en/docs/features/techdocs/index.js
@@ -5,7 +5,10 @@ const siteConfig = require(process.cwd() + '/siteConfig.js');
 
 function Docs() {
   return (
-    <Redirect redirect="/docs/features/techdocs/techdocs-overview" config={siteConfig} />
+    <Redirect
+      redirect="/docs/features/techdocs/techdocs-overview"
+      config={siteConfig}
+    />
   );
 }
 


### PR DESCRIPTION
We already have a URL redirect in place for backstage.io i.e. /docs to /docs/overview/what-is-backstage

This PR adds 3 new redirects

- /docs/features/software-catalog -> /docs/features/software-catalog/software-catalog-overview
- /docs/features/techdocs -> /docs/features/techdocs/techdocs-overview
- /docs/features/software-templates -> /docs/features/software-templates/software-templates-index

Thus, making great URLs like http://backstage.io/docs/features/techdocs (and http://backstage.io/docs/features/kubernetes) more meaningful than a 404 from GitHub pages. :P

