### PR TITLE
integrations: switch to using x-access-token for github git auth

### DIFF
--- a/.changeset/mean-grapes-march.md
+++ b/.changeset/mean-grapes-march.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-common': patch
+'@backstage/techdocs-common': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Switched to using `'x-access-token'` for authenticating Git over HTTPS towards GitHub.

--- a/packages/backend-common/src/scm/git.ts
+++ b/packages/backend-common/src/scm/git.ts
@@ -23,12 +23,11 @@ import fs from 'fs-extra';
 import { Logger } from 'winston';
 
 /*
-provider    username        password
-GitHub      token           'x-oauth-basic'
-GitHub App  token           'x-access-token'
-BitBucket   'x-token-auth'  token
-GitLab      'oauth2'        token
-From : https://isomorphic-git.org/docs/en/onAuth
+provider    username         password
+GitHub      'x-access-token' token
+BitBucket   'x-token-auth'   token
+GitLab      'oauth2'         token
+From : https://isomorphic-git.org/docs/en/onAuth with fix for GitHub
 
 Azure       'notempty'      token
 */

--- a/packages/techdocs-common/src/helpers.ts
+++ b/packages/techdocs-common/src/helpers.ts
@@ -133,11 +133,11 @@ export const checkoutGitRepository = async (
     switch (type) {
       case 'github':
         git = Git.fromAuth({
-          username: token,
-          password: 'x-oauth-basic',
+          username: 'x-access-token',
+          password: token,
           logger,
         });
-        parsedGitLocation.token = `${token}:x-oauth-basic`;
+        parsedGitLocation.token = `x-access-token:${token}`;
         break;
       case 'gitlab':
         git = Git.fromAuth({

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.test.ts
@@ -90,8 +90,8 @@ describe('GitHubPreparer', () => {
 
     expect(Git.fromAuth).toHaveBeenCalledWith({
       logger,
-      username: 'fake-token',
-      password: 'x-oauth-basic',
+      username: 'x-access-token',
+      password: 'fake-token',
     });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/github.ts
@@ -38,8 +38,8 @@ export class GithubPreparer implements PreparerBase {
 
     const git = this.config.token
       ? Git.fromAuth({
-          username: this.config.token,
-          password: 'x-oauth-basic',
+          username: 'x-access-token',
+          password: this.config.token,
           logger,
         })
       : Git.fromAuth({ logger });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts
@@ -97,7 +97,7 @@ describe('GitHub Publisher', () => {
         expect(initRepoAndPush).toHaveBeenCalledWith({
           dir: resultPath,
           remoteUrl: 'https://github.com/backstage/backstage.git',
-          auth: { username: 'fake-token', password: 'x-oauth-basic' },
+          auth: { username: 'x-access-token', password: 'fake-token' },
           logger,
         });
       });
@@ -148,7 +148,7 @@ describe('GitHub Publisher', () => {
         expect(initRepoAndPush).toHaveBeenCalledWith({
           dir: resultPath,
           remoteUrl: 'https://github.com/backstage/backstage.git',
-          auth: { username: 'fake-token', password: 'x-oauth-basic' },
+          auth: { username: 'x-access-token', password: 'fake-token' },
           logger,
         });
       });
@@ -206,7 +206,7 @@ describe('GitHub Publisher', () => {
       expect(initRepoAndPush).toHaveBeenCalledWith({
         dir: resultPath,
         remoteUrl: 'https://github.com/backstage/backstage.git',
-        auth: { username: 'fake-token', password: 'x-oauth-basic' },
+        auth: { username: 'x-access-token', password: 'fake-token' },
         logger,
       });
     });
@@ -257,7 +257,7 @@ describe('GitHub Publisher', () => {
       expect(initRepoAndPush).toHaveBeenCalledWith({
         dir: resultPath,
         remoteUrl: 'https://github.com/backstage/backstage.git',
-        auth: { username: 'fake-token', password: 'x-oauth-basic' },
+        auth: { username: 'x-access-token', password: 'fake-token' },
         logger,
       });
     });
@@ -307,7 +307,7 @@ describe('GitHub Publisher', () => {
       expect(initRepoAndPush).toHaveBeenCalledWith({
         dir: resultPath,
         remoteUrl: 'https://github.com/backstage/backstage.git',
-        auth: { username: 'fake-token', password: 'x-oauth-basic' },
+        auth: { username: 'x-access-token', password: 'fake-token' },
         logger,
       });
     });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -72,8 +72,8 @@ export class GithubPublisher implements PublisherBase {
       dir: path.join(workspacePath, 'result'),
       remoteUrl,
       auth: {
-        username: this.config.token,
-        password: 'x-oauth-basic',
+        username: 'x-access-token',
+        password: this.config.token,
       },
       logger,
     });


### PR DESCRIPTION
This seems like the newer method compared to using `'x-oauth-basic'` and works for all kinds of tokens, including GitHub App ones.

https://www.npmjs.com/package/@octokit/auth-token/v/2.4.0#use-token-for-git-operations
https://docs.github.com/en/developers/apps/authenticating-with-github-apps#http-based-git-access-by-an-installation