### PR TITLE
feat(catalog-import): use title for commit message

### DIFF
--- a/.changeset/new-suits-mate.md
+++ b/.changeset/new-suits-mate.md
@@ -1,0 +1,20 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Use title form field value for the commit message on catalog import PRs. Also allow customization of the pull requests title or body only. For example:
+
+```tsx
+<Route
+  path="/catalog-import"
+  element={
+    <CatalogImportPage
+      pullRequest={{
+        preparePullRequest: () => ({
+          title: 'chore: add backstage catalog file [skip ci]',
+        }),
+      }}
+    />
+  }
+/>
+```

--- a/plugins/catalog-import/src/api/CatalogImportClient.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.test.ts
@@ -301,7 +301,7 @@ describe('CatalogImportClient', () => {
         catalogImportClient.submitPullRequest({
           repositoryUrl: 'https://github.com/backstage/backstage',
           fileContent: 'some content',
-          title: 'A title',
+          title: 'A title/message',
           body: 'A body',
         }),
       ).resolves.toEqual({
@@ -325,7 +325,7 @@ describe('CatalogImportClient', () => {
         owner: 'backstage',
         repo: 'backstage',
         path: 'catalog-info.yaml',
-        message: 'Add catalog-info.yaml config file',
+        message: 'A title/message',
         content: 'c29tZSBjb250ZW50',
         branch: 'backstage-integration',
       });
@@ -334,7 +334,7 @@ describe('CatalogImportClient', () => {
       ).toEqual({
         owner: 'backstage',
         repo: 'backstage',
-        title: 'A title',
+        title: 'A title/message',
         head: 'backstage-integration',
         body: 'A body',
         base: 'main',

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -297,7 +297,7 @@ export class CatalogImportClient implements CatalogImportApi {
         owner,
         repo,
         path: fileName,
-        message: `Add ${fileName} config file`,
+        message: title,
         content: btoa(fileContent),
         branch: branchName,
       })

--- a/plugins/catalog-import/src/components/ImportStepper/defaults.tsx
+++ b/plugins/catalog-import/src/components/ImportStepper/defaults.tsx
@@ -39,7 +39,9 @@ import { ImportFlows, ImportState } from '../useImportState';
 export type StepperProviderOpts = {
   pullRequest?: {
     disable?: boolean;
-    preparePullRequest?: (apis: StepperApis) => { title: string; body: string };
+    preparePullRequest?: (
+      apis: StepperApis,
+    ) => { title?: string; body?: string };
   };
 };
 
@@ -71,13 +73,18 @@ export type StepperProvider = {
   ) => StepConfiguration;
 };
 
-function defaultPreparePullRequest(apis: StepperApis) {
+function defaultPreparePullRequest(
+  apis: StepperApis,
+  { title, body }: { title?: string; body?: string } = {},
+) {
   const appTitle = apis.configApi.getOptionalString('app.title') ?? 'Backstage';
   const appBaseUrl = apis.configApi.getString('app.baseUrl');
 
   return {
-    title: 'Add catalog-info.yaml config file',
-    body: `This pull request adds a **Backstage entity metadata file** \
+    title: title ?? 'Add catalog-info.yaml config file',
+    body:
+      body ??
+      `This pull request adds a **Backstage entity metadata file** \
 to this repository so that the component can be added to the \
 [${appTitle} software catalog](${appBaseUrl}).\n\nAfter this pull request is merged, \
 the component will become available.\n\nFor more information, read an \
@@ -160,10 +167,12 @@ export function defaultGenerateStepper(
             return defaults.prepare(state, opts);
           }
 
-          const { title, body } = (
-            opts?.opts?.pullRequest?.preparePullRequest ??
-            defaultPreparePullRequest
-          )(opts.apis);
+          const preparePullRequest =
+            opts?.opts?.pullRequest?.preparePullRequest;
+          const { title, body } = defaultPreparePullRequest(
+            opts.apis,
+            preparePullRequest ? preparePullRequest(opts.apis) : {},
+          );
 
           return {
             stepLabel: <StepLabel>Create Pull Request</StepLabel>,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The commit message for catalog imports is currently hard coded. This makes the commit message match the PR title. This can be useful if you use conventional commits or would like to use the common `[skip ci]` convention to bypass CI (supported by `jenkins`, `circleci`, `gh actions` etc.).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
