### PR TITLE
Add indices on columns referring locations(id). Refs #4406

### DIFF
--- a/.changeset/large-penguins-rescue.md
+++ b/.changeset/large-penguins-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+add indices on columns referring locations(id)

--- a/plugins/catalog-backend/migrations/20210209121210_locations_fk_index.js
+++ b/plugins/catalog-backend/migrations/20210209121210_locations_fk_index.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.up = async function up(knex) {
+  if (knex.client.config.client !== 'sqlite3') {
+    await knex.schema.alterTable('entities', table => {
+      table.index('location_id', 'entity_location_id_idx');
+    });
+    await knex.schema.alterTable('location_update_log', table => {
+      table.index('location_id', 'update_log_location_id_idx');
+    });
+  }
+};
+
+/**
+ * @param {import('knex')} knex
+ */
+exports.down = async function down(knex) {
+  if (knex.client.config.client !== 'sqlite3') {
+    await knex.schema.alterTable('entities', table => {
+      table.dropIndex([], 'entity_location_id_idx');
+    });
+    await knex.schema.alterTable('location_update_log', table => {
+      table.dropIndex([], 'update_log_location_id_idx');
+    });
+  }
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Adds a migration in `plugin-catalog-backend`  that creates indices on `entities(location_id)` and 
`location_update_log(location_id)`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
