### PR TITLE
TechDocs: Fix publishers to work on Windows (AWS, GCS and Azure)

### DIFF
--- a/.changeset/techdocs-wild-zoos-do.md
+++ b/.changeset/techdocs-wild-zoos-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Fix AWS, GCS and Azure publisher to work on Windows.

--- a/packages/techdocs-common/__mocks__/@azure/storage-blob.ts
+++ b/packages/techdocs-common/__mocks__/@azure/storage-blob.ts
@@ -23,10 +23,11 @@ import path from 'path';
 
 const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
 /**
- * @param sourceFile contains either / or \ as file separator depending upon OS.
+ * @param sourceFile Relative path to entity root dir. Contains either / or \ as file separator
+ * depending upon the OS.
  */
 const checkFileExists = async (sourceFile: string): Promise<boolean> => {
-  // sourceFile will always have / as file separator irrespective of OS since S3 expects /.
+  // sourceFile will always have / as file separator irrespective of OS since Azure expects /.
   // Normalize sourceFile to OS specific path before checking if file exists.
   const relativeFilePath = sourceFile.split(path.posix.sep).join(path.sep);
   const filePath = path.join(rootDir, sourceFile);

--- a/packages/techdocs-common/__mocks__/@azure/storage-blob.ts
+++ b/packages/techdocs-common/__mocks__/@azure/storage-blob.ts
@@ -13,11 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import fs from 'fs';
 import type {
   BlobUploadCommonResponse,
   ContainerGetPropertiesResponse,
 } from '@azure/storage-blob';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+
+const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
+/**
+ * @param sourceFile contains either / or \ as file separator depending upon OS.
+ */
+const checkFileExists = async (sourceFile: string): Promise<boolean> => {
+  // sourceFile will always have / as file separator irrespective of OS since S3 expects /.
+  // Normalize sourceFile to OS specific path before checking if file exists.
+  const relativeFilePath = sourceFile.split(path.posix.sep).join(path.sep);
+  const filePath = path.join(rootDir, sourceFile);
+
+  try {
+    await fs.access(filePath, fs.constants.F_OK);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
 
 export class BlockBlobClient {
   private readonly blobName;
@@ -39,7 +59,7 @@ export class BlockBlobClient {
   }
 
   exists() {
-    return Promise.resolve(fs.existsSync(this.blobName));
+    return checkFileExists(this.blobName);
   }
 }
 

--- a/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
+++ b/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
@@ -32,8 +32,6 @@ const checkFileExists = async (sourceFile: string): Promise<boolean> => {
     await fs.access(filePath, fs.constants.F_OK);
     return true;
   } catch (err) {
-    console.log("File doesn't exist");
-    console.log(filePath);
     return false;
   }
 };

--- a/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
+++ b/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { EventEmitter } from 'events';
 import fs from 'fs-extra';
+import os from 'os';
 import path from 'path';
 
 type storageOptions = {
   keyFilename?: string;
 };
 
+const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
 /**
  * @param sourceFile Absolute path. Contains either / or \ as file separator depending upon the OS.
  */
@@ -35,6 +38,41 @@ const checkFileExists = async (sourceFile: string): Promise<boolean> => {
     return false;
   }
 };
+
+class GCSFile {
+  private readonly localFilePath: string;
+
+  constructor(private readonly destinationFilePath: string) {
+    this.destinationFilePath = destinationFilePath;
+    this.localFilePath = path.join(rootDir, this.destinationFilePath);
+  }
+
+  exists() {
+    return new Promise(async (resolve, reject) => {
+      if (await checkFileExists(this.localFilePath)) {
+        resolve([true]);
+      } else {
+        reject();
+      }
+    });
+  }
+
+  createReadStream() {
+    const emitter = new EventEmitter();
+    process.nextTick(() => {
+      if (fs.existsSync(this.localFilePath)) {
+        emitter.emit('data', Buffer.from(fs.readFileSync(this.localFilePath)));
+        emitter.emit('end');
+      } else {
+        emitter.emit(
+          'error',
+          new Error(`The file ${this.localFilePath} does not exist !`),
+        );
+      }
+    });
+    return emitter;
+  }
+}
 
 class Bucket {
   private readonly bucketName;
@@ -57,6 +95,10 @@ class Bucket {
         reject(`Source file ${source} does not exist.`);
       }
     });
+  }
+
+  file(destinationFilePath: string) {
+    return new GCSFile(destinationFilePath);
   }
 }
 

