### PR TITLE
Add option to truncate title to bar chart tooltips

### DIFF
--- a/.changeset/cost-insights-cold-bulldogs-clean.md
+++ b/.changeset/cost-insights-cold-bulldogs-clean.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Fix tooltip title truncation with no way to view full title

--- a/plugins/cost-insights/src/components/BarChart/BarChartTooltip.tsx
+++ b/plugins/cost-insights/src/components/BarChart/BarChartTooltip.tsx
@@ -38,12 +38,12 @@ export const BarChartTooltip = ({
   children,
 }: PropsWithChildren<BarChartTooltipProps>) => {
   const classes = useStyles();
-  const titleClassName = classnames(
-    classes.maxWidth,
-    { [classes.fullTitle]: !truncateTitle },
-    { [classes.truncate]: truncateTitle },
-  );
-
+  const truncateClassName = truncateTitle
+    ? classes.truncate
+    : classes.fullTitle;
+  const titleClassName = classnames(truncateClassName, {
+    [classes.maxWidth]: topRight === undefined,
+  });
   return (
     <Box className={classes.tooltip} display="flex" flexDirection="column">
       <Box

--- a/plugins/cost-insights/src/components/BarChart/BarChartTooltip.tsx
+++ b/plugins/cost-insights/src/components/BarChart/BarChartTooltip.tsx
@@ -21,6 +21,7 @@ import { useTooltipStyles as useStyles } from '../../utils/styles';
 
 export type BarChartTooltipProps = {
   title: string;
+  truncateTitle?: boolean;
   content?: ReactNode | string;
   subtitle?: ReactNode;
   topRight?: ReactNode;
@@ -29,6 +30,7 @@ export type BarChartTooltipProps = {
 
 export const BarChartTooltip = ({
   title,
+  truncateTitle = false,
   content,
   subtitle,
   topRight,
@@ -36,9 +38,11 @@ export const BarChartTooltip = ({
   children,
 }: PropsWithChildren<BarChartTooltipProps>) => {
   const classes = useStyles();
-  const titleClassName = classnames(classes.truncate, {
-    [classes.maxWidth]: topRight === undefined,
-  });
+  const titleClassName = classnames(
+    classes.maxWidth,
+    { [classes.fullTitle]: !truncateTitle },
+    { [classes.truncate]: truncateTitle },
+  );
 
   return (
     <Box className={classes.tooltip} display="flex" flexDirection="column">

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsChart.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsChart.tsx
@@ -146,6 +146,7 @@ export const ProductInsightsChart = ({
       return (
         <BarChartTooltip
           title={title}
+          truncateTitle
           subtitle={subtitle}
           topRight={
             <CostGrowthIndicator

--- a/plugins/cost-insights/src/utils/styles.ts
+++ b/plugins/cost-insights/src/utils/styles.ts
@@ -445,6 +445,9 @@ export const useTooltipStyles = makeStyles<CostInsightsTheme>(
         overflow: 'hidden',
         textOverflow: 'ellipsis',
       },
+      fullTitle: {
+        overflowWrap: 'anywhere',
+      },
       subtitle: {
         fontStyle: 'italic',
       },

--- a/plugins/cost-insights/src/utils/styles.ts
+++ b/plugins/cost-insights/src/utils/styles.ts
@@ -446,6 +446,7 @@ export const useTooltipStyles = makeStyles<CostInsightsTheme>(
         textOverflow: 'ellipsis',
       },
       fullTitle: {
+        maxWidth: 200,
         overflowWrap: 'anywhere',
       },
       subtitle: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Fixes issue where there's no way to see the full id for entities with looong names. This mainly surfaces in alerts, where there's no breakdown modal (unlike the product panels) where we surface the full name. The solution here is to add an optional `truncateTitle` prop to bar chart tooltips which defaults to false. We should only truncate in the tooltip if there's an alternate way to view the full name (i.e. product panels for entities w/ sub-entities).

Alternate
Also considered making it so that alerts could have a breakdown modal similar to product panels, but decided against it since we wouldn't actually be surfacing any extra information other than the full entity name. 
**Before** 
<img width="673" alt="Screen Shot 2021-02-10 at 3 11 11 PM" src="https://user-images.githubusercontent.com/22461662/107566141-81be1180-6bb2-11eb-9c30-aeb916b15eb9.png">


**Long title - no cost indicator or entity breakdown** 
<img width="459" alt="Screen Shot 2021-02-10 at 3 49 46 PM" src="https://user-images.githubusercontent.com/22461662/107570573-b84a5b00-6bb7-11eb-9a88-553535f0049f.png">


**Long title - w/ cost indicator + entity breakdown**
<img width="373" alt="Screen Shot 2021-02-10 at 3 50 08 PM" src="https://user-images.githubusercontent.com/22461662/107570594-bf716900-6bb7-11eb-834b-d584b0a50fce.png">


**Long title - w/ cost indicator, no entity breakdown**
<img width="361" alt="Screen Shot 2021-02-10 at 3 50 00 PM" src="https://user-images.githubusercontent.com/22461662/107570610-c8fad100-6bb7-11eb-9068-1129bba64d8f.png">

**Normal title - no cost indicator or entity breakdown** 
<img width="463" alt="Screen Shot 2021-02-10 at 3 51 55 PM" src="https://user-images.githubusercontent.com/22461662/107570779-fe072380-6bb7-11eb-8819-2b7541b42e2d.png">

**Normal title - w/ cost indicator + entity breakdown**
<img width="391" alt="Screen Shot 2021-02-10 at 3 52 07 PM" src="https://user-images.githubusercontent.com/22461662/107570814-09f2e580-6bb8-11eb-8745-bb5a0955e12d.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
