### PR TITLE
Block the deletion of entities from the bootstrap location in the unregister dialog and list the correct delete preview

### DIFF
--- a/.changeset/angry-flowers-yawn.md
+++ b/.changeset/angry-flowers-yawn.md
@@ -1,0 +1,29 @@
+---
+'@backstage/catalog-model': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Adds a `backstage.io/managed-by-origin-location` annotation to all entities. It links to the
+location that was registered to the catalog and which emitted this entity. It has a different
+semantic than the existing `backstage.io/managed-by-location` annotation, which tells the direct
+parent location that created this entity.
+
+Consider this example: The Backstage operator adds a location of type `github-org` in the
+`app-config.yaml`. This setting will be added to a `bootstrap:boostrap` location. The processor
+discovers the entities in the following branch
+`Location bootstrap:bootstrap -> Location github-org:… -> User xyz`. The user `xyz` will be:
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: User
+metadata:
+  name: xyz
+  annotations:
+    # This entity was added by the 'github-org:…' location
+    backstage.io/managed-by-location: github-org:…
+    # The entity was added because the 'bootstrap:boostrap' was added to the catalog
+    backstage.io/managed-by-origin-location: bootstrap:bootstrap
+    # ...
+spec:
+  # ...
+```

--- a/.changeset/cool-horses-applaud.md
+++ b/.changeset/cool-horses-applaud.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Derive the list of to-deleted entities in the `UnregisterEntityDialog` from the `backstage.io/managed-by-origin-location` annotation.
+The dialog also rejects deleting entities that are created by the `bootstrap:bootstrap` location.

--- a/.changeset/cool-horses-applaud.md
+++ b/.changeset/cool-horses-applaud.md
@@ -2,5 +2,5 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Derive the list of to-deleted entities in the `UnregisterEntityDialog` from the `backstage.io/managed-by-origin-location` annotation.
+Derive the list of to-delete entities in the `UnregisterEntityDialog` from the `backstage.io/managed-by-origin-location` annotation.
 The dialog also rejects deleting entities that are created by the `bootstrap:bootstrap` location.

--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -50,12 +50,12 @@ metadata:
 ```
 
 The value of this annotation is a location reference string (see above). It
-points to the location, which registration lead to the creation of the entity.
+points to the location, whose registration lead to the creation of the entity.
 In most cases, the `backstage.io/managed-by-location` and
-`backstage.io/managed-by-origin-location` will be equal. It will be different if
-the original location delegates to another location. A common case is, that a
-location is registered via the `bootstrap:boostrap` which means that is part of
-the `app-config.yml` of a backstage installation.
+`backstage.io/managed-by-origin-location` will be equal. They will be different
+if the original location delegates to another location. A common case is, that a
+location is registered as `bootstrap:boostrap` which means that it is part of
+the `app-config.yaml` of a backstage installation.
 
 ### backstage.io/techdocs-ref
 

--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -22,7 +22,7 @@ use.
 # Example:
 metadata:
   annotations:
-    backstage.io/managed-by-location: github:http://github.com/backstage/backstage/catalog-info.yaml
+    backstage.io/managed-by-location: url:http://github.com/backstage/backstage/catalog-info.yaml
 ```
 
 The value of this annotation is a so called location reference string, that
@@ -30,8 +30,8 @@ points to the source from which the entity was originally fetched. This
 annotation is added automatically by the catalog as it fetches the data from a
 registered location, and is not meant to normally be written by humans. The
 annotation may point to any type of generic location that the catalog supports,
-so it cannot be relied on to always be specifically of type `github`, nor that
-it even represents a single file. Note also that a single location can be the
+so it cannot be relied on to always be specifically of type `url`, nor that it
+even represents a single file. Note also that a single location can be the
 source of many entities, so it represents a many-to-one relationship.
 
 The format of the value is `<type>:<target>`. Note that the target may also
@@ -46,7 +46,7 @@ colon is always present.
 # Example:
 metadata:
   annotations:
-    backstage.io/managed-by-origin-location: github:http://github.com/backstage/backstage/catalog-info.yaml
+    backstage.io/managed-by-origin-location: url:http://github.com/backstage/backstage/catalog-info.yaml
 ```
 
 The value of this annotation is a location reference string (see above). It
@@ -55,7 +55,7 @@ In most cases, the `backstage.io/managed-by-location` and
 `backstage.io/managed-by-origin-location` will be equal. They will be different
 if the original location delegates to another location. A common case is, that a
 location is registered as `bootstrap:boostrap` which means that it is part of
