### PR TITLE
Fix: Pass registered Logger in ServiceBuilderImpl to requestLoggingHandler

### DIFF
--- a/.changeset/afraid-dingos-own.md
+++ b/.changeset/afraid-dingos-own.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+pass registered logger to requestLoggingHandler

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -161,7 +161,7 @@ export class ServiceBuilderImpl implements ServiceBuilder {
       app.use(cors(corsOptions));
     }
     app.use(compression());
-    app.use(requestLoggingHandler());
+    app.use(requestLoggingHandler(logger));
     for (const [root, route] of this.routers) {
       app.use(root, route);
     }


### PR DESCRIPTION
`requestLoggingHandler` takes an optional `logger` parameter that it can use
to log incoming requests. The `ServiceBuilderImpl` was not passing  on this logger, if
set, to `requestLoggingHandler` middleware

## Hey, I just made a Pull Request!

Not tied to any Filed issue, but I noticeed that [ServiceBuilderImpl](
https://github.com/backstage/backstage/blob/3fc684738df54ee97d7e63fb599425acbeac4924/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts#L164) was not passing on the registered `Loggeer` in its instance to [requestLoggingHandler](https://github.com/backstage/backstage/blob/3fc684738df54ee97d7e63fb599425acbeac4924/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts#L164).

The `rootLogger` , returned by `getRootLogger` outputs colorized text (via ANSI escape codes). This is a problem for our log monitoring services as they do not parse  ANSI escape codes and we had setup a custom `Formatter` without colorized output, which was not getting honoured, thus leading to discovering this issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
