### PR TITLE
Fix for proxy-backend plugin when global-agent is enabled

### DIFF
--- a/.changeset/nervous-dogs-pull.md
+++ b/.changeset/nervous-dogs-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': minor
+---
+
+Fix for proxy-backend plugin when global-agent is enabled

--- a/.changeset/nervous-dogs-pull.md
+++ b/.changeset/nervous-dogs-pull.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-proxy-backend': minor
+'@backstage/plugin-proxy-backend': patch
 ---
 
 Fix for proxy-backend plugin when global-agent is enabled

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -68,11 +68,11 @@ describe('buildMiddleware', () => {
       (pathname: string, req: Partial<http.IncomingMessage>) => boolean,
       ProxyMiddlewareConfig,
     ];
-    expect(filter('', { method: 'GET' })).toBe(true);
-    expect(filter('', { method: 'POST' })).toBe(true);
-    expect(filter('', { method: 'PUT' })).toBe(true);
-    expect(filter('', { method: 'PATCH' })).toBe(true);
-    expect(filter('', { method: 'DELETE' })).toBe(true);
+    expect(filter('', { method: 'GET', headers: {} })).toBe(true);
+    expect(filter('', { method: 'POST', headers: {} })).toBe(true);
+    expect(filter('', { method: 'PUT', headers: {} })).toBe(true);
+    expect(filter('', { method: 'PATCH', headers: {} })).toBe(true);
+    expect(filter('', { method: 'DELETE', headers: {} })).toBe(true);
 
     expect(fullConfig.pathRewrite).toEqual({ '^/api/test/': '/' });
     expect(fullConfig.changeOrigin).toBe(true);
@@ -91,11 +91,11 @@ describe('buildMiddleware', () => {
       (pathname: string, req: Partial<http.IncomingMessage>) => boolean,
       ProxyMiddlewareConfig,
     ];
-    expect(filter('', { method: 'GET' })).toBe(true);
-    expect(filter('', { method: 'POST' })).toBe(false);
-    expect(filter('', { method: 'PUT' })).toBe(false);
-    expect(filter('', { method: 'PATCH' })).toBe(false);
-    expect(filter('', { method: 'DELETE' })).toBe(true);
+    expect(filter('', { method: 'GET', headers: {} })).toBe(true);
+    expect(filter('', { method: 'POST', headers: {} })).toBe(false);
+    expect(filter('', { method: 'PUT', headers: {} })).toBe(false);
+    expect(filter('', { method: 'PATCH', headers: {} })).toBe(false);
+    expect(filter('', { method: 'DELETE', headers: {} })).toBe(true);
 
     expect(fullConfig.pathRewrite).toEqual({ '^/api/test/': '/' });
     expect(fullConfig.changeOrigin).toBe(true);
@@ -109,38 +109,37 @@ describe('buildMiddleware', () => {
 
     expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
 
-    const config = mockCreateProxyMiddleware.mock
-      .calls[0][1] as ProxyMiddlewareConfig;
+    const [filter] = mockCreateProxyMiddleware.mock.calls[0] as [
+      (pathname: string, req: Partial<http.IncomingMessage>) => boolean,
+    ];
 
-    const testClientRequest = {
-      getHeaderNames: () => [
-        'cache-control',
-        'content-language',
-        'content-length',
-        'content-type',
-        'expires',
-        'last-modified',
-        'pragma',
-        'host',
-        'accept',
-        'accept-language',
-        'user-agent',
-        'cookie',
-      ],
-      removeHeader: jest.fn(),
-    } as Partial<http.ClientRequest>;
+    const testHeaders = {
+      'cache-control': 'mocked',
+      'content-language': 'mocked',
+      'content-length': 'mocked',
+      'content-type': 'mocked',
+      expires: 'mocked',
+      'last-modified': 'mocked',
+      pragma: 'mocked',
+      host: 'mocked',
+      accept: 'mocked',
+      'accept-language': 'mocked',
+      'user-agent': 'mocked',
+      cookie: 'mocked',
+    } as Partial<http.IncomingHttpHeaders>;
+    const expectedHeaders = { ...testHeaders } as Partial<
+      http.IncomingHttpHeaders
+    >;
+    delete expectedHeaders.cookie;
 
-    expect(config).toBeDefined();
-    expect(config.onProxyReq).toBeDefined();
+    expect(testHeaders).toBeDefined();
+    expect(expectedHeaders).toBeDefined();
+    expect(testHeaders).not.toEqual(expectedHeaders);
+    expect(filter).toBeDefined();
 
-    config.onProxyReq!(
-      testClientRequest as http.ClientRequest,
-      {} as http.IncomingMessage,
-      {} as http.ServerResponse,
-    );
+    filter!('', { method: 'GET', headers: testHeaders });
 
-    expect(testClientRequest.removeHeader).toHaveBeenCalledTimes(1);
-    expect(testClientRequest.removeHeader).toHaveBeenCalledWith('cookie');
+    expect(testHeaders).toEqual(expectedHeaders);
   });
 
   it('permits default and configured headers', async () => {
@@ -153,22 +152,27 @@ describe('buildMiddleware', () => {
 
     expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
 
-    const config = mockCreateProxyMiddleware.mock
-      .calls[0][1] as ProxyMiddlewareConfig;
+    const [filter] = mockCreateProxyMiddleware.mock.calls[0] as [
+      (pathname: string, req: Partial<http.IncomingMessage>) => boolean,
+    ];
 
-    const testClientRequest = {
-      getHeaderNames: () => ['authorization', 'Cookie'],
-      removeHeader: jest.fn(),
-    } as Partial<http.ClientRequest>;
+    const testHeaders = {
+      authorization: 'mocked',
+      cookie: 'mocked',
+    } as Partial<http.IncomingHttpHeaders>;
+    const expectedHeaders = { ...testHeaders } as Partial<
+      http.IncomingHttpHeaders
+    >;
+    delete expectedHeaders.cookie;
 
-    config.onProxyReq!(
-      testClientRequest as http.ClientRequest,
-      {} as http.IncomingMessage,
-      {} as http.ServerResponse,
-    );
+    expect(testHeaders).toBeDefined();
+    expect(expectedHeaders).toBeDefined();
+    expect(testHeaders).not.toEqual(expectedHeaders);
+    expect(filter).toBeDefined();
 
-    expect(testClientRequest.removeHeader).toHaveBeenCalledTimes(1);
-    expect(testClientRequest.removeHeader).toHaveBeenCalledWith('Cookie');
+    filter!('', { method: 'GET', headers: testHeaders });
+
+    expect(testHeaders).toEqual(expectedHeaders);
   });
 
   it('permits configured headers', async () => {
@@ -179,24 +183,28 @@ describe('buildMiddleware', () => {
 
     expect(createProxyMiddleware).toHaveBeenCalledTimes(1);
 
-    const config = mockCreateProxyMiddleware.mock
-      .calls[0][1] as ProxyMiddlewareConfig;
+    const [filter] = mockCreateProxyMiddleware.mock.calls[0] as [
+      (pathname: string, req: Partial<http.IncomingMessage>) => boolean,
+    ];
 
-    const testClientRequest = {
-      getHeaderNames: () => ['authorization', 'Cookie', 'X-Auth-Request-User'],
-      removeHeader: jest.fn(),
-    } as Partial<http.ClientRequest>;
+    const testHeaders = {
+      authorization: 'mocked',
+      cookie: 'mocked',
+      'x-auth-request-user': 'mocked',
+    } as Partial<http.IncomingHttpHeaders>;
+    const expectedHeaders = { ...testHeaders } as Partial<
+      http.IncomingHttpHeaders
+    >;
+    delete expectedHeaders['x-auth-request-user'];
 
-    config.onProxyReq!(
-      testClientRequest as http.ClientRequest,
-      {} as http.IncomingMessage,
-      {} as http.ServerResponse,
-    );
+    expect(testHeaders).toBeDefined();
+    expect(expectedHeaders).toBeDefined();
+    expect(testHeaders).not.toEqual(expectedHeaders);
+    expect(filter).toBeDefined();
 
-    expect(testClientRequest.removeHeader).toHaveBeenCalledTimes(1);
-    expect(testClientRequest.removeHeader).toHaveBeenCalledWith(
-      'X-Auth-Request-User',
-    );
+    filter!('', { method: 'GET', headers: testHeaders });
+
+    expect(testHeaders).toEqual(expectedHeaders);
   });
 
   it('responds default headers', async () => {
@@ -223,7 +231,7 @@ describe('buildMiddleware', () => {
     } as Partial<http.IncomingMessage>;
 
     expect(config).toBeDefined();
-    expect(config.onProxyReq).toBeDefined();
+    expect(config.onProxyRes).toBeDefined();
 
     config.onProxyRes!(
       testClientResponse as http.IncomingMessage,
@@ -259,6 +267,9 @@ describe('buildMiddleware', () => {
         'x-auth-request-user': 'asd',
       },
     } as Partial<http.IncomingMessage>;
+
+    expect(config).toBeDefined();
+    expect(config.onProxyRes).toBeDefined();
 
     config.onProxyRes!(
       testClientResponse as http.IncomingMessage,

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -102,6 +102,11 @@ export function buildMiddleware(
   // Use the custom middleware filter to do two things:
   //  1. Remove any headers not in the allow list to stop them being forwarded
   //  2. Only permit the allowed HTTP methods if configured
+  //
+  // We are filtering the proxy request headers here rather than in
+  // `onProxyReq` becuase when global-agent is enabled then `onProxyReq`
+  // fires _after_ the agent has already sent the headers to the proxy
+  // target, causing a ERR_HTTP_HEADERS_SENT crash
   const filter = (_pathname: string, req: http.IncomingMessage): boolean => {
     const headerNames = Object.keys(req.headers);
     headerNames.forEach(h => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)

#### Summary

When [global-agent](https://github.com/gajus/global-agent) is enabled the proxy-backend plugin generates a fatal error when sending the proxy request:  `Error [ERR_HTTP_HEADERS_SENT]: Cannot remove headers after they are sent to the client`. This is because the [`onProxyReq`](https://github.com/backstage/backstage/blob/master/plugins/proxy-backend/src/service/router.ts#L108) event fires _after_ the agent has already sent the headers to the target. This has been reported several times in the following issues:

* https://github.com/chimurai/http-proxy-middleware/issues/472
* https://github.com/chimurai/http-proxy-middleware/issues/318
* https://github.com/http-party/node-http-proxy/issues/1292
* https://github.com/http-party/node-http-proxy/issues/1502
* https://github.com/http-party/node-http-proxy/issues/1478

Looking through these reports it's clear that the issue is in `http-proxy`, not `http-proxy-middleware` used by the proxy-backend plugin.

Note that the problem only occurs in the [header filtering for the proxy request](https://github.com/backstage/backstage/blob/49be39b92a7c2c76f1a8f709c165de20dcede400/plugins/proxy-backend/src/service/router.ts#L93-L116). The [header filtering for the client response](https://github.com/backstage/backstage/blob/49be39b92a7c2c76f1a8f709c165de20dcede400/plugins/proxy-backend/src/service/router.ts#L118-L138) is unaffected.

#### Reproduce steps

* Enable `global-agent` as described in [help-im-behind-a-corporate-proxy.md](https://github.com/backstage/backstage/blob/49be39b92a7c2c76f1a8f709c165de20dcede400/contrib/docs/tutorials/help-im-behind-a-corporate-proxy.md)
* Add some proxy targets (I'm using the standard SonarQube and Jira plugin config)
* Send some requests to to the proxy and observe the `ERR_HTTP_HEADERS_SENT` crash
* Ensure that your requests include headers not in the [allow list](https://github.com/backstage/backstage/blob/49be39b92a7c2c76f1a8f709c165de20dcede400/plugins/proxy-backend/src/service/router.ts#L28-L47)

There are reports about seeing this when **any** [`http.Agent`](https://nodejs.org/api/http.html#http_class_http_agent) is registered on the proxy connection but I haven't tested with any other agents than the ones automatically set by `global-agent` ([`HttpProxyAgent`](https://github.com/gajus/global-agent/blob/f89883c39e7053bcc0d31b12c9c61d04961779df/src/classes/HttpProxyAgent.js) and [`HttpsProxyAgent`](https://github.com/gajus/global-agent/blob/f89883c39e7053bcc0d31b12c9c61d04961779df/src/classes/HttpsProxyAgent.js))

#### Workaround

My workaround is to use `http-proxy-middleware`'s [custom filter mechanism](https://github.com/chimurai/http-proxy-middleware/blob/3120f701f9b91ca0d6f32e1de5f1aaaa65520011/recipes/context-matching.md#custom-filtering) to alter the headers prior to the proxy request being set up. This filter mechanism was designed to allow you to implement custom matching logic, but it provides access to the `req: IncomingRequest` object [before the proxy request is created](https://github.com/chimurai/http-proxy-middleware/blob/3120f701f9b91ca0d6f32e1de5f1aaaa65520011/src/http-proxy-middleware.ts#L51), making it a convenient way to manipulate the headers before the `http-proxy` code is run.

As backstage [already uses the custom filter](https://github.com/backstage/backstage/blob/49be39b92a7c2c76f1a8f709c165de20dcede400/plugins/proxy-backend/src/service/router.ts#L88-L91) to reject proxy requests that don't match the allowed METHODs, I simply moved the existing header filtering code from `onProxyReq` into that function. 

Looking at what others have done, this approach is similar to the workarounds I've seen, although in most cases people did the header manipulation in a separate upstream middleware.

#### Testing

I've tested this with and without `global-agent` but I haven't added any regression tests as I wasn't sure how to register the agent and supporting forward proxy. Ideally we'd run the header tests twice, once without any agent being used and once with an agent. Setting up a mock forward proxy and using an agent-registration approach similar to that of `global-agent` looks like it would be complicated and difficult, however if the theory that this happens with any agent is correct, then setting up the test might be more doable? Suggestions welcome, though personally I think it's ok proceed without agent tests in this case.