### PR TITLE
fix: add aws auth provider on kubernetes plugin

### DIFF
--- a/.changeset/metal-pianos-repeat.md
+++ b/.changeset/metal-pianos-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Support AWS auth provider on kubernetes FE plugin

--- a/plugins/kubernetes/src/kubernetes-auth-provider/AwsKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/AwsKubernetesAuthProvider.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthProvider } from './types';
+import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-backend';
+
+export class AwsKubernetesAuthProvider implements KubernetesAuthProvider {
+  async decorateRequestBodyForAuth(
+    requestBody: KubernetesRequestBody,
+  ): Promise<KubernetesRequestBody> {
+    // No-op, with aws auth, server's AWS credentials are used for access
+    return requestBody;
+  }
+}

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -19,6 +19,7 @@ import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-backend';
 import { KubernetesAuthProvider, KubernetesAuthProvidersApi } from './types';
 import { GoogleKubernetesAuthProvider } from './GoogleKubernetesAuthProvider';
 import { ServiceAccountKubernetesAuthProvider } from './ServiceAccountKubernetesAuthProvider';
+import { AwsKubernetesAuthProvider } from './AwsKubernetesAuthProvider';
 
 export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
   private readonly kubernetesAuthProviderMap: Map<
@@ -36,6 +37,7 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
       'serviceAccount',
       new ServiceAccountKubernetesAuthProvider(),
     );
+    this.kubernetesAuthProviderMap.set('aws', new AwsKubernetesAuthProvider());
   }
 
   async decorateRequestBodyForAuth(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Adds an 'aws' auth provider no-op implementation on the frontend Kubernetes plugin so that the aws provider is usable out of the box. 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
