### PR TITLE
Add support for Security Hotspots that are provided by SonarQube and SonarCloud

### DIFF
--- a/.changeset/giant-hairs-collect.md
+++ b/.changeset/giant-hairs-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': patch
+---
+
+Add support for the security hotspots that are provided by SonarQube and SonarCloud.

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -92,6 +92,7 @@ Henneke
 Heroku
 horizontalpodautoscalers
 Hostname
+hotspots
 html
 http
 https

--- a/plugins/sonarqube/dev/index.tsx
+++ b/plugins/sonarqube/dev/index.tsx
@@ -59,6 +59,8 @@ createDevApp()
                 projectUrl: `/#${componentKey}`,
                 getIssuesUrl: i => `/#${componentKey}/issues/${i}`,
                 getComponentMeasuresUrl: i => `/#${componentKey}/measures/${i}`,
+                getSecurityHotspotsUrl: () =>
+                  `#${componentKey}/security_hotspots`,
               } as FindingSummary;
 
             case 'failed':
@@ -70,6 +72,7 @@ createDevApp()
                   reliability_rating: '2.0',
                   vulnerabilities: '18',
                   security_rating: '3.0',
+                  security_review_rating: '3.0',
                   code_smells: '22',
                   sqale_rating: '5.0',
                   coverage: '15.7',
@@ -78,6 +81,8 @@ createDevApp()
                 projectUrl: `/#${componentKey}`,
                 getIssuesUrl: i => `/#${componentKey}/issues/${i}`,
                 getComponentMeasuresUrl: i => `/#${componentKey}/measures/${i}`,
+                getSecurityHotspotsUrl: () =>
+                  `#${componentKey}/security_hotspots`,
               } as FindingSummary;
 
             case 'passed':
@@ -89,6 +94,8 @@ createDevApp()
                   reliability_rating: '1.0',
                   vulnerabilities: '0',
                   security_rating: '1.0',
+                  security_hotspots_reviewed: '100.0',
+                  security_review_rating: '1.0',
                   code_smells: '0',
                   sqale_rating: '1.0',
                   coverage: '100.0',
@@ -97,6 +104,8 @@ createDevApp()
                 projectUrl: `/#${componentKey}`,
                 getIssuesUrl: i => `/#${componentKey}/issues/${i}`,
                 getComponentMeasuresUrl: i => `/#${componentKey}/measures/${i}`,
+                getSecurityHotspotsUrl: () =>
+                  `#${componentKey}/security_hotspots`,
               } as FindingSummary;
 
             default:

