### PR TITLE
feat(core): support external link uris

### DIFF
--- a/.changeset/spotty-glasses-speak.md
+++ b/.changeset/spotty-glasses-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Add support for non external URI's in the Link component to `to` prop. For example `<Link to="slack://channel?team=T0000&id=C0000">Slack</Link>

--- a/packages/core/src/components/Link/Link.test.tsx
+++ b/packages/core/src/components/Link/Link.test.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { wrapInTestApp } from '@backstage/test-utils';
-import { Link } from './Link';
+import { isExternalUri, Link } from './Link';
 import { Route, Routes } from 'react-router';
 import { act } from 'react-dom/test-utils';
 
@@ -38,5 +38,32 @@ describe('<Link />', () => {
       fireEvent.click(getByText(linkText));
     });
     expect(getByText(testString)).toBeInTheDocument();
+  });
+
+  describe('isExternalUri', () => {
+    it.each([
+      [true, 'http://'],
+      [true, 'https://'],
+      [true, 'https://some-host'],
+      [true, 'https://some-host/path#fragment'],
+      [true, 'https://some-host/path?param1=value'],
+      [true, 'slack://'],
+      [true, 'mailto://'],
+      [true, 'ms-help://'],
+      [true, 'ms.help://'],
+      [true, 'ms+help://'],
+      [false, '//'],
+      [false, '123://'],
+      [false, 'abc&xzy://'],
+      [false, 'http'],
+      [false, 'https:/a'],
+      [false, 'path/to'],
+      [false, 'path/to/something#fragment'],
+      [false, 'path/to/something?param1=value'],
+      [false, '/path/to/something'],
+      [false, '/path/to/something#fragment'],
+    ])('should be %p when %p', (expected, uri) => {
+      expect(isExternalUri(uri)).toBe(expected);
+    });
   });
 });

--- a/packages/core/src/components/Link/Link.tsx
+++ b/packages/core/src/components/Link/Link.tsx
@@ -24,6 +24,8 @@ import {
   LinkProps as RouterLinkProps,
 } from 'react-router-dom';
 
+export const isExternalUri = (uri: string) => /^([a-z+.-]+):\/\//.test(uri);
+
 export type LinkProps = MaterialLinkProps &
   RouterLinkProps & {
     component?: ElementType<any>;
@@ -35,7 +37,7 @@ export type LinkProps = MaterialLinkProps &
  */
 export const Link = React.forwardRef<any, LinkProps>((props, ref) => {
   const to = String(props.to);
-  return /^https?:\/\//.test(to) ? (
+  return isExternalUri(to) ? (
     // External links
     <MaterialLink ref={ref} href={to} {...props} />
   ) : (


### PR DESCRIPTION
Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

## Hey, I just made a Pull Request!

The `Link` component's `to` prop currently supports linking to external `href` only if the URI schema is `https`. This adds support for any scheme. This can be useful if you want to for instance deep link to a slack channel in the `<SupportButton>` component which uses the `Link` component.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
