### PR TITLE
Add support for additional breakdowns of daily cost data

### DIFF
--- a/.changeset/cost-insights-yellow-trees-love.md
+++ b/.changeset/cost-insights-yellow-trees-love.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-cost-insights': minor
+---
+
+Add support for additional breakdowns of daily cost data.
+This changes the type of Cost.groupedCosts returned by CostInsightsApi.getGroupDailyCost.

--- a/plugins/cost-insights/src/client.ts
+++ b/plugins/cost-insights/src/client.ts
@@ -33,11 +33,12 @@ import {
   UnlabeledDataflowAlert,
 } from '../src/utils/alerts';
 import {
-  trendlineOf,
+  aggregationFor,
   changeOf,
   entityOf,
   getGroupedProducts,
-  aggregationFor,
+  getGroupedProjects,
+  trendlineOf,
 } from './utils/mockData';
 
 export class ExampleCostInsightsClient implements CostInsightsApi {
@@ -101,7 +102,10 @@ export class ExampleCostInsightsClient implements CostInsightsApi {
         trendline: trendlineOf(aggregation),
         // Optional field on Cost which needs to be supplied in order to see
         // the product breakdown view in the top panel.
-        groupedCosts: getGroupedProducts(intervals),
+        groupedCosts: {
+          product: getGroupedProducts(intervals),
+          project: getGroupedProjects(intervals),
+        },
       },
     );
 
@@ -119,7 +123,9 @@ export class ExampleCostInsightsClient implements CostInsightsApi {
         trendline: trendlineOf(aggregation),
         // Optional field on Cost which needs to be supplied in order to see
         // the product breakdown view in the top panel.
-        groupedCosts: getGroupedProducts(intervals),
+        groupedCosts: {
+          product: getGroupedProducts(intervals),
+        },
       },
     );
 

