### PR TITLE
storybook: Change category from Feedback to Data Display for three components

### DIFF
--- a/packages/core/src/components/ProgressBars/Gauge.stories.tsx
+++ b/packages/core/src/components/ProgressBars/Gauge.stories.tsx
@@ -20,7 +20,7 @@ import { Gauge } from './Gauge';
 const containerStyle = { width: 300 };
 
 export default {
-  title: 'Feedback/Gauge',
+  title: 'Data Display/Gauge',
   component: Gauge,
 };
 

--- a/packages/core/src/components/ProgressBars/LinearGauge.stories.tsx
+++ b/packages/core/src/components/ProgressBars/LinearGauge.stories.tsx
@@ -20,7 +20,7 @@ import { LinearGauge } from './LinearGauge';
 const containerStyle = { width: 300 };
 
 export default {
-  title: 'Feedback/LinearGauge',
+  title: 'Data Display/LinearGauge',
   component: LinearGauge,
 };
 

--- a/packages/core/src/components/Status/Status.stories.tsx
+++ b/packages/core/src/components/Status/Status.stories.tsx
@@ -27,7 +27,7 @@ import { Table } from '../Table';
 import { InfoCard } from '../../layout/InfoCard';
 
 export default {
-  title: 'Feedback/Status',
+  title: 'Data Display/Status',
   component: StatusOK,
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Changes three components from "Feedback" to "Data Display" category in the Storybook.

Other gauges in the same directory are already "Data Display", so thought that was an easy one.  The status circle is a bit harder, but my interpretation of the categories is:

* Data Display: Used to display data ABOUT things, like entities or information in entities.
* Feedback: Used to feed back to the user about things in Backstage or the UI, e.g. when there's an error, or an issue, or something can be dismissed, etc.

So it seems to me the Status icon ( 🔴  🟢 etc) to always be to display status ABOUT data (a Jenkins build, a Lighthouse result), rather than feedback about Backstage itself or the UI in anyway - so it seems to me it's a data display element, instead.

Open to counter opinions?

| Old | New |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33203301/105765605-ad8c9680-5f26-11eb-9822-a7f90a589660.png) | ![image](https://user-images.githubusercontent.com/33203301/105765540-964da900-5f26-11eb-9ba9-063a86aa3e72.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
