### PR TITLE
TechDocs: Update TechDocs Page Header Links

### DIFF
--- a/.changeset/techdocs-curvy-geckos-rhyme.md
+++ b/.changeset/techdocs-curvy-geckos-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+- Adds a link to the owner entity
+- Corrects the link to the component which includes the namespace

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.test.tsx
@@ -15,44 +15,49 @@
  */
 import React from 'react';
 import { TechDocsPageHeader } from './TechDocsPageHeader';
-import { render, act } from '@testing-library/react';
-import { wrapInTestApp } from '@backstage/test-utils';
+import { act } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { entityRouteRef } from '@backstage/plugin-catalog-react';
 
 describe('<TechDocsPageHeader />', () => {
   it('should render a techdocs page header', async () => {
     await act(async () => {
-      const rendered = render(
-        wrapInTestApp(
-          <TechDocsPageHeader
-            entityId={{
-              kind: 'test',
-              name: 'test-name',
-              namespace: 'test-namespace',
-            }}
-            metadataRequest={{
-              entity: {
-                loading: false,
-                value: {
-                  locationMetadata: {
-                    type: 'github',
-                    target: 'https://example.com/',
-                  },
-                  spec: {
-                    owner: 'test',
-                  },
+      const rendered = await renderInTestApp(
+        <TechDocsPageHeader
+          entityId={{
+            kind: 'test',
+            name: 'test-name',
+            namespace: 'test-namespace',
+          }}
+          metadataRequest={{
+            entity: {
+              loading: false,
+              value: {
+                locationMetadata: {
+                  type: 'github',
+                  target: 'https://example.com/',
+                },
+                spec: {
+                  owner: 'test',
                 },
               },
-              techdocs: {
-                loading: false,
-                value: {
-                  site_name: 'test-site-name',
-                  site_description: 'test-site-desc',
-                },
+            },
+            techdocs: {
+              loading: false,
+              value: {
+                site_name: 'test-site-name',
+                site_description: 'test-site-desc',
               },
-            }}
-          />,
-        ),
+            },
+          }}
+        />,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+          },
+        },
       );
+
       expect(rendered.container.innerHTML).toContain('header');
       expect(rendered.getAllByText('test-site-name')).toHaveLength(2);
       expect(rendered.getByText('test-site-desc')).toBeDefined();
@@ -61,27 +66,65 @@ describe('<TechDocsPageHeader />', () => {
 
   it('should render a techdocs page header even if metadata is missing', async () => {
     await act(async () => {
-      const rendered = render(
-        wrapInTestApp(
-          <TechDocsPageHeader
-            entityId={{
-              kind: 'test',
-              name: 'test-name',
-              namespace: 'test-namespace',
-            }}
-            metadataRequest={{
-              entity: {
-                loading: false,
-              },
-              techdocs: {
-                loading: false,
-              },
-            }}
-          />,
-        ),
+      const rendered = await renderInTestApp(
+        <TechDocsPageHeader
+          entityId={{
+            kind: 'test',
+            name: 'test-name',
+            namespace: 'test-namespace',
+          }}
+          metadataRequest={{
+            entity: {
+              loading: false,
+            },
+            techdocs: {
+              loading: false,
+            },
+          }}
+        />,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+          },
+        },
       );
 
       expect(rendered.container.innerHTML).toContain('header');
+    });
+  });
+
+  it('should render a link back to the component page', async () => {
+    await act(async () => {
+      const rendered = await renderInTestApp(
+        <TechDocsPageHeader
+          entityId={{
+            kind: 'test',
+            name: 'test-name',
+            namespace: 'test-namespace',
+          }}
+          metadataRequest={{
+            entity: {
+              loading: false,
+            },
+            techdocs: {
+              loading: false,
+              value: {
+                site_name: 'test-site-name',
+                site_description: 'test-site-desc',
+              },
+            },
+          }}
+        />,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+          },
+        },
+      );
+
+      expect(rendered.container.innerHTML).toContain(
+        '/catalog/test-namespace/test/test-name',
+      );
     });
   });
 });

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
@@ -71,7 +71,7 @@ export const TechDocsPageHeader = ({
       />
       {owner ? (
         <HeaderLabel
-          label="Site Owner"
+          label="Owner"
           value={
             ownerEntity ? (
               <EntityRefLink

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
@@ -18,8 +18,9 @@ import React from 'react';
 import { AsyncState } from 'react-use/lib/useAsync';
 import CodeIcon from '@material-ui/icons/Code';
 import { EntityName } from '@backstage/catalog-model';
-import { Header, HeaderLabel, Link } from '@backstage/core';
+import { Header, HeaderLabel, Link, useRouteRef } from '@backstage/core';
 import { TechDocsMetadata } from '../../types';
+import { entityRouteRef } from '@backstage/plugin-catalog-react';
 
 type TechDocsPageHeaderProps = {
   entityId: EntityName;
@@ -41,7 +42,7 @@ export const TechDocsPageHeader = ({
   const { value: techdocsMetadataValues } = techdocsMetadata;
   const { value: entityMetadataValues } = entityMetadata;
 
-  const { kind, name } = entityId;
+  const { name } = entityId;
 
   const { site_name: siteName, site_description: siteDescription } =
     techdocsMetadataValues || {};
@@ -51,14 +52,14 @@ export const TechDocsPageHeader = ({
     spec: { owner, lifecycle },
   } = entityMetadataValues || { spec: {} };
 
-  const componentLink = `/catalog/${kind}/${name}`;
+  const componentLink = useRouteRef(entityRouteRef);
 
   const labels = (
     <>
       <HeaderLabel
         label="Component"
         value={
-          <Link style={{ color: '#fff' }} to={componentLink}>
+          <Link style={{ color: '#fff' }} to={componentLink(entityId)}>
             {name}
           </Link>
         }
@@ -92,7 +93,7 @@ export const TechDocsPageHeader = ({
         siteDescription && siteDescription !== 'None' ? siteDescription : ''
       }
       type={name}
-      typeLink={componentLink}
+      typeLink={componentLink(entityId)}
     >
       {labels}
     </Header>

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
@@ -17,10 +17,10 @@
 import React from 'react';
 import { AsyncState } from 'react-use/lib/useAsync';
 import CodeIcon from '@material-ui/icons/Code';
-import { EntityName } from '@backstage/catalog-model';
+import { EntityName, parseEntityName } from '@backstage/catalog-model';
 import { Header, HeaderLabel, Link, useRouteRef } from '@backstage/core';
 import { TechDocsMetadata } from '../../types';
-import { entityRouteRef } from '@backstage/plugin-catalog-react';
+import { EntityRefLink, entityRouteRef } from '@backstage/plugin-catalog-react';
 
 type TechDocsPageHeaderProps = {
   entityId: EntityName;
@@ -54,6 +54,11 @@ export const TechDocsPageHeader = ({
 
   const componentLink = useRouteRef(entityRouteRef);
 
+  let ownerEntity;
+  if (owner) {
+    ownerEntity = parseEntityName(owner, { defaultKind: 'group' });
+  }
+
   const labels = (
     <>
       <HeaderLabel
@@ -64,7 +69,22 @@ export const TechDocsPageHeader = ({
           </Link>
         }
       />
-      {owner ? <HeaderLabel label="Site Owner" value={owner} /> : null}
+      {owner ? (
+        <HeaderLabel
+          label="Site Owner"
+          value={
+            ownerEntity ? (
+              <EntityRefLink
+                style={{ color: '#fff' }}
+                entityRef={ownerEntity}
+                defaultKind="group"
+              />
+            ) : (
+              owner
+            )
+          }
+        />
+      ) : null}
       {lifecycle ? <HeaderLabel label="Lifecycle" value={lifecycle} /> : null}
       {locationMetadata &&
       locationMetadata.type !== 'dir' &&


### PR DESCRIPTION
- Corrects the links to the component on the TechDocs Page Header
  - On https://demo.backstage.io the [TechDocs page](https://demo.backstage.io/docs/default/Component/backstage) appears to correctly redirect, but this was not the experience I was receiving locally, and given the redirect it makes me believe this is the correct behaviour.
- Adds an `EntityRefLink` to the owner, at the moment this is done in a similar way to the `AboutCard`
  - This isn't the nicest as the metadata requests are passed to this not fetching info from a context like I've seen in other places and using the relations. I tried to make just the smallest change for now and can expand if necessary, but if that is considered to be worthwhile for this change I can look into it
  - email owners link to a 404 not a `mailto:` this is the same functionality as the `AboutCard` (That doesn't mean however it's the best experience 😅)
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
