### PR TITLE
techdocs: Add build timestamp to techdocs_metadata.json

### DIFF
--- a/.changeset/techdocs-fast-foxes-relate.md
+++ b/.changeset/techdocs-fast-foxes-relate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+After TechDocs generate step, insert build timestamp to techdocs_metadata.json

--- a/packages/techdocs-common/src/stages/generate/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.test.ts
@@ -48,7 +48,7 @@ const mkdocsYmlWithRepoUrl = fs.readFileSync(
   resolvePath(__filename, '../__fixtures__/mkdocs_with_repo_url.yml'),
 );
 const mockLogger = getVoidLogger();
-const tmpDir = os.platform() === 'win32' ? 'C:\\tmp' : '/tmp';
+const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
 
 describe('helpers', () => {
   describe('getGeneratorKey', () => {
@@ -336,7 +336,7 @@ describe('helpers', () => {
     beforeEach(() => {
       mockFs.restore();
       mockFs({
-        [tmpDir]: {
+        [rootDir]: {
           'invalid_techdocs_metadata.json': 'dsds',
           'techdocs_metadata.json': '{"site_name": "Tech Docs"}',
         },
@@ -348,7 +348,7 @@ describe('helpers', () => {
     });
 
     it('should create the file if it does not exist', async () => {
-      const filePath = path.join(tmpDir, 'wrong_techdocs_metadata.json');
+      const filePath = path.join(rootDir, 'wrong_techdocs_metadata.json');
       await addBuildTimestampMetadata(filePath, mockLogger);
 
       // Check if the file exists
@@ -358,7 +358,7 @@ describe('helpers', () => {
     });
 
     it('should throw error when the JSON is invalid', async () => {
-      const filePath = path.join(tmpDir, 'invalid_techdocs_metadata.json');
+      const filePath = path.join(rootDir, 'invalid_techdocs_metadata.json');
 
       // Check if the file exists
       await expect(
@@ -367,7 +367,7 @@ describe('helpers', () => {
     });
 
     it('should add build timestamp to the metadata json', async () => {
-      const filePath = path.join(tmpDir, 'techdocs_metadata.json');
+      const filePath = path.join(rootDir, 'techdocs_metadata.json');
 
       await addBuildTimestampMetadata(filePath, mockLogger);
 

--- a/packages/techdocs-common/src/stages/generate/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.test.ts
@@ -13,22 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import fs from 'fs-extra';
-import os from 'os';
-import { resolve as resolvePath } from 'path';
-import Stream, { PassThrough } from 'stream';
+import { getVoidLogger } from '@backstage/backend-common';
 import Docker from 'dockerode';
+import fs from 'fs-extra';
 import mockFs from 'mock-fs';
-import * as winston from 'winston';
-import {
-  runDockerContainer,
-  getGeneratorKey,
-  isValidRepoUrlForMkdocs,
-  getRepoUrlFromLocationAnnotation,
-  patchMkdocsYmlPreBuild,
-} from './helpers';
-import { RemoteProtocol } from '../prepare/types';
+import os from 'os';
+import path, { resolve as resolvePath } from 'path';
+import Stream, { PassThrough } from 'stream';
 import { ParsedLocationAnnotation } from '../../helpers';
+import { RemoteProtocol } from '../prepare/types';
+import {
+  addBuildTimestampMetadata,
+  getGeneratorKey,
+  getRepoUrlFromLocationAnnotation,
+  isValidRepoUrlForMkdocs,
+  patchMkdocsYmlPreBuild,
+  runDockerContainer,
+} from './helpers';
 
 const mockEntity = {
   apiVersion: 'version',
@@ -46,7 +47,8 @@ const mkdocsYml = fs.readFileSync(
 const mkdocsYmlWithRepoUrl = fs.readFileSync(
   resolvePath(__filename, '../__fixtures__/mkdocs_with_repo_url.yml'),
 );
-const mockLogger = winston.createLogger();
+const mockLogger = getVoidLogger();
+const tmpDir = os.platform() === 'win32' ? 'C:\\tmp' : '/tmp';
 
 describe('helpers', () => {
   describe('getGeneratorKey', () => {
@@ -327,6 +329,49 @@ describe('helpers', () => {
       expect(updatedMkdocsYml.toString()).not.toContain(
         'repo_url: https://github.com/neworg/newrepo',
       );
+    });
+  });
+
+  describe('addBuildTimestampMetadata', () => {
+    beforeEach(() => {
+      mockFs({
+        [tmpDir]: {
+          'invalid_techdocs_metadata.json': 'dsds',
+          'techdocs_metadata.json': '{"site_name": "Tech Docs"}',
+        },
+      });
+    });
+
+    afterEach(() => {
+      mockFs.restore();
+    });
+
+    it('should create the file if it does not exist', async () => {
+      const filePath = path.join(tmpDir, 'wrong_techdocs_metadata.json');
+      await addBuildTimestampMetadata(filePath, mockLogger);
+
+      // Check if the file exists
+      await expect(
+        fs.access(filePath, fs.constants.F_OK),
+      ).resolves.not.toThrowError();
+    });
+
+    it('should throw error when the JSON is invalid', async () => {
+      const filePath = path.join(tmpDir, 'invalid_techdocs_metadata.json');
+
+      // Check if the file exists
+      await expect(
+        addBuildTimestampMetadata(filePath, mockLogger),
+      ).rejects.toThrowError();
+    });
+
+    it('should add build timestamp to the metadata json', async () => {
+      const filePath = path.join(tmpDir, 'techdocs_metadata.json');
+
+      await addBuildTimestampMetadata(filePath, mockLogger);
+
+      const json = await fs.readJson(filePath);
+      expect(json.build_timestamp).toBeLessThanOrEqual(Date.now());
     });
   });
 });

--- a/packages/techdocs-common/src/stages/generate/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.test.ts
@@ -360,7 +360,6 @@ describe('helpers', () => {
     it('should throw error when the JSON is invalid', async () => {
       const filePath = path.join(rootDir, 'invalid_techdocs_metadata.json');
 
-      // Check if the file exists
       await expect(
         addBuildTimestampMetadata(filePath, mockLogger),
       ).rejects.toThrowError();

--- a/packages/techdocs-common/src/stages/generate/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.test.ts
@@ -334,6 +334,7 @@ describe('helpers', () => {
 
   describe('addBuildTimestampMetadata', () => {
     beforeEach(() => {
+      mockFs.restore();
       mockFs({
         [tmpDir]: {
           'invalid_techdocs_metadata.json': 'dsds',

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import path from 'path';
-import { Logger } from 'winston';
-import { PassThrough } from 'stream';
 import { Config } from '@backstage/config';
-
-import { GeneratorBase, GeneratorRunOptions } from './types';
+import path from 'path';
+import { PassThrough } from 'stream';
+import { Logger } from 'winston';
 import {
-  runDockerContainer,
-  runCommand,
+  addBuildTimestampMetadata,
   patchMkdocsYmlPreBuild,
+  runCommand,
+  runDockerContainer,
 } from './helpers';
+import { GeneratorBase, GeneratorRunOptions } from './types';
 
 type TechdocsGeneratorOptions = {
   // This option enables users to configure if they want to use TechDocs container
@@ -118,5 +118,13 @@ export class TechdocsGenerator implements GeneratorBase {
         `Failed to generate docs from ${inputDir} into ${outputDir} with error ${error.message}`,
       );
     }
+
+    // Post Generate steps
+
+    // Add build timestamp to techdocs_metadata.json
+    addBuildTimestampMetadata(
+      path.join(outputDir, 'techdocs_metadata.json'),
+      this.logger,
+    );
   }
 }


### PR DESCRIPTION
Co-authored-by: Raghunandan Balachandran <soapraj@gmail.com>

Needed as a prerequisite to moving from using in-memory storage info. Build info should be part of TechDocs storage. In case of multi-region Backstage deployments, or even using multiple Kubernetes pods, if each instance creates its separate build info in-memory, it will result in duplicate builds per instance. Also if the pod restarts, all the sites will have to be re-built.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
