### PR TITLE
microsite: Added tip for viewing data in demo.backstage.io

### DIFF
--- a/microsite/pages/en/demos.js
+++ b/microsite/pages/en/demos.js
@@ -21,6 +21,8 @@ const Background = props => {
             <Block.Paragraph>
               To explore the UI and basic features of Backstage firsthand, go
               to: <a href="https://demo.backstage.io">demo.backstage.io</a>.
+              (Tip: click “All” to view all the example components in the
+              service catalog.)
             </Block.Paragraph>
             <Block.Paragraph>
               Watch the videos below to get an introduction to Backstage and to


### PR DESCRIPTION
Default view of demo.backstage.io is Owned/Starred software, so it looks like there is no data. Added tip to click "All" to see example software in the catalog. (Maybe default to "All" or add some to "Owned/Starred" in the future?)

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
