### PR TITLE
Customise view, edit and source links through annotations

### DIFF
--- a/.changeset/honest-hounds-exist.md
+++ b/.changeset/honest-hounds-exist.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-model': patch
+'@backstage/plugin-catalog': patch
+---
+
+Implement annotations for customising Entity URLs in the Catalog pages.

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -166,6 +166,7 @@ interop
 jq
 js
 json
+jsonnet
 jsx
 kubectl
 kubernetes

--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -70,7 +70,7 @@ The value of this annotation is a location reference string (see above). If this
 annotation is specified, it is expected to point to a repository that the
 TechDocs system can read and generate docs from.
 
-### backstage.io/browser-view-url, backstage.io/browser-edit-url, backstage.io/browser-source-url
+### backstage.io/browser-view-url, backstage.io/browser-edit-url
 
 ```yaml
 # Example:
@@ -78,16 +78,26 @@ metadata:
   annotations:
     backstage.io/browser-view-url: https://some.website/catalog-info.yaml
     backstage.io/browser-edit-url: https://github.com/my-org/catalog/edit/master/my-service.jsonnet
-    backstage.io/browser-source-url: https://github.com/my-org/my-service
 ```
 
 These annotations allow customising links from the catalog pages. The view URL
 should point to the canonical metadata YAML that governs this entity. The edit
-URL should point to the source file for the metadata. The source URL should
-point to the source code of the entity itself (where relevant, i.e. when the
-entity is a `Component`). In the example above, `my-org` generates its catalog
-data from Jsonnet files in a monorepo, and so for the `my-service` component, we
-need three custom links.
+URL should point to the source file for the metadata. In the example above,
+`my-org` generates its catalog data from Jsonnet files in a monorepo, so the
+view and edit links need changing.
+
+### backstage.io/source-location
+
+```yaml
+# Example:
+metadata:
+  annotations:
+    backstage.io/source-location: github:https://github.com/my-org/my-service
+```
+
+A `Location` reference that points to the source code of the entity (typically a
+`Component`). Useful when catalog files do not get ingested from the source code
+repository itself.
 
 ### jenkins.io/github-folder
 

--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -70,14 +70,14 @@ The value of this annotation is a location reference string (see above). If this
 annotation is specified, it is expected to point to a repository that the
 TechDocs system can read and generate docs from.
 
-### backstage.io/browser-view-url, backstage.io/browser-edit-url
+### backstage.io/view-url, backstage.io/edit-url
 
 ```yaml
 # Example:
 metadata:
   annotations:
-    backstage.io/browser-view-url: https://some.website/catalog-info.yaml
-    backstage.io/browser-edit-url: https://github.com/my-org/catalog/edit/master/my-service.jsonnet
+    backstage.io/view-url: https://some.website/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/my-org/catalog/edit/master/my-service.jsonnet
 ```
 
 These annotations allow customising links from the catalog pages. The view URL

--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -70,6 +70,25 @@ The value of this annotation is a location reference string (see above). If this
 annotation is specified, it is expected to point to a repository that the
 TechDocs system can read and generate docs from.
 
+### backstage.io/browser-view-url, backstage.io/browser-edit-url, backstage.io/browser-source-url
+
+```yaml
+# Example:
+metadata:
+  annotations:
+    backstage.io/browser-view-url: https://some.website/catalog-info.yaml
+    backstage.io/browser-edit-url: https://github.com/my-org/catalog/edit/master/my-service.jsonnet
+    backstage.io/browser-source-url: https://github.com/my-org/my-service
+```
+
+These annotations allow customising links from the catalog pages. The view URL
+should point to the canonical metadata YAML that governs this entity. The edit
+URL should point to the source file for the metadata. The source URL should
+point to the source code of the entity itself (where relevant, i.e. when the
+entity is a `Component`). In the example above, `my-org` generates its catalog
+data from Jsonnet files in a monorepo, and so for the `my-service` component, we
+need three custom links.
+
 ### jenkins.io/github-folder
 
 ```yaml

--- a/packages/catalog-model/src/entity/constants.ts
+++ b/packages/catalog-model/src/entity/constants.ts
@@ -27,3 +27,9 @@ export const ENTITY_META_GENERATED_FIELDS = [
   'etag',
   'generation',
 ] as const;
+
+/**
+ * Annotations for linking to entity from catalog pages.
+ */
+export const VIEW_URL_ANNOTATION = 'backstage.io/view-url';
+export const EDIT_URL_ANNOTATION = 'backstage.io/edit-url';

--- a/packages/catalog-model/src/entity/index.ts
+++ b/packages/catalog-model/src/entity/index.ts
@@ -17,6 +17,8 @@
 export {
   ENTITY_DEFAULT_NAMESPACE,
   ENTITY_META_GENERATED_FIELDS,
+  VIEW_URL_ANNOTATION,
+  EDIT_URL_ANNOTATION,
 } from './constants';
 export type {
   Entity,

--- a/packages/catalog-model/src/location/annotation.ts
+++ b/packages/catalog-model/src/location/annotation.ts
@@ -17,3 +17,5 @@
 export const LOCATION_ANNOTATION = 'backstage.io/managed-by-location';
 export const ORIGIN_LOCATION_ANNOTATION =
   'backstage.io/managed-by-origin-location';
+
+export const SOURCE_LOCATION_ANNOTATION = 'backstage.io/source-location';

--- a/packages/catalog-model/src/location/index.ts
+++ b/packages/catalog-model/src/location/index.ts
@@ -20,4 +20,8 @@ export {
   locationSpecSchema,
   analyzeLocationSchema,
 } from './validation';
-export { LOCATION_ANNOTATION, ORIGIN_LOCATION_ANNOTATION } from './annotation';
+export {
+  LOCATION_ANNOTATION,
+  ORIGIN_LOCATION_ANNOTATION,
+  SOURCE_LOCATION_ANNOTATION,
+} from './annotation';

--- a/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
@@ -135,7 +135,7 @@ describe('<AboutCard /> custom links', () => {
         annotations: {
           'backstage.io/managed-by-location':
             'bitbucket:https://bitbucket.org/backstage/backstage/src/master/software.yaml',
-          'backstage.io/browser-edit-url': 'https://another.place',
+          'backstage.io/edit-url': 'https://another.place',
           [SOURCE_LOCATION_ANNOTATION]:
             'url:https://another.place/backstage.git',
         },

--- a/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
@@ -123,3 +123,41 @@ describe('<AboutCard /> BitBucket', () => {
     );
   });
 });
+
+describe('<AboutCard /> custom links', () => {
+  it('renders info and "view source" link', () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+        annotations: {
+          'backstage.io/managed-by-location':
+            'bitbucket:https://bitbucket.org/backstage/backstage/src/master/software.yaml',
+          'backstage.io/browser-edit-url': 'https://another.place',
+          'backstage.io/browser-source-url':
+            'https://another.place/backstage.git',
+        },
+      },
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const { getByText } = render(
+      <EntityProvider entity={entity}>
+        <AboutCard />
+      </EntityProvider>,
+    );
+    expect(getByText('service')).toBeInTheDocument();
+    expect(getByText('View Source').closest('a')).toHaveAttribute(
+      'href',
+      'https://another.place/backstage.git',
+    );
+    expect(getByText('View Source').closest('a')).toHaveAttribute(
+      'edithref',
+      'https://another.place',
+    );
+  });
+});

--- a/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
@@ -15,7 +15,10 @@
  */
 
 import { EntityProvider } from '@backstage/plugin-catalog-react';
-import { SOURCE_LOCATION_ANNOTATION } from '@backstage/catalog-model';
+import {
+  SOURCE_LOCATION_ANNOTATION,
+  EDIT_URL_ANNOTATION,
+} from '@backstage/catalog-model';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { AboutCard } from './AboutCard';
@@ -135,7 +138,7 @@ describe('<AboutCard /> custom links', () => {
         annotations: {
           'backstage.io/managed-by-location':
             'bitbucket:https://bitbucket.org/backstage/backstage/src/master/software.yaml',
-          'backstage.io/edit-url': 'https://another.place',
+          [EDIT_URL_ANNOTATION]: 'https://another.place',
           [SOURCE_LOCATION_ANNOTATION]:
             'url:https://another.place/backstage.git',
         },

--- a/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { SOURCE_LOCATION_ANNOTATION } from '@backstage/catalog-model';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { AboutCard } from './AboutCard';
@@ -135,8 +136,8 @@ describe('<AboutCard /> custom links', () => {
           'backstage.io/managed-by-location':
             'bitbucket:https://bitbucket.org/backstage/backstage/src/master/software.yaml',
           'backstage.io/browser-edit-url': 'https://another.place',
-          'backstage.io/browser-source-url':
-            'https://another.place/backstage.git',
+          [SOURCE_LOCATION_ANNOTATION]:
+            'url:https://another.place/backstage.git',
         },
       },
       spec: {

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -74,7 +74,7 @@ function getSourceLocationForEntity(
 
 function getCodeLinkInfo(entity: Entity): CodeLinkInfo {
   const location = findLocationForEntityMeta(entity?.metadata);
-  const editUrl = findEditUrl(entity, location);
+  const editUrl = findEditUrl(entity);
   let sourceLocation = getSourceLocationForEntity(entity, location);
 
   if (location) {

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -35,7 +35,7 @@ import ExtensionIcon from '@material-ui/icons/Extension';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import React from 'react';
 import { findLocationForEntityMeta } from '../../data/utils';
-import { createEditLink, determineUrlType } from '../createEditLink';
+import { createEditLink, determineUrlType } from '../actions';
 import { AboutContent } from './AboutContent';
 
 const useStyles = makeStyles({

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -35,7 +35,7 @@ import ExtensionIcon from '@material-ui/icons/Extension';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import React from 'react';
 import { findLocationForEntityMeta } from '../../data/utils';
-import { createEditLink, determineUrlType } from '../actions';
+import { findEditUrl, determineUrlType } from '../actions';
 import { AboutContent } from './AboutContent';
 
 const useStyles = makeStyles({
@@ -61,19 +61,22 @@ type CodeLinkInfo = {
 };
 
 function getCodeLinkInfo(entity: Entity): CodeLinkInfo {
+  let sourceUrl =
+    entity.metadata?.annotations?.['backstage.io/browser-source-url'];
   const location = findLocationForEntityMeta(entity?.metadata);
+  const editUrl = findEditUrl(entity, location);
+
   if (location) {
+    sourceUrl = sourceUrl || location.target;
     const type =
-      location.type === 'url'
-        ? determineUrlType(location.target)
-        : location.type;
+      location.type === 'url' ? determineUrlType(sourceUrl) : location.type;
     return {
+      edithref: editUrl,
       icon: iconMap[type],
-      edithref: createEditLink(location),
-      href: location.target,
+      href: sourceUrl,
     };
   }
-  return {};
+  return { edithref: editUrl, href: sourceUrl };
 }
 
 type AboutCardProps = {

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -86,7 +86,7 @@ describe('CatalogTable component', () => {
       kind: 'Component',
       metadata: {
         name: 'component1',
-        annotations: { 'backstage.io/browser-edit-url': 'https://other.place' },
+        annotations: { 'backstage.io/edit-url': 'https://other.place' },
       },
     };
 
@@ -115,7 +115,7 @@ describe('CatalogTable component', () => {
       kind: 'Component',
       metadata: {
         name: 'component1',
-        annotations: { 'backstage.io/browser-view-url': 'https://other.place' },
+        annotations: { 'backstage.io/view-url': 'https://other.place' },
       },
     };
 

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
+import {
+  Entity,
+  VIEW_URL_ANNOTATION,
+  EDIT_URL_ANNOTATION,
+} from '@backstage/catalog-model';
 import { act, fireEvent } from '@testing-library/react';
 import { renderWithEffects, wrapInTestApp } from '@backstage/test-utils';
 import * as React from 'react';
@@ -86,7 +90,7 @@ describe('CatalogTable component', () => {
       kind: 'Component',
       metadata: {
         name: 'component1',
-        annotations: { 'backstage.io/edit-url': 'https://other.place' },
+        annotations: { [EDIT_URL_ANNOTATION]: 'https://other.place' },
       },
     };
 
@@ -115,7 +119,7 @@ describe('CatalogTable component', () => {
       kind: 'Component',
       metadata: {
         name: 'component1',
-        annotations: { 'backstage.io/view-url': 'https://other.place' },
+        annotations: { [VIEW_URL_ANNOTATION]: 'https://other.place' },
       },
     };
 

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -38,7 +38,6 @@ import { Chip } from '@material-ui/core';
 import Edit from '@material-ui/icons/Edit';
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import React from 'react';
-import { findLocationForEntityMeta } from '../../data/utils';
 import { findViewUrl, findEditUrl } from '../actions';
 import {
   favouriteEntityIcon,
@@ -152,8 +151,7 @@ export const CatalogTable = ({
 
   const actions: TableProps<EntityRow>['actions'] = [
     ({ entity }) => {
-      const location = findLocationForEntityMeta(entity.metadata);
-      const url = findViewUrl(entity, location);
+      const url = findViewUrl(entity);
       return {
         icon: () => <OpenInNew fontSize="small" />,
         tooltip: 'View',
@@ -164,8 +162,7 @@ export const CatalogTable = ({
       };
     },
     ({ entity }) => {
-      const location = findLocationForEntityMeta(entity.metadata);
-      const url = findEditUrl(entity, location);
+      const url = findEditUrl(entity);
       return {
         icon: () => <Edit fontSize="small" />,
         tooltip: 'Edit',

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -34,13 +34,12 @@ import {
   getEntityRelations,
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
-
 import { Chip } from '@material-ui/core';
 import Edit from '@material-ui/icons/Edit';
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import React from 'react';
 import { findLocationForEntityMeta } from '../../data/utils';
-import { createEditLink } from '../createEditLink';
+import { findViewUrl, findEditUrl } from '../actions';
 import {
   favouriteEntityIcon,
   favouriteEntityTooltip,
@@ -154,23 +153,25 @@ export const CatalogTable = ({
   const actions: TableProps<EntityRow>['actions'] = [
     ({ entity }) => {
       const location = findLocationForEntityMeta(entity.metadata);
+      const url = findViewUrl(entity, location);
       return {
         icon: () => <OpenInNew fontSize="small" />,
         tooltip: 'View',
         onClick: () => {
-          if (!location) return;
-          window.open(location.target, '_blank');
+          if (!url) return;
+          window.open(url, '_blank');
         },
       };
     },
     ({ entity }) => {
       const location = findLocationForEntityMeta(entity.metadata);
+      const url = findEditUrl(entity, location);
       return {
         icon: () => <Edit fontSize="small" />,
         tooltip: 'Edit',
         onClick: () => {
-          if (!location) return;
-          window.open(createEditLink(location), '_blank');
+          if (!url) return;
+          window.open(url, '_blank');
         },
       };
     },

--- a/plugins/catalog/src/components/actions.ts
+++ b/plugins/catalog/src/components/actions.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { LocationSpec, Entity } from '@backstage/catalog-model';
+import {
+  LocationSpec,
+  Entity,
+  EDIT_URL_ANNOTATION,
+  VIEW_URL_ANNOTATION,
+} from '@backstage/catalog-model';
 import parseGitUrl from 'git-url-parse';
 
 /**
@@ -82,7 +87,7 @@ export const findEditUrl = (
 ): string | undefined => {
   const annotations = metadata.annotations || {};
 
-  const editUrl = annotations['backstage.io/edit-url'];
+  const editUrl = annotations[EDIT_URL_ANNOTATION];
 
   if (editUrl) return editUrl;
 
@@ -95,5 +100,5 @@ export const findViewUrl = (
 ): string | undefined => {
   const annotations = metadata.annotations || {};
 
-  return annotations['backstage.io/view-url'] || location?.target;
+  return annotations[VIEW_URL_ANNOTATION] || location?.target;
 };

--- a/plugins/catalog/src/components/actions.ts
+++ b/plugins/catalog/src/components/actions.ts
@@ -20,6 +20,7 @@ import {
   EDIT_URL_ANNOTATION,
   VIEW_URL_ANNOTATION,
 } from '@backstage/catalog-model';
+import { findLocationForEntityMeta } from '../data/utils';
 import parseGitUrl from 'git-url-parse';
 
 /**
@@ -81,24 +82,21 @@ export const determineUrlType = (url: string): string => {
   return 'url';
 };
 
-export const findEditUrl = (
-  { metadata }: Entity,
-  location?: LocationSpec,
-): string | undefined => {
+export const findEditUrl = ({ metadata }: Entity): string | undefined => {
   const annotations = metadata.annotations || {};
 
   const editUrl = annotations[EDIT_URL_ANNOTATION];
 
   if (editUrl) return editUrl;
 
+  const location = findLocationForEntityMeta(metadata);
+
   return location && createEditLink(location);
 };
 
-export const findViewUrl = (
-  { metadata }: Entity,
-  location?: LocationSpec,
-): string | undefined => {
+export const findViewUrl = ({ metadata }: Entity): string | undefined => {
   const annotations = metadata.annotations || {};
+  const location = findLocationForEntityMeta(metadata);
 
   return annotations[VIEW_URL_ANNOTATION] || location?.target;
 };

--- a/plugins/catalog/src/components/actions.ts
+++ b/plugins/catalog/src/components/actions.ts
@@ -82,7 +82,7 @@ export const findEditUrl = (
 ): string | undefined => {
   const annotations = metadata.annotations || {};
 
-  const editUrl = annotations['backstage.io/browser-edit-url'];
+  const editUrl = annotations['backstage.io/edit-url'];
 
   if (editUrl) return editUrl;
 
@@ -95,5 +95,5 @@ export const findViewUrl = (
 ): string | undefined => {
   const annotations = metadata.annotations || {};
 
-  return annotations['backstage.io/browser-view-url'] || location?.target;
+  return annotations['backstage.io/view-url'] || location?.target;
 };

--- a/plugins/catalog/src/components/actions.ts
+++ b/plugins/catalog/src/components/actions.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { LocationSpec } from '@backstage/catalog-model';
+import { LocationSpec, Entity } from '@backstage/catalog-model';
 import parseGitUrl from 'git-url-parse';
 
 /**
@@ -74,4 +74,26 @@ export const determineUrlType = (url: string): string => {
     return 'gitlab';
   }
   return 'url';
+};
+
+export const findEditUrl = (
+  { metadata }: Entity,
+  location?: LocationSpec,
+): string | undefined => {
+  const annotations = metadata.annotations || {};
+
+  const editUrl = annotations['backstage.io/browser-edit-url'];
+
+  if (editUrl) return editUrl;
+
+  return location && createEditLink(location);
+};
+
+export const findViewUrl = (
+  { metadata }: Entity,
+  location?: LocationSpec,
+): string | undefined => {
+  const annotations = metadata.annotations || {};
+
+  return annotations['backstage.io/browser-view-url'] || location?.target;
 };

--- a/plugins/catalog/src/data/utils.ts
+++ b/plugins/catalog/src/data/utils.ts
@@ -32,13 +32,17 @@ export function findLocationForEntityMeta(
     return undefined;
   }
 
-  const separatorIndex = annotation.indexOf(':');
+  return parseLocation(annotation);
+}
+
+export function parseLocation(reference: string): LocationSpec | undefined {
+  const separatorIndex = reference.indexOf(':');
   if (separatorIndex === -1) {
     return undefined;
   }
 
   return {
-    type: annotation.substring(0, separatorIndex),
-    target: annotation.substring(separatorIndex + 1),
+    type: reference.substring(0, separatorIndex),
+    target: reference.substring(separatorIndex + 1),
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,7 +1874,6 @@
     "@backstage/catalog-model" "^0.7.1"
     "@backstage/core" "^0.6.2"
     "@backstage/plugin-catalog-react" "^0.0.4"
-    "@backstage/plugin-scaffolder" "^0.5.1"
     "@backstage/theme" "^0.2.3"
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
@@ -18238,7 +18237,7 @@ modify-values@^1.0.0:
   resolved "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@^2.19.3, moment@^2.25.3, moment@^2.26.0, moment@^2.27.0:
+moment@^2.19.3, moment@^2.25.3, moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
Fixes #4455.

## Hey, I just made a Pull Request!

Allow custom links on catalog and entity pages to entity metadata and source. So if a component has the following annotations:

```yaml
metadata:
  annotations:
    backstage.io/browser-view-url: https://some.website/catalog-info.yaml
    backstage.io/browser-edit-url: https://github.com/my-org/catalog/edit/master/my-service.jsonnet
    backstage.io/browser-source-url: https://github.com/my-org/my-service
```
These links in the Actions column on the CatalogPage:

![2021-02-18-143548_3840x1080_scrot](https://user-images.githubusercontent.com/2285130/108372826-1cdc6a00-71f7-11eb-9a50-340496238971.png)

... will point to `https://some.website/catalog-info.yaml` and `https://github.com/my-org/catalog/edit/master/my-service.jsonnet`, and on the entity's own page:
 
![2021-02-18-143626_3840x1080_scrot](https://user-images.githubusercontent.com/2285130/108372819-1c43d380-71f7-11eb-9895-346600677ac8.png)

... the View source link on the left, and the edit link on the right, will point to `https://github.com/my-org/my-service` and `https://github.com/my-org/catalog/edit/master/my-service.jsonnet`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
