### PR TITLE
[SonarQube] Collect all available metric types if the number exceeds the default page size of 100

### DIFF
--- a/.changeset/gentle-bears-fry.md
+++ b/.changeset/gentle-bears-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': patch
+---
+
+Collect all available metric types if the number exceeds the default page size of 100.

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -41,6 +41,7 @@
     "@material-ui/lab": "4.0.0-alpha.45",
     "@material-ui/styles": "^4.10.0",
     "cross-fetch": "^3.0.6",
+    "qs": "^6.9.4",
     "rc-progress": "^3.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -41,7 +41,6 @@
     "@material-ui/lab": "4.0.0-alpha.45",
     "@material-ui/styles": "^4.10.0",
     "cross-fetch": "^3.0.6",
-    "qs": "^6.9.4",
     "rc-progress": "^3.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/sonarqube/src/api/SonarQubeClient.test.ts
+++ b/plugins/sonarqube/src/api/SonarQubeClient.test.ts
@@ -53,7 +53,7 @@ describe('SonarQubeClient', () => {
           return res(
             ctx.json({
               metrics: metricKeys.slice(0, 5).map(k => ({ key: k })),
-              total: 2,
+              total: metricKeys.length,
             }),
           );
         }
@@ -63,7 +63,7 @@ describe('SonarQubeClient', () => {
         return res(
           ctx.json({
             metrics: metricKeys.slice(5).map(k => ({ key: k })),
-            total: 2,
+            total: metricKeys.length,
           }),
         );
       }),

--- a/plugins/sonarqube/src/api/SonarQubeClient.test.ts
+++ b/plugins/sonarqube/src/api/SonarQubeClient.test.ts
@@ -45,10 +45,25 @@ describe('SonarQubeClient', () => {
     ],
   ) => {
     server.use(
-      rest.get(`${mockBaseUrl}/sonarqube/metrics/search`, (_, res, ctx) => {
+      rest.get(`${mockBaseUrl}/sonarqube/metrics/search`, (req, res, ctx) => {
+        expect(req.url.searchParams.get('ps')).toBe('500');
+
+        // emulate paging to check if everything is requested
+        if (req.url.searchParams.get('p') === '1') {
+          return res(
+            ctx.json({
+              metrics: metricKeys.slice(0, 5).map(k => ({ key: k })),
+              total: 2,
+            }),
+          );
+        }
+
+        // make sure this is only called twice
+        expect(req.url.searchParams.get('p')).toBe('2');
         return res(
           ctx.json({
-            metrics: metricKeys.map(k => ({ key: k })),
+            metrics: metricKeys.slice(5).map(k => ({ key: k })),
+            total: 2,
           }),
         );
       }),


### PR DESCRIPTION
Our installation doesn't display some metrics since the total metric count in SonarCloud exceeded 100, which is the default page size of the `/metrics/search` endpoint. This lead to not displaying the `vulnerabilities` metric anymore since it was interpreted as being not supported.

This PR increases the default page size to the maximum of 500 and implements paging if the metric count exceeds that.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
