### PR TITLE
Add location to thrown exception when parsing YAML

### DIFF
--- a/.changeset/silver-tigers-tie.md
+++ b/.changeset/silver-tigers-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add location to thrown exception when parsing YAML

--- a/plugins/catalog-backend/src/ingestion/processors/util/parse.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/util/parse.test.ts
@@ -159,7 +159,7 @@ describe('parseEntityYaml', () => {
     expect(results).toEqual([
       result.generalError(
         testLoc,
-        'YAML error, YAMLSemanticError: Plain value cannot start with reserved character `',
+        'YAML error at my-loc-type:my-loc-target, YAMLSemanticError: Plain value cannot start with reserved character `',
       ),
     ]);
   });
@@ -198,7 +198,7 @@ describe('parseEntityYaml', () => {
       }),
       result.generalError(
         testLoc,
-        'YAML error, YAMLSemanticError: Nested mappings are not allowed in compact mappings',
+        'YAML error at my-loc-type:my-loc-target, YAMLSemanticError: Nested mappings are not allowed in compact mappings',
       ),
     ]);
   });

--- a/plugins/catalog-backend/src/ingestion/processors/util/parse.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/util/parse.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Entity, LocationSpec } from '@backstage/catalog-model';
+import {
+  Entity,
+  LocationSpec,
+  stringifyLocationReference,
+} from '@backstage/catalog-model';
 import lodash from 'lodash';
 import yaml from 'yaml';
 import * as result from '../results';
@@ -28,13 +32,16 @@ export function* parseEntityYaml(
   try {
     documents = yaml.parseAllDocuments(data.toString('utf8')).filter(d => d);
   } catch (e) {
-    yield result.generalError(location, `Failed to parse YAML, ${e}`);
+    const loc = stringifyLocationReference(location);
+    const message = `Failed to parse YAML at ${loc}, ${e}`;
+    yield result.generalError(location, message);
     return;
   }
 
   for (const document of documents) {
     if (document.errors?.length) {
-      const message = `YAML error, ${document.errors[0]}`;
+      const loc = stringifyLocationReference(location);
+      const message = `YAML error at ${loc}, ${document.errors[0]}`;
       yield result.generalError(location, message);
     } else {
       const json = document.toJSON();


### PR DESCRIPTION
Fixes #4763

...partially. It's still not great, but makes things a lot better when having nested locations.