### PR TITLE
tech-radar, cost-insights, sentry: migrate to new composability API

### DIFF
--- a/.changeset/gentle-bags-bathe.md
+++ b/.changeset/gentle-bags-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sentry': patch
+---
+
+Export the plugin instance as `sentryPlugin`. The plugin instance is still exported as `plugin` as well, but it will be removed in the future.

--- a/.changeset/orange-carrots-care.md
+++ b/.changeset/orange-carrots-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Migrated to new composability API, exporting the plugin instance as `costInsightsPlugin`, the root `'/cost-insights'` page as `CostInsightsPage`, the `'/cost-insights/investigating-growth'` page as `CostInsightsProjectGrowthInstructionsPage`, and the `'/cost-insights/labeling-jobs'` page as `CostInsightsLabelDataflowInstructionsPage`.

--- a/.changeset/witty-humans-arrive.md
+++ b/.changeset/witty-humans-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Migrated to new composability API, exporting the plugin instance as `techRadarPlugin` and the page as `TechRadarPage`.

--- a/docs/api/utility-apis.md
+++ b/docs/api/utility-apis.md
@@ -119,7 +119,7 @@ Plugins supply their APIs through the `apis` option of `createPlugin`, for
 example:
 
 ```ts
-export const plugin = createPlugin({
+export const techdocsPlugin = createPlugin({
   id: 'techdocs',
   apis: [
     createApiFactory({

--- a/plugins/cost-insights/dev/index.tsx
+++ b/plugins/cost-insights/dev/index.tsx
@@ -16,10 +16,10 @@
 import { createDevApp } from '@backstage/dev-utils';
 import { costInsightsApiRef } from '../src/api';
 import { ExampleCostInsightsClient } from '../src/client';
-import { plugin } from '../src/plugin';
+import { costInsightsPlugin } from '../src/plugin';
 
 createDevApp()
-  .registerPlugin(plugin)
+  .registerPlugin(costInsightsPlugin)
   .registerApi({
     api: costInsightsApiRef,
     deps: {},

--- a/plugins/cost-insights/src/index.ts
+++ b/plugins/cost-insights/src/index.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-export { plugin } from './plugin';
+export {
+  costInsightsPlugin,
+  costInsightsPlugin as plugin,
+  CostInsightsPage,
+  CostInsightsProjectGrowthInstructionsPage,
+  CostInsightsLabelDataflowInstructionsPage,
+} from './plugin';
 export * from './client';
 export * from './api';
 export { ProjectGrowthAlert, UnlabeledDataflowAlert } from './alerts';

--- a/plugins/cost-insights/src/plugin.test.ts
+++ b/plugins/cost-insights/src/plugin.test.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { plugin } from './plugin';
+import { costInsightsPlugin } from './plugin';
 
 describe('cost-insights', () => {
   it('should export plugin', () => {
-    expect(plugin).toBeDefined();
+    expect(costInsightsPlugin).toBeDefined();
   });
 });

--- a/plugins/cost-insights/src/plugin.ts
+++ b/plugins/cost-insights/src/plugin.ts
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-import { createPlugin, createRouteRef } from '@backstage/core';
-import { CostInsightsPage } from './components/CostInsightsPage';
-import { ProjectGrowthInstructionsPage } from './components/ProjectGrowthInstructionsPage';
-import { LabelDataflowInstructionsPage } from './components/LabelDataflowInstructionsPage';
+import {
+  createPlugin,
+  createRouteRef,
+  createRoutableExtension,
+} from '@backstage/core';
+import { CostInsightsPage as CostInsightsPageComponent } from './components/CostInsightsPage';
+import { ProjectGrowthInstructionsPage as ProjectGrowthInstructionsPageComponent } from './components/ProjectGrowthInstructionsPage';
+import { LabelDataflowInstructionsPage as LabelDataflowInstructionsPageComponent } from './components/LabelDataflowInstructionsPage';
 
 export const rootRouteRef = createRouteRef({
   path: '/cost-insights',
@@ -34,12 +38,51 @@ export const unlabeledDataflowAlertRef = createRouteRef({
   title: 'Labeling Dataflow Jobs',
 });
 
-export const plugin = createPlugin({
+export const costInsightsPlugin = createPlugin({
   id: 'cost-insights',
   register({ router, featureFlags }) {
-    router.addRoute(rootRouteRef, CostInsightsPage);
-    router.addRoute(projectGrowthAlertRef, ProjectGrowthInstructionsPage);
-    router.addRoute(unlabeledDataflowAlertRef, LabelDataflowInstructionsPage);
+    router.addRoute(rootRouteRef, CostInsightsPageComponent);
+    router.addRoute(
+      projectGrowthAlertRef,
+      ProjectGrowthInstructionsPageComponent,
+    );
+    router.addRoute(
+      unlabeledDataflowAlertRef,
+      LabelDataflowInstructionsPageComponent,
+    );
     featureFlags.register('cost-insights-currencies');
   },
+  routes: {
+    root: rootRouteRef,
+    growthAlerts: projectGrowthAlertRef,
+    unlabeledDataflowAlerts: unlabeledDataflowAlertRef,
+  },
 });
+
+export const CostInsightsPage = costInsightsPlugin.provide(
+  createRoutableExtension({
+    component: () =>
+      import('./components/CostInsightsPage').then(m => m.CostInsightsPage),
+    mountPoint: rootRouteRef,
+  }),
+);
+
+export const CostInsightsProjectGrowthInstructionsPage = costInsightsPlugin.provide(
+  createRoutableExtension({
+    component: () =>
+      import('./components/ProjectGrowthInstructionsPage').then(
+        m => m.ProjectGrowthInstructionsPage,
+      ),
+    mountPoint: projectGrowthAlertRef,
+  }),
+);
+
+export const CostInsightsLabelDataflowInstructionsPage = costInsightsPlugin.provide(
+  createRoutableExtension({
+    component: () =>
+      import('./components/LabelDataflowInstructionsPage').then(
+        m => m.LabelDataflowInstructionsPage,
+      ),
+    mountPoint: unlabeledDataflowAlertRef,
+  }),
+);

--- a/plugins/sentry/src/extensions.tsx
+++ b/plugins/sentry/src/extensions.tsx
@@ -20,9 +20,9 @@ import {
 } from '@backstage/core';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import React from 'react';
-import { plugin, rootRouteRef } from './plugin';
+import { sentryPlugin, rootRouteRef } from './plugin';
 
-export const EntitySentryContent = plugin.provide(
+export const EntitySentryContent = sentryPlugin.provide(
   createRoutableExtension({
     mountPoint: rootRouteRef,
     component: () =>
@@ -38,7 +38,7 @@ export const EntitySentryContent = plugin.provide(
   }),
 );
 
-export const EntitySentryCard = plugin.provide(
+export const EntitySentryCard = sentryPlugin.provide(
   createComponentExtension({
     component: {
       lazy: () =>

--- a/plugins/sentry/src/index.ts
+++ b/plugins/sentry/src/index.ts
@@ -16,6 +16,6 @@
 
 export * from './api';
 export * from './components';
-export { plugin } from './plugin';
+export { sentryPlugin, sentryPlugin as plugin } from './plugin';
 export { EntitySentryCard, EntitySentryContent } from './extensions';
 export { Router } from './components/Router';

--- a/plugins/sentry/src/plugin.test.ts
+++ b/plugins/sentry/src/plugin.test.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { plugin } from './plugin';
+import { sentryPlugin } from './plugin';
 
 describe('sentry', () => {
   it('should export plugin', () => {
-    expect(plugin).toBeDefined();
+    expect(sentryPlugin).toBeDefined();
   });
 });

--- a/plugins/sentry/src/plugin.ts
+++ b/plugins/sentry/src/plugin.ts
@@ -28,7 +28,7 @@ export const rootRouteRef = createRouteRef({
   title: 'Sentry',
 });
 
-export const plugin = createPlugin({
+export const sentryPlugin = createPlugin({
   id: 'sentry',
   apis: [
     createApiFactory({

--- a/plugins/tech-radar/dev/index.tsx
+++ b/plugins/tech-radar/dev/index.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
-import { plugin } from '../src';
+import { techRadarPlugin, TechRadarPage } from '../src';
 
-createDevApp().registerPlugin(plugin).render();
+createDevApp()
+  .registerPlugin(techRadarPlugin)
+  .addPage({
+    title: 'Tech Radar',
+    element: <TechRadarPage width={1280} height={720} />,
+  })
+  .render();

--- a/plugins/tech-radar/src/index.ts
+++ b/plugins/tech-radar/src/index.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-export { plugin } from './plugin';
+export {
+  techRadarPlugin,
+  techRadarPlugin as plugin,
+  TechRadarPage,
+} from './plugin';
 
 export { RadarPage as Router } from './components/RadarPage';
 

--- a/plugins/tech-radar/src/plugin.test.ts
+++ b/plugins/tech-radar/src/plugin.test.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { plugin } from './plugin';
+import { techRadarPlugin } from './plugin';
 
 describe('tech-radar', () => {
   it('should export plugin', () => {
-    expect(plugin).toBeDefined();
+    expect(techRadarPlugin).toBeDefined();
   });
 });

--- a/plugins/tech-radar/src/plugin.ts
+++ b/plugins/tech-radar/src/plugin.ts
@@ -14,8 +14,26 @@
  * limitations under the License.
  */
 
-import { createPlugin } from '@backstage/core';
+import {
+  createPlugin,
+  createRouteRef,
+  createRoutableExtension,
+} from '@backstage/core';
 
-export const plugin = createPlugin({
-  id: 'tech-radar',
+const rootRouteRef = createRouteRef({
+  title: 'Tech Radar',
 });
+
+export const techRadarPlugin = createPlugin({
+  id: 'tech-radar',
+  routes: {
+    root: rootRouteRef,
+  },
+});
+
+export const TechRadarPage = techRadarPlugin.provide(
+  createRoutableExtension({
+    component: () => import('./components/RadarPage').then(m => m.RadarPage),
+    mountPoint: rootRouteRef,
+  }),
+);


### PR DESCRIPTION
Final piece towards #3424, which will now allow us to start porting apps and using the route refs :grin: