### PR TITLE
Fix sonar plugin

### DIFF
--- a/.changeset/blue-lions-worry.md
+++ b/.changeset/blue-lions-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': patch
+---
+
+Fix bug retrieving current theme

--- a/plugins/sonarqube/src/components/SonarQubeCard/Percentage.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/Percentage.tsx
@@ -16,7 +16,7 @@
 
 import { BackstageTheme } from '@backstage/theme';
 import { makeStyles } from '@material-ui/core/styles';
-import { useTheme } from '@material-ui/styles';
+import { useTheme } from '@material-ui/core';
 import { Circle } from 'rc-progress';
 import React from 'react';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`useTheme()` imported from `@material-ui/styles` returns null. This change gets the sonar plugin working. Other plugins seem to be importing from `@material-ui/core`, e.g. [the catalog](https://github.com/backstage/backstage/blob/7ee15d2c5b40a8984aacabe7bdf5ccab759d95a6/plugins/catalog/src/components/CatalogFilter/AllServicesCount.tsx#L19)

I'm using the latest versions of everything.

Before the change I see this error in the UI:

![image](https://user-images.githubusercontent.com/14176917/108096237-aa458000-7078-11eb-8b38-964fd3cff090.png)

And this trace in the console:

```
The above error occurred in the <Percentage> component:
    in Percentage (created by SonarQubeCard)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (created by RatingCard)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (created by RatingCard)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (created by RatingCard)
    in a (created by ForwardRef(Typography))
    in ForwardRef(Typography) (created by WithStyles(ForwardRef(Typography)))
    in WithStyles(ForwardRef(Typography)) (created by ForwardRef(Link))
    in ForwardRef(Link) (created by WithStyles(ForwardRef(Link)))
    in WithStyles(ForwardRef(Link)) (created by RatingCard)
    in RatingCard (created by SonarQubeCard)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (created by SonarQubeCard)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (created by SonarQubeCard)
    in div (created by ForwardRef(CardContent))
    in ForwardRef(CardContent) (created by WithStyles(ForwardRef(CardContent)))
    in WithStyles(ForwardRef(CardContent)) (created by InfoCard)
    in ErrorBoundary2 (created by InfoCard)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by ForwardRef(Card))
    in ForwardRef(Card) (created by WithStyles(ForwardRef(Card)))
    in WithStyles(ForwardRef(Card)) (created by InfoCard)
    in InfoCard (created by SonarQubeCard)
    in SonarQubeCard (at EntityPage.tsx:67)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (at EntityPage.tsx:66)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (at EntityPage.tsx:62)
    in OverviewContent (at EntityPage.tsx:113)
    in article (created by Content)
    in Content (created by Layout)
    in Layout (created by EntityPageLayout)
    in div (created by Page)
    in ThemeProvider (created by Page)
    in Page (created by EntityPageLayout)
    in EntityPageLayout (at EntityPage.tsx:109)
    in WebsiteEntityPage (at EntityPage.tsx:148)
    in ComponentEntityPage (at EntityPage.tsx:198)
    in EntityPage (created by EntityPageSwitch)
    in EntityPageSwitch (created by Router)
    in EntityLoaderProvider (created by Router)
    in Route (created by Router)
    in Routes (created by Router)
    in Router (at App.tsx:58)
    in Route (at App.tsx:56)
    in FlatRoutes (at App.tsx:54)
    in div (created by SidebarPage)
    in SidebarPage (at App.tsx:52)
    in Route (created by AppRouter)
    in Routes (created by AppRouter)
    in Router (created by BrowserRouter)
    in BrowserRouter (created by AppRouter)
    in AppRouter (at App.tsx:51)
    in RoutingProvider (created by Provider)
    in CssBaseline (created by WithStyles(CssBaseline))
    in WithStyles(CssBaseline) (created by AppThemeProvider)
    in ThemeProvider (created by AppThemeProvider)
    in AppThemeProvider (created by Provider)
    in AppContextProvider (created by Provider)
    in ApiProvider (created by Provider)
    in Provider (at App.tsx:48)
    in App (at src/index.tsx:6)
```

After the change I see the SonarQube card as expected:

![image](https://user-images.githubusercontent.com/14176917/108096159-8eda7500-7078-11eb-9601-08bbafed3327.png)
