### PR TITLE
integration: update the gitlab config mandatory fields to match reality

### DIFF
--- a/.changeset/great-waves-reflect.md
+++ b/.changeset/great-waves-reflect.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-common': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Minor updates to reflect the changes in `@backstage/integration` that made the fields `apiBaseUrl` and `apiUrl` mandatory.

--- a/.changeset/pink-kids-bake.md
+++ b/.changeset/pink-kids-bake.md
@@ -1,0 +1,31 @@
+---
+'@backstage/integration': minor
+---
+
+Update the `GitLabIntegrationConfig` to require the fields `apiBaseUrl` and `baseUrl`. The `readGitLabIntegrationConfig` function is now more strict and has better error reporting. This change mirrors actual reality in code more properly - the fields are actually necessary for many parts of code to actually function, so they should no longer be optional.
+
+Some checks that used to happen deep inside code that consumed config, now happen upfront at startup. This means that you may encounter new errors at backend startup, if you had actual mistakes in config but didn't happen to exercise the code paths that actually would break. But for most users, no change will be necessary.
+
+An example minimal GitLab config block that just adds a token to public GitLab would look similar to this:
+
+```yaml
+integrations:
+  gitlab:
+    - host: gitlab.com
+      token:
+        $env: GITLAB_TOKEN
+```
+
+A full fledged config that points to a locally hosted GitLab could look like this:
+
+```yaml
+integrations:
+  gitlab:
+    - host: gitlab.my-company.com
+      apiBaseUrl: https://gitlab.my-company.com/api/v4
+      baseUrl: https://gitlab.my-company.com
+      token:
+        $env: OUR_GITLAB_TOKEN
+```
+
+In this case, the only optional field is `baseUrl` which is formed from the `host` if needed.

--- a/packages/backend-common/src/reading/GitlabUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.test.ts
@@ -36,6 +36,7 @@ const gitlabProcessor = new GitlabUrlReader(
   {
     host: 'gitlab.com',
     apiBaseUrl: 'https://gitlab.com/api/v4',
+    baseUrl: 'https://gitlab.com',
   },
   { treeResponseFactory },
 );
@@ -44,6 +45,7 @@ const hostedGitlabProcessor = new GitlabUrlReader(
   {
     host: 'gitlab.mycompany.com',
     apiBaseUrl: 'https://gitlab.mycompany.com/api/v4',
+    baseUrl: 'https://gitlab.mycompany.com',
   },
   { treeResponseFactory },
 );
@@ -378,18 +380,6 @@ describe('GitlabUrlReader', () => {
         );
       };
       await expect(fnGithub).rejects.toThrow(NotFoundError);
