### PR TITLE
Fix `OverflowTooltip` cutting off the bottom of letters like "g" and "y"

### DIFF
--- a/.changeset/curvy-ducks-tease.md
+++ b/.changeset/curvy-ducks-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Fix `OverflowTooltip` cutting off the bottom of letters like "g" and "y".

--- a/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Tooltip, TooltipProps } from '@material-ui/core';
+import { makeStyles, Tooltip, TooltipProps } from '@material-ui/core';
 import React, { useState } from 'react';
 import TextTruncate, { TextTruncateProps } from 'react-text-truncate';
 
@@ -26,8 +26,15 @@ type Props = {
   placement?: TooltipProps['placement'];
 };
 
+const useStyles = makeStyles({
+  container: {
+    overflow: 'visible !important',
+  },
+});
+
 export const OverflowTooltip = (props: Props) => {
   const [hover, setHover] = useState(false);
+  const classes = useStyles();
 
   const handleToggled = (truncated: boolean) => {
     setHover(truncated);
@@ -43,6 +50,7 @@ export const OverflowTooltip = (props: Props) => {
         text={props.text}
         line={props.line}
         onToggled={handleToggled}
+        containerClassName={classes.container}
       />
     </Tooltip>
   );


### PR DESCRIPTION
As noticed in #4602, the `OverflowTooltip` cuts off the bottom of letters like "g" and "y" (btw. if a typesetting expert is here, what is the correct term for the part under the "line"? 😆 ):

![image](https://user-images.githubusercontent.com/648527/108536479-cb0e0f80-72dc-11eb-947e-d75ba44bc402.png)

The issue is caused by setting `overflow: hidden` on the inner span inside `react-text-truncate`. In general it doesn't seem to have a negative effect if I remove that, but I'm not sure. I played a bit around if longer words and stuff, but it keeps behaving as it should?

Longer words behave strange with and without my change 😆 The german Word Oberweserdampfschifffahrtsgesellschaftskapitän is half wrapped and half not wrapped, not sure...

![image](https://user-images.githubusercontent.com/648527/108536897-4243a380-72dd-11eb-868f-f86aaf493262.png)

My fix isn't nice (`!important`), but I think the [implementation leaves no other choice](https://github.com/ShinyChang/React-Text-Truncate/blob/master/src/TextTruncate.js#L233-L243). Alternative would be fixing it upstream, but I'm unsure about that as it [might break other things](https://github.com/ShinyChang/React-Text-Truncate/commit/c65c134b095bf21064c2a5b71c0f76de2c4db3f3)... 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
