### PR TITLE
fix: Whitespace in unregister error dialog box

### DIFF
--- a/.changeset/purple-brooms-trade.md
+++ b/.changeset/purple-brooms-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fix whitespace around variable in unregister error dialog box

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -249,6 +249,7 @@ transpilation
 Tuite
 ui
 unmanaged
+unregister
 untracked
 upvote
 url

--- a/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -110,7 +110,7 @@ export const UnregisterEntityDialog = ({
             {error.name === 'DeniedLocationException' ? (
               <>
                 You cannot unregister this entity, since it originates from a
-                protected Backstage configuration (location
+                protected Backstage configuration (location{' '}
                 {`"${(error as DeniedLocationException).locationName}"`}). If
                 you believe this is in error, please contact the{' '}
                 {configApi.getOptionalString('app.title') ?? 'Backstage'}{' '}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Minor whitespace issue around a displayed variable when unregistering an entity that isn't allowed to be.  Note I could have squeezed the space on the next line, but chose to leave `{' '}` separately to help improve code readability for why it's there.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33203301/107273866-a339c480-6a1d-11eb-834d-7b5d8b23cc1b.png)| ![image](https://user-images.githubusercontent.com/33203301/107273679-5fdf5600-6a1d-11eb-9ed5-c66b2ee29e11.png) |



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
