### PR TITLE
core-api: skip wrapping the component data store in an object

### DIFF
--- a/packages/core-api/src/extensions/componentData.test.tsx
+++ b/packages/core-api/src/extensions/componentData.test.tsx
@@ -100,19 +100,16 @@ describe('elementData', () => {
       const element = <Component />;
       const container = (global as any)[
         '__@backstage/component-data-store__'
-      ].store.get(element.type);
+      ].get(element.type);
       expect(container.map.get('my-data')).toBe(data);
     });
 
     it('should should be able to attach data for newer versions', () => {
       const data = { foo: 'bar' };
       const Component = () => null;
-      (global as any)['__@backstage/component-data-store__'].store.set(
-        Component,
-        {
-          map: new Map([['my-data', data]]),
-        },
-      );
+      (global as any)['__@backstage/component-data-store__'].set(Component, {
+        map: new Map([['my-data', data]]),
+      });
 
       const element = <Component />;
       expect(getComponentData(element, 'my-data')).toBe(data);

--- a/packages/core-api/src/extensions/componentData.tsx
+++ b/packages/core-api/src/extensions/componentData.tsx
@@ -33,9 +33,10 @@ type MaybeComponentNode = ReactNode & {
 };
 
 // The store is bridged across versions using the global object
-const { store } = getGlobalSingleton('component-data-store', () => ({
-  store: new WeakMap<ComponentType<any>, DataContainer>(),
-}));
+const store = getGlobalSingleton(
+  'component-data-store',
+  () => new WeakMap<ComponentType<any>, DataContainer>(),
+);
 
 export function attachComponentData<P>(
   component: ComponentType<P>,


### PR DESCRIPTION
Realized it's not possible to do much with this anyway, so skipping the wrapping. It's a pending change for this release so no changeset