### PR TITLE
Add `AnnotateScmSlugEntityProcessor`

### DIFF
--- a/.changeset/angry-boats-hunt.md
+++ b/.changeset/angry-boats-hunt.md
@@ -11,5 +11,5 @@ builder. To add it to your instance, add it to your `CatalogBuilder` using
 
 ```typescript
 const builder = new CatalogBuilder(env);
-builder.addProcessor(new AnnotateScmSlugEntityProcessor());
+builder.addProcessor(AnnotateScmSlugEntityProcessor.fromConfig(env.config));
 ```

--- a/.changeset/angry-boats-hunt.md
+++ b/.changeset/angry-boats-hunt.md
@@ -1,0 +1,15 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add `AnnotateScmSlugEntityProcessor` that automatically adds the
+`github.com/project-slug` annotation for components coming from GitHub.
+
+The processor is optional and not automatically registered in the catalog
+builder. To add it to your instance, add it to your `CatalogBuilder` using
+`addProcessor()`:
+
+```typescript
+const builder = new CatalogBuilder(env);
+builder.addProcessor(new AnnotateScmSlugEntityProcessor());
+```

--- a/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.test.ts
@@ -14,7 +14,18 @@
  * limitations under the License.
  */
 import { Entity, LocationSpec } from '@backstage/catalog-model';
+import { ConfigReader } from '@backstage/config';
 import { AnnotateScmSlugEntityProcessor } from './AnnotateScmSlugEntityProcessor';
