### PR TITLE
Display the owner and system as links to the entity pages in the about card

### DIFF
--- a/.changeset/healthy-comics-drive.md
+++ b/.changeset/healthy-comics-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Display the owner and system as links to the entity pages in the about card.

--- a/.changeset/healthy-comics-drive.md
+++ b/.changeset/healthy-comics-drive.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Display the owner and system as links to the entity pages in the about card.
+Display the owner, system, and domain as links to the entity pages in the about card.
+Only display fields in the about card that are applicable to the entity kind.

--- a/plugins/catalog/src/components/AboutCard/AboutContent.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.tsx
@@ -37,8 +37,14 @@ type Props = {
 
 export const AboutContent = ({ entity }: Props) => {
   const classes = useStyles();
+  const isSystem = entity.kind.toLowerCase() === 'system';
+  const isDomain = entity.kind.toLowerCase() === 'domain';
+  const isResource = entity.kind.toLowerCase() === 'resource';
   const [partOfSystemRelation] = getEntityRelations(entity, RELATION_PART_OF, {
     kind: 'system',
+  });
+  const [partOfDomainRelation] = getEntityRelations(entity, RELATION_PART_OF, {
+    kind: 'domain',
   });
   const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
 
@@ -57,28 +63,48 @@ export const AboutContent = ({ entity }: Props) => {
           </React.Fragment>
         ))}
       </AboutField>
-      <AboutField
-        label="System"
-        value="No System"
-        gridSizes={{ xs: 12, sm: 6, lg: 4 }}
-      >
-        {partOfSystemRelation && (
-          <EntityRefLink
-            entityRef={partOfSystemRelation}
-            defaultKind="system"
-          />
-        )}
-      </AboutField>
-      <AboutField
-        label="Type"
-        value={entity?.spec?.type as string}
-        gridSizes={{ xs: 12, sm: 6, lg: 4 }}
-      />
-      <AboutField
-        label="Lifecycle"
-        value={entity?.spec?.lifecycle as string}
-        gridSizes={{ xs: 12, sm: 6, lg: 4 }}
-      />
+      {isSystem && (
+        <AboutField
+          label="Domain"
+          value="No Domain"
+          gridSizes={{ xs: 12, sm: 6, lg: 4 }}
+        >
+          {partOfDomainRelation && (
+            <EntityRefLink
+              entityRef={partOfDomainRelation}
+              defaultKind="domain"
+            />
+          )}
+        </AboutField>
+      )}
+      {!isSystem && !isDomain && (
+        <AboutField
+          label="System"
+          value="No System"
+          gridSizes={{ xs: 12, sm: 6, lg: 4 }}
+        >
+          {partOfSystemRelation && (
+            <EntityRefLink
+              entityRef={partOfSystemRelation}
+              defaultKind="system"
+            />
+          )}
+        </AboutField>
+      )}
+      {!isSystem && !isDomain && (
+        <AboutField
+          label="Type"
+          value={entity?.spec?.type as string}
+          gridSizes={{ xs: 12, sm: 6, lg: 4 }}
+        />
+      )}
+      {!isSystem && !isDomain && !isResource && (
+        <AboutField
+          label="Lifecycle"
+          value={entity?.spec?.lifecycle as string}
+          gridSizes={{ xs: 12, sm: 6, lg: 4 }}
+        />
+      )}
       <AboutField
         label="Tags"
         value="No Tags"

--- a/plugins/catalog/src/components/AboutCard/AboutContent.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.tsx
@@ -50,10 +50,12 @@ export const AboutContent = ({ entity }: Props) => {
         </Typography>
       </AboutField>
       <AboutField label="Owner" gridSizes={{ xs: 12, sm: 6, lg: 4 }}>
-        {ownedByRelations.map((t, i) => [
-          i > 0 && ', ',
-          <EntityRefLink key={i} entityRef={t} />,
-        ])}
+        {ownedByRelations.map((t, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && ', '}
+            <EntityRefLink entityRef={t} />
+          </React.Fragment>
+        ))}
       </AboutField>
       <AboutField
         label="System"
