### PR TITLE
Add check for outdated/duplicate packages to yarn start

### DIFF
--- a/.changeset/orange-pets-whisper.md
+++ b/.changeset/orange-pets-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add check for outdated/duplicate packages to yarn start

--- a/packages/cli/src/commands/app/serve.ts
+++ b/packages/cli/src/commands/app/serve.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs-extra';
 import chalk from 'chalk';
+import uniq from 'lodash/uniq';
 import { Command } from 'commander';
 import { serveBundle } from '../../lib/bundler';
 import { loadCliConfig } from '../../lib/config';
@@ -28,20 +29,22 @@ export default async (cmd: Command) => {
   const result = lockfile.analyze({
     filter: includedFilter,
   });
-  const problemPackages = result.newVersions.map(({ name }) => name);
+  const problemPackages = [...result.newVersions, ...result.newRanges].map(
+    ({ name }) => name,
+  );
 
   if (problemPackages.length > 1) {
     console.log(
       chalk.yellow(
-        `The following packages may be outdated or have duplicate installations:
+        `⚠️ Some of the following packages may be outdated or have duplicate installations:
 
-          ${problemPackages.join(', ')}
+          ${uniq(problemPackages).join(', ')}
         `,
       ),
     );
     console.log(
       chalk.yellow(
-        `This can be resolved using the following command:
+        `⚠️ This can be resolved using the following command:
 
           yarn backstage-cli versions:check --fix
       `,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR adds a check for duplicate/outdated packages to the `yarn start` command. 

Resolves [4101](https://github.com/backstage/backstage/issues/4101)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
