### PR TITLE
core-api: remove duplicate element check during traversal

### DIFF
--- a/.changeset/cold-birds-attack.md
+++ b/.changeset/cold-birds-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-api': patch
+---
+
+Allow elements to be used multiple times in the app element tree.

--- a/packages/core-api/src/extensions/traversal.ts
+++ b/packages/core-api/src/extensions/traversal.ts
@@ -37,7 +37,6 @@ export function traverseElementTree<Results>(options: {
   discoverers: Discoverer[];
   collectors: { [name in keyof Results]: Collector<Results[name], any> };
 }): Results {
-  const visited = new Set();
   const collectors: {
     [name in string]: ReturnType<Collector<any, any>>;
   } = {};
@@ -74,14 +73,6 @@ export function traverseElementTree<Results>(options: {
       if (!isValidElement(element)) {
         return;
       }
-      if (visited.has(element)) {
-        const anyType = element?.type as
-          | { displayName?: string; name?: string }
-          | undefined;
-        const name = anyType?.displayName || anyType?.name || String(anyType);
-        throw new Error(`Visited element ${name} twice`);
-      }
-      visited.add(element);
 
       const nextContexts: QueueItem['contexts'] = {};
 

--- a/packages/core-api/src/routing/collectors.test.tsx
+++ b/packages/core-api/src/routing/collectors.test.tsx
@@ -353,24 +353,4 @@ describe('discovery', () => {
       });
     }).toThrow('Mounted routable extension must have a path');
   });
-
-  it('should not visit the same element twice', () => {
-    const element = <Extension3 path="/baz" />;
-
-    expect(() =>
-      traverseElementTree({
-        root: (
-          <MemoryRouter>
-            <Extension1 path="/foo">{element}</Extension1>
-            <Extension2 path="/bar">{element}</Extension2>
-          </MemoryRouter>
-        ),
-        discoverers: [childDiscoverer, routeElementDiscoverer],
-        collectors: {
-          routes: routePathCollector,
-          routeParents: routeParentCollector,
-        },
-      }),
-    ).toThrow(`Visited element Extension(Component) twice`);
-  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The attempted check here is to make sure the app element tree traversal doesn't end up in an infinite loop, but it also prevents the pattern where elements are stored in variables and re-used in multiple places. Loop check is also probably silly because React wouldn't like that either 😅 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