@@ -61,7 +63,10 @@ export const AboutContent = ({ entity }: Props) => {
         gridSizes={{ xs: 12, sm: 6, lg: 4 }}
       >
         {partOfSystemRelation && (
-          <EntityRefLink entityRef={partOfSystemRelation} />
+          <EntityRefLink
+            entityRef={partOfSystemRelation}
+            defaultKind="system"
+          />
         )}
       </AboutField>
       <AboutField

--- a/plugins/catalog/src/components/AboutCard/AboutContent.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.tsx
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import { Grid, Typography, Chip, makeStyles } from '@material-ui/core';
-import { AboutField } from './AboutField';
 import {
   Entity,
-  ENTITY_DEFAULT_NAMESPACE,
   RELATION_OWNED_BY,
-  serializeEntityRef,
+  RELATION_PART_OF,
 } from '@backstage/catalog-model';
+import { Chip, Grid, makeStyles, Typography } from '@material-ui/core';
+import React from 'react';
+import { EntityRefLink } from '../EntityRefLink';
+import { getEntityRelations } from '../getEntityRelations';
+import { AboutField } from './AboutField';
 
 const useStyles = makeStyles({
   description: {
@@ -36,6 +37,11 @@ type Props = {
 
 export const AboutContent = ({ entity }: Props) => {
   const classes = useStyles();
+  const [partOfSystemRelation] = getEntityRelations(entity, RELATION_PART_OF, {
+    kind: 'system',
+  });
+  const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
+
   return (
     <Grid container>
       <AboutField label="Description" gridSizes={{ xs: 12 }}>
@@ -43,22 +49,21 @@ export const AboutContent = ({ entity }: Props) => {
           {entity?.metadata?.description || 'No description'}
         </Typography>
       </AboutField>
+      <AboutField label="Owner" gridSizes={{ xs: 12, sm: 6, lg: 4 }}>
+        {ownedByRelations.map((t, i) => [
+          i > 0 && ', ',
+          <EntityRefLink key={i} entityRef={t} />,
+        ])}
+      </AboutField>
       <AboutField
-        label="Owner"
-        value={entity?.relations
-          ?.filter(r => r.type === RELATION_OWNED_BY)
-          .map(({ target: { kind, name, namespace } }) =>
-            // TODO(Rugvip): we want to provide some utils for this
-            serializeEntityRef({
-              kind,
-              name,
-              namespace:
-                namespace === ENTITY_DEFAULT_NAMESPACE ? undefined : namespace,
-            }),
-          )
-          .join(', ')}
+        label="System"
+        value="No System"
         gridSizes={{ xs: 12, sm: 6, lg: 4 }}
-      />
+      >
+        {partOfSystemRelation && (
+          <EntityRefLink entityRef={partOfSystemRelation} />
+        )}
+      </AboutField>
       <AboutField
         label="Type"
         value={entity?.spec?.type as string}

--- a/plugins/catalog/src/components/EntityRefLink/EntityRefLink.test.tsx
+++ b/plugins/catalog/src/components/EntityRefLink/EntityRefLink.test.tsx
@@ -60,6 +60,29 @@ describe('<EntityRefLink />', () => {
     expect(getByText('component:test/software')).toBeInTheDocument();
   });
 
+  it('renders link for entity and hides default kind', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+        namespace: 'test',
+      },
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const { getByText } = render(
+      <EntityRefLink entityRef={entity} defaultKind="Component" />,
+      {
+        wrapper: MemoryRouter,
+      },
+    );
+    expect(getByText('test/software')).toBeInTheDocument();
+  });
+
   it('renders link for entity name in default namespace', () => {
     const entityName = {
       kind: 'Component',
@@ -82,5 +105,20 @@ describe('<EntityRefLink />', () => {
       wrapper: MemoryRouter,
     });
     expect(getByText('component:test/software')).toBeInTheDocument();
+  });
+
+  it('renders link for entity name and hides default kind', () => {
+    const entityName = {
+      kind: 'Component',
+      namespace: 'test',
+      name: 'software',
+    };
+    const { getByText } = render(
+      <EntityRefLink entityRef={entityName} defaultKind="component" />,
+      {
+        wrapper: MemoryRouter,
+      },
+    );
+    expect(getByText('test/software')).toBeInTheDocument();
   });
 });

--- a/plugins/catalog/src/components/EntityRefLink/EntityRefLink.test.tsx
+++ b/plugins/catalog/src/components/EntityRefLink/EntityRefLink.test.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { EntityRefLink } from './EntityRefLink';
+
+describe('<EntityRefLink />', () => {
+  it('renders link for entity in default namespace', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+      },
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const { getByText } = render(<EntityRefLink entityRef={entity} />, {
+      wrapper: MemoryRouter,
+    });
+
+    expect(getByText('component:software')).toBeInTheDocument();
+  });
+
+  it('renders link for entity in other namespace', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+        namespace: 'test',
+      },
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const { getByText } = render(<EntityRefLink entityRef={entity} />, {
+      wrapper: MemoryRouter,
+    });
+    expect(getByText('component:test/software')).toBeInTheDocument();
+  });
+
+  it('renders link for entity name in default namespace', () => {
+    const entityName = {
+      kind: 'Component',
+      namespace: 'default',
+      name: 'software',
+    };
+    const { getByText } = render(<EntityRefLink entityRef={entityName} />, {
+      wrapper: MemoryRouter,
+    });
+    expect(getByText('component:software')).toBeInTheDocument();
+  });
+
+  it('renders link for entity name in other namespace', () => {
+    const entityName = {
+      kind: 'Component',
+      namespace: 'test',
+      name: 'software',
+    };
+    const { getByText } = render(<EntityRefLink entityRef={entityName} />, {
+      wrapper: MemoryRouter,
+    });
+    expect(getByText('component:test/software')).toBeInTheDocument();
+  });
+});

--- a/plugins/catalog/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog/src/components/EntityRefLink/EntityRefLink.tsx
@@ -27,12 +27,16 @@ import { entityRoute } from '../../routes';
 
 type EntityRefLinkProps = {
   entityRef: Entity | EntityName;
+  defaultKind?: string;
 };
 
 // TODO: This component is private for now, as it should probably belong into
 // some kind of helper module for the catalog plugin to avoid a dependency on
 // the catalog plugin itself.
-export const EntityRefLink = ({ entityRef }: EntityRefLinkProps) => {
+export const EntityRefLink = ({
+  entityRef,
+  defaultKind,
+}: EntityRefLinkProps) => {
   let kind;
   let namespace;
   let name;
@@ -54,7 +58,7 @@ export const EntityRefLink = ({ entityRef }: EntityRefLinkProps) => {
   kind = kind.toLowerCase();
 
   const title = `${serializeEntityRef({
-    kind,
+    kind: defaultKind && defaultKind.toLowerCase() === kind ? undefined : kind,
     name,
     namespace,
   })}`;
@@ -64,6 +68,7 @@ export const EntityRefLink = ({ entityRef }: EntityRefLinkProps) => {
     name,
   };
 
+  // TODO: Use useRouteRef here to generate the path
   return (
     <Link
       component={RouterLink}

--- a/plugins/catalog/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog/src/components/EntityRefLink/EntityRefLink.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Entity,
+  EntityName,
+  ENTITY_DEFAULT_NAMESPACE,
+  serializeEntityRef,
+} from '@backstage/catalog-model';
+import { Link } from '@material-ui/core';
+import React from 'react';
+import { generatePath } from 'react-router';
+import { Link as RouterLink } from 'react-router-dom';
+import { entityRoute } from '../../routes';
+
+type EntityRefLinkProps = {
+  entityRef: Entity | EntityName;
+};
+
+// TODO: This component is private for now, as it should probably belong into
+// some kind of helper module for the catalog plugin to avoid a dependency on
+// the catalog plugin itself.
+export const EntityRefLink = ({ entityRef }: EntityRefLinkProps) => {
+  let kind;
+  let namespace;
+  let name;
+
+  if ('metadata' in entityRef) {
+    kind = entityRef.kind;
+    namespace = entityRef.metadata.namespace;
+    name = entityRef.metadata.name;
+  } else {
+    kind = entityRef.kind;
+    namespace = entityRef.namespace;
+    name = entityRef.name;
+  }
+
+  if (namespace === ENTITY_DEFAULT_NAMESPACE) {
+    namespace = undefined;
+  }
+
+  kind = kind.toLowerCase();
+
+  const title = `${serializeEntityRef({
+    kind,
+    name,
+    namespace,
+  })}`;
+  const routeParams = {
+    kind,
+    namespace: namespace?.toLowerCase() ?? ENTITY_DEFAULT_NAMESPACE,
+    name,
+  };
+
+  return (
+    <Link
+      component={RouterLink}
+      to={generatePath(`/catalog/${entityRoute.path}`, routeParams)}
+    >
+      {title}
+    </Link>
+  );
+};

--- a/plugins/catalog/src/components/EntityRefLink/index.ts
+++ b/plugins/catalog/src/components/EntityRefLink/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { EntityRefLink } from './EntityRefLink';


### PR DESCRIPTION
Owner and system now link to the entity page.

![image](https://user-images.githubusercontent.com/648527/104712729-32a3ce80-5723-11eb-88bd-8e02a7ae8aae.png)

Next steps would be adding this to the catalog and APIs table.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
