### PR TITLE
Removes the @types/helmet dependency

### DIFF
--- a/.changeset/unlucky-cougars-grin.md
+++ b/.changeset/unlucky-cougars-grin.md
@@ -1,0 +1,9 @@
+---
+'@backstage/create-app': patch
+---
+
+Remove the `@types/helmet` dev dependency from the app template. This
+dependency is now unused as the package `helmet` brings its own types.
+
+To update your existing app, simply remove the `@types/helmet` dependency from
+the `package.json` of your backend package.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -56,8 +56,7 @@
     "@backstage/cli": "^0.4.3",
     "@types/dockerode": "^3.2.1",
     "@types/express": "^4.17.6",
-    "@types/express-serve-static-core": "^4.17.5",
-    "@types/helmet": "^0.0.48"
+    "@types/express-serve-static-core": "^4.17.5"
   },
   "files": [
     "dist"

--- a/packages/create-app/templates/default-app/packages/backend/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/backend/package.json.hbs
@@ -45,8 +45,7 @@
     "@backstage/cli": "^{{version '@backstage/cli'}}",
     "@types/dockerode": "^3.2.1",
     "@types/express": "^4.17.6",
-    "@types/express-serve-static-core": "^4.17.5",
-    "@types/helmet": "^0.0.47"
+    "@types/express-serve-static-core": "^4.17.5"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6479,13 +6479,6 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/helmet@^0.0.48":
-  version "0.0.48"
-  resolved "https://registry.npmjs.org/@types/helmet/-/helmet-0.0.48.tgz#e754399d2f4672ba63962e8490efd3edd31d9799"
-  integrity sha512-C7MpnvSDrunS1q2Oy1VWCY7CDWHozqSnM8P4tFeRTuzwqni+PYOjEredwcqWG+kLpYcgLsgcY3orHB54gbx2Jw==
-  dependencies:
-    "@types/express" "*"
-
 "@types/history@*":
   version "4.7.5"
   resolved "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"


### PR DESCRIPTION
We are using helmet 4.0.0+ which has typings included. [The typing dependency is not needed anymore](https://www.npmjs.com/package/@types/helmet).

No changeset as it only removes a dev dependency.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
