### PR TITLE
document using locally-installed cookiecutter

### DIFF
--- a/docs/features/software-templates/extending/create-your-own-templater.md
+++ b/docs/features/software-templates/extending/create-your-own-templater.md
@@ -86,7 +86,7 @@ follows:
 
 _note_ Currently the templaters that we provide are basically Docker action
 containers that are run on top of the skeleton folder. This keeps dependencies
-to a minimal for running backstage scaffolder, but you don't /have/ to use
+to a minimum for running backstage scaffolder, but you don't _have_ to use
 Docker. You can `pip install cookiecutter` to run it locally in your backend.
 You could create your own templater that spins up an EC2 instance and downloads
 the folder and does everything using an AMI if you want. It's entirely up to

--- a/docs/features/software-templates/extending/create-your-own-templater.md
+++ b/docs/features/software-templates/extending/create-your-own-templater.md
@@ -87,9 +87,10 @@ follows:
 _note_ Currently the templaters that we provide are basically Docker action
 containers that are run on top of the skeleton folder. This keeps dependencies
 to a minimal for running backstage scaffolder, but you don't /have/ to use
-Docker. You could create your own templater that spins up an EC2 instance and
+Docker. You can `pip install cookiecutter` to run it locally in your backend.
+You could create your own templater that spins up an EC2 instance and
 downloads the folder and does everything using an AMI if you want. It's entirely
-up to you!
+up to you! 
 
 Now it's up to you to implement the `run` function, and then return a
 `TemplaterRunResult` which is `{ resultDir: string }`.

--- a/docs/features/software-templates/extending/create-your-own-templater.md
+++ b/docs/features/software-templates/extending/create-your-own-templater.md
@@ -88,9 +88,9 @@ _note_ Currently the templaters that we provide are basically Docker action
 containers that are run on top of the skeleton folder. This keeps dependencies
 to a minimal for running backstage scaffolder, but you don't /have/ to use
 Docker. You can `pip install cookiecutter` to run it locally in your backend.
-You could create your own templater that spins up an EC2 instance and
-downloads the folder and does everything using an AMI if you want. It's entirely
-up to you! 
+You could create your own templater that spins up an EC2 instance and downloads
+the folder and does everything using an AMI if you want. It's entirely up to
+you!
 
 Now it's up to you to implement the `run` function, and then return a
 `TemplaterRunResult` which is `{ resultDir: string }`.


### PR DESCRIPTION
This avoids running Docker in Docker.

See https://github.com/backstage/backstage/blob/57460cda021bddaf04e7c3351c3881a3f24859b0/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts#L56-L79

See also https://backstage.io/docs/features/techdocs/getting-started#disabling-docker-in-docker-situation-optional where it is configurable.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
