### PR TITLE
Don't respond to a request twice if an entity has not been found.

### DIFF
--- a/.changeset/fluffy-hats-hug.md
+++ b/.changeset/fluffy-hats-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Don't respond to a request twice if an entity has not been found.

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -76,8 +76,9 @@ export async function createRouter(
         );
         if (!entities.length) {
           res.status(404).send(`No entity with uid ${uid}`);
+        } else {
+          res.status(200).send(entities[0]);
         }
-        res.status(200).send(entities[0]);
       })
       .delete('/entities/by-uid/:uid', async (req, res) => {
         const { uid } = req.params;
@@ -99,8 +100,9 @@ export async function createRouter(
             .send(
               `No entity with kind ${kind} namespace ${namespace} name ${name}`,
             );
+        } else {
+          res.status(200).send(entities[0]);
         }
-        res.status(200).send(entities[0]);
       });
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This bug took us _days_ to find. Once we saw which code was troubling us, it was obvious. One can't sent http headers or bodies if the request has already been closed.

What confuses me is why there isn't any warning in the logs during the tests or the actual usage. We also made a similar mistake in a backend plugin a few weeks ago which led to a warning that I miss here:
```
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:558:11)
    at ServerResponse.header (/Users/***/node_modules/express/lib/response.js:771:10)
    at ServerResponse.json (/Users/***/git/terminal/node_modules/express/lib/response.js:264:10)
    at eval (webpack-internal:///./src/plugins/idTokenIdentityProvider.ts:51:9)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```
This also makes it hard to write a test that checks it. express neither complains, nor breaks here…

Short story why this error is frustrating: We have an automated end-to-end test-suite that runs against our production instance and randomly fails on specific tests; but only sometimes. It turned out that it only happens when it requests a non-existing entity `by-name` followed by another call. But only when using gzip 🙄. Disabling gzip in our reverse proxy made it work; also does fixing these two lines. As if the compression module gets confused when someone sends data after finishing a request.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
