### PR TITLE
core-api: switch component data to use a global store

### DIFF
--- a/.changeset/rich-socks-move.md
+++ b/.changeset/rich-socks-move.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-api': patch
+'@backstage/core': patch
+---
+
+Internal refactor of how component data is access to avoid polluting components and make it possible to bridge across versions.

--- a/packages/core-api/src/extensions/componentData.test.tsx
+++ b/packages/core-api/src/extensions/componentData.test.tsx
@@ -59,4 +59,63 @@ describe('elementData', () => {
       'Attempted to attach duplicate data "my-data" to component "MyComponent"',
     );
   });
+
+  describe('works across versions', () => {
+    function getDataSymbol() {
+      const Component = () => null;
+      attachComponentData(Component, 'my-data', {});
+      const [symbol] = Object.getOwnPropertySymbols(Component);
+      return symbol;
+    }
+
+    it('should should be able to get data from older versions', () => {
+      const symbol = getDataSymbol();
+
+      const data = { foo: 'bar' };
+      const Component = () => null;
+      attachComponentData(Component, 'my-data', data);
+
+      const element = <Component />;
+      expect((element as any).type[symbol].map.get('my-data')).toBe(data);
+    });
+
+    it('should should be able to attach data for older versions', () => {
+      const symbol = getDataSymbol();
+
+      const data = { foo: 'bar' };
+      const Component = () => null;
+      (Component as any)[symbol] = {
+        map: new Map([['my-data', data]]),
+      };
+
+      const element = <Component />;
+      expect(getComponentData(element, 'my-data')).toBe(data);
+    });
+
+    it('should be able to get data from newer versions', () => {
+      const data = { foo: 'bar' };
+      const Component = () => null;
+      attachComponentData(Component, 'my-data', data);
+
+      const element = <Component />;
+      const container = (global as any)[
+        '__@backstage/component-data-store__'
+      ].store.get(element.type);
+      expect(container.map.get('my-data')).toBe(data);
+    });
+
+    it('should should be able to attach data for newer versions', () => {
+      const data = { foo: 'bar' };
+      const Component = () => null;
+      (global as any)['__@backstage/component-data-store__'].store.set(
+        Component,
+        {
+          map: new Map([['my-data', data]]),
+        },
+      );
+
+      const element = <Component />;
+      expect(getComponentData(element, 'my-data')).toBe(data);
+    });
+  });
 });

--- a/packages/core-api/src/lib/globalObject.ts
+++ b/packages/core-api/src/lib/globalObject.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+function getGlobal() {
+  if (typeof window !== 'undefined' && window.Math === Math) {
+    return window;
+  }
+  if (typeof self !== 'undefined' && self.Math === Math) {
+    return self;
+  }
+  // eslint-disable-next-line no-new-func
+  return Function('return this')();
+}
+
+export const globalObject = getGlobal();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Switching to using a global store of component data to avoid assigning to component instances, and also take the time to make that accessible globally and bridged across multiple versions of `core-api`. Wanted to avoid a `minor` bump so made it backwards and forwards compatible.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
