### PR TITLE
Switch the default DB choice to SQLite

### DIFF
--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -110,7 +110,7 @@ export default async (cmd: Command): Promise<void> => {
       name: 'dbType',
       message: chalk.blue('Select database for the backend [required]'),
       // @ts-ignore
-      choices: ['PostgreSQL', 'SQLite'],
+      choices: ['SQLite', 'PostgreSQL'],
     },
   ];
   const answers: Answers = await inquirer.prompt(questions);

--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -203,7 +203,7 @@ async function createApp(
 
     await waitFor(() => stdout.includes('Select database for the backend'));
 
-    if (!isPostgres) {
+    if (isPostgres) {
       // Simulate down arrow press
       child.stdin?.write(`\u001B\u005B\u0042`);
     }


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

Switches the order of database choices in `@backstage/create-app` so that SQLite is the default if you just press enter.

I think this is preferable for potential adopters trying out Backstage. I went with the default PostgreSQL when first trying `create-app` and went through some unnecessary DB setup hurdles.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
