### PR TITLE
Use Breadcrumbs from @backstage/core

### DIFF
--- a/.changeset/blue-lemons-reflect.md
+++ b/.changeset/blue-lemons-reflect.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-circleci': patch
+'@backstage/plugin-cloudbuild': patch
+'@backstage/plugin-github-actions': patch
+---
+
+Use Breadcrumbs from @backstage/core rather than material-ui

--- a/.changeset/strange-apes-exercise.md
+++ b/.changeset/strange-apes-exercise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cloudbuild': patch
+---
+
+Change terminology for cloudbuild

--- a/plugins/circleci/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
+++ b/plugins/circleci/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
@@ -16,13 +16,12 @@
 
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { InfoCard, Progress, Link } from '@backstage/core';
+import { Breadcrumbs, InfoCard, Progress, Link } from '@backstage/core';
 import { BuildWithSteps, BuildStepAction } from '../../api';
 import {
   Grid,
   Box,
   IconButton,
-  Breadcrumbs,
   Typography,
   Link as MaterialLink,
 } from '@material-ui/core';
@@ -146,10 +145,12 @@ export const BuildWithStepsPage = () => {
 
   return (
     <>
-      <Breadcrumbs aria-label="breadcrumb">
-        <Link to="..">All builds</Link>
-        <Typography>Build details</Typography>
-      </Breadcrumbs>
+      <Box mb={3}>
+        <Breadcrumbs aria-label="breadcrumb">
+          <Link to="..">All builds</Link>
+          <Typography>Build details</Typography>
+        </Breadcrumbs>
+      </Box>
       <Grid container spacing={3} direction="column">
         <Grid item>
           <InfoCard

--- a/plugins/cloudbuild/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
+++ b/plugins/cloudbuild/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import { Entity } from '@backstage/catalog-model';
-import { Link, WarningPanel } from '@backstage/core';
+import { Breadcrumbs, Link, WarningPanel } from '@backstage/core';
 import {
-  Breadcrumbs,
+  Box,
   LinearProgress,
   Link as MaterialLink,
   makeStyles,
@@ -86,10 +86,12 @@ export const WorkflowRunDetails = ({ entity }: { entity: Entity }) => {
 
   return (
     <div className={classes.root}>
-      <Breadcrumbs aria-label="breadcrumb">
-        <Link to="..">Workflow runs</Link>
-        <Typography>Workflow run details</Typography>
-      </Breadcrumbs>
+      <Box mb={3}>
+        <Breadcrumbs aria-label="breadcrumb">
+          <Link to="..">Workflow runs</Link>
+          <Typography>Workflow run details</Typography>
+        </Breadcrumbs>
+      </Box>
       <TableContainer component={Paper} className={classes.table}>
         <Table>
           <TableBody>

--- a/plugins/cloudbuild/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
+++ b/plugins/cloudbuild/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
@@ -88,8 +88,8 @@ export const WorkflowRunDetails = ({ entity }: { entity: Entity }) => {
     <div className={classes.root}>
       <Box mb={3}>
         <Breadcrumbs aria-label="breadcrumb">
-          <Link to="..">Workflow runs</Link>
-          <Typography>Workflow run details</Typography>
+          <Link to="..">Build history</Link>
+          <Typography>Build details</Typography>
         </Breadcrumbs>
       </Box>
       <TableContainer component={Paper} className={classes.table}>

--- a/plugins/github-actions/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
@@ -54,9 +54,6 @@ const useStyles = makeStyles<Theme>(theme => ({
   title: {
     padding: theme.spacing(1, 0, 2, 0),
   },
-  breadcrumb: {
-    margin: theme.spacing(0, 0, 3, 0),
-  },
   table: {
     padding: theme.spacing(1),
   },
@@ -186,10 +183,12 @@ export const WorkflowRunDetails = ({ entity }: { entity: Entity }) => {
   }
   return (
     <div className={classes.root}>
-      <Breadcrumbs aria-label="breadcrumb" className={classes.breadcrumb}>
-        <Link to="..">Workflow runs</Link>
-        <Typography>Workflow run details</Typography>
-      </Breadcrumbs>
+      <Box mb={3}>
+        <Breadcrumbs aria-label="breadcrumb">
+          <Link to="..">Workflow runs</Link>
+          <Typography>Workflow run details</Typography>
+        </Breadcrumbs>
+      </Box>
       <TableContainer component={Paper} className={classes.table}>
         <Table>
           <TableBody>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Those are the remaining change to remove all usage of material-ui's Breadcrumbs to close issue #4641. Also refactored to use `Box` as suggested in the previous pull request 

Circle-ci plugin (I've tweaked the code so it shows, don't mind the content of the table)
<img width="1365" alt="Capture d’écran 2021-02-25 à 20 07 31" src="https://user-images.githubusercontent.com/4517991/109205456-e67a8e00-77a6-11eb-966e-835bbbe20e50.png">

Cloudbuild plugin (same)
<img width="1343" alt="Capture d’écran 2021-02-25 à 20 10 26" src="https://user-images.githubusercontent.com/4517991/109205464-e9757e80-77a6-11eb-9ee9-435a7e9634ac.png">

Github actions
<img width="1364" alt="Capture d’écran 2021-02-25 à 20 20 44" src="https://user-images.githubusercontent.com/4517991/109205591-188bf000-77a7-11eb-99db-c2027a96cde9.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
