### PR TITLE
Make sure that SidebarItems are also active when on sub route

### DIFF
--- a/.changeset/thick-scissors-notice.md
+++ b/.changeset/thick-scissors-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Make sure that SidebarItems are also active when on sub route.

--- a/packages/core/src/layout/Sidebar/Items.tsx
+++ b/packages/core/src/layout/Sidebar/Items.tsx
@@ -215,7 +215,6 @@ export const SidebarItem = forwardRef<any, SidebarItemProps>((props, ref) => {
       {...childProps}
       activeClassName={classes.selected}
       to={props.to}
-      end
       ref={ref}
     >
       {content}


### PR DESCRIPTION
While introducing the tabbed layout to the explore plugin, I noticed that it doesn't play well with the sidebar. The sidebar uses `<NavLink>` to mark the active navigation item. Till now we used `end` to do an exact match. This means that if I'm on `/catalog` the home icon is active and if I'm at `/explore` the explore icon is active. But if I click on a tab in explore, like domains the route is `/explore/domains` and the sidebar item looses its active state. Same goes for the catalog, once I'm in an entity page, the home icon is not considered as active anymore.

This might be a matter of taste, but it feels strange that I can be on a route without seeing which sidebar item I'm in. Are there any risks with this approach?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
