### PR TITLE
Fix prepare and publish stages for Gitlab

### DIFF
--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
@@ -85,7 +85,7 @@ describe('GitLabPreparer', () => {
       await preparer.prepare(mockEntity, { logger: getVoidLogger() });
 
       expect(mockGitClient.clone).toHaveBeenCalledWith({
-        url: 'https://gitlab.com/benjdlambert/backstage-graphql-template',
+        url: 'https://gitlab.com/benjdlambert/backstage-graphql-template.git',
         dir: expect.any(String),
       });
     });
@@ -143,7 +143,7 @@ describe('GitLabPreparer', () => {
       await preparer.prepare(mockEntity, { logger: getVoidLogger() });
 
       expect(mockGitClient.clone).toHaveBeenCalledWith({
-        url: 'https://gitlab.com/benjdlambert/backstage-graphql-template',
+        url: 'https://gitlab.com/benjdlambert/backstage-graphql-template.git',
         dir: expect.any(String),
       });
     });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.ts
@@ -56,6 +56,7 @@ export class GitlabPreparer implements PreparerBase {
     const templateId = template.metadata.name;
 
     const parsedGitLocation = parseGitUrl(location);
+    parsedGitLocation.git_suffix = true;
     const repositoryCheckoutUrl = parsedGitLocation.toString('https');
     const tempDir = await fs.promises.mkdtemp(
       path.join(workingDirectory, templateId),

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/gitlab.test.ts
@@ -45,7 +45,7 @@ describe('GitLab Publisher', () => {
         id: 42,
       } as { id: number });
       mockGitlabClient.Projects.create.mockResolvedValue({
-        http_url_to_repo: 'mockclone',
+        http_url_to_repo: 'https://github.com/backstage/backstage.git',
       } as { http_url_to_repo: string });
 
       const result = await publisher.publish({
@@ -58,14 +58,18 @@ describe('GitLab Publisher', () => {
         logger,
       });
 
-      expect(result).toEqual({ remoteUrl: 'mockclone' });
+      expect(result).toEqual({
+        remoteUrl: 'https://github.com/backstage/backstage.git',
+        catalogInfoUrl:
+          'https://github.com/backstage/backstage/-/blob/master/catalog-info.yaml',
+      });
       expect(mockGitlabClient.Projects.create).toHaveBeenCalledWith({
         namespace_id: 42,
         name: 'test',
       });
       expect(initRepoAndPush).toHaveBeenCalledWith({
         dir: '/tmp/test',
-        remoteUrl: 'mockclone',
+        remoteUrl: 'https://github.com/backstage/backstage.git',
         auth: { username: 'oauth2', password: 'fake-token' },
         logger,
       });
@@ -77,7 +81,7 @@ describe('GitLab Publisher', () => {
         id: 21,
       } as { id: number });
       mockGitlabClient.Projects.create.mockResolvedValue({
-        http_url_to_repo: 'mockclone',
+        http_url_to_repo: 'https://github.com/backstage/backstage.git',
       } as { http_url_to_repo: string });
 
       const result = await publisher.publish({
@@ -89,7 +93,11 @@ describe('GitLab Publisher', () => {
         logger,
       });
 
-      expect(result).toEqual({ remoteUrl: 'mockclone' });
+      expect(result).toEqual({
+        remoteUrl: 'https://github.com/backstage/backstage.git',
+        catalogInfoUrl:
+          'https://github.com/backstage/backstage/-/blob/master/catalog-info.yaml',
+      });
       expect(mockGitlabClient.Users.current).toHaveBeenCalled();
       expect(mockGitlabClient.Projects.create).toHaveBeenCalledWith({
         namespace_id: 21,
@@ -97,7 +105,7 @@ describe('GitLab Publisher', () => {
       });
       expect(initRepoAndPush).toHaveBeenCalledWith({
         dir: '/tmp/test',
-        remoteUrl: 'mockclone',
+        remoteUrl: 'https://github.com/backstage/backstage.git',
         auth: { username: 'oauth2', password: 'fake-token' },
         logger,
       });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/gitlab.ts
@@ -46,7 +46,12 @@ export class GitlabPublisher implements PublisherBase {
       logger,
     });
 
-    return { remoteUrl };
+    const catalogInfoUrl = remoteUrl.replace(
+      /\.git$/,
+      '/-/blob/master/catalog-info.yaml',
+    );
+
+    return { remoteUrl, catalogInfoUrl };
   }
 
   private async createRemote(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

PR to fix the prepare and publish stages for the GitLab integration. Closes  #4133.

Enable the [git-url-parse](https://github.com/IonicaBizau/git-url-parse) option to add the `.git` at the end.

It also adds the code to return the `catalogInfoUrl` variable in the publish stage.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
