### PR TITLE
integration: Fix commit and branch API urls for hosted bitbucket server

### DIFF
--- a/.changeset/eleven-lamps-hide.md
+++ b/.changeset/eleven-lamps-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fix default branch API url for custom hosted Bitbucket server

--- a/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
@@ -126,12 +126,12 @@ describe('BitbucketUrlReader', () => {
             ),
         ),
         rest.get(
-          'https://api.bitbucket.mycompany.net/rest/api/1.0/repositories/backstage/mock/commits/some-branch',
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/commits',
           (_, res, ctx) =>
             res(
               ctx.status(200),
               ctx.json({
-                values: [{ hash: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st' }],
+                values: [{ id: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st' }],
               }),
             ),
         ),

--- a/packages/integration/src/bitbucket/core.test.ts
+++ b/packages/integration/src/bitbucket/core.test.ts
@@ -116,7 +116,7 @@ describe('bitbucket core', () => {
       };
       worker.use(
         rest.get(
-          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches/default',
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
           (_, res, ctx) =>
             res(
               ctx.status(200),
@@ -144,7 +144,7 @@ describe('bitbucket core', () => {
       };
       worker.use(
         rest.get(
-          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches/default',
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
           (_, res, ctx) =>
             res(
               ctx.status(200),
@@ -231,7 +231,7 @@ describe('bitbucket core', () => {
       };
       worker.use(
         rest.get(
-          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches/default',
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
           (_, res, ctx) =>
             res(
               ctx.status(200),

--- a/packages/integration/src/bitbucket/core.ts
+++ b/packages/integration/src/bitbucket/core.ts
@@ -31,9 +31,10 @@ export async function getBitbucketDefaultBranch(
   const { name: repoName, owner: project, resource } = parseGitUrl(url);
 
   const isHosted = resource === 'bitbucket.org';
+  // Bitbucket Server https://docs.atlassian.com/bitbucket-server/rest/7.9.0/bitbucket-rest.html#idp184
   const branchUrl = isHosted
     ? `${config.apiBaseUrl}/repositories/${project}/${repoName}`
-    : `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/branches/default`;
+    : `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/default-branch`;
 
   const response = await fetch(branchUrl, getBitbucketRequestOptions(config));
   if (!response.ok) {
@@ -50,7 +51,10 @@ export async function getBitbucketDefaultBranch(
     defaultBranch = displayId;
   }
   if (!defaultBranch) {
-    throw new Error(`Failed to read default branch from ${branchUrl}`);
+    throw new Error(
+      `Failed to read default branch from ${branchUrl}. ` +
+        `Response ${response.status} ${response.json()}`,
+    );
   }
   return defaultBranch;
 }


### PR DESCRIPTION
Noted in https://github.com/backstage/backstage/issues/4121#issuecomment-764735647

Docs https://docs.atlassian.com/bitbucket-server/rest/7.9.0/bitbucket-rest.html#idp184

I think there are more problems that exist with hosted bitbucket server and URL Reader. Thinking about deploying a trial version soon to test it all out. _sigh_

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
