### PR TITLE
catalog: make initially selected filter configurable

### DIFF
--- a/.changeset/catalog-chocolate-cake.md
+++ b/.changeset/catalog-chocolate-cake.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Add the ability to change the initially selected filter, if not set it still defaults to `owned`.
+
+```js
+<Route
+  path="/catalog"
+  element={<CatalogIndexPage initiallySelectedFilter="all" />}
+/>
+```

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
@@ -134,6 +134,12 @@ describe('CatalogPage', () => {
     fireEvent.click(getByText(/All/));
     expect(await findByText(/All \(2\)/)).toBeInTheDocument();
   });
+  it('should set initial filter correctly', async () => {
+    const { findByText } = renderWrapped(
+      <CatalogPage initiallySelectedFilter="all" />,
+    );
+    expect(await findByText(/All \(2\)/)).toBeInTheDocument();
+  });
   // this test is for fixing the bug after favoriting an entity, the matching entities defaulting
   // to "owned" filter and not based on the selected filter
   it('should render the correct entities filtered on the selectedfilter', async () => {

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -59,11 +59,11 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export type CatalogPageOpts = {
+export type CatalogPageProps = {
   initiallySelectedFilter?: string;
 };
 
-const CatalogPageContents = (opt: CatalogPageOpts) => {
+const CatalogPageContents = (props: CatalogPageProps) => {
   const styles = useStyles();
   const {
     loading,
@@ -84,7 +84,7 @@ const CatalogPageContents = (opt: CatalogPageOpts) => {
   ] = useState<CatalogFilterType>();
   const orgName = configApi.getOptionalString('organization.name') ?? 'Company';
   const initiallySelectedFilter =
-    selectedSidebarItem?.id ?? opt.initiallySelectedFilter ?? 'owned';
+    selectedSidebarItem?.id ?? props.initiallySelectedFilter ?? 'owned';
   const createComponentLink = useRouteRef(createComponentRouteRef);
   const addMockData = useCallback(async () => {
     try {
@@ -219,8 +219,8 @@ const CatalogPageContents = (opt: CatalogPageOpts) => {
   );
 };
 
-export const CatalogPage = (opt: CatalogPageOpts) => (
+export const CatalogPage = (props: CatalogPageProps) => (
   <EntityFilterGroupsProvider>
-    <CatalogPageContents {...opt} />
+    <CatalogPageContents {...props} />
   </EntityFilterGroupsProvider>
 );

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -59,7 +59,11 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const CatalogPageContents = () => {
+export type CatalogPageOpts = {
+  initiallySelectedFilter?: string;
+};
+
+const CatalogPageContents = (opt: CatalogPageOpts) => {
   const styles = useStyles();
   const {
     loading,
@@ -79,6 +83,8 @@ const CatalogPageContents = () => {
     setSelectedSidebarItem,
   ] = useState<CatalogFilterType>();
   const orgName = configApi.getOptionalString('organization.name') ?? 'Company';
+  const initiallySelectedFilter =
+    selectedSidebarItem?.id ?? opt.initiallySelectedFilter ?? 'owned';
   const createComponentLink = useRouteRef(createComponentRouteRef);
   const addMockData = useCallback(async () => {
     try {
@@ -197,7 +203,7 @@ const CatalogPageContents = () => {
               onChange={({ label, id }) =>
                 setSelectedSidebarItem({ label, id })
               }
-              initiallySelected={selectedSidebarItem?.id ?? 'owned'}
+              initiallySelected={initiallySelectedFilter}
             />
             <ResultsFilter availableTags={availableTags} />
           </div>
@@ -213,8 +219,8 @@ const CatalogPageContents = () => {
   );
 };
 
-export const CatalogPage = () => (
+export const CatalogPage = (opt: CatalogPageOpts) => (
   <EntityFilterGroupsProvider>
-    <CatalogPageContents />
+    <CatalogPageContents {...opt} />
   </EntityFilterGroupsProvider>
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #4099

👋 Hey, I am adding a prop to select what is the initially selected filtered on catalog page.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Added a screenshot where the `all` tab is selected as default.
<img width="2318" alt="Screenshot 2021-03-09 at 10 32 37" src="https://user-images.githubusercontent.com/4247555/110458011-31f43c80-80c3-11eb-8c40-1138b21f4fb6.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
