### PR TITLE
backend-common: implement UrlReader.search that does glob matching

### DIFF
--- a/.changeset/shiny-shirts-worry.md
+++ b/.changeset/shiny-shirts-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Implement `UrlReader.search` which implements glob matching.

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -50,6 +50,7 @@
     "knex": "^0.21.6",
     "lodash": "^4.17.15",
     "logform": "^2.1.1",
+    "minimatch": "^3.0.4",
     "minimist": "^1.2.5",
     "morgan": "^1.10.0",
     "selfsigned": "^1.10.7",

--- a/packages/backend-common/src/reading/AzureUrlReader.ts
+++ b/packages/backend-common/src/reading/AzureUrlReader.ts
@@ -29,6 +29,7 @@ import {
   ReaderFactory,
   ReadTreeOptions,
   ReadTreeResponse,
+  SearchResponse,
   UrlReader,
 } from './types';
 import { ReadTreeResponseFactory } from './tree';
@@ -114,6 +115,10 @@ export class AzureUrlReader implements UrlReader {
       etag: commitSha,
       filter: options?.filter,
     });
+  }
+
+  async search(): Promise<SearchResponse> {
+    throw new Error('AzureUrlReader does not implement search');
   }
 
   toString() {

--- a/packages/backend-common/src/reading/BitbucketUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.ts
@@ -31,6 +31,7 @@ import {
   ReaderFactory,
   ReadTreeOptions,
   ReadTreeResponse,
+  SearchResponse,
   UrlReader,
 } from './types';
 
@@ -127,6 +128,10 @@ export class BitbucketUrlReader implements UrlReader {
       etag: lastCommitShortHash,
       filter: options?.filter,
     });
