### PR TITLE
fix: use .text instead of .json for ALB key http call

### DIFF
--- a/.changeset/honest-jokes-rush.md
+++ b/.changeset/honest-jokes-rush.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Use .text instead of .json for ALB key response

--- a/plugins/auth-backend/src/providers/aws-alb/provider.test.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.test.ts
@@ -36,7 +36,7 @@ jest.mock('cross-fetch', () => ({
   __esModule: true,
   default: async () => {
     return {
-      json: async () => {
+      text: async () => {
         return mockKey();
       },
     };

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -102,7 +102,7 @@ export class AwsAlbAuthProvider implements AuthProviderRouteHandlers {
     }
     const keyText: string = await fetch(
       `https://public-keys.auth.elb.${this.options.region}.amazonaws.com/${keyId}`,
-    ).then(response => response.json());
+    ).then(response => response.text());
     const keyValue = crypto.createPublicKey(keyText);
     this.keyCache.set(keyId, keyValue);
     return keyValue;


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Add fix for bug introduced in  ALB provider during code review  - fetch needs to use .text instead of .json for getting public key data from AWS. 
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
