### PR TITLE
explore: Add error trapping for catalog failures

### DIFF
--- a/.changeset/seven-pants-relate.md
+++ b/.changeset/seven-pants-relate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Catch catalog errors and display to user

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -90,4 +90,17 @@ describe('<DomainExplorerContent />', () => {
       expect(getByText('No domains to display')).toBeInTheDocument(),
     );
   });
+
+  it('renders a friendly error if it cannot collect domains', async () => {
+    const catalogError = new Error('Network timeout');
+    catalogApi.getEntities.mockRejectedValueOnce(catalogError);
+
+    const { getByText } = render(<DomainExplorerContent />, {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() =>
+      expect(getByText(/Could not load domains/)).toBeInTheDocument(),
+    );
+  });
 });

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.tsx
@@ -21,6 +21,7 @@ import {
   Progress,
   SupportButton,
   useApi,
+  WarningPanel,
 } from '@backstage/core';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { Button } from '@material-ui/core';
@@ -30,7 +31,7 @@ import { DomainCardGrid } from '../DomainCard';
 
 export const DomainExplorerContent = () => {
   const catalogApi = useApi(catalogApiRef);
-  const { value: entities, loading } = useAsync(async () => {
+  const { value: entities, loading, error } = useAsync(async () => {
     const response = await catalogApi.getEntities({
       filter: { kind: 'domain' },
     });
@@ -45,7 +46,12 @@ export const DomainExplorerContent = () => {
       </ContentHeader>
 
       {loading && <Progress />}
-      {!loading && (!entities || entities.length === 0) && (
+      {error && (
+        <WarningPanel severity="error" title="Could not load domains.">
+          {error.message}
+        </WarningPanel>
+      )}
+      {!loading && !error && (!entities || entities.length === 0) && (
         <EmptyState
           missing="info"
           title="No domains to display"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

If the catalogApi fails to respond, print a message to the user. This is a bit different than suggesting you have not added any domains. (which could cause a team to say, "Wait a second, yes I have? i was just looking at them yesterday")

In this example below, my database is down.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33203301/107406372-5d8d0280-6ad6-11eb-8dad-5f8a58239393.png) |  ![image](https://user-images.githubusercontent.com/33203301/107406256-3f270700-6ad6-11eb-9052-788819bee816.png) |


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
