### PR TITLE
Hide the kind of the owner if it's the default kind for the `ownedBy` relationship (group)

### DIFF
--- a/.changeset/cuddly-bags-share.md
+++ b/.changeset/cuddly-bags-share.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Hide the kind of the owner if it's the default kind for the `ownedBy`
+relationship (group).

--- a/plugins/catalog/src/components/AboutCard/AboutContent.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutContent.tsx
@@ -66,7 +66,7 @@ export const AboutContent = ({ entity }: Props) => {
         </Typography>
       </AboutField>
       <AboutField label="Owner" gridSizes={{ xs: 12, sm: 6, lg: 4 }}>
-        <EntityRefLinks entityRefs={ownedByRelations} />
+        <EntityRefLinks entityRefs={ownedByRelations} defaultKind="group" />
       </AboutField>
       {isSystem && (
         <AboutField


### PR DESCRIPTION
I guess I missed this one. In the catalog table & co we already hide it.

Signed-off-by: Oliver Sand oliver.sand@sda-se.com

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
