### PR TITLE
Kubernetes blog: fix image links

### DIFF
--- a/microsite/blog/2021-01-12-new-backstage-feature-kubernetes-for-service-owners.md
+++ b/microsite/blog/2021-01-12-new-backstage-feature-kubernetes-for-service-owners.md
@@ -4,13 +4,11 @@ author: Matthew Clarke, Spotify
 authorURL: https://github.com/mclarke47
 ---
 
-![Animation of Kubernetes and cloud provider icons becoming the Backstage logo](/microsite/blog/assets/21-01-12/backstage-k8s-1-hero.gif)
+![Animation of Kubernetes and cloud provider icons becoming the Backstage logo](/blog/assets/21-01-12/backstage-k8s-1-hero.gif)
 
 TLDR; We’re rethinking the Kubernetes developer experience with a new feature: a Kubernetes monitoring tool that’s designed around the needs of service owners, not cluster admins. Now developers can easily check the health of their services no matter how or where those services are deployed — whether it’s on a local host for testing or in production on dozens of clusters around the world.
 
 And since Backstage uses the native Kubernetes API, the feature works with whichever cloud provider (AWS, Azure, GCP, etc.) or managed service (OpenShift, IBM Cloud, GKE, etc.) you already use.
-
-<--truncate-->
 
 ## The missing link between K8s and your service
 
@@ -22,21 +20,21 @@ By navigating to a service’s overview page in Backstage, you can see everythin
 
 Kubernetes in Backstage can be configured to search multiple clusters for your services. It will then aggregate them together into a single view. So if you deploy to multiple clusters you will no longer need to switch kubectl contexts to understand the current state of your service.
 
-![List of deployments in Backstage Kubernetes plugin](/microsite/blog/assets/21-01-12/backstage-k8s-2-deployments.png)
+![List of deployments in Backstage Kubernetes plugin](/blog/assets/21-01-12/backstage-k8s-2-deployments.png)
 
 ## Automatic error reporting
 
 Instead of trying different kubectl commands to figure out where an error occurred, Backstage will automatically find and highlight errors in Kubernetes resources that are affecting your service. So you can spend time fixing errors, not hunting for them.
 
-![Error reporting screen in Backstage Kubernetes plugin](/microsite/blog/assets/21-01-12/backstage-k8s-3-error-reporting.png)
+![Error reporting screen in Backstage Kubernetes plugin](/blog/assets/21-01-12/backstage-k8s-3-error-reporting.png)
 
 ## Autoscaling limits at a glance
 
 Backstage also shows you how close your service is to its autoscaling limit. Coming up to a period of high load? Now you will be able to see how your horizontal autoscaling is dealing with it across multiple clusters.
 
-![Autoscaling limits screen in Backstage Kubernetes plugin](/microsite/blog/assets/21-01-12/backstage-k8s-4-autoscaling-limits.png)
+![Autoscaling limits screen in Backstage Kubernetes plugin](/blog/assets/21-01-12/backstage-k8s-4-autoscaling-limits.png)
 
-![Autoscaling limits screen in Backstage Kubernetes plugin](/microsite/blog/assets/21-01-12/backstage-k8s-5-autoscaling-limits.png)
+![Autoscaling limits screen in Backstage Kubernetes plugin](/blog/assets/21-01-12/backstage-k8s-5-autoscaling-limits.png)
 
 ## Pick a cloud, any Cloud
 

--- a/microsite/blog/2021-01-12-new-backstage-feature-kubernetes-for-service-owners.md
+++ b/microsite/blog/2021-01-12-new-backstage-feature-kubernetes-for-service-owners.md
@@ -10,6 +10,8 @@ TLDR; We’re rethinking the Kubernetes developer experience with a new feature:
 
 And since Backstage uses the native Kubernetes API, the feature works with whichever cloud provider (AWS, Azure, GCP, etc.) or managed service (OpenShift, IBM Cloud, GKE, etc.) you already use.
 
+<!--truncate-->
+
 ## The missing link between K8s and your service
 
 A core feature of Backstage is its service catalog, which aggregates information about software systems together inside a single tool, with a consistent, familiar UI.


### PR DESCRIPTION
Looks like the image links are broken. https://backstage.io/blog/2021/01/12/new-backstage-feature-kubernetes-for-service-owners