### PR TITLE
org: Update visual display on User and Group cards

### DIFF
--- a/.changeset/nine-trees-thank.md
+++ b/.changeset/nine-trees-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Visual updates to User and Group pages

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -22,7 +22,16 @@ import {
 } from '@backstage/catalog-model';
 import { Avatar, InfoCard } from '@backstage/core';
 import { entityRouteParams } from '@backstage/plugin-catalog-react';
-import { Box, Grid, Link, Tooltip, Typography } from '@material-ui/core';
+import {
+  Box,
+  Grid,
+  Link,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+} from '@material-ui/core';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';
@@ -76,66 +85,57 @@ export const GroupProfileCard = ({
     ?.map(groupItem => groupItem.target.name)
     .toString();
 
-  const childrens = group?.relations
+  const childRelations = group?.relations
     ?.filter(r => r.type === RELATION_PARENT_OF)
     ?.map(groupItem => groupItem.target.name);
 
   const displayName = profile?.displayName ?? name;
+  const descriptionHeading = description ?? name;
 
   if (!group) return <Alert severity="error">User not found</Alert>;
 
   return (
     <InfoCard
-      title={<CardTitle title={displayName} />}
-      subheader={description}
+      title={<CardTitle title={descriptionHeading} />}
       variant={variant}
     >
       <Grid container spacing={3}>
         <Grid item xs={12} sm={2} xl={1}>
-          <Box
-            display="flex"
-            alignItems="flex-start"
-            justifyContent="center"
-            height="100%"
-            width="100%"
-          >
-            <Avatar displayName={displayName} picture={profile?.picture} />
-          </Box>
+          <Avatar displayName={displayName} picture={profile?.picture} />
         </Grid>
         <Grid item md={10} xl={11}>
-          {profile?.email && (
-            <Typography variant="subtitle1">
-              <Box display="flex" alignItems="center">
-                <Tooltip title="Email">
-                  <EmailIcon fontSize="inherit" />
-                </Tooltip>
-
-                <Box ml={1} display="inline">
-                  {profile.email}
-                </Box>
-              </Box>
-            </Typography>
-          )}
-          {parent ? (
-            <Typography variant="subtitle1">
-              <Box display="flex" alignItems="center">
-                <Tooltip title="Group Parent">
-                  <AccountTreeIcon fontSize="inherit" />
-                </Tooltip>
-                <Box ml={1} display="inline">
+          <List>
+            {profile?.email && (
+              <ListItem>
+                <ListItemIcon>
+                  <Tooltip title="Email">
+                    <EmailIcon fontSize="inherit" />
+                  </Tooltip>
+                </ListItemIcon>
+                <ListItemText>{profile.email}</ListItemText>
+              </ListItem>
+            )}
+            {parent ? (
+              <ListItem>
+                <ListItemIcon>
+                  <Tooltip title="Parent Group">
+                    <AccountTreeIcon />
+                  </Tooltip>
+                </ListItemIcon>
+                <ListItemText>
                   <GroupLink groupName={parent} entity={group} />
-                </Box>
-              </Box>
-            </Typography>
-          ) : null}
-          {childrens?.length ? (
-            <Typography variant="subtitle1">
-              <Box display="flex" alignItems="center">
-                <Tooltip title="Parent of">
-                  <GroupIcon fontSize="inherit" />
-                </Tooltip>
-                <Box ml={1} display="inline">
-                  {childrens.map((children, index) => (
+                </ListItemText>
+              </ListItem>
+            ) : null}
+            {childRelations?.length ? (
+              <ListItem>
+                <ListItemIcon>
+                  <Tooltip title="Child Groups">
+                    <GroupIcon />
+                  </Tooltip>
+                </ListItemIcon>
+                <ListItemText>
+                  {childRelations.map((children, index) => (
                     <GroupLink
                       groupName={children}
                       entity={group}
@@ -143,10 +143,10 @@ export const GroupProfileCard = ({
                       key={children}
                     />
                   ))}
-                </Box>
-              </Box>
-            </Typography>
-          ) : null}
+                </ListItemText>
+              </ListItem>
+            ) : null}
+          </List>
         </Grid>
       </Grid>
     </InfoCard>

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -90,13 +90,13 @@ export const GroupProfileCard = ({
     ?.map(groupItem => groupItem.target.name);
 
   const displayName = profile?.displayName ?? name;
-  const descriptionHeading = description ?? name;
 
   if (!group) return <Alert severity="error">User not found</Alert>;
 
   return (
     <InfoCard
-      title={<CardTitle title={descriptionHeading} />}
+      title={<CardTitle title={displayName} />}
+      subheader={description}
       variant={variant}
     >
       <Grid container spacing={3}>

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -21,7 +21,10 @@ import {
   RELATION_PARENT_OF,
 } from '@backstage/catalog-model';
 import { Avatar, InfoCard } from '@backstage/core';
-import { entityRouteParams } from '@backstage/plugin-catalog-react';
+import {
+  getEntityRelations,
+  entityRouteParams,
+} from '@backstage/plugin-catalog-react';
 import {
   Box,
   Grid,
@@ -85,9 +88,9 @@ export const GroupProfileCard = ({
     ?.map(groupItem => groupItem.target.name)
     .toString();
 
-  const childRelations = group?.relations
-    ?.filter(r => r.type === RELATION_PARENT_OF)
-    ?.map(groupItem => groupItem.target.name);
+  const childRelations = getEntityRelations(group, RELATION_PARENT_OF, {
+    kind: 'group',
+  });
 
   const displayName = profile?.displayName ?? name;
 
@@ -137,10 +140,9 @@ export const GroupProfileCard = ({
                 <ListItemText>
                   {childRelations.map((children, index) => (
                     <GroupLink
-                      groupName={children}
+                      groupName={children.name}
                       entity={group}
                       index={index}
-                      key={children}
                     />
                   ))}
                 </ListItemText>

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
@@ -20,7 +20,17 @@ import {
 } from '@backstage/catalog-model';
 import { Avatar, InfoCard } from '@backstage/core';
 import { entityRouteParams } from '@backstage/plugin-catalog-react';
-import { Box, Grid, Link, Tooltip, Typography } from '@material-ui/core';
+import {
+  Box,
+  Grid,
+  Link,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
 import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';
 import PersonIcon from '@material-ui/icons/Person';
@@ -80,40 +90,35 @@ export const UserProfileCard = ({
     return <Alert severity="error">User not found</Alert>;
   }
 
+  const emailHref = profile?.email ? `mailto:${profile.email}` : '';
+
   return (
     <InfoCard title={<CardTitle title={displayName} />} variant={variant}>
-      <Grid container spacing={3}>
-        <Grid item xs={12} sm={2} xl={1}>
-          <Box
-            display="flex"
-            alignItems="flex-start"
-            justifyContent="center"
-            height="100%"
-            width="100%"
-          >
-            <Avatar displayName={displayName} picture={profile?.picture} />
-          </Box>
+      <Grid container spacing={3} alignItems="flex-start">
+        <Grid item md={2} lg={1}>
+          <Avatar displayName={displayName} picture={profile?.picture} />
         </Grid>
-        <Grid item md={10} xl={11}>
-          {profile?.email && (
-            <Typography variant="subtitle1">
-              <Box display="flex" alignItems="center">
-                <Tooltip title="Email">
-                  <EmailIcon fontSize="inherit" />
-                </Tooltip>
 
-                <Box ml={1} display="inline">
-                  {profile.email}
-                </Box>
-              </Box>
-            </Typography>
-          )}
-          <Typography variant="subtitle1">
-            <Box display="flex" alignItems="center">
-              <Tooltip title="Member of">
-                <GroupIcon />
-              </Tooltip>
-              <Box ml={1} display="inline">
+        <Grid item md={10} lg={11}>
+          <List>
+            {profile?.email && (
+              <ListItem>
+                <ListItemIcon>
+                  <EmailIcon />
+                </ListItemIcon>
+                <ListItemText>
+                  <Link href={emailHref}>{profile.email}</Link>
+                </ListItemText>
+              </ListItem>
+            )}
+
+            <ListItem>
+              <ListItemIcon>
+                <Tooltip title="Member of">
+                  <GroupIcon />
+                </Tooltip>
+              </ListItemIcon>
+              <ListItemText>
                 {groupNames.map((groupName, index) => (
                   <GroupLink
                     groupName={groupName}
@@ -122,9 +127,9 @@ export const UserProfileCard = ({
                     entity={user}
                   />
                 ))}
-              </Box>
-            </Box>
-          </Typography>
+              </ListItemText>
+            </ListItem>
+          </List>
         </Grid>
       </Grid>
     </InfoCard>

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
@@ -29,7 +29,6 @@ import {
   ListItemIcon,
   ListItemText,
   Tooltip,
-  Typography,
 } from '@material-ui/core';
 import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Closes #4211.

* Updates the contents of the about cards in both User and Group pages using a `<List>` to fix some minor visual alignment
* Grid/box fixes to improve alignment/reduce complexity. (avatar icons weren't truly 3 spaced and aligned with other content, I've tested varying sizes (sm/md/lg), resizing etc.)
* Makes the user's e-mail clickable (to mailto:, firing up your local e-mail client).
* Replaces the title of the Group about card with the group's description, if it's available. This better lines up with how the user card shows, with the user name (like `adamharvey`) or the group name (like `backend-team`) at the top of the page and the friendly version in the card (e.g., "Adam Harvey" or "Members of the Backend Team").

### User card

![image](https://user-images.githubusercontent.com/33203301/106993370-8f097500-6748-11eb-82e8-83feb2c9babb.png)

### Parent team with a child
![image](https://user-images.githubusercontent.com/33203301/106993227-4356cb80-6748-11eb-9ac7-592db2e960e8.png)

### Child team with a parent

![image](https://user-images.githubusercontent.com/33203301/106993247-4ce03380-6748-11eb-8536-919559ccc6d1.png)

### Group with no description; name repeated in about card

![image](https://user-images.githubusercontent.com/33203301/106993541-e9a2d100-6748-11eb-9b4b-7fb841e1ed7e.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
