### PR TITLE
Changed the way project slug is handled in Jenkins plugin

### DIFF
--- a/.changeset/warm-cows-wait.md
+++ b/.changeset/warm-cows-wait.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-jenkins': minor
+---
+
+Changed the way project slug is extracted from an entity. Up until now, the plugin assumed that the project slug is always of the format "owner/repo". However, this is not something that is enforced by Jenkins and sometimes the project name doesn't contain an owner.
+Since this split is not used anywhere and the entire project slug is always used as-is, removed this distinction and just read the project slug from the annotation as-is.

--- a/plugins/jenkins/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
+++ b/plugins/jenkins/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
@@ -47,10 +47,10 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const BuildWithStepsView = () => {
-  const { owner, repo } = useProjectSlugFromEntity();
+  const projectName = useProjectSlugFromEntity();
   const { branch, buildNumber } = useParams();
   const classes = useStyles();
-  const buildPath = `${owner}/${repo}/${branch}/${buildNumber}`;
+  const buildPath = `${projectName}/${branch}/${buildNumber}`;
   const [{ value }] = useBuildWithSteps(buildPath);
 
   return (

--- a/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -242,9 +242,9 @@ export const CITableView = ({
 };
 
 export const CITable = () => {
-  const { owner, repo } = useProjectSlugFromEntity();
+  const projectName = useProjectSlugFromEntity();
 
-  const [tableProps, { setPage, retry, setPageSize }] = useBuilds(owner, repo);
+  const [tableProps, { setPage, retry, setPageSize }] = useBuilds(projectName);
 
   return (
     <CITableView

--- a/plugins/jenkins/src/components/Cards/Cards.tsx
+++ b/plugins/jenkins/src/components/Cards/Cards.tsx
@@ -82,8 +82,8 @@ export const LatestRunCard = ({
   branch: string;
   variant?: InfoCardVariants;
 }) => {
-  const { owner, repo } = useProjectSlugFromEntity();
-  const [{ builds, loading }] = useBuilds(owner, repo, branch);
+  const projectName = useProjectSlugFromEntity();
+  const [{ builds, loading }] = useBuilds(projectName, branch);
   const latestRun = builds ?? {};
   return (
     <InfoCard title={`Latest ${branch} build`} variant={variant}>

--- a/plugins/jenkins/src/components/useBuilds.ts
+++ b/plugins/jenkins/src/components/useBuilds.ts
@@ -18,7 +18,7 @@ import { useState } from 'react';
 import { useAsyncRetry } from 'react-use';
 import { jenkinsApiRef } from '../api';
 
-export function useBuilds(owner: string, repo: string, branch?: string) {
+export function useBuilds(projectName: string, branch?: string) {
   const api = useApi(jenkinsApiRef);
   const errorApi = useApi(errorApiRef);
 
@@ -38,9 +38,9 @@ export function useBuilds(owner: string, repo: string, branch?: string) {
     try {
       let build;
       if (branch) {
-        build = await api.getLastBuild(`${owner}/${repo}/${branch}`);
+        build = await api.getLastBuild(`${projectName}/${branch}`);
       } else {
-        build = await api.getFolder(`${owner}/${repo}`);
+        build = await api.getFolder(`${projectName}`);
       }
 
       const size = Array.isArray(build) ? build?.[0].build_num! : 1;
@@ -51,9 +51,8 @@ export function useBuilds(owner: string, repo: string, branch?: string) {
       errorApi.post(e);
       throw e;
     }
-  }, [api, errorApi, owner, repo, branch]);
+  }, [api, errorApi, projectName, branch]);
 
-  const projectName = `${owner}/${repo}`;
   return [
     {
       page,

--- a/plugins/jenkins/src/components/useProjectSlugFromEntity.ts
+++ b/plugins/jenkins/src/components/useProjectSlugFromEntity.ts
@@ -19,8 +19,5 @@ import { JENKINS_ANNOTATION } from '../constants';
 export const useProjectSlugFromEntity = () => {
   const { entity } = useEntity();
 
-  const [owner, repo] = (
-    entity.metadata.annotations?.[JENKINS_ANNOTATION] ?? ''
-  ).split('/');
-  return { owner, repo };
+  return entity.metadata.annotations?.[JENKINS_ANNOTATION] ?? '';
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Changed the way project slug is extracted from an entity. Up until now, the plugin assumed that the project slug is always of the format "owner/repo". However, this is not something that is enforced by Jenkins and sometimes the project name doesn't contain an owner.
Since this split is not used anywhere and the entire project slug is always used as-is, removed this distinction and just read the project slug from the annotation as-is.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
