### PR TITLE
Remove all dot-folder imports everywhere

### DIFF
--- a/packages/core-api/src/apis/implementations/AlertApi/AlertApiForwarder.ts
+++ b/packages/core-api/src/apis/implementations/AlertApi/AlertApiForwarder.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AlertApi, AlertMessage } from '../..';
 import { PublishSubject } from '../../../lib';
 import { Observable } from '../../../types';
+import { AlertApi, AlertMessage } from '../../definitions';
 
 /**
  * Base implementation for the AlertApi that simply forwards alerts to consumers.

--- a/packages/core-api/src/apis/implementations/ErrorApi/ErrorAlerter.ts
+++ b/packages/core-api/src/apis/implementations/ErrorApi/ErrorAlerter.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorApi, ErrorContext, AlertApi } from '../..';
+import { AlertApi, ErrorApi, ErrorContext } from '../../definitions';
 
 /**
  * Decorates an ErrorApi by also forwarding error messages

--- a/packages/core-api/src/apis/implementations/ErrorApi/ErrorApiForwarder.ts
+++ b/packages/core-api/src/apis/implementations/ErrorApi/ErrorApiForwarder.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorApi, ErrorContext } from '../..';
 import { PublishSubject } from '../../../lib';
 import { Observable } from '../../../types';
+import { ErrorApi, ErrorContext } from '../../definitions';
 
 /**
  * Base implementation for the ErrorApi that simply forwards errors to consumers.

--- a/packages/core-api/src/apis/implementations/auth/github/types.ts
+++ b/packages/core-api/src/apis/implementations/auth/github/types.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { ProfileInfo } from '../../..';
-import { BackstageIdentity } from '../../../definitions';
+import { BackstageIdentity, ProfileInfo } from '../../../definitions';
 
 export type GithubSession = {
   providerInfo: {

--- a/packages/core-api/src/lib/AuthSessionManager/SessionStateTracker.ts
+++ b/packages/core-api/src/lib/AuthSessionManager/SessionStateTracker.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { BehaviorSubject } from '..';
 import { SessionState } from '../../apis';
 import { Observable } from '../../types';
+import { BehaviorSubject } from '../subjects';
 
 export class SessionStateTracker {
   private readonly subject = new BehaviorSubject<SessionState>(

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.stories.tsx
@@ -15,11 +15,11 @@
  */
 
 import React, { useState } from 'react';
