### PR TITLE
Reduce duplicate data from entity columns

### DIFF
--- a/.changeset/gentle-zoos-pump.md
+++ b/.changeset/gentle-zoos-pump.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Truncate and show ellipsis with tooltip if content of
+`createMetadataDescriptionColumn` is too wide.

--- a/.changeset/healthy-schools-kneel.md
+++ b/.changeset/healthy-schools-kneel.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-api-docs': patch
+'@backstage/plugin-catalog': patch
+---
+
+Remove domain column from `HasSystemsCard` and system from `HasComponentsCard`,
+`HasSubcomponentsCard`, and `HasApisCard`.

--- a/.changeset/olive-moons-melt.md
+++ b/.changeset/olive-moons-melt.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-api-docs': patch
+---
+
+Make the description column in the catalog table and api-docs table use up as
+much space as possible before hiding overflowing text.

--- a/packages/catalog-model/examples/components/petstore-component.yaml
+++ b/packages/catalog-model/examples/components/petstore-component.yaml
@@ -2,7 +2,8 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: petstore
-  description: Petstore
+  # This is an extra long description
+  description: The Petstore is an example API used to show features of the OpenAPI spec.
   links:
     - url: https://github.com/swagger-api/swagger-petstore
       title: GitHub Repo

--- a/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
@@ -99,6 +99,7 @@ const columns: TableColumn<EntityRow>[] = [
         placement="bottom-start"
       />
     ),
+    width: 'auto',
   },
   {
     title: 'Tags',

--- a/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
@@ -20,6 +20,7 @@ import {
   InfoCard,
   Link,
   Progress,
+  TableColumn,
   WarningPanel,
 } from '@backstage/core';
 import {
@@ -28,11 +29,19 @@ import {
   useRelatedEntities,
 } from '@backstage/plugin-catalog-react';
 import React from 'react';
-import { apiEntityColumns } from './presets';
+import { createSpecApiTypeColumn } from './presets';
 
 type Props = {
   variant?: 'gridItem';
 };
+
+const columns: TableColumn<ApiEntity>[] = [
+  EntityTable.columns.createEntityRefColumn({ defaultKind: 'API' }),
+  EntityTable.columns.createOwnerColumn(),
+  EntityTable.columns.createSpecLifecycleColumn(),
+  createSpecApiTypeColumn(),
+  EntityTable.columns.createMetadataDescriptionColumn(),
+];
 
 export const HasApisCard = ({ variant = 'gridItem' }: Props) => {
   const { entity } = useEntity();
@@ -73,7 +82,7 @@ export const HasApisCard = ({ variant = 'gridItem' }: Props) => {
           </Link>
         </div>
       }
-      columns={apiEntityColumns}
+      columns={columns}
       entities={entities as ApiEntity[]}
     />
   );

--- a/plugins/catalog-react/src/components/EntityTable/columns.tsx
+++ b/plugins/catalog-react/src/components/EntityTable/columns.tsx
@@ -20,7 +20,7 @@ import {
   RELATION_OWNED_BY,
   RELATION_PART_OF,
 } from '@backstage/catalog-model';
-import { TableColumn } from '@backstage/core';
+import { OverflowTooltip, TableColumn } from '@backstage/core';
 import React from 'react';
 import { getEntityRelations } from '../../utils';
 import {
@@ -139,6 +139,12 @@ export function createMetadataDescriptionColumn<
   return {
     title: 'Description',
     field: 'metadata.description',
+    render: entity => (
+      <OverflowTooltip
+        text={entity.metadata.description}
+        placement="bottom-start"
+      />
+    ),
     width: 'auto',
   };
 }

--- a/plugins/catalog-react/src/components/EntityTable/presets.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTable/presets.test.tsx
@@ -74,7 +74,7 @@ describe('systemEntityColumns', () => {
       expect(getByText('my-namespace/my-system')).toBeInTheDocument();
       expect(getByText('my-namespace/my-domain')).toBeInTheDocument();
       expect(getByText('Test')).toBeInTheDocument();
-      expect(getByText('Some description')).toBeInTheDocument();
+      expect(getByText(/Some/)).toBeInTheDocument();
     });
   });
 });
@@ -131,7 +131,7 @@ describe('componentEntityColumns', () => {
       expect(getByText('Test')).toBeInTheDocument();
       expect(getByText('production')).toBeInTheDocument();
       expect(getByText('service')).toBeInTheDocument();
-      expect(getByText('Some description')).toBeInTheDocument();
+      expect(getByText(/Some/)).toBeInTheDocument();
     });
   });
 });

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -98,6 +98,7 @@ const columns: TableColumn<EntityRow>[] = [
         placement="bottom-start"
       />
     ),
