### PR TITLE
Add pictures to users and groups

### DIFF
--- a/packages/catalog-model/examples/acme/backstage-group.yaml
+++ b/packages/catalog-model/examples/acme/backstage-group.yaml
@@ -8,6 +8,6 @@ spec:
   profile:
     displayName: Backstage
     email: backstage@example.com
-    picture: https://example.com/groups/backstage.jpeg
+    picture: https://avatars.dicebear.com/api/identicon/backstage@example.com.svg?background=%23fff&margin=25
   parent: infrastructure
   children: [team-a, team-b]

--- a/packages/catalog-model/examples/acme/org.yaml
+++ b/packages/catalog-model/examples/acme/org.yaml
@@ -8,7 +8,7 @@ spec:
   profile:
     displayName: ACME Corp
     email: info@example.com
-    picture: https://example.com/logo.jpeg
+    picture: https://avatars.dicebear.com/api/identicon/info@example.com.svg?background=%23fff&margin=25
   children: [infrastructure]
 ---
 apiVersion: backstage.io/v1alpha1

--- a/packages/catalog-model/examples/acme/team-a-group.yaml
+++ b/packages/catalog-model/examples/acme/team-a-group.yaml
@@ -8,7 +8,7 @@ spec:
   profile:
     # Intentional no displayName for testing
     email: team-a@example.com
-    picture: https://example.com/groups/team-a.jpeg
+    picture: https://avatars.dicebear.com/api/identicon/team-a@example.com.svg?background=%23fff&margin=25
   parent: backstage
   children: []
 ---
@@ -20,7 +20,7 @@ spec:
   profile:
     # Intentional no displayName for testing
     email: breanna-davison@example.com
-    picture: https://example.com/staff/breanna.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/breanna-davison@example.com.svg?background=%23fff
   memberOf: [team-a]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -31,7 +31,7 @@ spec:
   profile:
     displayName: Janelle Dawe
     email: janelle-dawe@example.com
-    picture: https://example.com/staff/janelle.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/janelle-dawe@example.com.svg?background=%23fff
   memberOf: [team-a]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -42,7 +42,7 @@ spec:
   profile:
     displayName: Nigel Manning
     email: nigel-manning@example.com
-    picture: https://example.com/staff/nigel.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/nigel-manning@example.com.svg?background=%23fff
   memberOf: [team-a]
 ---
 # This user is added as an example, to make it more easy for the "Guest"
@@ -56,5 +56,5 @@ spec:
   profile:
     displayName: Guest User
     email: guest@example.com
-    picture: https://example.com/staff/the-ceos-dog.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/guest@example.com.svg?background=%23fff
   memberOf: [team-a]

--- a/packages/catalog-model/examples/acme/team-b-group.yaml
+++ b/packages/catalog-model/examples/acme/team-b-group.yaml
@@ -8,7 +8,7 @@ spec:
   profile:
     displayName: Team B
     email: team-b@example.com
-    picture: https://example.com/groups/team-b.jpeg
+    picture: https://avatars.dicebear.com/api/identicon/team-b@example.com.svg?background=%23fff&margin=25
   parent: backstage
   children: []
 ---
@@ -20,7 +20,7 @@ spec:
   profile:
     displayName: Amelia Park
     email: amelia-park@example.com
-    picture: https://example.com/staff/amelia.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/amelia-park@example.com.svg?background=%23fff
   memberOf: [team-b]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -31,7 +31,7 @@ spec:
   profile:
     displayName: Colette Brock
     email: colette-brock@example.com
-    picture: https://example.com/staff/colette.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/colette-brock@example.com.svg?background=%23fff
   memberOf: [team-b]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -42,7 +42,7 @@ spec:
   profile:
     displayName: Jenny Doe
     email: jenny-doe@example.com
-    picture: https://example.com/staff/jenny.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/jenny-doe@example.com.svg?background=%23fff
   memberOf: [team-b]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -53,7 +53,7 @@ spec:
   profile:
     displayName: Jonathon Page
     email: jonathon-page@example.com
-    picture: https://example.com/staff/jonathon.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/jonathon-page@example.com.svg?background=%23fff
   memberOf: [team-b]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -64,5 +64,5 @@ spec:
   profile:
     displayName: Justine Barrow
     email: justine-barrow@example.com
-    picture: https://example.com/staff/justine.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/justine-barrow@example.com.svg?background=%23fff
   memberOf: [team-b]

--- a/packages/catalog-model/examples/acme/team-c-group.yaml
+++ b/packages/catalog-model/examples/acme/team-c-group.yaml
@@ -8,7 +8,7 @@ spec:
   profile:
     displayName: Team C
     email: team-c@example.com
-    picture: https://example.com/groups/team-c.jpeg
+    picture: https://avatars.dicebear.com/api/identicon/team-c@example.com.svg?background=%23fff&margin=25
   parent: boxoffice
   children: []
 ---
@@ -20,7 +20,7 @@ spec:
   profile:
     displayName: Calum Leavy
     email: calum-leavy@example.com
-    picture: https://example.com/staff/calum.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/calum-leavy@example.com.svg?background=%23fff
   memberOf: [team-c]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -31,7 +31,7 @@ spec:
   profile:
     displayName: Frank Tiernan
     email: frank-tiernan@example.com
-    picture: https://example.com/staff/frank.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/frank-tiernan@example.com.svg?background=%23fff
   memberOf: [team-c]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -42,7 +42,7 @@ spec:
   profile:
     displayName: Peadar MacMahon
     email: peadar-macmahon@example.com
-    picture: https://example.com/staff/peadar.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/peadar-macmahon@example.com.svg?background=%23fff
   memberOf: [team-c]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -53,7 +53,7 @@ spec:
   profile:
     displayName: Sarah Gilroy
     email: sarah-gilroy@example.com
-    picture: https://example.com/staff/sarah.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/sarah-gilroy@example.com.svg?background=%23fff
   memberOf: [team-c]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -64,5 +64,5 @@ spec:
   profile:
     displayName: Tara MacGovern
     email: tara-macgovern@example.com
-    picture: https://example.com/staff/tara.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/tara-macgovern@example.com.svg?background=%23fff
   memberOf: [team-c]

--- a/packages/catalog-model/examples/acme/team-d-group.yaml
+++ b/packages/catalog-model/examples/acme/team-d-group.yaml
@@ -8,7 +8,7 @@ spec:
   profile:
     displayName: Team D
     email: team-d@example.com
-    picture: https://example.com/groups/team-d.jpeg
+    picture: https://avatars.dicebear.com/api/identicon/team-d@example.com.svg?background=%23fff&margin=25
   parent: boxoffice
   children: []
 ---
@@ -20,7 +20,7 @@ spec:
   profile:
     displayName: Eva MacDowell
     email: eva-macdowell@example.com
-    picture: https://example.com/staff/eva.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/eva-macdowell@example.com.svg?background=%23fff
   memberOf: [team-d]
 ---
 apiVersion: backstage.io/v1alpha1
@@ -31,5 +31,5 @@ spec:
   profile:
     displayName: Lucy Sheehan
     email: lucy-sheehan@example.com
-    picture: https://example.com/staff/lucy.jpeg
+    picture: https://avatars.dicebear.com/api/avataaars/lucy-sheehan@example.com.svg?background=%23fff
   memberOf: [team-d]


### PR DESCRIPTION
I was a bit annoyed about the 404 errors 😆 

Users have human like images, groups have some kind of generic avatar.

![image](https://user-images.githubusercontent.com/648527/105739796-c9009d00-5f38-11eb-904f-ce97c592ab74.png)

Shouldn't need a changeset.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
