### PR TITLE
workflows: add new release detection method

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    outputs:
+      needs_release: ${{ steps.release_check.outputs.needs_release }}
+
     strategy:
       matrix:
         node-version: [12.x, 14.x]
@@ -47,6 +50,15 @@ jobs:
         run: yarn install --frozen-lockfile
       # End of yarn setup
 
+      - name: Fetch previous commit for release check
+        run: git fetch origin '${{ github.event.before }}'
+
+      - name: Check if release
+        id: release_check
+        run: node scripts/check-if-release.js
+        env:
+          COMMIT_SHA_BEFORE: '${{ github.event.before }}'
+
       - name: validate config
         run: yarn backstage-cli config:check
 
@@ -82,8 +94,9 @@ jobs:
   # We can't re-use the output from the above step, but we'll have a guaranteed node_modules cache and
   # only run the build steps that are necessary for publishing
   release:
-    if: contains(github.event.commits.*.author.username, 'github-actions[bot]') && contains(github.event.head_commit.message, 'from backstage/changeset-release/master')
     needs: build
+
+    if: needs.build.outputs.needs_release == 'true'
 
     runs-on: ubuntu-latest
 

--- a/scripts/check-if-release.js
+++ b/scripts/check-if-release.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/* eslint-disable import/no-extraneous-dependencies */
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This script is used to determine whether a particular commit has changes
+// that should lead to a release. It is run as part of the main master build
+// to determine whether the release flow should be run as well.
+//
+// It has the following output which can be used later in GitHub actions:
+//
+// needs_release = 'true' | 'false'
+
+const { execFile: execFileCb } = require('child_process');
+const { resolve: resolvePath } = require('path');
+const { promises: fs } = require('fs');
+const { promisify } = require('util');
+
+const parentRef = process.env.COMMIT_SHA_BEFORE || 'HEAD^';
+
+const execFile = promisify(execFileCb);
+
+async function runPlain(cmd, ...args) {
+  try {
+    const { stdout } = await execFile(cmd, args, { shell: true });
+    return stdout.trim();
+  } catch (error) {
+    if (error.stderr) {
+      process.stderr.write(error.stderr);
+    }
+    if (!error.code) {
+      throw error;
+    }
+    throw new Error(
+      `Command '${[cmd, ...args].join(' ')}' failed with code ${error.code}`,
+    );
+  }
+}
+
+async function main() {
+  process.cwd(resolvePath(__dirname, '..'));
+
+  const diff = await runPlain(
+    'git',
+    'diff',
+    '--name-only',
+    parentRef,
+    'packages/*/package.json',
+    'plugins/*/package.json',
+  );
+  const packageList = diff.split(/^(.*)$/gm).filter(s => s.trim());
+
+  const packageVersions = await Promise.all(
+    packageList.map(async path => {
+      const { name, version: newVersion } = JSON.parse(
+        await fs.readFile(path, 'utf8'),
+      );
+      const { version: oldVersion } = JSON.parse(
+        await runPlain('git', 'show', `${parentRef}:${path}`),
+      );
+      return { name, oldVersion, newVersion };
+    }),
+  );
+
+  const newVersions = packageVersions.filter(
+    ({ oldVersion, newVersion }) => oldVersion !== newVersion,
+  );
+
+  if (newVersions.length === 0) {
+    console.log('No package version bumps detected, no release needed');
+    console.log(`::set-output name=needs_release::false`);
+    return;
+  }
+
+  console.log('Package version bumps detected, a new release is needed');
+  const maxLength = Math.max(...newVersions.map(_ => _.name.length));
+  for (const { name, oldVersion, newVersion } of newVersions) {
+    console.log(
+      `  ${name.padEnd(maxLength, ' ')} ${oldVersion} -> ${newVersion}`,
+    );
+  }
+  console.log(`::set-output name=needs_release::true`);
+}
+
+main().catch(error => {
+  console.error(error.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
We're currently determining whether a release should be made basted on the commit author and message. This is a bit fragile but more importantly doesn't allow for ad-hoc releases through PRs other than the "Version Packages" one.

This switches the logic to be based on a script that checks whether any of the relevant `package.json`s have received a versions bump in the latest commit.