### PR TITLE
fix(lighthouse): Display errors of floating point precision on card category scores

### DIFF
--- a/.changeset/warm-months-bake.md
+++ b/.changeset/warm-months-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-lighthouse': patch
+---
+
+Fix display of floating point precision errors in card category scores

--- a/plugins/lighthouse/src/components/Cards/LastLighthouseAuditCard.test.tsx
+++ b/plugins/lighthouse/src/components/Cards/LastLighthouseAuditCard.test.tsx
@@ -38,7 +38,7 @@ const websiteListResponse = data as WebsiteListResponse;
 let entityWebsite = websiteListResponse.items[2];
 
 describe('<LastLighthouseAuditCard />', () => {
-  const asPercentage = (fraction: number) => `${fraction * 100}%`;
+  const asPercentage = (fraction: number) => `${Math.round(fraction * 100)}%`;
 
   beforeEach(() => {
     (useWebsiteForEntity as jest.Mock).mockReturnValue({

--- a/plugins/lighthouse/src/components/Cards/LastLighthouseAuditCard.tsx
+++ b/plugins/lighthouse/src/components/Cards/LastLighthouseAuditCard.tsx
@@ -27,7 +27,7 @@ import { useWebsiteForEntity } from '../../hooks/useWebsiteForEntity';
 import AuditStatusIcon from '../AuditStatusIcon';
 
 const LighthouseCategoryScoreStatus = ({ score }: { score: number }) => {
-  const scoreAsPercentage = score * 100;
+  const scoreAsPercentage = Math.round(score * 100);
   switch (true) {
     case scoreAsPercentage >= 90:
       return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes a precision error I happened to come across in the Lighthouse card. I'd guess this is platform dependent, and my magic number was 0.56. Interesting, the same calc (with same bug) is used in the test to validate the card, so for now just fixed both.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33203301/104988827-120b9b00-59e7-11eb-9053-48926faafedc.png) | ![image](https://user-images.githubusercontent.com/33203301/104988933-51d28280-59e7-11eb-831d-19ed40084fb2.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
