### PR TITLE
Made all locations outputted by GithubDiscoveryProcessor optional

### DIFF
--- a/.changeset/curvy-pugs-type.md
+++ b/.changeset/curvy-pugs-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+GithubDiscoveryProcessor outputs locations as optional to avoid outputting errors for missing locations (see https://github.com/backstage/backstage/issues/4730).

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
@@ -133,7 +133,7 @@ describe('GithubDiscoveryProcessor', () => {
           target:
             'https://github.com/backstage/backstage/blob/master/catalog.yaml',
         },
-        optional: false,
+        optional: true,
       });
       expect(emitter).toHaveBeenCalledWith({
         type: 'location',
@@ -141,7 +141,7 @@ describe('GithubDiscoveryProcessor', () => {
           type: 'url',
           target: 'https://github.com/backstage/demo/blob/master/catalog.yaml',
         },
-        optional: false,
+        optional: true,
       });
     });
 
@@ -175,7 +175,7 @@ describe('GithubDiscoveryProcessor', () => {
           target:
             'https://github.com/backstage/techdocs-cli/blob/master/catalog.yaml',
         },
-        optional: false,
+        optional: true,
       });
       expect(emitter).toHaveBeenCalledWith({
         type: 'location',
@@ -184,7 +184,7 @@ describe('GithubDiscoveryProcessor', () => {
           target:
             'https://github.com/backstage/techdocs-container/blob/master/catalog.yaml',
         },
-        optional: false,
+        optional: true,
       });
     });
     it('filter unrelated repositories', async () => {
@@ -215,7 +215,7 @@ describe('GithubDiscoveryProcessor', () => {
           type: 'url',
           target: 'https://github.com/backstage/test/blob/master/catalog.yaml',
         },
-        optional: false,
+        optional: true,
       });
     });
   });

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
@@ -94,6 +94,9 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
             type: 'url',
             target: `${repository.url}${catalogPath}`,
           },
+          // Not all locations may actually exist, since the user defined them as a wildcard pattern.
+          // Thus, we omit them as optional and let the downstream processor find them while not outputting
+          // an error if it couldn't.
           true,
         ),
       );

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
@@ -94,7 +94,7 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
             type: 'url',
             target: `${repository.url}${catalogPath}`,
           },
-          false,
+          true,
         ),
       );
     }

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
@@ -95,7 +95,7 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
             target: `${repository.url}${catalogPath}`,
           },
           // Not all locations may actually exist, since the user defined them as a wildcard pattern.
-          // Thus, we omit them as optional and let the downstream processor find them while not outputting
+          // Thus, we emit them as optional and let the downstream processor find them while not outputting
           // an error if it couldn't.
           true,
         ),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #4730.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This avoids errors when specifying locations as `https://github.com/backstage/*mkdocs/blob/master/catalog.yaml` where not all repositories actually contain a file named `catalog.yaml`, which is ok from the user's perspective - but currently throws an error.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
