### PR TITLE
Techdocs static docs should use external url

### DIFF
--- a/.changeset/itchy-items-serve.md
+++ b/.changeset/itchy-items-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+---
+
+Use external url for static docs

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -104,7 +104,7 @@ export async function createRouter({
     const { kind, namespace, name } = req.params;
     const storageUrl =
       config.getOptionalString('techdocs.storageUrl') ??
-      `${await discovery.getBaseUrl('techdocs')}/static/docs`;
+      `${await discovery.getExternalBaseUrl('techdocs')}/static/docs`;
 
     const catalogUrl = await discovery.getBaseUrl('catalog');
     const triple = [kind, namespace, name].map(encodeURIComponent).join('/');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

My backstage instance is served at `backstage.example.com`, but when trying to view techdocs previously published on an S3 bucket, I get a 404. Looking at the network request shows that `https://backstage.example.com/api/techdocs/docs/default/Component/example/index.html` is redirected to `http://localhost:7000/api/techdocs/static/docs/default/Component/example/index.html` which refuses to connect.

I believe the fix is to use `discovery.getExternalBaseUrl` instead of ´discovery.getBaseUrl` for this particular URL.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
