### PR TITLE
core-api: migrate app context to separate type and deprecate most methods + not found page for FlatRoutes

### DIFF
--- a/.changeset/chilly-eels-try.md
+++ b/.changeset/chilly-eels-try.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-api': patch
+'@backstage/core': patch
+---
+
+The `FlatRoutes` components now renders the not found page of the app if no routes are matched.

--- a/.changeset/silly-pandas-flash.md
+++ b/.changeset/silly-pandas-flash.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-api': patch
+'@backstage/core': patch
+---
+
+Created separate `AppContext` type to be returned from `useApp` rather than the `BackstageApp` itself. The `AppContext` type includes but deprecates `getPlugins`, `getProvider`, `getRouter`, and `getRoutes`. In addition, the `AppContext` adds a new `getComponents` method which providers access to the app components.

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -64,6 +64,7 @@ import { AppThemeProvider } from './AppThemeProvider';
 import {
   AppComponents,
   AppConfigLoader,
+  AppContext,
   AppOptions,
   AppRouteBinder,
   BackstageApp,
@@ -137,6 +138,38 @@ function useConfigLoader(
   const configReader = ConfigReader.fromConfigs(config.value ?? []);
 
   return { api: configReader };
+}
+
+class AppContextImpl implements AppContext {
+  constructor(private readonly app: PrivateAppImpl) {}
+
+  getPlugins(): BackstagePlugin<any, any>[] {
+    // eslint-disable-next-line no-console
+    console.warn('appContext.getPlugins() is deprecated and will be removed');
+    return this.app.getPlugins();
+  }
+
+  getSystemIcon(key: string): IconComponent {
+    return this.app.getSystemIcon(key);
+  }
+
+  getProvider(): React.ComponentType<{}> {
+    // eslint-disable-next-line no-console
+    console.warn('appContext.getProvider() is deprecated and will be removed');
+    return this.app.getProvider();
+  }
+
+  getRouter(): React.ComponentType<{}> {
+    // eslint-disable-next-line no-console
+    console.warn('appContext.getRouter() is deprecated and will be removed');
+    return this.app.getRouter();
+  }
+
+  getRoutes(): JSX.Element[] {
+    // eslint-disable-next-line no-console
+    console.warn('appContext.getRoutes() is deprecated and will be removed');
+    return this.app.getRoutes();
+  }
 }
 
 export class PrivateAppImpl implements BackstageApp {
@@ -236,6 +269,8 @@ export class PrivateAppImpl implements BackstageApp {
   }
 
   getProvider(): ComponentType<{}> {
+    const appContext = new AppContextImpl(this);
+
     const Provider = ({ children }: PropsWithChildren<{}>) => {
       const appThemeApi = useMemo(
         () => AppThemeSelector.createWithStorage(this.themes),
@@ -273,7 +308,7 @@ export class PrivateAppImpl implements BackstageApp {
 
       return (
         <ApiProvider apis={this.getApiHolder()}>
-          <AppContextProvider app={this}>
+          <AppContextProvider appContext={appContext}>
             <AppThemeProvider>
               <RoutingProvider
                 routePaths={routePaths}

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -153,6 +153,10 @@ class AppContextImpl implements AppContext {
     return this.app.getSystemIcon(key);
   }
 
+  getComponents(): AppComponents {
+    return this.app.getComponents();
+  }
+
   getProvider(): React.ComponentType<{}> {
     // eslint-disable-next-line no-console
     console.warn('appContext.getProvider() is deprecated and will be removed');
@@ -204,6 +208,10 @@ export class PrivateAppImpl implements BackstageApp {
 
   getSystemIcon(key: IconKey): IconComponent {
     return this.icons[key];
+  }
+
+  getComponents(): AppComponents {
+    return this.components;
   }
 
   getRoutes(): JSX.Element[] {

--- a/packages/core-api/src/app/AppContext.tsx
+++ b/packages/core-api/src/app/AppContext.tsx
@@ -15,25 +15,25 @@
  */
 
 import React, { createContext, PropsWithChildren, useContext } from 'react';
-import { BackstageApp } from './types';
+import { AppContext } from './types';
 
-const Context = createContext<BackstageApp | undefined>(undefined);
+const Context = createContext<AppContext | undefined>(undefined);
 
 type Props = {
-  app: BackstageApp;
+  appContext: AppContext;
 };
 
 export const AppContextProvider = ({
-  app,
+  appContext,
   children,
 }: PropsWithChildren<Props>) => (
-  <Context.Provider value={app} children={children} />
+  <Context.Provider value={appContext} children={children} />
 );
 
-export const useApp = (): BackstageApp => {
-  const app = useContext(Context);
-  if (!app) {
+export const useApp = (): AppContext => {
+  const appContext = useContext(Context);
+  if (!appContext) {
     throw new Error('No app context available');
   }
-  return app;
+  return appContext;
 };

--- a/packages/core-api/src/app/types.ts
+++ b/packages/core-api/src/app/types.ts
@@ -203,6 +203,11 @@ export type AppContext = {
   getSystemIcon(key: IconKey): IconComponent;
 
   /**
+   * Get the components registered for various purposes in the app.
+   */
+  getComponents(): AppComponents;
+
+  /**
    * @deprecated Will be removed
    */
   getProvider(): ComponentType<{}>;

--- a/packages/core-api/src/app/types.ts
+++ b/packages/core-api/src/app/types.ts
@@ -190,3 +190,30 @@ export type BackstageApp = {
    */
   getRoutes(): JSX.Element[];
 };
+
+export type AppContext = {
+  /**
+   * @deprecated Will be removed
+   */
+  getPlugins(): BackstagePlugin<any, any>[];
+
+  /**
+   * Get a common or custom icon for this app.
+   */
+  getSystemIcon(key: IconKey): IconComponent;
+
+  /**
+   * @deprecated Will be removed
+   */
+  getProvider(): ComponentType<{}>;
+
+  /**
+   * @deprecated Will be removed
+   */
+  getRouter(): ComponentType<{}>;
+
+  /**
+   * @deprecated Will be removed
+   */
+  getRoutes(): JSX.Element[];
+};

--- a/packages/core-api/src/app/types.ts
+++ b/packages/core-api/src/app/types.ts
@@ -187,6 +187,8 @@ export type BackstageApp = {
 
   /**
    * Routes component that contains all routes for plugin pages in the app.
+   *
+   * @deprecated Registering routes in plugins is deprecated and this method will be removed.
    */
   getRoutes(): JSX.Element[];
 };

--- a/packages/core-api/src/routing/FlatRoutes.tsx
+++ b/packages/core-api/src/routing/FlatRoutes.tsx
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { ReactNode, Children, isValidElement, Fragment } from 'react';
+import React, { ReactNode, Children, isValidElement, Fragment } from 'react';
 import { useRoutes } from 'react-router-dom';
+import { useApp } from '../app';
 
 type RouteObject = {
   path: string;
@@ -71,6 +72,15 @@ type FlatRoutesProps = {
 };
 
 export const FlatRoutes = (props: FlatRoutesProps): JSX.Element | null => {
+  const app = useApp();
+  const { NotFoundErrorPage } = app.getComponents();
   const routes = createRoutesFromChildren(props.children);
+
+  // TODO(Rugvip): Possibly add a way to skip this, like a noNotFoundPage prop
+  routes.push({
+    element: <NotFoundErrorPage />,
+    path: '/*',
+  });
+
   return useRoutes(routes);
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A refactor to get the app context in shape, with the purpose of being access the app components via the context. The purpose of that is to be able to pick up the not found page and add it as fallback to `FlatRoutes`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
