### PR TITLE
kubernetes: Update display of errors

### DIFF
--- a/.changeset/giant-geckos-tickle.md
+++ b/.changeset/giant-geckos-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Minor updates to display of errors

--- a/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
+++ b/plugins/kubernetes/src/components/ErrorReporting/ErrorReporting.tsx
@@ -113,17 +113,17 @@ export const ErrorEmptyState = () => {
   return (
     <Grid
       container
-      justify="center"
-      direction="column"
+      justify="space-around"
+      direction="row"
       alignItems="center"
       spacing={2}
     >
-      <Grid item xs={12}>
+      <Grid item xs={4}>
         <Typography variant="h5">
           Nice! There are no errors to report!
         </Typography>
       </Grid>
-      <Grid item xs={12}>
+      <Grid item xs={4}>
         <img
           src={EmptyStateImage}
           alt="EmptyState"

--- a/plugins/kubernetes/src/components/KubernetesContent/ErrorPanel.test.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent/ErrorPanel.test.tsx
@@ -33,7 +33,7 @@ describe('ErrorPanel', () => {
     // title
     expect(
       getByText(
-        'There was an error retrieving some Kubernetes resources for the entity: THIS_ENTITY',
+        'There was a problem retrieving some Kubernetes resources for the entity: THIS_ENTITY. This could mean that the Error Reporting card is not completely accurate.',
       ),
     ).toBeInTheDocument();
 
@@ -67,7 +67,7 @@ describe('ErrorPanel', () => {
     // title
     expect(
       getByText(
-        'There was an error retrieving some Kubernetes resources for the entity: THIS_ENTITY',
+        'There was a problem retrieving some Kubernetes resources for the entity: THIS_ENTITY. This could mean that the Error Reporting card is not completely accurate.',
       ),
     ).toBeInTheDocument();
 

--- a/plugins/kubernetes/src/components/KubernetesContent/ErrorPanel.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent/ErrorPanel.tsx
@@ -52,8 +52,8 @@ export const ErrorPanel = ({
   clustersWithErrors,
 }: ErrorPanelProps) => (
   <WarningPanel
-    title="There was an error retrieving kubernetes objects"
-    message={`There was an error retrieving some Kubernetes resources for the entity: ${entityName}`}
+    title="There was a problem retrieving Kubernetes objects"
+    message={`There was a problem retrieving some Kubernetes resources for the entity: ${entityName}. This could mean that the Error Reporting card is not completely accurate.`}
   >
     {clustersWithErrors && (
       <div>Errors: {clustersWithErrorsToErrorMessage(clustersWithErrors)}</div>

--- a/plugins/kubernetes/src/components/KubernetesContent/KubernetesContent.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent/KubernetesContent.tsx
@@ -106,51 +106,55 @@ export const KubernetesContent = ({ entity }: KubernetesContentProps) => {
   return (
     <Page themeId="tool">
       <Content>
-        <Grid container spacing={3} direction="column">
-          {kubernetesObjects === undefined && error === undefined && (
-            <Progress />
-          )}
+        {kubernetesObjects === undefined && error === undefined && <Progress />}
 
-          {/* errors retrieved from the kubernetes clusters */}
-          {clustersWithErrors.length > 0 && (
-            <ErrorPanel
-              entityName={entity.metadata.name}
-              clustersWithErrors={clustersWithErrors}
-            />
-          )}
+        {/* errors retrieved from the kubernetes clusters */}
+        {clustersWithErrors.length > 0 && (
+          <Grid container spacing={3} direction="column">
+            <Grid item>
+              <ErrorPanel
+                entityName={entity.metadata.name}
+                clustersWithErrors={clustersWithErrors}
+              />
+            </Grid>
+          </Grid>
+        )}
 
-          {/* other errors */}
-          {error !== undefined && (
-            <ErrorPanel
-              entityName={entity.metadata.name}
-              errorMessage={error}
-            />
-          )}
+        {/* other errors */}
+        {error !== undefined && (
+          <Grid container spacing={3} direction="column">
+            <Grid item>
+              <ErrorPanel
+                entityName={entity.metadata.name}
+                errorMessage={error}
+              />
+            </Grid>
+          </Grid>
+        )}
 
-          {kubernetesObjects && (
-            <>
-              <Grid item>
-                <ErrorReporting detectedErrors={detectedErrors} />
-              </Grid>
-              <Grid item>
-                <Divider />
-              </Grid>
-              <Grid item>
-                <Typography variant="h3">Your Clusters</Typography>
-              </Grid>
-              <Grid item container>
-                {kubernetesObjects?.items.map((item, i) => (
-                  <Grid item key={i} xs={12}>
-                    <Cluster
-                      clusterObjects={item}
-                      detectedErrors={detectedErrors.get(item.cluster.name)}
-                    />
-                  </Grid>
-                ))}
-              </Grid>
-            </>
-          )}
-        </Grid>
+        {kubernetesObjects && (
+          <Grid container spacing={3} direction="column">
+            <Grid item>
+              <ErrorReporting detectedErrors={detectedErrors} />
+            </Grid>
+            <Grid item>
+              <Divider />
+            </Grid>
+            <Grid item>
+              <Typography variant="h3">Your Clusters</Typography>
+            </Grid>
+            <Grid item container>
+              {kubernetesObjects?.items.map((item, i) => (
+                <Grid item key={i} xs={12}>
+                  <Cluster
+                    clusterObjects={item}
+                    detectedErrors={detectedErrors.get(item.cluster.name)}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          </Grid>
+        )}
       </Content>
     </Page>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

A few changes to how errors are displayed.

* Fixes a misalignment when the plugin is misconfigured of the ErrorPanel to the rest of the content
* Slightly changes wording to separate "plugin problems" (it's misconfigured, K8S API not responding) with "Kubernetes errors" (CPU is high, pod restarting, whatnot); open to input on that
* Squashed the "Nice!" panel so it doesn't take up quite as much screen real estate

| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/33203301/104550090-178d6d80-5602-11eb-8bcf-84b58dc2742f.png) | ![image](https://user-images.githubusercontent.com/33203301/104548927-d300d280-55ff-11eb-8fd6-828190dbec00.png) |

And slightly compressed "nice" messaging at different widths:

| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/33203301/104549796-8918ec00-5601-11eb-959d-0b6cc5dfa04f.png) | ![image](https://user-images.githubusercontent.com/33203301/104549840-97ff9e80-5601-11eb-99b8-53aa4a6ccc24.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
