### PR TITLE
auth-backend: revert jose to v1

### DIFF
--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -16,11 +16,6 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "plugins/auth-backend"
   },
-  "jest": {
-    "moduleNameMapper": {
-      "^jose/(.*)$": "<rootDir>/../../../node_modules/jose/dist/node/cjs/$1"
-    }
-  },
   "keywords": [
     "backstage"
   ],
@@ -49,7 +44,7 @@
     "fs-extra": "^9.0.0",
     "got": "^11.5.2",
     "helmet": "^4.0.0",
-    "jose": "^3.5.1",
+    "jose": "^1.27.1",
     "jwt-decode": "^3.1.0",
     "knex": "^0.21.6",
     "moment": "^2.26.0",

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -24,7 +24,7 @@ import * as crypto from 'crypto';
 import { KeyObject } from 'crypto';
 import { Logger } from 'winston';
 import NodeCache from 'node-cache';
-import jwtVerify from 'jose/jwt/verify';
+import { JWT } from 'jose';
 import { CatalogApi } from '@backstage/catalog-client';
 
 const ALB_JWT_HEADER = 'x-amzn-oidc-data';
@@ -68,7 +68,7 @@ export class AwsAlbAuthProvider implements AuthProviderRouteHandlers {
       try {
         const headers = getJWTHeaders(jwt);
         const key = await this.getKey(headers.kid);
-        const verifiedToken = await jwtVerify(jwt, key, {});
+        const payload = JWT.verify(jwt, key);
 
         if (
           this.options.issuer !== '' &&
@@ -78,7 +78,7 @@ export class AwsAlbAuthProvider implements AuthProviderRouteHandlers {
         }
 
         const resolvedEntity = await this.options.identityResolutionCallback(
-          verifiedToken.payload,
+          payload,
           this.catalogClient,
         );
         res.send(resolvedEntity);

--- a/plugins/auth-backend/src/providers/oidc/provider.test.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.test.ts
@@ -13,17 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TextDecoder, TextEncoder } from 'util';
 
-// @ts-ignore
-global.TextDecoder = TextDecoder;
-global.TextEncoder = TextEncoder;
 import express from 'express';
 import { Session } from 'express-session';
 import nock from 'nock';
 import { ClientMetadata, IssuerMetadata } from 'openid-client';
 import { createOidcProvider, OidcAuthProvider } from './provider';
-import UnsecuredJWT from 'jose/jwt/unsecured';
+import { JWT, JWK } from 'jose';
 import { AuthProviderFactoryOptions } from '../types';
 import { Config } from '@backstage/config';
 import { OAuthAdapter } from '../../lib/oauth';
@@ -84,7 +80,7 @@ describe('OidcAuthProvider', () => {
       .reply(200, issuerMetadata)
       .post('/as/token.oauth2')
       .reply(200, {
-        id_token: new UnsecuredJWT(jwt).encode(),
+        id_token: JWT.sign(jwt, JWK.None),
         access_token: 'test',
         authorization_signed_response_alg: 'HS256',
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -16714,17 +16714,19 @@ jest@^26.0.1:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
+jose@^1.27.1:
+  version "1.28.0"
+  resolved "https://registry.npmjs.org/jose/-/jose-1.28.0.tgz#0803f8c71f43cd293a9d931c555c30531f5ca5dc"
+  integrity sha512-JmfDRzt/HSj8ipd9TsDtEHoLUnLYavG+7e8F6s1mx2jfVSfXOTaFQsJUydbjJpTnTDHP1+yKL9Ke7ktS/a0Eiw==
+  dependencies:
+    "@panva/asn1.js" "^1.0.0"
+
 jose@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/jose/-/jose-2.0.3.tgz#9c931ab3e13e2d16a5b9e6183e60b2fc40a8e1b8"
   integrity sha512-L+RlDgjO0Tk+Ki6/5IXCSEnmJCV8iMFZoBuEgu2vPQJJ4zfG/k3CAqZUMKDYNRHIDyy0QidJpOvX0NgpsAqFlw==
   dependencies:
     "@panva/asn1.js" "^1.0.0"
-
-jose@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.npmjs.org/jose/-/jose-3.5.1.tgz#adc0d5000dbf64a7f4db171d449dbcf6b556b6f0"
-  integrity sha512-BQQJafCDvsmtc/LaK57cjfhU/1AKBhJSbJhKPq+uhrjMoV/sh3/dbk9cm08nAeSGS6j+sjhWoY+LZPUXiKzYzw==
 
 joycon@^2.2.5:
   version "2.2.5"


### PR DESCRIPTION
Reverting jose back to v3 for the time being, since it has a minimum requirement of Node 14.

@backjo got no way of verify the alb changes ^_> are you able to have a look?

We do want this included in todays release so may end up having to break the alb auth in favor of introducing the Node v14 requirement without warning.