### PR TITLE
Add "techdocs-core" as codeowners for search documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 
 *                                           @backstage/maintainers
 /docs/features/techdocs                     @backstage/techdocs-core
+/docs/features/search                       @backstage/techdocs-core
 /plugins/cost-insights                      @backstage/silver-lining
 /plugins/cloudbuild                         @trivago/ebarrios
 /plugins/search                             @backstage/techdocs-core


### PR DESCRIPTION
we should by the way maybe change our github team name soon..

