### PR TITLE
feat: Improve Jenkins duration to show as relative time units

### DIFF
--- a/.changeset/hip-pets-sell.md
+++ b/.changeset/hip-pets-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins': patch
+---
+
+Improve display of duration in latest build card

--- a/plugins/jenkins/src/components/Cards/Cards.tsx
+++ b/plugins/jenkins/src/components/Cards/Cards.tsx
@@ -40,13 +40,13 @@ const WidgetContent = ({
   const classes = useStyles();
   if (loading || !latestRun) return <LinearProgress />;
   const displayDate = DateTime.fromMillis(latestRun.timestamp).toRelative();
-  // TODO This works, but hard codes as minutes. Would prefer something smarter/relative.
-  const durationInMinutes = Math.round(
-    Duration.fromMillis(latestRun.duration).as('minutes'),
-  );
-  const displayDuration = `${durationInMinutes} minute${
-    durationInMinutes > 1 ? 's' : ''
-  }`;
+  const displayDuration =
+    (latestRun.building ? 'Running for ' : '') +
+    DateTime.local()
+      .minus(Duration.fromMillis(latestRun.duration))
+      .toRelative()
+      ?.replace(' ago', '');
+
   return (
     <StructuredMetadataTable
       metadata={{

--- a/plugins/jenkins/src/components/Cards/Cards.tsx
+++ b/plugins/jenkins/src/components/Cards/Cards.tsx
@@ -44,7 +44,7 @@ const WidgetContent = ({
     (latestRun.building ? 'Running for ' : '') +
     DateTime.local()
       .minus(Duration.fromMillis(latestRun.duration))
-      .toRelative()
+      .toRelative({ locale: "en" })
       ?.replace(' ago', '');
 
   return (

--- a/plugins/jenkins/src/components/Cards/Cards.tsx
+++ b/plugins/jenkins/src/components/Cards/Cards.tsx
@@ -44,7 +44,7 @@ const WidgetContent = ({
     (latestRun.building ? 'Running for ' : '') +
     DateTime.local()
       .minus(Duration.fromMillis(latestRun.duration))
-      .toRelative({ locale: "en" })
+      .toRelative({ locale: 'en' })
       ?.replace(' ago', '');
 
   return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Removes a TODO where currently the Jenkins plugin only displays duration in minutes, by using Luxon to better display the Jenkins duration as fully relative.  Uses a quick hack to strip out the " ago" from the resulting Luxon `toRelative()` call, so welcome smarter approaches!

![image](https://user-images.githubusercontent.com/33203301/107298930-5b7a6380-6a44-11eb-8e46-fcc33b122939.png)

![image](https://user-images.githubusercontent.com/33203301/107299004-82d13080-6a44-11eb-8e3d-b748119e462f.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
