### PR TITLE
Allow customisation of remoteUrl text with template outputs

### DIFF
--- a/.changeset/chilled-meals-do.md
+++ b/.changeset/chilled-meals-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Allow setting the text for the remoteUrl link in the TaskPage component by setting the remoteUrlText template output

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -260,11 +260,12 @@ scaffolder frontend for after the job is finished. This is useful for things
 like linking to the entity that has been created with the backend, and also
 linking to the created repository.
 
-The main two that are used are the following:
+The main three that are used are the following:
 
 ```yaml
 output:
   remoteUrl: '{{ steps.publish.output.remoteUrl }}' # link to the remote repository
+  remoteUrlText: '{{ steps.publish.output.remoteUrlText }}' # Text for link (defaults to 'Repo')
   entityRef: '{{ steps.register.output.entityRef }}' # link to the entitiy that has been ingested to the catalog
 ```
 

--- a/plugins/scaffolder/src/components/TaskPage/TaskPage.tsx
+++ b/plugins/scaffolder/src/components/TaskPage/TaskPage.tsx
@@ -263,6 +263,7 @@ export const TaskPage = () => {
 
   const entityRef = taskStream.output?.entityRef;
   const remoteUrl = taskStream.output?.remoteUrl;
+  const remoteUrlText = taskStream.output?.remoteUrlText || 'Repo';
   return (
     <Page themeId="home">
       <Header
@@ -319,7 +320,7 @@ export const TaskPage = () => {
                           variant="outlined"
                           href={remoteUrl}
                         >
-                          Repo
+                          {remoteUrlText}
                         </Button>
                       )}
                     </Box>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently, the scaffolder's `TaskPage` component hardcodes the text of the link to the remoteUrl output with the text "Repo". This works if (obviously) the remote resource is a new git repository, but not in other scenarios - for example, if it is a pull request against an existing monorepo.

This change defines a new output key, `remoteUrlText`, which will be used if present in `TaskPage`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
