### PR TITLE
Fix: added a check for invalid timezone

### DIFF
--- a/packages/core/src/layout/HomepageTimer/HomepageTimer.test.tsx
+++ b/packages/core/src/layout/HomepageTimer/HomepageTimer.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderWithEffects } from '@backstage/test-utils';
+import { HomepageTimer } from './HomepageTimer';
+import React from 'react';
+import { lightTheme } from '@backstage/theme';
+import { ThemeProvider } from '@material-ui/core';
+
+import {
+  ApiProvider,
+  ApiRegistry,
+  ConfigReader,
+  ConfigApi,
+  configApiRef,
+} from '@backstage/core-api';
+
+it('changes default timezone to GMT', async () => {
+  const configApi: ConfigApi = new ConfigReader({
+    homepage: {
+      clocks: [
+        {
+          label: 'New York',
+          timezone: 'America/New_Pork',
+        },
+      ],
+    },
+    context: 'test',
+  });
+
+  const rendered = await renderWithEffects(
+    <ThemeProvider theme={lightTheme}>
+      <ApiProvider apis={ApiRegistry.from([[configApiRef, configApi]])}>
+        <HomepageTimer />
+      </ApiProvider>
+    </ThemeProvider>,
+  );
+
+  expect(rendered.getByText('GMT')).toBeInTheDocument();
+});

--- a/packages/core/src/layout/HomepageTimer/HomepageTimer.tsx
+++ b/packages/core/src/layout/HomepageTimer/HomepageTimer.tsx
@@ -39,18 +39,28 @@ function getTimes(configApi: ConfigApi) {
 
   for (const clock of clockConfigs) {
     if (clock.has('label') && clock.has('timezone')) {
+      let label = clock.getString('label');
+
       const options = {
         timeZone: clock.getString('timezone'),
         ...timeFormat,
       };
 
-      const time = d.toLocaleTimeString(lang, options);
-      const label = clock.getString('label');
+      try {
+        new Date().toLocaleString(lang, options);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `The timezone ${options.timeZone} is invalid. Defaulting to America/Los Angeles`,
+        );
+        options.timeZone = 'America/Los_Angeles';
+        label = 'Los Angeles';
+      }
 
+      const time = d.toLocaleTimeString(lang, options);
       clocks.push({ time, label });
     }
   }
-
   return clocks;
 }
 

--- a/packages/core/src/layout/HomepageTimer/HomepageTimer.tsx
+++ b/packages/core/src/layout/HomepageTimer/HomepageTimer.tsx
@@ -51,10 +51,10 @@ function getTimes(configApi: ConfigApi) {
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn(
-          `The timezone ${options.timeZone} is invalid. Defaulting to America/Los Angeles`,
+          `The timezone ${options.timeZone} is invalid. Defaulting to GMT`,
         );
-        options.timeZone = 'America/Los_Angeles';
-        label = 'Los Angeles';
+        options.timeZone = 'GMT';
+        label = 'GMT';
       }
 
       const time = d.toLocaleTimeString(lang, options);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes #4263 - An invalid timezone will now emit a warning to the console, and default to Los Angeles time zone instead of a blank ui

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
![backstage_screenshot](https://user-images.githubusercontent.com/10580296/106105384-cb692e00-61a8-11eb-9fab-85eea6ad4e64.PNG)

