### PR TITLE
microsite/docs: Scroll nav sidebar to view to improve discoverability

### DIFF
--- a/microsite/siteConfig.js
+++ b/microsite/siteConfig.js
@@ -83,6 +83,7 @@ const siteConfig = {
     'https://unpkg.com/medium-zoom@1.0.6/dist/medium-zoom.min.js',
     '/js/medium-zoom.js',
     '/js/dismissable-banner.js',
+    '/js/scroll-nav-to-view-in-docs.js',
   ],
 
   // On page navigation for the current documentation page.

--- a/microsite/static/js/scroll-nav-to-view-in-docs.js
+++ b/microsite/static/js/scroll-nav-to-view-in-docs.js
@@ -1,0 +1,23 @@
+// On backstage.io/docs pages, scroll the Nav sidebar to focus on
+// the page being viewed. Helpful when the Nav is large enough that
+// the selected page is hidden somewhere at bottom.
+// Credits: https://github.com/facebook/docusaurus/issues/823#issuecomment-421152269
+document.addEventListener('DOMContentLoaded', () => {
+  // Find the active nav item in the sidebar
+  const item = document.getElementsByClassName('navListItemActive')[0];
+  if (!item) {
+    return;
+  }
+  const bounding = item.getBoundingClientRect();
+  if (
+    bounding.top >= 0 &&
+    bounding.bottom <=
+      (window.innerHeight || document.documentElement.clientHeight)
+  ) {
+    // Already visible.  Do nothing.
+  } else {
+    // Not visible.  Scroll sidebar.
+    item.scrollIntoView({ block: 'start', inline: 'nearest' });
+    document.body.scrollTop = document.documentElement.scrollTop = 0;
+  }
+});


### PR DESCRIPTION
# Problem

Current behavior - On page load or switch, the nav sidebar by default is always at the top even if the selected page is far at the bottom in the tree.

![old](https://user-images.githubusercontent.com/8065913/106579866-7d09b580-6541-11eb-90ed-b9c42abc29d1.gif)

An implication of it - when someone lands on a page like https://backstage.io/docs/features/techdocs, they don't immediately discover all the other pages of TechDocs that could be useful for them.

# Solution

Scroll nav sidebar to view on page load. This feature is by default in Docusaurus v2, but we are still using v1 to generate our site, hence we need a manual script.

![new2](https://user-images.githubusercontent.com/8065913/106580878-86dfe880-6542-11eb-8add-5a52c1008000.gif)

