### PR TITLE
core-api: add parameters to external type refs + reactor types

### DIFF
--- a/.changeset/large-eggs-help.md
+++ b/.changeset/large-eggs-help.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-explore': minor
+---
+
+Introduce external route for linking to the entity page from the explore plugin.
+
+To use the explore plugin you have to bind the external route in your app:
+
+```typescript
+const app = createApp({
+  ...
+  bindRoutes({ bind }) {
+    ...
+    bind(explorePlugin.externalRoutes, {
+      catalogEntity: catalogPlugin.routes.catalogEntity,
+    });
+  },
+});
+```

--- a/.changeset/soft-months-invite.md
+++ b/.changeset/soft-months-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Introduce parameters for namespace, kind, and name to `entityRouteRef`.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -33,7 +33,7 @@ import {
   CostInsightsPage,
   CostInsightsProjectGrowthInstructionsPage,
 } from '@backstage/plugin-cost-insights';
-import { ExplorePage } from '@backstage/plugin-explore';
+import { ExplorePage, explorePlugin } from '@backstage/plugin-explore';
 import { GcpProjectsPage } from '@backstage/plugin-gcp-projects';
 import { GraphiQLPage } from '@backstage/plugin-graphiql';
 import { LighthousePage } from '@backstage/plugin-lighthouse';
@@ -78,6 +78,9 @@ const app = createApp({
     });
     bind(apiDocsPlugin.externalRoutes, {
       createComponent: scaffolderPlugin.routes.root,
+    });
+    bind(explorePlugin.externalRoutes, {
+      catalogEntity: catalogPlugin.routes.catalogEntity,
     });
   },
 });

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -50,6 +50,7 @@ import {
 } from '../extensions/traversal';
 import { IconComponent, IconComponentMap, IconKey } from '../icons';
 import { BackstagePlugin } from '../plugin';
