### PR TITLE
scaffolder: Improve GitHub publishers permission update error message

### DIFF
--- a/.changeset/wet-hounds-vanish.md
+++ b/.changeset/wet-hounds-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Update GitHub publisher to display a more helpful error message when repository access update fails.

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -141,7 +141,7 @@ export class GithubPublisher implements PublisherBase {
           repo: name,
           permission: 'admin',
         });
-        // no need to add access if it's the person who own's the personal account
+        // no need to add access if it's the person who owns the personal account
       } else if (access && access !== owner) {
         await client.repos.addCollaborator({
           owner,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -151,8 +151,9 @@ export class GithubPublisher implements PublisherBase {
         });
       }
     } catch (e) {
-      e.message = `Failed to add access to '${access}': ${e.message}`;
-      throw e;
+      throw new Error(
+        `Failed to add access to '${access}'. Status ${e.status} ${e.message}`,
+      );
     }
     return data?.clone_url;
   }

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -131,25 +131,29 @@ export class GithubPublisher implements PublisherBase {
 
     const { data } = await repoCreationPromise;
 
-    if (access?.startsWith(`${owner}/`)) {
-      const [, team] = access.split('/');
-      await client.teams.addOrUpdateRepoPermissionsInOrg({
-        org: owner,
-        team_slug: team,
-        owner,
-        repo: name,
-        permission: 'admin',
-      });
-      // no need to add access if it's the person who own's the personal account
-    } else if (access && access !== owner) {
-      await client.repos.addCollaborator({
-        owner,
-        repo: name,
-        username: access,
-        permission: 'admin',
-      });
+    try {
+      if (access?.startsWith(`${owner}/`)) {
+        const [, team] = access.split('/');
+        await client.teams.addOrUpdateRepoPermissionsInOrg({
+          org: owner,
+          team_slug: team,
+          owner,
+          repo: name,
+          permission: 'admin',
+        });
+        // no need to add access if it's the person who own's the personal account
+      } else if (access && access !== owner) {
+        await client.repos.addCollaborator({
+          owner,
+          repo: name,
+          username: access,
+          permission: 'admin',
+        });
+      }
+    } catch (e) {
+      e.message = `Failed to add access to '${access}': ${e.message}`;
+      throw e;
     }
-
     return data?.clone_url;
   }
 }


### PR DESCRIPTION
Signed-off-by: Johan Haals <johan.haals@gmail.com>

## Hey, I just made a Pull Request!

Update GitHub publisher to display a more helpful error message when repository access update fails.

Before:

```
2021-03-09T11:26:54.000Z info: Will now store the template {"timestamp":"2021-03-09T11:26:54.685Z"}
2021-03-09T11:26:56.000Z HttpError: Not Found
```

After
```
2021-03-09T11:26:54.000Z info: Will now store the template {"timestamp":"2021-03-09T11:26:54.685Z"}
2021-03-09T11:26:56.000Z HttpError: Failed to add access to 'wazzamazza': Not Found
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
