### PR TITLE
Uses the correct jwks_uri for oidc configuration endpoint

### DIFF
--- a/.changeset/violet-donuts-press.md
+++ b/.changeset/violet-donuts-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Change the JWKS url value for the oidc configuration endpoint

--- a/plugins/auth-backend/src/identity/router.ts
+++ b/plugins/auth-backend/src/identity/router.ts
@@ -31,7 +31,7 @@ export function createOidcRouter(options: Options) {
     issuer: baseUrl,
     token_endpoint: `${baseUrl}/v1/token`,
     userinfo_endpoint: `${baseUrl}/v1/userinfo`,
-    jwks_uri: `${baseUrl}/v1/certs`,
+    jwks_uri: `${baseUrl}/.well-known/jwks.json`,
     response_types_supported: ['id_token'],
     subject_types_supported: ['public'],
     id_token_signing_alg_values_supported: ['RS256'],


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Fixed the jwks url for the oidc configuration endpoint 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
