### PR TITLE
fix(catalog): entity links incorrect wrapping

### DIFF
--- a/plugins/catalog/src/components/EntityLinksCard/LinksGridList.tsx
+++ b/plugins/catalog/src/components/EntityLinksCard/LinksGridList.tsx
@@ -15,7 +15,7 @@
  */
 
 import { IconComponent } from '@backstage/core';
-import { Grid, GridList, GridListTile } from '@material-ui/core';
+import { GridList, GridListTile } from '@material-ui/core';
 import React from 'react';
 import { IconLink } from './IconLink';
 import { ColumnBreakpoints } from './types';
@@ -36,21 +36,12 @@ export const LinksGridList = ({ items, cols = undefined }: Props) => {
   const numOfCols = useDynamicColumns(cols);
 
   return (
-    <Grid
-      container
-      item
-      direction="column"
-      justify="space-evenly"
-      alignItems="flex-start"
-      spacing={0}
-    >
-      <GridList cellHeight="auto" cols={numOfCols}>
-        {items.map(({ text, href, Icon }, i) => (
-          <GridListTile key={i}>
-            <IconLink href={href} text={text ?? href} Icon={Icon} />
-          </GridListTile>
-        ))}
-      </GridList>
-    </Grid>
+    <GridList cellHeight="auto" cols={numOfCols}>
+      {items.map(({ text, href, Icon }, i) => (
+        <GridListTile key={i}>
+          <IconLink href={href} text={text ?? href} Icon={Icon} />
+        </GridListTile>
+      ))}
+    </GridList>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

fixes: #4480

Quick fix the new `EntityLinksCard` incorrectly wrapping in some cases. I did not include a changeset since it's not released yet.

<img width="552" alt="image" src="https://user-images.githubusercontent.com/6507159/107613795-06db1200-6c17-11eb-9a45-afba75e865a2.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
