### PR TITLE
Org: Themed ownership card

### DIFF
--- a/.changeset/cyan-feet-hide.md
+++ b/.changeset/cyan-feet-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Use the `pageTheme` to colour the OwnershipCard boxes with their respective theme colours.

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.stories.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.stories.tsx
@@ -13,10 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Grid } from '@material-ui/core';
+import { Grid, ThemeProvider } from '@material-ui/core';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { GroupEntity } from '@backstage/catalog-model';
+import {
+  lightTheme,
+  createTheme,
+  genPageTheme,
+  shapes,
+} from '@backstage/theme';
 import {
   EntityContext,
   CatalogApi,
@@ -83,14 +89,51 @@ const apiRegistry = ApiRegistry.from([[catalogApiRef, catalogApi]]);
 
 export const Default = () => (
   <MemoryRouter>
-    <ApiProvider apis={apiRegistry}>
-      <EntityContext.Provider value={{ entity: defaultEntity, loading: false }}>
-        <Grid container spacing={4}>
-          <Grid item xs={12} md={6}>
-            <OwnershipCard variant="gridItem" />
+    <ThemeProvider theme={lightTheme}>
+      <ApiProvider apis={apiRegistry}>
+        <EntityContext.Provider
+          value={{ entity: defaultEntity, loading: false }}
+        >
+          <Grid container spacing={4}>
+            <Grid item xs={12} md={6}>
+              <OwnershipCard />
+            </Grid>
           </Grid>
-        </Grid>
-      </EntityContext.Provider>
-    </ApiProvider>
+        </EntityContext.Provider>
+      </ApiProvider>
+    </ThemeProvider>
+  </MemoryRouter>
+);
+
+const monochromeTheme = createTheme({
+  ...lightTheme,
+  defaultPageTheme: 'home',
+  pageTheme: {
+    home: genPageTheme(['#444'], shapes.wave2),
+    documentation: genPageTheme(['#474747'], shapes.wave2),
+    tool: genPageTheme(['#222'], shapes.wave2),
+    service: genPageTheme(['#aaa'], shapes.wave2),
+    website: genPageTheme(['#0e0e0e'], shapes.wave2),
+    library: genPageTheme(['#9d9d9d'], shapes.wave2),
+    other: genPageTheme(['#aaa'], shapes.wave2),
+    app: genPageTheme(['#666'], shapes.wave2),
+  },
+});
+
+export const Themed = () => (
+  <MemoryRouter>
+    <ThemeProvider theme={monochromeTheme}>
+      <ApiProvider apis={apiRegistry}>
+        <EntityContext.Provider
+          value={{ entity: defaultEntity, loading: false }}
+        >
+          <Grid container spacing={4}>
+            <Grid item xs={12} md={6}>
+              <OwnershipCard />
+            </Grid>
+          </Grid>
+        </EntityContext.Provider>
+      </ApiProvider>
+    </ThemeProvider>
   </MemoryRouter>
 );

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.stories.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.stories.tsx
@@ -18,10 +18,10 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { GroupEntity } from '@backstage/catalog-model';
 import {
-  lightTheme,
   createTheme,
   genPageTheme,
   shapes,
+  BackstageTheme,
 } from '@backstage/theme';
 import {
   EntityContext,
@@ -89,36 +89,33 @@ const apiRegistry = ApiRegistry.from([[catalogApiRef, catalogApi]]);
 
 export const Default = () => (
   <MemoryRouter>
-    <ThemeProvider theme={lightTheme}>
-      <ApiProvider apis={apiRegistry}>
-        <EntityContext.Provider
-          value={{ entity: defaultEntity, loading: false }}
-        >
-          <Grid container spacing={4}>
-            <Grid item xs={12} md={6}>
-              <OwnershipCard />
-            </Grid>
+    <ApiProvider apis={apiRegistry}>
+      <EntityContext.Provider value={{ entity: defaultEntity, loading: false }}>
+        <Grid container spacing={4}>
+          <Grid item xs={12} md={6}>
+            <OwnershipCard />
           </Grid>
-        </EntityContext.Provider>
-      </ApiProvider>
-    </ThemeProvider>
+        </Grid>
+      </EntityContext.Provider>
+    </ApiProvider>
   </MemoryRouter>
 );
 
-const monochromeTheme = createTheme({
-  ...lightTheme,
-  defaultPageTheme: 'home',
-  pageTheme: {
-    home: genPageTheme(['#444'], shapes.wave2),
-    documentation: genPageTheme(['#474747'], shapes.wave2),
-    tool: genPageTheme(['#222'], shapes.wave2),
-    service: genPageTheme(['#aaa'], shapes.wave2),
-    website: genPageTheme(['#0e0e0e'], shapes.wave2),
-    library: genPageTheme(['#9d9d9d'], shapes.wave2),
-    other: genPageTheme(['#aaa'], shapes.wave2),
-    app: genPageTheme(['#666'], shapes.wave2),
-  },
-});
+const monochromeTheme = (outer: BackstageTheme) =>
+  createTheme({
+    ...outer,
+    defaultPageTheme: 'home',
+    pageTheme: {
+      home: genPageTheme(['#444'], shapes.wave2),
+      documentation: genPageTheme(['#474747'], shapes.wave2),
+      tool: genPageTheme(['#222'], shapes.wave2),
+      service: genPageTheme(['#aaa'], shapes.wave2),
+      website: genPageTheme(['#0e0e0e'], shapes.wave2),
+      library: genPageTheme(['#9d9d9d'], shapes.wave2),
+      other: genPageTheme(['#aaa'], shapes.wave2),
+      app: genPageTheme(['#666'], shapes.wave2),
+    },
+  });
 
 export const Themed = () => (
   <MemoryRouter>

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -21,13 +21,12 @@ import {
   isOwnerOf,
   useEntity,
 } from '@backstage/plugin-catalog-react';
-import { pageTheme } from '@backstage/theme';
+import { BackstageTheme, genPageTheme } from '@backstage/theme';
 import {
   Box,
   createStyles,
   Grid,
   makeStyles,
-  Theme,
   Typography,
 } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
@@ -43,7 +42,17 @@ type EntitiesTypes =
   | 'api'
   | 'tool';
 
-const useStyles = makeStyles((theme: Theme) =>
+const createPageTheme = (
+  theme: BackstageTheme,
+  shapeKey: string,
+  colorsKey: string,
+) => {
+  const { colors } = theme.getPageTheme({ themeId: colorsKey });
+  const { shape } = theme.getPageTheme({ themeId: shapeKey });
+  return genPageTheme(colors, shape).backgroundImage;
+};
+
+const useStyles = makeStyles((theme: BackstageTheme) =>
   createStyles({
     card: {
       border: `1px solid ${theme.palette.divider}`,
@@ -60,22 +69,22 @@ const useStyles = makeStyles((theme: Theme) =>
       fontWeight: theme.typography.fontWeightBold,
     },
     service: {
-      background: `${pageTheme.home.shape}, linear-gradient(90deg, ${pageTheme.service.colors})`,
+      background: createPageTheme(theme, 'home', 'service'),
     },
     website: {
-      background: `${pageTheme.home.shape}, linear-gradient(90deg, ${pageTheme.website.colors})`,
+      background: createPageTheme(theme, 'home', 'website'),
     },
     library: {
-      background: `${pageTheme.home.shape}, linear-gradient(90deg, ${pageTheme.library.colors})`,
+      background: createPageTheme(theme, 'home', 'library'),
     },
     documentation: {
-      background: `${pageTheme.home.shape}, linear-gradient(90deg, ${pageTheme.documentation.colors})`,
+      background: createPageTheme(theme, 'home', 'documentation'),
     },
     api: {
-      background: `${pageTheme.home.shape}, linear-gradient(90deg, #005B4B, #005B4B)`,
+      background: createPageTheme(theme, 'home', 'home'),
     },
     tool: {
-      background: `${pageTheme.home.shape}, linear-gradient(90deg, ${pageTheme.tool.colors})`,
+      background: createPageTheme(theme, 'home', 'tool'),
     },
   }),
 );


### PR DESCRIPTION
Adds the ability to use the current theme to colour the cards in the OwnershipCard component.
Currently the colours are implemented to match the original design using the keys:
 - API: `home`
 - Service: `service`
 - Website: `website`
 - Library: `library`
 - Documentation: `documentation`
 - Tool: `tool`

which should mean the colours match the defaults for the entities. I admit the API -> home is a bit of a curveball, but that was the colour mapping before (although it was more hardcoded).

@freben hopefully ^ answers your [question in the issue] (https://github.com/backstage/backstage/issues/4519#issuecomment-781444818) of at least how I had gone about implementing this, but I'm open to suggestions!

### Screenshot

(Sorry for the boring theme)

<img width="839" alt="Skärmavbild 2021-02-18 kl  20 56 35" src="https://user-images.githubusercontent.com/2790386/108422080-fb4aa500-722d-11eb-83f7-35a1652cd2bf.png">

Closes #4519

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
