### PR TITLE
fix: change issuer to iss to conform to JWT spec. Make issuer verification optional

### DIFF
--- a/.changeset/stale-tools-confess.md
+++ b/.changeset/stale-tools-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fix issuer check

--- a/.changeset/stale-tools-confess.md
+++ b/.changeset/stale-tools-confess.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-Fix issuer check
+Fix AWS ALB issuer check

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -72,6 +72,10 @@ export interface Config {
       onelogin?: {
         development: { [key: string]: string };
       };
+      awsalb?: {
+        issuer?: string;
+        region: string;
+      };
     };
   };
 }

--- a/plugins/auth-backend/src/providers/aws-alb/provider.test.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.test.ts
@@ -80,7 +80,7 @@ describe('AwsALBAuthProvider', () => {
   const mockResponseSend = jest.fn();
   const mockRequest = ({
     header: jest.fn(() => {
-      return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImZvbyIsImlzc3VlciI6ImZvbyJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.zUkMYAuMwC1T0tyHMpxXrkbFDa4aGhB8d9um_tI2hsI';
+      return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImZvbyIsImlzcyI6ImZvbyJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.T2BNS4G-6RoiFnXc8Q8TiwdWzTpNitY8jcsGM3N3-Yo';
     }),
   } as unknown) as express.Request;
   const mockRequestWithoutJwt = ({

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -34,7 +34,7 @@ const ALB_JWT_HEADER = 'x-amzn-oidc-data';
  */
 type AwsAlbAuthProviderOptions = {
   region: string;
-  issuer: string;
+  issuer?: string;
   identityResolutionCallback: ExperimentalIdentityResolver;
 };
 export const getJWTHeaders = (input: string) => {
@@ -70,10 +70,7 @@ export class AwsAlbAuthProvider implements AuthProviderRouteHandlers {
         const key = await this.getKey(headers.kid);
         const payload = JWT.verify(jwt, key);
 
-        if (
-          this.options.issuer !== '' &&
-          headers.issuer !== this.options.issuer
-        ) {
+        if (this.options.issuer && headers.iss !== this.options.issuer) {
           throw new Error('issuer mismatch on JWT');
         }
 
@@ -116,7 +113,7 @@ export const createAwsAlbProvider = ({
   identityResolver,
 }: AuthProviderFactoryOptions) => {
   const region = config.getString('region');
-  const issuer = config.getString('iss');
+  const issuer = config.getOptionalString('iss');
   if (identityResolver !== undefined) {
     return new AwsAlbAuthProvider(logger, catalogApi, {
       region,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR fixes a slight issue with the AWS ALB processor - it was validating the "issuer" header on JWTs issued by Amazon, where it should have been checking the standard "iss". Also made this verification optional, instead of checking for '', which was not possible. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
