### PR TITLE
UnregisterEntity: Removed Dialog modal fullscreen prop (#4685).

### DIFF
--- a/.changeset/swift-cows-thank.md
+++ b/.changeset/swift-cows-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Removed fullScreen property from UnregisterEntity Dialog modal.

--- a/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -28,8 +28,6 @@ import {
   DialogContentText,
   DialogTitle,
   Typography,
-  useMediaQuery,
-  useTheme,
 } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import React from 'react';
@@ -79,8 +77,6 @@ export const UnregisterEntityDialog = ({
   entity,
 }: Props) => {
   const { value: entities, loading, error } = useColocatedEntities(entity);
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const catalogApi = useApi(catalogApiRef);
   const alertApi = useApi(alertApiRef);
   const configApi = useApi(configApiRef);
@@ -97,7 +93,7 @@ export const UnregisterEntityDialog = ({
   };
 
   return (
-    <Dialog fullScreen={fullScreen} open={open} onClose={onClose}>
+    <Dialog open={open} onClose={onClose}>
       <DialogTitle id="responsive-dialog-title">
         Are you sure you want to unregister this entity?
       </DialogTitle>


### PR DESCRIPTION
Added a small fix by removing the `fullscreen` prop from the `UnregisterEntity` Dialog modal (as suggested by @wrousseau).
Adding on to @adamdmharvey suggestion, Would a <a href = 'https://material-ui.com/customization/breakpoints/'>breakpoint</a> of `xs` be fine? (if removing the  `fullscreen` prop doesn't feel right.)

<strong>ScreenShots:</strong>
(Width at 700px)
![Screen Shot 2021-03-01 at 00 05 09](https://user-images.githubusercontent.com/53977614/109430022-0c14cb00-7a25-11eb-9c07-f48b3f84f3d6.png)
