### PR TITLE
fix: forward auth on scaffolder backend reqeuests

### DIFF
--- a/.changeset/fuzzy-taxis-hammer.md
+++ b/.changeset/fuzzy-taxis-hammer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Forward authorization on scaffolder backend requests

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -288,7 +288,9 @@ export async function createRouter(
           );
         }
 
-        const template = await entityClient.findTemplate(name);
+        const template = await entityClient.findTemplate(name, {
+          token: getBearerToken(req.headers.authorization),
+        });
         if (isBeta2Template(template)) {
           const parameters = [template.spec.parameters ?? []].flat();
           res.json({
@@ -356,7 +358,9 @@ export async function createRouter(
     .post('/v2/tasks', async (req, res) => {
       const templateName: string = req.body.templateName;
       const values: TemplaterValues = req.body.values;
-      const template = await entityClient.findTemplate(templateName);
+      const template = await entityClient.findTemplate(templateName, {
+        token: getBearerToken(req.headers.authorization),
+      });
 
       let taskSpec;
       if (isAlpha1Template(template)) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Version 2 of the scaffolder backend does not forward the authorization header from the client when making backend requests to the catalog API, causing a 401 error when [requiring api authentication](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md). This PR fixes that.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
