### PR TITLE
Flatten the options of the CatalogImportPage

### DIFF
--- a/.changeset/afraid-rings-taste.md
+++ b/.changeset/afraid-rings-taste.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Flatten the options of the `CatalogImportPage` from the `options` property to the `pullRequest` property.
+
+```diff
+- <CatalogImportPage options={{ pullRequest: { disable: true } }} />
++ <CatalogImportPage pullRequest={{ disable: true }} />
+```

--- a/plugins/catalog-import/README.md
+++ b/plugins/catalog-import/README.md
@@ -52,7 +52,7 @@ The pull request feature can be disabled by options that are passed to the `Cata
 
 <Route
   path="/catalog-import"
-  element={<CatalogImportPage options={{ pullRequest: { disable: true } }} />}
+  element={<CatalogImportPage pullRequest={{ disable: true }} />}
 />
 ```
 
@@ -68,13 +68,11 @@ This can be configured by options that are passed to the `CatalogImportPage`:
   path="/catalog-import"
   element={
     <CatalogImportPage
-      options={{
-        pullRequest: {
-          preparePullRequest: () => ({
-            title: 'My title',
-            body: 'My **markdown** body',
-          }),
-        },
+      pullRequest={{
+        preparePullRequest: () => ({
+          title: 'My title',
+          body: 'My **markdown** body',
+        }),
       }}
     />
   }

--- a/plugins/catalog-import/src/components/ImportComponentPage.tsx
+++ b/plugins/catalog-import/src/components/ImportComponentPage.tsx
@@ -48,11 +48,7 @@ function repositories(configApi: ConfigApi): string[] {
   return repos;
 }
 
-export const ImportComponentPage = ({
-  opts,
-}: {
-  opts?: StepperProviderOpts;
-}) => {
+export const ImportComponentPage = (opts: StepperProviderOpts) => {
   const configApi = useApi(configApiRef);
   const appTitle = configApi.getOptional('app.title') || 'Backstage';
 

--- a/plugins/catalog-import/src/components/Router.tsx
+++ b/plugins/catalog-import/src/components/Router.tsx
@@ -19,8 +19,8 @@ import { Route, Routes } from 'react-router-dom';
 import { ImportComponentPage } from './ImportComponentPage';
 import { StepperProviderOpts } from './ImportStepper/defaults';
 
-export const Router = ({ options }: { options?: StepperProviderOpts }) => (
+export const Router = (opts: StepperProviderOpts) => (
   <Routes>
-    <Route element={<ImportComponentPage opts={options} />} />
+    <Route element={<ImportComponentPage {...opts} />} />
   </Routes>
 );


### PR DESCRIPTION
@Rugvip noticed that it might be better to flatten the props of the `CatalogImportPage` https://github.com/backstage/backstage/pull/4271#discussion_r573657244. `pullRequestOpts` could be an alternative to `pullRequest`. We could also flatten them one more layer, but I think I like the grouping of all options for the pull request functionality more.

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