-the `app-config.yaml` of a backstage installation.
+the `app-config.yaml` of a Backstage installation.
 
 ### backstage.io/techdocs-ref
 
@@ -63,7 +63,7 @@ the `app-config.yaml` of a backstage installation.
 # Example:
 metadata:
   annotations:
-    backstage.io/techdocs-ref: github:https://github.com/backstage/backstage.git
+    backstage.io/techdocs-ref: url:https://github.com/backstage/backstage.git
 ```
 
 The value of this annotation is a location reference string (see above). If this

--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -40,6 +40,23 @@ expecting a two-item array out of it. The format of the target part is
 type-dependent and could conceivably even be an empty string, but the separator
 colon is always present.
 
+### backstage.io/managed-by-origin-location
+
+```yaml
+# Example:
+metadata:
+  annotations:
+    backstage.io/managed-by-origin-location: github:http://github.com/backstage/backstage/catalog-info.yaml
+```
+
+The value of this annotation is a location reference string (see above). It
+points to the location, which registration lead to the creation of the entity.
+In most cases, the `backstage.io/managed-by-location` and
+`backstage.io/managed-by-origin-location` will be equal. It will be different if
+the original location delegates to another location. A common case is, that a
+location is registered via the `bootstrap:boostrap` which means that is part of
+the `app-config.yml` of a backstage installation.
+
 ### backstage.io/techdocs-ref
 
 ```yaml

--- a/packages/catalog-model/src/location/annotation.ts
+++ b/packages/catalog-model/src/location/annotation.ts
@@ -15,3 +15,5 @@
  */
 
 export const LOCATION_ANNOTATION = 'backstage.io/managed-by-location';
+export const ORIGIN_LOCATION_ANNOTATION =
+  'backstage.io/managed-by-origin-location';

--- a/packages/catalog-model/src/location/index.ts
+++ b/packages/catalog-model/src/location/index.ts
@@ -20,4 +20,4 @@ export {
   locationSpecSchema,
   analyzeLocationSchema,
 } from './validation';
-export { LOCATION_ANNOTATION } from './annotation';
+export { LOCATION_ANNOTATION, ORIGIN_LOCATION_ANNOTATION } from './annotation';

