### PR TITLE
catalog-backend: Reduce log noise on locations refresh

### DIFF
--- a/.changeset/spotty-moons-tap.md
+++ b/.changeset/spotty-moons-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Reduce log noise on locations refresh

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
@@ -186,7 +186,7 @@ export class HigherOrderOperations implements HigherOrderOperation {
       throw e;
     }
 
-    this.logger.info(`Posting update success markers`);
+    this.logger.debug(`Posting update success markers`);
 
     await this.locationsCatalog.logUpdateSuccess(
       location.id,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Reduces log noise during repetitive locations refresh by taking a statement which prints but provides no changing value output to only show if debugging, as introduced in https://github.com/backstage/backstage/pull/2896.

```diff
 2021-01-15T03:21:10.940Z catalog info Locations Refresh: Refreshing location url:https://github-url.net/org/repo/blob/master/infra-core.yaml type=plugin component=catalog-all-locations-refresh
 2021-01-15T03:21:11.093Z catalog info Read 1 entities from location url:https://github-url.net/org/repo/blob/master/infra-core.yaml in 153ms type=plugin
-2021-01-15T03:21:11.135Z catalog info Posting update success markers type=plugin
 2021-01-15T03:21:11.157Z catalog info Wrote 1 entities from location url:https://github-url.net/org/repo/blob/master/infra-core.yaml in 63ms type=plugin
 2021-01-15T03:21:11.177Z catalog info Locations Refresh: Refreshing location url:https://github-url.net/org/repo/blob/master/teams.yaml type=plugin component=catalog-all-locations-refresh
 2021-01-15T03:21:11.312Z catalog info Read 3 entities from location url:https://github-url.net/org/repo/blob/master/teams.yaml in 135ms type=plugin
-2021-01-15T03:21:11.394Z catalog info Posting update success markers type=plugin
 2021-01-15T03:21:11.414Z catalog info Wrote 3 entities from location url:https://github-url.net/org/repo/blob/master/teams.yaml in 102ms type=plugin
 2021-01-15T03:21:11.435Z catalog info Locations Refresh: Refreshing location url:https://github-url.net/org/repo/blob/master/test-group.yaml type=plugin component=catalog-all-locations-refresh
 2021-01-15T03:21:11.573Z catalog info Read 1 entities from location url:https://github-url.net/org/repo/blob/master/test-group.yaml in 136ms type=plugin
-2021-01-15T03:21:11.614Z catalog info Posting update success markers type=plugin
 2021-01-15T03:21:11.634Z catalog info Wrote 1 entities from location url:https://github-url.net/org/repo/blob/master/test-group.yaml in 61ms type=plugin
 2021-01-15T03:21:11.655Z catalog info Locations Refresh: Completed locations refresh in 7.5s type=plugin component=catalog-all-locations-refresh
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
