### PR TITLE
TechDocs: Replace S3 read-store-upload loop with file streams

### DIFF
--- a/.changeset/young-pens-argue.md
+++ b/.changeset/young-pens-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Remove read-store-upload loop when uploading S3 objects for TechDocs

--- a/packages/techdocs-common/src/stages/publish/awsS3.test.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.test.ts
@@ -99,6 +99,9 @@ describe('AwsS3Publish', () => {
           assets: {
             'main.css': '',
           },
+          attachments: {
+            'image.png': Buffer.from([2, 3, 5, 3, 5, 3, 5, 9, 1]),
+          },
         },
       });
     });


### PR DESCRIPTION
This no longer buffers file contents in memory.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
