### PR TITLE
Fix Scaffolder Prepare step when templates on disk

### DIFF
--- a/.changeset/soft-rings-obey.md
+++ b/.changeset/soft-rings-obey.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed the `prepare` step for when using local templates that were added to the catalog using the `file:` target configuration.
+No more `EPERM: operation not permitted` error messages. ðŸ‘�

--- a/.changeset/soft-rings-obey.md
+++ b/.changeset/soft-rings-obey.md
@@ -3,4 +3,4 @@
 ---
 
 Fixed the `prepare` step for when using local templates that were added to the catalog using the `file:` target configuration.
-No more `EPERM: operation not permitted` error messages. ðŸ‘�
+No more `EPERM: operation not permitted` error messages.

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.test.ts
@@ -28,7 +28,7 @@ describe('File preparer', () => {
     const preparer = new FilePreparer();
     const root = os.platform() === 'win32' ? 'C:\\' : '/';
     const workspacePath = path.join(root, 'tmp');
-    const checkoutPath = path.resolve(workspacePath, 'checkout');
+    const targetPath = path.resolve(workspacePath, 'template');
 
     await preparer.prepare({
       url: `file:///${root}path/to/template`,
@@ -37,12 +37,12 @@ describe('File preparer', () => {
     });
     expect(fs.copy).toHaveBeenCalledWith(
       path.join(root, 'path', 'to', 'template'),
-      checkoutPath,
+      targetPath,
       {
         recursive: true,
       },
     );
-    expect(fs.ensureDir).toHaveBeenCalledWith(checkoutPath);
+    expect(fs.ensureDir).toHaveBeenCalledWith(targetPath);
 
     await expect(
       preparer.prepare({

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
@@ -25,12 +25,12 @@ export class FilePreparer implements PreparerBase {
       throw new InputError(`Wrong location protocol, should be 'file', ${url}`);
     }
 
-    const templateDir = path.join(workspacePath, 'template');
-    await fs.ensureDir(templateDir);
+    const targetDir = path.join(workspacePath, 'template');
+    await fs.ensureDir(targetDir);
 
     const templatePath = fileURLToPath(url);
 
-    await fs.copy(templatePath, templateDir, {
+    await fs.copy(templatePath, targetDir, {
       recursive: true,
     });
   }

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/file.ts
@@ -25,12 +25,12 @@ export class FilePreparer implements PreparerBase {
       throw new InputError(`Wrong location protocol, should be 'file', ${url}`);
     }
 
-    const checkoutDir = path.join(workspacePath, 'checkout');
-    await fs.ensureDir(checkoutDir);
+    const templateDir = path.join(workspacePath, 'template');
+    await fs.ensureDir(templateDir);
 
     const templatePath = fileURLToPath(url);
 
-    await fs.copy(templatePath, checkoutDir, {
+    await fs.copy(templatePath, templateDir, {
       recursive: true,
     });
   }

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -17,7 +17,7 @@
 import { Config } from '@backstage/config';
 import Docker from 'dockerode';
 import express from 'express';
-import { resolve as resolvePath } from 'path';
+import { resolve as resolvePath, dirname } from 'path';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
 import {
@@ -164,7 +164,7 @@ export async function createRouter(
                 const preparer = new FilePreparer();
 
                 const path = resolvePath(
-                  templateEntityLocation,
+                  dirname(templateEntityLocation),
                   template.spec.path || '.',
                 );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
- Template entity location should be a directory name and resolve from there
- And actually copy to the path that the templater expects `/template` rather than `/checkout` as there is no need for the `/checkout` folder.

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)