### PR TITLE
Remove the "Move repository" menu entry from the catalog page, as it's just a placeholder

### DIFF
--- a/.changeset/five-guests-promise.md
+++ b/.changeset/five-guests-promise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Remove the "Move repository" menu entry from the catalog page, as it's just a placeholder.

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -25,7 +25,6 @@ import {
 import { makeStyles } from '@material-ui/core/styles';
 import Cancel from '@material-ui/icons/Cancel';
 import MoreVert from '@material-ui/icons/MoreVert';
-import SwapHoriz from '@material-ui/icons/SwapHoriz';
 import React, { useState } from 'react';
 
 // TODO(freben): It should probably instead be the case that Header sets the theme text color to white inside itself unconditionally instead
@@ -81,12 +80,6 @@ export const EntityContextMenu = ({ onUnregisterEntity }: Props) => {
               <Cancel fontSize="small" />
             </ListItemIcon>
             <Typography variant="inherit">Unregister entity</Typography>
-          </MenuItem>
-          <MenuItem>
-            <ListItemIcon>
-              <SwapHoriz fontSize="small" />
-            </ListItemIcon>
-            <Typography variant="inherit">Move repository</Typography>
           </MenuItem>
         </MenuList>
       </Popover>


### PR DESCRIPTION
It will be easy to bring it back later, but for now it just confuses users that it's not doing anything. It's also hard to remove for integrators.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
