### PR TITLE
Hide scrollbar of collapsed sidebar

### DIFF
--- a/.changeset/lovely-panthers-peel.md
+++ b/.changeset/lovely-panthers-peel.md
@@ -1,0 +1,8 @@
+---
+'@backstage/core': minor
+---
+
+Closes #3556
+The scrollbar of collapsed sidebar is now hidden wihtout full screen.
+
+![image](https://user-images.githubusercontent.com/46953622/105390193-0bfd0080-5c19-11eb-8e86-2161bbe6e8d9.png)

--- a/packages/core/src/layout/Sidebar/Bar.tsx
+++ b/packages/core/src/layout/Sidebar/Bar.tsx
@@ -39,6 +39,8 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
     padding: 0,
     background: theme.palette.navigation.background,
     overflowX: 'hidden',
+    msOverflowStyle: 'none',
+    scrollbarWidth: 'none',
     width: sidebarConfig.drawerWidthClosed,
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
@@ -46,6 +48,9 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
     }),
     '& > *': {
       flexShrink: 0,
+    },
+    '&::-webkit-scrollbar': {
+      display: 'none',
     },
   },
   drawerOpen: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #3556
The scrollbar of collapsed sidebar is now hidden wihtout full screen.
Check on : 
- Firefox v84.0.2
- Opera GX LVL2 (core: 72.0.3815.473)
- IE v87.0.664.75
- Chrome  v87.0.4280.141

![image](https://user-images.githubusercontent.com/46953622/105390389-46ff3400-5c19-11eb-99ca-01435179c376.png)

![image](https://user-images.githubusercontent.com/46953622/105390193-0bfd0080-5c19-11eb-8e86-2161bbe6e8d9.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
