### PR TITLE
Add example org entities to default create-app

### DIFF
--- a/.changeset/short-olives-mate.md
+++ b/.changeset/short-olives-mate.md
@@ -1,0 +1,22 @@
+---
+'@backstage/create-app': patch
+---
+
+Adds example groups and users to the default app template.
+
+To apply this change in an existing application, change the following in `app-config.yaml`:
+
+```diff
+     - type: url
+       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-apis.yaml
+
++    # Backstage example organization groups
++    - type: url
++      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme/org.yaml
++      rules:
++        - allow: [Group, User]
++
+     # Backstage example templates
+     - type: url
+       target: https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml
+```

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -89,6 +89,12 @@ catalog:
     - type: url
       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-apis.yaml
 
+    # Backstage example organization groups
+    - type: url
+      target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme/org.yaml
+      rules:
+        - allow: [Group, User]
+
     # Backstage example templates
     - type: url
       target: https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

The `@backstage/create-app` command scaffolds a Backstage app with example components, but does not include the example org group/user entities. The default `Owned` catalog page therefore displays nothing, as the Guest user is not known:

![Screen Shot 2021-03-16 at 08 57 02](https://user-images.githubusercontent.com/556258/111333289-2a3f1580-8638-11eb-86f5-1af8e77ee6f0.png)

And from the `All` components view, clicking on any owner shows a "Entity not found" page:

![Screen Shot 2021-03-16 at 08 57 18](https://user-images.githubusercontent.com/556258/111333379-3f1ba900-8638-11eb-9cd6-f6e97f191a4c.png)

This adds the example org url location to the default `@backstage/create-app` template.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
