### PR TITLE
techdocs-backend: cache docs site when built using urlReader for 30 minutes

### DIFF
--- a/.changeset/techdocs-rotten-crabs-ring.md
+++ b/.changeset/techdocs-rotten-crabs-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+If using Url Reader, cache downloaded source files for 30 minutes.

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -144,6 +144,18 @@ export class DocsBuilder {
       }
     }
 
+    // Cache downloaded source files for 30 minutes.
+    // TODO: When urlReader/readTree supports some way to get latest commit timestamp,
+    // it should be used to invalidate cache.
+    if (type === 'url') {
+      const builtAt = buildMetadataStorage.getTimestamp();
+      const now = Date.now();
+
+      if (builtAt > now - 1800000) {
+        return true;
+      }
+    }
+
     this.logger.debug(
       `Docs for entity ${getEntityId(this.entity)} was outdated.`,
     );


### PR DESCRIPTION
This caching makes URL reader a usable experience in TechDocs, so that docs are not built on every load.
In future readTree will support a method to fetch the timestamp of the HEAD of the repository. And
the timestamp will be used to invalidate the cache. cc @Rugvip 

We already had this in https://github.com/backstage/backstage/pull/3551 but probably we lost the changes in a refactor of creating techdocs-common.

Btw. URL Reader is so much faster than usual `git clone` (current default) way of preparing the github.com/backstage/backstage mono-repo's docs. Doing a git clone downloads 522 MB, but Url Reader downloads a zip which is just 62 MB.



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
