### PR TITLE
fix(techdocs-common): Allow techdocs-cli to import package in a non-backstage environment

### DIFF
--- a/.changeset/techdocs-mean-items-behave.md
+++ b/.changeset/techdocs-mean-items-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+@backstage/techdocs-common can now be imported in an environment without @backstage/plugin-techdocs-backend being installed.

--- a/packages/techdocs-common/src/stages/publish/local.ts
+++ b/packages/techdocs-common/src/stages/publish/local.ts
@@ -16,6 +16,8 @@
 import fetch from 'cross-fetch';
 import express from 'express';
 import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
 import { Logger } from 'winston';
 import { Entity, EntityName } from '@backstage/catalog-model';
 import {
@@ -25,10 +27,20 @@ import {
 import { Config } from '@backstage/config';
 import { PublisherBase, PublishRequest, PublishResponse } from './types';
 
-const staticDocsDir = resolvePackagePath(
-  '@backstage/plugin-techdocs-backend',
-  'static/docs',
-);
+// TODO: Use a more persistent storage than node_modules or /tmp directory.
+// Make it configurable with techdocs.publisher.local.publishDirectory
+let staticDocsDir = '';
+try {
+  staticDocsDir = resolvePackagePath(
+    '@backstage/plugin-techdocs-backend',
+    'static/docs',
+  );
+} catch (err) {
+  // This will most probably never be used.
+  // The try/catch is introduced so that techdocs-cli can import @backstage/techdocs-common
+  // on CI/CD without installing techdocs backend plugin.
+  staticDocsDir = os.tmpdir();
+}
 
 /**
  * Local publisher which uses the local filesystem to store the generated static files. It uses a directory
@@ -39,6 +51,9 @@ export class LocalPublish implements PublisherBase {
   private readonly logger: Logger;
   private readonly discovery: PluginEndpointDiscovery;
 
+  // TODO: Use a static fromConfig method to create a LocalPublish instance, similar to aws/gcs publishers.
+  // Move the logic of setting staticDocsDir based on config over to fromConfig,
+  // and set the value as a class parameter.
   constructor(
     config: Config,
     logger: Logger,
@@ -52,9 +67,8 @@ export class LocalPublish implements PublisherBase {
   publish({ entity, directory }: PublishRequest): Promise<PublishResponse> {
     const entityNamespace = entity.metadata.namespace ?? 'default';
 
-    const publishDir = resolvePackagePath(
-      '@backstage/plugin-techdocs-backend',
-      'static/docs',
+    const publishDir = path.join(
+      staticDocsDir,
       entityNamespace,
       entity.kind,
       entity.metadata.name,


### PR DESCRIPTION
`@backstage/techdocs-common` is a shared package with capabilities of prepare/generate/publish steps of the TechDocs workflow. It is used by `@backstage/plugin-techdocs-backend` in a Backstage app, but also by `techdocs-cli` on a CI/CD environment.

![Untitled Diagram (1)](https://user-images.githubusercontent.com/8065913/104700583-aee2e580-5714-11eb-941a-c437a9813a35.png)

This PR removes the dependency of `techdocs-common` on `plugin-techdocs-backend` so that `techdocs-cli` can import `techdocs-common` without having to install the plugin package.

Required for https://github.com/backstage/techdocs-cli/pull/20 to work.

I didn't notice this problem since I used `yarn link` when developing on techdocs-cli and the problem of missing backend plugin package did not appear.

---

I have added a couple of TODOs, and didn't do them in this PR since I want to unblock techdocs-cli to be released with newer features. But we can improve how the path of persistent storage for techdocs sites is decided in case of Local publisher.

