### PR TITLE
fix(backend): URL Reader should not hardcode the archive filename, use response header instead

### DIFF
--- a/.changeset/purple-olives-destroy.md
+++ b/.changeset/purple-olives-destroy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+URL Reader: Use API response headers for archive filename in readTree. Fixes bug for users with hosted Bitbucket.

--- a/packages/backend-common/src/reading/AzureUrlReader.ts
+++ b/packages/backend-common/src/reading/AzureUrlReader.ts
@@ -76,6 +76,8 @@ export class AzureUrlReader implements UrlReader {
     url: string,
     options?: ReadTreeOptions,
   ): Promise<ReadTreeResponse> {
+    // TODO: Support filepath based reading tree feature like other providers
+
     // Get latest commit SHA
 
     const commitsAzureResponse = await fetch(

--- a/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
@@ -95,6 +95,10 @@ describe('BitbucketUrlReader', () => {
             res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/zip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename=backstage-mock-12ab34cd56ef.zip',
+              ),
               ctx.body(repoBuffer),
             ),
         ),
@@ -114,6 +118,10 @@ describe('BitbucketUrlReader', () => {
             res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/zip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename=backstage-mock.zip',
+              ),
               ctx.body(privateBitbucketRepoBuffer),
             ),
         ),

--- a/packages/backend-common/src/reading/BitbucketUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.ts
@@ -101,16 +101,12 @@ export class BitbucketUrlReader implements UrlReader {
     url: string,
     options?: ReadTreeOptions,
   ): Promise<ReadTreeResponse> {
-    const { name: repoName, owner: project, resource, filepath } = parseGitUrl(
-      url,
-    );
+    const { filepath } = parseGitUrl(url);
 
     const lastCommitShortHash = await this.getLastCommitShortHash(url);
     if (options?.etag && options.etag === lastCommitShortHash) {
       throw new NotModifiedError();
     }
-
-    const isHosted = resource === 'bitbucket.org';
 
     const downloadUrl = await getBitbucketDownloadUrl(url, this.config);
     const archiveBitbucketResponse = await fetch(

--- a/packages/backend-common/src/reading/BitbucketUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.ts
@@ -125,14 +125,31 @@ export class BitbucketUrlReader implements UrlReader {
       throw new Error(message);
     }
 
-    let folderPath = `${project}-${repoName}`;
-    if (isHosted) {
-      folderPath = `${project}-${repoName}-${lastCommitShortHash}`;
+    // Get the filename of archive from the header of the response
+    const contentDispositionHeader = archiveBitbucketResponse.headers.get(
+      'content-disposition',
+    ) as string;
+    if (!contentDispositionHeader) {
+      throw new Error(
+        `Failed to read tree from ${url}. ` +
+          'Bitbucket API response for downloading archive does not contain content-disposition header ',
+      );
+    }
+    const fileNameRegEx = new RegExp(
+      /^attachment; filename=(?<fileName>.*).zip$/,
+    );
+    const archiveFileName = contentDispositionHeader.match(fileNameRegEx)
+      ?.groups?.fileName;
+    if (!archiveFileName) {
+      throw new Error(
+        `Failed to read tree from ${url}. Bitbucket API response for downloading archive has an unexpected ` +
+          `format of content-disposition header ${contentDispositionHeader} `,
+      );
     }
 
     return await this.treeResponseFactory.fromZipArchive({
       stream: (archiveBitbucketResponse.body as unknown) as Readable,
-      path: `${folderPath}/${filepath}`,
+      path: `${archiveFileName}/${filepath}`,
       etag: lastCommitShortHash,
       filter: options?.filter,
     });

--- a/packages/backend-common/src/reading/GithubUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.test.ts
@@ -165,6 +165,10 @@ describe('GithubUrlReader', () => {
             res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/x-gzip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename=backstage-mock-etag123.tar.gz',
+              ),
               ctx.body(repoBuffer),
             ),
         ),
@@ -178,6 +182,10 @@ describe('GithubUrlReader', () => {
             res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/x-gzip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename=backstage-mock-etag123.tar.gz',
+              ),
               ctx.body(repoBuffer),
             ),
         ),
@@ -244,6 +252,10 @@ describe('GithubUrlReader', () => {
             return res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/x-gzip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename=backstage-mock-etag123.tar.gz',
+              ),
               ctx.body(repoBuffer),
             );
           },

--- a/packages/backend-common/src/reading/GitlabUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.test.ts
@@ -176,6 +176,10 @@ describe('GitlabUrlReader', () => {
             res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/zip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename="mock-main-sha123abc.zip"',
+              ),
               ctx.body(archiveBuffer),
             ),
         ),
@@ -225,6 +229,10 @@ describe('GitlabUrlReader', () => {
             res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/zip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename="mock-main-sha123abc.zip"',
+              ),
               ctx.body(archiveBuffer),
             ),
         ),
@@ -254,6 +262,10 @@ describe('GitlabUrlReader', () => {
             res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/zip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename="mock-main-sha123abc.zip"',
+              ),
               ctx.body(archiveBuffer),
             ),
         ),

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -78,7 +78,7 @@ export class GitlabUrlReader implements UrlReader {
     url: string,
     options?: ReadTreeOptions,
   ): Promise<ReadTreeResponse> {
-    const { name: repoName, ref, full_name, filepath } = parseGitUrl(url);
+    const { ref, full_name, filepath } = parseGitUrl(url);
 
     // Use GitLab API to get the default branch
     // encodeURIComponent is required for GitLab API


### PR DESCRIPTION
Hopefully fixes #4121 and other potential bugs in future due to this.

When URL Reader's readTree method downloads an archive, it currently guesses the name of archive. This name is pretty much hardcoded and differs from different source code providers. An incorrect guess or change in filename with API version or provider would mean `readTree` failing to work.

This PR makes use of the `content-disposition` header in the API responses since it contains the file name. ~If that is not available, I guess we can directly use existing tar/zip libraries.~

TODOs
- [x] GitHub/GHE
- [x] GitLab
- [x] Bitbucket.org and hosted
- [x] Azure DevOps (Not really since it doesn't support subpath based readTree)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
