### PR TITLE
Fix build issues in master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: build changed packages
         if: ${{ steps.yarn-lock.outcome == 'success' }}
-        run: yarn lerna -- run build --since origin/master
+        run: yarn lerna -- run build --since origin/master --include-dependencies
 
       - name: build all packages
         if: ${{ steps.yarn-lock.outcome == 'failure' }}


### PR DESCRIPTION
When only building the changed packages we run into trouble with @backstage/cli-common not being build and breaking the CLI