### PR TITLE
docs: Remove missing installation page

### DIFF
--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -13,7 +13,6 @@
     "Getting Started": [
       "getting-started/index",
       "getting-started/running-backstage-locally",
-      "getting-started/installation",
       "getting-started/development-environment",
       "getting-started/create-an-app",
       {


### PR DESCRIPTION
The "Next" page on https://backstage.io/docs/getting-started/running-backstage-locally does not exist any more.