### PR TITLE
bugfix: [3310] Favoriting a component resets interface to your owned components

### DIFF
--- a/.changeset/giant-kids-hear.md
+++ b/.changeset/giant-kids-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+bug fix: 3310 fixes reloading entities with the default owned filter

--- a/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
+++ b/plugins/catalog/src/components/CatalogFilter/CatalogFilter.tsx
@@ -81,6 +81,14 @@ type Props = {
 };
 
 /**
+ * Sidebar filter type and human readable label for it. owned/starred/all
+ */
+export type CatalogFilterType = {
+  id: string;
+  label: string;
+};
+
+/**
  * The main filter group in the sidebar, toggling owned/starred/all.
  */
 export const CatalogFilter = ({

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
@@ -30,7 +30,7 @@ import {
 } from '@backstage/core';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { MockStorageApi, wrapInTestApp } from '@backstage/test-utils';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { EntityFilterGroupsProvider } from '../../filter';
 import { CatalogPage } from './CatalogPage';
@@ -127,5 +127,25 @@ describe('CatalogPage', () => {
     expect(await findByText(/Owned \(1\)/)).toBeInTheDocument();
     fireEvent.click(getByText(/All/));
     expect(await findByText(/All \(2\)/)).toBeInTheDocument();
+  });
+  // this test is for fixing the bug after favoriting an entity, the matching entities defaulting
+  // to "owned" filter and not based on the selected filter
+  it('should render the correct entities filtered on the selectedfilter', async () => {
+    const { findByText, findAllByTitle, getByText } = renderWrapped(
+      <CatalogPage />,
+    );
+    expect(await findByText(/Owned \(1\)/)).toBeInTheDocument();
+    expect(await findByText(/Starred/)).toBeInTheDocument();
+    fireEvent.click(getByText(/Starred/));
+    expect(await findByText(/Starred \(0\)/)).toBeInTheDocument();
+    fireEvent.click(getByText(/All/));
+    expect(await findByText(/All \(2\)/)).toBeInTheDocument();
+
+    const starredIcons = await findAllByTitle('Add to favorites');
+    fireEvent.click(starredIcons[0]);
+    expect(await findByText(/All \(2\)/)).toBeInTheDocument();
+
+    fireEvent.click(getByText(/Starred/));
+    waitFor(() => expect(findByText(/Starred \(1\)/)).toBeInTheDocument());
   });
 });

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -31,7 +31,11 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { EntityFilterGroupsProvider, useFilteredEntities } from '../../filter';
 import { useStarredEntities } from '../../hooks/useStarredEntities';
-import { ButtonGroup, CatalogFilter } from '../CatalogFilter/CatalogFilter';
+import {
+  ButtonGroup,
+  CatalogFilter,
+  CatalogFilterType,
+} from '../CatalogFilter/CatalogFilter';
 import { CatalogTable } from '../CatalogTable/CatalogTable';
 import { ResultsFilter } from '../ResultsFilter/ResultsFilter';
 import { useOwnUser } from '../useOwnUser';
@@ -65,7 +69,9 @@ const CatalogPageContents = () => {
   const errorApi = useApi(errorApiRef);
   const { isStarredEntity } = useStarredEntities();
   const [selectedTab, setSelectedTab] = useState<string>();
-  const [selectedSidebarItem, setSelectedSidebarItem] = useState<string>();
+  const [selectedSidebarItem, setSelectedSidebarItem] = useState<
+    CatalogFilterType
+  >();
   const orgName = configApi.getOptionalString('organization.name') ?? 'Company';
 
   const addMockData = useCallback(async () => {
@@ -180,13 +186,15 @@ const CatalogPageContents = () => {
           <div>
             <CatalogFilter
               buttonGroups={filterGroups}
-              onChange={({ label }) => setSelectedSidebarItem(label)}
-              initiallySelected="owned"
+              onChange={({ label, id }) =>
+                setSelectedSidebarItem({ label, id })
+              }
+              initiallySelected={selectedSidebarItem?.id ?? 'owned'}
             />
             <ResultsFilter availableTags={availableTags} />
           </div>
           <CatalogTable
-            titlePreamble={selectedSidebarItem ?? ''}
+            titlePreamble={selectedSidebarItem?.label ?? ''}
             entities={matchingEntities}
             loading={loading}
             error={error}

--- a/plugins/catalog/src/filter/useEntityFilterGroup.ts
+++ b/plugins/catalog/src/filter/useEntityFilterGroup.ts
@@ -43,15 +43,19 @@ export const useEntityFilterGroup = (
     filterGroupStates,
   } = context;
 
-  // Intentionally consider initial set only at mount time
+  // on state changes unregisters and registers the filtergroup
+  // ensure that it re-registers with the correct filter as the prop changes and not the default
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const initialMemo = useMemo(() => initialSelectedFilters?.slice(), []);
+  const initialMemo = useMemo(() => {
+    return initialSelectedFilters?.slice();
+  }, [initialSelectedFilters]);
 
   // Register the group on mount, and unregister on unmount
   useEffect(() => {
     register(filterGroupId, filterGroup, initialMemo);
     return () => unregister(filterGroupId);
-  }, [register, unregister, filterGroupId, filterGroup, initialMemo]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [register, unregister, filterGroupId, filterGroup]);
 
   const setSelectedFilters = useCallback(
     (filters: string[]) => {


### PR DESCRIPTION
…components

## Hey, I just made a Pull Request!

[Closes #3310](https://github.com/backstage/backstage/issues/3310)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

**What:**
Favoriting a catalog entity would result in entites reloading with filter "owned" regardless of being on selectedfilter "Starred" or "All". The Sidebar filter would be correct, but not the list items and the items count (e.g. All(7) would display All(2) if the number of Owned Entities were "2")
**Why:**
When the `state` changes in the FilterGroups context provider, it causes `useEntityFilterGroup` to unregister. When it reregisters, it re-registered with the initiallySelected filter which was hardcoded to "owned"
**Fix:**
Pass the current selected filter up to Catalog Page and pass the selected filter as a prop
That way when state changes (entities are rebuilt), `useEntityFilterGroup` will use that value

Please let me know if there was a better way for a fix!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)



https://user-images.githubusercontent.com/43722865/107119223-3d4e1100-6854-11eb-9bfe-199dab3cbb8d.mov