--- a/plugins/cost-insights/src/client.ts
+++ b/plugins/cost-insights/src/client.ts
@@ -100,8 +100,8 @@ export class ExampleCostInsightsClient implements CostInsightsApi {
         aggregation: aggregation,
         change: changeOf(aggregation),
         trendline: trendlineOf(aggregation),
-        // Optional field on Cost which needs to be supplied in order to see
-        // the product breakdown view in the top panel.
+        // Optional field providing cost groupings / breakdowns keyed by the type. In this example,
+        // daily cost grouped by cloud product OR by project / billing account.
         groupedCosts: {
           product: getGroupedProducts(intervals),
           project: getGroupedProjects(intervals),
@@ -121,8 +121,8 @@ export class ExampleCostInsightsClient implements CostInsightsApi {
         aggregation: aggregation,
         change: changeOf(aggregation),
         trendline: trendlineOf(aggregation),
-        // Optional field on Cost which needs to be supplied in order to see
-        // the product breakdown view in the top panel.
+        // Optional field providing cost groupings / breakdowns keyed by the type. In this example,
+        // daily project cost grouped by cloud product.
         groupedCosts: {
           product: getGroupedProducts(intervals),
         },

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.test.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { CostOverviewCard } from './CostOverviewCard';
+import { Cost } from '../../types';
+import {
+  changeOf,
+  getGroupedProducts,
+  getGroupedProjects,
+  MockAggregatedDailyCosts,
+  trendlineOf,
+} from '../../utils/mockData';
+import {
+  MockBillingDateProvider,
+  MockConfigProvider,
+  MockFilterProvider,
+  MockScrollProvider,
+} from '../../utils/tests';
+import { CostInsightsThemeProvider } from '../CostInsightsPage/CostInsightsThemeProvider';
+
+const mockGroupDailyCost: Cost = {
+  id: 'test-group',
+  aggregation: MockAggregatedDailyCosts,
+  change: changeOf(MockAggregatedDailyCosts),
+  trendline: trendlineOf(MockAggregatedDailyCosts),
+};
+
+function renderInContext(children: JSX.Element) {
+  return renderInTestApp(
+    <CostInsightsThemeProvider>
+      <MockConfigProvider>
+        <MockFilterProvider>
+          <MockBillingDateProvider>
+            <MockScrollProvider>{children}</MockScrollProvider>
+          </MockBillingDateProvider>
+        </MockFilterProvider>
+      </MockConfigProvider>
+    </CostInsightsThemeProvider>,
+  );
+}
+
+describe('<CostOverviewCard/>', () => {
+  it('Renders without exploding', async () => {
+    const { getByText } = await renderInContext(
+      <CostOverviewCard dailyCostData={mockGroupDailyCost} metricData={null} />,
+    );
+    expect(getByText('Cloud Cost')).toBeInTheDocument();
+  });
+
+  it('Shows breakdown tabs if provided', async () => {
+    const mockDailyCostWithBreakdowns = {
+      ...mockGroupDailyCost,
+      groupedCosts: {
+        product: getGroupedProducts('R2/P90D/2021-01-01'),
+        project: getGroupedProjects('R2/P90D/2021-01-01'),
+      },
+    };
+    const { getByText } = await renderInContext(
+      <CostOverviewCard
+        dailyCostData={mockDailyCostWithBreakdowns}
+        metricData={null}
+      />,
+    );
+    expect(getByText('Cloud Cost')).toBeInTheDocument();
+    expect(getByText('Breakdown by product')).toBeInTheDocument();
+    expect(getByText('Breakdown by project')).toBeInTheDocument();
+
+    fireEvent.click(getByText('Breakdown by product'));
+    expect(getByText('Cloud Cost By Product')).toBeInTheDocument();
+
+    fireEvent.click(getByText('Breakdown by project'));
+    expect(getByText('Cloud Cost By Project')).toBeInTheDocument();
+  });
+});

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
@@ -17,6 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import {
   Box,
+  capitalize,
   Card,
   CardContent,
   Divider,
@@ -72,7 +73,7 @@ export const CostOverviewCard = ({
     key => ({
       id: key,
       label: `Breakdown by ${key}`,
-      title: `Cloud Cost By ${key.charAt(0).toUpperCase() + key.slice(1)}`,
+      title: `Cloud Cost By ${capitalize(key)}`,
     }),
   );
   const tabs = [

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box,
   Card,
   CardContent,
   Divider,
-  useTheme,
   Tab,
   Tabs,
+  useTheme,
 } from '@material-ui/core';
 import { CostOverviewChart } from './CostOverviewChart';
-import { CostOverviewByProductChart } from './CostOverviewByProductChart';
+import { CostOverviewBreakdownChart } from './CostOverviewBreakdownChart';
 import { CostOverviewHeader } from './CostOverviewHeader';
 import { MetricSelect } from '../MetricSelect';
 import { PeriodSelect } from '../PeriodSelect';
-import { useScroll, useFilters, useConfig } from '../../hooks';
+import { useConfig, useFilters, useScroll } from '../../hooks';
 import { mapFiltersToProps } from './selector';
 import { DefaultNavigation } from '../../utils/navigation';
 import { findAlways } from '../../utils/assert';
@@ -49,6 +49,15 @@ export const CostOverviewCard = ({
   const config = useConfig();
   const [tabIndex, setTabIndex] = useState(0);
 
+  // Reset tabIndex if breakdowns available change
+  useEffect(() => {
+    // Intentionally off-by-one to account for the overview tab
+    const lastIndex = Object.keys(dailyCostData.groupedCosts ?? {}).length;
+    if (tabIndex > lastIndex) {
+      setTabIndex(0);
+    }
+  }, [dailyCostData, tabIndex, setTabIndex]);
+
   const { ScrollAnchor } = useScroll(DefaultNavigation.CostOverviewCard);
   const { setDuration, setProject, setMetric, ...filters } = useFilters(
     mapFiltersToProps,
@@ -59,14 +68,18 @@ export const CostOverviewCard = ({
     : null;
   const styles = useOverviewTabsStyles(theme);
 
+  const breakdownTabs = Object.keys(dailyCostData.groupedCosts ?? {}).map(
+    key => ({
+      id: key,
+      label: `Breakdown by ${key}`,
+      title: `Cloud Cost By ${key.charAt(0).toUpperCase() + key.slice(1)}`,
+    }),
+  );
   const tabs = [
     { id: 'overview', label: 'Total cost', title: 'Cloud Cost' },
-    {
-      id: 'breakdown',
-      label: 'Breakdown by product',
-      title: 'Cloud Cost By Product',
-    },
-  ];
+  ].concat(breakdownTabs);
+  // tabIndex can temporarily be invalid while the useEffect above processes
+  const safeTabIndex = tabIndex > tabs.length - 1 ? 0 : tabIndex;
 
   const OverviewTabs = () => {
     return (
@@ -74,7 +87,7 @@ export const CostOverviewCard = ({
         <Tabs
           indicatorColor="primary"
           onChange={(_, index) => setTabIndex(index)}
-          value={tabIndex}
+          value={safeTabIndex}
         >
           {tabs.map((tab, index) => (
             <Tab
@@ -91,27 +104,27 @@ export const CostOverviewCard = ({
   };
 
   // Metrics can only be selected on the total cost graph
-  const showMetricSelect = config.metrics.length && tabIndex === 0;
+  const showMetricSelect = config.metrics.length && safeTabIndex === 0;
 
   return (
     <Card style={{ position: 'relative' }}>
       <ScrollAnchor behavior="smooth" top={-20} />
       <CardContent>
         {dailyCostData.groupedCosts && <OverviewTabs />}
-        <CostOverviewHeader title={tabs[tabIndex].title}>
+        <CostOverviewHeader title={tabs[safeTabIndex].title}>
           <PeriodSelect duration={filters.duration} onSelect={setDuration} />
         </CostOverviewHeader>
         <Divider />
         <Box ml={2} my={1} display="flex" flexDirection="column">
-          {tabIndex === 0 ? (
+          {safeTabIndex === 0 ? (
             <CostOverviewChart
               dailyCostData={dailyCostData}
               metric={metric}
               metricData={metricData}
             />
           ) : (
-            <CostOverviewByProductChart
-              costsByProduct={dailyCostData.groupedCosts!}
+            <CostOverviewBreakdownChart
+              costBreakdown={dailyCostData.groupedCosts![tabs[safeTabIndex].id]}
             />
           )}
         </Box>

--- a/plugins/cost-insights/src/types/Cost.ts
+++ b/plugins/cost-insights/src/types/Cost.ts
@@ -23,5 +23,5 @@ export interface Cost {
   aggregation: DateAggregation[];
   change?: ChangeStatistic;
   trendline?: Trendline;
-  groupedCosts?: Cost[];
+  groupedCosts?: Record<string, Cost[]>;
 }

--- a/plugins/cost-insights/src/utils/mockData.ts
+++ b/plugins/cost-insights/src/utils/mockData.ts
@@ -1064,3 +1064,18 @@ export const getGroupedProducts = (intervals: string) => [
     aggregation: aggregationFor(intervals, 250),
   },
 ];
+
+export const getGroupedProjects = (intervals: string) => [
+  {
+    id: 'project-a',
+    aggregation: aggregationFor(intervals, 1_700),
+  },
+  {
+    id: 'project-b',
+    aggregation: aggregationFor(intervals, 350),
+  },
+  {
+    id: 'project-c',
+    aggregation: aggregationFor(intervals, 1_300),
+  },
+];


### PR DESCRIPTION
Adds support for multiple breakdowns of daily cost, such as product and project:

![multiple-breakdowns-tabs](https://user-images.githubusercontent.com/556258/105544516-4f5a7c00-5cb8-11eb-9bd4-4bd040a10694.gif)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
