### PR TITLE
Improve rendering of multiple support item links in the SupportButton

### DIFF
--- a/.changeset/rude-ways-camp.md
+++ b/.changeset/rude-ways-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Improve rendering of multiple support item links in the `SupportButton`

--- a/packages/core/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core/src/components/SupportButton/SupportButton.tsx
@@ -66,12 +66,12 @@ const SupportListItem = ({ item }: { item: SupportItem }) => {
       <ListItemText
         primary={item.title}
         secondary={
-          <>
-            {item.links &&
-              item.links.map(link => (
-                <SupportLink link={link} key={link.url} />
-              ))}
-          </>
+          item.links &&
+          item.links
+            .map<React.ReactNode>(link => (
+              <SupportLink link={link} key={link.url} />
+            ))
+            .reduce((prev, curr, idx) => [prev, <br key={idx} />, curr])
         }
       />
     </ListItem>

--- a/packages/core/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core/src/components/SupportButton/SupportButton.tsx
@@ -65,14 +65,14 @@ const SupportListItem = ({ item }: { item: SupportItem }) => {
       </ListItemIcon>
       <ListItemText
         primary={item.title}
-        secondary={
-          item.links &&
-          item.links
-            .map<React.ReactNode>(link => (
-              <SupportLink link={link} key={link.url} />
-            ))
-            .reduce((prev, curr, idx) => [prev, <br key={idx} />, curr])
-        }
+        secondary={item.links?.reduce<React.ReactNodeArray>(
+          (prev, link, idx) => [
+            ...prev,
+            idx > 0 && <br key={idx} />,
+            <SupportLink link={link} key={link.url} />,
+          ],
+          [],
+        )}
       />
     </ListItem>
   );


### PR DESCRIPTION
A config like this:
```yaml
app:
  support:
    url: https://github.com/backstage/backstage/issues # Used by common ErrorPage
    items: # Used by common SupportButton component
      - title: Issues
        icon: github
        links:
          - url: https://github.com/backstage/backstage/issues
            title: GitHub Issues
          - url: https://github.com/backstage/backstage/pulls
            title: GitHub Pull Requests
# ...
```

is rendered like this:
![image](https://user-images.githubusercontent.com/720821/109524830-3c09b000-7ab1-11eb-87bb-67bee3823c5a.png)

With this change, it is rendered like this:
![image](https://user-images.githubusercontent.com/720821/109524892-488e0880-7ab1-11eb-9f08-717731c62f71.png)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
