### PR TITLE
Scaffolder: ensure cookiecutter intermediateDir

### DIFF
--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.test.ts
@@ -56,6 +56,7 @@ describe('CookieCutter Templater', () => {
       dockerClient: mockDocker,
     });
 
+    expect(fs.ensureDir).toBeCalledWith(path.join('tempdir', 'intermediate'));
     expect(fs.writeJson).toBeCalledWith(
       path.join('tempdir', 'template', 'cookiecutter.json'),
       expect.objectContaining(values),

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
@@ -44,6 +44,7 @@ export class CookieCutter implements TemplaterBase {
   }: TemplaterRunOptions): Promise<void> {
     const templateDir = path.join(workspacePath, 'template');
     const intermediateDir = path.join(workspacePath, 'intermediate');
+    await fs.ensureDir(intermediateDir);
     const resultDir = path.join(workspacePath, 'result');
 
     // First lets grab the default cookiecutter.json file


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change ensures that the `intermediateDir` is created before running cookiecutter.
This fixes scaffolding in Linux where the directory is not created automatically(probably due to a difference in how Docker handles file system mounting in OSX/Linux). 

fixes #4330

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
