### PR TITLE
Switch to using file locations in app-config.yaml

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -185,8 +185,19 @@ catalog:
       #    groupFilter: securityEnabled eq false and mailEnabled eq true and groupTypes/any(c:c+eq+'Unified')
 
   locations:
+    # Add a location here to ingest it, for example from an URL:
+    #
+    #     - type: url
+    #       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-components.yaml
+    #
+    # For local development you can use a file location instead:
+    #
+    #     - type: file
+    #       target: ../catalog-model/examples/all-components.yaml
+    #
     # File locations are relative to the current working directory of the
     # backend, for example packages/backend/.
+
     # Backstage example components
     - type: file
       target: ../catalog-model/examples/all-components.yaml

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -185,33 +185,35 @@ catalog:
       #    groupFilter: securityEnabled eq false and mailEnabled eq true and groupTypes/any(c:c+eq+'Unified')
 
   locations:
+    # File locations are relative to the current working directory of the
+    # backend, for example packages/backend/.
     # Backstage example components
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-components.yaml
+    - type: file
+      target: ../catalog-model/examples/all-components.yaml
     # Example component for github-actions
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/plugins/github-actions/examples/sample.yaml
+    - type: file
+      target: ../../plugins/github-actions/examples/sample.yaml
     # Example component for TechDocs
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/plugins/techdocs-backend/examples/documented-component/catalog-info.yaml
+    - type: file
+      target: ../../plugins/techdocs-backend/examples/documented-component/catalog-info.yaml
     # Backstage example APIs
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-apis.yaml
+    - type: file
+      target: ../catalog-model/examples/all-apis.yaml
     # Backstage example resources
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-resources.yaml
+    - type: file
+      target: ../catalog-model/examples/all-resources.yaml
     # Backstage example systems
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-systems.yaml
+    - type: file
+      target: ../catalog-model/examples/all-systems.yaml
     # Backstage example domains
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-domains.yaml
+    - type: file
+      target: ../catalog-model/examples/all-domains.yaml
     # Backstage example templates
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/all-templates.yaml
+    - type: file
+      target: ../../plugins/scaffolder-backend/sample-templates/all-templates.yaml
     # Backstage example groups and users
-    - type: url
-      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
+    - type: file
+      target: ../catalog-model/examples/acme-corp.yaml
 
 scaffolder:
   github:


### PR DESCRIPTION
Having file locations makes the local workflow of editing entities, e.g. for testing much easier. When you add new files, you don't run into a circular dependency anymore, previously you couldn't test whether the configuration worked before merging it into master.

It also resolves the hard dependency on the GitHub repository - which allows to do "breaking changes" to the files without having to worry that existing instances used for development locally will break. However after this change we should have a grace period in that we should still be careful.

But I didn't performed this change for `create-app`, because it doesn't make sense for new standalone apps. Therefore the previous paragraph is not entirely true.

Beside that there might be hidden risks that might break others workflows. We have this configuration locally for a long time and it works well.

No changeset I guess? 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
