### PR TITLE
Limit the props that are forwarded to the Link component in the EntityRefLink

### DIFF
--- a/.changeset/ninety-lemons-shake.md
+++ b/.changeset/ninety-lemons-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Limit the props that are forwarded to the `Link` component in the `EntityRefLink`.

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
@@ -32,7 +32,7 @@ type EntityRefLinkProps = {
 
 export const EntityRefLink = React.forwardRef<any, EntityRefLinkProps>(
   (props, ref) => {
-    const { entityRef, defaultKind, children } = props;
+    const { entityRef, defaultKind, children, ...linkProps } = props;
 
     let kind;
     let namespace;
@@ -61,7 +61,7 @@ export const EntityRefLink = React.forwardRef<any, EntityRefLinkProps>(
       <Link
         ref={ref}
         to={generatePath(`/catalog/${entityRoute.path}`, routeParams)}
-        {...props}
+        {...linkProps}
       >
         {children}
         {!children && formatEntityRefTitle(entityRef, { defaultKind })}


### PR DESCRIPTION
I broke this in #4271. The `EntityRefLink` forwarded all properties to the `Link` component so the browser complains with this warning:

```
Warning: React does not recognize the `defaultKind` prop on a DOM element. If you intentionally want it to
appear in the DOM as a custom attribute, spell it as lowercase `defaultkind` instead. If you accidentally
passed it from a parent component, remove it from the DOM element.
    in a (created by Link)
    in Link (created by ForwardRef(Typography))
    in ForwardRef(Typography) (created by WithStyles(ForwardRef(Typography)))
    in WithStyles(ForwardRef(Typography)) (created by ForwardRef(Link))
    in ForwardRef(Link) (created by WithStyles(ForwardRef(Link)))
    in WithStyles(ForwardRef(Link)) (at Link.tsx:43)
…
```

Now it only forwards all props that are not yet handled by the `EntityRefLink`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
