### PR TITLE
sonarqube: Default to -% if no coverage is reported

### DIFF
--- a/.changeset/shaggy-spiders-shop.md
+++ b/.changeset/shaggy-spiders-shop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': patch
+---
+
+Display '-' instead of 'undefined' if no code coverage is reported.

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -235,7 +235,7 @@ export const SonarQubeCard = ({
                 rightSlot={
                   <Value
                     value={
-                      value.metrics.coverage
+                      value.metrics.coverage !== undefined
                         ? `${value.metrics.coverage}%`
                         : '—'
                     }

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -232,7 +232,9 @@ export const SonarQubeCard = ({
                 link={value.getComponentMeasuresUrl('COVERAGE')}
                 title="Coverage"
                 leftSlot={<Percentage value={value.metrics.coverage} />}
-                rightSlot={<Value value={`${value.metrics.coverage || 0}%`} />}
+                rightSlot={
+                  <Value value={`${value.metrics.coverage || '-'}%`} />
+                }
               />
               <RatingCard
                 title="Duplications"

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -232,7 +232,7 @@ export const SonarQubeCard = ({
                 link={value.getComponentMeasuresUrl('COVERAGE')}
                 title="Coverage"
                 leftSlot={<Percentage value={value.metrics.coverage} />}
-                rightSlot={<Value value={`${value.metrics.coverage||0}%`} />}
+                rightSlot={<Value value={`${value.metrics.coverage || 0}%`}/>}
               />
               <RatingCard
                 title="Duplications"

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -85,9 +85,9 @@ const defaultDuplicationRatings: DuplicationRating[] = [
 ];
 
 export const SonarQubeCard = ({
-                                variant = 'gridItem',
-                                duplicationRatings = defaultDuplicationRatings,
-                              }: {
+  variant = 'gridItem',
+  duplicationRatings = defaultDuplicationRatings,
+}: {
   entity?: Entity;
   variant?: InfoCardVariants;
   duplicationRatings?: DuplicationRating[];
@@ -105,9 +105,9 @@ export const SonarQubeCard = ({
   const deepLink =
     !loading && value
       ? {
-        title: 'View more',
-        link: value.projectUrl,
-      }
+          title: 'View more',
+          link: value.projectUrl,
+        }
       : undefined;
 
   const classes = useStyles();

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -233,7 +233,13 @@ export const SonarQubeCard = ({
                 title="Coverage"
                 leftSlot={<Percentage value={value.metrics.coverage} />}
                 rightSlot={
-                  <Value value={`${value.metrics.coverage || '—'}%`} />
+                  <Value
+                    value={
+                      value.metrics.coverage
+                        ? `${value.metrics.coverage}%`
+                        : '—'
+                    }
+                  />
                 }
               />
               <RatingCard

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -85,9 +85,9 @@ const defaultDuplicationRatings: DuplicationRating[] = [
 ];
 
 export const SonarQubeCard = ({
-  variant = 'gridItem',
-  duplicationRatings = defaultDuplicationRatings,
-}: {
+                                variant = 'gridItem',
+                                duplicationRatings = defaultDuplicationRatings,
+                              }: {
   entity?: Entity;
   variant?: InfoCardVariants;
   duplicationRatings?: DuplicationRating[];
@@ -105,9 +105,9 @@ export const SonarQubeCard = ({
   const deepLink =
     !loading && value
       ? {
-          title: 'View more',
-          link: value.projectUrl,
-        }
+        title: 'View more',
+        link: value.projectUrl,
+      }
       : undefined;
 
   const classes = useStyles();
@@ -232,7 +232,7 @@ export const SonarQubeCard = ({
                 link={value.getComponentMeasuresUrl('COVERAGE')}
                 title="Coverage"
                 leftSlot={<Percentage value={value.metrics.coverage} />}
-                rightSlot={<Value value={`${value.metrics.coverage || 0}%`}/>}
+                rightSlot={<Value value={`${value.metrics.coverage || 0}%`} />}
               />
               <RatingCard
                 title="Duplications"

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -232,7 +232,7 @@ export const SonarQubeCard = ({
                 link={value.getComponentMeasuresUrl('COVERAGE')}
                 title="Coverage"
                 leftSlot={<Percentage value={value.metrics.coverage} />}
-                rightSlot={<Value value={`${value.metrics.coverage}%`} />}
+                rightSlot={<Value value={`${value.metrics.coverage||0}%`} />}
               />
               <RatingCard
                 title="Duplications"

--- a/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -233,7 +233,7 @@ export const SonarQubeCard = ({
                 title="Coverage"
                 leftSlot={<Percentage value={value.metrics.coverage} />}
                 rightSlot={
-                  <Value value={`${value.metrics.coverage || '-'}%`} />
+                  <Value value={`${value.metrics.coverage || '—'}%`} />
                 }
               />
               <RatingCard


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Instead of this:
<img width="191" alt="Screen Shot 2021-02-25 at 2 06 23 PM" src="https://user-images.githubusercontent.com/8467862/109225805-a8637700-7772-11eb-8e9a-753187335615.png">

You get this:
![Screen Shot 2021-02-26 at 12 01 15 PM](https://user-images.githubusercontent.com/8467862/109349159-5aaa4580-782a-11eb-8381-3d7e93bee3fb.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
