### PR TITLE
core-api: remove deprecated registerRoute and deprecate addRoute

### DIFF
--- a/.changeset/proud-news-impress.md
+++ b/.changeset/proud-news-impress.md
@@ -1,0 +1,55 @@
+---
+'@backstage/core': minor
+---
+
+Removed deprecated `router.registerRoute` method in `createPlugin`.
+
+Deprecated `router.addRoute` method in `createPlugin`.
+
+Replace usage of the above two components with a routable extension.
+
+For example, given the following:
+
+```ts
+import { createPlugin } from '@backstage/core';
+import { MyPage } from './components/MyPage';
+import { rootRoute } from './routes';
+
+export const plugin = createPlugin({
+  id: 'my-plugin',
+  register({ router }) {
+    router.addRoute(rootRoute, MyPage);
+  },
+});
+```
+
+Migrate to
+
+```ts
+import { createPlugin, createRoutableExtension } from '@backstage/core';
+import { rootRoute } from './routes';
+
+export const plugin = createPlugin({
+  id: 'my-plugin',
+  routes: {
+    root: rootRoute,
+  },
+});
+
+export const MyPage = plugin.provide(
+  createRoutableExtension({
+    component: () => import('./components/MyPage').then(m => m.MyPage),
+    mountPoint: rootRoute,
+  }),
+);
+```
+
+And then use `MyPage` like this in the app:
+
+```tsx
+<FlatRoutes>
+...
+  <Route path='/my-path' element={<MyPage />}>
+...
+</FlatRoutes>
+```

--- a/docs/plugins/plugin-development.md
+++ b/docs/plugins/plugin-development.md
@@ -54,13 +54,4 @@ addRoute(
   Component: ComponentType<any>,
   options?: RouteOptions,
 ): void;
-
-/**
- * @deprecated See the `addRoute` method
- */
-registerRoute(
-  path: RoutePath,
-  Component: ComponentType<any>,
-  options?: RouteOptions,
-): void;
 ```

--- a/docs/reference/createPlugin-router.md
+++ b/docs/reference/createPlugin-router.md
@@ -15,15 +15,6 @@ addRoute(
   Component: ComponentType<any>,
   options?: RouteOptions,
 ): void;
-
-/**
- * @deprecated See the `addRoute` method
- */
-registerRoute(
-  path: RoutePath,
-  Component: ComponentType<any>,
-  options?: RouteOptions,
-): void;
 ```
 
 ## RouteRef

--- a/packages/core-api/src/plugin/Plugin.tsx
+++ b/packages/core-api/src/plugin/Plugin.tsx
@@ -68,9 +68,6 @@ export class PluginImpl<
             options,
           });
         },
-        registerRoute(path, component, options) {
-          outputs.push({ type: 'legacy-route', path, component, options });
-        },
       },
       featureFlags: {
         register(name) {

--- a/packages/core-api/src/plugin/types.ts
+++ b/packages/core-api/src/plugin/types.ts
@@ -99,23 +99,19 @@ export type PluginConfig<
 };
 
 export type PluginHooks = {
+  /**
+   * @deprecated All router hooks have been deprecated
+   */
   router: RouterHooks;
   featureFlags: FeatureFlagsHooks;
 };
 
 export type RouterHooks = {
+  /**
+   * @deprecated Use a routable extension instead, see https://backstage.io/docs/plugins/composability#porting-existing-plugins
+   */
   addRoute(
     target: RouteRef,
-    Component: ComponentType<any>,
-    options?: RouteOptions,
-  ): void;
-
-  /**
-   * @deprecated See the `addRoute` method
-   * @see https://github.com/backstage/backstage/issues/418
-   */
-  registerRoute(
-    path: RoutePath,
     Component: ComponentType<any>,
     options?: RouteOptions,
   ): void;


### PR DESCRIPTION
Removing some really old deprecated stuff, and setting up for more migrations :grin: