### PR TITLE
Automatically rebuild TechDocs based on ETAGs

### DIFF
--- a/.changeset/large-cameras-attend.md
+++ b/.changeset/large-cameras-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Automaticly rebuild docs if etag differs between stored and latest commit

--- a/.changeset/large-cameras-attend.md
+++ b/.changeset/large-cameras-attend.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-backend': patch
 ---
 
-Automaticly rebuild docs if etag differs between stored and latest commit
+Rebuild docs if etag differ between stored and latest commit

--- a/.changeset/large-cameras-attend.md
+++ b/.changeset/large-cameras-attend.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/plugin-techdocs-backend': patch
+'@backstage/techdocs-common': patch
 ---
 
 Rebuild docs if etag differ between stored and latest commit

--- a/packages/techdocs-common/src/stages/publish/awsS3.test.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.test.ts
@@ -192,13 +192,14 @@ describe('AwsS3Publish', () => {
       mockFs({
         [entityRootDir]: {
           'techdocs_metadata.json':
-            '{"site_name": "backstage", "site_description": "site_content"}',
+            '{"site_name": "backstage", "site_description": "site_content", "etag": "etag" }',
         },
       });
 
       const expectedMetadata: TechDocsMetadata = {
         site_name: 'backstage',
         site_description: 'site_content',
+        etag: 'etag',
       };
       expect(
         await publisher.fetchTechDocsMetadata(entityNameMock),
@@ -213,13 +214,14 @@ describe('AwsS3Publish', () => {
 
       mockFs({
         [entityRootDir]: {
-          'techdocs_metadata.json': `{'site_name': 'backstage', 'site_description': 'site_content'}`,
+          'techdocs_metadata.json': `{'site_name': 'backstage', 'site_description': 'site_content', 'etag': 'etag' }`,
         },
       });
 
       const expectedMetadata: TechDocsMetadata = {
         site_name: 'backstage',
         site_description: 'site_content',
+        etag: 'etag',
       };
       expect(
         await publisher.fetchTechDocsMetadata(entityNameMock),

--- a/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
@@ -193,13 +193,14 @@ describe('GoogleGCSPublish', () => {
       mockFs({
         [entityRootDir]: {
           'techdocs_metadata.json':
-            '{"site_name": "backstage", "site_description": "site_content"}',
+            '{"site_name": "backstage", "site_description": "site_content", "etag": "etag"}',
         },
       });
 
       const expectedMetadata: TechDocsMetadata = {
         site_name: 'backstage',
         site_description: 'site_content',
+        etag: 'etag',
       };
       expect(
         await publisher.fetchTechDocsMetadata(entityNameMock),
@@ -214,13 +215,14 @@ describe('GoogleGCSPublish', () => {
       mockFs({
         [entityRootDir]: {
           'techdocs_metadata.json':
-            "{'site_name': 'backstage', 'site_description': 'site_content'}",
+            "{'site_name': 'backstage', 'site_description': 'site_content', 'etag': 'etag'}",
         },
       });
 
       const expectedMetadata: TechDocsMetadata = {
         site_name: 'backstage',
         site_description: 'site_content',
+        etag: 'etag',
       };
       expect(
         await publisher.fetchTechDocsMetadata(entityNameMock),

--- a/packages/techdocs-common/src/stages/publish/types.ts
+++ b/packages/techdocs-common/src/stages/publish/types.ts
@@ -42,6 +42,7 @@ export type PublishResponse = {
 export type TechDocsMetadata = {
   site_name: string;
   site_description: string;
+  etag?: string;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Updates techdocs-backend to automaticly rebuild techdocs if updated.

It uses the etag value from the stored `techdocs_metadata.json` file and the etag value from the `preparerResponse` to determine 

