### PR TITLE
TechDocs: handle inline img tags

### DIFF
--- a/.changeset/empty-mails-sparkle.md
+++ b/.changeset/empty-mails-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+TechDocs: handle conversion of img src for inline HTML in Markdown

--- a/.changeset/empty-mails-sparkle.md
+++ b/.changeset/empty-mails-sparkle.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-techdocs': minor
+'@backstage/plugin-techdocs': patch
 ---
 
 TechDocs: handle conversion of img src for inline HTML in Markdown

--- a/plugins/techdocs/src/reader/transformers/addBaseUrl.test.ts
+++ b/plugins/techdocs/src/reader/transformers/addBaseUrl.test.ts
@@ -50,7 +50,7 @@ describe('addBaseUrl', () => {
         addBaseUrl({
           techdocsStorageApi,
           entityId: mockEntityId,
-          path: '',
+          path: 'testPath',
         }),
       ],
       postTransformers: [],
@@ -66,13 +66,13 @@ describe('addBaseUrl', () => {
       2,
       'script.js',
       mockEntityId,
-      '',
+      'testPath',
     );
     expect(techdocsStorageApi.getBaseUrl).toHaveBeenNthCalledWith(
       3,
       'astyle.css',
       mockEntityId,
-      '',
+      'testPath',
     );
   });
 });

--- a/plugins/techdocs/src/reader/transformers/addBaseUrl.ts
+++ b/plugins/techdocs/src/reader/transformers/addBaseUrl.ts
@@ -32,6 +32,7 @@ export const addBaseUrl = ({
     const updateDom = <T extends Element>(
       list: HTMLCollectionOf<T> | NodeListOf<T>,
       attributeName: string,
+      noPath?: boolean,
     ): void => {
       Array.from(list)
         .filter(elem => !!elem.getAttribute(attributeName))
@@ -40,12 +41,16 @@ export const addBaseUrl = ({
           if (!elemAttribute) return;
           elem.setAttribute(
             attributeName,
-            techdocsStorageApi.getBaseUrl(elemAttribute, entityId, path),
+            techdocsStorageApi.getBaseUrl(
+              elemAttribute,
+              entityId,
+              noPath ? '' : path,
+            ),
           );
         });
     };
 
-    updateDom<HTMLImageElement>(dom.querySelectorAll('img'), 'src');
+    updateDom<HTMLImageElement>(dom.querySelectorAll('img'), 'src', true);
     updateDom<HTMLScriptElement>(dom.querySelectorAll('script'), 'src');
     updateDom<HTMLLinkElement>(dom.querySelectorAll('link'), 'href');
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is to patch conversion of 'src' attribute values for img tags inside inline HTML in Markdown files for TechDocs

For example, the initial URL in the markdown file (inline HTML inside markdown) is 
`<img src="attachments/287934438/287934439.png" />` 
The value for src here is the same as what one would put for a normal markdown image tag, which is something like
`[Image Description](attachments/287934438/287934439.png)`

So it appears that for this path, Backstage would serve the image on the path
`<serverpath>/api/techdocs/static/docs/default/Component/<componentName>/attachments/287934438/287934439.png`
and thus this should be the value the link transforms to.

But the current transformer seems to be also adding the current page path into the URL so that we get
`<serverpath>/api/techdocs/static/docs/default/Component/<componentName>/<pagePath>/attachments/287934438/287934439.png`

This fix causes the page path to be discarded for handling img tags.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [:heavy_check_mark:  ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ NA ] Added or updated documentation
- [:heavy_check_mark: ] Tests for new functionality and regression tests for bug fixes
- [ NA ] Screenshots attached (for UI changes)
