### PR TITLE
catalog-react: remove Domain column from System table

### DIFF
--- a/.changeset/brown-geckos-double.md
+++ b/.changeset/brown-geckos-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Remove Domain column from system table preset

--- a/plugins/catalog-react/src/components/EntityTable/presets.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTable/presets.test.tsx
@@ -72,7 +72,6 @@ describe('systemEntityColumns', () => {
 
     await waitFor(() => {
       expect(getByText('my-namespace/my-system')).toBeInTheDocument();
-      expect(getByText('my-namespace/my-domain')).toBeInTheDocument();
       expect(getByText('Test')).toBeInTheDocument();
       expect(getByText('Some description')).toBeInTheDocument();
     });

--- a/plugins/catalog-react/src/components/EntityTable/presets.tsx
+++ b/plugins/catalog-react/src/components/EntityTable/presets.tsx
@@ -17,7 +17,6 @@
 import { ComponentEntity, SystemEntity } from '@backstage/catalog-model';
 import { TableColumn } from '@backstage/core';
 import {
-  createDomainColumn,
   createEntityRefColumn,
   createMetadataDescriptionColumn,
   createOwnerColumn,
@@ -28,7 +27,6 @@ import {
 
 export const systemEntityColumns: TableColumn<SystemEntity>[] = [
   createEntityRefColumn({ defaultKind: 'system' }),
-  createDomainColumn(),
   createOwnerColumn(),
   createMetadataDescriptionColumn(),
 ];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Supports #4553 by removing the "Domain" column from the System table presets.  This table is shown on the Domains page, and thus there's no need to repeat showing the domains systems are attached to.

| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/33203301/108450898-e5d87980-7233-11eb-9845-28e685134fce.png) | ![image](https://user-images.githubusercontent.com/33203301/108450724-aa3daf80-7233-11eb-8113-2ccfdca9d0ed.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