+
+const config = new ConfigReader({
+  /* integrations: {
+    github: [
+      {
+        host: 'github.com',
+      },
+    ],
+  },*/
+});
 
 describe('AnnotateScmSlugEntityProcessor', () => {
   describe('github', () => {
@@ -32,7 +43,7 @@ describe('AnnotateScmSlugEntityProcessor', () => {
           'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
       };
 
-      const processor = new AnnotateScmSlugEntityProcessor();
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(config);
 
       expect(await processor.preProcessEntity(entity, location)).toEqual({
         apiVersion: 'backstage.io/v1alpha1',
@@ -63,7 +74,7 @@ describe('AnnotateScmSlugEntityProcessor', () => {
           'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
       };
 
-      const processor = new AnnotateScmSlugEntityProcessor();
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(config);
 
       expect(await processor.preProcessEntity(entity, location)).toEqual({
         apiVersion: 'backstage.io/v1alpha1',
@@ -91,14 +102,13 @@ describe('AnnotateScmSlugEntityProcessor', () => {
           'https://gitlab.com/backstage/backstage/-/blob/master/catalog-info.yaml',
       };
 
-      const processor = new AnnotateScmSlugEntityProcessor();
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(config);
 
       expect(await processor.preProcessEntity(entity, location)).toEqual({
         apiVersion: 'backstage.io/v1alpha1',
         kind: 'Component',
         metadata: {
           name: 'my-component',
-          annotations: {},
         },
       });
     });

--- a/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity, LocationSpec } from '@backstage/catalog-model';
+import { AnnotateScmSlugEntityProcessor } from './AnnotateScmSlugEntityProcessor';
+
+describe('AnnotateScmSlugEntityProcessor', () => {
+  describe('github', () => {
+    it('adds annotation', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+        },
+      };
+      const location: LocationSpec = {
+        type: 'url',
+        target:
+          'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+      };
+
+      const processor = new AnnotateScmSlugEntityProcessor();
+
+      expect(await processor.preProcessEntity(entity, location)).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+          annotations: {
+            'github.com/project-slug': 'backstage/backstage',
+          },
+        },
+      });
+    });
+
+    it('does not override existing annotation', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+          annotations: {
+            'github.com/project-slug': 'backstage/community',
+          },
+        },
+      };
+      const location: LocationSpec = {
+        type: 'url',
+        target:
+          'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+      };
+
+      const processor = new AnnotateScmSlugEntityProcessor();
+
+      expect(await processor.preProcessEntity(entity, location)).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+          annotations: {
+            'github.com/project-slug': 'backstage/community',
+          },
+        },
+      });
+    });
+
+    it('should not add annotation for other providers', async () => {
+      const entity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+        },
+      };
+      const location: LocationSpec = {
+        type: 'url',
+        target:
+          'https://gitlab.com/backstage/backstage/-/blob/master/catalog-info.yaml',
+      };
+
+      const processor = new AnnotateScmSlugEntityProcessor();
+
+      expect(await processor.preProcessEntity(entity, location)).toEqual({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'my-component',
+          annotations: {},
+        },
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.test.ts
@@ -17,16 +17,6 @@ import { Entity, LocationSpec } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import { AnnotateScmSlugEntityProcessor } from './AnnotateScmSlugEntityProcessor';
 
-const config = new ConfigReader({
-  /* integrations: {
-    github: [
-      {
-        host: 'github.com',
-      },
-    ],
-  },*/
-});
-
 describe('AnnotateScmSlugEntityProcessor', () => {
   describe('github', () => {
     it('adds annotation', async () => {
@@ -43,7 +33,9 @@ describe('AnnotateScmSlugEntityProcessor', () => {
           'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
       };
 
-      const processor = AnnotateScmSlugEntityProcessor.fromConfig(config);
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(
+        new ConfigReader({}),
+      );
 
       expect(await processor.preProcessEntity(entity, location)).toEqual({
         apiVersion: 'backstage.io/v1alpha1',
@@ -74,7 +66,9 @@ describe('AnnotateScmSlugEntityProcessor', () => {
           'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
       };
 
-      const processor = AnnotateScmSlugEntityProcessor.fromConfig(config);
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(
+        new ConfigReader({}),
+      );
 
       expect(await processor.preProcessEntity(entity, location)).toEqual({
         apiVersion: 'backstage.io/v1alpha1',
@@ -102,7 +96,9 @@ describe('AnnotateScmSlugEntityProcessor', () => {
           'https://gitlab.com/backstage/backstage/-/blob/master/catalog-info.yaml',
       };
 
-      const processor = AnnotateScmSlugEntityProcessor.fromConfig(config);
+      const processor = AnnotateScmSlugEntityProcessor.fromConfig(
+        new ConfigReader({}),
+      );
 
       expect(await processor.preProcessEntity(entity, location)).toEqual({
         apiVersion: 'backstage.io/v1alpha1',

--- a/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity, LocationSpec } from '@backstage/catalog-model';
+import parseGitUrl from 'git-url-parse';
+import { identity, merge, pickBy } from 'lodash';
+import { CatalogProcessor } from './types';
+
+const GITHUB_ACTIONS_ANNOTATION = 'github.com/project-slug';
+
+export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
+  async preProcessEntity(
+    entity: Entity,
+    location: LocationSpec,
+  ): Promise<Entity> {
+    if (entity.kind !== 'Component' || location.type !== 'url') {
+      return entity;
+    }
+
+    const gitUrl = parseGitUrl(location.target);
+    let githubProjectSlug =
+      entity.metadata.annotations?.[GITHUB_ACTIONS_ANNOTATION];
+
+    if (gitUrl.source === 'github.com' && !githubProjectSlug) {
+      githubProjectSlug = `${gitUrl.owner}/${gitUrl.name}`;
+    }
+
+    return merge(
+      {
+        metadata: {
+          annotations: pickBy(
+            {
+              [GITHUB_ACTIONS_ANNOTATION]: githubProjectSlug,
+            },
+            identity,
+          ),
+        },
+      },
+      entity,
+    );
+  }
+}

--- a/plugins/catalog-backend/src/ingestion/processors/index.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/index.ts
@@ -17,6 +17,7 @@
 import * as results from './results';
 
 export { AnnotateLocationEntityProcessor } from './AnnotateLocationEntityProcessor';
+export { AnnotateScmSlugEntityProcessor } from './AnnotateScmSlugEntityProcessor';
 export { AwsOrganizationCloudAccountProcessor } from './AwsOrganizationCloudAccountProcessor';
 export { BuiltinKindsEntityProcessor } from './BuiltinKindsEntityProcessor';
 export { CodeOwnersProcessor } from './CodeOwnersProcessor';


### PR DESCRIPTION

Add `AnnotateScmSlugEntityProcessor` that automatically adds the
`github.com/project-slug` annotation for components coming from GitHub.

The processor is optional and not automatically registered in the catalog
builder. To add it to your instance, add it to your `CatalogBuilder` using
`addProcessor()`:

```typescript
const builder = new CatalogBuilder(env);
builder.addProcessor(new AnnotateScmSlugEntityProcessor());
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
