### PR TITLE
TechDocs/Scaffolder: Use URL Reader in existing software templates

### DIFF
--- a/plugins/scaffolder-backend/sample-templates/docs-template/{{cookiecutter.component_id}}/catalog-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/docs-template/{{cookiecutter.component_id}}/catalog-info.yaml
@@ -5,7 +5,7 @@ metadata:
   description: {{cookiecutter.description | jsonify}}
   annotations:
     github.com/project-slug: {{cookiecutter.storePath | jsonify}}
-    backstage.io/techdocs-ref: github:https://github.com/{{cookiecutter.storePath}}
+    backstage.io/techdocs-ref: url:https://github.com/{{cookiecutter.storePath}}/tree/master
 spec:
   type: documentation
   lifecycle: experimental

--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/catalog-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/{{cookiecutter.component_id}}/catalog-info.yaml
@@ -5,7 +5,7 @@ metadata:
   description: {{cookiecutter.description | jsonify}}
   annotations:
     github.com/project-slug: {{cookiecutter.storePath | jsonify}}
-    backstage.io/techdocs-ref: github:https://github.com/{{cookiecutter.storePath}}
+    backstage.io/techdocs-ref: url:https://github.com/{{cookiecutter.storePath}}/tree/master
 spec:
   type: website
   lifecycle: experimental

--- a/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/catalog-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/{{cookiecutter.component_id}}/catalog-info.yaml
@@ -5,7 +5,7 @@ metadata:
   description: {{cookiecutter.description | jsonify}}
   annotations:
     github.com/project-slug: {{cookiecutter.storePath | jsonify}}
-    backstage.io/techdocs-ref: github:https://github.com/{{cookiecutter.storePath}}
+    backstage.io/techdocs-ref: url:https://github.com/{{cookiecutter.storePath}}/tree/master
 spec:
   type: service
   lifecycle: experimental


### PR DESCRIPTION
Recommending URL Reader since it is much faster than common git preparers. Added benefit - URL Reader will be capable of using temporary GitHub tokens with GitHub app work that is going on. Thus, this will help the users hitting the API rate limit in their org.

~~Not to be merged before https://github.com/backstage/backstage/pull/4061.~~ We may also want to wait until improved caching by latest commit timestamp in URL Reader is in place. But I think it is still an improvement over the current git clone way of preparing a TechDocs source repository.

I don't think this needs a changeset for software templates, right? Should/Do we announce changes to these templates using a Changelog? I guess when we have a [new repository for templates](https://github.com/backstage/backstage/issues/3383), it will be easier to maintain a changelog there, with more visibility.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
