### PR TITLE
cli: Remove api url from GitHub app configuration

### DIFF
--- a/.changeset/real-vans-provide.md
+++ b/.changeset/real-vans-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Remove `apiUrl` from the output of the create-github-app because apiUrl already exist in the GitHub integration config.

--- a/.changeset/real-vans-provide.md
+++ b/.changeset/real-vans-provide.md
@@ -1,5 +1,0 @@
----
-'@backstage/cli': patch
----
-
-Remove `apiUrl` from the output of the create-github-app because apiUrl already exist in the GitHub integration config.

--- a/packages/cli/src/commands/create-github-app/GithubCreateAppServer.ts
+++ b/packages/cli/src/commands/create-github-app/GithubCreateAppServer.ts
@@ -47,7 +47,6 @@ const FORM_PAGE = `
 
 type GithubAppConfig = {
   appId: number;
-  apiUrl: string;
   slug?: string;
   name?: string;
   webhookUrl?: string;
@@ -88,14 +87,11 @@ export class GithubCreateAppServer {
           `POST /app-manifests/${encodeURIComponent(
             req.query.code as string,
           )}/conversions`,
-        ).then(({ data, url }) => {
-          // url = https://api.github.com/app-manifests/<code>/conversions
-          const apiUrl = url.replace(/(?:\/[^\/]+){3}$/, '');
+        ).then(({ data }) => {
           resolve({
             name: data.name,
             slug: data.slug,
             appId: data.id,
-            apiUrl,
             webhookUrl: this.webhookUrl,
             clientId: data.client_id,
             clientSecret: data.client_secret,


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Remove `apiUrl` from the output of the create-github-app because apiUrl already exist in the GitHub integration config.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
