### PR TITLE
core-api: export SubRouteRef and make them assignable to plugin.routes

### DIFF
--- a/.changeset/chilled-mugs-learn.md
+++ b/.changeset/chilled-mugs-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-api': patch
+---
+
+Export `SubRouteRef` type, and allow `SubRouteRef`s to be assigned to `plugin.routes`.

--- a/packages/core-api/src/app/App.test.tsx
+++ b/packages/core-api/src/app/App.test.tsx
@@ -98,6 +98,12 @@ describe('Integration Test', () => {
 
   const plugin1 = createPlugin({
     id: 'blob',
+    // Both absolute and sub route refs should be assignable to the plugin routes
+    routes: {
+      ref1: plugin1RouteRef,
+      ref2: plugin2RouteRef,
+      ref3: subRouteRef1,
+    },
     externalRoutes: {
       extRouteRef1,
       extRouteRef2,

--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -53,7 +53,7 @@ import {
 import { IconComponent, IconComponentMap, IconKey } from '../icons';
 import { BackstagePlugin } from '../plugin';
 import { AnyRoutes } from '../plugin/types';
-import { RouteRef, ExternalRouteRef } from '../routing';
+import { RouteRef, ExternalRouteRef, SubRouteRef } from '../routing';
 import {
   routeObjectCollector,
   routeParentCollector,
@@ -75,10 +75,8 @@ import {
   SignInResult,
 } from './types';
 
-export function generateBoundRoutes(
-  bindRoutes: AppOptions['bindRoutes'],
-): Map<ExternalRouteRef, RouteRef> {
-  const result = new Map<ExternalRouteRef, RouteRef>();
+export function generateBoundRoutes(bindRoutes: AppOptions['bindRoutes']) {
+  const result = new Map<ExternalRouteRef, RouteRef | SubRouteRef>();
 
   if (bindRoutes) {
     const bind: AppRouteBinder = (externalRoutes, targetRoutes: AnyRoutes) => {

--- a/packages/core-api/src/plugin/types.ts
+++ b/packages/core-api/src/plugin/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { ComponentType } from 'react';
-import { RouteRef, ExternalRouteRef } from '../routing';
+import { RouteRef, SubRouteRef, ExternalRouteRef } from '../routing';
 import { AnyApiFactory } from '../apis/system';
 
 export type RouteOptions = {
@@ -70,7 +70,7 @@ export type Extension<T> = {
   expose(plugin: BackstagePlugin<any, any>): T;
 };
 
-export type AnyRoutes = { [name: string]: RouteRef<any> };
+export type AnyRoutes = { [name: string]: RouteRef | SubRouteRef };
 
 export type AnyExternalRoutes = { [name: string]: ExternalRouteRef };
 

--- a/packages/core-api/src/routing/index.ts
+++ b/packages/core-api/src/routing/index.ts
@@ -16,6 +16,7 @@
 
 export type {
   RouteRef,
+  SubRouteRef,
   AbsoluteRouteRef,
   ConcreteRoute,
   MutableRouteRef,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Missed these when adding SubRouteRefs

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
