### PR TITLE
feat(catalog-backend): support more codeownerprocessor kinds

### DIFF
--- a/.changeset/bright-spiders-sniff.md
+++ b/.changeset/bright-spiders-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow CodeOwnersProcessor to set spec.owner for System and Resource entity kinds.

--- a/.changeset/bright-spiders-sniff.md
+++ b/.changeset/bright-spiders-sniff.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Allow CodeOwnersProcessor to set spec.owner for System and Resource entity kinds.
+Allow CodeOwnersProcessor to set `spec.owner` for `System`, `Resource`, and `Domain` entity kinds.

--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
@@ -29,7 +29,7 @@ import { filter, get, head, pipe, reverse } from 'lodash/fp';
 import { Logger } from 'winston';
 import { CatalogProcessor } from './types';
 
-const ALLOWED_KINDS = ['API', 'Component', 'Resource', 'System'];
+const ALLOWED_KINDS = ['API', 'Component', 'Domain', 'Resource', 'System'];
 
 const ALLOWED_LOCATION_TYPES = [
   'url',

--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
@@ -29,6 +29,8 @@ import { filter, get, head, pipe, reverse } from 'lodash/fp';
 import { Logger } from 'winston';
 import { CatalogProcessor } from './types';
 
+const ALLOWED_KINDS = ['API', 'Component', 'Resource', 'System'];
+
 const ALLOWED_LOCATION_TYPES = [
   'url',
   'azure/api',
@@ -59,7 +61,7 @@ export class CodeOwnersProcessor implements CatalogProcessor {
     // Only continue if the owner is not set
     if (
       !entity ||
-      !['Component', 'API'].includes(entity.kind) ||
+      !ALLOWED_KINDS.includes(entity.kind) ||
       !ALLOWED_LOCATION_TYPES.includes(location.type) ||
       (entity.spec && entity.spec.owner)
     ) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

This allows the existing `CodeOwnersProcessor` to support `System` & `Resource` entity kinds in addition to the already supported `Component` & `API` kinds.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
