### PR TITLE
core: implement optional external routes and use to toggle "Create Component" button

### DIFF
--- a/.changeset/empty-windows-nail.md
+++ b/.changeset/empty-windows-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Make the external `createComponent` route optional, hiding the "Create Component" button if it isn't bound.

--- a/.changeset/popular-sheep-act.md
+++ b/.changeset/popular-sheep-act.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-api': patch
+'@backstage/core': patch
+---
+
+Added support for optional external route references. By setting `optional: true` when creating an `ExternalRouteRef` it is no longer a requirement to bind the route in the app. If the app isn't bound `useRouteRef` will return `undefined`.

--- a/docs/plugins/composability.md
+++ b/docs/plugins/composability.md
@@ -321,7 +321,7 @@ app, allowing it to be used as a switch for whether a particular link should be
 displayed or action should be taken.
 
 When calling `useRouteRef` with an optional external route, its return signature
-is change to `RouteFunc | undefined`, allowing for logic like this:
+is changed to `RouteFunc | undefined`, allowing for logic like this:
 
 ```tsx
 const MyComponent = () => {

--- a/docs/plugins/composability.md
+++ b/docs/plugins/composability.md
@@ -305,6 +305,37 @@ in a different file than the one that creates the plugin instance, for example a
 top-level `routes.ts`. This is to avoid circular imports when you use the route
 references from other parts of the same plugin.
 
+### Optional External Routes
+
+When creating an `ExternalRouteRef` it is possible to mark it as optional:
+
+```ts
+const headerLinkRouteRef = createExternalRouteRef({
+  id: 'header-link',
+  optional: true,
+});
+```
+
+An external route that is marked as optional is not required to be bound in the
+app, allowing it to be used as a switch for whether a particular link should be
+displayed or action should be taken.
+
+When calling `useRouteRef` with an optional external route, its return signature
+is change to `RouteFunc | undefined`, allowing for logic like this:
+
+```tsx
+const MyComponent = () => {
+  const headerLink = useRouteRef(headerLinkRouteRef);
+
+  return (
+    <header>
+      My Header
+      {headerLink && <a href={headerLink()}>External Link</a>}
+    </header>
+  );
+};
+```
+
 ### Parameterized Routes
 
 A new addition to `RouteRef`s is the possibility of adding named and typed

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -84,8 +84,14 @@ export function generateBoundRoutes(
         if (!externalRoute) {
           throw new Error(`Key ${key} is not an existing external route`);
         }
-
-        result.set(externalRoute, value);
+        if (!value && !externalRoute.optional) {
+          throw new Error(
+            `External route ${key} is required but was undefined`,
+          );
+        }
+        if (value) {
+          result.set(externalRoute, value);
+        }
       }
     };
     bindRoutes({ bind });

--- a/packages/core-api/src/app/types.ts
+++ b/packages/core-api/src/app/types.ts
@@ -96,7 +96,7 @@ type ExtractKeysWithType<Obj extends { [key in string]: any }, Type> = {
 }[keyof Obj];
 
 /**
- * Given a map of boolean values denoting whether a rout is optional, create a
+ * Given a map of boolean values denoting whether a route is optional, create a
  * map of needed RouteRefs.
  *
  * For example { foo: false, bar: true } gives { foo: RouteRef<any>, bar?: RouteRef<any> }

--- a/packages/core-api/src/app/types.ts
+++ b/packages/core-api/src/app/types.ts
@@ -16,8 +16,8 @@
 
 import { ComponentType } from 'react';
 import { IconComponent, IconComponentMap, IconKey } from '../icons';
-import { BackstagePlugin, AnyExternalRoutes } from '../plugin/types';
-import { RouteRef } from '../routing';
+import { BackstagePlugin } from '../plugin/types';
+import { ExternalRouteRef, RouteRef } from '../routing';
 import { AnyApiFactory } from '../apis';
 import { AppTheme, ProfileInfo } from '../apis/definitions';
 import { AppConfig } from '@backstage/config';
@@ -79,9 +79,49 @@ export type AppComponents = {
  */
 export type AppConfigLoader = () => Promise<AppConfig[]>;
 
-export type AppRouteBinder = <T extends AnyExternalRoutes>(
-  externalRoutes: T,
-  targetRoutes: { [key in keyof T]: RouteRef<any> },
+/**
+ * Extracts the Optional type of a map of ExternalRouteRefs, leaving only the boolean in place as value
+ */
+type ExternalRouteRefsToOptionalMap<
+  T extends { [name in string]: ExternalRouteRef<boolean> }
+> = {
+  [name in keyof T]: T[name] extends ExternalRouteRef<infer U> ? U : never;
+};
+
+/**
+ * Extracts a union of the keys in a map whose value extends the given type
+ */
+type ExtractKeysWithType<Obj extends { [key in string]: any }, Type> = {
+  [key in keyof Obj]: Obj[key] extends Type ? key : never;
+}[keyof Obj];
+
+/**
+ * Given a map of boolean values denoting whether a rout is optional, create a
+ * map of needed RouteRefs.
+ *
+ * For example { foo: false, bar: true } gives { foo: RouteRef<any>, bar?: RouteRef<any> }
+ */
+type CombineOptionalAndRequiredRoutes<
+  OptionalMap extends { [key in string]: boolean }
+> = {
+  [name in ExtractKeysWithType<OptionalMap, false>]: RouteRef<any>;
+} &
+  { [name in keyof OptionalMap]?: RouteRef<any> };
+
+/**
+ * Creates a map of required target routes based on whether the input external
+ * routes are optional or not. The external routes that are marked as optional
+ * will also be optional in the target routes map.
+ */
+type TargetRoutesMap<
+  T extends { [name in string]: ExternalRouteRef<boolean> }
+> = CombineOptionalAndRequiredRoutes<ExternalRouteRefsToOptionalMap<T>>;
+
+export type AppRouteBinder = <
+  ExternalRoutes extends { [name in string]: ExternalRouteRef<boolean> }
+>(
+  externalRoutes: ExternalRoutes,
+  targetRoutes: TargetRoutesMap<ExternalRoutes>,
 ) => void;
 
 export type AppOptions = {

--- a/packages/core-api/src/routing/RouteRef.ts
+++ b/packages/core-api/src/routing/RouteRef.ts
@@ -64,23 +64,36 @@ export function createRouteRef<
   return new AbsoluteRouteRef<Params>(config);
 }
 
-export class ExternalRouteRef {
-  private constructor(id: string) {
+export class ExternalRouteRef<Optional extends boolean = true> {
+  readonly optional: boolean;
+
+  private constructor({ id, optional }: ExternalRouteRefOptions<Optional>) {
     this.toString = () => `externalRouteRef{${id}}`;
+    this.optional = Boolean(optional);
   }
 }
 
-export type ExternalRouteRefOptions = {
+export type ExternalRouteRefOptions<Optional extends boolean = false> = {
   /**
    * An identifier for this route, used to identify it in error messages
    */
   id: string;
+
+  /**
+   * Whether or not this route is optional, defaults to false.
+   *
+   * Optional external routes are not required to be bound in the app, and
+   * if aren't, `useRouteRef` will return `undefined`.
+   */
+  optional?: Optional;
 };
 
-export function createExternalRouteRef(
-  options: ExternalRouteRefOptions,
-): ExternalRouteRef {
+export function createExternalRouteRef<Optional extends boolean = false>(
+  options: ExternalRouteRefOptions<Optional>,
+): ExternalRouteRef<Optional> {
   return new ((ExternalRouteRef as unknown) as {
-    new (id: string): ExternalRouteRef;
-  })(options.id);
+    new (options: ExternalRouteRefOptions<Optional>): ExternalRouteRef<
+      Optional
+    >;
+  })(options);
 }

--- a/packages/core-api/src/routing/RouteRef.ts
+++ b/packages/core-api/src/routing/RouteRef.ts
@@ -83,7 +83,7 @@ export type ExternalRouteRefOptions<Optional extends boolean = false> = {
    * Whether or not this route is optional, defaults to false.
    *
    * Optional external routes are not required to be bound in the app, and
-   * if aren't, `useRouteRef` will return `undefined`.
+   * if they aren't, `useRouteRef` will return `undefined`.
    */
   optional?: Optional;
 };

--- a/packages/core-api/src/routing/hooks.test.tsx
+++ b/packages/core-api/src/routing/hooks.test.tsx
@@ -41,7 +41,7 @@ import {
   ExternalRouteRef,
   RouteRefConfig,
 } from './RouteRef';
-import { RouteRef } from './types';
+import { AnyRouteRef, RouteRef } from './types';
 
 const mockConfig = (extra?: Partial<RouteRefConfig<{}>>) => ({
   path: '/unused',
@@ -62,18 +62,22 @@ const ref5 = createRouteRef(mockConfig({ path: '/wat5' }));
 const eRefA = createExternalRouteRef({ id: '1' });
 const eRefB = createExternalRouteRef({ id: '2' });
 const eRefC = createExternalRouteRef({ id: '3' });
+const eRefD = createExternalRouteRef({ id: '4', optional: true });
+const eRefE = createExternalRouteRef({ id: '5', optional: true });
 
 const MockRouteSource = <T extends { [name in string]: string }>(props: {
   path?: string;
   name: string;
-  routeRef: RouteRef<T> | ExternalRouteRef;
+  routeRef: AnyRouteRef;
   params?: T;
 }) => {
   try {
-    const routeFunc = useRouteRef(props.routeRef) as RouteFunc<any>;
+    const routeFunc = useRouteRef(props.routeRef as any) as
+      | RouteFunc<any>
+      | undefined;
     return (
       <div>
-        Path at {props.name}: {routeFunc(props.params)}
+        Path at {props.name}: {routeFunc?.(props.params) ?? '<none>'}
       </div>
     );
   } catch (ex) {
@@ -156,6 +160,8 @@ describe('discovery', () => {
         <MockRouteSource name="outside" routeRef={ref2} />
         <MockRouteSource name="outsideExternal1" routeRef={eRefB} />
         <MockRouteSource name="outsideExternal2" routeRef={eRefC} />
+        <MockRouteSource name="outsideExternal3" routeRef={eRefD} />
+        <MockRouteSource name="outsideExternal4" routeRef={eRefE} />
       </MemoryRouter>
     );
 
@@ -164,6 +170,7 @@ describe('discovery', () => {
         [eRefA, ref3],
         [eRefB, ref1],
         [eRefC, ref2],
+        [eRefD, ref1],
       ]),
     );
 
@@ -179,6 +186,12 @@ describe('discovery', () => {
     ).toBeInTheDocument();
     expect(
       rendered.getByText('Path at outsideExternal2: /foo/bar'),
+    ).toBeInTheDocument();
+    expect(
+      rendered.getByText('Path at outsideExternal3: /foo'),
+    ).toBeInTheDocument();
+    expect(
+      rendered.getByText('Path at outsideExternal4: <none>'),
     ).toBeInTheDocument();
   });
 

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { IconComponent } from '../icons';
+import { ExternalRouteRef } from './RouteRef';
 
 // @ts-ignore, we're just embedding the Params type for usage in other places
 export type RouteRef<Params extends { [param in string]: string } = {}> = {
@@ -25,7 +26,7 @@ export type RouteRef<Params extends { [param in string]: string } = {}> = {
   title: string;
 };
 
-export type AnyRouteRef = RouteRef<any>;
+export type AnyRouteRef = RouteRef<any> | ExternalRouteRef<any>;
 
 /**
  * This type should not be used

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -167,14 +167,16 @@ const CatalogPageContents = () => {
       />
       <Content>
         <ContentHeader title={selectedTab ?? ''}>
-          <Button
-            component={RouterLink}
-            variant="contained"
-            color="primary"
-            to={createComponentLink()}
-          >
-            Create Component
-          </Button>
+          {createComponentLink && (
+            <Button
+              component={RouterLink}
+              variant="contained"
+              color="primary"
+              to={createComponentLink()}
+            >
+              Create Component
+            </Button>
+          )}
           {showAddExampleEntities && (
             <Button
               className={styles.buttonSpacing}

--- a/plugins/catalog/src/routes.ts
+++ b/plugins/catalog/src/routes.ts
@@ -18,4 +18,5 @@ import { createExternalRouteRef } from '@backstage/core';
 
 export const createComponentRouteRef = createExternalRouteRef({
   id: 'create-component',
+  optional: true,
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds support for

```tsx
const myRouteRef = createExternalRouteRef({ id: 'my-ref', optional: true })

// ...

const MyComponent = () => {
  const myLink = useRouteRef(myRouteRef)
  if (myLink) {
    return <a href={myLink()}>Link</a>
  } else {
    return <span>No link :( </span>
  }
}
```

+ optional "Create Component" button!

![out](https://user-images.githubusercontent.com/4984472/109189178-0785b380-7794-11eb-8145-ed2f1d4949f7.gif)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
