### PR TITLE
OverflowTooltip: Don't render component when text is empty

### DIFF
--- a/.changeset/yellow-bananas-live.md
+++ b/.changeset/yellow-bananas-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Fix PropTypes error with OverflowTooltip component

--- a/packages/core/src/components/OverflowTooltip/OverflowTooltip.test.tsx
+++ b/packages/core/src/components/OverflowTooltip/OverflowTooltip.test.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { OverflowTooltip } from '.';
+
+describe('<OverflowTooltip />', () => {
+  it('renders without exploding', async () => {
+    render(<OverflowTooltip text="Text that may overflow" />);
+  });
+
+  it('renders without exploding when the text prop is missing', async () => {
+    render(<OverflowTooltip text={undefined} />);
+  });
+});

--- a/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
@@ -40,6 +40,10 @@ export const OverflowTooltip = (props: Props) => {
     setHover(truncated);
   };
 
+  if (!props.text) {
+    return null;
+  }
+
   return (
     <Tooltip
       title={props.title ?? props.text!}

--- a/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx
@@ -40,13 +40,9 @@ export const OverflowTooltip = (props: Props) => {
     setHover(truncated);
   };
 
-  if (!props.text) {
-    return null;
-  }
-
   return (
     <Tooltip
-      title={props.title ?? props.text!}
+      title={props.title ?? (props.text || '')}
       placement={props.placement}
       disableHoverListener={!hover}
     >


### PR DESCRIPTION
This PR fixes a bug that I believe was introduced in #4372 where `Tooltip` components could be instantiated without a `title` (which is a require prop).

After upgrading Backstage I noticed this error in the console:

<img width="1913" alt="Screenshot 2021-02-25 at 12 45 28" src="https://user-images.githubusercontent.com/917111/109169016-4b1df480-7777-11eb-9989-dcf774e4d2f5.png">

I believe this is happening because some of the components in our catalog don't have a `description` (which is an optional property) but we're attempting to render an `OverflowTooltip`:

https://github.com/backstage/backstage/blob/647bbb14f39a0399cee5b33f64291afbe507685e/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx#L95-L98

This leads to us creating a `Tooltip` without a title:

https://github.com/backstage/backstage/blob/647bbb14f39a0399cee5b33f64291afbe507685e/packages/core/src/components/OverflowTooltip/OverflowTooltip.tsx#L44-L48

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
