### PR TITLE
remove kubernetes client caching

### DIFF
--- a/.changeset/three-squids-explain.md
+++ b/.changeset/three-squids-explain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Remove Kubernetes client caching

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.test.ts
@@ -45,42 +45,6 @@ describe('KubernetesClientProvider', () => {
     expect(mockGetKubeConfig.mock.calls.length).toBe(1);
   });
 
-  it('can get cached core client by cluster details', async () => {
-    const sut = new KubernetesClientProvider();
-
-    const mockGetKubeConfig = jest.fn(sut.getKubeConfig.bind({}));
-
-    sut.getKubeConfig = mockGetKubeConfig;
-
-    const result1 = sut.getCoreClientByClusterDetails({
-      name: 'cluster-name',
-      url: 'http://localhost:9999',
-      serviceAccountToken: 'TOKEN',
-      authProvider: 'serviceAccount',
-    });
-
-    const result2 = sut.getCoreClientByClusterDetails({
-      name: 'cluster-name',
-      url: 'http://localhost:9999',
-      serviceAccountToken: 'TOKEN',
-      authProvider: 'serviceAccount',
-    });
-
-    expect(result1.basePath).toBe('http://localhost:9999');
-    // These fields aren't on the type but are there
-    const auth1 = (result1 as any).authentications.default;
-    expect(auth1.users[0].token).toBe('TOKEN');
-    expect(auth1.clusters[0].name).toBe('cluster-name');
-
-    expect(result2.basePath).toBe('http://localhost:9999');
-    // These fields aren't on the type but are there
-    const auth2 = (result2 as any).authentications.default;
-    expect(auth2.users[0].token).toBe('TOKEN');
-    expect(auth2.clusters[0].name).toBe('cluster-name');
-
-    expect(mockGetKubeConfig.mock.calls.length).toBe(1);
-  });
-
   it('can get apps client by cluster details', async () => {
     const sut = new KubernetesClientProvider();
 
@@ -100,42 +64,6 @@ describe('KubernetesClientProvider', () => {
     const auth = (result as any).authentications.default;
     expect(auth.users[0].token).toBe('TOKEN');
     expect(auth.clusters[0].name).toBe('cluster-name');
-
-    expect(mockGetKubeConfig.mock.calls.length).toBe(1);
-  });
-
-  it('can get cached apps client by cluster details', async () => {
-    const sut = new KubernetesClientProvider();
-
-    const mockGetKubeConfig = jest.fn(sut.getKubeConfig.bind({}));
-
-    sut.getKubeConfig = mockGetKubeConfig;
-
-    const result1 = sut.getAppsClientByClusterDetails({
-      name: 'cluster-name',
-      url: 'http://localhost:9999',
-      serviceAccountToken: 'TOKEN',
-      authProvider: 'serviceAccount',
-    });
-
-    const result2 = sut.getAppsClientByClusterDetails({
-      name: 'cluster-name',
-      url: 'http://localhost:9999',
-      serviceAccountToken: 'TOKEN',
-      authProvider: 'serviceAccount',
-    });
-
-    expect(result1.basePath).toBe('http://localhost:9999');
-    // These fields aren't on the type but are there
-    const auth1 = (result1 as any).authentications.default;
-    expect(auth1.users[0].token).toBe('TOKEN');
-    expect(auth1.clusters[0].name).toBe('cluster-name');
-
-    expect(result2.basePath).toBe('http://localhost:9999');
-    // These fields aren't on the type but are there
-    const auth2 = (result2 as any).authentications.default;
-    expect(auth2.users[0].token).toBe('TOKEN');
-    expect(auth2.clusters[0].name).toBe('cluster-name');
 
     expect(mockGetKubeConfig.mock.calls.length).toBe(1);
   });

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -24,29 +24,6 @@ import {
 } from '@kubernetes/client-node';
 
 export class KubernetesClientProvider {
-  private readonly coreClientMap: {
-    [key: string]: CoreV1Api;
-  };
-
-  private readonly appsClientMap: {
-    [key: string]: AppsV1Api;
-  };
-
-  private readonly autoscalingClientMap: {
-    [key: string]: AutoscalingV1Api;
-  };
-
-  private readonly networkingBeta1ClientMap: {
-    [key: string]: NetworkingV1beta1Api;
-  };
-
-  constructor() {
-    this.coreClientMap = {};
-    this.appsClientMap = {};
-    this.autoscalingClientMap = {};
-    this.networkingBeta1ClientMap = {};
-  }
-
   // visible for testing
   getKubeConfig(clusterDetails: ClusterDetails) {
     const cluster = {
@@ -58,7 +35,7 @@ export class KubernetesClientProvider {
 
     // TODO configure
     const user = {
-      name: 'service-account',
+      name: 'backstage',
       token: clusterDetails.serviceAccountToken,
     };
 
@@ -79,66 +56,26 @@ export class KubernetesClientProvider {
   }
 
   getCoreClientByClusterDetails(clusterDetails: ClusterDetails) {
-    const clientMapKey = clusterDetails.name;
-
-    if (this.coreClientMap.hasOwnProperty(clientMapKey)) {
-      return this.coreClientMap[clientMapKey];
-    }
-
     const kc = this.getKubeConfig(clusterDetails);
 
-    const client = kc.makeApiClient(CoreV1Api);
-
-    this.coreClientMap[clientMapKey] = client;
-
-    return client;
+    return kc.makeApiClient(CoreV1Api);
   }
 
   getAppsClientByClusterDetails(clusterDetails: ClusterDetails) {
-    const clientMapKey = clusterDetails.name;
-
-    if (this.appsClientMap.hasOwnProperty(clientMapKey)) {
-      return this.appsClientMap[clientMapKey];
-    }
-
     const kc = this.getKubeConfig(clusterDetails);
 
-    const client = kc.makeApiClient(AppsV1Api);
-
-    this.appsClientMap[clientMapKey] = client;
-
-    return client;
+    return kc.makeApiClient(AppsV1Api);
   }
 
   getAutoscalingClientByClusterDetails(clusterDetails: ClusterDetails) {
-    const clientMapKey = clusterDetails.name;
-
-    if (this.autoscalingClientMap.hasOwnProperty(clientMapKey)) {
-      return this.autoscalingClientMap[clientMapKey];
-    }
-
     const kc = this.getKubeConfig(clusterDetails);
 
-    const client = kc.makeApiClient(AutoscalingV1Api);
-
-    this.autoscalingClientMap[clientMapKey] = client;
-
-    return client;
+    return kc.makeApiClient(AutoscalingV1Api);
   }
 
   getNetworkingBeta1Client(clusterDetails: ClusterDetails) {
-    const clientMapKey = clusterDetails.name;
-
-    if (this.networkingBeta1ClientMap.hasOwnProperty(clientMapKey)) {
-      return this.networkingBeta1ClientMap[clientMapKey];
-    }
-
     const kc = this.getKubeConfig(clusterDetails);
 
-    const client = kc.makeApiClient(NetworkingV1beta1Api);
-
-    this.networkingBeta1ClientMap[clientMapKey] = client;
-
-    return client;
+    return kc.makeApiClient(NetworkingV1beta1Api);
   }
 }


### PR DESCRIPTION
Signed-off-by: mclarke <mclarke@spotify.com>

## Hey, I just made a Pull Request!

Remove Kubernetes client caching, which only worked when we used service account token authentication, but now that we are using client side auth like google/aws needs to be reworked.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
