### PR TITLE
kubernetes: Improve error reporting for plugin misconfiguration

### DIFF
--- a/.changeset/healthy-cameras-suffer.md
+++ b/.changeset/healthy-cameras-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Improve error reporting for plugin misconfiguration.

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -129,6 +129,7 @@ microsite
 middleware
 minikube
 Minikube
+misconfiguration
 misgendering
 mkdocs
 Mkdocs

--- a/plugins/kubernetes/src/api/KubernetesBackendClient.ts
+++ b/plugins/kubernetes/src/api/KubernetesBackendClient.ts
@@ -43,7 +43,15 @@ export class KubernetesBackendClient implements KubernetesApi {
 
     if (!response.ok) {
       const payload = await response.text();
-      const message = `Request failed with ${response.status} ${response.statusText}, ${payload}`;
+      let message;
+      switch (response.status) {
+        case 404:
+          message =
+            'Could not find the Kubernetes Backend (HTTP 404). Make sure the plugin has been fully installed.';
+          break;
+        default:
+          message = `Request failed with ${response.status} ${response.statusText}, ${payload}`;
+      }
       throw new Error(message);
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I started writing up some instructions for #4170, and in so doing installed the k8s plugin raw into a freshly scaffolded app. I purposely did not have the backend configured, and realized the error messaging could be improved.

Currently, if you only install `plugin-kubernetes` in your frontend you'll get an error message that looks like this:

![image](https://user-images.githubusercontent.com/33203301/105663300-dddd2200-5e9f-11eb-8e19-ff2c16c47fb0.png)

The payload is empty, which is why you get the trailing comma as well.

The updated error messaging from this PR makes an assumption that if the frontend client gets a 404 from the `await this.discoveryApi.get BaseUrl('kubernetes')${path}` which was _supposed_ to have been collected from the running backend `plugin-kubernetes-backend`, then it must be a misconfiguration, and clarifies that:

> Could not find the Kubernetes Backend (HTTP 404). Make sure the plugin has been fully installed.

![image](https://user-images.githubusercontent.com/33203301/105663253-c1d98080-5e9f-11eb-830c-7f8004d5d291.png)

In situations where the entire backend service (:7000), the catalog entry doesn't even load up.

The goal is this hopefully improves first time setup.  Welcome feedback as to edge cases I may not have considered.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
