### PR TITLE
feat(backend-common): support custom logger options

### DIFF
--- a/.changeset/fluffy-nails-sort.md
+++ b/.changeset/fluffy-nails-sort.md
@@ -5,7 +5,6 @@
 Updated the `rootLogger` in `@backstage/backend-common` to support custom logging options. This is useful when you want to make some changes without re-implementing the entire logger and calling `setRootLogger` or `logger.configure`. For example you can add additional `defaultMeta` tags to each log entry. The following changes are included:
 
 - Added `createRootLogger` which accepts winston `LoggerOptions`. These options allow overriding the default keys.
-- Added an additional error format that can include stack traces. This can be enabled by setting a `LOG_STACKTRACE=true` environment variable. Any `Error` objects passed to `logger.error('message', err)` will include the full stack trace in a `stack` log entry key.
 
 Example Usage:
 

--- a/.changeset/fluffy-nails-sort.md
+++ b/.changeset/fluffy-nails-sort.md
@@ -1,0 +1,25 @@
+---
+'@backstage/backend-common': patch
+---
+
+Updated the `rootLogger` in `@backstage/backend-common` to support custom logging options. This is useful when you want to make some changes without re-implementing the entire logger and calling `setRootLogger` or `logger.configure`. For example you can add additional `defaultMeta` tags to each log entry. The following changes are included:
+
+- Added `createRootLogger` which accepts winston `LoggerOptions`. These options allow overriding the default keys.
+- Added an additional error format that can include stack traces. This can be enabled by setting a `LOG_STACKTRACE=true` environment variable. Any `Error` objects passed to `logger.error('message', err)` will include the full stack trace in a `stack` log entry key.
+
+Example Usage:
+
+```ts
+// Create the logger
+const logger = createRootLogger({
+  defaultMeta: { appName: 'backstage', appEnv: 'prod' },
+});
+
+// Add a custom logger transport
+logger.add(new MyCustomTransport());
+
+const config = await loadBackendConfig({
+  argv: process.argv,
+  logger: getRootLogger(), // already set to new logger instance
+});
+```

--- a/packages/backend-common/src/logging/formats.ts
+++ b/packages/backend-common/src/logging/formats.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import * as winston from 'winston';
 import { TransformableInfo } from 'logform';
 

--- a/packages/backend-common/src/logging/index.ts
+++ b/packages/backend-common/src/logging/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
+export * from './formats';
 export * from './rootLogger';
 export * from './voidLogger';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

See changeset for more details.

- Adds support customizing the logger without having to re-implement various parts of the default setup. 
- ~~Adds `winston.format.errors` support for logging stack traces~~

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
