### PR TITLE
auth-backend: fix for refresh token being lost during microsoft login

### DIFF
--- a/.changeset/breezy-jobs-brake.md
+++ b/.changeset/breezy-jobs-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fix for refresh token being lost during Microsoft login.

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -54,12 +54,12 @@ export class GithubAuthProvider implements OAuthHandlers {
       },
       (
         accessToken: any,
-        refreshToken: any,
+        _refreshToken: any,
         params: any,
         fullProfile: any,
         done: PassportDoneCallback<OAuthResult>,
       ) => {
-        done(undefined, { fullProfile, params, accessToken, refreshToken });
+        done(undefined, { fullProfile, params, accessToken });
       },
     );
   }

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -51,12 +51,12 @@ export class GitlabAuthProvider implements OAuthHandlers {
       },
       (
         accessToken: any,
-        refreshToken: any,
+        _refreshToken: any,
         params: any,
         fullProfile: any,
         done: PassportDoneCallback<OAuthResult>,
       ) => {
-        done(undefined, { fullProfile, params, accessToken, refreshToken });
+        done(undefined, { fullProfile, params, accessToken });
       },
     );
   }

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -72,7 +72,7 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
         fullProfile: passport.Profile,
         done: PassportDoneCallback<OAuthResult, PrivateInfo>,
       ) => {
-        done(undefined, { fullProfile, accessToken, refreshToken, params });
+        done(undefined, { fullProfile, accessToken, params }, { refreshToken });
       },
     );
   }


### PR DESCRIPTION
Fix for bug introduced in #4531 where some refresh tokens were being passed through the auth result instead of private info there therefore being lost