### PR TITLE
feat(backend-commmon): Change debug color to grey

### DIFF
--- a/.changeset/late-singers-speak.md
+++ b/.changeset/late-singers-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Change debug log format to print as color grey

--- a/packages/backend-common/src/logging/formats.ts
+++ b/packages/backend-common/src/logging/formats.ts
@@ -34,7 +34,7 @@ const coloredTemplate = (info: TransformableInfo) => {
 export const coloredFormat = winston.format.combine(
   winston.format.timestamp(),
   winston.format.colorize({
-    colors: { timestamp: 'dim', prefix: 'blue', field: 'cyan' },
+    colors: { timestamp: 'dim', prefix: 'blue', field: 'cyan', debug: 'grey' },
   }),
   winston.format.printf(coloredTemplate),
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Change the debug log color to make them more easily visible in the console.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33203301/109052065-38d58500-76a9-11eb-8136-c1c015193f1e.png) | ![image](https://user-images.githubusercontent.com/33203301/109051968-1b082000-76a9-11eb-824c-7047dad05a62.png) |
| |  ![image](https://user-images.githubusercontent.com/33203301/109051798-e5633700-76a8-11eb-91ad-e50167ff9b8d.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
