### PR TITLE
Expose `verifyNonce` and `readState` publicly

### DIFF
--- a/.changeset/violet-bobcats-sin.md
+++ b/.changeset/violet-bobcats-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+expose verifyNonce and readState publicly from auth-backend

--- a/plugins/auth-backend/src/lib/oauth/index.ts
+++ b/plugins/auth-backend/src/lib/oauth/index.ts
@@ -16,7 +16,7 @@
 
 export { OAuthEnvironmentHandler } from './OAuthEnvironmentHandler';
 export { OAuthAdapter } from './OAuthAdapter';
-export { encodeState } from './helpers';
+export { encodeState, verifyNonce, readState } from './helpers';
 export type {
   OAuthHandlers,
   OAuthProviderInfo,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Expose `readState` and `verifyNonce` publicly from the `auth-backend` package.

As an application implementing a customized  `OAuthAdapter`, I would like to make use of the functions in Backstage, to encode, read and verify the state parameter during the `OAuth` flow. This way, I can ensure that all of the behaviour in my `OAuthAdapter` implementation remains correct with the rest of Backstage.

Apologies for not raising an issue for this. I felt like this was a small enough change that probably didn't need a corresponding ticket.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
