### PR TITLE
Ask the SonarQube server for all support metrics prior to querying them for a project

### DIFF
--- a/.changeset/loud-terms-kiss.md
+++ b/.changeset/loud-terms-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': patch
+---
+
+Ask the SonarQube server for all support metrics prior to querying them for a project.

--- a/plugins/sonarqube/src/api/SonarQubeClient.test.ts
+++ b/plugins/sonarqube/src/api/SonarQubeClient.test.ts
@@ -29,7 +29,31 @@ describe('SonarQubeClient', () => {
   const mockBaseUrl = 'http://backstage:9191/api/proxy';
   const discoveryApi = UrlPatternDiscovery.compile(mockBaseUrl);
 
-  const setupHandlers = () => {
+  const setupHandlers = (
+    metricKeys = [
+      'alert_status',
+      'bugs',
+      'reliability_rating',
+      'vulnerabilities',
+      'security_rating',
+      'security_hotspots_reviewed',
+      'security_review_rating',
+      'code_smells',
+      'sqale_rating',
+      'coverage',
+      'duplicated_lines_density',
+    ],
+  ) => {
+    server.use(
+      rest.get(`${mockBaseUrl}/sonarqube/metrics/search`, (_, res, ctx) => {
+        return res(
+          ctx.json({
+            metrics: metricKeys.map(k => ({ key: k })),
+          }),
+        );
+      }),
+    );
+
     server.use(
       rest.get(`${mockBaseUrl}/sonarqube/components/show`, (req, res, ctx) => {
         expect(req.url.searchParams.toString()).toBe('component=our-service');
@@ -46,8 +70,9 @@ describe('SonarQubeClient', () => {
     server.use(
       rest.get(`${mockBaseUrl}/sonarqube/measures/search`, (req, res, ctx) => {
         expect(req.url.searchParams.toString()).toBe(
-          'projectKeys=our-service&metricKeys=alert_status%2Cbugs%2Creliability_rating%2Cvulnerabilities%2Csecurity_rating%2Csecurity_hotspots_reviewed%2Csecurity_review_rating%2Ccode_smells%2Csqale_rating%2Ccoverage%2Cduplicated_lines_density',
+          `projectKeys=our-service&metricKeys=${metricKeys.join('%2C')}`,
         );
+
         return res(
           ctx.json({
             measures: [
@@ -111,7 +136,7 @@ describe('SonarQubeClient', () => {
                 value: '1.0',
                 component: 'our-service',
               },
-            ],
+            ].filter(m => metricKeys.includes(m.metric)),
           } as MeasuresWrapper),
         );
       }),
@@ -176,6 +201,34 @@ describe('SonarQubeClient', () => {
           sqale_rating: '2.0',
           coverage: '55.5',
           duplicated_lines_density: '1.0',
+        },
+        projectUrl: 'http://a.instance.local/dashboard?id=our-service',
+      }) as FindingSummary,
+    );
+    expect(summary?.getIssuesUrl('CODE_SMELL')).toEqual(
+      'http://a.instance.local/project/issues?id=our-service&types=CODE_SMELL&resolved=false',
+    );
+    expect(summary?.getComponentMeasuresUrl('COVERAGE')).toEqual(
+      'http://a.instance.local/component_measures?id=our-service&metric=coverage&resolved=false&view=list',
+    );
+  });
+
+  it('should only request selected metrics', async () => {
+    setupHandlers(['alert_status', 'bugs']);
+
+    const client = new SonarQubeClient({
+      discoveryApi,
+      baseUrl: 'http://a.instance.local',
+    });
+
+    const summary = await client.getFindingSummary('our-service');
+
+    expect(summary).toEqual(
+      expect.objectContaining({
+        lastAnalysis: '2020-01-01T00:00:00Z',
+        metrics: {
+          alert_status: 'OK',
+          bugs: '2',
         },
         projectUrl: 'http://a.instance.local/dashboard?id=our-service',
       }) as FindingSummary,


### PR DESCRIPTION
Closes #4197

#4132 added the support for metrics that are only available in SonarCloud and in newer SonarQube instances. This PR gets a list of all supported metrics prior to requesting the actual metrics for a project. This should make the change backward compatible to the old versions.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
