### PR TITLE
backend-common: introduce ChangeTrackingFetcher

### DIFF
--- a/packages/backend-common/src/errors.test.ts
+++ b/packages/backend-common/src/errors.test.ts
@@ -34,7 +34,7 @@ describe('errors', () => {
       const error = new E('abcdef', cause);
       expect(error.cause).toBe(cause);
       expect(error.toString()).toContain(
-        `${name}: abcdef; caused by Error: hello`,
+        `${error.name}: abcdef; caused by Error: hello`,
       );
     }
   });

--- a/packages/backend-common/src/middleware/errorHandler.test.ts
+++ b/packages/backend-common/src/middleware/errorHandler.test.ts
@@ -34,14 +34,14 @@ describe('errorHandler', () => {
     expect(response.text).toBe('some message');
   });
 
-  it('doesnt try to send the response again if its already been sent', async () => {
+  it('does not try to send the response again if its already been sent', async () => {
     const app = express();
     const mockSend = jest.fn();
 
     app.use('/works_with_async_fail', (_, res) => {
       res.status(200).send('hello');
 
-      // mutate the response object to test the middlware.
+      // mutate the response object to test the middleware.
       // it's hard to catch errors inside middleware from the outside.
       // @ts-ignore
       res.send = mockSend;

--- a/packages/backend-common/src/middleware/errorHandler.ts
+++ b/packages/backend-common/src/middleware/errorHandler.ts
@@ -41,7 +41,7 @@ export type ErrorHandlerOptions = {
  * This is commonly the very last middleware in the chain.
  *
  * Its primary purpose is not to do translation of business logic exceptions,
- * but rather to be a gobal catch-all for uncaught "fatal" errors that are
+ * but rather to be a global catch-all for uncaught "fatal" errors that are
  * expected to result in a 500 error. However, it also does handle some common
  * error types (such as http-error exceptions) and returns the enclosed status
  * code accordingly.

--- a/packages/backend-common/src/reading/ChangeTrackingFetcher.test.ts
+++ b/packages/backend-common/src/reading/ChangeTrackingFetcher.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { msw } from '@backstage/test-utils';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { NotModifiedError } from '../errors';
+import { ChangeTrackingFetcher } from './ChangeTrackingFetcher';
+
+describe('ChangeTrackingFetcher', () => {
+  const worker = setupServer();
+  msw.setupDefaultHandlers(worker);
+
+  it('issues a regular fetch when no options', async () => {
+    worker.use(
+      rest.get('http://a.com/', (req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.json({
+            url: req.url.toString(),
+            headers: req.headers.getAllHeaders(),
+          }),
+        ),
+      ),
+    );
+
+    const f = new ChangeTrackingFetcher({ maxAgeMillis: 1000 });
+
+    let response = await f.fetch('http://a.com/');
+    let inputs = await response.json();
+    expect(response.status).toBe(200);
+    expect(inputs.url).toBe('http://a.com/');
+    expect(inputs.headers.etag).toBeUndefined();
+
+    response = await f.fetch('http://a.com/');
+    inputs = await response.json();
+    expect(response.status).toBe(200);
+    expect(inputs.url).toBe('http://a.com/');
+    expect(inputs.headers.etag).toBeUndefined();
+  });
+
+  it('issues a regular fetch first and handle a 304', async () => {
+    worker.use(
+      rest.get('http://a.com/', (req, res, ctx) => {
+        if (!req.headers.has('if-none-match')) {
+          return res(
+            ctx.status(200),
+            ctx.set('ETag', 'blah'),
+            ctx.json({
+              url: req.url.toString(),
+              headers: req.headers.getAllHeaders(),
+            }),
+          );
+        }
+        return res(
+          ctx.status(304),
+          ctx.json({
+            url: req.url.toString(),
+            headers: req.headers.getAllHeaders(),
+          }),
+        );
+      }),
+    );
+
+    const f = new ChangeTrackingFetcher({ maxAgeMillis: 1000000 });
+
+    let response = await f.fetch('http://a.com/', undefined, {
+      refetchStrategy: 'if-changed',
+    });
+    let inputs = await response.json();
+    expect(response.status).toBe(200);
+    expect(inputs.url).toBe('http://a.com/');
+    expect(inputs.headers.etag).toBeUndefined();
+
+    await expect(
+      f.fetch('http://a.com/', undefined, {
+        refetchStrategy: 'if-changed',
+      }),
+    ).rejects.toThrow(NotModifiedError);
+
+    await expect(
+      f.fetch('http://a.com/', undefined, {
+        refetchStrategy: 'if-changed',
+      }),
+    ).rejects.toThrow(NotModifiedError);
+
+    response = await f.fetch('http://a.com/');
+    inputs = await response.json();
+    expect(response.status).toBe(200);
+    expect(inputs.url).toBe('http://a.com/');
+    expect(inputs.headers.etag).toBeUndefined();
+  });
+
+  it('merges headers', async () => {
+    worker.use(
+      rest.get('http://a.com/', (req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.json({
+            url: req.url.toString(),
+            headers: req.headers.getAllHeaders(),
+          }),
+        ),
+      ),
+    );
+
+    const f = new ChangeTrackingFetcher({ maxAgeMillis: 1000 });
+
+    const response = await f.fetch(
+      'http://a.com/',
+      { headers: { prev: 'v' } },
+      {
+        refetchStrategy: 'if-changed',
+      },
+    );
+    const inputs = await response.json();
+    expect(response.status).toBe(200);
+    expect(inputs.url).toBe('http://a.com/');
+    expect(inputs.headers.etag).toBeUndefined();
+    expect(inputs.headers.prev).toBe('v');
+  });
+});

--- a/packages/backend-common/src/reading/ChangeTrackingFetcher.ts
+++ b/packages/backend-common/src/reading/ChangeTrackingFetcher.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NotModifiedError } from '../errors';
+import { ReadOptions } from './types';
+import fetch from 'cross-fetch';
+
+type UrlState = {
+  expiresAt: number;
+  etag: string;
+};
+
+/**
+ * Works like fetch, but with the addition that it memorizes and uses ETag
+ * headers.
+ */
+export class ChangeTrackingFetcher {
+  private readonly state = new Map<string, UrlState>();
+  private readonly maxAgeMillis: number;
+
+  constructor(options: { maxAgeMillis: number }) {
+    this.maxAgeMillis = options.maxAgeMillis;
+  }
+
+  /**
+   * Fetches a URL.
+   *
+   * @param url The URL to fetch
+   * @param init The init options, as in the second fetch argument
+   * @param options Additional options affecting the fetch
+   * @returns The response
+   * @throws NotModifiedError if options.refetchStrategy is 'if-changed' and
+   *         the request ended in a 304.
+   */
+  async fetch(
+    url: string,
+    init?: RequestInit | undefined,
+    options?: ReadOptions | undefined,
+  ): Promise<Response> {
+    const headers = new Headers(init?.headers);
+    const key = this.stateKey(url, headers);
+    let updatedInit = init;
+
+    if (options?.refetchStrategy === 'if-changed') {
+      const oldState = this.state.get(key);
+      if (oldState && oldState.expiresAt > Date.now()) {
+        headers.set('if-none-match', oldState.etag);
+        updatedInit = { ...updatedInit, headers };
+      }
+    }
+
+    const response = await fetch(url, updatedInit);
+
+    const etag = response.headers?.get('etag');
+    if (etag) {
+      const oldState = this.state.get(key);
+      if (
+        !oldState ||
+        oldState.expiresAt < Date.now() ||
+        oldState.etag !== etag
+      ) {
+        this.state.set(key, {
+          expiresAt: Date.now() + this.maxAgeMillis,
+          etag,
+        });
+      }
+    }
+
+    if (response.status === 304) {
+      throw new NotModifiedError();
+    }
+
+    return response;
+  }
+
+  private stateKey(url: string, headers: Headers): string {
+    const data = [url];
+
+    const vary = headers.get('vary');
+    if (vary) {
+      data.push(vary);
+      for (const headerName of vary.split(',').map(x => x.trim())) {
+        data.push(headers.get(headerName) || '');
+      }
+    }
+
+    return data.join('~');
+  }
+}

--- a/packages/backend-common/src/reading/GithubUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.test.ts
@@ -17,6 +17,7 @@
 import { ConfigReader } from '@backstage/config';
 import { GithubCredentialsProvider } from '@backstage/integration';
 import { msw } from '@backstage/test-utils';
+import fetch from 'cross-fetch';
 import fs from 'fs';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
@@ -38,7 +39,11 @@ const githubProcessor = new GithubUrlReader(
     host: 'github.com',
     apiBaseUrl: 'https://api.github.com',
   },
-  { treeResponseFactory, credentialsProvider: mockCredentialsProvider },
+  {
+    treeResponseFactory,
+    credentialsProvider: mockCredentialsProvider,
+    delegateFetcher: fetch,
+  },
 );
 
 const gheProcessor = new GithubUrlReader(
@@ -46,7 +51,11 @@ const gheProcessor = new GithubUrlReader(
     host: 'ghe.github.com',
     apiBaseUrl: 'https://ghe.github.com/api/v3',
   },
-  { treeResponseFactory, credentialsProvider: mockCredentialsProvider },
+  {
+    treeResponseFactory,
+    credentialsProvider: mockCredentialsProvider,
+    delegateFetcher: fetch,
+  },
 );
 
 describe('GithubUrlReader', () => {

--- a/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
+++ b/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
@@ -33,7 +33,7 @@ export class UrlReaderPredicateMux implements UrlReader {
     this.readers.push(tuple);
   }
 
-  read(url: string): Promise<Buffer> {
+  async read(url: string): Promise<Buffer> {
     const parsed = new URL(url);
 
     for (const { predicate, reader } of this.readers) {

--- a/packages/backend-common/src/reading/index.ts
+++ b/packages/backend-common/src/reading/index.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-export type { UrlReader, ReadTreeResponse } from './types';
-export { UrlReaders } from './UrlReaders';
 export { AzureUrlReader } from './AzureUrlReader';
 export { BitbucketUrlReader } from './BitbucketUrlReader';
+export { ChangeTrackingFetcher } from './ChangeTrackingFetcher';
 export { GithubUrlReader } from './GithubUrlReader';
 export { GitlabUrlReader } from './GitlabUrlReader';
+export type { ReadTreeResponse, UrlReader } from './types';
+export { UrlReaders } from './UrlReaders';

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -18,6 +18,31 @@ import { Logger } from 'winston';
 import { Config } from '@backstage/config';
 import { ReadTreeResponseFactory } from './tree';
 
+/**
+ * Options that affect the reading of URLs.
+ */
+export type ReadOptions = {
+  /**
+   * Control the data re-fetching strategy.
+   *
+   * This option can be used when the caller is only interested in the data if
+   * it known to have changed since the last time it was requested.
+   *
+   * Implementations are free to ignore this option, and to treat it as being
+   * equal to 'always'.
+   *
+   * Possible values are:
+   *
+   * - 'always': Always get the latest data from the remote. This is the
+   *   default.
+   * - 'if-changed': A check may be issued to the remote to see if the data has
+   *   changed. If no previous read had been issued, or if the data was found
+   *   to be changed, the data is returned as normal. If the data was found to
+   *   not have changed, the read throws a NotModifiedError.
+   */
+  refetchStrategy?: 'always' | 'if-changed';
+};
+
 export type ReadTreeOptions = {
   /**
    * A filter that can be used to select which files should be included.
@@ -51,7 +76,7 @@ export type ReadTreeOptions = {
  * A generic interface for fetching plain data from URLs.
  */
 export type UrlReader = {
-  read(url: string): Promise<Buffer>;
+  read(url: string, options?: ReadOptions): Promise<Buffer>;
   readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
 };
 


### PR DESCRIPTION
Addresses #3734 and others.

This is left hanging as a draft indefinitely. We may want to actually have something like this in place, which properly checks for ETags and avoids duplicate work. But to be able to merge something like this, we would have to revamp how the ingestion pipeline works. As it stands, it depends on being able to fetch the actual data over and over again; it just doesn't handle absence well.

One other way to fix this would be to use caching together with etags - such that it can return the old data immediately out of memory if the remote returned a 302. That of course comes with a memory cost. But it could be very worthwhile in some situations.