### PR TITLE
auth-backend: implement sign-in resolver and profile transform for google provider

### DIFF
--- a/.changeset/seven-adults-act.md
+++ b/.changeset/seven-adults-act.md
@@ -1,0 +1,15 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Adds custom sign-in resolvers and profile transformation for Google auth provider. Read more about what this means for Backstage user identity and determining ownership of entities https://backstage.io/docs/auth/identity-resolver
+Related the [RFC] From Identity to Ownership, v2 https://github.com/backstage/backstage/issues/4089
+
+Adds `ent` field in the claims of Backstage ID Token with a list of entity references containing identity and membership info about the user across multiple systems.
+
+Adds an optional `providerFactories` to the `createRouter` exported by the auth-backend plugin.
+
+Updates `BackstageIdentity` so that
+
+- `idToken` is deprecated in favor of `token`
+- An optional `entity` field is added which represents the entity that the user is represented by within Backstage.

--- a/.changeset/seven-adults-act.md
+++ b/.changeset/seven-adults-act.md
@@ -2,14 +2,24 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-Adds custom sign-in resolvers and profile transformation for Google auth provider. Read more about what this means for Backstage user identity and determining ownership of entities https://backstage.io/docs/auth/identity-resolver
-Related the [RFC] From Identity to Ownership, v2 https://github.com/backstage/backstage/issues/4089
+Adds support for custom sign-in resolvers and profile transformations for the
+Google auth provider.
 
