### PR TITLE
TechDocs: Introduce execution limiter for file uploads

### DIFF
--- a/.changeset/techdocs-dirty-rivers-hope.md
+++ b/.changeset/techdocs-dirty-rivers-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Add rate limiter for concurrent execution of file uploads in AWS and Google publishers

--- a/packages/techdocs-common/package.json
+++ b/packages/techdocs-common/package.json
@@ -53,6 +53,7 @@
     "json5": "^2.1.3",
     "mime-types": "^2.1.27",
     "mock-fs": "^4.13.0",
+    "p-limit": "^3.1.0",
     "recursive-readdir": "^2.2.2",
     "winston": "^3.2.1"
   },

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -150,10 +150,8 @@ export class AwsS3Publish implements PublisherBase {
           Body: fileContent,
         };
 
-        // Rate limit the concurrent execution of file uploads to batches of 10
-        const uploadFile = limiter(async () =>
-          this.storageClient.putObject(params),
-        );
+        // Rate limit the concurrent execution of file uploads to batches of 10 (per publish)
+        const uploadFile = limiter(() => this.storageClient.putObject(params));
         uploadPromises.push(uploadFile);
       }
       await Promise.all(uploadPromises);

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -24,7 +24,7 @@ import { PublisherBase, PublishRequest, TechDocsMetadata } from './types';
 import fs from 'fs-extra';
 import { Readable } from 'stream';
 import JSON5 from 'json5';
-import limiterFactory from 'p-limit';
+import createLimiter from 'p-limit';
 
 const streamToBuffer = (stream: Readable): Promise<Buffer> => {
   return new Promise((resolve, reject) => {
@@ -132,7 +132,7 @@ export class AwsS3Publish implements PublisherBase {
       // So collecting path of only the files is good enough.
       const allFilesToUpload = await getFileTreeRecursively(directory);
 
-      const limiter = limiterFactory(10);
+      const limiter = createLimiter(10);
       const uploadPromises: Array<Promise<PutObjectCommandOutput>> = [];
       for (const filePath of allFilesToUpload) {
         // Remove the absolute path prefix of the source directory

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -24,6 +24,7 @@ import { PublisherBase, PublishRequest, TechDocsMetadata } from './types';
 import fs from 'fs-extra';
 import { Readable } from 'stream';
 import JSON5 from 'json5';
+import limiterFactory from 'p-limit';
 
 const streamToBuffer = (stream: Readable): Promise<Buffer> => {
   return new Promise((resolve, reject) => {
@@ -131,8 +132,8 @@ export class AwsS3Publish implements PublisherBase {
       // So collecting path of only the files is good enough.
       const allFilesToUpload = await getFileTreeRecursively(directory);
 
+      const limiter = limiterFactory(10);
       const uploadPromises: Array<Promise<PutObjectCommandOutput>> = [];
-
       for (const filePath of allFilesToUpload) {
         // Remove the absolute path prefix of the source directory
         // Path of all files to upload, relative to the root of the source directory
@@ -149,7 +150,11 @@ export class AwsS3Publish implements PublisherBase {
           Body: fileContent,
         };
 
-        uploadPromises.push(this.storageClient.putObject(params));
+        // Rate limit the concurrent execution of file uploads to batches of 10
+        const uploadFile = limiter(async () =>
+          this.storageClient.putObject(params),
+        );
+        uploadPromises.push(uploadFile);
       }
       await Promise.all(uploadPromises);
       this.logger.info(

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -113,8 +113,8 @@ export class GoogleGCSPublish implements PublisherBase {
         const entityRootDir = `${entity.metadata.namespace}/${entity.kind}/${entity.metadata.name}`;
         const destination = `${entityRootDir}/${relativeFilePath}`; // GCS Bucket file relative path
 
-        // Rate limit the concurrent execution of file uploads to batches of 10
-        const uploadFile = limiter(async () =>
+        // Rate limit the concurrent execution of file uploads to batches of 10 (per publish)
+        const uploadFile = limiter(() =>
           this.storageClient
             .bucket(this.bucketName)
             .upload(filePath, { destination }),

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -26,7 +26,7 @@ import { Config } from '@backstage/config';
 import { getHeadersForFileExtension, getFileTreeRecursively } from './helpers';
 import { PublisherBase, PublishRequest, TechDocsMetadata } from './types';
 import JSON5 from 'json5';
-import limitFactory from 'p-limit';
+import createLimiter from 'p-limit';
 
 export class GoogleGCSPublish implements PublisherBase {
   static async fromConfig(
@@ -103,7 +103,7 @@ export class GoogleGCSPublish implements PublisherBase {
       // So collecting path of only the files is good enough.
       const allFilesToUpload = await getFileTreeRecursively(directory);
 
-      const limiter = limitFactory(10);
+      const limiter = createLimiter(10);
       const uploadPromises: Array<Promise<UploadResponse>> = [];
       allFilesToUpload.forEach(filePath => {
         // Remove the absolute path prefix of the source directory

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -26,6 +26,7 @@ import { Config } from '@backstage/config';
 import { getHeadersForFileExtension, getFileTreeRecursively } from './helpers';
 import { PublisherBase, PublishRequest, TechDocsMetadata } from './types';
 import JSON5 from 'json5';
+import limitFactory from 'p-limit';
 
 export class GoogleGCSPublish implements PublisherBase {
   static async fromConfig(
@@ -102,6 +103,7 @@ export class GoogleGCSPublish implements PublisherBase {
       // So collecting path of only the files is good enough.
       const allFilesToUpload = await getFileTreeRecursively(directory);
 
+      const limiter = limitFactory(10);
       const uploadPromises: Array<Promise<UploadResponse>> = [];
       allFilesToUpload.forEach(filePath => {
         // Remove the absolute path prefix of the source directory
@@ -110,12 +112,14 @@ export class GoogleGCSPublish implements PublisherBase {
         const relativeFilePath = filePath.replace(`${directory}/`, '');
         const entityRootDir = `${entity.metadata.namespace}/${entity.kind}/${entity.metadata.name}`;
         const destination = `${entityRootDir}/${relativeFilePath}`; // GCS Bucket file relative path
-        // TODO: Upload in chunks of ~10 files instead of all files at once.
-        uploadPromises.push(
-          this.storageClient.bucket(this.bucketName).upload(filePath, {
-            destination,
-          }),
+
+        // Rate limit the concurrent execution of file uploads to batches of 10
+        const uploadFile = limiter(async () =>
+          this.storageClient
+            .bucket(this.bucketName)
+            .upload(filePath, { destination }),
         );
+        uploadPromises.push(uploadFile);
       });
 
       Promise.all(uploadPromises)

--- a/yarn.lock
+++ b/yarn.lock
@@ -19780,7 +19780,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.1, p-limit@^3.0.2:
+p-limit@^3.0.1, p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Quick PR to add rate limiting to the concurrent execution of file uploads for techdocs publishers. Not much to say, used `p-limit`, created a limit factory in both publishers (`AWS` & `GoogleStorage`) and wrapped every call to the external service in the limiter.

The limit is `10`, think it's more visible as a hardcoded value than a constant; it's also used only in one place.

#### Changelog:
---
 * TechDoc publishers for storage providers (i.e aws, google storage)
 should now rate limit concurrent executions allowing for file uploads to run in batches of 10.
 * Add PATCH changeset to techdocs common (prefixed with techdocs based on the prev PR)
 * Update yarn.lock (had to remove @backstage/core updates manually)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Unfortunately, can't test it without an AWS/GStorage account :(

To test, I have only checked it can be compiled successfully, e.g `yarn tsc`. I think it wouldn't  add much to test with the local publisher since no changes have been made there. Existing test suite is 👌 

_Fixes #4143_

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
