### PR TITLE
TechDocs: Add visibility to migrate away from basic setup

### DIFF
--- a/.changeset/metal-monkeys-do.md
+++ b/.changeset/metal-monkeys-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+TechDocs: Add comments about migrating away from basic setup in app-config.yaml

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -73,6 +73,9 @@ organization:
   name: My Company
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
+# Note: After experimenting with basic setup, use CI/CD to generate docs
+# and an external cloud storage when deploying TechDocs for production use-case.
+# https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
 techdocs:
   builder: 'local' # Alternatives - 'external'
   generators:

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -57,6 +57,9 @@ proxy:
     changeOrigin: true
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
+# Note: After experimenting with basic setup, use CI/CD to generate docs
+# and an external cloud storage when deploying TechDocs for production use-case.
+# https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
 techdocs:
   builder: 'local' # Alternatives - 'external'
   generators:


### PR DESCRIPTION
Adding a note in `app-config.yaml` improves visibility that what's shipped by default is only out-of-the-box setup and should not be used in production.