### PR TITLE
Entity suspense for async entity loading

### DIFF
--- a/.changeset/fluffy-carrots-smile.md
+++ b/.changeset/fluffy-carrots-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Added EntitySuspense for rendering async loaded entities

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -32,6 +32,7 @@
     "@backstage/catalog-model": "^0.7.2",
     "@backstage/core": "^0.6.3",
     "@material-ui/core": "^4.11.0",
+    "@material-ui/lab": "4.0.0-alpha.45",
     "@types/react": "^16.9",
     "react": "^16.13.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/catalog-react/src/components/EntitySuspense/EntitySuspense.tsx
+++ b/plugins/catalog-react/src/components/EntitySuspense/EntitySuspense.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useEffect } from 'react';
+import { useApi, errorApiRef, Progress } from '@backstage/core';
+import Alert from '@material-ui/lab/Alert';
+import { useEntity } from '../../hooks';
+
+export interface EntitySuspenseProps {
+  fallback?: React.ComponentType;
+  children: React.ReactNode;
+}
+
+export const EntitySuspense = ({
+  fallback: Fallback = Progress,
+  children,
+}: EntitySuspenseProps) => {
+  const { loading, error } = useEntity();
+  const errorApi = useApi(errorApiRef);
+
+  useEffect(() => {
+    if (error) {
+      errorApi.post(error);
+    }
+  }, [error, errorApi]);
+
+  if (loading) {
+    return <Fallback />;
+  } else if (error) {
+    return <Alert severity="error">{error?.message}</Alert>;
+  }
+  return <>{children}</>;
+};
+
+export function withEntitySuspense<P>(
+  Component: React.ComponentType<P>,
+  options?: Omit<EntitySuspenseProps, 'children'>,
+) {
+  return (props: P) => (
+    <EntitySuspense {...options}>
+      <Component {...props} />
+    </EntitySuspense>
+  );
+}

--- a/plugins/catalog-react/src/components/EntitySuspense/index.ts
+++ b/plugins/catalog-react/src/components/EntitySuspense/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Spotify AB
+ * Copyright 2021 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './EntityProvider';
-export * from './EntityRefLink';
-export * from './EntitySuspense';
-export * from './EntityTable';
+export { EntitySuspense, withEntitySuspense } from './EntitySuspense';

--- a/plugins/pagerduty/package.json
+++ b/plugins/pagerduty/package.json
@@ -37,7 +37,6 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
-    "@types/react": "^16.9",
     "classnames": "^2.2.6",
     "luxon": "1.25.0",
     "react": "^16.13.1",
@@ -54,6 +53,7 @@
     "@testing-library/user-event": "^12.0.7",
     "@types/jest": "^26.0.7",
     "@types/node": "^12.0.0",
+    "@types/react": "^16.9",
     "cross-fetch": "^3.0.6",
     "msw": "^0.21.2",
     "node-fetch": "^2.6.1"

--- a/plugins/pagerduty/src/components/PagerDutyCard.tsx
+++ b/plugins/pagerduty/src/components/PagerDutyCard.tsx
@@ -16,7 +16,7 @@
 import React, { useState, useCallback } from 'react';
 import { useApi, Progress, HeaderIconLinkRow } from '@backstage/core';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import { useEntity, withEntitySuspense } from '@backstage/plugin-catalog-react';
 import { Card, CardHeader, Divider, CardContent } from '@material-ui/core';
 import { Incidents } from './Incident';
 import { EscalationPolicy } from './Escalation';
@@ -32,7 +32,7 @@ import { TriggerButton, useShowDialog } from './TriggerButton';
 export const isPluginApplicableToEntity = (entity: Entity) =>
   Boolean(entity.metadata.annotations?.[PAGERDUTY_INTEGRATION_KEY]);
 
-export const PagerDutyCard = () => {
+export const PagerDutyCard = withEntitySuspense(() => {
   const { entity } = useEntity();
   const api = useApi(pagerDutyApiRef);
   const [refreshIncidents, setRefreshIncidents] = useState<boolean>(false);
@@ -104,4 +104,4 @@ export const PagerDutyCard = () => {
       </CardContent>
     </Card>
   );
-};
+});

--- a/plugins/pagerduty/src/components/TriggerButton/index.tsx
+++ b/plugins/pagerduty/src/components/TriggerButton/index.tsx
@@ -16,7 +16,7 @@
 import React, { useCallback, PropsWithChildren } from 'react';
 import { createGlobalState } from 'react-use';
 import { makeStyles, Button } from '@material-ui/core';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import { useEntity, withEntitySuspense } from '@backstage/plugin-catalog-react';
 import { BackstageTheme } from '@backstage/theme';
 
 import { TriggerDialog } from '../TriggerDialog';
@@ -52,7 +52,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 
 export const useShowDialog = createGlobalState(false);
 
-export function TriggerButton({
+export const TriggerButton = withEntitySuspense(function TriggerButton({
   design,
   onIncidentCreated,
   children,
@@ -91,4 +91,4 @@ export function TriggerButton({
       />
     </>
   );
-}
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using `useEntity()`, one must have code paths for handling the *loading* and *error* states. With `<EntitySuspense>` this gets handled uniformly with a `<Progress>` when *loading* and an `<Alert>` when in *error* state. Only when the entity is there, error-free, will the wrapped components render, so they don't need to handle loading and error.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
