### PR TITLE
api-docs,catalog: Update messaging when no entities are in tables

### DIFF
--- a/.changeset/empty-taxis-search.md
+++ b/.changeset/empty-taxis-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Update messaging when no entities are in a table.

--- a/.changeset/empty-taxis-search.md
+++ b/.changeset/empty-taxis-search.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/plugin-api-docs': patch
+'@backstage/plugin-catalog': patch
 ---
 
 Update messaging when no entities are in a table.

--- a/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.test.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.test.tsx
@@ -74,7 +74,7 @@ describe('<ConsumedApisCard />', () => {
     );
 
     expect(getByText(/Consumed APIs/i)).toBeInTheDocument();
-    expect(getByText(/No Component consumes this API/i)).toBeInTheDocument();
+    expect(getByText(/does not consume any APIs/i)).toBeInTheDocument();
   });
 
   it('shows consumed APIs', async () => {

--- a/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
@@ -72,9 +72,9 @@ export const ConsumedApisCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div>
-          No Component consumes this API.{' '}
+          This {entity.kind.toLowerCase()} does not consume any APIs.{' '}
           <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">
-            Learn how to consume APIs.
+            (Learn how to change this.)
           </Link>
         </div>
       }

--- a/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
@@ -26,6 +26,7 @@ import {
   Progress,
   WarningPanel,
 } from '@backstage/core';
+import { Typography } from '@material-ui/core';
 import {
   EntityTable,
   useEntity,
@@ -71,11 +72,15 @@ export const ConsumedApisCard = ({ variant = 'gridItem' }: Props) => {
       title="Consumed APIs"
       variant={variant}
       emptyContent={
-        <div>
-          This {entity.kind.toLowerCase()} does not consume any APIs.{' '}
-          <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">
-            (Learn how to change this.)
-          </Link>
+        <div style={{ textAlign: 'center' }}>
+          <Typography variant="h6">
+            This {entity.kind.toLowerCase()} does not consume any APIs.{' '}
+          </Typography>
+          <Typography variant="body2">
+            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">
+              Learn how to change this.
+            </Link>
+          </Typography>
         </div>
       }
       columns={apiEntityColumns}

--- a/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
@@ -73,7 +73,7 @@ export const ConsumedApisCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">
+          <Typography variant="body1">
             This {entity.kind.toLowerCase()} does not consume any APIs.
           </Typography>
           <Typography variant="body2">

--- a/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ConsumedApisCard.tsx
@@ -74,7 +74,7 @@ export const ConsumedApisCard = ({ variant = 'gridItem' }: Props) => {
       emptyContent={
         <div style={{ textAlign: 'center' }}>
           <Typography variant="h6">
-            This {entity.kind.toLowerCase()} does not consume any APIs.{' '}
+            This {entity.kind.toLowerCase()} does not consume any APIs.
           </Typography>
           <Typography variant="body2">
             <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">

--- a/plugins/api-docs/src/components/ApisCards/HasApisCard.test.tsx
+++ b/plugins/api-docs/src/components/ApisCards/HasApisCard.test.tsx
@@ -74,7 +74,7 @@ describe('<HasApisCard />', () => {
     );
 
     expect(getByText('APIs')).toBeInTheDocument();
-    expect(getByText(/No API is part of this system/i)).toBeInTheDocument();
+    expect(getByText(/does not contain any APIs/i)).toBeInTheDocument();
   });
 
   it('shows related APIs', async () => {

--- a/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
@@ -23,6 +23,7 @@ import {
   TableColumn,
   WarningPanel,
 } from '@backstage/core';
+import { Typography } from '@material-ui/core';
 import {
   EntityTable,
   useEntity,
@@ -75,11 +76,15 @@ export const HasApisCard = ({ variant = 'gridItem' }: Props) => {
       title="APIs"
       variant={variant}
       emptyContent={
-        <div>
-          This {entity.kind.toLowerCase()} does not contain any APIs.{' '}
-          <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-api">
-            (Learn how to add APIs.)
-          </Link>
+        <div style={{ textAlign: 'center' }}>
+          <Typography variant="h6">
+            This {entity.kind.toLowerCase()} does not contain any APIs.{' '}
+          </Typography>
+          <Typography variant="body2">
+            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-api">
+              Learn how to change this.
+            </Link>
+          </Typography>
         </div>
       }
       columns={columns}

--- a/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
@@ -76,9 +76,9 @@ export const HasApisCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div>
-          No API is part of this system.{' '}
+          This {entity.kind.toLowerCase()} does not contain any APIs.{' '}
           <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-api">
-            Learn how to add APIs.
+            (Learn how to add APIs.)
           </Link>
         </div>
       }

--- a/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
@@ -78,7 +78,7 @@ export const HasApisCard = ({ variant = 'gridItem' }: Props) => {
       emptyContent={
         <div style={{ textAlign: 'center' }}>
           <Typography variant="h6">
-            This {entity.kind.toLowerCase()} does not contain any APIs.{' '}
+            This {entity.kind.toLowerCase()} does not contain any APIs.
           </Typography>
           <Typography variant="body2">
             <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-api">

--- a/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
@@ -77,7 +77,7 @@ export const HasApisCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">
+          <Typography variant="body1">
             This {entity.kind.toLowerCase()} does not contain any APIs.
           </Typography>
           <Typography variant="body2">

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.test.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.test.tsx
@@ -74,7 +74,7 @@ describe('<ProvidedApisCard />', () => {
     );
 
     expect(getByText(/Provided APIs/i)).toBeInTheDocument();
-    expect(getByText(/No component provides this API/i)).toBeInTheDocument();
+    expect(getByText(/does not provide it's own APIs/i)).toBeInTheDocument();
   });
 
   it('shows consumed APIs', async () => {

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.test.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.test.tsx
@@ -74,7 +74,7 @@ describe('<ProvidedApisCard />', () => {
     );
 
     expect(getByText(/Provided APIs/i)).toBeInTheDocument();
-    expect(getByText(/does not provide it's own APIs/i)).toBeInTheDocument();
+    expect(getByText(/does not provide its own APIs/i)).toBeInTheDocument();
   });
 
   it('shows consumed APIs', async () => {

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.test.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.test.tsx
@@ -74,7 +74,7 @@ describe('<ProvidedApisCard />', () => {
     );
 
     expect(getByText(/Provided APIs/i)).toBeInTheDocument();
-    expect(getByText(/does not provide its own APIs/i)).toBeInTheDocument();
+    expect(getByText(/does not provide any APIs/i)).toBeInTheDocument();
   });
 
   it('shows consumed APIs', async () => {

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
@@ -26,6 +26,7 @@ import {
   Progress,
   WarningPanel,
 } from '@backstage/core';
+import { Typography } from '@material-ui/core';
 import {
   EntityTable,
   useEntity,
@@ -71,11 +72,15 @@ export const ProvidedApisCard = ({ variant = 'gridItem' }: Props) => {
       title="Provided APIs"
       variant={variant}
       emptyContent={
-        <div>
-          This {entity.kind.toLowerCase()} does not provide its own APIs.{' '}
-          <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
-            (Learn how to change this.)
-          </Link>
+        <div style={{ textAlign: 'center' }}>
+          <Typography variant="h6">
+            This {entity.kind.toLowerCase()} does not provide its own APIs.{' '}
+          </Typography>
+          <Typography variant="body2">
+            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
+              Learn how to change this.
+            </Link>
+          </Typography>
         </div>
       }
       columns={apiEntityColumns}

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
@@ -72,7 +72,7 @@ export const ProvidedApisCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div>
-          This {entity.kind.toLowerCase()} does not provide it's own APIs.{' '}
+          This {entity.kind.toLowerCase()} does not provide its own APIs.{' '}
           <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
             (Learn how to change this.)
           </Link>

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
@@ -74,7 +74,7 @@ export const ProvidedApisCard = ({ variant = 'gridItem' }: Props) => {
       emptyContent={
         <div style={{ textAlign: 'center' }}>
           <Typography variant="h6">
-            This {entity.kind.toLowerCase()} does not provide its own APIs.{' '}
+            This {entity.kind.toLowerCase()} does not provide its own APIs.
           </Typography>
           <Typography variant="body2">
             <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
@@ -73,8 +73,8 @@ export const ProvidedApisCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">
-            This {entity.kind.toLowerCase()} does not provide its own APIs.
+          <Typography variant="body1">
+            This {entity.kind.toLowerCase()} does not provide any APIs.
           </Typography>
           <Typography variant="body2">
             <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">

--- a/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/ProvidedApisCard.tsx
@@ -72,9 +72,9 @@ export const ProvidedApisCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div>
-          No component provides this API.{' '}
+          This {entity.kind.toLowerCase()} does not provide it's own APIs.{' '}
           <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
-            Learn how to provide APIs.
+            (Learn how to change this.)
           </Link>
         </div>
       }

--- a/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
@@ -72,7 +72,9 @@ export const ConsumingComponentsCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">No component consumes this API.</Typography>
+          <Typography variant="body1">
+            No component consumes this API.
+          </Typography>
           <Typography variant="body2">
             <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">
               Learn how to change this.

--- a/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
@@ -73,7 +73,7 @@ export const ConsumingComponentsCard = ({ variant = 'gridItem' }: Props) => {
         <div>
           No component consumes this API.{' '}
           <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">
-            Learn how to consume APIs.
+            (Learn how to consume APIs.)
           </Link>
         </div>
       }

--- a/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
@@ -72,7 +72,7 @@ export const ConsumingComponentsCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">No component consumes this API. </Typography>
+          <Typography variant="h6">No component consumes this API.</Typography>
           <Typography variant="body2">
             <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">
               Learn how to change this.

--- a/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ConsumingComponentsCard.tsx
@@ -26,6 +26,7 @@ import {
   Progress,
   WarningPanel,
 } from '@backstage/core';
+import { Typography } from '@material-ui/core';
 import {
   EntityTable,
   useEntity,
@@ -70,11 +71,13 @@ export const ConsumingComponentsCard = ({ variant = 'gridItem' }: Props) => {
       title="Consumers"
       variant={variant}
       emptyContent={
-        <div>
-          No component consumes this API.{' '}
-          <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">
-            (Learn how to consume APIs.)
-          </Link>
+        <div style={{ textAlign: 'center' }}>
+          <Typography variant="h6">No component consumes this API. </Typography>
+          <Typography variant="body2">
+            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specconsumesapis-optional">
+              Learn how to change this.
+            </Link>
+          </Typography>
         </div>
       }
       columns={EntityTable.componentEntityColumns}

--- a/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
@@ -26,6 +26,7 @@ import {
   Progress,
   WarningPanel,
 } from '@backstage/core';
+import { Typography } from '@material-ui/core';
 import {
   EntityTable,
   useEntity,
@@ -70,11 +71,13 @@ export const ProvidingComponentsCard = ({ variant = 'gridItem' }: Props) => {
       title="Providers"
       variant={variant}
       emptyContent={
-        <div>
-          No component provides this API.{' '}
-          <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
-            (Learn how to provide APIs.)
-          </Link>
+        <div style={{ textAlign: 'center' }}>
+          <Typography variant="h6">No component provides this API. </Typography>
+          <Typography variant="body2">
+            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
+              Learn how to change this.
+            </Link>
+          </Typography>
         </div>
       }
       columns={EntityTable.componentEntityColumns}

--- a/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
@@ -72,7 +72,9 @@ export const ProvidingComponentsCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">No component provides this API.</Typography>
+          <Typography variant="body1">
+            No component provides this API.
+          </Typography>
           <Typography variant="body2">
             <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
               Learn how to change this.

--- a/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
@@ -72,7 +72,7 @@ export const ProvidingComponentsCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">No component provides this API. </Typography>
+          <Typography variant="h6">No component provides this API.</Typography>
           <Typography variant="body2">
             <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
               Learn how to change this.

--- a/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
+++ b/plugins/api-docs/src/components/ComponentsCards/ProvidingComponentsCard.tsx
@@ -73,7 +73,7 @@ export const ProvidingComponentsCard = ({ variant = 'gridItem' }: Props) => {
         <div>
           No component provides this API.{' '}
           <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional">
-            Learn how to provide APIs.
+            (Learn how to provide APIs.)
           </Link>
         </div>
       }

--- a/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
+++ b/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
@@ -22,6 +22,7 @@ import {
   Progress,
   WarningPanel,
 } from '@backstage/core';
+import { Typography } from '@material-ui/core';
 import {
   EntityTable,
   useEntity,
@@ -73,11 +74,15 @@ export const HasComponentsCard = ({ variant = 'gridItem' }: Props) => {
       title="Components"
       variant={variant}
       emptyContent={
-        <div>
-          No component is part of this system.{' '}
-          <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component">
-            (Learn how to add components.)
-          </Link>
+        <div style={{ textAlign: 'center' }}>
+          <Typography variant="h6">
+            No component is part of this system.
+          </Typography>
+          <Typography variant="body2">
+            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component">
+              Learn how to change this.
+            </Link>
+          </Typography>
         </div>
       }
       columns={columns}

--- a/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
+++ b/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
@@ -76,7 +76,7 @@ export const HasComponentsCard = ({ variant = 'gridItem' }: Props) => {
         <div>
           No component is part of this system.{' '}
           <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component">
-            Learn how to add components.
+            (Learn how to add components.)
           </Link>
         </div>
       }

--- a/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
+++ b/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
@@ -75,7 +75,7 @@ export const HasComponentsCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">
+          <Typography variant="body1">
             No component is part of this system.
           </Typography>
           <Typography variant="body2">

--- a/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
+++ b/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
@@ -76,7 +76,7 @@ export const HasSubcomponentsCard = ({ variant = 'gridItem' }: Props) => {
         <div>
           No subcomponent is part of this component.{' '}
           <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specsubcomponentof-optional">
-            Learn how to add subcomponents.
+            (Learn how to add subcomponents.)
           </Link>
         </div>
       }

--- a/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
+++ b/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
@@ -22,6 +22,7 @@ import {
   Progress,
   WarningPanel,
 } from '@backstage/core';
+import { Typography } from '@material-ui/core';
 import {
   EntityTable,
   useEntity,
@@ -73,11 +74,15 @@ export const HasSubcomponentsCard = ({ variant = 'gridItem' }: Props) => {
       title="Subcomponents"
       variant={variant}
       emptyContent={
-        <div>
-          No subcomponent is part of this component.{' '}
-          <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specsubcomponentof-optional">
-            (Learn how to add subcomponents.)
-          </Link>
+        <div style={{ textAlign: 'center' }}>
+          <Typography variant="h6">
+            No subcomponent is part of this component.
+          </Typography>
+          <Typography variant="body2">
+            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#specsubcomponentof-optional">
+              Learn how to change this.
+            </Link>
+          </Typography>
         </div>
       }
       columns={columns}

--- a/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
+++ b/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
@@ -75,7 +75,7 @@ export const HasSubcomponentsCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">
+          <Typography variant="body1">
             No subcomponent is part of this component.
           </Typography>
           <Typography variant="body2">

--- a/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
+++ b/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
@@ -22,6 +22,7 @@ import {
   Progress,
   WarningPanel,
 } from '@backstage/core';
+import { Typography } from '@material-ui/core';
 import {
   EntityTable,
   useEntity,
@@ -70,11 +71,15 @@ export const HasSystemsCard = ({ variant = 'gridItem' }: Props) => {
       title="Systems"
       variant={variant}
       emptyContent={
-        <div>
-          No system is part of this domain.{' '}
-          <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system">
-            (Learn how to add systems.)
-          </Link>
+        <div style={{ textAlign: 'center' }}>
+          <Typography variant="h6">
+            No system is part of this domain.
+          </Typography>
+          <Typography variant="body2">
+            <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system">
+              Learn how to change this.
+            </Link>
+          </Typography>
         </div>
       }
       columns={columns}

--- a/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
+++ b/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
@@ -73,7 +73,7 @@ export const HasSystemsCard = ({ variant = 'gridItem' }: Props) => {
         <div>
           No system is part of this domain.{' '}
           <Link to="https://backstage.io/docs/features/software-catalog/descriptor-format#kind-system">
-            Learn how to add systems.
+            (Learn how to add systems.)
           </Link>
         </div>
       }

--- a/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
+++ b/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
@@ -72,7 +72,7 @@ export const HasSystemsCard = ({ variant = 'gridItem' }: Props) => {
       variant={variant}
       emptyContent={
         <div style={{ textAlign: 'center' }}>
-          <Typography variant="h6">
+          <Typography variant="body1">
             No system is part of this domain.
           </Typography>
           <Typography variant="body2">


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Minor change to the wording when there are no values in certain component tables. The intent is to help clarify in certain instances that it's not just that there's no info in the table (no provides API), but a bit more about what it means.

Was going to open an issue to discuss it, but figured easy enough to just file a PR and await any feedback/other wording suggestions, etc.  The primary for me was rewording "No component provides this API" to instead saying "This component does not provide it's own APIs".

I also made some of the kinds dynamic, which may not be necessary but figured some teams may have services but also libraries that might "provide" an API?


| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/33203301/108799601-afb23700-755e-11eb-85a4-3d3ff741d0b0.png) |  ![image](https://user-images.githubusercontent.com/33203301/109688030-d5889e80-7b51-11eb-8d6f-dcc002ddf297.png) |
| ![image](https://user-images.githubusercontent.com/33203301/108799556-97421c80-755e-11eb-83d1-a3f0abd113fb.png) | ![image](https://user-images.githubusercontent.com/33203301/109688181-ff41c580-7b51-11eb-9749-ebabff02ffae.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
