### PR TITLE
Hide the kind of owners in the about card if it's the default kind (group)

### DIFF
--- a/.changeset/fair-months-enjoy.md
+++ b/.changeset/fair-months-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Hide the kind of owners in the about card if it's the default kind (group)

--- a/plugins/catalog/src/components/AboutCard/AboutContent.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.tsx
@@ -59,7 +59,7 @@ export const AboutContent = ({ entity }: Props) => {
         {ownedByRelations.map((t, i) => (
           <React.Fragment key={i}>
             {i > 0 && ', '}
-            <EntityRefLink entityRef={t} />
+            <EntityRefLink entityRef={t} defaultKind="group" />
           </React.Fragment>
         ))}
       </AboutField>


### PR DESCRIPTION
We do so in the table, but I missed it here...

![image](https://user-images.githubusercontent.com/648527/105358274-3ee1cd00-5bf6-11eb-9461-01f678b44bc2.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
