### PR TITLE
Use entity relation for the owner of an entity in the catalog entity page header

### DIFF
--- a/.changeset/new-forks-perform.md
+++ b/.changeset/new-forks-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Use entity relation for the owner of an entity in the catalog entity page header.

--- a/plugins/catalog/src/components/EntityPageLayout/EntityPageLayout.tsx
+++ b/plugins/catalog/src/components/EntityPageLayout/EntityPageLayout.tsx
@@ -13,20 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Entity, ENTITY_DEFAULT_NAMESPACE } from '@backstage/catalog-model';
+import {
+  Entity,
+  ENTITY_DEFAULT_NAMESPACE,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
 import { Content, Header, HeaderLabel, Page, Progress } from '@backstage/core';
+import {
+  EntityContext,
+  EntityRefLinks,
+  getEntityRelations,
+  useEntityCompoundName,
+} from '@backstage/plugin-catalog-react';
 import { Box } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import React, { PropsWithChildren, useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
-import {
-  EntityContext,
-  useEntityCompoundName,
-} from '@backstage/plugin-catalog-react';
 import { EntityContextMenu } from '../EntityContextMenu/EntityContextMenu';
 import { FavouriteEntity } from '../FavouriteEntity/FavouriteEntity';
 import { UnregisterEntityDialog } from '../UnregisterEntityDialog/UnregisterEntityDialog';
-
 import { Tabbed } from './Tabbed';
 
 const EntityPageTitle = ({
@@ -41,6 +46,26 @@ const EntityPageTitle = ({
     {entity && <FavouriteEntity entity={entity} />}
   </Box>
 );
+
+const EntityLabels = ({ entity }: { entity: Entity }) => {
+  const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
+
+  return (
+    <>
+      {ownedByRelations.length > 0 && (
+        <HeaderLabel
+          label="Owner"
+          value={
+            <EntityRefLinks entityRefs={ownedByRelations} color="inherit" />
+          }
+        />
+      )}
+      {entity.spec?.lifecycle && (
+        <HeaderLabel label="Lifecycle" value={entity.spec.lifecycle} />
+      )}
+    </>
+  );
+};
 
 const headerProps = (
   kind: string,
@@ -91,17 +116,10 @@ export const EntityPageLayout = ({ children }: PropsWithChildren<{}>) => {
         pageTitleOverride={headerTitle}
         type={headerType}
       >
-        {/* TODO: fix after catalog page customization is added */}
-        {entity && kind !== 'user' && (
+        {/* TODO: Make entity labels configurable for entity kind / type */}
+        {entity && (
           <>
-            <HeaderLabel
-              label="Owner"
-              value={entity.spec?.owner || 'unknown'}
-            />
-            <HeaderLabel
-              label="Lifecycle"
-              value={entity.spec?.lifecycle || 'unknown'}
-            />
+            <EntityLabels entity={entity} />
             <EntityContextMenu onUnregisterEntity={showRemovalDialog} />
           </>
         )}


### PR DESCRIPTION
Oh there was still a place were we didn't used the relations. I only see this change as an intermediate step to make the header configurable per entity kind / type.

I also changed the behavior a bit:
* Both owner and lifecycle are only displayed when they are available. They don't apply to all entities. Here is where customization would be handy.
* The context menu is now always displayed, since we now have a guard against removing bootstrap locations, this should be fine.
* I removed the workaround that was in place for user entities (why was it there in the first place, but not for groups? 😆 )

I did not touch the old `EntityLayout`, as I expect it to be deprecated soon.

In the future I could imaging an evolution like this:

```typescript
const ServiceEntityPage = () => (
  <EntityPageLayout>
    <EntityPageLayout.Header variant="for the color of the header">
       <OwnerHeaderLabel />
       <LifecycleHeaderLabel />
    <EntityPageLayout.Header/>

    <EntityPageLayout.Content
      path="/"
      title="Overview"
      element={<ComponentOverviewContent />}
    />
    ...
  <EntityPageLayout/>
);
```

`OwnerHeaderLabel` and `LifecycleHeaderLabel` could internally use `useEntity()` to access the current entity.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
