### PR TITLE
microsite: fix display of summary elements

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -48,6 +48,11 @@ h6 {
   color: $textColor;
 }
 
+summary {
+  color: $textColor;
+  cursor: pointer;
+}
+
 h2:hover .hash-link {
   opacity: 1;
 }


### PR DESCRIPTION
Summary elements are currently rendered with dark text, making them almost invisible 😅 