### PR TITLE
catalog-plugin: Hide "Create Component" button using config

### DIFF
--- a/.changeset/pink-cougars-fly.md
+++ b/.changeset/pink-cougars-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Support hiding the "Create Component" button using `catalog.showCreateComponentLink` config

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -159,6 +159,9 @@ const CatalogPageContents = () => {
   const showAddExampleEntities =
     configApi.has('catalog.exampleEntityLocations') && isCatalogEmpty;
 
+  const showCreateComponent =
+    configApi.getOptionalBoolean('catalog.showCreateComponentLink') ?? true;
+
   return (
     <CatalogLayout>
       <CatalogTabs
@@ -167,14 +170,16 @@ const CatalogPageContents = () => {
       />
       <Content>
         <ContentHeader title={selectedTab ?? ''}>
-          <Button
-            component={RouterLink}
-            variant="contained"
-            color="primary"
-            to={createComponentLink()}
-          >
-            Create Component
-          </Button>
+          {showCreateComponent && (
+            <Button
+              component={RouterLink}
+              variant="contained"
+              color="primary"
+              to={createComponentLink()}
+            >
+              Create Component
+            </Button>
+          )}
           {showAddExampleEntities && (
             <Button
               className={styles.buttonSpacing}


### PR DESCRIPTION
Hey 👋🏻 We're deploying Backstage internally but we're not currently using the scaffolder functionality. Because of this we'd like to remove the "Create Component" button from the catalog plugin home page.

This PR makes it possible to hide the button using config.

**Config missing or `true`**:
<img width="1359" alt="Screenshot 2021-02-24 at 12 37 51" src="https://user-images.githubusercontent.com/917111/109001797-471da400-769d-11eb-83fd-4ebc265c5e13.png">

**Config `false`**:
<img width="1357" alt="Screenshot 2021-02-24 at 12 38 50" src="https://user-images.githubusercontent.com/917111/109001800-484ed100-769d-11eb-8a76-4a4c5d6bd456.png">


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))