### PR TITLE
Update adr006 on using PropsWithChildren

### DIFF
--- a/docs/architecture-decisions/adr006-avoid-react-fc.md
+++ b/docs/architecture-decisions/adr006-avoid-react-fc.md
@@ -43,6 +43,15 @@ const GoodComponent = ({ text, children }: GoodProps) => (
     {children}
   </div>
 );
+
+/* Or as a shorthand, if no specifc child type is required */
+type GoodProps = PropsWithChildren<{ text: string }>;
+const GoodComponent = ({ text, children }: GoodProps) => (
+  <div>
+    <div>{text}</div>
+    {children}
+  </div>
+);
 ```
 
 ## Consequences


### PR DESCRIPTION
We had some discussions around using `PropsWithChildren` for react props in #4130. To avoid blocking the other PR I moved these changes here.

Following the current state of ADR006 I would simply use `{ children?: ReactNode }` in my props:

```typescript
type GoodProps = { text: string; children?: React.ReactNode };
const GoodComponent = ({ text, children }: GoodProps) => (
  <div>
    <div>{text}</div>
    {children}
  </div>
);
```

However we might consider recommending to use `PropsWithChildren<{...}>`:

```typescript
type GoodProps = PropsWithChildren<{ text: string }>;
const GoodComponent = ({ text, children }: GoodProps) => (
  <div>
    <div>{text}</div>
    {children}
  </div>
);
```

The bad part of `PropsWithChildren` is that it doesn't allow to specify a type for the children, in case you need this you have to fallback to the current suggestion.

We should also recommend **not** to use it like this, as it makes it difficult to export the props:

```typescript
type GoodProps = { text: string };
const GoodComponent = ({ text, children }: PropsWithChildren<GoodProps>) => (
  <div>
    <div>{text}</div>
    {children}
  </div>
);
```

About the actual usage in Backstage:
* `PropsWithChildren<GoodProps>` in the function argument (the last one) is used the most
* There is some usage of `PropsWithChildren<{...}>`
* There is some usage of `children?: React.ReactNode`

See also the discussion here https://github.com/backstage/backstage/pull/4130#discussion_r559621382

What do you think?