### PR TITLE
Integration gitlab fix spaces in paths

### DIFF
--- a/.changeset/dry-kings-hear.md
+++ b/.changeset/dry-kings-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fix gitlab handling of paths with spaces

--- a/packages/integration/src/gitlab/core.test.ts
+++ b/packages/integration/src/gitlab/core.test.ts
@@ -49,23 +49,23 @@ describe('gitlab core', () => {
       {
         config: configWithNoToken,
         url:
-          'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
+          'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path%20with%20spaces/to/file.yaml',
         result:
-          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%20with%20spaces%2Fto%2Ffile.yaml/raw?ref=branch',
       },
       {
         config: configWithToken,
         url:
-          'https://gitlab.example.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yaml',
+          'https://gitlab.example.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path%20with%20spaces/to/file.yaml',
         result:
-          'https://gitlab.example.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+          'https://gitlab.example.com/api/v4/projects/12345/repository/files/my%2Fpath%20with%20spaces%2Fto%2Ffile.yaml/raw?ref=branch',
       },
       {
         config: configWithNoToken,
         url:
-          'https://gitlab.com/groupA/teams/teamA/repoA/-/blob/branch/my/path/to/file.yaml', // Repo not in subgroup
+          'https://gitlab.com/groupA/teams/teamA/repoA/-/blob/branch/my/path%20with%20spaces/to/file.yaml', // Repo not in subgroup
         result:
-          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yaml/raw?ref=branch',
+          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%20with%20spaces%2Fto%2Ffile.yaml/raw?ref=branch',
       },
       // Raw URLs
       {

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -109,7 +109,7 @@ export function buildProjectUrl(target: string, projectID: Number): URL {
       '/api/v4/projects',
       projectID,
       'repository/files',
-      encodeURIComponent(filePath.join('/')),
+      encodeURIComponent(decodeURIComponent(filePath.join('/'))),
       'raw',
     ].join('/');
     url.search = `?ref=${branch}`;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix gitlab integration handling of paths with spaces. Previously was converting %20 to %2520.

#### :heavy_check_mark: Checklist

- [ :heavy_check_mark: ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ NA ] Added or updated documentation
- [ :heavy_check_mark: ] Tests for new functionality and regression tests for bug fixes
- [ NA ] Screenshots attached (for UI changes)