--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -78,13 +78,17 @@ export class LocationReaders implements LocationReader {
           if (rulesEnforcer.isAllowed(item.entity, item.location)) {
             const relations = Array<EntityRelationSpec>();
 
-            const entity = await this.handleEntity(item, emitResult => {
-              if (emitResult.type === 'relation') {
-                relations.push(emitResult.relation);
-                return;
-              }
-              emit(emitResult);
-            });
+            const entity = await this.handleEntity(
+              item,
+              emitResult => {
+                if (emitResult.type === 'relation') {
+                  relations.push(emitResult.relation);
+                  return;
+                }
+                emit(emitResult);
+              },
+              location,
+            );
 
             if (entity) {
               output.entities.push({
@@ -165,6 +169,7 @@ export class LocationReaders implements LocationReader {
   private async handleEntity(
     item: CatalogProcessorEntityResult,
     emit: CatalogProcessorEmit,
+    originLocation: LocationSpec,
   ): Promise<Entity | undefined> {
     const { processors, logger } = this.options;
 
@@ -185,6 +190,7 @@ export class LocationReaders implements LocationReader {
             current,
             item.location,
             emit,
+            originLocation,
           );
         } catch (e) {
           const message = `Processor ${processor.constructor.name} threw an error while preprocessing entity ${kind}:${namespace}/${name} at ${item.location.type} ${item.location.target}, ${e}`;

--- a/plugins/catalog-backend/src/ingestion/processors/AnnotateLocationEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AnnotateLocationEntityProcessor.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity, LocationSpec } from '@backstage/catalog-model';
+import { AnnotateLocationEntityProcessor } from './AnnotateLocationEntityProcessor';
+
+describe('AnnotateLocationEntityProcessor', () => {
+  describe('preProcessEntity', () => {
+    it('adds annotations', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+        },
+      };
+
+      const location: LocationSpec = {
+        type: 'url',
+        target: 'my-location',
+      };
+      const originLocation: LocationSpec = {
+        type: 'url',
+        target: 'my-origin-location',
+      };
+
+      const processor = new AnnotateLocationEntityProcessor();
+
+      expect(
+        await processor.preProcessEntity(
+          entity,
+          location,
+          () => {},
+          originLocation,
+        ),
+      ).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+          annotations: {
+            'backstage.io/managed-by-location': 'url:my-location',
+            'backstage.io/managed-by-origin-location': 'url:my-origin-location',
+          },
+        },
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend/src/ingestion/processors/AnnotateLocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AnnotateLocationEntityProcessor.ts
@@ -14,20 +14,28 @@
  * limitations under the License.
  */
 
-import { Entity, LocationSpec } from '@backstage/catalog-model';
+import {
+  Entity,
+  LOCATION_ANNOTATION,
+  LocationSpec,
+  ORIGIN_LOCATION_ANNOTATION,
+} from '@backstage/catalog-model';
 import lodash from 'lodash';
-import { CatalogProcessor } from './types';
+import { CatalogProcessor, CatalogProcessorEmit } from './types';
 
 export class AnnotateLocationEntityProcessor implements CatalogProcessor {
   async preProcessEntity(
     entity: Entity,
     location: LocationSpec,
+    _: CatalogProcessorEmit,
+    originLocation: LocationSpec,
   ): Promise<Entity> {
     return lodash.merge(
       {
         metadata: {
           annotations: {
-            'backstage.io/managed-by-location': `${location.type}:${location.target}`,
+            [LOCATION_ANNOTATION]: `${location.type}:${location.target}`,
+            [ORIGIN_LOCATION_ANNOTATION]: `${originLocation.type}:${originLocation.target}`,
           },
         },
       },

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -46,12 +46,16 @@ export type CatalogProcessor = {
    * @param entity The (possibly partial) entity to process
    * @param location The location that the entity came from
    * @param emit A sink for auxiliary items resulting from the processing
+   * @param originLocation The location that the entity originally came from.
+   *   While location resolves to the direct parent location, originLocation
+   *   tells which location was used to start the ingestion loop.
    * @returns The same entity or a modified version of it
    */
   preProcessEntity?(
     entity: Entity,
     location: LocationSpec,
     emit: CatalogProcessorEmit,
+    originLocation: LocationSpec,
   ): Promise<Entity>;
 
   /**

--- a/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -112,7 +112,7 @@ export const UnregisterEntityDialog = ({
                 {`"${(error as DeniedLocationException).locationName}"`}). If
                 you believe this is in error, please contact the{' '}
                 {configApi.getOptionalString('app.title') ?? 'Backstage'}{' '}
-                operator.
+                integrator.
               </>
             ) : (
               error.toString()

--- a/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Entity, ORIGIN_LOCATION_ANNOTATION } from '@backstage/catalog-model';
-import { alertApiRef, Progress, useApi } from '@backstage/core';
+import { alertApiRef, configApiRef, Progress, useApi } from '@backstage/core';
 import {
   Button,
   Dialog,
@@ -81,6 +81,7 @@ export const UnregisterEntityDialog = ({
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const catalogApi = useApi(catalogApiRef);
   const alertApi = useApi(alertApiRef);
+  const configApi = useApi(configApiRef);
 
   const removeEntity = async () => {
     const uid = entity.metadata.uid;
@@ -104,12 +105,14 @@ export const UnregisterEntityDialog = ({
 
         {error ? (
           <Alert severity="error" style={{ wordBreak: 'break-word' }}>
-            {error instanceof DeniedLocationException ? (
+            {error.name === 'DeniedLocationException' ? (
               <>
                 You cannot unregister this entity, since it originates from a
                 protected Backstage configuration (location
-                {`"${error.locationName}"`}). If you believe this is in error,
-                please contact your Backstage operator.
+                {`"${(error as DeniedLocationException).locationName}"`}). If
+                you believe this is in error, please contact the{' '}
+                {configApi.getOptionalString('app.title') ?? 'Backstage'}{' '}
+                operator.
               </>
             ) : (
               error.toString()


### PR DESCRIPTION
Closes #3398.

This PR adds a new entity-annotation `backstage.io/managed-by-origin-location` that tells users which registered location emitted which entity. The existing `backstage.io/managed-by-location` might show locations that are discovered during the import and don't match with the location that is stored in the database as "origin location" that is also used in the deletion process of an entity.

This change allows a fix in the `UnregisterEntityDialog` to show all entities that will be removed:
<img width="600" src="https://user-images.githubusercontent.com/720821/105052424-28116e00-5a70-11eb-9cec-df8e22ec20a2.png">

And it shows an error message if it came from the bootstrap location:
<img width="600" src="https://user-images.githubusercontent.com/720821/105051785-66f2f400-5a6f-11eb-99f1-f33f52a30a4d.png">


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
