### PR TITLE
Display systems in catalog table and make both owner and system link to the entity pages

### DIFF
--- a/.changeset/strong-ligers-lay.md
+++ b/.changeset/strong-ligers-lay.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Display systems in catalog table and make both owner and system link to the entity pages.
+The owner field is now taken from the relations of the entity instead of its spec.

--- a/plugins/catalog/src/components/EntityRefLink/EntityRefLink.test.tsx
+++ b/plugins/catalog/src/components/EntityRefLink/EntityRefLink.test.tsx
@@ -37,7 +37,10 @@ describe('<EntityRefLink />', () => {
       wrapper: MemoryRouter,
     });
 
-    expect(getByText('component:software')).toBeInTheDocument();
+    expect(getByText('component:software')).toHaveAttribute(
+      'href',
+      '/catalog/default/component/software',
+    );
   });
 
   it('renders link for entity in other namespace', () => {
@@ -57,7 +60,10 @@ describe('<EntityRefLink />', () => {
     const { getByText } = render(<EntityRefLink entityRef={entity} />, {
       wrapper: MemoryRouter,
     });
-    expect(getByText('component:test/software')).toBeInTheDocument();
+    expect(getByText('component:test/software')).toHaveAttribute(
+      'href',
+      '/catalog/test/component/software',
+    );
   });
 
   it('renders link for entity and hides default kind', () => {
@@ -80,7 +86,10 @@ describe('<EntityRefLink />', () => {
         wrapper: MemoryRouter,
       },
     );
-    expect(getByText('test/software')).toBeInTheDocument();
+    expect(getByText('test/software')).toHaveAttribute(
+      'href',
+      '/catalog/test/component/software',
+    );
   });
 
   it('renders link for entity name in default namespace', () => {
@@ -92,7 +101,10 @@ describe('<EntityRefLink />', () => {
     const { getByText } = render(<EntityRefLink entityRef={entityName} />, {
       wrapper: MemoryRouter,
     });
-    expect(getByText('component:software')).toBeInTheDocument();
+    expect(getByText('component:software')).toHaveAttribute(
+      'href',
+      '/catalog/default/component/software',
+    );
   });
 
   it('renders link for entity name in other namespace', () => {
@@ -104,7 +116,10 @@ describe('<EntityRefLink />', () => {
     const { getByText } = render(<EntityRefLink entityRef={entityName} />, {
       wrapper: MemoryRouter,
     });
-    expect(getByText('component:test/software')).toBeInTheDocument();
+    expect(getByText('component:test/software')).toHaveAttribute(
+      'href',
+      '/catalog/test/component/software',
+    );
   });
 
   it('renders link for entity name and hides default kind', () => {
@@ -119,6 +134,29 @@ describe('<EntityRefLink />', () => {
         wrapper: MemoryRouter,
       },
     );
-    expect(getByText('test/software')).toBeInTheDocument();
+    expect(getByText('test/software')).toHaveAttribute(
+      'href',
+      '/catalog/test/component/software',
+    );
+  });
+
+  it('renders link with custom children', () => {
+    const entityName = {
+      kind: 'Component',
+      namespace: 'test',
+      name: 'software',
+    };
+    const { getByText } = render(
+      <EntityRefLink entityRef={entityName} defaultKind="component">
+        Custom Children
+      </EntityRefLink>,
+      {
+        wrapper: MemoryRouter,
+      },
+    );
+    expect(getByText('Custom Children')).toHaveAttribute(
+      'href',
+      '/catalog/test/component/software',
+    );
   });
 });

--- a/plugins/catalog/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog/src/components/EntityRefLink/EntityRefLink.tsx
@@ -17,17 +17,18 @@ import {
   Entity,
   EntityName,
   ENTITY_DEFAULT_NAMESPACE,
-  serializeEntityRef,
 } from '@backstage/catalog-model';
 import { Link } from '@material-ui/core';
 import React from 'react';
 import { generatePath } from 'react-router';
 import { Link as RouterLink } from 'react-router-dom';
 import { entityRoute } from '../../routes';
+import { formatEntityRefTitle } from './format';
 
 type EntityRefLinkProps = {
   entityRef: Entity | EntityName;
   defaultKind?: string;
+  children?: React.ReactNode;
 };
 
 // TODO: This component is private for now, as it should probably belong into
@@ -36,6 +37,7 @@ type EntityRefLinkProps = {
 export const EntityRefLink = ({
   entityRef,
   defaultKind,
+  children,
 }: EntityRefLinkProps) => {
   let kind;
   let namespace;
@@ -51,17 +53,8 @@ export const EntityRefLink = ({
     name = entityRef.name;
   }
 
-  if (namespace === ENTITY_DEFAULT_NAMESPACE) {
-    namespace = undefined;
-  }
-
   kind = kind.toLowerCase();
 
-  const title = `${serializeEntityRef({
-    kind: defaultKind && defaultKind.toLowerCase() === kind ? undefined : kind,
-    name,
-    namespace,
-  })}`;
   const routeParams = {
     kind,
     namespace: namespace?.toLowerCase() ?? ENTITY_DEFAULT_NAMESPACE,
@@ -74,7 +67,8 @@ export const EntityRefLink = ({
       component={RouterLink}
       to={generatePath(`/catalog/${entityRoute.path}`, routeParams)}
     >
-      {title}
+      {children}
+      {!children && formatEntityRefTitle(entityRef, { defaultKind })}
     </Link>
   );
 };

--- a/plugins/catalog/src/components/EntityRefLink/format.test.ts
+++ b/plugins/catalog/src/components/EntityRefLink/format.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatEntityRefTitle } from './format';
+
+describe('formatEntityRefTitle', () => {
+  it('formats entity in default namespace', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+      },
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const title = formatEntityRefTitle(entity);
+    expect(title).toEqual('component:software');
+  });
+
+  it('formats entity in other namespace', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+        namespace: 'test',
+      },
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const title = formatEntityRefTitle(entity);
+    expect(title).toEqual('component:test/software');
+  });
+
+  it('formats entity and hides default kind', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+        namespace: 'test',
+      },
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const title = formatEntityRefTitle(entity, { defaultKind: 'Component' });
+    expect(title).toEqual('test/software');
+  });
+
+  it('formats entity name in default namespace', () => {
+    const entityName = {
+      kind: 'Component',
+      namespace: 'default',
+      name: 'software',
+    };
+    const title = formatEntityRefTitle(entityName);
+    expect(title).toEqual('component:software');
+  });
+
+  it('formats entity name in other namespace', () => {
+    const entityName = {
+      kind: 'Component',
+      namespace: 'test',
+      name: 'software',
+    };
+
+    const title = formatEntityRefTitle(entityName);
+    expect(title).toEqual('component:test/software');
+  });
+
+  it('renders link for entity name and hides default kind', () => {
+    const entityName = {
+      kind: 'Component',
+      namespace: 'test',
+      name: 'software',
+    };
+
+    const title = formatEntityRefTitle(entityName, {
+      defaultKind: 'component',
+    });
+    expect(title).toEqual('test/software');
+  });
+});

--- a/plugins/catalog/src/components/EntityRefLink/format.ts
+++ b/plugins/catalog/src/components/EntityRefLink/format.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  EntityName,
+  ENTITY_DEFAULT_NAMESPACE,
+  serializeEntityRef,
+} from '@backstage/catalog-model';
+
+export function formatEntityRefTitle(
+  entityRef: Entity | EntityName,
+  opts?: { defaultKind?: string },
+) {
+  const defaultKind = opts?.defaultKind;
+  let kind;
+  let namespace;
+  let name;
+
+  if ('metadata' in entityRef) {
+    kind = entityRef.kind;
+    namespace = entityRef.metadata.namespace;
+    name = entityRef.metadata.name;
+  } else {
+    kind = entityRef.kind;
+    namespace = entityRef.namespace;
+    name = entityRef.name;
+  }
+
+  if (namespace === ENTITY_DEFAULT_NAMESPACE) {
+    namespace = undefined;
+  }
+
+  kind = kind.toLowerCase();
+
+  return `${serializeEntityRef({
+    kind: defaultKind && defaultKind.toLowerCase() === kind ? undefined : kind,
+    name,
+    namespace,
+  })}`;
+}

--- a/plugins/catalog/src/components/EntityRefLink/index.ts
+++ b/plugins/catalog/src/components/EntityRefLink/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { EntityRefLink } from './EntityRefLink';
+export { formatEntityRefTitle } from './format';


### PR DESCRIPTION
Not sure about the links yet, maybe we just want to display them as plain text.
This also makes sure that the owner is taken from the relation instead of the spec.

![image](https://user-images.githubusercontent.com/648527/104925837-9df9d480-599f-11eb-8b8f-ecbf523b936a.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
