### PR TITLE
codeowners: add changeset prefix for techdocs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,4 @@
 /plugins/techdocs-backend                   @backstage/techdocs-core
 /packages/techdocs-common                   @backstage/techdocs-core
 /.changeset/cost-insights-*                 @backstage/silver-lining
+/.changeset/techdocs-*                      @backstage/techdocs-core


### PR DESCRIPTION
@backstage/techdocs-core Use a `techdocs-` prefix for your changesets if you want to avoid needing a review from @backstage/maintainers  :grin: