### PR TITLE
Use Breadcrumb from @backstage/core

### DIFF
--- a/.changeset/tame-wolves-hunt.md
+++ b/.changeset/tame-wolves-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-actions': patch
+---
+
+Use Breadcrumbs from @backstage/core

--- a/plugins/github-actions/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 import { Entity } from '@backstage/catalog-model';
-import { configApiRef, Link, useApi } from '@backstage/core';
+import { configApiRef, Breadcrumbs, Link, useApi } from '@backstage/core';
 import { readGitHubIntegrationConfigs } from '@backstage/integration';
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
   Box,
-  Breadcrumbs,
   CircularProgress,
   LinearProgress,
   Link as MaterialLink,
@@ -54,6 +53,9 @@ const useStyles = makeStyles<Theme>(theme => ({
   },
   title: {
     padding: theme.spacing(1, 0, 2, 0),
+  },
+  breadcrumb: {
+    margin: theme.spacing(0, 0, 3, 0),
   },
   table: {
     padding: theme.spacing(1),
@@ -184,7 +186,7 @@ export const WorkflowRunDetails = ({ entity }: { entity: Entity }) => {
   }
   return (
     <div className={classes.root}>
-      <Breadcrumbs aria-label="breadcrumb">
+      <Breadcrumbs aria-label="breadcrumb" className={classes.breadcrumb}>
         <Link to="..">Workflow runs</Link>
         <Typography>Workflow run details</Typography>
       </Breadcrumbs>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've switched to `@backstage/core`'s `Breadcrumbs` components in the github actions plugin as described in #4641 

Here is the before

<img width="1420" alt="Capture d’écran 2021-02-24 à 19 21 04" src="https://user-images.githubusercontent.com/4517991/109048354-49045900-76d7-11eb-8b85-6d6b91ae26bf.png">

Here is the after (I've taken the liberty to add a bottom margin to make it look better)

<img width="1430" alt="Capture d’écran 2021-02-24 à 19 20 54" src="https://user-images.githubusercontent.com/4517991/109048434-5b7e9280-76d7-11eb-8d7a-8a2f7b3ace40.png">

This is my first contribution here so feel free to give me additional instructions to make this mergeable :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
