### PR TITLE
[TechDocs] Stream files directly from GCS instead of buffering and sending

### DIFF
--- a/.changeset/techdocs-glasses-wonder.md
+++ b/.changeset/techdocs-glasses-wonder.md
@@ -1,0 +1,5 @@
+---
+"@backstage/techdocs-common": patch
+---
+
+TechDocs backend now streams files through from Google Cloud Storage to the browser, improving memory usage.

--- a/.changeset/techdocs-glasses-wonder.md
+++ b/.changeset/techdocs-glasses-wonder.md
@@ -1,5 +1,5 @@
 ---
-"@backstage/techdocs-common": patch
+'@backstage/techdocs-common': patch
 ---
 
 TechDocs backend now streams files through from Google Cloud Storage to the browser, improving memory usage.

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -169,12 +169,7 @@ export class GoogleGCSPublish implements PublisherBase {
       // Files with different extensions (CSS, HTML) need to be served with different headers
       const fileExtension = path.extname(filePath);
       const responseHeaders = getHeadersForFileExtension(fileExtension);
-      res.writeHead(200, {
-        ...{
-          'Transfer-Encoding': 'chunked',
-        },
-        ...responseHeaders,
-      });
+      res.writeHead(200, responseHeaders);
 
       // Pipe file chunks directly from storage to client.
       this.storageClient


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Small optimization to the way we read data from GCS.  This appears to have negligible impact to performance, but should make the memory footprint of the backend much more predictable, especially when docs sites use large image or other assets.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
