### PR TITLE
Changed UrlReaderProcessor to emit location for each found result in search()

### DIFF
--- a/.changeset/two-bugs-pay.md
+++ b/.changeset/two-bugs-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Changed `UrlReaderProcessor` to be less optimistic. It now emits a location entity for each found path in calls to `search()` so that entity pre-processors (such as `EntityPolicy.enforce`) have a chance to run on each found entity.

--- a/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.test.ts
@@ -120,4 +120,31 @@ describe('UrlReaderProcessor', () => {
 
     expect(reader.search).toBeCalledTimes(1);
   });
+
+  it('emits locations for every search result', async () => {
+    const logger = getVoidLogger();
+
+    const files = [
+      { url: 'https://github.com/a/b/blob/x/path1/b.yaml', content: jest.fn() },
+      { url: 'https://github.com/a/b/blob/x/path2/b.yaml', content: jest.fn() },
+    ];
+    const reader: jest.Mocked<UrlReader> = {
+      read: jest.fn(),
+      readTree: jest.fn(),
+      search: jest.fn().mockResolvedValue({ files, etag: '' }),
+    };
+
+    const processor = new UrlReaderProcessor({ reader, logger });
+
+    const emit = jest.fn();
+
+    await processor.readLocation(
+      { type: 'url', target: 'https://github.com/a/b/blob/x/**/b.yaml' },
+      false,
+      emit,
+      defaultEntityDataParser,
+    );
+
+    expect(emit).toBeCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Fixes #4521.

Changed `UrlReaderProcessor` to be less optimistic. It now emits a location entity for each found path in calls to `search()` so that entity pre-processors (such as `EntityPolicy.enforce`) have a chance to run on each found entity.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
