### PR TITLE
graphiql,app: export icon and avoid routeRef usage in SidebarItem

### DIFF
--- a/.changeset/dirty-flowers-fail.md
+++ b/.changeset/dirty-flowers-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-graphiql': patch
+---
+
+Export `GraphiQLIcon`.

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -36,7 +36,7 @@ import {
   SidebarSpace,
 } from '@backstage/core';
 import { NavLink } from 'react-router-dom';
-import { graphiQLRouteRef } from '@backstage/plugin-graphiql';
+import { GraphiQLIcon } from '@backstage/plugin-graphiql';
 import { Settings as SidebarSettings } from '@backstage/plugin-user-settings';
 import { SidebarSearch } from '@backstage/plugin-search';
 
@@ -90,11 +90,7 @@ const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarItem icon={MapIcon} to="tech-radar" text="Tech Radar" />
       <SidebarItem icon={RuleIcon} to="lighthouse" text="Lighthouse" />
       <SidebarItem icon={MoneyIcon} to="cost-insights" text="Cost Insights" />
-      <SidebarItem
-        icon={graphiQLRouteRef.icon!}
-        to={graphiQLRouteRef.path}
-        text={graphiQLRouteRef.title}
-      />
+      <SidebarItem icon={GraphiQLIcon} to="graphiql" text="GraphiQL" />
       <SidebarSpace />
       <SidebarDivider />
       <SidebarSettings />

--- a/plugins/graphiql/src/index.ts
+++ b/plugins/graphiql/src/index.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { IconComponent } from '@backstage/core';
+import GraphiQLIconComponent from './assets/graphiql.icon.svg';
+
 export {
   graphiqlPlugin,
   graphiqlPlugin as plugin,
@@ -22,3 +25,4 @@ export {
 export { GraphiQLPage as Router } from './components';
 export * from './lib/api';
 export * from './route-refs';
+export const GraphiQLIcon: IconComponent = GraphiQLIconComponent;


### PR DESCRIPTION
Co-authored-by: Juan Lulkin <jmaiz@spotify.com>

## Hey, I just made a Pull Request!

Avoiding usage of the deprecated RouteRef properties

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