--- a/plugins/sonarqube/src/api/SonarQubeApi.ts
+++ b/plugins/sonarqube/src/api/SonarQubeApi.ts
@@ -30,6 +30,7 @@ export interface FindingSummary {
   projectUrl: string;
   getIssuesUrl: SonarUrlProcessorFunc;
   getComponentMeasuresUrl: SonarUrlProcessorFunc;
+  getSecurityHotspotsUrl: () => string;
 }
 
 export const sonarQubeApiRef = createApiRef<SonarQubeApi>({

--- a/plugins/sonarqube/src/api/SonarQubeClient.test.ts
+++ b/plugins/sonarqube/src/api/SonarQubeClient.test.ts
@@ -46,7 +46,7 @@ describe('SonarQubeClient', () => {
     server.use(
       rest.get(`${mockBaseUrl}/sonarqube/measures/search`, (req, res, ctx) => {
         expect(req.url.searchParams.toString()).toBe(
-          'projectKeys=our-service&metricKeys=alert_status%2Cbugs%2Creliability_rating%2Cvulnerabilities%2Csecurity_rating%2Ccode_smells%2Csqale_rating%2Ccoverage%2Cduplicated_lines_density',
+          'projectKeys=our-service&metricKeys=alert_status%2Cbugs%2Creliability_rating%2Cvulnerabilities%2Csecurity_rating%2Csecurity_hotspots_reviewed%2Csecurity_review_rating%2Ccode_smells%2Csqale_rating%2Ccoverage%2Cduplicated_lines_density',
         );
         return res(
           ctx.json({
@@ -78,6 +78,16 @@ describe('SonarQubeClient', () => {
               },
               {
                 metric: 'security_rating',
+                value: '1.0',
+                component: 'our-service',
+              },
+              {
+                metric: 'security_hotspots_reviewed',
+                value: '100',
+                component: 'our-service',
+              },
+              {
+                metric: 'security_review_rating',
                 value: '1.0',
                 component: 'our-service',
               },
@@ -123,6 +133,8 @@ describe('SonarQubeClient', () => {
           reliability_rating: '3.0',
           vulnerabilities: '4',
           security_rating: '1.0',
+          security_hotspots_reviewed: '100',
+          security_review_rating: '1.0',
           code_smells: '100',
           sqale_rating: '2.0',
           coverage: '55.5',
@@ -158,6 +170,8 @@ describe('SonarQubeClient', () => {
           reliability_rating: '3.0',
           vulnerabilities: '4',
           security_rating: '1.0',
+          security_hotspots_reviewed: '100',
+          security_review_rating: '1.0',
           code_smells: '100',
           sqale_rating: '2.0',
           coverage: '55.5',

--- a/plugins/sonarqube/src/api/SonarQubeClient.ts
+++ b/plugins/sonarqube/src/api/SonarQubeClient.ts
@@ -63,6 +63,8 @@ export class SonarQubeClient implements SonarQubeApi {
       reliability_rating: undefined,
       vulnerabilities: undefined,
       security_rating: undefined,
+      security_hotspots_reviewed: undefined,
+      security_review_rating: undefined,
       code_smells: undefined,
       sqale_rating: undefined,
       coverage: undefined,
@@ -92,10 +94,12 @@ export class SonarQubeClient implements SonarQubeApi {
         `${
           this.baseUrl
         }project/issues?id=${componentKey}&types=${identifier.toUpperCase()}&resolved=false`,
-      getComponentMeasuresUrl: (identifier: string) =>
+      getComponentMeasuresUrl: identifier =>
         `${
           this.baseUrl
         }component_measures?id=${componentKey}&metric=${identifier.toLowerCase()}&resolved=false&view=list`,
+      getSecurityHotspotsUrl: () =>
+        `${this.baseUrl}project/security_hotspots?id=${componentKey}`,
     };
   }
 }

--- a/plugins/sonarqube/src/api/types.ts
+++ b/plugins/sonarqube/src/api/types.ts
@@ -42,6 +42,10 @@ export type MetricKey =
   | 'code_smells'
   | 'sqale_rating'
 
+  // security hotspots
+  | 'security_hotspots_reviewed'
+  | 'security_review_rating'
+
   // coverage
   | 'coverage'
 

--- a/plugins/sonarqube/src/components/SonarQubeCard/RatingCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/RatingCard.tsx
@@ -22,6 +22,7 @@ const useStyles = makeStyles(theme => {
   return {
     root: {
       margin: theme.spacing(1, 0),
+      minWidth: '140px',
     },
     upper: {
       display: 'flex',

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -26,6 +26,7 @@ import { Chip, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import BugReport from '@material-ui/icons/BugReport';
 import LockOpen from '@material-ui/icons/LockOpen';
+import Security from '@material-ui/icons/Security';
 import SentimentVeryDissatisfied from '@material-ui/icons/SentimentVeryDissatisfied';
 import React, { useMemo } from 'react';
 import { useAsync } from 'react-use';
@@ -205,6 +206,25 @@ export const SonarQubeCard = ({
                 leftSlot={<Value value={value.metrics.code_smells} />}
                 rightSlot={<Rating rating={value.metrics.sqale_rating} />}
               />
+              {value.metrics.security_review_rating && (
+                <RatingCard
+                  titleIcon={<Security />}
+                  title="Hotspots Reviewed"
+                  link={value.getSecurityHotspotsUrl()}
+                  leftSlot={
+                    <Value
+                      value={
+                        value.metrics.security_hotspots_reviewed
+                          ? `${value.metrics.security_hotspots_reviewed}%`
+                          : '—'
+                      }
+                    />
+                  }
+                  rightSlot={
+                    <Rating rating={value.metrics.security_review_rating} />
+                  }
+                />
+              )}
               <div style={{ width: '100%' }} />
               <RatingCard
                 link={value.getComponentMeasuresUrl('COVERAGE')}


### PR DESCRIPTION
SonarCloud has recently added a new badge in the overview:
![image](https://user-images.githubusercontent.com/720821/104945644-4d8f7080-59b9-11eb-84d2-697eb485db3f.png)

This PR adds it to the SonarQube plugin:

![image](https://user-images.githubusercontent.com/720821/105054292-1df06f00-5a72-11eb-9b37-888ff24693f5.png)



Since we don't have a SonarQube installation but use SonarCloud, I'm not sure if this reduces the compatibility with older SonarQube versions. The code is written that it ignores the missing values, but it seems that the SonarQube API returns an error if one requests invalid metrics. From what I found, it looks like the metrics should be there since at least version [7.8](https://github.com/SonarSource/sonarqube/blob/cbe9ef6132c84901a834e624043b343109e8c1c7/sonar-plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java#L1520-L1524) / [8.2](https://github.com/SonarSource/sonarqube/blob/cbe9ef6132c84901a834e624043b343109e8c1c7/sonar-plugin-api/src/main/java/org/sonar/api/measures/CoreMetrics.java#L1557-L1561) with a "proper" introduction in [8.2](https://www.sonarqube.org/sonarqube-8-2/).



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
