### PR TITLE
fix(saml-auth): Add default option for getBackstageIdentity

### DIFF
--- a/.changeset/shy-vans-return.md
+++ b/.changeset/shy-vans-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-api': patch
+---
+
+Fix error when querying Backstage Identity with SAML authentication

--- a/packages/core-api/src/apis/implementations/auth/saml/SamlAuth.ts
+++ b/packages/core-api/src/apis/implementations/auth/saml/SamlAuth.ts
@@ -83,7 +83,7 @@ class SamlAuth implements ProfileInfoApi, BackstageIdentityApi, SessionApi {
   }
 
   async getBackstageIdentity(
-    options: AuthRequestOptions,
+    options: AuthRequestOptions = {},
   ): Promise<BackstageIdentity | undefined> {
     const session = await this.sessionManager.getSession(options);
     return session?.backstageIdentity;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes this when obtaining the Backstage Identity for API calls:

```
TypeError: Cannot destructure property 'scopes' of 'options' as it is undefined.
    at AuthSessionStore.getSession (webpack-internal:///../../node_modules/@backstage/core-api/dist/index.esm.js:911:12)
    at SamlAuth.getBackstageIdentity (webpack-internal:///../../node_modules/@backstage/core-api/dist/index.esm.js:1277:47)
    at AppIdentity.getIdToken [as idTokenFunc] (webpack-internal:///../../node_modules/@backstage/core/dist/index.esm.js:3996:26)
    at AppIdentity.getIdToken (webpack-internal:///../../node_modules/@backstage/core-api/dist/index.esm.js:2250:58)
    at eval (webpack-internal:///../../../backstage/plugins/catalog/src/CatalogClientWrapper.ts:60:158)
    at _asyncNullishCoalesce (webpack-internal:///../../../backstage/plugins/catalog/src/CatalogClientWrapper.ts:3:285)
    at CatalogClientWrapper.getEntities (webpack-internal:///../../../backstage/plugins/catalog/src/CatalogClientWrapper.ts:60:20)
    at async eval (webpack-internal:///../../../backstage/plugins/catalog/src/filter/EntityFilterGroupsProvider.tsx:58:22)
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
