### PR TITLE
fix(cli): Fix Hot Module Reload breaking backend router

### DIFF
--- a/.changeset/rich-ravens-battle.md
+++ b/.changeset/rich-ravens-battle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix Hot Module Reload breaking the backend router after a reload

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -41,8 +41,7 @@ export async function serveBundle(options: ServeOptions) {
     baseUrl: url,
   });
   const compiler = webpack(config);
-
-  const server = new WebpackDevServer(compiler, {
+  const webpackOptions: WebpackDevServer.Configuration = {
     hot: true,
     contentBase: paths.targetPublic,
     contentBasePublicPath: config.output?.publicPath,
@@ -60,7 +59,10 @@ export async function serveBundle(options: ServeOptions) {
     proxy: pkg.proxy,
     // When the dev server is behind a proxy, the host and public hostname differ
     allowedHosts: [url.hostname],
-  });
+  };
+
+  WebpackDevServer.addDevServerEntrypoints(config, webpackOptions);
+  const server = new WebpackDevServer(compiler, webpackOptions);
 
   await new Promise<void>((resolve, reject) => {
     server.listen(port, host, (err?: Error) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

After a Hot Module Reload, the backend no longer responds to API requests. For example:

```
$ curl -v http://localhost:7000/api/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 7000 (#0)
> GET /api/ HTTP/1.1
> Host: localhost:7000
> User-Agent: curl/7.64.1
> Accept: */*
> 
* Empty reply from server
* Connection #0 to host localhost left intact
curl: (52) Empty reply from server
* Closing connection 0
```

This fixes this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
