### PR TITLE
workflows: fix PROJECT_NAME in fossa.yml

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure Fossa
         # The --option flag for fossa init does not work yet, see https://github.com/fossas/fossa-cli/issues/614
         run: |
-          fossa init --project PROJECT_NAME
+          fossa init
           yq eval -i '.analyze.modules[].options.strategy = "yarn-list"' .fossa.yml
 
           # This deletes entries for template and example packages found within packages and plugins


### PR DESCRIPTION
https://github.com/backstage/backstage/pull/4077#issuecomment-763808492 😅 

Not sure whether we should be setting the project name or not btw, but the original from @idvoretskyi doesn't, so going with that