### PR TITLE
techdocs-common: Release v0.3.4

### DIFF
--- a/.changeset/techdocs-mean-items-behave.md
+++ b/.changeset/techdocs-mean-items-behave.md
@@ -1,5 +1,0 @@
----
-'@backstage/techdocs-common': patch
----
-
-@backstage/techdocs-common can now be imported in an environment without @backstage/plugin-techdocs-backend being installed.

--- a/packages/techdocs-common/CHANGELOG.md
+++ b/packages/techdocs-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/techdocs-common
 
+## 0.3.4
+
+### Patch Changes
+
+- a594a7257: @backstage/techdocs-common can now be imported in an environment without @backstage/plugin-techdocs-backend being installed.
+
 ## 0.3.3
 
 ### Patch Changes

--- a/packages/techdocs-common/package.json
+++ b/packages/techdocs-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/techdocs-common",
   "description": "Common functionalities for TechDocs, to be shared between techdocs-backend plugin and techdocs-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "private": false,


### PR DESCRIPTION
Release a newer version of `@backstage/techdocs-common` including a bug fix https://github.com/backstage/backstage/pull/4088.

---

Reference documentation (if a package has to be released independently): (Inspiration from @backstage/silver-lining )

1. Remove all changesets inside `.changeset`.
2. Restore changesets that belong to your package.
3. Run `yarn changeset version`.
4. Restore all other changesets, except the ones that belong to your package.
5. Create PR

The version change in the package.json will trigger the publish workflow.