-Adds `ent` field in the claims of Backstage ID Token with a list of entity references containing identity and membership info about the user across multiple systems.
+Adds an `ent` claim in Backstage tokens, with a list of
+[entity references](https://backstage.io/docs/features/software-catalog/references)
+related to your signed-in user's identities and groups across multiple systems.
 
-Adds an optional `providerFactories` to the `createRouter` exported by the auth-backend plugin.
+Adds an optional `providerFactories` argument to the `createRouter` exported by
+the `auth-backend` plugin.
 
 Updates `BackstageIdentity` so that
 
 - `idToken` is deprecated in favor of `token`
 - An optional `entity` field is added which represents the entity that the user is represented by within Backstage.
+
+More information:
+
+- [The identity resolver documentation](https://backstage.io/docs/auth/identity-resolver)
+  explains the concepts and shows how to implement your own.
+- The [From Identity to Ownership](https://github.com/backstage/backstage/issues/4089)
+  RFC contains details about how this affects ownership in the catalog

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -13,9 +13,10 @@ Backstage entity by a user. The ideas here were originally proposed in the RFC
 
 When a user signs in to Backstage, inside the `claims` field of their Backstage
 ID Token (which are standard JWT tokens) a special `ent` field is set. `ent`
-contains a list of [entity references](../features/software-catalog/references),
-each of which denotes an identity or a membership that is relevant to the user.
-There is no guarantee that these correspond to actual existing catalog entities.
+contains a list of
+[entity references](../features/software-catalog/references.md), each of which
+denotes an identity or a membership that is relevant to the user. There is no
+guarantee that these correspond to actual existing catalog entities.
 
 Let's take an example sign-in resolver for the Google auth provider and explore
 how the `ent` field inside `claims` can be set.

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -1,0 +1,161 @@
+---
+id: identity-resolver
+title: Identity resolver
+description: Identity resolvers of Backstage users after they sign-in
+---
+
+This guide explains how the identity of a Backstage user is stored inside their
+Backstage Identity Token and how you can customize the Sign In resolvers to
+include identity and group membership information of the user from other
+external systems. This ultimately helps with determining the ownership of a
+Backstage entity by a user. The ideas here were originally proposed in the RFC
+[#4089](https://github.com/backstage/backstage/issues/4089).
+
+When a user signs in to Backstage, inside the `claims` field of their Backstage
+ID Token (which are standard JWT tokens) a special `ent` field is set. `ent`
+contains a list of [entity references](../features/software-catalog/references),
+each of which denotes an identity or a membership that is relevant to the user.
+There is no guarantee that these correspond to actual existing catalog entities.
+
+Let's take an example sign-in resolver for the Google auth provider and explore
+how the `ent` field inside `claims` can be set.
+
+Inside your `packages/backend/src/plugins/auth.ts` file, you can provide custom
+sign-in resolvers and set them for any of the Authentication providers inside
+`providerFactories` of the `createRouter` imported from the
+`@backstage/plugin-auth-backend` plugin.
+
+```ts
+export default async function createPlugin({
+  ...
+}: PluginEnvironment): Promise<Router> {
+  return await createRouter({
+    ...
+    providerFactories: {
+      google: createGoogleProvider({
+        signIn: {
+          resolver: async ({ profile: { email } }, ctx) => {
+            if (!email) {
+              throw new Error('No email associated with user account');
+            }
+
+            // Ignore email addresses which do not belong to company's domain name
+            if (email.split('@')[1] != 'mycompany.com') {
+              throw new Error('Unrecognized domain name of the email ID used to sign in.')
+            }
+
+            // List of entity references that denote the identity and membership of the user
+            const ent = [];
+
+            // Let's use the username in the email ID as the user's default unique identifier inside Backstage
+            const id = email.split('@')[0];
+            // Let's add the unique ID in the list
+            ent.push(id)
+            // Note: While the complete entity references look like `kind:namespace/name`, it should be safe to assume
+            // that standalone strings without any : or / can be interpresed as user kind in the default namespace. So,
+            // a 'freben' inside the `ent` list should be translated to `User:default/freben` when making any assertions.
+
+            // Let's call the GitHub Enterprise API inside the company and get the teams that the user belongs to
+            const gheUsername = getGheUsername(email);
+            const gheTeams = getGheTeams(gheUsername);
+
+            // Let's add the GHE identities to ent claims inside a new ghe namespace to keep things separate from the
+            // default namespace.
+            ent.push(`User:ghe/${gheUsername}`)
+            gheTeams.forEach(team => ent.push(`Group:ghe/${team}`))
+
+            // Let's call the internal LDAP provider to get a list of groups the user belongs to
+            const ldapGroups = getLdapGroups(email);
+            ldapGroups.forEach(ldapGroup => ent.push(`Group:myldap/${ldapGroup}`))
+
+            // Issue the token containing the entity claims
+            const token = await ctx.tokenIssuer.issueToken({
+              claims: { sub: id, ent },
+            });
+            return { id, token };
+          },
+        },
+      }),
+    },
+  });
+}
+```
+
+As you can see, the generated Backstage ID Token now contains all the claims
+about the identity and membership of the user. Once the sign-in process is
+complete, and we need to find out if a user owns an Entity in the Software
+Catalog, these `ent` claims can be used to determine the ownership. A full
+algorithm as proposed in the RFC is as follows
+
+The definition of the ownership of an entity E, for a user U, is as follows:
+
+- Get all the `ownedBy` relations of E, and call them O
+- Get all the claims of the user U and call them C
+- If any C matches any O, return `true`
+- Get all Group entities that U is a member of, using the regular
+  `memberOf`/`hasMember` relation mechanism, and call them G
+- If any G matches any O, return `true`
+- Otherwise, return `false`
+
+## Default sign-in resolvers
+
+Of course you don't have to customize the sign-in resolver if you don't need to.
+The Auth backend plugin comes with a set of default sign-in resolvers which you
+can use. For example - the Google provider has a default email-based sign in
+resolver, which will search the catalog for a single user entity that has a
+matching `google.com/email` annotation.
+
+It can be enabled like this
+
+```tsx
+# File: packages/backend/src/plugins/auth.ts
+...
+export default async function createPlugin({
+  ...
+}: PluginEnvironment): Promise<Router> {
+  return await createRouter({
+    ...
+    providerFactories: {
+      google: createGoogleProvider({
+        signIn: {
+          resolver: 'email'
+        }
+...
+```
+
+## Profile transform
+
+Similar to a custom sign-in resolver, you can also write custom profile
+transformation function which is used to verify and convert the auth response
+into the profile that will be presented to the user. This is where you can
+customize things like display name and profile picture.
+
+```tsx
+# File: packages/backend/src/plugins/auth.ts
+...
+export default async function createPlugin({
+  ...
+}: PluginEnvironment): Promise<Router> {
+  return await createRouter({
+    ...
+    providerFactories: {
+      google: createGoogleProvider({
+        signIn: {
+          resolver: 'email'
+        },
+        profileTransform: async ({
+          fullProfile  // Type: passport.Profile,
+          idToken      // Type: (Optional) string,
+        }): ProfileInfo => {
+          // Do stuff
+          return {
+            email,
+            picture,
+            displayName,
+          };
+        }
+      })
+    }
+  })
+}
+```

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -108,6 +108,8 @@ It can be enabled like this
 ```tsx
 # File: packages/backend/src/plugins/auth.ts
 ...
+import { googleEmailSignInResolver } from '@backstage/plugin-auth-backend';
+
 export default async function createPlugin({
   ...
 }: PluginEnvironment): Promise<Router> {
@@ -116,21 +118,26 @@ export default async function createPlugin({
     providerFactories: {
       google: createGoogleProvider({
         signIn: {
-          resolver: 'email'
+          resolver: googleEmailSignInResolver
         }
 ...
 ```
 
-## Profile transform
+## AuthHandler
 
-Similar to a custom sign-in resolver, you can also write a custom profile
-transformation function which is used to verify and convert the auth response
-into the profile that will be presented to the user. This is where you can
-customize things like display name and profile picture.
+Similar to a custom sign-in resolver, you can also write a custom auth handler
+function which is used to verify and convert the auth response into the profile
+that will be presented to the user. This is where you can customize things like
+display name and profile picture.
+
+This is also the place where you can do authorization and validation of the user
+and throw errors if the user should not be allowed access in Backstage.
 
 ```tsx
 # File: packages/backend/src/plugins/auth.ts
 ...
+import { googleEmailSignInResolver } from '@backstage/plugin-auth-backend';
+
 export default async function createPlugin({
   ...
 }: PluginEnvironment): Promise<Router> {
@@ -139,17 +146,19 @@ export default async function createPlugin({
     providerFactories: {
       google: createGoogleProvider({
         signIn: {
-          resolver: 'email'
+          resolver: googleEmailSignInResolver
         },
-        profileTransform: async ({
+        authHandler: async ({
           fullProfile  // Type: passport.Profile,
           idToken      // Type: (Optional) string,
-        }): ProfileInfo => {
-          // Do stuff
+        }) => {
+          // Custom validation
           return {
-            email,
-            picture,
-            displayName,
+            profile: {
+              email,
+              picture,
+              displayName,
+            }
           };
         }
       })

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -12,7 +12,7 @@ Backstage entity by a user. The ideas here were originally proposed in the RFC
 [#4089](https://github.com/backstage/backstage/issues/4089).
 
 When a user signs in to Backstage, inside the `claims` field of their Backstage
-ID Token (which are standard JWT tokens) a special `ent` field is set. `ent`
+Token (which are standard JWT tokens) a special `ent` claim is set. `ent`
 contains a list of
 [entity references](../features/software-catalog/references.md), each of which
 denotes an identity or a membership that is relevant to the user. There is no
@@ -41,7 +41,7 @@ export default async function createPlugin({
             }
 
             // Ignore email addresses which do not belong to company's domain name
-            if (email.split('@')[1] != 'mycompany.com') {
+            if (email.split('@')[1] !== 'mycompany.com') {
               throw new Error('Unrecognized domain name of the email ID used to sign in.')
             }
 
@@ -82,11 +82,11 @@ export default async function createPlugin({
 }
 ```
 
-As you can see, the generated Backstage ID Token now contains all the claims
-about the identity and membership of the user. Once the sign-in process is
-complete, and we need to find out if a user owns an Entity in the Software
-Catalog, these `ent` claims can be used to determine the ownership. A full
-algorithm as proposed in the RFC is as follows
+As you can see, the generated Backstage Token now contains all the claims about
+the identity and membership of the user. Once the sign-in process is complete,
+and we need to find out if a user owns an Entity in the Software Catalog, these
+`ent` claims can be used to determine the ownership. A full algorithm as
+proposed in the RFC is as follows
 
 The definition of the ownership of an entity E, for a user U, is as follows:
 
@@ -126,7 +126,7 @@ export default async function createPlugin({
 
 ## Profile transform
 
-Similar to a custom sign-in resolver, you can also write custom profile
+Similar to a custom sign-in resolver, you can also write a custom profile
 transformation function which is used to verify and convert the auth response
 into the profile that will be presented to the user. This is where you can
 customize things like display name and profile picture.

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -51,10 +51,7 @@ export default async function createPlugin({
             // Let's use the username in the email ID as the user's default unique identifier inside Backstage
             const id = email.split('@')[0];
             // Let's add the unique ID in the list
-            ent.push(id)
-            // Note: While the complete entity references look like `kind:namespace/name`, it should be safe to assume
-            // that standalone strings without any : or / can be interpresed as user kind in the default namespace. So,
-            // a 'freben' inside the `ent` list should be translated to `User:default/freben` when making any assertions.
+            ent.push(`User:default/${id}`)
 
             // Let's call the GitHub Enterprise API inside the company and get the teams that the user belongs to
             const gheUsername = getGheUsername(email);

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -206,6 +206,7 @@
       },
       "auth/add-auth-provider",
       "auth/using-auth",
+      "auth/identity-resolver",
       "auth/auth-backend",
       "auth/oauth",
       "auth/auth-backend-classes",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
           - OneLogin: 'auth/onelogin/provider.md'
       - Adding authentication providers: 'auth/add-auth-provider.md'
       - Using authentication and identity: 'auth/using-auth.md'
+      - Sign in resolvers: 'auth/identity-resolver.md'
       - Auth backend: 'auth/auth-backend.md'
       - OAuth and OpenID Connect: 'auth/oauth.md'
       - Auth backend classes: 'auth/auth-backend-classes.md'

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -17,7 +17,6 @@
 import {
   createGoogleProvider,
   createRouter,
-  defaultAuthProviderFactories,
 } from '@backstage/plugin-auth-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
@@ -34,7 +33,6 @@ export default async function createPlugin({
     database,
     discovery,
     providerFactories: {
-      ...defaultAuthProviderFactories,
       google: createGoogleProvider({
         signIn: {
           // resolver: 'email',

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -42,7 +42,7 @@ export default async function createPlugin({
             }
             const id = email.split('@')[0];
             const token = await ctx.tokenIssuer.issueToken({
-              claims: { sub: id, ent: [id] },
+              claims: { sub: id, ent: [`User:default/${id}`] },
             });
             return { id, token };
           },

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  createGoogleProvider,
-  createRouter,
-} from '@backstage/plugin-auth-backend';
+import { createRouter } from '@backstage/plugin-auth-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 
@@ -27,27 +24,5 @@ export default async function createPlugin({
   config,
   discovery,
 }: PluginEnvironment): Promise<Router> {
-  return await createRouter({
-    logger,
-    config,
-    database,
-    discovery,
-    providerFactories: {
-      google: createGoogleProvider({
-        signIn: {
-          // resolver: 'email',
-          resolver: async ({ profile: { email } }, ctx) => {
-            if (!email) {
-              throw new Error('No email associated with user account');
-            }
-            const id = email.split('@')[0];
-            const token = await ctx.tokenIssuer.issueToken({
-              claims: { sub: id, ent: [`User:default/${id}`] },
-            });
-            return { id, token };
-          },
-        },
-      }),
-    },
-  });
+  return await createRouter({ logger, config, database, discovery });
 }

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -67,13 +67,14 @@ export class TokenFactory implements TokenIssuer {
 
     const iss = this.issuer;
     const sub = params.claims.sub;
+    const ent = params.claims.ent;
     const aud = 'backstage';
     const iat = Math.floor(Date.now() / MS_IN_S);
     const exp = iat + this.keyDurationSeconds;
 
-    this.logger.info(`Issuing token for ${sub}`);
+    this.logger.info(`Issuing token for ${sub}, with entities ${ent ?? []}`);
 
-    return JWS.sign({ iss, sub, aud, iat, exp }, key, {
+    return JWS.sign({ iss, sub, aud, iat, exp, ent }, key, {
       alg: key.alg,
       kid: key.kid,
     });

--- a/plugins/auth-backend/src/identity/types.ts
+++ b/plugins/auth-backend/src/identity/types.ts
@@ -28,6 +28,8 @@ export type TokenParams = {
   claims: {
     /** The token subject, i.e. User ID */
     sub: string;
+    /** A list of entity references that the user claims ownership through */
+    ent?: string[];
   };
 };
 

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -16,6 +16,7 @@
 
 import { CatalogApi } from '@backstage/catalog-client';
 import { UserEntity } from '@backstage/catalog-model';
+import { TokenIssuer } from '../../identity';
 import { CatalogIdentityClient } from './CatalogIdentityClient';
 
 describe('CatalogIdentityClient', () => {
@@ -29,25 +30,36 @@ describe('CatalogIdentityClient', () => {
     getLocationByEntity: jest.fn(),
     removeEntityByUid: jest.fn(),
   };
+  const tokenIssuer: jest.Mocked<TokenIssuer> = {
+    issueToken: jest.fn(),
+    listPublicKeys: jest.fn(),
+  };
 
   afterEach(() => jest.resetAllMocks());
 
   it('passes through the correct search params', async () => {
     catalogApi.getEntities.mockResolvedValueOnce({ items: [{} as UserEntity] });
+    tokenIssuer.issueToken.mockResolvedValue('my-token');
     const client = new CatalogIdentityClient({
-      catalogApi: catalogApi as CatalogApi,
+      catalogApi: catalogApi,
+      tokenIssuer: tokenIssuer,
     });
 
-    client.findUser({ annotations: { key: 'value' } });
+    await client.findUser({ annotations: { key: 'value' } });
 
-    expect(catalogApi.getEntities).toBeCalledWith(
+    expect(catalogApi.getEntities).toHaveBeenCalledWith(
       {
         filter: {
           kind: 'user',
           'metadata.annotations.key': 'value',
         },
       },
-      undefined,
+      { token: 'my-token' },
     );
+    expect(tokenIssuer.issueToken).toHaveBeenCalledWith({
+      claims: {
+        sub: 'backstage.io/auth-backend',
+      },
+    });
   });
 });

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
@@ -17,6 +17,7 @@
 import { ConflictError, NotFoundError } from '@backstage/errors';
 import { CatalogApi } from '@backstage/catalog-client';
 import { UserEntity } from '@backstage/catalog-model';
+import { TokenIssuer } from '../../identity';
 
 type UserQuery = {
   annotations: Record<string, string>;
@@ -27,9 +28,11 @@ type UserQuery = {
  */
 export class CatalogIdentityClient {
   private readonly catalogApi: CatalogApi;
+  private readonly tokenIssuer: TokenIssuer;
 
-  constructor(options: { catalogApi: CatalogApi }) {
+  constructor(options: { catalogApi: CatalogApi; tokenIssuer: TokenIssuer }) {
     this.catalogApi = options.catalogApi;
+    this.tokenIssuer = options.tokenIssuer;
   }
 
   /**
@@ -37,10 +40,7 @@ export class CatalogIdentityClient {
    *
    * Throws a NotFoundError or ConflictError if 0 or multiple users are found.
    */
-  async findUser(
-    query: UserQuery,
-    options?: { token?: string },
-  ): Promise<UserEntity> {
+  async findUser(query: UserQuery): Promise<UserEntity> {
     const filter: Record<string, string> = {
       kind: 'user',
     };
@@ -48,7 +48,11 @@ export class CatalogIdentityClient {
       filter[`metadata.annotations.${key}`] = value;
     }
 
-    const { items } = await this.catalogApi.getEntities({ filter }, options);
+    // TODO(Rugvip): cache the token
+    const token = await this.tokenIssuer.issueToken({
+      claims: { sub: 'backstage.io/auth-backend' },
+    });
+    const { items } = await this.catalogApi.getEntities({ filter }, { token });
 
     if (items.length !== 1) {
       if (items.length > 1) {

--- a/plugins/auth-backend/src/lib/catalog/helpers.ts
+++ b/plugins/auth-backend/src/lib/catalog/helpers.ts
@@ -26,7 +26,11 @@ export function getEntityClaims(entity: UserEntity): TokenParams['claims'] {
 
   const membershipRefs =
     entity.relations
-      ?.filter(r => r.type === RELATION_MEMBER_OF)
+      ?.filter(
+        r =>
+          r.type === RELATION_MEMBER_OF &&
+          r.target.kind.toLocaleLowerCase() === 'group',
+      )
       .map(r => stringifyEntityRef(r.target)) ?? [];
 
   return {

--- a/plugins/auth-backend/src/lib/catalog/helpers.ts
+++ b/plugins/auth-backend/src/lib/catalog/helpers.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  UserEntity,
+  serializeEntityRef,
+  RELATION_MEMBER_OF,
+} from '@backstage/catalog-model';
+import { TokenParams } from '../../identity';
+
+export function getEntityClaims(entity: UserEntity): TokenParams['claims'] {
+  const userRef = serializeEntityRef(entity);
+  if (typeof userRef !== 'string') {
+    throw new Error(
+      `Failed to serialize user entity ref, ${JSON.stringify(userRef)}`,
+    );
+  }
+
+  const membershipRefs =
+    entity.relations
+      ?.filter(r => r.type === RELATION_MEMBER_OF)
+      .map(r => {
+        const ref = serializeEntityRef(r.target);
+        if (typeof ref !== 'string') {
+          throw new Error(
+            `Failed to serialize relation entity ref, ${JSON.stringify(ref)}`,
+          );
+        }
+        return ref;
+      }) ?? [];
+
+  return {
+    sub: userRef,
+    ent: [userRef, ...membershipRefs],
+  };
+}

--- a/plugins/auth-backend/src/lib/catalog/helpers.ts
+++ b/plugins/auth-backend/src/lib/catalog/helpers.ts
@@ -15,32 +15,19 @@
  */
 
 import {
-  UserEntity,
-  serializeEntityRef,
   RELATION_MEMBER_OF,
+  stringifyEntityRef,
+  UserEntity,
 } from '@backstage/catalog-model';
 import { TokenParams } from '../../identity';
 
 export function getEntityClaims(entity: UserEntity): TokenParams['claims'] {
-  const userRef = serializeEntityRef(entity);
-  if (typeof userRef !== 'string') {
-    throw new Error(
-      `Failed to serialize user entity ref, ${JSON.stringify(userRef)}`,
-    );
-  }
+  const userRef = stringifyEntityRef(entity);
 
   const membershipRefs =
     entity.relations
       ?.filter(r => r.type === RELATION_MEMBER_OF)
-      .map(r => {
-        const ref = serializeEntityRef(r.target);
-        if (typeof ref !== 'string') {
-          throw new Error(
-            `Failed to serialize relation entity ref, ${JSON.stringify(ref)}`,
-          );
-        }
-        return ref;
-      }) ?? [];
+      .map(r => stringifyEntityRef(r.target)) ?? [];
 
   return {
     sub: userRef,

--- a/plugins/auth-backend/src/lib/catalog/helpers.ts
+++ b/plugins/auth-backend/src/lib/catalog/helpers.ts
@@ -29,7 +29,7 @@ export function getEntityClaims(entity: UserEntity): TokenParams['claims'] {
       ?.filter(
         r =>
           r.type === RELATION_MEMBER_OF &&
-          r.target.kind.toLocaleLowerCase() === 'group',
+          r.target.kind.toLocaleLowerCase('en-US') === 'group',
       )
       .map(r => stringifyEntityRef(r.target)) ?? [];
 

--- a/plugins/auth-backend/src/lib/catalog/index.ts
+++ b/plugins/auth-backend/src/lib/catalog/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { CatalogIdentityClient } from './CatalogIdentityClient';
+export { getEntityClaims } from './helpers';

--- a/plugins/auth-backend/src/providers/google/index.ts
+++ b/plugins/auth-backend/src/providers/google/index.ts
@@ -14,5 +14,9 @@
  * limitations under the License.
  */
 
-export { createGoogleProvider } from './provider';
+export {
+  createGoogleProvider,
+  googleDefaultSignInResolver,
+  googleEmailSignInResolver,
+} from './provider';
 export type { GoogleProviderOptions } from './provider';

--- a/plugins/auth-backend/src/providers/google/provider.test.ts
+++ b/plugins/auth-backend/src/providers/google/provider.test.ts
@@ -42,10 +42,12 @@ describe('createGoogleProvider', () => {
       logger: getVoidLogger(),
       catalogIdentityClient: (catalogIdentityClient as unknown) as CatalogIdentityClient,
       tokenIssuer: (tokenIssuer as unknown) as TokenIssuer,
-      profileTransform: async ({ fullProfile }) => ({
-        email: fullProfile.emails![0]!.value,
-        displayName: fullProfile.displayName,
-        picture: 'http://google.com/lols',
+      authHandler: async ({ fullProfile }) => ({
+        profile: {
+          email: fullProfile.emails![0]!.value,
+          displayName: fullProfile.displayName,
+          picture: 'http://google.com/lols',
+        },
       }),
       clientId: 'mock',
       clientSecret: 'mock',

--- a/plugins/auth-backend/src/providers/google/provider.test.ts
+++ b/plugins/auth-backend/src/providers/google/provider.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GoogleAuthProvider } from './provider';
+import * as helpers from '../../lib/passport/PassportStrategyHelper';
+import { OAuthResult } from '../../lib/oauth';
+import { getVoidLogger } from '@backstage/backend-common';
+import { TokenIssuer } from '../../identity/types';
+import { CatalogIdentityClient } from '../../lib/catalog';
+
+const mockFrameHandler = (jest.spyOn(
+  helpers,
+  'executeFrameHandlerStrategy',
+) as unknown) as jest.MockedFunction<
+  () => Promise<{ result: OAuthResult; privateInfo: any }>
+>;
+
+describe('createGoogleProvider', () => {
+  it('should auth', async () => {
+    const tokenIssuer = {
+      issueToken: jest.fn(),
+      listPublicKeys: jest.fn(),
+    };
+    const catalogIdentityClient = {
+      findUser: jest.fn(),
+    };
+
+    const provider = new GoogleAuthProvider({
+      logger: getVoidLogger(),
+      catalogIdentityClient: (catalogIdentityClient as unknown) as CatalogIdentityClient,
+      tokenIssuer: (tokenIssuer as unknown) as TokenIssuer,
+      profileTransform: async ({ fullProfile }) => ({
+        email: fullProfile.emails![0]!.value,
+        displayName: fullProfile.displayName,
+        picture: 'http://google.com/lols',
+      }),
+      clientId: 'mock',
+      clientSecret: 'mock',
+      callbackUrl: 'mock',
+    });
+
+    mockFrameHandler.mockResolvedValueOnce({
+      result: {
+        fullProfile: {
+          emails: [{ value: 'conrad@example.com' }],
+          displayName: 'Conrad',
+          id: 'conrad',
+          provider: 'google',
+        },
+        params: {
+          id_token: 'idToken',
+          scope: 'scope',
+          expires_in: 123,
+        },
+        accessToken: 'accessToken',
+      },
+      privateInfo: {
+        refreshToken: 'wacka',
+      },
+    });
+    const { response } = await provider.handler({} as any);
+    expect(response).toEqual({
+      providerInfo: {
+        accessToken: 'accessToken',
+        expiresInSeconds: 123,
+        idToken: 'idToken',
+        scope: 'scope',
+      },
+      profile: {
+        email: 'conrad@example.com',
+        displayName: 'Conrad',
+        picture: 'http://google.com/lols',
+      },
+    });
+  });
+});

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -205,7 +205,7 @@ export type GoogleProviderOptions = {
      * Maps an auth result to a Backstage identity for the user.
      *
      * Set to `'email'` to use the default email-based sign in resolver, which will search
-     * for the catalog for a single user entity that has a matching `google.com/email` annotation.
+     * the catalog for a single user entity that has a matching `google.com/email` annotation.
      */
     resolver?: 'email' | SignInResolver<OAuthResult>;
   };

--- a/plugins/auth-backend/src/providers/index.ts
+++ b/plugins/auth-backend/src/providers/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export * from './google';
 export { factories as defaultAuthProviderFactories } from './factories';
 
 // Export the minimal interface required for implementing a

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -16,10 +16,12 @@
 
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
+import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import express from 'express';
 import { Logger } from 'winston';
 import { TokenIssuer } from '../identity/types';
+import { CatalogIdentityClient } from '../lib/catalog';
 
 export type AuthProviderConfig = {
   /**
@@ -148,14 +150,30 @@ export type AuthResponse<ProviderInfo> = {
 
 export type BackstageIdentity = {
   /**
-   * The backstage user ID.
+   * An opaque ID that uniquely identifies the user within Backstage.
+   *
+   * This is typically the same as the user entity `metadata.name`.
    */
   id: string;
 
   /**
-   * An ID token that can be used to authenticate the user within Backstage.
+   * This is deprecated, use `token` instead.
+   * @deprecated
    */
   idToken?: string;
+
+  /**
+   * The token used to authenticate the user within Backstage.
+   */
+  token?: string;
+
+  /**
+   * The entity that the user is represented by within Backstage.
+   *
+   * This entity may or may not exist within the Catalog, and it can be used
+   * to read and store additional metadata about the user.
+   */
+  entity?: Entity;
 };
 
 /**
@@ -179,3 +197,35 @@ export type ProfileInfo = {
    */
   picture?: string;
 };
+
+export type SignInInfo<AuthResult> = {
+  /**
+   * The simple profile passed down for use in the frontend.
+   */
+  profile: ProfileInfo;
+
+  /**
+   * The authentication result that was received from the authentication provider.
+   */
+  result: AuthResult;
+};
+
+export type SignInResolver<AuthResult> = (
+  info: SignInInfo<AuthResult>,
+  context: {
+    tokenIssuer: TokenIssuer;
+    catalogIdentityClient: CatalogIdentityClient;
+  },
+) => Promise<BackstageIdentity>;
+
+/**
+ * A transformation function called every time the user authenticates using the provider.
+ *
+ * The transform should return a profile that represents the session for the user in the frontend.
+ *
+ * Throwing an error in the function will cause the authentication to fail, making it
+ * possible to use this function as a way to limit access to a certain group of users.
+ */
+export type ProfileTransform<AuthResult> = (
+  input: AuthResult,
+) => Promise<ProfileInfo>;

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -215,6 +215,7 @@ export type SignInResolver<AuthResult> = (
   context: {
     tokenIssuer: TokenIssuer;
     catalogIdentityClient: CatalogIdentityClient;
+    logger: Logger;
   },
 ) => Promise<BackstageIdentity>;
 

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -219,14 +219,16 @@ export type SignInResolver<AuthResult> = (
   },
 ) => Promise<BackstageIdentity>;
 
+export type AuthHandlerResult = { profile: ProfileInfo };
+
 /**
- * A transformation function called every time the user authenticates using the provider.
+ * The AuthHandler function is called every time the user authenticates using the provider.
  *
- * The transform should return a profile that represents the session for the user in the frontend.
+ * The handler should return a profile that represents the session for the user in the frontend.
  *
  * Throwing an error in the function will cause the authentication to fail, making it
  * possible to use this function as a way to limit access to a certain group of users.
  */
-export type ProfileTransform<AuthResult> = (
+export type AuthHandler<AuthResult> = (
   input: AuthResult,
-) => Promise<ProfileInfo>;
+) => Promise<AuthHandlerResult>;


### PR DESCRIPTION
~Draft for now, as this doesn't update docs~ or the frontend yet, but want to get a discussion going.

Mostly implements the auth side of #4089, although only for the Google provider
