### PR TITLE
feat: omit default namespace in catalog-import

### DIFF
--- a/.changeset/dirty-buckets-flow.md
+++ b/.changeset/dirty-buckets-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Omits the entity namespace from a generated entity when it has not be explicitly defined in the analyze-location result.

--- a/.changeset/dirty-buckets-flow.md
+++ b/.changeset/dirty-buckets-flow.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-catalog-import': patch
 ---
 
-Omits the entity namespace from a generated entity when it has not be explicitly defined in the analyze-location result.
+This updates the `catalog-import` plugin to omit the default metadata namespace
+field and also use the short form entity reference format for selected group owners.

--- a/plugins/catalog-import/src/components/ImportStepper/defaults.tsx
+++ b/plugins/catalog-import/src/components/ImportStepper/defaults.tsx
@@ -230,7 +230,7 @@ export function defaultGenerateStepper(
                       errorHelperText="required value"
                       textFieldProps={{
                         label: 'Entity Owner',
-                        placeholder: 'Group:default/my-group',
+                        placeholder: 'my-group',
                       }}
                       rules={{ required: true }}
                       required

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -286,7 +286,7 @@ spec:
       renderFormFieldsFn.mock.calls[
         renderFormFieldsFn.mock.calls.length - 1
       ][0],
-    ).toMatchObject({ groups: ['Group:my-group'], groupsLoading: false });
+    ).toMatchObject({ groups: ['my-group'], groupsLoading: false });
   });
 
   describe('generateEntities', () => {

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -21,7 +21,10 @@ import { act, render, RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { AnalyzeResult, catalogImportApiRef } from '../../api';
-import { StepPrepareCreatePullRequest } from './StepPrepareCreatePullRequest';
+import {
+  generateEntities,
+  StepPrepareCreatePullRequest,
+} from './StepPrepareCreatePullRequest';
 
 describe('<StepPrepareCreatePullRequest />', () => {
   const catalogImportApi: jest.Mocked<typeof catalogImportApiRef.T> = {
@@ -60,6 +63,7 @@ describe('<StepPrepareCreatePullRequest />', () => {
         kind: 'Component',
         metadata: {
           name: 'my-component',
+          namespace: 'default',
         },
         spec: {
           owner: 'my-owner',
@@ -283,5 +287,45 @@ spec:
         renderFormFieldsFn.mock.calls.length - 1
       ][0],
     ).toMatchObject({ groups: ['Group:my-group'], groupsLoading: false });
+  });
+
+  describe('generateEntities', () => {
+    it.each([[undefined], [null]])(
+      'should not include blank namespace for %s',
+      namespace => {
+        expect(
+          generateEntities(
+            [{ metadata: { namespace: namespace as any } }],
+            'my-component',
+            'group-1',
+          ),
+        ).toEqual([
+          expect.objectContaining({
+            metadata: expect.not.objectContaining({
+              namespace: 'default',
+            }),
+          }),
+        ]);
+      },
+    );
+
+    it.each([['default'], ['my-namespace']])(
+      'should include explicit namespace %s',
+      namespace => {
+        expect(
+          generateEntities(
+            [{ metadata: { namespace } }],
+            'my-component',
+            'group-1',
+          ),
+        ).toEqual([
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              namespace,
+            }),
+          }),
+        ]);
+      },
+    );
   });
 });

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
@@ -66,7 +66,7 @@ type Props = {
   ) => React.ReactNode;
 };
 
-function generateEntities(
+export function generateEntities(
   entities: PartialEntity[],
   componentName: string,
   owner: string,
@@ -78,7 +78,6 @@ function generateEntities(
     metadata: {
       ...e.metadata,
       name: componentName,
-      namespace: e.metadata?.namespace ?? 'default',
     },
     spec: {
       ...e.spec,

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import { Entity, serializeEntityRef } from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core';
-import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import {
+  catalogApiRef,
+  formatEntityRefTitle,
+} from '@backstage/plugin-catalog-react';
 import { Box, FormHelperText, Grid, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import React, { useCallback, useState } from 'react';
@@ -106,8 +109,9 @@ export const StepPrepareCreatePullRequest = ({
       filter: { kind: 'group' },
     });
 
-    // TODO: defaultKind (=group), defaultNamespace (=same as entity)
-    return groupEntities.items.map(e => serializeEntityRef(e) as string).sort();
+    return groupEntities.items
+      .map(e => formatEntityRefTitle(e, { defaultKind: 'group' }))
+      .sort();
   });
 
   const handleResult = useCallback(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change omits the `namespace` field whenever the field has not be explicitly provided by the location analyzer.

#### Why

- `namespace: default` is already the default and can be omitted
- It's not a common usage in examples and very likely existing catalog files out in the wild (note: this is an assumption)
- It breaks the ability for for a custom `LocationAnalyzer` to control the structure of the resulting entity file.

#### Additional Considerations

We could maintain this behaviour by default by simply adding the `namespace: default` to the default `RepoLocationAnalyzer`. This change does not preclude a backstage integrator from creating a custom analyzer in their backend and explicitly adding this field either.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
