### PR TITLE
integration: forward errors from gitlab project lookups

### DIFF
--- a/.changeset/moody-buckets-visit.md
+++ b/.changeset/moody-buckets-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Properly forward errors that occur when looking up GitLab project IDs.

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -147,10 +147,15 @@ export async function getProjectId(
       repoIDLookup.toString(),
       getGitLabRequestOptions(config),
     );
-    const projectIDJson = await response.json();
-    const projectID = Number(projectIDJson.id);
+    const data = await response.json();
 
-    return projectID;
+    if (!response.ok) {
+      throw new Error(
+        `GitLab Error '${data.error}', ${data.error_description}`,
+      );
+    }
+
+    return Number(data.id);
   } catch (e) {
     throw new Error(`Could not get GitLab project ID for: ${target}, ${e}`);
   }


### PR DESCRIPTION
Small thing I ran into when creating an access token that didn't include API scope :grin: