### PR TITLE
Removing .git from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 node_modules
 packages/*/node_modules
 plugins/*/node_modules


### PR DESCRIPTION
It looks like the command `backstage-cli app:build` requires the git metadata.  With `.git` in the dockerignore file, I saw this error:

```
➜  backstage git:(master) docker build -t backstage-frontend -f ./contrib/docker/multi-stage-frontend/Dockerfile .

Sending build context to Docker daemon  87.31MB
Step 1/13 : FROM node:12-buster AS build
 ---> b247258c051b
Step 2/13 : RUN mkdir /app
 ---> Using cache
 ---> 19921b2b70f3
Step 3/13 : COPY . /app
 ---> Using cache
 ---> adf3190957a7
Step 4/13 : WORKDIR /app
 ---> Using cache
 ---> d57d193dd053
Step 5/13 : RUN yarn install
 ---> Using cache
 ---> 23cbb5d4cdbd
Step 6/13 : RUN yarn workspace example-app build
 ---> Running in f1de25e8396d
yarn workspace v1.22.1
yarn run v1.22.1
$ backstage-cli app:build
Loaded config from app-config.yaml
fatal: not a git repository (or any of the parent directories): .git
WARNING: Failed to read git commit, ExitCodeError: Command 'git rev-parse HEAD' exited with code 128
fatal: not a git repository (or any of the parent directories): .git
WARNING: Failed to describe git version, ExitCodeError: Command 'git describe --always' exited with code 128
```

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
