### PR TITLE
Add a `Cache-Control: no-store` header to the `index.html` response to instruct the browser to not cache the pages

### DIFF
--- a/.changeset/good-humans-draw.md
+++ b/.changeset/good-humans-draw.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Add a `Cache-Control: no-store` header to the `index.html` response to instruct the browser to not cache the pages.
+This is a workaround for a missing `staticFallbackHandler` since an old `index.html` might link to static assets from a previous deployment.

--- a/plugins/app-backend/src/service/router.test.ts
+++ b/plugins/app-backend/src/service/router.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { resolve as resolvePath } from 'path';
 import { getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import express from 'express';
 import Router from 'express-promise-router';
+import { resolve as resolvePath } from 'path';
 import request from 'supertest';
 import { createRouter } from './router';
 
@@ -68,6 +68,22 @@ describe('createRouter', () => {
     expect(response.status).toBe(200);
     expect(response.text.trim()).toBe('this is index.html');
   });
+
+  it.each(['/index.html', '/other.html', '/missing.html'])(
+    'returns %s with no-store Cache-Control header',
+    async file => {
+      const response = await request(app).get(file);
+      expect(response.header['cache-control']).toBe('no-store');
+    },
+  );
+
+  it.each(['/static/main.txt'])(
+    'returns %s with default Cache-Control header',
+    async file => {
+      const response = await request(app).get(file);
+      expect(response.header['cache-control']).toBe('public, max-age=0');
+    },
+  );
 });
 
 describe('createRouter with static fallback handler', () => {


### PR DESCRIPTION
When we deploy a new Backstage version with the app-backend, the assets from the previous deployment are not available anymore and browsers that cached the html content, might not be aware that they need to refresh it. So the users are stuck with a white page and a lot of network errors. The app-backend has the `staticFallbackHandler` option, but we don't plan to setup such a long-term storage solution for static content yet.

A quick workaround that we are using in our nginx-based deployment of the frontend is the use of a `Cache-Control: no-store` header for the html files. This means the browser can't cache this file, but I think the risk of getting broken deployments is higher than the performance impact of a few repeatedly transferred bytes. This is also a common practice of hosters such as Netlify.

This doesn't affect the files in the `/static` folder.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
