### PR TITLE
fixed: Expose a configuration option for the oidc scope

### DIFF
--- a/.changeset/sweet-experts-whisper.md
+++ b/.changeset/sweet-experts-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Expose a configuration option for the oidc scope


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In release 0.3.0, the default oidc scope was removed.  The changelog includes sample code to set the scope using a factory, but this is cumbersome.  

This PR introduces a app-config parameter that can be used to set the scope.  The new config is optional, so this change is backwards compatible.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
