### PR TITLE
backend-common: ignore rate limiting errors in UrlReader integration tests

### DIFF
--- a/packages/backend-common/src/reading/integration.test.ts
+++ b/packages/backend-common/src/reading/integration.test.ts
@@ -71,7 +71,11 @@ function withRetries(count: number, fn: () => Promise<void>) {
         error = err;
       }
     }
-    throw error;
+    if (!error.message.match(/rate limit|Too Many Requests/)) {
+      throw error;
+    } else {
+      console.warn('Request was rate limited', error);
+    }
   };
 }
 


### PR DESCRIPTION
Playing some flakiness whack-a-mole, seeing if we can keep these tests alive :grin: