### PR TITLE
Add google analytics scripts in template for standalone app

### DIFF
--- a/.changeset/mighty-masks-hear.md
+++ b/.changeset/mighty-masks-hear.md
@@ -1,0 +1,29 @@
+---
+'@backstage/create-app': patch
+---
+
+Add the google analytics scripts in the `index.html` template for new applications.
+
+To apply this change to an existing application, change the following in `packages\app\public\index.html`:
+
+```diff
+    <title><%= app.title %></title>
+
++    <% if (app.googleAnalyticsTrackingId && typeof app.googleAnalyticsTrackingId
++    === 'string') { %>
++    <script
++      async
++      src="https://www.googletagmanager.com/gtag/js?id=<%= app.googleAnalyticsTrackingId %>"
++    ></script>
++    <script>
++      window.dataLayer = window.dataLayer || [];
++      function gtag() {
++        dataLayer.push(arguments);
++      }
++      gtag('js', new Date());
++
++      gtag('config', '<%= app.googleAnalyticsTrackingId %>');
++    </script>
++    <% } %>
+  </head>
+```

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -204,6 +204,7 @@ octokit
 oidc
 onboarding
 pagerduty
+pageview
 parallelization
 plantuml
 postgres

--- a/docs/integrations/google-analytics/installation.md
+++ b/docs/integrations/google-analytics/installation.md
@@ -1,6 +1,7 @@
 ---
 id: installation
 title: Google Analytics Installation
+sidebar_label: Installation
 # prettier-ignore
 description: Adding Google Analytics to Your App
 ---

--- a/docs/integrations/google-analytics/installation.md
+++ b/docs/integrations/google-analytics/installation.md
@@ -1,0 +1,23 @@
+---
+id: installation
+title: Google Analytics Installation
+# prettier-ignore
+description: Adding Google Analytics to Your App
+---
+
+There is a basic Google Analytics integration built into Backstage. You can
+enable it by adding the following to your app configuration:
+
+```yaml
+app:
+  googleAnalyticsTrackingId: UA-000000-0
+```
+
+Replace the tracking ID with your own.
+
+For more information, learn about Google Analytics
+[here](https://marketingplatform.google.com/about/analytics/).
+
+The default behavior is only to send a pageview hit to Google Analytics. To
+record more, look at the developer documentation
+[here](https://developers.google.com/analytics/devguides/collection/gtagjs).

--- a/docs/plugins/observability.md
+++ b/docs/plugins/observability.md
@@ -10,18 +10,8 @@ Backstage integrator.
 
 ## Google Analytics
 
-There is a basic Google Analytics integration built into Backstage. You can
-enable it by adding the following to your app configuration:
-
-```yaml
-app:
-  googleAnalyticsTrackingId: UA-000000-0
-```
-
-Replace the tracking ID with your own.
-
-For more information, learn about Google Analytics
-[here](https://marketingplatform.google.com/about/analytics/).
+See how to install Google Analytics in your app
+[here](../integrations/google-analytics/installation.md)
 
 ## Logging
 

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -112,6 +112,11 @@
         "type": "subcategory",
         "label": "LDAP",
         "ids": ["integrations/ldap/org"]
+      },
+      {
+        "type": "subcategory",
+        "label": "Google Analytics",
+        "ids": ["integrations/google-analytics/installation"]
       }
     ],
     "Plugins": [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,8 @@ nav:
           - Org Data: 'integrations/github/org.md'
       - LDAP:
           - Org Data: 'integrations/ldap/org.md'
+      - Google Analytics:
+          - Installation: 'integrations/google-analytics/installation.md'
   - Plugins:
       - Overview: 'plugins/index.md'
       - Existing plugins: 'plugins/existing-plugins.md'

--- a/packages/create-app/templates/default-app/packages/app/public/index.html
+++ b/packages/create-app/templates/default-app/packages/app/public/index.html
@@ -48,6 +48,22 @@
       }
     </style>
     <title><%= app.title %></title>
+    <% if (app.googleAnalyticsTrackingId && typeof app.googleAnalyticsTrackingId
+    === 'string') { %>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=<%= app.googleAnalyticsTrackingId %>"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', '<%= app.googleAnalyticsTrackingId %>');
+    </script>
+    <% } %>
   </head>
   <body style="margin: 0;">
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Signed-off-by: r.bideau <7304827+rbideau@users.noreply.github.com>

## Hey, I just made a Pull Request!

Add the google analytics snippet in the index.html template for new app, this was present in the index.html in the app but missing in the template.



Fix #4576 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
