### PR TITLE
Fix WORKDIR change in contrib plain_single_backend_deployment

### DIFF
--- a/contrib/kubernetes/plain_single_backend_deployment/README.md
+++ b/contrib/kubernetes/plain_single_backend_deployment/README.md
@@ -6,6 +6,8 @@ This directory contains an example of a simple Kubernetes deployment of Backstag
 
 You can try the deployment out as is. The easiest way is to use [Docker Desktop](https://www.docker.com/products/docker-desktop) with [Kubernetes](https://docs.docker.com/get-started/kube-deploy/).
 
+You can now follow the documentation here to build the Backend Container [Docker Build](https://backstage.io/docs/getting-started/deployment-docker)
+
 From a fresh clone of this repo, run the following in the root:
 
 ```bash

--- a/contrib/kubernetes/plain_single_backend_deployment/deployment.yaml
+++ b/contrib/kubernetes/plain_single_backend_deployment/deployment.yaml
@@ -53,7 +53,7 @@ spec:
 
           volumeMounts:
             - name: config-volume
-              mountPath: /usr/src/app/k8s-config.yaml
+              mountPath: /app/k8s-config.yaml
               subPath: k8s-config.yaml
 
           resources:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Following the changes done in the Backend Dockerfile and the change of `WORKDIR` to `/app`, the container wasn't starting anymore because it couldn't find the `k8s-config.yaml` config file.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
