### PR TITLE
Both Authorization patterns are valid for both versions of Bitbucket

### DIFF
--- a/.changeset/hungry-frogs-flow.md
+++ b/.changeset/hungry-frogs-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Consider both authentication methods for both onprem and cloud bitbucket

--- a/.changeset/hungry-frogs-flow.md
+++ b/.changeset/hungry-frogs-flow.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Consider both authentication methods for both onprem and cloud bitbucket
+Consider both authentication methods for both `onprem` and `cloud` BitBucket

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
@@ -98,10 +98,6 @@ export class BitbucketPublisher implements PublisherBase {
     const { project, name, description } = opts;
 
     let response: Response;
-    const buffer = Buffer.from(
-      `${this.config.username}:${this.config.appPassword}`,
-      'utf8',
-    );
 
     const options: RequestInit = {
       method: 'POST',
@@ -111,7 +107,7 @@ export class BitbucketPublisher implements PublisherBase {
         is_private: this.config.repoVisibility === 'private',
       }),
       headers: {
-        Authorization: `Basic ${buffer.toString('base64')}`,
+        Authorization: this.getAuthorizationHeader(),
         'Content-Type': 'application/json',
       },
     };
@@ -132,11 +128,30 @@ export class BitbucketPublisher implements PublisherBase {
         }
       }
 
-      // TODO use the urlReader to get the defautl branch
+      // TODO use the urlReader to get the default branch
       const catalogInfoUrl = `${r.links.html.href}/src/master/catalog-info.yaml`;
       return { remoteUrl, catalogInfoUrl };
     }
     throw new Error(`Not a valid response code ${await response.text()}`);
+  }
+
+  private getAuthorizationHeader(): string {
+    if (this.config.username && this.config.appPassword) {
+      const buffer = Buffer.from(
+        `${this.config.username}:${this.config.appPassword}`,
+        'utf8',
+      );
+
+      return `Basic ${buffer.toString('base64')}`;
+    }
+
+    if (this.config.token) {
+      return `Bearer ${this.config.token}`;
+    }
+
+    throw new Error(
+      `Authorization has not been provided for Bitbucket. Please add username + appPassword or token to the integration config `,
+    );
   }
 
   private async createBitbucketServerRepository(opts: {
@@ -155,10 +170,11 @@ export class BitbucketPublisher implements PublisherBase {
         is_private: this.config.repoVisibility === 'private',
       }),
       headers: {
-        Authorization: `Bearer ${this.config.token}`,
+        Authorization: this.getAuthorizationHeader(),
         'Content-Type': 'application/json',
       },
     };
+
     try {
       response = await fetch(
         `https://${this.config.host}/rest/api/1.0/projects/${project}/repos`,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
@@ -150,7 +150,7 @@ export class BitbucketPublisher implements PublisherBase {
     }
 
     throw new Error(
-      `Authorization has not been provided for Bitbucket. Please add username + appPassword or token to the integration config `,
+      `Authorization has not been provided for Bitbucket. Please add either username + appPassword or token to the Integrations config`,
     );
   }
 


### PR DESCRIPTION
Fixes #4554

Both the combination of `appPassword` and `username`, or `token` is valid for both `onprem` and `cloud` versions of Bitbucket. Previously you needed to have both forms of authentication for it to work properly. But this isn't the case.

Updated the publisher to generate the Authorization header from config, and use that in the proper places.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
