### PR TITLE
Include uiSchema in Template forms

### DIFF
--- a/.changeset/slow-windows-beam.md
+++ b/.changeset/slow-windows-beam.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-model': minor
+'@backstage/plugin-scaffolder': minor
+---
+
+Implement rjsf-uiSchema for Template forms

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -565,6 +565,9 @@ spec:
         title: Description
         type: string
         description: Description of the component
+  uiSchema:
+    description:
+      ui:widget: textarea
 ```
 
 In addition to the [common envelope metadata](#common-to-all-kinds-the-metadata)
@@ -630,6 +633,15 @@ specify relative to the `template.yaml` definition.
 
 This is also particularly useful when you have multiple template definitions in
 the same repository but only a single `template.yaml` registered in backstage.
+
+### `spec.uiSchema` [optional]
+
+Object that describes how the form should be rendered.  
+While `spec.schema` describes **what** is rendered, `spec.uiSchema` describes
+**how**.
+
+It follows the
+[react-jsonschema-form - uiSchema reference](https://react-jsonschema-form.readthedocs.io/en/latest/api-reference/uiSchema/).
 
 ## Kind: API
 

--- a/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.ts
@@ -33,6 +33,7 @@ export interface TemplateEntityV1alpha1 extends Entity {
     templater: string;
     path?: string;
     schema: JSONSchema;
+    uiSchema?: JSONSchema;
   };
 }
 

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -66,7 +66,7 @@ export const MultistepJsonForm = ({
   return (
     <>
       <Stepper activeStep={activeStep} orientation="vertical">
-        {steps.map(({ label, schema, ...formProps }) => (
+        {steps.map(({ label, schema, uiSchema, ...formProps }) => (
           <StepUI key={label}>
             <StepLabel>{label}</StepLabel>
             <StepContent key={label}>
@@ -76,6 +76,7 @@ export const MultistepJsonForm = ({
                 formData={formData}
                 onChange={onChange}
                 schema={schema as FormProps<any>['schema']}
+                uiSchema={uiSchema as FormProps<any>['uiSchema']}
                 onSubmit={e => {
                   if (e.errors.length === 0) handleNext();
                 }}

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -176,10 +176,12 @@ export const TemplatePage = () => {
                 {
                   label: 'Fill in template parameters',
                   schema: template.spec.schema,
+                  uiSchema: template.spec.uiSchema,
                 },
                 {
                   label: 'Choose owner and repo',
                   schema: OWNER_REPO_SCHEMA,
+                  uiSchema: template.spec.uiSchema,
                   validate: (formData, errors) => {
                     const { storePath } = formData;
                     try {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Problem Statement
Unable to add textarea fields in a template. 

### Solution  
Allowing templates to make use of the [react-jsonschema-form uiSchema](https://react-jsonschema-form.readthedocs.io/en/latest/api-reference/uiSchema/) to modify how the form is rendered. (_Not only textarea_ 😎)

### Changes
* Adding `uiSchema` prop to `MultistepJsonForm`
* Enabling `uiSchema` object in Templates **YAML** files 

> Template Page. 

<img width="788" alt="Screen Shot 2021-02-18 at 8 56 36" src="https://user-images.githubusercontent.com/18434722/108419109-bdcb2500-71f7-11eb-87f8-d71e7f458562.png">. 

> Template YML.  

<img width="490" alt="Screen Shot 2021-02-18 at 8 49 25" src="https://user-images.githubusercontent.com/18434722/108419096-ba379e00-71f7-11eb-83f0-d7dd81d03c94.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
