### PR TITLE
Fix aws alb auth provider key caching

### DIFF
--- a/.changeset/fuzzy-points-whisper.md
+++ b/.changeset/fuzzy-points-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed serialization issue with caching of public keys in AWS ALB auth provider

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -95,13 +95,13 @@ export class AwsAlbAuthProvider implements AuthProviderRouteHandlers {
   async getKey(keyId: string): Promise<KeyObject> {
     const optionalCacheKey = this.keyCache.get<KeyObject>(keyId);
     if (optionalCacheKey) {
-      return optionalCacheKey;
+      return crypto.createPublicKey(optionalCacheKey);
     }
     const keyText: string = await fetch(
       `https://public-keys.auth.elb.${this.options.region}.amazonaws.com/${keyId}`,
     ).then(response => response.text());
     const keyValue = crypto.createPublicKey(keyText);
-    this.keyCache.set(keyId, keyValue);
+    this.keyCache.set(keyId, keyValue.export({ format: 'pem', type: 'spki' }));
     return keyValue;
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This fixes the issue discovered by @mfrinnstrom  on #4047 where public keys for the AWS ALB provider are not formatted correctly when stored in node-cache. The underlying issue was that the introduction of node-cache during the review phase was not functionally tested - it appeared to work because the first time a key is used, it is not served from cache :/ 

This change has been tested more than once :) 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
