### PR TITLE
Support GitHub tree URLs in getGitHubFileFetchUrl

### DIFF
--- a/.changeset/friendly-schools-sing.md
+++ b/.changeset/friendly-schools-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Support GitHub `tree` URLs in `getGitHubFileFetchUrl`.

--- a/packages/integration/src/github/core.test.ts
+++ b/packages/integration/src/github/core.test.ts
@@ -84,6 +84,36 @@ describe('github core', () => {
       );
     });
 
+    it('happy path for github tree', () => {
+      const config: GitHubIntegrationConfig = {
+        host: 'github.com',
+        apiBaseUrl: 'https://api.github.com',
+      };
+      expect(
+        getGitHubFileFetchUrl(
+          'https://github.com/a/b/tree/branchname/path/to/c.yaml',
+          config,
+        ),
+      ).toEqual(
+        'https://api.github.com/repos/a/b/contents/path/to/c.yaml?ref=branchname',
+      );
+    });
+
+    it('happy path for ghe tree', () => {
+      const config: GitHubIntegrationConfig = {
+        host: 'ghe.mycompany.net',
+        apiBaseUrl: 'https://ghe.mycompany.net/api/v3',
+      };
+      expect(
+        getGitHubFileFetchUrl(
+          'https://ghe.mycompany.net/a/b/tree/branchname/path/to/c.yaml',
+          config,
+        ),
+      ).toEqual(
+        'https://ghe.mycompany.net/api/v3/repos/a/b/contents/path/to/c.yaml?ref=branchname',
+      );
+    });
+
     it('happy path for github raw', () => {
       const config: GitHubIntegrationConfig = {
         host: 'github.com',

--- a/packages/integration/src/github/core.ts
+++ b/packages/integration/src/github/core.ts
@@ -39,7 +39,11 @@ export function getGitHubFileFetchUrl(
       !owner ||
       !name ||
       !ref ||
-      (filepathtype !== 'blob' && filepathtype !== 'raw')
+      // GitHub is automatically redirecting tree urls to blob urls so it's
+      // fine to pass a tree url.
+      (filepathtype !== 'blob' &&
+        filepathtype !== 'raw' &&
+        filepathtype !== 'tree')
     ) {
       throw new Error('Invalid GitHub URL or file path');
     }


### PR DESCRIPTION
Co-authored-by: Oliver Sand <oliver.sand@sda-se.com>
Signed-off-by: Dominik Henneke <dominik.henneke@sda-se.com>

## Hey, I just made a Pull Request!

Now that we have introduced the workaround for GitHub URLs in [`GitHubIntegration.ts#L49-L54`](https://github.com/backstage/backstage/blob/b028502c2defeb28791c2e7f6ce9b3a1ca820d00/packages/integration/src/github/GitHubIntegration.ts#L49-L54), we run into issues that the `GitHubUrlReader` tries to download files from `tree` URLs. We run into this in a very special case: We have a `Location` entity that uses glob-urls to import other `catalog-info.yaml` files and one of those files tries to use the `$text` placeholder with a relative file in the same directory. As the `LocationEntityProcessor` is resolving the URL using the `GitHubIntegration`, all following code is receiving `tree` URLs.

However, `getGitHubFileFetchUrl` doesn't allow downloading files from `tree` URLs. But as mentioned in the above workaround, GitHub allows to download files form `tree` URLs.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
