### PR TITLE
remove last usages of APP_ENV

### DIFF
--- a/docs/getting-started/deployment-other.md
+++ b/docs/getting-started/deployment-other.md
@@ -13,7 +13,7 @@ Run the following commands if you have Docker environment
 ```bash
 $ yarn install
 $ yarn docker-build
-$ docker run --rm -it -p 7000:7000 -e APP_ENV=production -e NODE_ENV=development example-backend:latest
+$ docker run --rm -it -p 7000:7000 -e NODE_ENV=development example-backend:latest
 ```
 
 Then open http://localhost:7000 on your browser.

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -37,7 +37,6 @@ export async function loadBackendConfig(options: Options): Promise<Config> {
   /* eslint-disable-next-line no-restricted-syntax */
   const paths = findPaths(__dirname);
   const configs = await loadConfig({
-    env: process.env.APP_ENV ?? process.env.NODE_ENV ?? 'development',
     configRoot: paths.targetRoot,
     configPaths: configOpts.map(opt => resolvePath(opt)),
   });


### PR DESCRIPTION
Skipping changeset as there's no need to trigger a release of `backend-common`, the option is just being ignored anyway.