### PR TITLE
Added a verification for URLs in proxy backend

### DIFF
--- a/.changeset/hot-islands-kick.md
+++ b/.changeset/hot-islands-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Added a verification for well formed URLs when processing proxy targets. Otherwise users gets a cryptic error message thrown from Express which makes it hard to debug.

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -268,4 +268,13 @@ describe('buildMiddleware', () => {
 
     expect(Object.keys(testClientResponse.headers!)).toEqual(['set-cookie']);
   });
+
+  it('rejects malformed target URLs', async () => {
+    expect(() =>
+      buildMiddleware('/api/', logger, 'test', 'backstage.io'),
+    ).toThrowError(/Proxy target is not a valid URL/);
+    expect(() =>
+      buildMiddleware('/api/', logger, 'test', { target: 'backstage.io' }),
+    ).toThrowError(/Proxy target is not a valid URL/);
+  });
 });

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -68,6 +68,15 @@ export function buildMiddleware(
   const fullConfig =
     typeof config === 'string' ? { target: config } : { ...config };
 
+  // Validate that target is a valid URL.
+  try {
+    // eslint-disable-next-line no-new
+    new URL(fullConfig.target!);
+  } catch {
+    throw new Error(
+      `Proxy target is not a valid URL: ${fullConfig.target ?? ''}`,
+    );
+  }
   // Default is to do a path rewrite that strips out the proxy's path prefix
   // and the rest of the route.
   if (fullConfig.pathRewrite === undefined) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #4728.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Added a verification for target URLs when processing them in proxy backend, throwing a user-friendly error in order to avoid a cryptic error messages thrown by Express / HTTP Proxy when receiving target URLs like `facebook.com` instead of `https://facebook.com`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
