### PR TITLE
Supress log single location. Refs #3602

### DIFF
--- a/.changeset/early-hotels-mate.md
+++ b/.changeset/early-hotels-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+use child logger, if provided, to log single location refresh


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use a child logger, if it exists, to log when refreshing a single Location.  

When refreshing locations, I added in a filter to `refreshAllLocations` to enable filtering out location refresh logs.
Unfortunately, this child logger was not passed on correctly to the `refreshSingleLocation` and consequently did not really solve the problem. 

refreshSingeLocation's parameters have been modified to accept a `logger` as a optional that is used to log from `refreshSingleLocation`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