+    width: 'auto',
   },
   {
     title: 'Tags',

--- a/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
+++ b/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
@@ -33,6 +33,14 @@ type Props = {
   variant?: 'gridItem';
 };
 
+const columns = [
+  EntityTable.columns.createEntityRefColumn({ defaultKind: 'component' }),
+  EntityTable.columns.createOwnerColumn(),
+  EntityTable.columns.createSpecTypeColumn(),
+  EntityTable.columns.createSpecLifecycleColumn(),
+  EntityTable.columns.createMetadataDescriptionColumn(),
+];
+
 export const HasComponentsCard = ({ variant = 'gridItem' }: Props) => {
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
@@ -72,7 +80,7 @@ export const HasComponentsCard = ({ variant = 'gridItem' }: Props) => {
           </Link>
         </div>
       }
-      columns={EntityTable.componentEntityColumns}
+      columns={columns}
       entities={entities as ComponentEntity[]}
     />
   );

--- a/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
+++ b/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
@@ -33,6 +33,14 @@ type Props = {
   variant?: 'gridItem';
 };
 
+const columns = [
+  EntityTable.columns.createEntityRefColumn({ defaultKind: 'component' }),
+  EntityTable.columns.createOwnerColumn(),
+  EntityTable.columns.createSpecTypeColumn(),
+  EntityTable.columns.createSpecLifecycleColumn(),
+  EntityTable.columns.createMetadataDescriptionColumn(),
+];
+
 export const HasSubcomponentsCard = ({ variant = 'gridItem' }: Props) => {
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
@@ -72,7 +80,7 @@ export const HasSubcomponentsCard = ({ variant = 'gridItem' }: Props) => {
           </Link>
         </div>
       }
-      columns={EntityTable.componentEntityColumns}
+      columns={columns}
       entities={entities as ComponentEntity[]}
     />
   );

--- a/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
+++ b/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
@@ -33,6 +33,12 @@ type Props = {
   variant?: 'gridItem';
 };
 
+const columns = [
+  EntityTable.columns.createEntityRefColumn({ defaultKind: 'system' }),
+  EntityTable.columns.createOwnerColumn(),
+  EntityTable.columns.createMetadataDescriptionColumn(),
+];
+
 export const HasSystemsCard = ({ variant = 'gridItem' }: Props) => {
   const { entity } = useEntity();
   const { entities, loading, error } = useRelatedEntities(entity, {
@@ -71,7 +77,7 @@ export const HasSystemsCard = ({ variant = 'gridItem' }: Props) => {
           </Link>
         </div>
       }
-      columns={EntityTable.systemEntityColumns}
+      columns={columns}
       entities={entities as SystemEntity[]}
     />
   );


### PR DESCRIPTION
I hate that this PR had three features in it, but these matched so well together 😉 If desired we can split it up and land them one by one.

**Change No.1**

I removed the system and domain column in some of the tables as suggested in #4553. @adamdmharvey can you take a look if I missed something? I choose not to modify the presets as they are also used in other places (except the one for the domains, but I would prefer to keep that one as-is, too).

![image](https://user-images.githubusercontent.com/648527/108529144-78c8f080-72d4-11eb-8506-6c65d7ba773c.png)

![image](https://user-images.githubusercontent.com/648527/108529189-87170c80-72d4-11eb-91c7-3d1e56104839.png)

![image](https://user-images.githubusercontent.com/648527/108529288-9b5b0980-72d4-11eb-9b0e-3390dffefb0c.png)

**Change No.2**

I change the description column to take up as much space as possible while keeping the overflow support. That work quite neat when resizing. Both for the catalog and api-docs.

Before (actual this screenshot is wrong, because it's without the new overflow feature...):

![image](https://user-images.githubusercontent.com/648527/108529617-f0971b00-72d4-11eb-8a24-494d1c0cb40e.png)

After:

![image](https://user-images.githubusercontent.com/648527/108529488-cd6c6b80-72d4-11eb-89d7-15c5b638a9fd.png)


**Change No.3**

Introduced the new overflow component in the description column of the entity table:

![image](https://user-images.githubusercontent.com/648527/108529380-b6c61480-72d4-11eb-84f4-4eaa54d2910e.png)

Here I noticed an issue with the overflow component. Look closely at the "g" in the description. The lowest 1-2 pixel rows are cut off...

![image](https://user-images.githubusercontent.com/648527/108531341-dfe7a480-72d6-11eb-83ab-48fe8473fad4.png)

This is actual an issue with react-text-truncate as it sets the inner span to `overflow: hidden` but I don't get why. If I remove it, it still works fine... We could do it ugly this way, but I'm not sure which other stuff I might break that way:

```diff
+const useStyles = makeStyles({
+  container: {
+    overflow: 'visible !important',
+  },
+});

 export const OverflowTooltip = (props: Props) => {
   const [hover, setHover] = useState(false);
+  const classes = useStyles();
 
   const handleToggled = (truncated: boolean) => {
     setHover(truncated);
   };
 
   return (
     <Tooltip
       title={props.title ?? props.text!}
       placement={props.placement}
       disableHoverListener={!hover}
     >
       <TextTruncate
         text={props.text}
         line={props.line}
         onToggled={handleToggled}
+        containerClassName={classes.container}
       />
     </Tooltip>
   );
 };

```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
