### PR TITLE
Fix issue with radar description dialog display

### DIFF
--- a/.changeset/cyan-rings-live.md
+++ b/.changeset/cyan-rings-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Fixes issue where radar description dialog is not shown when the entry has an url external to the radar page

--- a/plugins/tech-radar/src/components/RadarEntry/RadarEntry.test.tsx
+++ b/plugins/tech-radar/src/components/RadarEntry/RadarEntry.test.tsx
@@ -79,4 +79,20 @@ describe('RadarEntry', () => {
     expect(radarDescription).toBeInTheDocument();
     expect(screen.getByText(String(minProps.value))).toBeInTheDocument();
   });
+
+  it('should render blip with url equal to # if description present', () => {
+    const withUrl = {
+      ...optionalProps,
+      url: 'http://backstage.io',
+    };
+    render(
+      <ThemeProvider theme={lightTheme}>
+        <svg>
+          <RadarEntry {...withUrl} />
+        </svg>
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole('button')).toHaveAttribute('href', '#');
+  });
 });

--- a/plugins/tech-radar/src/components/RadarEntry/RadarEntry.tsx
+++ b/plugins/tech-radar/src/components/RadarEntry/RadarEntry.tsx
@@ -111,11 +111,12 @@ const RadarEntry = (props: Props): JSX.Element => {
         />
       )}
       {description ? (
+        // eslint-disable-next-line jsx-a11y/anchor-is-valid
         <a
           className={classes.link}
           onClick={handleClickOpen}
-          href={url ? url : '#'}
           role="button"
+          href="#"
           tabIndex={0}
           onKeyPress={toggle}
         >

--- a/plugins/tech-radar/src/sampleData.ts
+++ b/plugins/tech-radar/src/sampleData.ts
@@ -72,9 +72,11 @@ entries.push({
       moved: 1,
       ringId: 'use',
       date: new Date('2020-08-06'),
+      description:
+        'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
     },
   ],
-  url: '#',
+  url: 'https://webpack.js.org/',
   key: 'webpack',
   id: 'webpack',
   title: 'Webpack',


### PR DESCRIPTION
If an entry has both a radar description and a non anchor url then
when a userclicked on the blip the description dialog would briefly appear before
the user was redirected to the specified url.

Expected behaviour is not to automatically redirect the user so that
they can read the dialog and choose to follow the link for more details.

Signed-off-by: Niall McCullagh <mccullagh_niall@hotmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
