### PR TITLE
Support parameters in external route refs

### DIFF
--- a/.changeset/large-eggs-help.md
+++ b/.changeset/large-eggs-help.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-explore': minor
+---
+
+Introduce external route for linking to the entity page from the explore plugin.
+
+To use the explore plugin you have to bind the external route in your app:
+
+```typescript
+const app = createApp({
+  ...
+  bindRoutes({ bind }) {
+    ...
+    bind(explorePlugin.externalRoutes, {
+      catalogEntity: catalogPlugin.routes.catalogEntity,
+    });
+  },
+});
+```

--- a/.changeset/perfect-mails-own.md
+++ b/.changeset/perfect-mails-own.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-api': patch
+---
+
+Support parameters for external routes.

--- a/.changeset/soft-months-invite.md
+++ b/.changeset/soft-months-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Introduce parameters for namespace, kind, and name to `entityRouteRef`.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -28,7 +28,7 @@ import {
   CatalogEntityPage,
 } from '@backstage/plugin-catalog';
 import { CatalogImportPage } from '@backstage/plugin-catalog-import';
-import { ExplorePage } from '@backstage/plugin-explore';
+import { ExplorePage, explorePlugin } from '@backstage/plugin-explore';
 import { Router as GraphiQLRouter } from '@backstage/plugin-graphiql';
 import { Router as LighthouseRouter } from '@backstage/plugin-lighthouse';
 import { Router as RegisterComponentRouter } from '@backstage/plugin-register-component';
@@ -68,6 +68,9 @@ const app = createApp({
   bindRoutes({ bind }) {
     bind(catalogPlugin.externalRoutes, {
       createComponent: scaffolderPlugin.routes.root,
+    });
+    bind(explorePlugin.externalRoutes, {
+      catalogEntity: catalogPlugin.routes.catalogEntity,
     });
   },
 });

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -57,7 +57,7 @@ import {
   routePathCollector,
 } from '../routing/collectors';
 import { RoutingProvider, validateRoutes } from '../routing/hooks';
-import { ExternalRouteRef } from '../routing/RouteRef';
+import { ExternalRouteRef } from '../routing/types';
 import { AppContextProvider } from './AppContext';
 import { AppIdentity } from './AppIdentity';
 import { AppThemeProvider } from './AppThemeProvider';

--- a/packages/core-api/src/plugin/types.ts
+++ b/packages/core-api/src/plugin/types.ts
@@ -17,7 +17,7 @@
 import { ComponentType } from 'react';
 import { RouteRef } from '../routing';
 import { AnyApiFactory } from '../apis/system';
