### PR TITLE
storybook: Add opinionated Button examples

### DIFF
--- a/packages/core/src/components/Button/Button.stories.tsx
+++ b/packages/core/src/components/Button/Button.stories.tsx
@@ -17,6 +17,17 @@ import React, { FunctionComponentFactory } from 'react';
 import { Button } from './Button';
 import { MemoryRouter, Route, useLocation } from 'react-router-dom';
 import { createRouteRef } from '@backstage/core-api';
+import {
+  Divider,
+  Grid,
+  Link,
+  List,
+  ListItem,
+  ListItemText,
+  ListSubheader,
+  Typography,
+  Button as MaterialButton,
+} from '@material-ui/core';
 
 const Location = () => {
   const location = useLocation();
@@ -28,14 +39,27 @@ export default {
   component: Button,
   decorators: [
     (storyFn: FunctionComponentFactory<{}>) => (
-      <MemoryRouter>
-        <div>
+      <>
+        <Typography>
+          A collection of buttons that should be used in the Backstage
+          interface. These leverage the properties inherited from{' '}
+          <Link href="https://material-ui.com/components/buttons/">
+            Material-UI Button
+          </Link>
+          , but include an opinionated set that align to the Backstage design.
+        </Typography>
+
+        <Divider />
+
+        <MemoryRouter>
           <div>
-            <Location />
+            <div>
+              <Location />
+            </div>
+            {storyFn()}
           </div>
-          {storyFn()}
-        </div>
-      </MemoryRouter>
+        </MemoryRouter>
+      </>
     ),
   ],
 };
@@ -46,36 +70,107 @@ export const Default = () => {
     title: 'Hi there!',
   });
 
+  // Design Permutations:
+  // color   = default | primary | secondary
+  // variant = contained | outlined | text
   return (
-    <>
-      <Button to={routeRef.path}>This button</Button>&nbsp;will utilise the
-      react-router MemoryRouter's navigation
-      <Route path={routeRef.path}>
-        <h1>{routeRef.title}</h1>
-      </Route>
-    </>
+    <List>
+      <ListItem>
+        <ListItemText>
+          <Typography variant="h6">Default Button:</Typography>
+          This is the default button design which should be used in most cases.
+          <br />
+          <pre>color="primary" variant="contained"</pre>
+        </ListItemText>
+
+        <Button to={routeRef.path} color="primary" variant="contained">
+          Register Component
+        </Button>
+      </ListItem>
+      <ListItem>
+        <ListItemText>
+          <Typography variant="h6">Secondary Button:</Typography>
+          Used for actions that cancel, skip, and in general perform negative
+          functions, etc.
+          <br />
+          <pre>color="secondary" variant="contained"</pre>
+        </ListItemText>
+
+        <Button to={routeRef.path} color="secondary" variant="contained">
+          Cancel
+        </Button>
+      </ListItem>
+      <ListItem>
+        <ListItemText>
+          <Typography variant="h6">Tertiary Button:</Typography>
+          Used commonly in a ButtonGroup and when the button function itself is
+          not a primary function on a page.
+          <br />
+          <pre>color="default" variant="outlined"</pre>
+        </ListItemText>
+
+        <Button to={routeRef.path} color="default" variant="outlined">
+          View Details
+        </Button>
+      </ListItem>
+    </List>
   );
 };
 
