### PR TITLE
kubernetes-backend: allow apps to pass in a KubernetesClustersSupplier

### DIFF
--- a/.changeset/lucky-turtles-sort.md
+++ b/.changeset/lucky-turtles-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Allow apps to pass in a KubernetesClustersSupplier

--- a/plugins/kubernetes-backend/src/service/router.ts
+++ b/plugins/kubernetes-backend/src/service/router.ts
@@ -104,7 +104,6 @@ export async function createRouter(
 
   if (options.clusterSupplier) {
     clusterDetails = await options.clusterSupplier.getClusters();
-    // Append supplied clusters to cluster retrieved via getCombinedClusterDetails
   } else {
     clusterDetails = await getCombinedClusterDetails(
       clusterLocatorMethods,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR adds a `KubernetesClustersSupplier` optional field to the RouterOptions passed in when initializing the kubernetes-backend plugin. This allows application owners to implement their own custom implementations for supplying the list of kubernetes clusters that they want to integrate into Backstage.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
