### PR TITLE
fix: kafka plugin breaking the example-app backend

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -372,3 +372,8 @@ homepage:
       timezone: 'Asia/Tokyo'
 pagerduty:
   eventsBaseUrl: 'https://events.pagerduty.com/v2'
+
+kafka:
+  clientId: backstage
+  brokers:
+    - localhost:9092


### PR DESCRIPTION
Unable to start the backend without `kafka` configs in `app-config.yaml`.

Kafka was added in https://github.com/backstage/backstage/pull/3985

```
2021-01-20T21:55:12.695Z kafka info Initializing Kafka backend type=plugin
Backend failed to start up Error: Missing required config value at 'kafka.brokers'
    at ConfigReader.getStringArray (webpack-internal:///../config/src/reader.ts:247:13)
    at createRouter (webpack-internal:///../../plugins/kafka-backend/src/service/router.ts:83:34)
    at createPlugin (webpack-internal:///./src/plugins/kafka.ts:27:100)
    at main (webpack-internal:///./src/index.ts:98:95)
```