### PR TITLE
Kubernetes plugin: Read cluster config from api

### DIFF
--- a/.changeset/twelve-seahorses-flow.md
+++ b/.changeset/twelve-seahorses-flow.md
@@ -1,5 +1,5 @@
 ---
-"@backstage/plugin-kubernetes": patch
+'@backstage/plugin-kubernetes': patch
 ---
 
 Adds a new method `getClusters` to grab cluster configuration in the frontend

--- a/.changeset/twelve-seahorses-flow.md
+++ b/.changeset/twelve-seahorses-flow.md
@@ -1,0 +1,5 @@
+---
+"@backstage/plugin-kubernetes": patch
+---
+
+Adds a new method `getClusters` to grab cluster configuration in the frontend

--- a/plugins/kubernetes/src/api/KubernetesBackendClient.ts
+++ b/plugins/kubernetes/src/api/KubernetesBackendClient.ts
@@ -14,23 +14,27 @@
  * limitations under the License.
  */
 
-import { DiscoveryApi, IdentityApi } from '@backstage/core';
+import { ConfigApi, DiscoveryApi, IdentityApi } from '@backstage/core';
 import { KubernetesApi } from './types';
 import {
   KubernetesRequestBody,
   ObjectsByEntityResponse,
 } from '@backstage/plugin-kubernetes-backend';
+import { Config } from '@backstage/config';
 
 export class KubernetesBackendClient implements KubernetesApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly identityApi: IdentityApi;
+  private readonly configApi: ConfigApi;
 
   constructor(options: {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
+    configApi: ConfigApi;
   }) {
     this.discoveryApi = options.discoveryApi;
     this.identityApi = options.identityApi;
+    this.configApi = options.configApi;
   }
 
   private async getRequired(
@@ -72,5 +76,9 @@ export class KubernetesBackendClient implements KubernetesApi {
       `/services/${requestBody.entity.metadata.name}`,
       requestBody,
     );
+  }
+
+  getClusters(): Config[] {
+    return this.configApi.getConfigArray('kubernetes.clusters');
   }
 }

--- a/plugins/kubernetes/src/api/types.ts
+++ b/plugins/kubernetes/src/api/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Config } from '@backstage/config';
 import { createApiRef } from '@backstage/core';
 import {
   KubernetesRequestBody,
@@ -30,4 +31,5 @@ export interface KubernetesApi {
   getObjectsByEntity(
     requestBody: KubernetesRequestBody,
   ): Promise<ObjectsByEntityResponse>;
+  getClusters(): Config[];
 }

--- a/plugins/kubernetes/src/components/KubernetesContent/KubernetesContent.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent/KubernetesContent.tsx
@@ -25,7 +25,6 @@ import {
 } from '@material-ui/core';
 import { Config } from '@backstage/config';
 import {
-  configApiRef,
   Content,
   Page,
   Progress,
@@ -169,8 +168,7 @@ export const KubernetesContent = ({ entity }: KubernetesContentProps) => {
   >(undefined);
   const [error, setError] = useState<string | undefined>(undefined);
 
-  const configApi = useApi(configApiRef);
-  const clusters: Config[] = configApi.getConfigArray('kubernetes.clusters');
+  const clusters: Config[] = kubernetesApi.getClusters();
   const allAuthProviders: string[] = clusters.map(c =>
     c.getString('authProvider'),
   );

--- a/plugins/kubernetes/src/plugin.ts
+++ b/plugins/kubernetes/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   identityApiRef,
   googleAuthApiRef,
   createRoutableExtension,
+  configApiRef,
 } from '@backstage/core';
 import { KubernetesBackendClient } from './api/KubernetesBackendClient';
 import { kubernetesApiRef } from './api/types';
@@ -37,9 +38,13 @@ export const kubernetesPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: kubernetesApiRef,
-      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-      factory: ({ discoveryApi, identityApi }) =>
-        new KubernetesBackendClient({ discoveryApi, identityApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        identityApi: identityApiRef,
+        configApi: configApiRef,
+      },
+      factory: ({ discoveryApi, identityApi, configApi }) =>
+        new KubernetesBackendClient({ discoveryApi, identityApi, configApi }),
     }),
     createApiFactory({
       api: kubernetesAuthProvidersApiRef,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #3590

This PR adds a new method `getClusters` to the Kubernetes backend which returns the clusters config to the frontend.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