--- a/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
+++ b/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
@@ -21,10 +21,10 @@ type storageOptions = {
 };
 
 /**
- * @param sourceFile contains either / or \ as file separator depending upon OS.
+ * @param sourceFile Absolute path. Contains either / or \ as file separator depending upon the OS.
  */
 const checkFileExists = async (sourceFile: string): Promise<boolean> => {
-  // sourceFile will always have / as file separator irrespective of OS since S3 expects /.
+  // sourceFile will always have / as file separator irrespective of OS since GCS expects /.
   // Normalize sourceFile to OS specific path before checking if file exists.
   const filePath = sourceFile.split(path.posix.sep).join(path.sep);
 

--- a/packages/techdocs-common/__mocks__/aws-sdk.ts
+++ b/packages/techdocs-common/__mocks__/aws-sdk.ts
@@ -41,7 +41,7 @@ export class S3 {
           } else {
             emitter.emit(
               'error',
-              new Error(`The file ${Key} doest not exist !`),
+              new Error(`The file ${Key} does not exist !`),
             );
           }
           emitter.emit('end');
@@ -56,7 +56,7 @@ export class S3 {
       if (fs.existsSync(Key)) {
         resolve('');
       } else {
-        reject({ message: 'The object doest not exist !' });
+        reject({ message: 'The object does not exist !' });
       }
     });
   }
@@ -71,7 +71,11 @@ export class S3 {
     return {
       promise: () =>
         new Promise((resolve, reject) => {
-          resolve('');
+          if (!fs.existsSync(Key)) {
+            reject('');
+          } else {
+            resolve('');
+          }
         }),
     };
   }

