### PR TITLE
chore(core): Remove deprecated InfoCard variant "height100"

### DIFF
--- a/.changeset/calm-turtles-smoke.md
+++ b/.changeset/calm-turtles-smoke.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core': patch
+---
+
+Removed InfoCard variant "height100", originally deprecated in [#2826](https://github.com/backstage/backstage/pull/2826).
+
+If your component still relies on this variant, simply replace it with "gridItem".

--- a/.changeset/calm-turtles-smoke.md
+++ b/.changeset/calm-turtles-smoke.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/core': patch
+'@backstage/core': minor
 ---
 
 Removed `InfoCard` variant `height100`, originally deprecated in [#2826](https://github.com/backstage/backstage/pull/2826).

--- a/.changeset/calm-turtles-smoke.md
+++ b/.changeset/calm-turtles-smoke.md
@@ -2,6 +2,6 @@
 '@backstage/core': patch
 ---
 
-Removed InfoCard variant "height100", originally deprecated in [#2826](https://github.com/backstage/backstage/pull/2826).
+Removed `InfoCard` variant `height100`, originally deprecated in [#2826](https://github.com/backstage/backstage/pull/2826).
 
-If your component still relies on this variant, simply replace it with "gridItem".
+If your component still relies on this variant, simply replace it with `gridItem`.

--- a/packages/core/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.tsx
@@ -76,24 +76,9 @@ const VARIANT_STYLES = {
       height: 'calc(100% - 10px)', // for pages without content header
       marginBottom: '10px',
     },
-    /**
-     * @deprecated This variant is replaced by 'gridItem'.
-     */
-    height100: {
-      display: 'flex',
-      flexDirection: 'column',
-      height: 'calc(100% - 10px)', // for pages without content header
-      marginBottom: '10px',
-    },
   },
   cardContent: {
     fullHeight: {
-      flex: 1,
-    },
-    /**
-     * @deprecated This variant is replaced by 'gridItem'.
-     */
-    height100: {
       flex: 1,
     },
     gridItem: {
@@ -167,12 +152,6 @@ export const InfoCard = ({
   if (variant) {
     const variants = variant.split(/[\s]+/g);
     variants.forEach(name => {
-      if (name === 'height100') {
-        // eslint-disable-next-line no-console
-        console.warn(
-          "Variant 'height100' of InfoCard is deprecated. Use variant 'gridItem' instead.",
-        );
-      }
       calculatedStyle = {
         ...calculatedStyle,
         ...VARIANT_STYLES.card[name as keyof typeof VARIANT_STYLES['card']],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The `InfoCard` variant "height100" was deprecated in https://github.com/backstage/backstage/pull/2826, roughly three months ago.  The `core` package has a [stability index of 1](https://backstage.io/docs/overview/stability-index#core-githubhttpsgithubcombackstagebackstagetreemasterpackagescore), which should mean breaking changes are OK in patches.

This variant is not currently used in Backstage itself. The changeset provides the alternative for the users to use.

Just sweeping up 🧹 ...

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
