### PR TITLE
Default dismiss form bugfix

### DIFF
--- a/.changeset/cost-insights-kind-moons-clap.md
+++ b/.changeset/cost-insights-kind-moons-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+fixes a bug in default dismiss form where other text input persists between reason selections

--- a/plugins/cost-insights/src/forms/AlertDismissForm.tsx
+++ b/plugins/cost-insights/src/forms/AlertDismissForm.tsx
@@ -66,6 +66,9 @@ export const AlertDismissForm = forwardRef<
   };
 
   const onReasonChange = (_: ChangeEvent<HTMLInputElement>, value: string) => {
+    if (other) {
+      setOther(null);
+    }
     setReason(value as AlertDismissReason);
   };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a bug in the default dismiss form where "Other" text input would persist between reason selections.

### Before
![dismiss-form-other-bug](https://user-images.githubusercontent.com/3030003/107542598-59c0b500-6b96-11eb-92c2-948863f4aa7c.gif)

### After
![dismiss-form-other-fix](https://user-images.githubusercontent.com/3030003/107542629-6218f000-6b96-11eb-8cde-a47eb56dd615.gif)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
