### PR TITLE
Changed the signature of createComponentExtension to be aligned with that of React.lazy

### DIFF
--- a/packages/core-api/src/extensions/extensions.tsx
+++ b/packages/core-api/src/extensions/extensions.tsx
@@ -60,15 +60,18 @@ export function createRoutableExtension<
   });
 }
 
+// We do not use ComponentType as the return type, since it doesn't let us convey the children prop.
+// ComponentType inserts children as an optional prop whether the inner component accepts it or not,
+// making it impossible to make the usage of children type safe.
 export function createComponentExtension<
-  T extends (props: any) => JSX.Element
+  T extends (props: any) => JSX.Element | null
 >(options: { component: ComponentLoader<T> }): Extension<T> {
   const { component } = options;
   return createReactExtension({ component });
 }
 
 export function createReactExtension<
-  T extends (props: any) => JSX.Element
+  T extends (props: any) => JSX.Element | null
 >(options: {
   component: ComponentLoader<T>;
   data?: Record<string, unknown>;


### PR DESCRIPTION
## Type change: Changed the signature of createComponentExtension to be aligned with that of React.lazy

The declaration:
`createComponentExtension<T extends (props: any) => JSX.Element>`
breaks with a component that implements the React.FunctionComponent interface with the error:
`Type 'ReactElement<any, any> | null' is not assignable to type 'Element'.`

Looking at React.lazy, it has the signature:
```
function lazy<T extends ComponentType<any>>(
        factory: () => Promise<{ default: T }>
): LazyExoticComponent<T>;
```

This PR changes the signature of createComponentExtension to match that of React.lazy.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
