### PR TITLE
core-api: workaround for backend:dev port conflict issue

### DIFF
--- a/.changeset/perfect-scissors-swim.md
+++ b/.changeset/perfect-scissors-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed an issue where the `backend:dev` command would get stuck executing the backend process multiple times, causing port conflict issues.

--- a/packages/cli/src/commands/backend/dev.ts
+++ b/packages/cli/src/commands/backend/dev.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
+import fs from 'fs-extra';
 import { Command } from 'commander';
+import { paths } from '../../lib/paths';
 import { serveBackend } from '../../lib/bundler/backend';
 
 export default async (cmd: Command) => {
+  // Cleaning dist/ before we start the dev process helps work around an issue
+  // where we end up with the entrypoint executing multiple times, causing
+  // a port bind conflict among other things.
+  await fs.remove(paths.resolveTarget('dist'));
+
   const waitForExit = await serveBackend({
     entry: 'src/index',
     checksEnabled: cmd.check,


### PR DESCRIPTION
Should be a fix for the pretty common issue where the backend dev process seemingly executes the entrypoint multiple times, causing port conflict issues. The usual way this would show up is with an `EADDRINUSE` error along with more than expected log outputs.