### PR TITLE
Show subcomponent in the about card

### DIFF
--- a/.changeset/few-geckos-shout.md
+++ b/.changeset/few-geckos-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Show the parent component in the about card (via partOf relationship)

--- a/packages/catalog-model/examples/all-components.yaml
+++ b/packages/catalog-model/examples/all-components.yaml
@@ -15,4 +15,6 @@ spec:
     - ./components/www-artist-component.yaml
     - ./components/shuffle-api-component.yaml
     - ./components/wayback-archive-component.yaml
+    - ./components/wayback-archive-ingestion-component.yaml
+    - ./components/wayback-archive-storage-component.yaml
     - ./components/wayback-search-component.yaml

--- a/packages/catalog-model/examples/components/wayback-archive-ingestion-component.yaml
+++ b/packages/catalog-model/examples/components/wayback-archive-ingestion-component.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: wayback-archive-ingestion
+  description: Ingestion subsystem of the Wayback Archive
+spec:
+  type: service
+  lifecycle: production
+  owner: team-d
+  subcomponentOf: wayback-archive

--- a/packages/catalog-model/examples/components/wayback-archive-storage-component.yaml
+++ b/packages/catalog-model/examples/components/wayback-archive-storage-component.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: wayback-archive-storage
+  description: Storage subsystem of the Wayback Archive
+spec:
+  type: service
+  lifecycle: production
+  owner: team-a
+  subcomponentOf: wayback-archive

--- a/plugins/catalog/src/components/AboutCard/AboutContent.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.tsx
@@ -40,9 +40,17 @@ export const AboutContent = ({ entity }: Props) => {
   const isSystem = entity.kind.toLowerCase() === 'system';
   const isDomain = entity.kind.toLowerCase() === 'domain';
   const isResource = entity.kind.toLowerCase() === 'resource';
+  const isComponent = entity.kind.toLowerCase() === 'component';
   const [partOfSystemRelation] = getEntityRelations(entity, RELATION_PART_OF, {
     kind: 'system',
   });
+  const [partOfComponentRelation] = getEntityRelations(
+    entity,
+    RELATION_PART_OF,
+    {
+      kind: 'component',
+    },
+  );
   const [partOfDomainRelation] = getEntityRelations(entity, RELATION_PART_OF, {
     kind: 'domain',
   });
@@ -89,6 +97,18 @@ export const AboutContent = ({ entity }: Props) => {
               defaultKind="system"
             />
           )}
+        </AboutField>
+      )}
+      {isComponent && partOfComponentRelation && (
+        <AboutField
+          label="Parent Component"
+          value="No Parent Component"
+          gridSizes={{ xs: 12, sm: 6, lg: 4 }}
+        >
+          <EntityRefLink
+            entityRef={partOfComponentRelation}
+            defaultKind="component"
+          />
         </AboutField>
       )}
       {!isSystem && !isDomain && (


### PR DESCRIPTION
Subcomponents to model monoliths were introduced recently but till now they aren't surfaced at all. This PR adds some example subcomponents and shows the parent in the about card. Showing everything in the about card might not be a the perfect solution, but follows the current design for now. As subcomponents are kind of a special feature I decided to hide the entry completely if no parent component is available, thoughts?

![image](https://user-images.githubusercontent.com/648527/105364256-4193f080-5bfd-11eb-81ea-9ff945601eeb.png)




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