+import { AnyRoutes } from '../plugin/types';
 import { RouteRef, ExternalRouteRef } from '../routing';
 import {
   routeObjectCollector,
@@ -77,7 +78,7 @@ export function generateBoundRoutes(
   const result = new Map<ExternalRouteRef, RouteRef>();
 
   if (bindRoutes) {
-    const bind: AppRouteBinder = (externalRoutes, targetRoutes) => {
+    const bind: AppRouteBinder = (externalRoutes, targetRoutes: AnyRoutes) => {
       for (const [key, value] of Object.entries(targetRoutes)) {
         const externalRoute = externalRoutes[key];
         if (!externalRoute) {

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -50,14 +50,13 @@ import {
 } from '../extensions/traversal';
 import { IconComponent, IconComponentMap, IconKey } from '../icons';
 import { BackstagePlugin } from '../plugin';
-import { RouteRef } from '../routing';
+import { RouteRef, ExternalRouteRef } from '../routing';
 import {
   routeObjectCollector,
   routeParentCollector,
   routePathCollector,
 } from '../routing/collectors';
 import { RoutingProvider, validateRoutes } from '../routing/hooks';
-import { ExternalRouteRef } from '../routing/RouteRef';
 import { AppContextProvider } from './AppContext';
 import { AppIdentity } from './AppIdentity';
 import { AppThemeProvider } from './AppThemeProvider';

--- a/packages/core-api/src/plugin/types.ts
+++ b/packages/core-api/src/plugin/types.ts
@@ -15,9 +15,8 @@
  */
 
 import { ComponentType } from 'react';
-import { RouteRef } from '../routing';
+import { RouteRef, ExternalRouteRef } from '../routing';
 import { AnyApiFactory } from '../apis/system';
-import { ExternalRouteRef } from '../routing/RouteRef';
 
 export type RouteOptions = {
   // Whether the route path must match exactly, defaults to true.

--- a/packages/core-api/src/routing/RouteRef.ts
+++ b/packages/core-api/src/routing/RouteRef.ts
@@ -31,13 +31,14 @@ export type RouteRefConfig<Params extends AnyParams> = {
   title: string;
 };
 
-class RouteRefBaseBase {
+class RouteRefBase {
   constructor(type: string, id: string) {
     this.toString = () => `routeRef{type=${type},id=${id}}`;
   }
 }
 
-export class RouteRefImpl<Params extends AnyParams> extends RouteRefBaseBase {
+export class RouteRefImpl<Params extends AnyParams> extends RouteRefBase
+  implements RouteRef<Params> {
   readonly [routeRefType] = 'absolute';
 
   constructor(private readonly config: RouteRefConfig<Params>) {
@@ -92,7 +93,7 @@ export function createRouteRef<
 export class ExternalRouteRefImpl<
   Params extends AnyParams,
   Optional extends boolean
-> extends RouteRefBaseBase {
+> extends RouteRefBase implements ExternalRouteRef<Params, Optional> {
   readonly [routeRefType] = 'external';
 
   constructor(

--- a/packages/core-api/src/routing/hooks.test.tsx
+++ b/packages/core-api/src/routing/hooks.test.tsx
@@ -57,12 +57,19 @@ const ref1 = createRouteRef(mockConfig({ path: '/wat1' }));
 const ref2 = createRouteRef(mockConfig({ path: '/wat2' }));
 const ref3 = createRouteRef(mockConfig({ path: '/wat3' }));
 const ref4 = createRouteRef(mockConfig({ path: '/wat4' }));
-const ref5 = createRouteRef(mockConfig({ path: '/wat5' }));
+const ref5 = createRouteRef({
+  ...mockConfig({ path: '/wat5' }),
+  params: ['x'],
+});
 const eRefA = createExternalRouteRef({ id: '1' });
 const eRefB = createExternalRouteRef({ id: '2' });
-const eRefC = createExternalRouteRef({ id: '3' });
+const eRefC = createExternalRouteRef({ id: '3', params: ['y'] });
 const eRefD = createExternalRouteRef({ id: '4', optional: true });
-const eRefE = createExternalRouteRef({ id: '5', optional: true });
+const eRefE = createExternalRouteRef({
+  id: '5',
+  optional: true,
+  params: ['z'],
+});
 
 const MockRouteSource = <T extends { [name in string]: string }>(props: {
   path?: string;

--- a/packages/core-api/src/routing/hooks.test.tsx
+++ b/packages/core-api/src/routing/hooks.test.tsx
@@ -38,10 +38,9 @@ import {
 import {
   createRouteRef,
   createExternalRouteRef,
-  ExternalRouteRef,
   RouteRefConfig,
 } from './RouteRef';
-import { AnyRouteRef, RouteRef } from './types';
+import { AnyRouteRef, RouteRef, ExternalRouteRef } from './types';
 
 const mockConfig = (extra?: Partial<RouteRefConfig<{}>>) => ({
   path: '/unused',

--- a/packages/core-api/src/routing/hooks.tsx
+++ b/packages/core-api/src/routing/hooks.tsx
@@ -15,9 +15,13 @@
  */
 
 import React, { createContext, ReactNode, useContext, useMemo } from 'react';
-import { AnyRouteRef, BackstageRouteObject, RouteRef } from './types';
+import {
+  AnyRouteRef,
+  BackstageRouteObject,
+  RouteRef,
+  ExternalRouteRef,
+} from './types';
 import { generatePath, matchRoutes, useLocation } from 'react-router-dom';
-import { ExternalRouteRef } from './RouteRef';
 
 // The extra TS magic here is to require a single params argument if the RouteRef
 // had at least one param defined, but require 0 arguments if there are no params defined.

--- a/packages/core-api/src/routing/hooks.tsx
+++ b/packages/core-api/src/routing/hooks.tsx
@@ -20,6 +20,7 @@ import {
   BackstageRouteObject,
   RouteRef,
   ExternalRouteRef,
+  AnyParams,
 } from './types';
 import { generatePath, matchRoutes, useLocation } from 'react-router-dom';
 
@@ -28,10 +29,8 @@ import { generatePath, matchRoutes, useLocation } from 'react-router-dom';
 // Without this we'd have to pass in empty object to all parameter-less RouteRefs
 // just to make TypeScript happy, or we would have to make the argument optional in
 // which case you might forget to pass it in when it is actually required.
-export type RouteFunc<Params extends { [param in string]: string }> = (
-  ...[params]: Params[keyof Params] extends never
-    ? readonly []
-    : readonly [Params]
+export type RouteFunc<Params extends AnyParams> = (
+  ...[params]: Params extends undefined ? readonly [] : readonly [Params]
 ) => string;
 
 class RouteResolver {
@@ -42,8 +41,8 @@ class RouteResolver {
     private readonly routeBindings: Map<RouteRef | ExternalRouteRef, RouteRef>,
   ) {}
 
-  resolve<Params extends { [param in string]: string }>(
-    routeRefOrExternalRouteRef: RouteRef<Params> | ExternalRouteRef,
+  resolve<Params extends AnyParams>(
+    routeRefOrExternalRouteRef: RouteRef<Params> | ExternalRouteRef<Params>,
     sourceLocation: ReturnType<typeof useLocation>,
   ): RouteFunc<Params> | undefined {
     const routeRef =
@@ -116,14 +115,14 @@ class RouteResolver {
 
 const RoutingContext = createContext<RouteResolver | undefined>(undefined);
 
-export function useRouteRef<Optional extends boolean>(
-  routeRef: ExternalRouteRef<Optional>,
-): Optional extends true ? RouteFunc<{}> | undefined : RouteFunc<{}>;
-export function useRouteRef<Params extends { [param in string]: string } = {}>(
+export function useRouteRef<Optional extends boolean, Params extends AnyParams>(
+  routeRef: ExternalRouteRef<Params, Optional>,
+): Optional extends true ? RouteFunc<Params> | undefined : RouteFunc<Params>;
+export function useRouteRef<Params extends AnyParams>(
   routeRef: RouteRef<Params>,
 ): RouteFunc<Params>;
-export function useRouteRef<Params extends { [param in string]: string } = {}>(
-  routeRef: RouteRef<Params> | ExternalRouteRef,
+export function useRouteRef<Params extends AnyParams>(
+  routeRef: RouteRef<Params> | ExternalRouteRef<Params, any>,
 ): RouteFunc<Params> | undefined {
   const sourceLocation = useLocation();
   const resolver = useContext(RoutingContext);

--- a/packages/core-api/src/routing/index.ts
+++ b/packages/core-api/src/routing/index.ts
@@ -19,12 +19,9 @@ export type {
   AbsoluteRouteRef,
   ConcreteRoute,
   MutableRouteRef,
+  ExternalRouteRef,
 } from './types';
 export { FlatRoutes } from './FlatRoutes';
-export {
-  createRouteRef,
-  createExternalRouteRef,
-  ExternalRouteRef,
-} from './RouteRef';
+export { createRouteRef, createExternalRouteRef } from './RouteRef';
 export type { RouteRefConfig } from './RouteRef';
 export { useRouteRef } from './hooks';

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -17,15 +17,20 @@
 import { IconComponent } from '../icons';
 import { getGlobalSingleton } from '../lib/globalObject';
 
+export type AnyParams = { [param in string]: string } | undefined;
+export type ParamKeys<Params extends AnyParams> = keyof Params extends never
+  ? []
+  : (keyof Params)[];
+
 export const routeRefType: unique symbol = getGlobalSingleton<any>(
   'route-ref-type',
   () => Symbol('route-ref-type'),
 );
 
-export type RouteRef<Params extends { [param in string]: string } = any> = {
+export type RouteRef<Params extends AnyParams = any> = {
   [routeRefType]: 'absolute';
 
-  params?: keyof Params;
+  params: ParamKeys<Params>;
 
   // TODO(Rugvip): Remove all of these once plugins don't rely on the path
   /** @deprecated paths are no longer accessed directly from RouteRefs, use useRouteRef instead */
@@ -36,13 +41,18 @@ export type RouteRef<Params extends { [param in string]: string } = any> = {
   title?: string;
 };
 
-export type ExternalRouteRef<Optional extends boolean = any> = {
+export type ExternalRouteRef<
+  Params extends AnyParams = any,
+  Optional extends boolean = any
+> = {
   [routeRefType]: 'external';
+
+  params: ParamKeys<Params>;
 
   optional?: Optional;
 };
 
-export type AnyRouteRef = RouteRef<any> | ExternalRouteRef<any>;
+export type AnyRouteRef = RouteRef<any> | ExternalRouteRef<any, any>;
 
 // TODO(Rugvip): None of these should be found in the wild anymore, remove in next minor release
 /** @deprecated */

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -28,7 +28,7 @@ export const routeRefType: unique symbol = getGlobalSingleton<any>(
 );
 
 export type RouteRef<Params extends AnyParams = any> = {
-  [routeRefType]: 'absolute';
+  readonly [routeRefType]: 'absolute';
 
   params: ParamKeys<Params>;
 
@@ -45,7 +45,7 @@ export type ExternalRouteRef<
   Params extends AnyParams = any,
   Optional extends boolean = any
 > = {
-  [routeRefType]: 'external';
+  readonly [routeRefType]: 'external';
 
   params: ParamKeys<Params>;
 

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -15,35 +15,41 @@
  */
 
 import { IconComponent } from '../icons';
-import { ExternalRouteRef } from './RouteRef';
+import { getGlobalSingleton } from '../lib/globalObject';
 
-// @ts-ignore, we're just embedding the Params type for usage in other places
-export type RouteRef<Params extends { [param in string]: string } = {}> = {
-  // TODO(Rugvip): Remove path, look up via registry instead
+export const routeRefType: unique symbol = getGlobalSingleton<any>(
+  'route-ref-type',
+  () => Symbol('route-ref-type'),
+);
+
+export type RouteRef<Params extends { [param in string]: string } = any> = {
+  [routeRefType]: 'absolute';
+
+  params?: keyof Params;
+
+  // TODO(Rugvip): Remove all of these once plugins don't rely on the path
   /** @deprecated paths are no longer accessed directly from RouteRefs, use useRouteRef instead */
   path: string;
+  /** @deprecated icons are no longer accessed via RouteRefs */
   icon?: IconComponent;
-  title: string;
+  /** @deprecated titles are no longer accessed via RouteRefs */
+  title?: string;
+};
+
+export type ExternalRouteRef<Optional extends boolean = any> = {
+  [routeRefType]: 'external';
+
+  optional?: Optional;
 };
 
 export type AnyRouteRef = RouteRef<any> | ExternalRouteRef<any>;
 
-/**
- * This type should not be used
- * @deprecated
- */
+// TODO(Rugvip): None of these should be found in the wild anymore, remove in next minor release
+/** @deprecated */
 export type ConcreteRoute = {};
-
-/**
- * This type should not be used, use RouteRef instead
- * @deprecated
- */
+/** @deprecated */
 export type AbsoluteRouteRef = RouteRef<{}>;
-
-/**
- * This type should not be used, use RouteRef instead
- * @deprecated
- */
+/** @deprecated */
 export type MutableRouteRef = RouteRef<{}>;
 
 // A duplicate of the react-router RouteObject, but with routeRef added

--- a/plugins/explore/src/components/DomainCard/DomainCard.test.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCard.test.tsx
@@ -15,13 +15,13 @@
  */
 
 import { DomainEntity } from '@backstage/catalog-model';
-import { render } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { catalogEntityRouteRef } from '../../routes';
 import { DomainCard } from './DomainCard';
 
 describe('<DomainCard />', () => {
-  it('renders a domain card', () => {
+  it('renders a domain card', async () => {
     const entity: DomainEntity = {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'Domain',
@@ -34,9 +34,14 @@ describe('<DomainCard />', () => {
         owner: 'guest',
       },
     };
-    const { getByText } = render(<DomainCard entity={entity} />, {
-      wrapper: MemoryRouter,
-    });
+    const { getByText } = await renderInTestApp(
+      <DomainCard entity={entity} />,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
+    );
 
     expect(getByText('artists')).toBeInTheDocument();
     expect(getByText('Everything about artists')).toBeInTheDocument();

--- a/plugins/explore/src/components/DomainCard/DomainCard.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCard.tsx
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 import { DomainEntity, RELATION_OWNED_BY } from '@backstage/catalog-model';
-import { ItemCard } from '@backstage/core';
+import { ItemCard, useRouteRef } from '@backstage/core';
 import {
   EntityRefLinks,
-  entityRoute,
   entityRouteParams,
   getEntityRelations,
 } from '@backstage/plugin-catalog-react';
 import React from 'react';
-import { generatePath } from 'react-router-dom';
+import { catalogEntityRouteRef } from '../../routes';
 
 type DomainCardProps = {
   entity: DomainEntity;
@@ -30,6 +29,7 @@ type DomainCardProps = {
 
 export const DomainCard = ({ entity }: DomainCardProps) => {
   const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
+  const catalogEntityRoute = useRouteRef(catalogEntityRouteRef);
 
   return (
     <ItemCard
@@ -44,11 +44,7 @@ export const DomainCard = ({ entity }: DomainCardProps) => {
         />
       }
       label="Explore"
-      // TODO: Use useRouteRef here to generate the path
-      href={generatePath(
-        `/catalog/${entityRoute.path}`,
-        entityRouteParams(entity),
-      )}
+      href={catalogEntityRoute(entityRouteParams(entity))}
     />
   );
 };

--- a/plugins/explore/src/components/DomainCard/DomainCardGrid.test.tsx
+++ b/plugins/explore/src/components/DomainCard/DomainCardGrid.test.tsx
@@ -15,13 +15,13 @@
  */
 
 import { DomainEntity } from '@backstage/catalog-model';
-import { render } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { catalogEntityRouteRef } from '../../routes';
 import { DomainCardGrid } from './DomainCardGrid';
 
 describe('<DomainCardGrid />', () => {
-  it('renders a grid of domain cards', () => {
+  it('renders a grid of domain cards', async () => {
     const entities: DomainEntity[] = [
       {
         apiVersion: 'backstage.io/v1alpha1',
@@ -44,9 +44,14 @@ describe('<DomainCardGrid />', () => {
         },
       },
     ];
-    const { getByText } = render(<DomainCardGrid entities={entities} />, {
-      wrapper: MemoryRouter,
-    });
+    const { getByText } = await renderInTestApp(
+      <DomainCardGrid entities={entities} />,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
+    );
 
     expect(getByText('artists')).toBeInTheDocument();
     expect(getByText('playback')).toBeInTheDocument();

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -20,6 +20,7 @@ import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { renderInTestApp } from '@backstage/test-utils';
 import { waitFor } from '@testing-library/react';
 import React from 'react';
+import { catalogEntityRouteRef } from '../../routes';
 import { DomainExplorerContent } from './DomainExplorerContent';
 
 describe('<DomainExplorerContent />', () => {
@@ -71,6 +72,11 @@ describe('<DomainExplorerContent />', () => {
       <Wrapper>
         <DomainExplorerContent />
       </Wrapper>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
     );
 
     await waitFor(() => {
@@ -86,6 +92,11 @@ describe('<DomainExplorerContent />', () => {
       <Wrapper>
         <DomainExplorerContent />
       </Wrapper>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
     );
 
     await waitFor(() =>
@@ -101,6 +112,11 @@ describe('<DomainExplorerContent />', () => {
       <Wrapper>
         <DomainExplorerContent />
       </Wrapper>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': catalogEntityRouteRef,
+        },
+      },
     );
 
     await waitFor(() =>

--- a/plugins/explore/src/plugin.ts
+++ b/plugins/explore/src/plugin.ts
@@ -16,7 +16,7 @@
 
 import { createApiFactory, createPlugin } from '@backstage/core';
 import { exploreToolsConfigRef } from '@backstage/plugin-explore-react';
-import { exploreRouteRef } from './routes';
+import { catalogEntityRouteRef, exploreRouteRef } from './routes';
 import { exampleTools } from './util/examples';
 
 export const explorePlugin = createPlugin({
@@ -36,5 +36,8 @@ export const explorePlugin = createPlugin({
   ],
   routes: {
     explore: exploreRouteRef,
+  },
+  externalRoutes: {
+    catalogEntity: catalogEntityRouteRef,
   },
 });

--- a/plugins/explore/src/routes.ts
+++ b/plugins/explore/src/routes.ts
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-import { createRouteRef } from '@backstage/core';
+import { createExternalRouteRef, createRouteRef } from '@backstage/core';
 
 const NoIcon = () => null;
 
 export const exploreRouteRef = createRouteRef({
   icon: NoIcon,
   title: 'Explore',
+});
+
+export const catalogEntityRouteRef = createExternalRouteRef({
+  id: 'catalog-entity',
+  params: ['namespace', 'kind', 'name'],
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Built on top of #4628 and merged optional external route refs together with parameterized external route refs. Didn't manage to figure out a way to make TypeScript infer parameter mapping functions in a nice way, so for now parameters have to have matching names. We can add parameter mapping on top of this later but want to take some more time to see what's possible there.

This also introduces a bit of a rework of how parameter-less route refs are represented. They used to be represented as `RouteRef<{}>`, but this switches it to `RouteRef<undefined>`. The reason for that is that any route ref could be assigned to `RouteRef<{}>`, which ended up in some type checks not failing when they should.

There's also a rework in how route refs are identified, now using a symbol along with a string identifier for what type of ref it is, again allowing for proper type checking where there earlier wasn't really a proper check for `RouteRef` vs `ExternalRouteRef`.

Expecting this to be backwards compatible as the runtime representation is really unchanged, but depends a bit on how TypeScript behaves, so wanna run this through CI before continuing.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
