### PR TITLE
More compliant, more dense template cards

### DIFF
--- a/.changeset/late-tables-provide.md
+++ b/.changeset/late-tables-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Tweak the template cards to be even more compliant with MUI examples, and a little bit more dense.

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -19,6 +19,7 @@ import {
   Card,
   CardActions,
   CardContent,
+  CardMedia,
   Chip,
   makeStyles,
   Typography,
@@ -31,7 +32,7 @@ import { rootRouteRef } from '../../routes';
 const useStyles = makeStyles(theme => ({
   header: {
     color: theme.palette.common.white,
-    padding: theme.spacing(2, 2, 6),
+    padding: theme.spacing(2, 2, 3),
     backgroundImage: (props: { backgroundImage: string }) =>
       props.backgroundImage,
     backgroundPosition: 0,
@@ -79,15 +80,15 @@ export const TemplateCard = ({
 
   return (
     <Card className={classes.card}>
-      <div className={classes.header}>
+      <CardMedia className={classes.header}>
         <Typography variant="subtitle2">{type}</Typography>
         <Typography variant="h6">{title}</Typography>
-      </div>
+      </CardMedia>
       <CardContent className={classes.cardContent}>
         {tags?.map(tag => (
-          <Chip label={tag} key={tag} />
+          <Chip size="small" label={tag} key={tag} />
         ))}
-        <Typography variant="body2" paragraph className={classes.description}>
+        <Typography variant="body2" className={classes.description}>
           {description}
         </Typography>
       </CardContent>


### PR DESCRIPTION
Before:
![Screenshot 2021-03-02 at 13 26 28](https://user-images.githubusercontent.com/3097461/109649900-cb1fd200-7b5c-11eb-8b88-6525f259fc17.png)

After:
![Screenshot 2021-03-02 at 13 36 04](https://user-images.githubusercontent.com/3097461/109649876-c529f100-7b5c-11eb-92fa-ad76284b5c7e.png)

One significant change, as can be seen, is that the `CardMedia` sets `background-size: cover` which I think is what we actually wanted in the first place - without it, the waves (if they'd been smaller, or on a very large screen) would be cut off.