### PR TITLE
auth-backend: fix key timestamp parsing with sqlite

### DIFF
--- a/.changeset/rich-apricots-lick.md
+++ b/.changeset/rich-apricots-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed parsing of OIDC key timestamps when using SQLite.

--- a/plugins/auth-backend/src/identity/DatabaseKeyStore.ts
+++ b/plugins/auth-backend/src/identity/DatabaseKeyStore.ts
@@ -39,7 +39,7 @@ type Options = {
 const parseDate = (date: string | Date) => {
   const parsedDate =
     typeof date === 'string'
-      ? DateTime.fromSQL(date, { locale: 'UTC' })
+      ? DateTime.fromSQL(date, { zone: 'UTC' })
       : DateTime.fromJSDate(date);
 
   if (!parsedDate.isValid) {


### PR DESCRIPTION
Fixes the key store in SQLite for some people, depending on where you are :grin:

