### PR TITLE
fix: Loading should be true when *not* having an entity

### DIFF
--- a/.changeset/twenty-pandas-crash.md
+++ b/.changeset/twenty-pandas-crash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed EntityProvider setting 'loading' bool erroneously to true

--- a/plugins/catalog-react/src/components/EntityProvider/EntityProvider.tsx
+++ b/plugins/catalog-react/src/components/EntityProvider/EntityProvider.tsx
@@ -26,7 +26,7 @@ export const EntityProvider = ({ entity, children }: EntityProviderProps) => (
   <EntityContext.Provider
     value={{
       entity,
-      loading: Boolean(entity),
+      loading: !Boolean(entity),
       error: undefined,
     }}
   >


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `EntityProvider` create a context with an entity provided as a prop. It should set the `loading` boolean to be inverse to the existence of an entity.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
