### PR TITLE
TechDocs: Pass user and group ID when invoking docker container

### DIFF
--- a/.changeset/techdocs-metal-turkeys-sleep.md
+++ b/.changeset/techdocs-metal-turkeys-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Pass user and group ID when invoking docker container. When TechDocs invokes Docker, docker could be run as a `root` user which results in generation of files by applications run by non-root user (e.g. TechDocs) will not have access to modify. This PR passes in current user and group ID to docker so that the file permissions of the generated files and folders are correct.


### PR DESCRIPTION
When TechDocs invokes Docker, docker could be run as a `root` user which results in generation of files by applications run by non-root user (e.g. TechDocs) will not have access to modify. This PR passes in current user and group ID to docker so that the file permissions of the generated files and folders are correct.


Literally copy pasted from scaffolder. To be replaced very soon by a utility function from @backstage/backend-common https://github.com/backstage/backstage/issues/4560