+  }
+
+  async search(): Promise<SearchResponse> {
+    throw new Error('BitbucketUrlReader does not implement search');
   }
 
   toString() {

--- a/packages/backend-common/src/reading/FetchUrlReader.ts
+++ b/packages/backend-common/src/reading/FetchUrlReader.ts
@@ -16,7 +16,12 @@
 
 import fetch from 'cross-fetch';
 import { NotFoundError } from '../errors';
-import { ReaderFactory, ReadTreeResponse, UrlReader } from './types';
+import {
+  ReaderFactory,
+  ReadTreeResponse,
+  SearchResponse,
+  UrlReader,
+} from './types';
 
 /**
  * A UrlReader that does a plain fetch of the URL.
@@ -68,8 +73,12 @@ export class FetchUrlReader implements UrlReader {
     throw new Error(message);
   }
 
-  readTree(): Promise<ReadTreeResponse> {
+  async readTree(): Promise<ReadTreeResponse> {
     throw new Error('FetchUrlReader does not implement readTree');
+  }
+
+  async search(): Promise<SearchResponse> {
+    throw new Error('FetchUrlReader does not implement search');
   }
 
   toString() {

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -21,16 +21,17 @@ import {
   readGitLabIntegrationConfigs,
 } from '@backstage/integration';
 import fetch from 'cross-fetch';
+import parseGitUrl from 'git-url-parse';
+import { Readable } from 'stream';
 import { NotFoundError, NotModifiedError } from '../errors';
 import { ReadTreeResponseFactory } from './tree';
 import {
   ReaderFactory,
   ReadTreeOptions,
   ReadTreeResponse,
+  SearchResponse,
   UrlReader,
 } from './types';
-import parseGitUrl from 'git-url-parse';
-import { Readable } from 'stream';
 
 export class GitlabUrlReader implements UrlReader {
   private readonly treeResponseFactory: ReadTreeResponseFactory;
@@ -152,6 +153,10 @@ export class GitlabUrlReader implements UrlReader {
       etag: commitSha,
       filter: options?.filter,
     });
+  }
+
+  async search(): Promise<SearchResponse> {
+    throw new Error('GitlabUrlReader does not implement search');
   }
 
   toString() {

--- a/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
+++ b/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
@@ -18,6 +18,8 @@ import { NotAllowedError } from '../errors';
 import {
   ReadTreeOptions,
   ReadTreeResponse,
+  SearchOptions,
+  SearchResponse,
   UrlReader,
   UrlReaderPredicateTuple,
 } from './types';
@@ -54,6 +56,18 @@ export class UrlReaderPredicateMux implements UrlReader {
     for (const { predicate, reader } of this.readers) {
       if (predicate(parsed)) {
         return await reader.readTree(url, options);
+      }
+    }
+
+    throw new NotAllowedError(`Reading from '${url}' is not allowed`);
+  }
+
+  async search(url: string, options?: SearchOptions): Promise<SearchResponse> {
+    const parsed = new URL(url);
+
+    for (const { predicate, reader } of this.readers) {
+      if (predicate(parsed)) {
+        return await reader.search(url, options);
       }
     }
 

--- a/packages/backend-common/src/reading/index.ts
+++ b/packages/backend-common/src/reading/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export type { UrlReader, ReadTreeResponse } from './types';
+export type { UrlReader, ReadTreeResponse, SearchResponse } from './types';
 export { UrlReaders } from './UrlReaders';
 export { AzureUrlReader } from './AzureUrlReader';
 export { BitbucketUrlReader } from './BitbucketUrlReader';

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -24,6 +24,7 @@ import { ReadTreeResponseFactory } from './tree';
 export type UrlReader = {
   read(url: string): Promise<Buffer>;
   readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
+  search(url: string, options?: SearchOptions): Promise<SearchResponse>;
 };
 
 export type UrlReaderPredicateTuple = {
@@ -101,5 +102,53 @@ export type ReadTreeResponseDirOptions = {
  */
 export type ReadTreeResponseFile = {
   path: string;
+  content(): Promise<Buffer>;
+};
+
+/**
+ * An options object for search operations.
+ */
+export type SearchOptions = {
+  /**
+   * An etag can be provided to check whether the search response has changed from a previous execution.
+   *
+   * In the search() response, an etag is returned along with the files. The etag is a unique identifer
+   * of the current tree, usually the commit SHA or etag from the target.
+   *
+   * When an etag is given in SearchOptions, search will first compare the etag against the etag
+   * on the target branch. If they match, search will throw a NotModifiedError indicating that the search
+   * response will not differ from the previous response which included this particular etag. If they mismatch,
+   * search will return the rest of SearchResponse along with a new etag.
+   */
+  etag?: string;
+};
+
+/**
+ * The output of a search operation.
+ */
+export type SearchResponse = {
+  /**
+   * The files that matched the search query.
+   */
+  files: SearchResponseFile[];
+
+  /**
+   * A unique identifer of the current remote tree, usually the commit SHA or etag from the target.
+   */
+  etag: string;
+};
+
+/**
+ * Represents a single file in a search response.
+ */
+export type SearchResponseFile = {
+  /**
+   * The full URL to the file.
+   */
+  url: string;
+
+  /**
+   * The binary contents of the file.
+   */
   content(): Promise<Buffer>;
 };

--- a/packages/techdocs-common/src/helpers.test.ts
+++ b/packages/techdocs-common/src/helpers.test.ts
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
+import {
+  ReadTreeResponse,
+  SearchResponse,
+  UrlReader,
+} from '@backstage/backend-common';
+import { Entity } from '@backstage/catalog-model';
 import { Readable } from 'stream';
 import {
   getDocFilesFromRepository,
   getLocationForEntity,
   parseReferenceAnnotation,
 } from './helpers';
-import { UrlReader, ReadTreeResponse } from '@backstage/backend-common';
-import { Entity } from '@backstage/catalog-model';
 
 const entityBase: Entity = {
   metadata: {
@@ -136,6 +140,13 @@ describe('getDocFilesFromRepository', () => {
             return Readable.from('');
           },
           etag: '',
+        };
+      }
+
+      async search(): Promise<SearchResponse> {
+        return {
+          etag: '',
+          files: [],
         };
       }
     }

--- a/packages/techdocs-common/src/stages/prepare/dir.test.ts
+++ b/packages/techdocs-common/src/stages/prepare/dir.test.ts
@@ -49,6 +49,7 @@ const mockConfig = new ConfigReader({});
 const mockUrlReader: jest.Mocked<UrlReader> = {
   read: jest.fn(),
   readTree: jest.fn(),
+  search: jest.fn(),
 };
 
 describe('directory preparer', () => {

--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -139,6 +139,16 @@ export class LocationReaders implements LocationReader {
       if (emitResult.type === 'relation') {
         throw new Error('readLocation may not emit entity relations');
       }
+      if (
+        emitResult.type === 'location' &&
+        emitResult.location.type === item.location.type &&
+        emitResult.location.target === item.location.target
+      ) {
+        // Ignore self-referential locations silently (this can happen for
+        // example if you use a glob target like "**/*.yaml" in a Location
+        // entity)
+        return;
+      }
       emit(emitResult);
     };
 

--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.test.ts
@@ -160,7 +160,7 @@ describe('CodeOwnersProcessor', () => {
       const read = jest
         .fn()
         .mockResolvedValue(mockReadResult({ data: ownersText }));
-      const reader = { read, readTree: jest.fn() };
+      const reader = { read, readTree: jest.fn(), search: jest.fn() };
       const result = await findRawCodeOwners(mockLocation(), {
         reader,
         logger,
@@ -170,7 +170,7 @@ describe('CodeOwnersProcessor', () => {
 
     it('should return undefined when no codeowner', async () => {
       const read = jest.fn().mockRejectedValue(mockReadResult());
-      const reader = { read, readTree: jest.fn() };
+      const reader = { read, readTree: jest.fn(), search: jest.fn() };
 
       await expect(
         findRawCodeOwners(mockLocation(), { reader, logger }),
@@ -184,7 +184,7 @@ describe('CodeOwnersProcessor', () => {
         .mockImplementationOnce(() => mockReadResult({ error: 'foo' }))
         .mockImplementationOnce(() => mockReadResult({ error: 'bar' }))
         .mockResolvedValue(mockReadResult({ data: ownersText }));
-      const reader = { read, readTree: jest.fn() };
+      const reader = { read, readTree: jest.fn(), search: jest.fn() };
 
       const result = await findRawCodeOwners(mockLocation(), {
         reader,
@@ -206,7 +206,7 @@ describe('CodeOwnersProcessor', () => {
       const read = jest
         .fn()
         .mockResolvedValue(mockReadResult({ data: mockCodeOwnersText() }));
-      const reader = { read, readTree: jest.fn() };
+      const reader = { read, readTree: jest.fn(), search: jest.fn() };
 
       const owner = await resolveCodeOwner(mockLocation(), { reader, logger });
       expect(owner).toBe('backstage-core');
@@ -216,7 +216,7 @@ describe('CodeOwnersProcessor', () => {
       const read = jest
         .fn()
         .mockImplementation(() => mockReadResult({ error: 'error: foo' }));
-      const reader = { read, readTree: jest.fn() };
+      const reader = { read, readTree: jest.fn(), search: jest.fn() };
 
       await expect(
         resolveCodeOwner(mockLocation(), { reader, logger }),
@@ -230,7 +230,7 @@ describe('CodeOwnersProcessor', () => {
       const read = jest
         .fn()
         .mockResolvedValue(mockReadResult({ data: mockCodeOwnersText() }));
-      const reader = { read, readTree: jest.fn() };
+      const reader = { read, readTree: jest.fn(), search: jest.fn() };
       const processor = new CodeOwnersProcessor({ reader, logger });
 
       return { entity, processor, read };

--- a/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.test.ts
@@ -27,7 +27,7 @@ import {
 
 describe('PlaceholderProcessor', () => {
   const read: jest.MockedFunction<ResolverRead> = jest.fn();
-  const reader: UrlReader = { read, readTree: jest.fn() };
+  const reader: UrlReader = { read, readTree: jest.fn(), search: jest.fn() };
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
@@ -16,6 +16,8 @@
 
 import { UrlReader } from '@backstage/backend-common';
 import { LocationSpec } from '@backstage/catalog-model';
+import parseGitUrl from 'git-url-parse';
+import limiterFactory from 'p-limit';
 import { Logger } from 'winston';
 import * as result from './results';
 import {
@@ -59,10 +61,14 @@ export class UrlReaderProcessor implements CatalogProcessor {
     }
 
     try {
-      const data = await this.options.reader.read(location.target);
-
-      for await (const parseResult of parser({ data, location })) {
-        emit(parseResult);
+      const output = await this.doRead(location.target);
+      for (const item of output) {
+        for await (const parseResult of parser({
+          data: item.data,
+          location: { type: location.type, target: item.url },
+        })) {
+          emit(parseResult);
+        }
       }
     } catch (error) {
       const message = `Unable to read ${location.type}, ${error}`;
@@ -77,5 +83,26 @@ export class UrlReaderProcessor implements CatalogProcessor {
     }
 
     return true;
+  }
+
+  private async doRead(
+    location: string,
+  ): Promise<{ data: Buffer; url: string }[]> {
+    // Does it contain globs? I.e. does it contain asterisks or question marks
+    // (no curly braces for now)
+    const { filepath } = parseGitUrl(location);
+    if (filepath?.match(/[*?]/)) {
+      const limiter = limiterFactory(5);
+      const response = await this.options.reader.search(location);
+      const output = response.files.map(async file => ({
+        url: file.url,
+        data: await limiter(file.content),
+      }));
+      return Promise.all(output);
+    }
+
+    // Otherwise do a plain read
+    const data = await this.options.reader.read(location);
+    return [{ url: location, data }];
   }
 }

--- a/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.test.ts
@@ -44,6 +44,7 @@ describe('CatalogBuilder', () => {
   const reader: jest.Mocked<UrlReader> = {
     read: jest.fn(),
     readTree: jest.fn(),
+    search: jest.fn(),
   };
   const env: CatalogEnvironment = {
     logger: getVoidLogger(),

--- a/plugins/techdocs-backend/src/service/standaloneServer.ts
+++ b/plugins/techdocs-backend/src/service/standaloneServer.ts
@@ -53,6 +53,7 @@ export async function startStandaloneServer(
   const mockUrlReader: jest.Mocked<UrlReader> = {
     read: jest.fn(),
     readTree: jest.fn(),
+    search: jest.fn(),
   };
 
   logger.debug('Creating application...');


### PR DESCRIPTION
First stab, only implementing GitHub for starters. The others will likely just use the readTree method initially.