### PR TITLE
Refactor product chart tooltip

### DIFF
--- a/.changeset/cost-insights-curvy-dingos-live.md
+++ b/.changeset/cost-insights-curvy-dingos-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Allow expand functionality to top panel product chart tooltip.

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewByProductChart.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewByProductChart.tsx
@@ -16,7 +16,13 @@
 import React, { useState } from 'react';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import { useTheme, Box, Typography } from '@material-ui/core';
+import {
+  useTheme,
+  Box,
+  Typography,
+  Divider,
+  emphasize,
+} from '@material-ui/core';
 import { default as FullScreenIcon } from '@material-ui/icons/Fullscreen';
 import {
   AreaChart,
@@ -182,9 +188,17 @@ export const CostOverviewByProductChart = ({
       fill: p.fill!,
     }));
     const expandText = (
-      <Box display="flex" justifyContent="space-between" alignItems="center">
-        <FullScreenIcon />
-        <Typography>Click to expand</Typography>
+      <Box>
+        <Divider
+          style={{
+            backgroundColor: emphasize(theme.palette.divider, 1),
+            margin: '10px 0',
+          }}
+        />
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <FullScreenIcon />
+          <Typography>Click to expand</Typography>
+        </Box>
       </Box>
     );
     return (

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewByProductChart.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewByProductChart.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { useTheme, Box } from '@material-ui/core';
@@ -62,6 +62,7 @@ export const CostOverviewByProductChart = ({
   const styles = useStyles(theme);
   const lastCompleteBillingDate = useLastCompleteBillingDate();
   const { duration } = useFilters(mapFiltersToProps);
+  const [isExpanded, setExpanded] = useState(false);
 
   if (!costsByProduct) {
     return null;
@@ -79,23 +80,27 @@ export const CostOverviewByProductChart = ({
     lastCompleteBillingDate,
   );
   const currentPeriodTotal = totalCost - previousPeriodTotal;
+  const otherProducts: string[] = [];
+
   const productsByDate = costsByProduct.reduce((prodByDate, product) => {
     const productTotal = aggregationSum(product.aggregation);
     // Group products with less than 10% of the total cost into "Other" category
-    // when there we have >= 5 products.
+    // when we have >= 8 products.
     const isOtherProduct =
-      costsByProduct.length >= 5 &&
+      costsByProduct.length >= 8 &&
       productTotal < totalCost * LOW_COST_THRESHOLD;
-    const productName = isOtherProduct ? 'Other' : product.id;
-    const updatedProdByDate = { ...prodByDate };
 
+    const updatedProdByDate = { ...prodByDate };
+    if (isOtherProduct) {
+      otherProducts.push(product.id);
+    }
     product.aggregation.forEach(curAggregation => {
       const productCostsForDate = updatedProdByDate[curAggregation.date] || {};
 
       updatedProdByDate[curAggregation.date] = {
         ...productCostsForDate,
-        [productName]:
-          (productCostsForDate[productName] || 0) + curAggregation.amount,
+        [product.id]:
+          (productCostsForDate[product.id] || 0) + curAggregation.amount,
       };
     });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
- Adds ability to expand 'Other' category in product breakdown chart tooltip which will update the chart itself to show all products. Also increases default number of separate products shown at a time in the area chart. 
<img width="1040" alt="Screen Shot 2021-01-21 at 4 56 53 PM" src="https://user-images.githubusercontent.com/22461662/105417489-bb31db80-5c09-11eb-8d43-91bec3c6d6ea.png">
<img width="1029" alt="Screen Shot 2021-01-21 at 4 57 00 PM" src="https://user-images.githubusercontent.com/22461662/105417504-bff68f80-5c09-11eb-8cda-b4ae2dbd1d60.png">


#### :heavy_check_mark: Checklist
- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
