### PR TITLE
Implement proper AWS Credentials precedence

### DIFF
--- a/.changeset/little-kids-pull.md
+++ b/.changeset/little-kids-pull.md
@@ -1,0 +1,6 @@
+---
+'@backstage/techdocs-common': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Implement proper AWS Credentials precedence with assume-role and explicit credentials

--- a/packages/techdocs-common/__mocks__/aws-sdk.ts
+++ b/packages/techdocs-common/__mocks__/aws-sdk.ts
@@ -19,6 +19,8 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 
+export { Credentials } from 'aws-sdk';
+
 const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
 
 /**


### PR DESCRIPTION
This properly configures the precedence for explicit assume-role ARNs,
explicit AWS credentials (via access keys), and the default fallback for
the AWS SDK.

The general precedence of using:
 1. explicitly provided credentials
 2. AWS SDK config (AWS.config.credentials)
 3. AWS SDK credentials provider chain (AWS.config.credentialProviders)

has been respected. This removes the need to explicitly configure
`AWS.config.credentials` in Backstage installations also.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