-    });
-
-    it('should throw error when apiBaseUrl is missing', () => {
-      expect(() => {
-        /* eslint-disable no-new */
-        new GitlabUrlReader(
-          {
-            host: 'gitlab.mycompany.com',
-          },
-          { treeResponseFactory },
-        );
-      }).toThrowError('must configure an explicit apiBaseUrl');
     });
   });
 });

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -51,12 +51,6 @@ export class GitlabUrlReader implements UrlReader {
     deps: { treeResponseFactory: ReadTreeResponseFactory },
   ) {
     this.treeResponseFactory = deps.treeResponseFactory;
-
-    if (!config.apiBaseUrl) {
-      throw new Error(
-        `GitLab integration for '${config.host}' must configure an explicit apiBaseUrl`,
-      );
-    }
   }
 
   async read(url: string): Promise<Buffer> {

--- a/packages/integration/src/gitlab/GitLabIntegration.test.ts
+++ b/packages/integration/src/gitlab/GitLabIntegration.test.ts
@@ -26,6 +26,8 @@ describe('GitLabIntegration', () => {
             {
               host: 'h.com',
               token: 't',
+              apiBaseUrl: 'https://h.com/api/v4',
+              baseUrl: 'https://h.com',
             },
           ],
         },

--- a/packages/integration/src/gitlab/config.test.ts
+++ b/packages/integration/src/gitlab/config.test.ts
@@ -31,6 +31,7 @@ describe('readGitLabIntegrationConfig', () => {
       buildConfig({
         host: 'a.com',
         token: 't',
+        apiBaseUrl: 'https://a.com',
         baseUrl: 'https://baseurl.for.me/gitlab',
       }),
     );
@@ -38,12 +39,15 @@ describe('readGitLabIntegrationConfig', () => {
     expect(output).toEqual({
       host: 'a.com',
       token: 't',
+      apiBaseUrl: 'https://a.com',
       baseUrl: 'https://baseurl.for.me/gitlab',
     });
   });
 
   it('inserts the defaults if missing', () => {
-    const output = readGitLabIntegrationConfig(buildConfig({}));
+    const output = readGitLabIntegrationConfig(
+      buildConfig({ host: 'gitlab.com' }),
+    );
     expect(output).toEqual({
       host: 'gitlab.com',
       apiBaseUrl: 'https://gitlab.com/api/v4',
@@ -88,12 +92,15 @@ describe('readGitLabIntegrationConfigs', () => {
         {
           host: 'a.com',
           token: 't',
+          apiBaseUrl: 'https://a.com/api/v4',
+          baseUrl: 'https://a.com',
         },
       ]),
     );
     expect(output).toContainEqual({
       host: 'a.com',
       token: 't',
+      apiBaseUrl: 'https://a.com/api/v4',
       baseUrl: 'https://a.com',
     });
   });
@@ -104,6 +111,7 @@ describe('readGitLabIntegrationConfigs', () => {
       {
         host: 'gitlab.com',
         apiBaseUrl: 'https://gitlab.com/api/v4',
+        baseUrl: 'https://gitlab.com',
       },
     ]);
   });

--- a/packages/integration/src/gitlab/core.test.ts
+++ b/packages/integration/src/gitlab/core.test.ts
@@ -37,10 +37,14 @@ describe('gitlab core', () => {
   const configWithToken: GitLabIntegrationConfig = {
     host: 'g.com',
     token: '0123456789',
+    apiBaseUrl: '<ignored>',
+    baseUrl: '<ignored>',
   };
 
   const configWithNoToken: GitLabIntegrationConfig = {
     host: 'g.com',
+    apiBaseUrl: '<ignored>',
+    baseUrl: '<ignored>',
   };
 
   describe('getGitLabFileFetchUrl', () => {

--- a/packages/integration/src/helpers.ts
+++ b/packages/integration/src/helpers.ts
@@ -16,11 +16,22 @@
 
 import { ScmIntegration, ScmIntegrationsGroup } from './types';
 
-/** Checks whether the given url is a valid host */
-export function isValidHost(url: string): boolean {
+/** Checks whether the given argument is a valid URL hostname */
+export function isValidHost(host: string): boolean {
   const check = new URL('http://example.com');
-  check.host = url;
-  return check.host === url;
+  check.host = host;
+  return check.host === host;
+}
+
+/** Checks whether the given argument is a valid URL */
+export function isValidUrl(url: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function basicIntegrations<T extends ScmIntegration>(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/gitlab.test.ts
@@ -37,8 +37,10 @@ describe('GitLabPreparer', () => {
     jest.clearAllMocks();
   });
   const preparer = GitlabPreparer.fromConfig({
-    host: 'gitlab.com',
+    host: '<ignored>',
     token: 'fake-token',
+    apiBaseUrl: '<ignored>',
+    baseUrl: '<ignored>',
   });
 
   it(`calls the clone command with the correct arguments for a repository`, async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/gitlab.test.ts
@@ -57,6 +57,7 @@ describe('GitLab Publisher', () => {
       const publisher = await GitlabPublisher.fromConfig(
         {
           host: 'gitlab.com',
+          apiBaseUrl: 'https://gitlab.com/api/v4',
           token: 'fake-token',
           baseUrl: 'https://gitlab.hosted.com',
         },
@@ -105,7 +106,9 @@ describe('GitLab Publisher', () => {
       const publisher = await GitlabPublisher.fromConfig(
         {
           host: 'gitlab.com',
+          apiBaseUrl: 'https://gitlab.com/api/v4',
           token: 'fake-token',
+          baseUrl: 'https://gitlab.com',
         },
         { repoVisibility: 'public' },
       );

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/publishers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/publishers.ts
@@ -126,6 +126,8 @@ export class Publishers implements PublisherBuilder {
             {
               token: config.getOptionalString('scaffolder.gitlab.token') ?? '',
               host: integration.config.host,
+              apiBaseUrl: `<ignored>`,
+              baseUrl: `https://${integration.config.host}`,
             },
             { repoVisibility },
           ),


### PR DESCRIPTION
As a response to https://discord.com/channels/687207715902193673/687207715902193679/808192034359345153.

This one is a bit tricky in terms of deprecation notice time. The corresponding change could be done for at least bitbucket too.