### PR TITLE
tech-radar: fix mapping of moved attribute and made urls clickable

### DIFF
--- a/.changeset/shaggy-dingos-suffer.md
+++ b/.changeset/shaggy-dingos-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Fix mapping RadarEntry and Entry for moved and url attributes

--- a/.changeset/shaggy-dingos-suffer.md
+++ b/.changeset/shaggy-dingos-suffer.md
@@ -3,3 +3,4 @@
 ---
 
 Fix mapping RadarEntry and Entry for moved and url attributes
+Fix clicking of links in the radar legend

--- a/plugins/tech-radar/src/components/RadarComponent.tsx
+++ b/plugins/tech-radar/src/components/RadarComponent.tsx
@@ -59,7 +59,7 @@ const RadarComponent = (props: TechRadarComponentProps): JSX.Element => {
         ring: loaderResponse!.rings.find(
           r => r.id === entry.timeline[0].ringId,
         )!,
-        history: entry.timeline.map(e => {
+        timeline: entry.timeline.map(e => {
           return {
             date: e.date,
             ring: loaderResponse!.rings.find(a => a.id === e.ringId)!,
@@ -67,6 +67,8 @@ const RadarComponent = (props: TechRadarComponentProps): JSX.Element => {
             moved: e.moved,
           };
         }),
+        moved: entry.timeline[0].moved,
+        url: entry.url,
       };
     });
   };

--- a/plugins/tech-radar/src/components/RadarLegend/RadarLegend.tsx
+++ b/plugins/tech-radar/src/components/RadarLegend/RadarLegend.tsx
@@ -71,12 +71,12 @@ const useStyles = makeStyles<Theme>(theme => ({
     'font-feature-settings': 'pnum',
   },
   entry: {
-    pointerEvents: 'none',
+    pointerEvents: 'visiblePainted',
     userSelect: 'none',
     fontSize: '11px',
   },
   entryLink: {
-    pointerEvents: 'none',
+    pointerEvents: 'visiblePainted',
   },
 }));
 

--- a/plugins/tech-radar/src/sampleData.ts
+++ b/plugins/tech-radar/src/sampleData.ts
@@ -53,7 +53,7 @@ entries.push({
 entries.push({
   timeline: [
     {
-      moved: 0,
+      moved: -1,
       ringId: 'use',
       date: new Date('2020-08-06'),
       description:
@@ -69,7 +69,7 @@ entries.push({
 entries.push({
   timeline: [
     {
-      moved: 0,
+      moved: 1,
       ringId: 'use',
       date: new Date('2020-08-06'),
     },
@@ -88,7 +88,7 @@ entries.push({
       date: new Date('2020-08-06'),
     },
   ],
-  url: '#',
+  url: 'https://reactjs.org/',
   key: 'react',
   id: 'react',
   title: 'React',


### PR DESCRIPTION
## Hey, I just made a Pull Request!


As part of the refactor to include entry history, the moved and url attributes were
no longer being mapped. This resulted in the radar not indicating if an entry had moved,
and the bubble not being clickable. Also the links in the Radar Legend was not clickable.

Updated sample data to show the functionality.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
