### PR TITLE
feat(scaffolder-backend): add more config options for github repos (WIP)

### DIFF
--- a/.changeset/olive-dogs-swim.md
+++ b/.changeset/olive-dogs-swim.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Allow specifying default attributes for new commits, such as requiring signed
+commits, enabling dependabot, setting read/write permissions and branch
+protection options.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -238,6 +238,33 @@ scaffolder:
     token:
       $env: GITHUB_TOKEN
     visibility: public # or 'internal' or 'private'
+    # # Customize created repos:
+    # readers:
+    #   - 'myorg/developers'
+    # writers:
+    #   - 'myorg/ci'
+    # enableAutomatedSecurityFixes: true
+    # enableVulnerabilityAlerts: true
+    # branchConfig:
+    #   # key/value for each branch to configure
+    #   master:
+    #     allowForcePush: false
+    #     allowDeletions: false
+    #     requireSignedCommits: true
+    #     enforceAdmins: true
+    #     # requirePRReviews must be enabled when setting dismissStaleReviews,
+    #     #  requireCodeOwnerReviews or requiredApprovingReviewCount
+    #     requirePRReview: true
+    #     dismissStaleReviews: false
+    #     requireCodeOwnerReviews: true
+    #     requiredApprovingReviewCount: 1
+    #     # Enforce status checks.
+    #     #  Must be enabled to enforce requiredUpToDateBeforeMerging or requiredContexts
+    #     requireStatusChecksBeforeMerging: true
+    #     requireUpToDateBeforeMerge: false
+    #     requiredContexts:
+    #       - 'tests'
+
   gitlab:
     api:
       baseUrl: https://gitlab.com

--- a/plugins/scaffolder-backend/config.d.ts
+++ b/plugins/scaffolder-backend/config.d.ts
@@ -18,7 +18,11 @@ export interface Config {
   /** Configuration options for the scaffolder plugin */
   scaffolder?: {
     github?: {
-      [key: string]: string;
+      visibility?: 'private' | 'internal' | 'public';
+      writers?: string[];
+      readers?: string[];
+      requireSignedCommits?: boolean;
+      enableAutomatedSecurityFixes?: boolean;
     };
     gitlab?: {
       api: { [key: string]: string };

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
@@ -19,7 +19,7 @@ jest.mock('./helpers');
 
 import { getVoidLogger } from '@backstage/backend-common';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
-import { GithubPublisher } from './github';
+import { GithubPublisher, GithubPublisherConfig } from './github';
 import { initRepoAndPush } from './helpers';
 
 const { mockGithubClient } = require('@octokit/rest') as {
@@ -29,6 +29,22 @@ const { mockGithubClient } = require('@octokit/rest') as {
     teams: jest.Mocked<Octokit['teams']>;
   };
 };
+
+const createPublishConfig = ({
+  repoVisibility = 'public',
+  enableAutomatedSecurityFixes = false,
+  enableVulnerabilityAlerts = false,
+  readers = [],
+  writers = [],
+  branchConfig = {},
+}: Partial<GithubPublisherConfig>): GithubPublisherConfig => ({
+  repoVisibility,
+  enableAutomatedSecurityFixes,
+  enableVulnerabilityAlerts,
+  readers,
+  writers,
+  branchConfig,
+});
 
 describe('GitHub Publisher', () => {
   const logger = getVoidLogger();
@@ -44,7 +60,7 @@ describe('GitHub Publisher', () => {
             token: 'fake-token',
             host: 'github.com',
           },
-          { repoVisibility: 'public' },
+          createPublishConfig({ repoVisibility: 'public' }),
         );
 
         mockGithubClient.repos.createInOrg.mockResolvedValue({
@@ -102,7 +118,7 @@ describe('GitHub Publisher', () => {
             token: 'fake-token',
             host: 'github.com',
           },
-          { repoVisibility: 'public' },
+          createPublishConfig({ repoVisibility: 'public' }),
         );
 
         mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
@@ -154,7 +170,7 @@ describe('GitHub Publisher', () => {
           token: 'fake-token',
           host: 'github.com',
         },
-        { repoVisibility: 'public' },
+        createPublishConfig({ repoVisibility: 'public' }),
       );
 
       mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
@@ -213,7 +229,7 @@ describe('GitHub Publisher', () => {
           token: 'fake-token',
           host: 'github.com',
         },
-        { repoVisibility: 'internal' },
+        createPublishConfig({ repoVisibility: 'internal' }),
       );
 
       mockGithubClient.repos.createInOrg.mockResolvedValue({
@@ -264,7 +280,7 @@ describe('GitHub Publisher', () => {
           token: 'fake-token',
           host: 'github.com',
         },
-        { repoVisibility: 'private' },
+        createPublishConfig({ repoVisibility: 'private' }),
       );
 
       mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({


### PR DESCRIPTION
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

To use the scaffolder plugin internally we need to set up the repo to
our conventions.  This change allows us to specify default behaviors for
signed commits, security fixes, read/write permissions and branch
protection options.


New configuration options:

```yaml
scaffolder:
  github:
    # Customize created repos:
    readers:
      - 'myorg/developers'
    writers:
      - 'myorg/ci'
    enableAutomatedSecurityFixes: true
    enableVulnerabilityAlerts: true
    branchConfig:
      # key/value for each branch to configure
      master:
        allowForcePush: false
        allowDeletions: false
        requireSignedCommits: true
        enforceAdmins: true
        # requirePRReviews must be enabled when setting dismissStaleReviews,
        #  requireCodeOwnerReviews or requiredApprovingReviewCount
        requirePRReview: true
        dismissStaleReviews: false
        requireCodeOwnerReviews: true
        requiredApprovingReviewCount: 1
        # Enforce status checks.
        #  Must be enabled to enforce requiredUpToDateBeforeMerging or requiredContexts
        requireStatusChecksBeforeMerging: true
        requireUpToDateBeforeMerge: false
        requiredContexts:
          - 'tests'
```

#### Docs

Question: is more docs needed than adding the above example config?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