--- a/packages/techdocs-common/__mocks__/aws-sdk.ts
+++ b/packages/techdocs-common/__mocks__/aws-sdk.ts
@@ -22,7 +22,7 @@ import path from 'path';
 const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
 
 /**
- * @param Key Contains either / or \ as file separator depending upon OS.
+ * @param Key contains either / or \ as file separator depending upon OS.
  */
 const checkFileExists = async (Key: string): Promise<boolean> => {
   // Key will always have / as file separator irrespective of OS since S3 expects /.

--- a/packages/techdocs-common/__mocks__/aws-sdk.ts
+++ b/packages/techdocs-common/__mocks__/aws-sdk.ts
@@ -22,7 +22,8 @@ import path from 'path';
 const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
 
 /**
- * @param Key contains either / or \ as file separator depending upon OS.
+ * @param Key Relative path to entity root dir. Contains either / or \ as file separator
+ * depending upon the OS.
  */
 const checkFileExists = async (Key: string): Promise<boolean> => {
   // Key will always have / as file separator irrespective of OS since S3 expects /.

--- a/packages/techdocs-common/__mocks__/aws-sdk.ts
+++ b/packages/techdocs-common/__mocks__/aws-sdk.ts
@@ -65,13 +65,13 @@ export class S3 {
         process.nextTick(() => {
           if (fs.existsSync(filePath)) {
             emitter.emit('data', Buffer.from(fs.readFileSync(filePath)));
+            emitter.emit('end');
           } else {
             emitter.emit(
               'error',
               new Error(`The file ${filePath} does not exist !`),
             );
           }
-          emitter.emit('end');
         });
         return emitter;
       },

--- a/packages/techdocs-common/__mocks__/aws-sdk.ts
+++ b/packages/techdocs-common/__mocks__/aws-sdk.ts
@@ -15,7 +15,28 @@
  */
 import type { S3 as S3Types } from 'aws-sdk';
 import { EventEmitter } from 'events';
-import fs from 'fs';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+
+const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
+
+/**
+ * @param Key Contains either / or \ as file separator depending upon OS.
+ */
+const checkFileExists = async (Key: string): Promise<boolean> => {
+  // Key will always have / as file separator irrespective of OS since S3 expects /.
+  // Normalize Key to OS specific path before checking if file exists.
+  const relativeFilePath = Key.split(path.posix.sep).join(path.sep);
+  const filePath = path.join(rootDir, Key);
+
+  try {
+    await fs.access(filePath, fs.constants.F_OK);
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
 
 export class S3 {
   private readonly options;
@@ -26,22 +47,27 @@ export class S3 {
 
   headObject({ Key }: { Key: string }) {
     return {
-      promise: () => this.checkFileExists(Key),
+      promise: async () => {
+        if (!(await checkFileExists(Key))) {
+          throw new Error('File does not exist');
+        }
+      },
     };
   }
 
   getObject({ Key }: { Key: string }) {
+    const filePath = path.join(rootDir, Key);
     return {
-      promise: () => this.checkFileExists(Key),
+      promise: () => checkFileExists(filePath),
       createReadStream: () => {
         const emitter = new EventEmitter();
         process.nextTick(() => {
-          if (fs.existsSync(Key)) {
-            emitter.emit('data', Buffer.from(fs.readFileSync(Key)));
+          if (fs.existsSync(filePath)) {
+            emitter.emit('data', Buffer.from(fs.readFileSync(filePath)));
           } else {
             emitter.emit(
               'error',
-              new Error(`The file ${Key} does not exist !`),
+              new Error(`The file ${filePath} does not exist !`),
             );
           }
           emitter.emit('end');
@@ -49,16 +75,6 @@ export class S3 {
         return emitter;
       },
     };
-  }
-
-  checkFileExists(Key: string) {
-    return new Promise((resolve, reject) => {
-      if (fs.existsSync(Key)) {
-        resolve('');
-      } else {
-        reject({ message: 'The object does not exist !' });
-      }
-    });
   }
 
   headBucket() {
@@ -70,9 +86,9 @@ export class S3 {
   upload({ Key }: { Key: string }) {
     return {
       promise: () =>
-        new Promise((resolve, reject) => {
-          if (!fs.existsSync(Key)) {
-            reject('');
+        new Promise(async (resolve, reject) => {
+          if (!(await checkFileExists(Key))) {
+            reject(`The file ${Key} does not exist`);
           } else {
             resolve('');
           }

--- a/packages/techdocs-common/src/stages/publish/awsS3.test.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.test.ts
@@ -82,11 +82,7 @@ beforeEach(() => {
 
 describe('AwsS3Publish', () => {
   describe('publish', () => {
-    afterEach(() => {
-      mockFs.restore();
-    });
-
-    it('should publish a directory', async () => {
+    beforeEach(() => {
       const entity = createMockEntity();
       const entityRootDir = getEntityRootDir(entity);
 
@@ -99,6 +95,15 @@ describe('AwsS3Publish', () => {
           },
         },
       });
+    });
+
+    afterEach(() => {
+      mockFs.restore();
+    });
+
+    it('should publish a directory', async () => {
+      const entity = createMockEntity();
+      const entityRootDir = getEntityRootDir(entity);
 
       expect(
         await publisher.publish({
@@ -116,18 +121,14 @@ describe('AwsS3Publish', () => {
         'to',
         'generatedDirectory',
       );
-      const entity = createMockEntity();
-      const entityRootDir = getEntityRootDir(entity);
 
-      mockFs({
-        [entityRootDir]: {
-          'index.html': '',
-          '404.html': '',
-          assets: {
-            'main.css': '',
-          },
-        },
-      });
+      const entity = createMockEntity();
+      await expect(
+        publisher.publish({
+          entity,
+          directory: wrongPathToGeneratedDirectory,
+        }),
+      ).rejects.toThrowError();
 
       await publisher
         .publish({
@@ -139,7 +140,7 @@ describe('AwsS3Publish', () => {
             // Can not do exact error message match due to mockFs adding unexpected characters in the path when throwing the error
             // Issue reported https://github.com/tschaub/mock-fs/issues/118
             expect.stringContaining(
-              `Unable to upload file(s) to AWS S3. Error Failed to read template directory: ENOENT, no such file or directory`,
+              `Unable to upload file(s) to AWS S3. Error: Failed to read template directory: ENOENT, no such file or directory`,
             ),
           );
           expect(error.message).toEqual(

--- a/packages/techdocs-common/src/stages/publish/awsS3.test.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.test.ts
@@ -120,6 +120,7 @@ describe('AwsS3Publish', () => {
     });
 
     it('should fail to publish a directory', async () => {
+      expect.assertions(3);
       const wrongPathToGeneratedDirectory = path.join(
         rootDir,
         'wrong',

--- a/packages/techdocs-common/src/stages/publish/awsS3.test.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.test.ts
@@ -127,9 +127,9 @@ describe('AwsS3Publish', () => {
           directory: wrongPathToGeneratedDirectory,
         })
         .catch(error =>
-          expect(error.message).toEqual(
-            expect.stringContaining(
-              'Unable to upload file(s) to AWS S3. Error Failed to read template directory: ENOENT, no such file or directory',
+          expect(error).toEqual(
+            new Error(
+              `Unable to upload file(s) to AWS S3. Error Failed to read template directory: ENOENT, no such file or directory '${wrongPathToGeneratedDirectory}'`,
             ),
           ),
         );
@@ -205,12 +205,19 @@ describe('AwsS3Publish', () => {
 
     it('should return an error if the techdocs_metadata.json file is not present', async () => {
       const entityNameMock = createMockEntityName();
+      const entity = createMockEntity();
+      const entityRootDir = getEntityRootDir(entity);
 
       await publisher
         .fetchTechDocsMetadata(entityNameMock)
         .catch(error =>
-          expect(error.message).toEqual(
-            expect.stringContaining('TechDocs metadata fetch'),
+          expect(error).toEqual(
+            new Error(
+              `TechDocs metadata fetch failed, The file ${path.join(
+                entityRootDir,
+                'techdocs_metadata.json',
+              )} does not exist !`,
+            ),
           ),
         );
     });

--- a/packages/techdocs-common/src/stages/publish/awsS3.test.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.test.ts
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { Entity, EntityName } from '@backstage/catalog-model';
+import {
+  Entity,
+  EntityName,
+  ENTITY_DEFAULT_NAMESPACE,
+} from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import mockFs from 'mock-fs';
 import os from 'os';
@@ -52,7 +56,7 @@ const getEntityRootDir = (entity: Entity) => {
     metadata: { namespace, name },
   } = entity;
 
-  return path.join(rootDir, namespace as string, kind, name);
+  return path.join(rootDir, namespace || ENTITY_DEFAULT_NAMESPACE, kind, name);
 };
 
 const logger = winston.createLogger();

--- a/packages/techdocs-common/src/stages/publish/awsS3.test.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.test.ts
@@ -22,6 +22,8 @@ import * as winston from 'winston';
 import { AwsS3Publish } from './awsS3';
 import { PublisherBase, TechDocsMetadata } from './types';
 
+// NOTE: /packages/techdocs-common/__mocks__ is being used to mock aws-sdk client library
+
 const createMockEntity = (annotations = {}): Entity => {
   return {
     apiVersion: 'version',

--- a/packages/techdocs-common/src/stages/publish/awsS3.test.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.test.ts
@@ -16,8 +16,8 @@
 import type { Entity, EntityName } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import mockFs from 'mock-fs';
-import * as os from 'os';
-import * as path from 'path';
+import os from 'os';
+import path from 'path';
 import * as winston from 'winston';
 import { AwsS3Publish } from './awsS3';
 import { PublisherBase, TechDocsMetadata } from './types';

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -140,9 +140,17 @@ export class AwsS3Publish implements PublisherBase {
         // Remove the absolute path prefix of the source directory
         // Path of all files to upload, relative to the root of the source directory
         // e.g. ['index.html', 'sub-page/index.html', 'assets/images/favicon.png']
-        const relativeFilePath = filePath.replace(`${directory}/`, '');
+        const relativeFilePath = path.relative(directory, filePath);
+
+        // Convert destination file path to a POSIX path for uploading.
+        // S3 expects / as path separator and relativeFilePath will contain \\ on Windows.
+        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+        const relativeFilePathPosix = relativeFilePath
+          .split(path.sep)
+          .join(path.posix.sep);
+
         const entityRootDir = `${entity.metadata.namespace}/${entity.kind}/${entity.metadata.name}`;
-        const destination = `${entityRootDir}/${relativeFilePath}`; // S3 Bucket file relative path
+        const destination = `${entityRootDir}/${relativeFilePathPosix}`; // S3 Bucket file relative path
 
         const fileContent = await fs.readFile(filePath, 'utf8');
 

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -172,7 +172,7 @@ export class AwsS3Publish implements PublisherBase {
       );
       return;
     } catch (e) {
-      const errorMessage = `Unable to upload file(s) to AWS S3. Error ${e.message}`;
+      const errorMessage = `Unable to upload file(s) to AWS S3. ${e}`;
       this.logger.error(errorMessage);
       throw new Error(errorMessage);
     }

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -149,6 +149,7 @@ export class AwsS3Publish implements PublisherBase {
           .split(path.sep)
           .join(path.posix.sep);
 
+        // The / delimiter is intentional since it represents the cloud storage and not the local file system.
         const entityRootDir = `${entity.metadata.namespace}/${entity.kind}/${entity.metadata.name}`;
         const destination = `${entityRootDir}/${relativeFilePathPosix}`; // S3 Bucket file relative path
 

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
@@ -111,6 +111,7 @@ describe('publishing with valid credentials', () => {
     });
 
     it('should fail to publish a directory', async () => {
+      expect.assertions(1);
       const wrongPathToGeneratedDirectory = path.join(
         rootDir,
         'wrong',

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
@@ -126,11 +126,17 @@ describe('publishing with valid credentials', () => {
           entity,
           directory: wrongPathToGeneratedDirectory,
         })
-        .catch(error =>
-          expect(error.message).toBe(
-            `Unable to upload file(s) to Azure Blob Storage. Error: Failed to read template directory: ENOENT, no such file or directory '${wrongPathToGeneratedDirectory}'`,
-          ),
-        );
+        .catch(error => {
+          // Can not do exact error message match due to mockFs adding unexpected characters in the path when throwing the error
+          // Issue reported https://github.com/tschaub/mock-fs/issues/118
+          expect.stringContaining(
+            `Unable to upload file(s) to Azure Blob Storage. Error: Failed to read template directory: ENOENT, no such file or directory`,
+          );
+
+          expect(error.message).toEqual(
+            expect.stringContaining(wrongPathToGeneratedDirectory),
+          );
+        });
       mockFs.restore();
     });
   });

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { getVoidLogger } from '@backstage/backend-common';
-import type { Entity } from '@backstage/catalog-model';
+import { Entity, ENTITY_DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import mockFs from 'mock-fs';
 import os from 'os';
@@ -45,7 +45,7 @@ const getEntityRootDir = (entity: Entity) => {
     metadata: { namespace, name },
   } = entity;
 
-  return path.join(rootDir, namespace as string, kind, name);
+  return path.join(rootDir, namespace || ENTITY_DEFAULT_NAMESPACE, kind, name);
 };
 
 function createLogger() {

--- a/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 import { getVoidLogger } from '@backstage/backend-common';
-import { Entity, EntityName } from '@backstage/catalog-model';
+import {
+  Entity,
+  EntityName,
+  ENTITY_DEFAULT_NAMESPACE,
+} from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import mockFs from 'mock-fs';
 import os from 'os';
@@ -52,7 +56,7 @@ const getEntityRootDir = (entity: Entity) => {
     metadata: { namespace, name },
   } = entity;
 
-  return path.join(rootDir, namespace as string, kind, name);
+  return path.join(rootDir, namespace || ENTITY_DEFAULT_NAMESPACE, kind, name);
 };
 
 const logger = getVoidLogger();

--- a/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
@@ -117,6 +117,8 @@ describe('GoogleGCSPublish', () => {
     });
 
     it('should fail to publish a directory', async () => {
+      expect.assertions(3);
+
       const wrongPathToGeneratedDirectory = path.join(
         rootDir,
         'wrong',

--- a/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
@@ -22,6 +22,8 @@ import path from 'path';
 import { GoogleGCSPublish } from './googleStorage';
 import { PublisherBase } from './types';
 
+// NOTE: /packages/techdocs-common/__mocks__ is being used to mock Google Cloud Storage client library
+
 const createMockEntity = (annotations = {}): Entity => {
   return {
     apiVersion: 'version',

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -118,6 +118,7 @@ export class GoogleGCSPublish implements PublisherBase {
           .split(path.sep)
           .join(path.posix.sep);
 
+        // The / delimiter is intentional since it represents the cloud storage and not the local file system.
         const entityRootDir = `${entity.metadata.namespace}/${entity.kind}/${entity.metadata.name}`;
         const destination = `${entityRootDir}/${relativeFilePathPosix}`; // GCS Bucket file relative path
 

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -160,9 +160,9 @@ export class GoogleGCSPublish implements PublisherBase {
           fileStreamChunks.push(chunk);
         })
         .on('end', () => {
-          const techdocsMetadataJson = Buffer.concat(
-            fileStreamChunks,
-          ).toString();
+          const techdocsMetadataJson = Buffer.concat(fileStreamChunks).toString(
+            'utf-8',
+          );
           resolve(JSON5.parse(techdocsMetadataJson));
         });
     });


### PR DESCRIPTION
This PR removes hardcoded `/` file separator when reading files from local filesystem. All the three cloud providers still use `/` delimiter by default - so the upload destination file paths will still use `/` irrespective of the OS.

Improves tests and fixes failing master build. https://github.com/backstage/backstage/runs/1930144017

Closes #4036

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
