### PR TITLE
Support globs in FileReaderProcessor

### DIFF
--- a/.changeset/many-bags-sort.md
+++ b/.changeset/many-bags-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Support globs in `FileReaderProcessor`.

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -45,6 +45,7 @@
     "express-promise-router": "^3.0.3",
     "fs-extra": "^9.0.0",
     "git-url-parse": "^11.4.4",
+    "glob": "^7.1.6",
     "knex": "^0.21.6",
     "ldapjs": "^2.2.0",
     "lodash": "^4.17.15",

--- a/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FileReaderProcessor } from './FileReaderProcessor';
+import {
+  CatalogProcessorEntityResult,
+  CatalogProcessorErrorResult,
+  CatalogProcessorResult,
+} from './types';
+
+describe('FileReaderProcessor', () => {
+  const fixturesRoot =
+    'src/ingestion/processors/__fixtures__/fileReaderProcessor';
+
+  it('should load from file', async () => {
+    const processor = new FileReaderProcessor();
+    const spec = {
+      type: 'file',
+      target: `${fixturesRoot}/component.yaml`,
+    };
+
+    const generated = (await new Promise<CatalogProcessorResult>(emit =>
+      processor.readLocation(spec, false, emit),
+    )) as CatalogProcessorEntityResult;
+
+    expect(generated.type).toBe('entity');
+    expect(generated.location).toEqual(spec);
+    expect(generated.entity).toEqual({ kind: 'Component' });
+  });
+
+  it('should fail load from file with error', async () => {
+    const processor = new FileReaderProcessor();
+    const spec = {
+      type: 'file',
+      target: `${fixturesRoot}/missing.yaml`,
+    };
+
+    const generated = (await new Promise<CatalogProcessorResult>(emit =>
+      processor.readLocation(spec, false, emit),
+    )) as CatalogProcessorErrorResult;
+
+    expect(generated.type).toBe('error');
+    expect(generated.location).toBe(spec);
+    expect(generated.error.name).toBe('NotFoundError');
+    expect(generated.error.message).toBe(
+      `file ${fixturesRoot}/missing.yaml does not exist`,
+    );
+  });
+
+  it('should support globs', async () => {
+    const processor = new FileReaderProcessor();
+
+    const emit = jest.fn();
+
+    await processor.readLocation(
+      { type: 'file', target: `${fixturesRoot}/**/*.yaml` },
+      false,
+      emit,
+    );
+
+    expect(emit).toBeCalledTimes(2);
+  });
+});

--- a/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.test.ts
@@ -78,5 +78,7 @@ describe('FileReaderProcessor', () => {
     );
 
     expect(emit).toBeCalledTimes(2);
+    expect(emit.mock.calls[0][0].entity).toEqual({ kind: 'Component' });
+    expect(emit.mock.calls[1][0].entity).toEqual({ kind: 'API' });
   });
 });

--- a/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.test.ts
@@ -20,16 +20,22 @@ import {
   CatalogProcessorErrorResult,
   CatalogProcessorResult,
 } from './types';
+import path from 'path';
 
 describe('FileReaderProcessor', () => {
-  const fixturesRoot =
-    'src/ingestion/processors/__fixtures__/fileReaderProcessor';
+  const fixturesRoot = path.join(
+    'src',
+    'ingestion',
+    'processors',
+    '__fixtures__',
+    'fileReaderProcessor',
+  );
 
   it('should load from file', async () => {
     const processor = new FileReaderProcessor();
     const spec = {
       type: 'file',
-      target: `${fixturesRoot}/component.yaml`,
+      target: `${path.join(fixturesRoot, 'component.yaml')}`,
     };
 
     const generated = (await new Promise<CatalogProcessorResult>(emit =>
@@ -45,7 +51,7 @@ describe('FileReaderProcessor', () => {
     const processor = new FileReaderProcessor();
     const spec = {
       type: 'file',
-      target: `${fixturesRoot}/missing.yaml`,
+      target: `${path.join(fixturesRoot, 'missing.yaml')}`,
     };
 
     const generated = (await new Promise<CatalogProcessorResult>(emit =>
@@ -56,7 +62,7 @@ describe('FileReaderProcessor', () => {
     expect(generated.location).toBe(spec);
     expect(generated.error.name).toBe('NotFoundError');
     expect(generated.error.message).toBe(
-      `file ${fixturesRoot}/missing.yaml does not exist`,
+      `file ${path.join(fixturesRoot, 'missing.yaml')} does not exist`,
     );
   });
 
@@ -66,7 +72,7 @@ describe('FileReaderProcessor', () => {
     const emit = jest.fn();
 
     await processor.readLocation(
-      { type: 'file', target: `${fixturesRoot}/**/*.yaml` },
+      { type: 'file', target: `${path.join(fixturesRoot, '**', '*.yaml')}` },
       false,
       emit,
     );

--- a/plugins/catalog-backend/src/ingestion/processors/__fixtures__/fileReaderProcessor/component.yaml
+++ b/plugins/catalog-backend/src/ingestion/processors/__fixtures__/fileReaderProcessor/component.yaml
@@ -1,0 +1,1 @@
+kind: Component

--- a/plugins/catalog-backend/src/ingestion/processors/__fixtures__/fileReaderProcessor/dir/api.yaml
+++ b/plugins/catalog-backend/src/ingestion/processors/__fixtures__/fileReaderProcessor/dir/api.yaml
@@ -1,0 +1,1 @@
+kind: API

--- a/plugins/catalog-backend/src/ingestion/processors/__fixtures__/fileReaderProcessor/test.txt
+++ b/plugins/catalog-backend/src/ingestion/processors/__fixtures__/fileReaderProcessor/test.txt
@@ -1,0 +1,1 @@
+Just a text file


### PR DESCRIPTION
As the UrlReaderProcessor supports this now, it would be nice for the FileReaderProcessor supports that too. Also added some tests 🙂 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
