### PR TITLE
Scaffolder: Fix allowed host field from RepoUrlPicker

### DIFF
--- a/plugins/scaffolder/src/api.test.ts
+++ b/plugins/scaffolder/src/api.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ConfigReader } from '@backstage/core';
+import { ScaffolderClient } from './api';
+
+describe('api', () => {
+  const discoveryApi = {} as any;
+  const identityApi = {} as any;
+  const configApi = new ConfigReader({
+    integrations: {
+      github: [
+        {
+          host: 'hello.com',
+        },
+      ],
+    },
+  });
+  const apiClient = new ScaffolderClient({
+    configApi,
+    discoveryApi,
+    identityApi,
+  });
+
+  it('should return default and custom integrations', async () => {
+    const allowedHosts = [
+      'hello.com',
+      'gitlab.com',
+      'github.com',
+      'dev.azure.com',
+      'bitbucket.org',
+    ];
+    const integrations = await apiClient.getIntegrationsList({ allowedHosts });
+    integrations.forEach(integration =>
+      expect(allowedHosts).toContain(integration.host),
+    );
+  });
+});

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -99,9 +99,7 @@ export class ScaffolderClient implements ScaffolderApi {
   }
 
   async getIntegrationsList(options: { allowedHosts: string[] }) {
-    const integrations = ScmIntegrations.fromConfig(
-      this.configApi.getConfig('integrations'),
-    );
+    const integrations = ScmIntegrations.fromConfig(this.configApi);
 
     return [
       ...integrations.azure.list(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Here at Expedia, while upgrading our backstage app with the latest scaffolder plugins we were having a small issue trying to use the [UrlRepoPicker](https://github.com/backstage/backstage/blob/master/docs/features/software-templates/writing-templates.md#the-repository-picker). It was not allowing us to use our enterprise repo integration 😮 

After digging around, we found that the builtin integration factories were trying to access the incorrect config key/pair value:
* [GitHubIntegration](https://github.com/backstage/backstage/blob/master/packages/integration/src/github/GitHubIntegration.ts#L27) for example, is trying to read `integrations.github`
* While [Scaffolder plugin](https://github.com/backstage/backstage/blob/master/plugins/scaffolder/src/api.ts#L103) was already reading the`integrations` config
* This was making the Github integration to read  integrations as `integrations.integrations.[integrationName]`

Thanks to this, now we are able my custom integrations in the Host Picker 😃 
![Screen Shot 2021-03-11 at 11 56 46](https://user-images.githubusercontent.com/18434722/110832394-deb7f080-8260-11eb-9250-87fa12369512.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
