### PR TITLE
TechDocs: Change breadcrumbs link to be static "/docs"

### DIFF
--- a/.changeset/fluffy-cooks-smoke.md
+++ b/.changeset/fluffy-cooks-smoke.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs': patch
 ---
 
-Change breadcrumbs link to be static
+On TechDocs page header, change the breadcrumbs link to be static and point to TechDocs homepage.

--- a/.changeset/fluffy-cooks-smoke.md
+++ b/.changeset/fluffy-cooks-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Change breadcrumbs link to be static

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.test.tsx
@@ -18,6 +18,7 @@ import { TechDocsPageHeader } from './TechDocsPageHeader';
 import { act } from '@testing-library/react';
 import { renderInTestApp } from '@backstage/test-utils';
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
+import { rootRouteRef } from '../../plugin';
 
 describe('<TechDocsPageHeader />', () => {
   it('should render a techdocs page header', async () => {
@@ -54,6 +55,7 @@ describe('<TechDocsPageHeader />', () => {
         {
           mountedRoutes: {
             '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+            '/docs': rootRouteRef,
           },
         },
       );
@@ -85,6 +87,7 @@ describe('<TechDocsPageHeader />', () => {
         {
           mountedRoutes: {
             '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+            '/docs': rootRouteRef,
           },
         },
       );
@@ -118,6 +121,7 @@ describe('<TechDocsPageHeader />', () => {
         {
           mountedRoutes: {
             '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+            '/docs': rootRouteRef,
           },
         },
       );

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
@@ -21,6 +21,7 @@ import { EntityName, parseEntityName } from '@backstage/catalog-model';
 import { Header, HeaderLabel, Link, useRouteRef } from '@backstage/core';
 import { TechDocsMetadata } from '../../types';
 import { EntityRefLink, entityRouteRef } from '@backstage/plugin-catalog-react';
+import { rootRouteRef } from '../../plugin';
 
 type TechDocsPageHeaderProps = {
   entityId: EntityName;
@@ -58,6 +59,8 @@ export const TechDocsPageHeader = ({
   if (owner) {
     ownerEntity = parseEntityName(owner, { defaultKind: 'group' });
   }
+
+  const docsRootLink = useRouteRef(rootRouteRef)();
 
   const labels = (
     <>
@@ -113,7 +116,7 @@ export const TechDocsPageHeader = ({
         siteDescription && siteDescription !== 'None' ? siteDescription : ''
       }
       type="Docs"
-      typeLink="/docs"
+      typeLink={docsRootLink}
     >
       {labels}
     </Header>

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
@@ -112,8 +112,8 @@ export const TechDocsPageHeader = ({
       subtitle={
         siteDescription && siteDescription !== 'None' ? siteDescription : ''
       }
-      type={name}
-      typeLink={componentLink(entityId)}
+      type="Docs"
+      typeLink="/docs"
     >
       {labels}
     </Header>


### PR DESCRIPTION
Change breadcrumbs link to static reference to docs page.

Closes #4825 

![image](https://user-images.githubusercontent.com/8904624/110496503-d2635480-80f5-11eb-8a1a-8ce616150339.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
