### PR TITLE
api-docs: Add organization name to page header

### DIFF
--- a/.changeset/light-vans-hide.md
+++ b/.changeset/light-vans-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Add organization name to the API Explorer page title

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerLayout.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerLayout.tsx
@@ -14,20 +14,25 @@
  * limitations under the License.
  */
 
-import { Header, Page } from '@backstage/core';
+import { Header, Page, useApi, configApiRef } from '@backstage/core';
 import React from 'react';
 
 type Props = {
   children?: React.ReactNode;
 };
-
-export const ApiExplorerLayout = ({ children }: Props) => (
-  <Page themeId="home">
-    <Header
-      title="APIs"
-      subtitle="Backstage API Explorer"
-      pageTitleOverride="APIs"
-    />
-    {children}
-  </Page>
-);
+export const ApiExplorerLayout = ({ children }: Props) => {
+  const configApi = useApi(configApiRef);
+  const generatedSubtitle = `${
+    configApi.getString('organization.name') ?? 'Backstage'
+  } API Explorer`;
+  return (
+    <Page themeId="home">
+      <Header
+        title="APIs"
+        subtitle={generatedSubtitle}
+        pageTitleOverride="APIs"
+      />
+      {children}
+    </Page>
+  );
+};

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerLayout.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerLayout.tsx
@@ -23,7 +23,7 @@ type Props = {
 export const ApiExplorerLayout = ({ children }: Props) => {
   const configApi = useApi(configApiRef);
   const generatedSubtitle = `${
-    configApi.getString('organization.name') ?? 'Backstage'
+    configApi.getOptionalString('organization.name') ?? 'Backstage'
   } API Explorer`;
   return (
     <Page themeId="home">

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.test.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.test.tsx
@@ -15,7 +15,14 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { ApiProvider, ApiRegistry, storageApiRef } from '@backstage/core';
+import {
+  ApiProvider,
+  ApiRegistry,
+  storageApiRef,
+  ConfigApi,
+  configApiRef,
+  ConfigReader,
+} from '@backstage/core';
 import { CatalogApi, catalogApiRef } from '@backstage/plugin-catalog-react';
 import { MockStorageApi, wrapInTestApp } from '@backstage/test-utils';
 import { render } from '@testing-library/react';
@@ -50,6 +57,12 @@ describe('ApiCatalogPage', () => {
       Promise.resolve({ id: 'id', type: 'github', target: 'url' }),
   };
 
+  const configApi: ConfigApi = new ConfigReader({
+    organization: {
+      name: 'My Company',
+    },
+  });
+
   const apiDocsConfig = {
     getApiDefinitionWidget: () => undefined,
   };
@@ -60,6 +73,7 @@ describe('ApiCatalogPage', () => {
         <ApiProvider
           apis={ApiRegistry.from([
             [catalogApiRef, catalogApi],
+            [configApiRef, configApi],
             [storageApiRef, MockStorageApi.create()],
             [apiDocsConfigRef, apiDocsConfig],
           ])}
@@ -74,6 +88,6 @@ describe('ApiCatalogPage', () => {
   // https://github.com/mbrn/material-table/issues/1293
   it('should render', async () => {
     const { findByText } = renderWrapped(<ApiExplorerPage />);
-    expect(await findByText(/Backstage API Explorer/)).toBeInTheDocument();
+    expect(await findByText(/My Company API Explorer/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Current API Explorer always displayed, "Backstage API Explorer". Updates to use the org name such as "My Company API Explorer", if defined, falling back to Backstage if not.

![image](https://user-images.githubusercontent.com/33203301/109256115-539c1c80-77c3-11eb-9d56-6afb42e12ffa.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