-export const PassProps = () => {
+export const ButtonLinks = () => {
   const routeRef = createRouteRef({
     path: '/hello',
     title: 'Hi there!',
   });
 
+  const handleClick = () => {
+    return 'Your click worked!';
+  };
+
   return (
     <>
-      <Button to={routeRef.path} color="secondary" variant="outlined">
-        This link
-      </Button>
-      &nbsp;has props for both material-ui's component as well as for
-      react-router-dom's
-      <Route path={routeRef.path}>
-        <h1>{routeRef.title}</h1>
-      </Route>
+      <List>
+        {
+          // TODO: Refactor to use new routing mechanisms
+        }
+        <ListItem>
+          <Button to={routeRef.path} color="tertiary" variant="outlined">
+            Route Ref
+          </Button>
+          &nbsp; has props for both Material-UI's component as well as for
+          react-router-dom's Route object.
+        </ListItem>
+
+        <ListItem>
+          <Button to="/staticpath" color="tertiary" variant="outlined">
+            Static Path
+          </Button>
+          &nbsp; links to a statically defined route. In general, this should be
+          avoided.
+        </ListItem>
+
+        <ListItem>
+          <MaterialButton
+            href="https://backstage.io"
+            color="tertiary"
+            variant="outlined"
+          >
+            View URL
+          </MaterialButton>
+          &nbsp; links to a defined URL using Material-UI's Button.
+        </ListItem>
+
+        <ListItem>
+          <MaterialButton
+            onClick={handleClick}
+            color="tertiary"
+            variant="outlined"
+          >
+            Trigger Event
+          </MaterialButton>
+          &nbsp; triggers an onClick event using Material-UI's Button.
+        </ListItem>
+      </List>
     </>
   );
-};
-PassProps.story = {
-  name: `Accepts material-ui Button's and react-router-dom Link's props`,
 };

--- a/packages/core/src/components/Button/Button.stories.tsx
+++ b/packages/core/src/components/Button/Button.stories.tsx
@@ -15,16 +15,14 @@
  */
 import React, { FunctionComponentFactory } from 'react';
 import { Button } from './Button';
-import { MemoryRouter, Route, useLocation } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { createRouteRef } from '@backstage/core-api';
 import {
   Divider,
-  Grid,
   Link,
   List,
   ListItem,
   ListItemText,
-  ListSubheader,
   Typography,
   Button as MaterialButton,
 } from '@material-ui/core';

--- a/packages/core/src/components/Button/Button.stories.tsx
+++ b/packages/core/src/components/Button/Button.stories.tsx
@@ -132,7 +132,7 @@ export const ButtonLinks = () => {
           // TODO: Refactor to use new routing mechanisms
         }
         <ListItem>
-          <Button to={routeRef.path} color="tertiary" variant="outlined">
+          <Button to={routeRef.path} color="default" variant="outlined">
             Route Ref
           </Button>
           &nbsp; has props for both Material-UI's component as well as for
@@ -140,7 +140,7 @@ export const ButtonLinks = () => {
         </ListItem>
 
         <ListItem>
-          <Button to="/staticpath" color="tertiary" variant="outlined">
+          <Button to="/staticpath" color="default" variant="outlined">
             Static Path
           </Button>
           &nbsp; links to a statically defined route. In general, this should be
@@ -150,7 +150,7 @@ export const ButtonLinks = () => {
         <ListItem>
           <MaterialButton
             href="https://backstage.io"
-            color="tertiary"
+            color="default"
             variant="outlined"
           >
             View URL
@@ -161,7 +161,7 @@ export const ButtonLinks = () => {
         <ListItem>
           <MaterialButton
             onClick={handleClick}
-            color="tertiary"
+            color="default"
             variant="outlined"
           >
             Trigger Event


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Updates button examples in the story book to be opinionated about which button stylings should be opted for. Relates to this [Discord thread](https://discord.com/channels/687207715902193673/696709358544879716/806392236899958825).

Also reworked the link examples, though didn't change anything about how the button itself works or it's react-router-dom routing. I think this example needs some work to use the new routeRef approaches (given `.path` is deprecated), and potentially to clarify the use of `@backstage/core`'s `<Button>` which requires a `to` prop vs. Material-UI's `<Button>` which is used a lot in our repo for doing `onClick={event}` and `href='http://foo.com'` (since we can't use the core one as it requires a route!).

So this is just a visual update as opposed to any functional changes to the button itself.

![image](https://user-images.githubusercontent.com/33203301/106784606-8286fe80-661a-11eb-89ba-38619f82b2b8.png)

![image](https://user-images.githubusercontent.com/33203301/106785015-f5907500-661a-11eb-85bd-75d7159cf922.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
