### PR TITLE
plugin-jenkins: Update Jenkins card with date, duration, and rename to "Latest build"

### DIFF
--- a/.changeset/unlucky-jokes-grab.md
+++ b/.changeset/unlucky-jokes-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins': patch
+---
+
+Update Jenkins card with build date, duration, and rename card to "latest" build.

--- a/plugins/jenkins/package.json
+++ b/plugins/jenkins/package.json
@@ -39,6 +39,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
     "jenkins": "^0.28.0",
+    "luxon": "^1.25.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Updates to the Jenkins card.

* Rename card and refactor vars to "Latest build".  (Semantics, but "latest" = most recent, "last" = the last run that will happen, assuming there will be no more)
* Add relative latest run time.
* Add duration, hardcoded to seconds. (could use iterating that for sure, hence added TODO; welcome contribs)

| New1 | New2 | New3 |
| --- | --- | --- |
|  ![image](https://user-images.githubusercontent.com/33203301/105258645-320e9c00-5b58-11eb-8572-6653d2ec800a.png) |    ![image](https://user-images.githubusercontent.com/33203301/105258675-3fc42180-5b58-11eb-895c-117a244d5dac.png) |  ![image](https://user-images.githubusercontent.com/33203301/105258715-58343c00-5b58-11eb-9bf8-f395a961f6f9.png) |

NB: Didn't touch the monorepo `yarn.lock` - should I have?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
