### PR TITLE
TechDocs: Proper caching with URL Reader, warnings for git/dir preparers and cleanups

### DIFF
--- a/.changeset/techdocs-green-singers-jump.md
+++ b/.changeset/techdocs-green-singers-jump.md
@@ -1,0 +1,6 @@
+---
+'@backstage/techdocs-common': minor
+'@backstage/plugin-techdocs-backend': minor
+---
+
+URL Preparer will now use proper etag based caching introduced in https://github.com/backstage/backstage/pull/4120. Previously, builds used to be cached for 30 minutes.

--- a/.changeset/techdocs-new-needles-arrive.md
+++ b/.changeset/techdocs-new-needles-arrive.md
@@ -1,0 +1,8 @@
+---
+'@backstage/techdocs-common': patch
+'@backstage/plugin-techdocs-backend': patch
+---
+
+TechDocs will throw warning in backend logs when legacy git preparer or dir preparer is used to preparer docs. Migrate to URL Preparer by updating `backstage.io/techdocs-ref` annotation to be prefixed with `url:`.
+Detailed docs are here https://backstage.io/docs/features/techdocs/how-to-guides#how-to-use-url-reader-in-techdocs-prepare-step
+See benefits and reason for doing so https://github.com/backstage/backstage/issues/4409

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -157,15 +157,17 @@ techdocs:
   builder: 'local'
 ```
 
-Set `techdocs.builder` to `'local'` if you want your TechDocs Backend to be
-responsible for generating documentation sites. If set to `'external'`,
-Backstage will assume that the sites are being generated on each entity's CI/CD
-pipeline, and are being stored in a storage somewhere.
+Note that we recommend generating docs on CI/CD instead. Read more in the
+"Basic" and "Recommended" sections of the
+[TechDocs Architecture](architecture.md). But if you want to get started quickly
+set `techdocs.builder` to `'local'` so that TechDocs Backend is responsible for
+generating documentation sites. If set to `'external'`, Backstage will assume
+that the sites are being generated on each entity's CI/CD pipeline, and are
+being stored in a storage somewhere.
 
 When `techdocs.builder` is set to `'external'`, TechDocs becomes more or less a
 read-only experience where it serves static files from a storage containing all
-the generated documentation. Read more in the "Basic" and "Recommended" sections
-of the [TechDocs Architecture](architecture.md).
+the generated documentation.
 
 ### Choosing storage (publisher)
 

--- a/packages/techdocs-common/src/helpers.test.ts
+++ b/packages/techdocs-common/src/helpers.test.ts
@@ -139,7 +139,7 @@ describe('getDocFilesFromRepository', () => {
           archive: async () => {
             return Readable.from('');
           },
-          etag: '',
+          etag: 'etag123abc',
         };
       }
 
@@ -156,6 +156,7 @@ describe('getDocFilesFromRepository', () => {
       mockEntityWithAnnotation,
     );
 
-    expect(output).toBe('/tmp/testfolder');
+    expect(output.preparedDir).toBe('/tmp/testfolder');
+    expect(output.etag).toBe('etag123abc');
   });
 });

--- a/packages/techdocs-common/src/helpers.ts
+++ b/packages/techdocs-common/src/helpers.ts
@@ -209,16 +209,19 @@ export const getLastCommitTimestamp = async (
 export const getDocFilesFromRepository = async (
   reader: UrlReader,
   entity: Entity,
-  opts?: { etag?: string },
+  opts?: { etag?: string; logger?: Logger },
 ): Promise<PreparerResponse> => {
   const { target } = parseReferenceAnnotation(
     'backstage.io/techdocs-ref',
     entity,
   );
 
+  opts?.logger?.info(`Reading files from ${target}`);
   // readTree will throw NotModifiedError if etag has not changed.
   const readTreeResponse = await reader.readTree(target, { etag: opts?.etag });
   const preparedDir = await readTreeResponse.dir();
+
+  opts?.logger?.info(`Tree downloaded and stored at ${preparedDir}`);
 
   return {
     preparedDir,

--- a/packages/techdocs-common/src/helpers.ts
+++ b/packages/techdocs-common/src/helpers.ts
@@ -196,16 +196,9 @@ export const checkoutGitRepository = async (
 };
 
 export const getLastCommitTimestamp = async (
-  repositoryUrl: string,
-  config: Config,
+  repositoryLocation: string,
   logger: Logger,
 ): Promise<number> => {
-  const repositoryLocation = await checkoutGitRepository(
-    repositoryUrl,
-    config,
-    logger,
-  );
-
   const git = Git.fromAuth({ logger });
   const sha = await git.resolveRef({ dir: repositoryLocation, ref: 'HEAD' });
   const commit = await git.readCommit({ dir: repositoryLocation, sha });

--- a/packages/techdocs-common/src/stages/prepare/commonGit.test.ts
+++ b/packages/techdocs-common/src/stages/prepare/commonGit.test.ts
@@ -16,8 +16,8 @@
 
 import { getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
-import { CommonGitPreparer } from './commonGit';
 import { checkoutGitRepository } from '../../helpers';
+import { CommonGitPreparer } from './commonGit';
 
 function normalizePath(path: string) {
   return path
@@ -57,9 +57,9 @@ describe('commonGit preparer', () => {
         'github:https://github.com/backstage/backstage/blob/master/plugins/techdocs-backend/examples/documented-component',
     });
 
-    const tempDocsPath = await preparer.prepare(mockEntity);
+    const { preparedDir } = await preparer.prepare(mockEntity);
     expect(checkoutGitRepository).toHaveBeenCalledTimes(1);
-    expect(normalizePath(tempDocsPath)).toEqual(
+    expect(normalizePath(preparedDir)).toEqual(
       '/tmp/backstage-repo/org/name/branch/plugins/techdocs-backend/examples/documented-component',
     );
   });
@@ -72,9 +72,9 @@ describe('commonGit preparer', () => {
         'gitlab:https://gitlab.com/xesjkeee/go-logger/blob/master/catalog-info.yaml',
     });
 
-    const tempDocsPath = await preparer.prepare(mockEntity);
+    const { preparedDir } = await preparer.prepare(mockEntity);
     expect(checkoutGitRepository).toHaveBeenCalledTimes(2);
-    expect(normalizePath(tempDocsPath)).toEqual(
+    expect(normalizePath(preparedDir)).toEqual(
       '/tmp/backstage-repo/org/name/branch/catalog-info.yaml',
     );
   });
@@ -87,9 +87,9 @@ describe('commonGit preparer', () => {
         'azure/api:https://dev.azure.com/backstage-org/backstage-project/_git/template-repo?path=%2Ftemplate.yaml',
     });
 
-    const tempDocsPath = await preparer.prepare(mockEntity);
+    const { preparedDir } = await preparer.prepare(mockEntity);
     expect(checkoutGitRepository).toHaveBeenCalledTimes(3);
-    expect(normalizePath(tempDocsPath)).toEqual(
+    expect(normalizePath(preparedDir)).toEqual(
       '/tmp/backstage-repo/org/name/branch/template.yaml',
     );
   });

--- a/packages/techdocs-common/src/stages/prepare/commonGit.test.ts
+++ b/packages/techdocs-common/src/stages/prepare/commonGit.test.ts
@@ -29,6 +29,7 @@ function normalizePath(path: string) {
 jest.mock('../../helpers', () => ({
   ...jest.requireActual<{}>('../../helpers'),
   checkoutGitRepository: jest.fn(() => '/tmp/backstage-repo/org/name/branch'),
+  getLastCommitTimestamp: jest.fn(() => 12345678),
 }));
 
 const createMockEntity = (annotations = {}) => {

--- a/packages/techdocs-common/src/stages/prepare/commonGit.ts
+++ b/packages/techdocs-common/src/stages/prepare/commonGit.ts
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import path from 'path';
-import parseGitUrl from 'git-url-parse';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import { PreparerBase } from './types';
-import { parseReferenceAnnotation, checkoutGitRepository } from '../../helpers';
-
+import parseGitUrl from 'git-url-parse';
+import path from 'path';
 import { Logger } from 'winston';
+import { checkoutGitRepository, parseReferenceAnnotation } from '../../helpers';
+import { PreparerBase, PreparerResponse } from './types';
 
 export class CommonGitPreparer implements PreparerBase {
   private readonly config: Config;
@@ -31,7 +30,7 @@ export class CommonGitPreparer implements PreparerBase {
     this.logger = logger;
   }
 
-  async prepare(entity: Entity): Promise<string> {
+  async prepare(entity: Entity): Promise<PreparerResponse> {
     const { target } = parseReferenceAnnotation(
       'backstage.io/techdocs-ref',
       entity,
@@ -45,7 +44,13 @@ export class CommonGitPreparer implements PreparerBase {
       );
       const parsedGitLocation = parseGitUrl(target);
 
-      return path.join(repoPath, parsedGitLocation.filepath);
+      // TODO: Return git commit sha
+      const etag = '';
+
+      return {
+        preparedDir: path.join(repoPath, parsedGitLocation.filepath),
+        etag,
+      };
     } catch (error) {
       this.logger.debug(`Repo checkout failed with error ${error.message}`);
       throw error;

--- a/packages/techdocs-common/src/stages/prepare/commonGit.ts
+++ b/packages/techdocs-common/src/stages/prepare/commonGit.ts
@@ -39,6 +39,12 @@ export class CommonGitPreparer implements PreparerBase {
     entity: Entity,
     options?: { etag?: string },
   ): Promise<PreparerResponse> {
+    this.logger.warn(
+      'You are using the legacy git preparer in TechDocs which will be removed in near future (30 days). ' +
+        'Migrate to URL reader by updating `backstage.io/techdocs-ref` annotation in `catalog-info.yaml` ' +
+        'to be prefixed with `url:`. Read the migration guide and benefits at https://github.com/backstage/backstage/issues/4409 ',
+    );
+
     const { target } = parseReferenceAnnotation(
       'backstage.io/techdocs-ref',
       entity,

--- a/packages/techdocs-common/src/stages/prepare/commonGit.ts
+++ b/packages/techdocs-common/src/stages/prepare/commonGit.ts
@@ -40,7 +40,7 @@ export class CommonGitPreparer implements PreparerBase {
     options?: { etag?: string },
   ): Promise<PreparerResponse> {
     this.logger.warn(
-      'You are using the legacy git preparer in TechDocs which will be removed in near future (30 days). ' +
+      'You are using the legacy git preparer in TechDocs which will be removed in near future (March 2021). ' +
         'Migrate to URL reader by updating `backstage.io/techdocs-ref` annotation in `catalog-info.yaml` ' +
         'to be prefixed with `url:`. Read the migration guide and benefits at https://github.com/backstage/backstage/issues/4409 ',
     );
@@ -57,13 +57,8 @@ export class CommonGitPreparer implements PreparerBase {
         this.config,
         this.logger,
       );
-
       // Check if etag has changed for cache invalidation.
-      const etag = await getLastCommitTimestamp(
-        target,
-        this.config,
-        this.logger,
-      );
+      const etag = await getLastCommitTimestamp(repoPath, this.logger);
       if (options?.etag === etag.toString()) {
         throw new NotModifiedError();
       }

--- a/packages/techdocs-common/src/stages/prepare/dir.test.ts
+++ b/packages/techdocs-common/src/stages/prepare/dir.test.ts
@@ -15,8 +15,8 @@
  */
 import { getVoidLogger, UrlReader } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
-import { DirectoryPreparer } from './dir';
 import { checkoutGitRepository } from '../../helpers';
+import { DirectoryPreparer } from './dir';
 
 function normalizePath(path: string) {
   return path
@@ -66,9 +66,8 @@ describe('directory preparer', () => {
       'backstage.io/techdocs-ref': 'dir:./our-documentation',
     });
 
-    expect(normalizePath(await directoryPreparer.prepare(mockEntity))).toEqual(
-      '/directory/our-documentation',
-    );
+    const { preparedDir } = await directoryPreparer.prepare(mockEntity);
+    expect(normalizePath(preparedDir)).toEqual('/directory/our-documentation');
   });
 
   it('should merge managed-by-location and techdocs-ref when techdocs-ref is absolute', async () => {
@@ -84,9 +83,8 @@ describe('directory preparer', () => {
       'backstage.io/techdocs-ref': 'dir:/our-documentation/techdocs',
     });
 
-    expect(normalizePath(await directoryPreparer.prepare(mockEntity))).toEqual(
-      '/our-documentation/techdocs',
-    );
+    const { preparedDir } = await directoryPreparer.prepare(mockEntity);
+    expect(normalizePath(preparedDir)).toEqual('/our-documentation/techdocs');
   });
 
   it('should merge managed-by-location and techdocs-ref when managed-by-location is a git repository', async () => {
@@ -102,7 +100,8 @@ describe('directory preparer', () => {
       'backstage.io/techdocs-ref': 'dir:./docs',
     });
 
-    expect(normalizePath(await directoryPreparer.prepare(mockEntity))).toEqual(
+    const { preparedDir } = await directoryPreparer.prepare(mockEntity);
+    expect(normalizePath(preparedDir)).toEqual(
       '/tmp/backstage-repo/org/name/branch/docs',
     );
     expect(checkoutGitRepository).toHaveBeenCalledTimes(1);

--- a/packages/techdocs-common/src/stages/prepare/dir.test.ts
+++ b/packages/techdocs-common/src/stages/prepare/dir.test.ts
@@ -28,6 +28,7 @@ function normalizePath(path: string) {
 jest.mock('../../helpers', () => ({
   ...jest.requireActual<{}>('../../helpers'),
   checkoutGitRepository: jest.fn(() => '/tmp/backstage-repo/org/name/branch/'),
+  getLastCommitTimestamp: jest.fn(() => 12345678),
 }));
 
 const logger = getVoidLogger();

--- a/packages/techdocs-common/src/stages/prepare/dir.ts
+++ b/packages/techdocs-common/src/stages/prepare/dir.ts
@@ -69,6 +69,12 @@ export class DirectoryPreparer implements PreparerBase {
   }
 
   async prepare(entity: Entity): Promise<PreparerResponse> {
+    this.logger.warn(
+      'You are using the legacy dir preparer in TechDocs which will be removed in near future (30 days). ' +
+        'Migrate to URL reader by updating `backstage.io/techdocs-ref` annotation in `catalog-info.yaml` ' +
+        'to be prefixed with `url:`. Read the migration guide and benefits at https://github.com/backstage/backstage/issues/4409 ',
+    );
+
     const { target } = parseReferenceAnnotation(
       'backstage.io/techdocs-ref',
       entity,

--- a/packages/techdocs-common/src/stages/prepare/dir.ts
+++ b/packages/techdocs-common/src/stages/prepare/dir.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PreparerBase } from './types';
+import { InputError, UrlReader } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import path from 'path';
-import { parseReferenceAnnotation, checkoutGitRepository } from '../../helpers';
-import { UrlReader, InputError } from '@backstage/backend-common';
 import parseGitUrl from 'git-url-parse';
+import path from 'path';
 import { Logger } from 'winston';
+import { checkoutGitRepository, parseReferenceAnnotation } from '../../helpers';
+import { PreparerBase, PreparerResponse } from './types';
 
 export class DirectoryPreparer implements PreparerBase {
   constructor(
@@ -68,7 +68,7 @@ export class DirectoryPreparer implements PreparerBase {
     }
   }
 
-  async prepare(entity: Entity): Promise<string> {
+  async prepare(entity: Entity): Promise<PreparerResponse> {
     const { target } = parseReferenceAnnotation(
       'backstage.io/techdocs-ref',
       entity,
@@ -78,8 +78,12 @@ export class DirectoryPreparer implements PreparerBase {
       entity,
     );
 
-    return new Promise(resolve => {
-      resolve(path.resolve(managedByLocationDirectory, target));
-    });
+    // TODO: etag will be returned as a commit sha from resolveManagedByLocationToDir.
+    const etag = '';
+
+    return {
+      preparedDir: path.resolve(managedByLocationDirectory, target),
+      etag,
+    };
   }
 }

--- a/packages/techdocs-common/src/stages/prepare/dir.ts
+++ b/packages/techdocs-common/src/stages/prepare/dir.ts
@@ -70,7 +70,7 @@ export class DirectoryPreparer implements PreparerBase {
 
   async prepare(entity: Entity): Promise<PreparerResponse> {
     this.logger.warn(
-      'You are using the legacy dir preparer in TechDocs which will be removed in near future (30 days). ' +
+      'You are using the legacy dir preparer in TechDocs which will be removed in near future (March 2021). ' +
         'Migrate to URL reader by updating `backstage.io/techdocs-ref` annotation in `catalog-info.yaml` ' +
         'to be prefixed with `url:`. Read the migration guide and benefits at https://github.com/backstage/backstage/issues/4409 ',
     );

--- a/packages/techdocs-common/src/stages/prepare/types.ts
+++ b/packages/techdocs-common/src/stages/prepare/types.ts
@@ -33,13 +33,13 @@ export type PreparerBase = {
    * with contents from the location in temporary storage and return the path.
    *
    * @param entity The entity from the Service Catalog
-   * @param opts.etag (Optional) If etag is provider, it will be used to check if the target has
+   * @param options.etag (Optional) If etag is provider, it will be used to check if the target has
    * updated since the last build.
    * @throws {NotModifiedError} when the prepared directory has not been changed since the last build.
    */
   prepare(
     entity: Entity,
-    opts?: { logger: Logger; etag?: string },
+    options?: { logger?: Logger; etag?: string },
   ): Promise<PreparerResponse>;
 };
 

--- a/packages/techdocs-common/src/stages/prepare/types.ts
+++ b/packages/techdocs-common/src/stages/prepare/types.ts
@@ -16,13 +16,31 @@
 import type { Entity } from '@backstage/catalog-model';
 import { Logger } from 'winston';
 
+export type PreparerResponse = {
+  /**
+   * The path to directory where the tree is downloaded.
+   */
+  preparedDir: string;
+  /**
+   * A unique identifer of the tree blob, usually the commit SHA or etag from the target.
+   */
+  etag: string;
+};
+
 export type PreparerBase = {
   /**
    * Given an Entity definition from the Service Catalog, go and prepare a directory
-   * with contents from the location in temporary storage and return the path
+   * with contents from the location in temporary storage and return the path.
+   *
    * @param entity The entity from the Service Catalog
+   * @param opts.etag (Optional) If etag is provider, it will be used to check if the target has
+   * updated since the last build.
+   * @throws {NotModifiedError} when the prepared directory has not been changed since the last build.
    */
-  prepare(entity: Entity, opts?: { logger: Logger }): Promise<string>;
+  prepare(
+    entity: Entity,
+    opts?: { logger: Logger; etag?: string },
+  ): Promise<PreparerResponse>;
 };
 
 export type PreparerBuilder = {
@@ -30,10 +48,14 @@ export type PreparerBuilder = {
   get(entity: Entity): PreparerBase;
 };
 
+/**
+ * Everything except `url` will be deprecated.
+ * Read more https://github.com/backstage/backstage/issues/4409
+ */
 export type RemoteProtocol =
+  | 'url'
   | 'dir'
   | 'github'
   | 'gitlab'
   | 'file'
-  | 'azure/api'
-  | 'url';
+  | 'azure/api';

--- a/packages/techdocs-common/src/stages/prepare/url.ts
+++ b/packages/techdocs-common/src/stages/prepare/url.ts
@@ -35,6 +35,7 @@ export class UrlPreparer implements PreparerBase {
     try {
       return await getDocFilesFromRepository(this.reader, entity, {
         etag: options?.etag,
+        logger: this.logger,
       });
     } catch (error) {
       // NotModifiedError means that etag based cache is still valid.

--- a/packages/techdocs-common/src/stages/prepare/url.ts
+++ b/packages/techdocs-common/src/stages/prepare/url.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Logger } from 'winston';
-import { Entity } from '@backstage/catalog-model';
 import { UrlReader } from '@backstage/backend-common';
-import { PreparerBase } from './types';
+import { Entity } from '@backstage/catalog-model';
+import { Logger } from 'winston';
 import { getDocFilesFromRepository } from '../../helpers';
+import { PreparerBase, PreparerResponse } from './types';
 
 export class UrlPreparer implements PreparerBase {
   private readonly logger: Logger;
@@ -28,9 +28,15 @@ export class UrlPreparer implements PreparerBase {
     this.reader = reader;
   }
 
-  async prepare(entity: Entity): Promise<string> {
+  async prepare(entity: Entity): Promise<PreparerResponse> {
     try {
-      return getDocFilesFromRepository(this.reader, entity);
+      const preparedDir = await getDocFilesFromRepository(this.reader, entity);
+      // TODO: This will be actual etag from URL Reader.
+      const etag = '';
+      return {
+        preparedDir,
+        etag,
+      };
     } catch (error) {
       this.logger.debug(
         `Unable to fetch files for building docs ${error.message}`,

--- a/packages/techdocs-common/src/stages/publish/local.ts
+++ b/packages/techdocs-common/src/stages/publish/local.ts
@@ -88,7 +88,7 @@ export class LocalPublish implements PublisherBase {
           );
           reject(err);
         }
-
+        this.logger.info(`Published site stored at ${publishDir}`);
         this.discovery
           .getBaseUrl('techdocs')
           .then(techdocsApiUrl => {

--- a/plugins/techdocs-backend/src/DocsBuilder/BuildMetadataStorage.test.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/BuildMetadataStorage.test.ts
@@ -17,11 +17,11 @@ import { BuildMetadataStorage } from './BuildMetadataStorage';
 
 describe('BuildMetadataStorage', () => {
   it('should return build timestamp', () => {
-    const newMetadataStorage = new BuildMetadataStorage('123abc');
-    newMetadataStorage.storeBuildTimestamp();
+    const newMetadataStorage = new BuildMetadataStorage('entityID123abc');
+    newMetadataStorage.setEtag('etag123abc');
 
-    const timestamp = newMetadataStorage.getTimestamp();
+    const timestamp = newMetadataStorage.getEtag();
 
-    expect(timestamp).toBeLessThanOrEqual(Date.now());
+    expect(timestamp).toBe('etag123abc');
   });
 });

--- a/plugins/techdocs-backend/src/DocsBuilder/BuildMetadataStorage.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/BuildMetadataStorage.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 type buildInfo = {
-  // uid: timestamp
-  [key: string]: number;
+  // Entity uid: etag
+  [key: string]: string;
 };
 
 // TODO: Build info should be part of TechDocs storage, inside `techdocs_metadata.json`
@@ -39,11 +39,11 @@ export class BuildMetadataStorage {
     this.builds = builds;
   }
 
-  storeBuildTimestamp() {
-    this.builds[this.entityUid] = Date.now();
+  setEtag(etag: string): void {
+    this.builds[this.entityUid] = etag;
   }
 
-  getTimestamp() {
+  getEtag(): string | undefined {
     return this.builds[this.entityUid];
   }
 }

--- a/plugins/techdocs-backend/src/DocsBuilder/BuildMetadataStorage.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/BuildMetadataStorage.ts
@@ -18,6 +18,11 @@ type buildInfo = {
   [key: string]: number;
 };
 
+// TODO: Build info should be part of TechDocs storage, inside `techdocs_metadata.json`
+// instead of in-memory storage of the Backstage instance.
+// In case of multi-region Backstage deployments, or even using multiple Kubernetes pods,
+// if each instance creates its separate build info in-memory, it will result in duplicate
+// builds per instance. Also if the pod restarts, all the sites will have to be re-built.
 const builds = {} as buildInfo;
 
 /**

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { NotModifiedError } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import {
   GeneratorBase,
@@ -98,9 +99,12 @@ export class DocsBuilder {
 
       preparedDir = preparerResponse.preparedDir;
       etag = preparerResponse.etag;
-    } catch (NotModifiedError) {
-      // No need to prepare anymore since cache is valid.
-      return;
+    } catch (err) {
+      if (err instanceof NotModifiedError) {
+        // No need to prepare anymore since cache is valid.
+        return;
+      }
+      throw new Error(err.message);
     }
 
     this.logger.info(

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -76,6 +76,10 @@ export class DocsBuilder {
       );
     }
 
+    /**
+     * Prepare and cache check
+     */
+
     // Use the in-memory storage for setting and getting etag for this entity.
     const buildMetadataStorage = new BuildMetadataStorage(
       this.entity.metadata.uid,
@@ -103,6 +107,11 @@ export class DocsBuilder {
       `TechDocs prepare step completed for entity ${getEntityId(this.entity)}.`,
     );
     this.logger.debug(`Prepared files temporarily stored at ${preparedDir}`);
+
+    /**
+     * Generate
+     */
+
     this.logger.info(`Running generator on entity ${getEntityId(this.entity)}`);
     // Create a temporary directory to store the generated files in.
     const tmpdirPath = os.tmpdir();
@@ -111,7 +120,6 @@ export class DocsBuilder {
     const outputDir = await fs.mkdtemp(
       path.join(tmpdirResolvedPath, 'techdocs-tmp-'),
     );
-
     const parsedLocationAnnotation = getLocationForEntity(this.entity);
     await this.generator.run({
       inputDir: preparedDir,
@@ -121,9 +129,9 @@ export class DocsBuilder {
     });
 
     this.logger.debug(`Generated files temporarily stored at ${outputDir}`);
-    // Remove Prepared directory
-    // Can not remove prepared directory in case of git preparer since the local git repository
-    // is used to get etag on subsequent requests.
+    // Remove Prepared directory since it is no longer needed.
+    // Caveat: Can not remove prepared directory in case of git preparer since the
+    // local git repository is used to get etag on subsequent requests.
     if (this.preparer instanceof UrlPreparer) {
       this.logger.debug(
         `Removing prepared directory ${preparedDir} since the site has been generated.`,
@@ -135,6 +143,10 @@ export class DocsBuilder {
         this.logger.debug(`Error removing prepared directory ${error.message}`);
       }
     }
+
+    /**
+     * Publish
+     */
 
     this.logger.info(`Running publisher on entity ${getEntityId(this.entity)}`);
     await this.publisher.publish({

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import fs from 'fs-extra';
-import os from 'os';
-import path from 'path';
-import Docker from 'dockerode';
-import { Logger } from 'winston';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
+  GeneratorBase,
+  GeneratorBuilder,
+  getLastCommitTimestamp,
+  getLocationForEntity,
+  PreparerBase,
   PreparerBuilder,
   PublisherBase,
-  GeneratorBuilder,
-  PreparerBase,
-  GeneratorBase,
-  getLocationForEntity,
-  getLastCommitTimestamp,
 } from '@backstage/techdocs-common';
+import Docker from 'dockerode';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { Logger } from 'winston';
 import { BuildMetadataStorage } from '.';
 
 const getEntityId = (entity: Entity) => {
@@ -76,7 +76,9 @@ export class DocsBuilder {
 
   public async build() {
     this.logger.info(`Running preparer on entity ${getEntityId(this.entity)}`);
-    const preparedDir = await this.preparer.prepare(this.entity);
+    // TODO: This will throw an error if no further build is required, site is cached.
+    // TODO: Use etag from here and store in memory.
+    const { preparedDir } = await this.preparer.prepare(this.entity);
 
     const parsedLocationAnnotation = getLocationForEntity(this.entity);
 

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -141,7 +141,6 @@ export async function createRouter({
         dockerClient,
         logger,
         entity,
-        config,
       });
       switch (publisherType) {
         case 'local':

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -184,7 +184,7 @@ export async function createRouter({
             );
             // TODO: re-trigger build for cache invalidation.
             // Add build info in techdocs_metadata.json and compare it against
-            // the eTag/commit in the repository.
+            // the etag/commit in the repository.
             // Without this, docs will not be re-built once they have been generated.
             // Although it is unconventional that anyone will face this issue - because
             // if you have an external storage, you should be using CI/CD to build and publish docs.

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -13,23 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Logger } from 'winston';
-import Router from 'express-promise-router';
-import express from 'express';
-import Knex from 'knex';
-import fetch from 'cross-fetch';
-import { Config } from '@backstage/config';
-import Docker from 'dockerode';
-import {
-  GeneratorBuilder,
-  PreparerBuilder,
-  PublisherBase,
-  getLocationForEntity,
-} from '@backstage/techdocs-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
-import { getEntityNameFromUrlPath } from './helpers';
+import { Config } from '@backstage/config';
+import {
+  GeneratorBuilder,
+  getLocationForEntity,
+  PreparerBuilder,
+  PublisherBase,
+} from '@backstage/techdocs-common';
+import fetch from 'cross-fetch';
+import Docker from 'dockerode';
+import express from 'express';
+import Router from 'express-promise-router';
+import Knex from 'knex';
+import { Logger } from 'winston';
 import { DocsBuilder } from '../DocsBuilder';
+import { getEntityNameFromUrlPath } from './helpers';
 
 type RouterOptions = {
   preparers: PreparerBuilder;
@@ -145,9 +145,7 @@ export async function createRouter({
       });
       switch (publisherType) {
         case 'local':
-          if (!(await docsBuilder.docsUpToDate())) {
-            await docsBuilder.build();
-          }
+          await docsBuilder.build();
           break;
         case 'awsS3':
         case 'azureBlobStorage':
@@ -186,9 +184,11 @@ export async function createRouter({
               'Found pre-generated docs for this entity. Serving them.',
             );
             // TODO: re-trigger build for cache invalidation.
-            // Compare the date modified of the requested file on storage and compare it against
-            // the last modified or last commit timestamp in the repository.
+            // Add build info in techdocs_metadata.json and compare it against
+            // the eTag/commit in the repository.
             // Without this, docs will not be re-built once they have been generated.
+            // Although it is unconventional that anyone will face this issue - because
+            // if you have an external storage, you should be using CI/CD to build and publish docs.
           }
           break;
         default:


### PR DESCRIPTION
Closes #3548 
Closes #4011 (with cleanup of temp dirs)
Address #4409 partially with warnings

This PR accomplishes the following -

1. Previously sites built using URL Reader were cached for 30 minutes. Now, an `etag` will be stored and used for caching. Support for etag based caching was added to URL Reader in https://github.com/backstage/backstage/pull/4120
2. Throw warning when legacy git/dir preparer is used. See https://github.com/backstage/backstage/issues/4409 for reasons of doing so.
3. Clean up prepared and generated temporary directories once they are used. They used to occupy a lot of `/tmp` space over time.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