-import { ExternalRouteRef } from '../routing/RouteRef';
+import { ExternalRouteRef } from '../routing/types';
 
 export type RouteOptions = {
   // Whether the route path must match exactly, defaults to true.

--- a/packages/core-api/src/routing/hooks.test.tsx
+++ b/packages/core-api/src/routing/hooks.test.tsx
@@ -25,23 +25,22 @@ import {
 } from '../extensions/traversal';
 import { createPlugin } from '../plugin';
 import {
-  routePathCollector,
-  routeParentCollector,
   routeObjectCollector,
+  routeParentCollector,
+  routePathCollector,
 } from './collectors';
 import {
-  useRouteRef,
-  RoutingProvider,
-  validateRoutes,
   RouteFunc,
+  RoutingProvider,
+  useRouteRef,
+  validateRoutes,
 } from './hooks';
 import {
-  createRouteRef,
   createExternalRouteRef,
-  ExternalRouteRef,
+  createRouteRef,
   RouteRefConfig,
 } from './RouteRef';
-import { RouteRef } from './types';
+import { ExternalRouteRef, RouteRef } from './types';
 
 const mockConfig = (extra?: Partial<RouteRefConfig<{}>>) => ({
   path: '/unused',

--- a/packages/core-api/src/routing/hooks.tsx
+++ b/packages/core-api/src/routing/hooks.tsx
@@ -15,9 +15,13 @@
  */
 
 import React, { createContext, ReactNode, useContext, useMemo } from 'react';
-import { AnyRouteRef, BackstageRouteObject, RouteRef } from './types';
 import { generatePath, matchRoutes, useLocation } from 'react-router-dom';
-import { ExternalRouteRef } from './RouteRef';
+import {
+  AnyRouteRef,
+  BackstageRouteObject,
+  ExternalRouteRef,
+  RouteRef,
+} from './types';
 
 // The extra TS magic here is to require a single params argument if the RouteRef
 // had at least one param defined, but require 0 arguments if there are no params defined.
@@ -112,7 +116,7 @@ class RouteResolver {
 const RoutingContext = createContext<RouteResolver | undefined>(undefined);
 
 export function useRouteRef<Params extends { [param in string]: string } = {}>(
-  routeRef: RouteRef<Params> | ExternalRouteRef,
+  routeRef: RouteRef<Params> | ExternalRouteRef<Params>,
 ): RouteFunc<Params> {
   const sourceLocation = useLocation();
   const resolver = useContext(RoutingContext);

--- a/packages/core-api/src/routing/index.ts
+++ b/packages/core-api/src/routing/index.ts
@@ -19,12 +19,9 @@ export type {
   AbsoluteRouteRef,
   ConcreteRoute,
   MutableRouteRef,
+  ExternalRouteRef,
 } from './types';
 export { FlatRoutes } from './FlatRoutes';
-export {
-  createRouteRef,
-  createExternalRouteRef,
-  ExternalRouteRef,
-} from './RouteRef';
+export { createRouteRef, createExternalRouteRef } from './RouteRef';
 export type { RouteRefConfig } from './RouteRef';
 export { useRouteRef } from './hooks';

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -27,6 +27,11 @@ export type RouteRef<Params extends { [param in string]: string } = {}> = {
 
 export type AnyRouteRef = RouteRef<any>;
 
+// @ts-ignore, we're just embedding the Params type for usage in other places
+export type ExternalRouteRef<
+  Params extends { [param in string]: string } = {}
+> = {};
+
 /**
  * This type should not be used
  * @deprecated

--- a/plugins/catalog-react/src/routes.ts
+++ b/plugins/catalog-react/src/routes.ts
@@ -31,6 +31,7 @@ export const entityRoute = createRouteRef({
   icon: NoIcon,
   path: ':namespace/:kind/:name/*',
   title: 'Entity',
+  params: ['namespace', 'kind', 'name'],
 });
 export const entityRouteRef = entityRoute;
 

--- a/plugins/explore/src/components/DomainCard/DomainCard.test.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCard.test.tsx
@@ -15,13 +15,13 @@
  */
 
 import { DomainEntity } from '@backstage/catalog-model';
-import { render } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { catalogEntityRouteRef } from '../../routes';
 import { DomainCard } from './DomainCard';
 
 describe('<DomainCard />', () => {
-  it('renders a domain card', () => {
+  it('renders a domain card', async () => {
     const entity: DomainEntity = {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'Domain',
@@ -34,9 +34,14 @@ describe('<DomainCard />', () => {
         owner: 'guest',
       },
     };
-    const { getByText } = render(<DomainCard entity={entity} />, {
-      wrapper: MemoryRouter,
-    });
+    const { getByText } = await renderInTestApp(
+      <DomainCard entity={entity} />,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
+    );
 
     expect(getByText('artists')).toBeInTheDocument();
     expect(getByText('Everything about artists')).toBeInTheDocument();

--- a/plugins/explore/src/components/DomainCard/DomainCard.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCard.tsx
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 import { DomainEntity, RELATION_OWNED_BY } from '@backstage/catalog-model';
-import { ItemCard } from '@backstage/core';
+import { ItemCard, useRouteRef } from '@backstage/core';
 import {
   EntityRefLinks,
-  entityRoute,
   entityRouteParams,
   getEntityRelations,
 } from '@backstage/plugin-catalog-react';
 import React from 'react';
-import { generatePath } from 'react-router-dom';
+import { catalogEntityRouteRef } from '../../routes';
 
 type DomainCardProps = {
   entity: DomainEntity;
@@ -30,6 +29,7 @@ type DomainCardProps = {
 
 export const DomainCard = ({ entity }: DomainCardProps) => {
   const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
+  const catalogEntityRoute = useRouteRef(catalogEntityRouteRef);
 
   return (
     <ItemCard
@@ -44,11 +44,7 @@ export const DomainCard = ({ entity }: DomainCardProps) => {
         />
       }
       label="Explore"
-      // TODO: Use useRouteRef here to generate the path
-      href={generatePath(
-        `/catalog/${entityRoute.path}`,
-        entityRouteParams(entity),
-      )}
+      href={catalogEntityRoute(entityRouteParams(entity))}
     />
   );
 };

--- a/plugins/explore/src/components/DomainCard/DomainCardGrid.test.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCardGrid.test.tsx
@@ -15,13 +15,13 @@
  */
 
 import { DomainEntity } from '@backstage/catalog-model';
-import { render } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { catalogEntityRouteRef } from '../../routes';
 import { DomainCardGrid } from './DomainCardGrid';
 
 describe('<DomainCardGrid />', () => {
-  it('renders a grid of domain cards', () => {
+  it('renders a grid of domain cards', async () => {
     const entities: DomainEntity[] = [
       {
         apiVersion: 'backstage.io/v1alpha1',
@@ -44,9 +44,14 @@ describe('<DomainCardGrid />', () => {
         },
       },
     ];
-    const { getByText } = render(<DomainCardGrid entities={entities} />, {
-      wrapper: MemoryRouter,
-    });
+    const { getByText } = await renderInTestApp(
+      <DomainCardGrid entities={entities} />,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
+    );
 
     expect(getByText('artists')).toBeInTheDocument();
     expect(getByText('playback')).toBeInTheDocument();

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -17,9 +17,10 @@
 import { DomainEntity } from '@backstage/catalog-model';
 import { ApiProvider, ApiRegistry } from '@backstage/core';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
-import { render, waitFor } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { catalogEntityRouteRef } from '../../routes';
 import { DomainExplorerContent } from './DomainExplorerContent';
 
 describe('<DomainExplorerContent />', () => {
@@ -33,11 +34,9 @@ describe('<DomainExplorerContent />', () => {
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (
-    <MemoryRouter>
-      <ApiProvider apis={ApiRegistry.with(catalogApiRef, catalogApi)}>
-        {children}
-      </ApiProvider>
-    </MemoryRouter>
+    <ApiProvider apis={ApiRegistry.with(catalogApiRef, catalogApi)}>
+      {children}
+    </ApiProvider>
   );
 
   beforeEach(() => {
@@ -69,9 +68,16 @@ describe('<DomainExplorerContent />', () => {
     ];
     catalogApi.getEntities.mockResolvedValue({ items: entities });
 
-    const { getByText } = render(<DomainExplorerContent />, {
-      wrapper: Wrapper,
-    });
+    const { getByText } = await renderInTestApp(
+      <Wrapper>
+        <DomainExplorerContent />
+      </Wrapper>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
+    );
 
     await waitFor(() => {
       expect(getByText('artists')).toBeInTheDocument();
@@ -82,9 +88,16 @@ describe('<DomainExplorerContent />', () => {
   it('renders empty state', async () => {
     catalogApi.getEntities.mockResolvedValue({ items: [] });
 
-    const { getByText } = render(<DomainExplorerContent />, {
-      wrapper: Wrapper,
-    });
+    const { getByText } = await renderInTestApp(
+      <Wrapper>
+        <DomainExplorerContent />
+      </Wrapper>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
+    );
 
     await waitFor(() =>
       expect(getByText('No domains to display')).toBeInTheDocument(),
@@ -95,9 +108,16 @@ describe('<DomainExplorerContent />', () => {
     const catalogError = new Error('Network timeout');
     catalogApi.getEntities.mockRejectedValueOnce(catalogError);
 
-    const { getByText } = render(<DomainExplorerContent />, {
-      wrapper: Wrapper,
-    });
+    const { getByText } = await renderInTestApp(
+      <Wrapper>
+        <DomainExplorerContent />
+      </Wrapper>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
+    );
 
     await waitFor(() =>
       expect(getByText(/Could not load domains/)).toBeInTheDocument(),

--- a/plugins/explore/src/plugin.ts
+++ b/plugins/explore/src/plugin.ts
@@ -16,7 +16,7 @@
 
 import { createApiFactory, createPlugin } from '@backstage/core';
 import { exploreToolsConfigRef } from '@backstage/plugin-explore-react';
-import { exploreRouteRef } from './routes';
+import { catalogEntityRouteRef, exploreRouteRef } from './routes';
 import { exampleTools } from './util/examples';
 
 export const explorePlugin = createPlugin({
@@ -36,5 +36,8 @@ export const explorePlugin = createPlugin({
   ],
   routes: {
     explore: exploreRouteRef,
+  },
+  externalRoutes: {
+    catalogEntity: catalogEntityRouteRef,
   },
 });

--- a/plugins/explore/src/routes.ts
+++ b/plugins/explore/src/routes.ts
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-import { createRouteRef } from '@backstage/core';
+import { createExternalRouteRef, createRouteRef } from '@backstage/core';
 
 const NoIcon = () => null;
 
 export const exploreRouteRef = createRouteRef({
   icon: NoIcon,
   title: 'Explore',
+});
+
+export const catalogEntityRouteRef = createExternalRouteRef({
+  id: 'catalog-entity',
+  params: ['namespace', 'kind', 'name'],
 });


### PR DESCRIPTION
While playing around with the new routing, I noticed that external route refs can't have parameters yet. So I gave it a try. I'm not sure if it's the correct thing to do or the right way to go 😆 

While working on that, I was a bit wondering how to [resolve this comment](https://github.com/backstage/backstage/blob/master/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx#L59), especially if we plan to move the [route refs back to plugin-catalog](https://github.com/backstage/backstage/blob/master/plugins/catalog-react/src/routes.ts#L22). That would require a circular dependency. On the other side, routeRefs should probably be exported by a plugin or only used internally.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
