### PR TITLE
skip entities if location returns multiple similar entities.

### DIFF
--- a/.changeset/six-coats-attend.md
+++ b/.changeset/six-coats-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+skip entities if location returns multiple similar entities


### PR DESCRIPTION
 - previously if a location returned a whole lot of entities some
   of which were duplicated, then the whole batch were failing.
 - this changes to to instead log an error where there are duplicates
   and continue to load the remaining good enities.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