-import { CheckboxTree } from '.';
+import { CheckboxTree } from './CheckboxTree';
 
 const CHECKBOX_TREE_ITEMS = [
   {
-    label: 'Genereic subcategory name 1',
+    label: 'Generic subcategory name 1',
     options: [
       {
         label: 'Option 1',
@@ -32,7 +32,7 @@ const CHECKBOX_TREE_ITEMS = [
     ],
   },
   {
-    label: 'Genereic subcategory name 2',
+    label: 'Generic subcategory name 2',
     options: [
       {
         label: 'Option 1',
@@ -45,7 +45,7 @@ const CHECKBOX_TREE_ITEMS = [
     ],
   },
   {
-    label: 'Genereic subcategory name 3',
+    label: 'Generic subcategory name 3',
     options: [
       {
         label: 'Option 1',

--- a/packages/core/src/components/CheckboxTree/CheckboxTree.test.tsx
+++ b/packages/core/src/components/CheckboxTree/CheckboxTree.test.tsx
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
-
-import { CheckboxTree } from '.';
+import { CheckboxTree } from './CheckboxTree';
 
 const CHECKBOX_TREE_ITEMS = [
   {
-    label: 'Genereic subcategory name 1',
+    label: 'Generic subcategory name 1',
     options: [
       {
         label: 'Option 1',
@@ -45,7 +44,7 @@ describe('<CheckboxTree />', () => {
   it('renders without exploding', async () => {
     const { getByText, getByTestId } = render(<CheckboxTree {...minProps} />);
 
-    expect(getByText('Genereic subcategory name 1')).toBeInTheDocument();
+    expect(getByText('Generic subcategory name 1')).toBeInTheDocument();
     const checkbox = await getByTestId('expandable');
 
     // Simulate click on expandable arrow

--- a/packages/core/src/components/CopyTextButton/CopyTextButton.stories.tsx
+++ b/packages/core/src/components/CopyTextButton/CopyTextButton.stories.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { CopyTextButton } from '.';
+import { CopyTextButton } from './CopyTextButton';
 
 export default {
   title: 'Inputs/CopyTextButton',

--- a/packages/core/src/components/Progress/Progress.stories.tsx
+++ b/packages/core/src/components/Progress/Progress.stories.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Progress } from '.';
+import { Progress } from './Progress';
 
 export default {
   title: 'Feedback/Progress',

--- a/packages/core/src/components/Select/Select.stories.tsx
+++ b/packages/core/src/components/Select/Select.stories.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Select } from '.';
+import { SelectComponent as Select } from './Select';
 
 export default {
   title: 'Inputs/Select',

--- a/packages/core/src/components/Select/Select.test.tsx
+++ b/packages/core/src/components/Select/Select.test.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
-
-import { Select } from '.';
+import { SelectComponent as Select } from './Select';
 
 const SELECT_ITEMS = [
   {

--- a/packages/core/src/components/SimpleStepper/SimpleStepper.stories.tsx
+++ b/packages/core/src/components/SimpleStepper/SimpleStepper.stories.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
 import { TextField } from '@material-ui/core';
-import { SimpleStepper, SimpleStepperStep } from '.';
+import React, { useState } from 'react';
+import { SimpleStepper } from './SimpleStepper';
+import { SimpleStepperStep } from './SimpleStepperStep';
 
 export default {
   title: 'Navigation/SimpleStepper',

--- a/packages/core/src/layout/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/layout/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -18,9 +18,10 @@ import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import React, { Fragment } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { Breadcrumbs } from '.';
-import { Header, Page } from '..';
 import { Link } from '../../components/Link';
+import { Header } from '../Header';
+import { Page } from '../Page';
+import { Breadcrumbs } from './Breadcrumbs';
 
 export default {
   title: 'Layout/Breadcrumbs',

--- a/packages/core/src/layout/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/core/src/layout/Breadcrumbs/Breadcrumbs.test.tsx
@@ -18,7 +18,7 @@ import { renderInTestApp } from '@backstage/test-utils';
 import { Typography } from '@material-ui/core';
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
-import { Link } from '../..';
+import { Link } from '../../components/Link';
 import { Breadcrumbs } from './Breadcrumbs';
 
 describe('<Breadcrumbs/>', () => {

--- a/packages/core/src/layout/Header/Header.stories.tsx
+++ b/packages/core/src/layout/Header/Header.stories.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Header } from '.';
 import { HeaderLabel } from '../HeaderLabel';
 import { Page } from '../Page';
+import { Header } from './Header';
 
 export default {
   title: 'Layout/Header',

--- a/packages/core/src/layout/Header/Header.tsx
+++ b/packages/core/src/layout/Header/Header.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import React, { ReactNode, CSSProperties, PropsWithChildren } from 'react';
-import { Helmet } from 'react-helmet';
-import { Typography, Tooltip, makeStyles } from '@material-ui/core';
 import { BackstageTheme } from '@backstage/theme';
-import { Breadcrumbs } from '..';
-import { Link } from '../../components';
+import { makeStyles, Tooltip, Typography } from '@material-ui/core';
+import React, { CSSProperties, PropsWithChildren, ReactNode } from 'react';
+import { Helmet } from 'react-helmet';
+import { Link } from '../../components/Link';
+import { Breadcrumbs } from '../Breadcrumbs';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   header: {

--- a/packages/core/src/layout/InfoCard/InfoCard.stories.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.stories.tsx
@@ -16,7 +16,7 @@
 import { Grid, Typography } from '@material-ui/core';
 import React, { PropsWithChildren } from 'react';
 import { MemoryRouter } from 'react-router';
-import { InfoCard } from '.';
+import { InfoCard } from './InfoCard';
 
 const linkInfo = { title: 'Go to XYZ Location', link: '#' };
 

--- a/packages/core/src/layout/Sidebar/Sidebar.stories.tsx
+++ b/packages/core/src/layout/Sidebar/Sidebar.stories.tsx
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
+import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
+import HomeOutlinedIcon from '@material-ui/icons/HomeOutlined';
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import {
   Sidebar,
+  SidebarDivider,
   SidebarIntro,
   SidebarItem,
-  SidebarDivider,
   SidebarSearchField,
   SidebarSpace,
-} from '.';
-import HomeOutlinedIcon from '@material-ui/icons/HomeOutlined';
-import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
-import { MemoryRouter } from 'react-router-dom';
+} from '../Sidebar';
 
 export default {
   title: 'Layout/Sidebar',

--- a/packages/core/src/layout/TabbedCard/TabbedCard.stories.tsx
+++ b/packages/core/src/layout/TabbedCard/TabbedCard.stories.tsx
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useState, PropsWithChildren } from 'react';
-import { TabbedCard, CardTab } from '.';
 import { Grid } from '@material-ui/core';
+import React, { PropsWithChildren, useState } from 'react';
 import { MemoryRouter } from 'react-router';
+import { CardTab, TabbedCard } from './TabbedCard';
 
 const cardContentStyle = { height: 200, width: 500 };
 

--- a/packages/core/src/layout/TabbedCard/TabbedCard.test.tsx
+++ b/packages/core/src/layout/TabbedCard/TabbedCard.test.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
 import { renderInTestApp, wrapInTestApp } from '@backstage/test-utils';
-import { TabbedCard, CardTab } from '.';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { CardTab, TabbedCard } from './TabbedCard';
 
 const minProps = {
   title: 'Some title',

--- a/packages/techdocs-common/src/stages/generate/generators.test.ts
+++ b/packages/techdocs-common/src/stages/generate/generators.test.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { Generators, TechdocsGenerator } from '.';
 import { getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
+import { Generators } from './generators';
+import { TechdocsGenerator } from './techdocs';
 
 const logger = getVoidLogger();
 

--- a/packages/techdocs-common/src/stages/generate/generators.ts
+++ b/packages/techdocs-common/src/stages/generate/generators.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { Logger } from 'winston';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import { TechdocsGenerator } from '.';
+import { Logger } from 'winston';
+import { getGeneratorKey } from './helpers';
+import { TechdocsGenerator } from './techdocs';
 import {
   GeneratorBase,
-  SupportedGeneratorKey,
   GeneratorBuilder,
+  SupportedGeneratorKey,
 } from './types';
-import { getGeneratorKey } from './helpers';
 
 export class Generators implements GeneratorBuilder {
   private generatorMap = new Map<SupportedGeneratorKey, GeneratorBase>();

--- a/packages/techdocs-common/src/stages/prepare/preparers.ts
+++ b/packages/techdocs-common/src/stages/prepare/preparers.ts
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Logger } from 'winston';
 import { UrlReader } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import { DirectoryPreparer, CommonGitPreparer, UrlPreparer } from '.';
-import { PreparerBase, RemoteProtocol, PreparerBuilder } from './types';
+import { Logger } from 'winston';
 import { parseReferenceAnnotation } from '../../helpers';
+import { CommonGitPreparer, DirectoryPreparer, UrlPreparer } from '../prepare';
+import { PreparerBase, PreparerBuilder, RemoteProtocol } from './types';
 
 type factoryOptions = {
   logger: Logger;

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { ClusterDetails, KubernetesClustersSupplier } from '..';
 import { Config } from '@backstage/config';
+import { ClusterDetails, KubernetesClustersSupplier } from '../types/types';
 
 export class ConfigClusterLocator implements KubernetesClustersSupplier {
   private readonly clusterDetails: ClusterDetails[];

--- a/plugins/kubernetes-backend/src/cluster-locator/GkeClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/GkeClusterLocator.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { ClusterDetails, KubernetesClustersSupplier } from '..';
 import { Config } from '@backstage/config';
 import * as container from '@google-cloud/container';
+import { ClusterDetails, KubernetesClustersSupplier } from '../types/types';
 
 export class GkeClusterLocator implements KubernetesClustersSupplier {
   private readonly projectId: string;

--- a/plugins/kubernetes-backend/src/cluster-locator/index.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { ClusterDetails } from '..';
 import { Config } from '@backstage/config';
+import { ClusterDetails } from '../types/types';
 import { ConfigClusterLocator } from './ConfigClusterLocator';
 import { GkeClusterLocator } from './GkeClusterLocator';
 

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { sign } from 'aws4';
-import { KubernetesAuthTranslator } from './types';
-import { ClusterDetails } from '..';
 import AWS, { Credentials } from 'aws-sdk';
+import { sign } from 'aws4';
+import { ClusterDetails } from '../types/types';
+import { KubernetesAuthTranslator } from './types';
 
 const base64 = (str: string) =>
   Buffer.from(str.toString(), 'binary').toString('base64');

--- a/plugins/kubernetes-backend/src/service-locator/MultiTenantServiceLocator.ts
+++ b/plugins/kubernetes-backend/src/service-locator/MultiTenantServiceLocator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ClusterDetails, KubernetesServiceLocator } from '..';
+import { ClusterDetails, KubernetesServiceLocator } from '../types/types';
 
 // This locator assumes that every service is located on every cluster
 // Therefore it will always return all clusters provided

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { ClusterDetails } from '..';
 import {
   AppsV1Api,
   AutoscalingV1Api,
@@ -22,6 +21,7 @@ import {
   KubeConfig,
   NetworkingV1beta1Api,
 } from '@kubernetes/client-node';
+import { ClusterDetails } from '../types/types';
 
 export class KubernetesClientProvider {
   // visible for testing

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import { ObjectFetchParams } from '..';
+import { ObjectFetchParams } from '../types/types';
 import { KubernetesFanOutHandler } from './KubernetesFanOutHandler';
 
 const fetchObjectsForService = jest.fn();

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -15,8 +15,8 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
+import { ObjectFetchParams } from '../types/types';
 import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
-import { ObjectFetchParams } from '..';
 
 describe('KubernetesClientProvider', () => {
   let clientMock: any;

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import http from 'http';
 import {
   AppsV1Api,
   AutoscalingV1Api,
@@ -27,20 +26,21 @@ import {
   V1Pod,
   V1ReplicaSet,
 } from '@kubernetes/client-node';
-import { KubernetesClientProvider } from './KubernetesClientProvider';
 import { V1Service } from '@kubernetes/client-node/dist/gen/model/v1Service';
+import http from 'http';
+import lodash, { Dictionary } from 'lodash';
 import { Logger } from 'winston';
 import {
-  KubernetesFetcher,
   ClusterDetails,
-  KubernetesObjectTypes,
   FetchResponse,
   FetchResponseWrapper,
-  KubernetesFetchError,
   KubernetesErrorTypes,
+  KubernetesFetcher,
+  KubernetesFetchError,
+  KubernetesObjectTypes,
   ObjectFetchParams,
-} from '..';
-import lodash, { Dictionary } from 'lodash';
+} from '../types/types';
+import { KubernetesClientProvider } from './KubernetesClientProvider';
 
 export interface Clients {
   core: CoreV1Api;

--- a/plugins/kubernetes-backend/src/service/router.ts
+++ b/plugins/kubernetes-backend/src/service/router.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
+import { Config } from '@backstage/config';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
-import { Config } from '@backstage/config';
+import { getCombinedClusterDetails } from '../cluster-locator';
 import { MultiTenantServiceLocator } from '../service-locator/MultiTenantServiceLocator';
-import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
-import { KubernetesClientProvider } from './KubernetesClientProvider';
 import {
+  ClusterDetails,
+  KubernetesClustersSupplier,
   KubernetesRequestBody,
   KubernetesServiceLocator,
   ServiceLocatorMethod,
-  ClusterDetails,
-  KubernetesClustersSupplier,
-} from '..';
-import { getCombinedClusterDetails } from '../cluster-locator';
+} from '../types/types';
+import { KubernetesClientProvider } from './KubernetesClientProvider';
 import { KubernetesFanOutHandler } from './KubernetesFanOutHandler';
+import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
 
 export interface RouterOptions {
   logger: Logger;

--- a/plugins/lighthouse/src/components/AuditList/index.test.tsx
+++ b/plugins/lighthouse/src/components/AuditList/index.test.tsx
@@ -23,24 +23,22 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+import { ApiProvider, ApiRegistry } from '@backstage/core';
+import { msw, wrapInTestApp } from '@backstage/test-utils';
+import { fireEvent, render } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
-import { ApiRegistry, ApiProvider } from '@backstage/core';
-import { wrapInTestApp, msw } from '@backstage/test-utils';
-
 import {
   lighthouseApiRef,
   LighthouseRestApi,
   WebsiteListResponse,
 } from '../../api';
-import AuditList from '.';
-
 import * as data from '../../__fixtures__/website-list-response.json';
+import AuditList from './index';
 
 const { useNavigate } = jest.requireMock('react-router-dom');
 const websiteListResponse = data as WebsiteListResponse;
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
 
 describe('AuditList', () => {
   let apis: ApiRegistry;

--- a/plugins/lighthouse/src/components/AuditList/index.tsx
+++ b/plugins/lighthouse/src/components/AuditList/index.tsx
@@ -13,28 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useState, useMemo, ReactNode } from 'react';
-import { useLocalStorage, useAsync } from 'react-use';
-import { useNavigate } from 'react-router-dom';
-import { Grid, Button } from '@material-ui/core';
-import Pagination from '@material-ui/lab/Pagination';
+
 import {
-  InfoCard,
-  Header,
-  Page,
   Content,
   ContentHeader,
+  Header,
   HeaderLabel,
+  InfoCard,
+  Page,
   Progress,
   useApi,
   WarningPanel,
 } from '@backstage/core';
-
+import { Button, Grid } from '@material-ui/core';
+import Pagination from '@material-ui/lab/Pagination';
+import React, { ReactNode, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAsync, useLocalStorage } from 'react-use';
 import { lighthouseApiRef } from '../../api';
 import { useQuery } from '../../utils';
-import LighthouseSupportButton from '../SupportButton';
 import LighthouseIntro, { LIGHTHOUSE_INTRO_LOCAL_STORAGE } from '../Intro';
+import LighthouseSupportButton from '../SupportButton';
 import AuditListTable from './AuditListTable';
+
+// TODO(freben): move all of this out of index
 
 export const LIMIT = 10;
 

--- a/plugins/lighthouse/src/components/AuditStatusIcon/index.tsx
+++ b/plugins/lighthouse/src/components/AuditStatusIcon/index.tsx
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { StatusPending, StatusError, StatusOK } from '@backstage/core';
 
+import { StatusError, StatusOK, StatusPending } from '@backstage/core';
+import React from 'react';
 import { Audit } from '../../api';
+
+// TODO(freben): move all of this out of index
 
 const AuditStatusIcon = ({ audit }: { audit: Audit }) => {
   if (audit.status === 'FAILED') return <StatusError />;

--- a/plugins/lighthouse/src/components/AuditView/index.test.tsx
+++ b/plugins/lighthouse/src/components/AuditView/index.test.tsx
@@ -26,17 +26,16 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-import React from 'react';
+import { ApiProvider, ApiRegistry } from '@backstage/core';
+import { msw, wrapInTestApp } from '@backstage/test-utils';
 import { render } from '@testing-library/react';
-import { wrapInTestApp, msw } from '@backstage/test-utils';
-import { ApiRegistry, ApiProvider } from '@backstage/core';
-import AuditView from '.';
-import { lighthouseApiRef, LighthouseRestApi, Audit, Website } from '../../api';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import React from 'react';
+import { Audit, lighthouseApiRef, LighthouseRestApi, Website } from '../../api';
 import { formatTime } from '../../utils';
 import * as data from '../../__fixtures__/website-response.json';
-
-import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import AuditView from './index';
 
 const { useParams }: { useParams: jest.Mock } = jest.requireMock(
   'react-router-dom',

--- a/plugins/lighthouse/src/components/AuditView/index.tsx
+++ b/plugins/lighthouse/src/components/AuditView/index.tsx
@@ -13,40 +13,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useState, useEffect, ReactNode } from 'react';
+
 import {
-  Link,
-  useParams,
-  useNavigate,
-  generatePath,
-  resolvePath,
-} from 'react-router-dom';
-import { useAsync } from 'react-use';
+  Content,
+  ContentHeader,
+  Header,
+  HeaderLabel,
+  InfoCard,
+  Page,
+  Progress,
+  useApi,
+} from '@backstage/core';
 import {
-  makeStyles,
+  Button,
   Grid,
   List,
   ListItem,
-  Button,
   ListItemIcon,
   ListItemText,
+  makeStyles,
 } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
+import React, { ReactNode, useEffect, useState } from 'react';
 import {
-  useApi,
-  InfoCard,
-  Header,
-  Page,
-  Content,
-  ContentHeader,
-  HeaderLabel,
-  Progress,
-} from '@backstage/core';
-
-import { lighthouseApiRef, Website, Audit } from '../../api';
+  generatePath,
+  Link,
+  resolvePath,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
+import { useAsync } from 'react-use';
+import { Audit, lighthouseApiRef, Website } from '../../api';
+import { formatTime } from '../../utils';
 import AuditStatusIcon from '../AuditStatusIcon';
 import LighthouseSupportButton from '../SupportButton';
-import { formatTime } from '../../utils';
+
+// TODO(freben): move all of this out of index
 
 const useStyles = makeStyles({
   contentGrid: {

--- a/plugins/lighthouse/src/components/Cards/index.ts
+++ b/plugins/lighthouse/src/components/Cards/index.ts
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export { LastLighthouseAuditCard } from './LastLighthouseAuditCard';

--- a/plugins/lighthouse/src/components/CreateAudit/index.test.tsx
+++ b/plugins/lighthouse/src/components/CreateAudit/index.test.tsx
@@ -23,22 +23,20 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-import React from 'react';
-import { waitFor, render, fireEvent } from '@testing-library/react';
 import {
-  ApiRegistry,
   ApiProvider,
+  ApiRegistry,
   ErrorApi,
   errorApiRef,
 } from '@backstage/core';
-import { wrapInTestApp, msw } from '@backstage/test-utils';
-
-import { lighthouseApiRef, LighthouseRestApi, Audit } from '../../api';
-import CreateAudit from '.';
-import * as data from '../../__fixtures__/create-audit-response.json';
-
-import { setupServer } from 'msw/node';
+import { msw, wrapInTestApp } from '@backstage/test-utils';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import React from 'react';
+import { Audit, lighthouseApiRef, LighthouseRestApi } from '../../api';
+import * as data from '../../__fixtures__/create-audit-response.json';
+import CreateAudit from './index';
 
 const { useNavigate }: { useNavigate: jest.Mock } = jest.requireMock(
   'react-router-dom',

--- a/plugins/lighthouse/src/components/CreateAudit/index.tsx
+++ b/plugins/lighthouse/src/components/CreateAudit/index.tsx
@@ -13,31 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+
 import {
-  makeStyles,
-  Grid,
+  Content,
+  ContentHeader,
+  errorApiRef,
+  Header,
+  HeaderLabel,
+  InfoCard,
+  Page,
+  useApi,
+} from '@backstage/core';
+import {
   Button,
+  Grid,
   List,
   ListItem,
+  makeStyles,
   MenuItem,
   TextField,
 } from '@material-ui/core';
-import {
-  errorApiRef,
-  useApi,
-  InfoCard,
-  Header,
-  Page,
-  Content,
-  ContentHeader,
-  HeaderLabel,
-} from '@backstage/core';
-
+import React, { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { lighthouseApiRef } from '../../api';
 import { useQuery } from '../../utils';
 import LighthouseSupportButton from '../SupportButton';
+
+// TODO(freben): move all of this out of index
 
 const useStyles = makeStyles(theme => ({
   input: {

--- a/plugins/lighthouse/src/components/Intro/index.test.tsx
+++ b/plugins/lighthouse/src/components/Intro/index.test.tsx
@@ -16,11 +16,10 @@
 
 /* eslint-disable jest/no-disabled-tests */
 
-import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
 import { wrapInTestApp } from '@backstage/test-utils';
-
-import LighthouseIntro from '.';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import LighthouseIntro from './index';
 
 describe('LighthouseIntro', () => {
   it('renders successfully', () => {

--- a/plugins/lighthouse/src/components/Intro/index.tsx
+++ b/plugins/lighthouse/src/components/Intro/index.tsx
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { ContentHeader, InfoCard, MarkdownContent } from '@backstage/core';
+import { Button, Grid, makeStyles, Tab, Tabs } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
 import React, { useState } from 'react';
 import { useLocalStorage } from 'react-use';
-import { ContentHeader, InfoCard, MarkdownContent } from '@backstage/core';
-import { makeStyles, Button, Grid, Tabs, Tab } from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
-
 import LighthouseSupportButton from '../SupportButton';
+
+// TODO(freben): move all of this out of index
 
 export const LIGHTHOUSE_INTRO_LOCAL_STORAGE =
   '@backstage/lighthouse-plugin/intro-dismissed';

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.stories.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.stories.tsx
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { GroupEntity } from '@backstage/catalog-model';
+import { EntityContext } from '@backstage/plugin-catalog-react';
 import { Grid } from '@material-ui/core';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
-import { GroupEntity } from '@backstage/catalog-model';
-import { EntityContext } from '@backstage/plugin-catalog-react';
-import { GroupProfileCard } from '.';
+import { GroupProfileCard } from './GroupProfileCard';
 
 export default {
   title: 'Plugins/Org/Group Profile Card',

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.stories.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.stories.tsx
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { Entity, GroupEntity } from '@backstage/catalog-model';
+import { ApiProvider, ApiRegistry } from '@backstage/core-api';
+import { catalogApiRef, EntityContext } from '@backstage/plugin-catalog-react';
 import { Grid } from '@material-ui/core';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
-import { Entity, GroupEntity } from '@backstage/catalog-model';
-import { EntityContext, catalogApiRef } from '@backstage/plugin-catalog-react';
-import { ApiProvider, ApiRegistry } from '@backstage/core-api';
-
-import { MembersListCard } from '.';
+import { MembersListCard } from './MembersListCard';
 
 export default {
   title: 'Plugins/Org/Group Members List Card',

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.stories.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.stories.tsx
@@ -13,24 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Grid, ThemeProvider } from '@material-ui/core';
-import React from 'react';
-import { MemoryRouter } from 'react-router';
+
 import { GroupEntity } from '@backstage/catalog-model';
+import { ApiProvider, ApiRegistry } from '@backstage/core-api';
 import {
+  CatalogApi,
+  catalogApiRef,
+  EntityContext,
+} from '@backstage/plugin-catalog-react';
+import {
+  BackstageTheme,
   createTheme,
   genPageTheme,
   shapes,
-  BackstageTheme,
 } from '@backstage/theme';
-import {
-  EntityContext,
-  CatalogApi,
-  catalogApiRef,
-} from '@backstage/plugin-catalog-react';
-import { ApiProvider, ApiRegistry } from '@backstage/core-api';
-
-import { OwnershipCard } from '.';
+import { Grid, ThemeProvider } from '@material-ui/core';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { OwnershipCard } from './OwnershipCard';
 
 export default {
   title: 'Plugins/Org/Ownership Card',

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.stories.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.stories.tsx
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { UserEntity } from '@backstage/catalog-model';
+import { EntityContext } from '@backstage/plugin-catalog-react';
 import { Grid } from '@material-ui/core';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
-import { UserEntity } from '@backstage/catalog-model';
-import { EntityContext } from '@backstage/plugin-catalog-react';
-import { UserProfileCard } from '.';
+import { UserProfileCard } from './UserProfileCard';
 
 export default {
   title: 'Plugins/Org/User Profile Card',

--- a/plugins/scaffolder-backend/src/scaffolder/stages/prepare/preparers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/prepare/preparers.test.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Preparers } from '.';
+
 import { GithubPreparer } from './github';
+import { Preparers } from './preparers';
 
 describe('Preparers', () => {
   it('should return the correct preparer based on the hostname', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { runDockerContainer } from '@backstage/backend-common';
 import { JsonValue } from '@backstage/config';
 import fs from 'fs-extra';
 import path from 'path';
-import { TemplaterBase, TemplaterRunOptions } from '.';
 import { runCommand } from './helpers';
+import { TemplaterBase, TemplaterRunOptions } from './types';
 
 const commandExists = require('command-exists-promise');
 

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cra/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cra/index.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { runDockerContainer } from '@backstage/backend-common';
 import fs from 'fs-extra';
 import path from 'path';
 import * as yaml from 'yaml';
-import { TemplaterBase, TemplaterRunOptions } from '..';
+import { TemplaterBase, TemplaterRunOptions } from '../types';
 
 // TODO(blam): Replace with the universal import from github-actions after a release
 // As it will break the E2E without it

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/templaters.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/templaters.test.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Templaters } from '.';
+
 import { CookieCutter } from './cookiecutter';
+import { Templaters } from './templaters';
 
 describe('Templaters', () => {
   it('should throw an error when the templater is not registered', () => {

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -29,7 +29,7 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 import { Logger } from 'winston';
-import { BuildMetadataStorage } from '.';
+import { BuildMetadataStorage } from './BuildMetadataStorage';
 
 type DocsBuilderArguments = {
   preparers: PreparerBuilder;

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -13,28 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { useAsync } from 'react-use';
-import { useTheme } from '@material-ui/core';
-import { useParams, useNavigate } from 'react-router-dom';
 import { EntityName } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core';
 import { BackstageTheme } from '@backstage/theme';
-import { useShadowDom } from '..';
+import { useTheme } from '@material-ui/core';
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useAsync } from 'react-use';
 import { techdocsStorageApiRef } from '../../api';
-import TechDocsProgressBar from './TechDocsProgressBar';
-
+import { useShadowDom } from '../hooks';
 import transformer, {
   addBaseUrl,
-  rewriteDocLinks,
   addLinkClickListener,
-  removeMkdocsHeader,
-  simplifyMkdocsFooter,
-  onCssReady,
-  sanitizeDOM,
   injectCss,
+  onCssReady,
+  removeMkdocsHeader,
+  rewriteDocLinks,
+  sanitizeDOM,
+  simplifyMkdocsFooter,
 } from '../transformers';
 import { TechDocsNotFound } from './TechDocsNotFound';
+import TechDocsProgressBar from './TechDocsProgressBar';
 
 type Props = {
   entityId: EntityName;

--- a/plugins/techdocs/src/reader/transformers/addLinkClickListener.test.ts
+++ b/plugins/techdocs/src/reader/transformers/addLinkClickListener.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { createTestShadowDom } from '../../test-utils';
-import { addLinkClickListener } from '.';
+import { addLinkClickListener } from './addLinkClickListener';
 
 describe('addLinkClickListener', () => {
   it('calls onClick when a link has been clicked', () => {

--- a/plugins/techdocs/src/reader/transformers/index.test.ts
+++ b/plugins/techdocs/src/reader/transformers/index.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import transform, { Transformer } from '.';
+import transform, { Transformer } from './index';
 
 describe('transform', () => {
   it('calls the transformers', () => {

--- a/plugins/techdocs/src/reader/transformers/index.ts
+++ b/plugins/techdocs/src/reader/transformers/index.ts
@@ -23,6 +23,8 @@ export * from './onCssReady';
 export * from './sanitizeDOM';
 export * from './injectCss';
 
+// TODO(freben): move all of this out of index
+
 export type Transformer = (dom: Element) => Element;
 
 function transform(

--- a/plugins/techdocs/src/reader/transformers/sanitizeDOM/index.test.ts
+++ b/plugins/techdocs/src/reader/transformers/sanitizeDOM/index.test.ts
@@ -15,7 +15,8 @@
  */
 
 import { createTestShadowDom, FIXTURES } from '../../../test-utils';
-import { Transformer, sanitizeDOM } from '..';
+import { Transformer } from '../index';
+import { sanitizeDOM } from '../sanitizeDOM';
 
 const injectMaliciousLink = (): Transformer => dom => {
   const link = document.createElement('a');

--- a/plugins/techdocs/src/reader/transformers/sanitizeDOM/index.ts
+++ b/plugins/techdocs/src/reader/transformers/sanitizeDOM/index.ts
@@ -16,9 +16,11 @@
 
 // @ts-ignore
 import sanitizeHtml from 'sanitize-html';
-import type { Transformer } from '..';
+import type { Transformer } from '../index';
 import { TECHDOCS_ALLOWED_TAGS } from './tags';
 import { TECHDOCS_ALLOWED_ATTRIBUTES } from './attributes';
+
+// TODO(freben): move all of this out of index
 
 export const sanitizeDOM = (): Transformer => {
   return dom => {

--- a/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.test.ts
+++ b/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { createTestShadowDom, FIXTURES } from '../../test-utils';
-import { simplifyMkdocsFooter } from '.';
+import { simplifyMkdocsFooter } from './simplifyMkdocsFooter';
 
 describe('simplifyMkdocsFooter', () => {
   it('does not remove mkdocs copyright', () => {


### PR DESCRIPTION
We aren't supposed to import from `'.'` or `'../..'` etc; point to the actual node being imported instead. I did allow e.g. `'../../bigfolder'` however. Going all the way to the individual file could be done too, but is a matter of taste perhaps.

Also ran Organize Imports on all the touched files :)

No changeset since there are no functional changes at all - only the imports changed, and a couple typos in tests