### PR TITLE
feat(plugin-tech-radar): map description in API RadarEntry to Entry

### DIFF
--- a/.changeset/clean-points-glow.md
+++ b/.changeset/clean-points-glow.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-tech-radar': minor
+'@backstage/plugin-tech-radar': patch
 ---
 
 Map description in API RadarEntry to Entry

--- a/.changeset/clean-points-glow.md
+++ b/.changeset/clean-points-glow.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-tech-radar': minor
+---
+
+Map description in API RadarEntry to Entry
+
+The description in the Entry was mapped to the latest timeline entry, which is a changelog. This
+change maps the description in the API to the entry. To maintain backwards compatibility it
+will set the description to the last timeline entry if no description exists at the entry level.

--- a/plugins/tech-radar/src/api.ts
+++ b/plugins/tech-radar/src/api.ts
@@ -38,6 +38,7 @@ export interface RadarEntry {
   title: string;
   url: string;
   timeline: Array<RadarEntrySnapshot>;
+  description?: string;
 }
 
 export interface RadarEntrySnapshot {

--- a/plugins/tech-radar/src/components/RadarComponent.tsx
+++ b/plugins/tech-radar/src/components/RadarComponent.tsx
@@ -68,7 +68,7 @@ const RadarComponent = (props: TechRadarComponentProps): JSX.Element => {
           };
         }),
         moved: entry.timeline[0].moved,
-        description: entry.timeline[0].description,
+        description: entry.description || entry.timeline[0].description,
         url: entry.url,
       };
     });

--- a/plugins/tech-radar/src/sampleData.ts
+++ b/plugins/tech-radar/src/sampleData.ts
@@ -49,6 +49,8 @@ entries.push({
   id: 'javascript',
   title: 'JavaScript',
   quadrant: 'languages',
+  description:
+    'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
 });
 entries.push({
   timeline: [
@@ -65,6 +67,8 @@ entries.push({
   id: 'typescript',
   title: 'TypeScript',
   quadrant: 'languages',
+  description:
+    'Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat',
 });
 entries.push({
   timeline: [


### PR DESCRIPTION
The description in the Entry was mapped to the latest timeline entry, which is a changelog. This
change maps the description in the API to the entry. To maintain backwards compatibility it
will set the description to the last timeline entry if no description exists at the entry level.


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
