### PR TITLE
Introduce `useRouteRefParams` to `core-api` to retrieve typed route params

### DIFF
--- a/.changeset/curvy-peaches-applaud.md
+++ b/.changeset/curvy-peaches-applaud.md
@@ -1,0 +1,8 @@
+---
+'@backstage/core-api': patch
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-github-actions': patch
+'@backstage/plugin-jenkins': patch
+---
+
+Introduce `useRouteRefParams` to `core-api` to retrieve typed route parameters.

--- a/packages/core-api/src/routing/hooks.tsx
+++ b/packages/core-api/src/routing/hooks.tsx
@@ -21,7 +21,7 @@ import React, {
   useMemo,
   Context,
 } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import {
   BackstageRouteObject,
   RouteRef,
@@ -111,3 +111,9 @@ export const RoutingProvider = ({
     </RoutingContext.Provider>
   );
 };
+
+export function useRouteRefParams<Params extends AnyParams>(
+  _routeRef: RouteRef<Params> | SubRouteRef<Params>,
+): Params {
+  return useParams() as Params;
+}

--- a/packages/core-api/src/routing/index.ts
+++ b/packages/core-api/src/routing/index.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
+export { createExternalRouteRef } from './ExternalRouteRef';
+export { FlatRoutes } from './FlatRoutes';
+export { useRouteRef, useRouteRefParams } from './hooks';
+export { createRouteRef } from './RouteRef';
+export type { RouteRefConfig } from './RouteRef';
+export { createSubRouteRef } from './SubRouteRef';
 export type {
-  RouteRef,
-  SubRouteRef,
   AbsoluteRouteRef,
   ConcreteRoute,
-  MutableRouteRef,
   ExternalRouteRef,
+  MutableRouteRef,
+  RouteRef,
+  SubRouteRef,
 } from './types';
-export { FlatRoutes } from './FlatRoutes';
-export { createRouteRef } from './RouteRef';
-export { createSubRouteRef } from './SubRouteRef';
-export { createExternalRouteRef } from './ExternalRouteRef';
-export type { RouteRefConfig } from './RouteRef';
-export { useRouteRef } from './hooks';

--- a/plugins/catalog-react/src/hooks/useEntityCompoundName.ts
+++ b/plugins/catalog-react/src/hooks/useEntityCompoundName.ts
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useParams } from 'react-router';
+import { useRouteRefParams } from '@backstage/core';
+import { entityRouteRef } from '../routes';
 
 /**
  * Grabs entity kind, namespace, and name from the location
  */
 export const useEntityCompoundName = () => {
-  const { kind, namespace, name } = useParams();
+  const { kind, namespace, name } = useRouteRefParams(entityRouteRef);
   return { kind, namespace, name };
 };

--- a/plugins/github-actions/src/components/WorkflowRunDetails/useWorkflowRunsDetails.ts
+++ b/plugins/github-actions/src/components/WorkflowRunDetails/useWorkflowRunsDetails.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useApi } from '@backstage/core';
-import { useParams } from 'react-router-dom';
+import { useApi, useRouteRefParams } from '@backstage/core';
 import { useAsync } from 'react-use';
 import { githubActionsApiRef } from '../../api';
+import { buildRouteRef } from '../../plugin';
 
 export const useWorkflowRunsDetails = ({
   hostname,
@@ -28,7 +28,7 @@ export const useWorkflowRunsDetails = ({
   repo: string;
 }) => {
   const api = useApi(githubActionsApiRef);
-  const { id } = useParams();
+  const { id } = useRouteRefParams(buildRouteRef);
   const details = useAsync(async () => {
     return repo && owner
       ? api.getWorkflowRun({

--- a/plugins/github-actions/src/plugin.ts
+++ b/plugins/github-actions/src/plugin.ts
@@ -33,6 +33,7 @@ export const rootRouteRef = createRouteRef({
 
 export const buildRouteRef = createRouteRef({
   path: ':id',
+  params: ['id'],
   title: 'GitHub Actions Workflow Run',
 });
 

--- a/plugins/jenkins/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
+++ b/plugins/jenkins/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
@@ -13,25 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { useParams } from 'react-router-dom';
-import { Breadcrumbs, Content, Link } from '@backstage/core';
+import { Breadcrumbs, Content, Link, useRouteRefParams } from '@backstage/core';
 import {
   Box,
-  Typography,
-  Paper,
-  TableContainer,
-  Table,
-  TableRow,
-  TableCell,
-  TableBody,
   Link as MaterialLink,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
+import ExternalLinkIcon from '@material-ui/icons/Launch';
+import React from 'react';
+import { buildRouteRef } from '../../plugin';
+import { JenkinsRunStatus } from '../BuildsPage/lib/Status';
 import { useBuildWithSteps } from '../useBuildWithSteps';
 import { useProjectSlugFromEntity } from '../useProjectSlugFromEntity';
-import { JenkinsRunStatus } from '../BuildsPage/lib/Status';
-import ExternalLinkIcon from '@material-ui/icons/Launch';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -48,7 +48,7 @@ const useStyles = makeStyles(theme => ({
 
 const BuildWithStepsView = () => {
   const projectName = useProjectSlugFromEntity();
-  const { branch, buildNumber } = useParams();
+  const { branch, buildNumber } = useRouteRefParams(buildRouteRef);
   const classes = useStyles();
   const buildPath = `${projectName}/${branch}/${buildNumber}`;
   const [{ value }] = useBuildWithSteps(buildPath);

--- a/plugins/jenkins/src/plugin.ts
+++ b/plugins/jenkins/src/plugin.ts
@@ -15,14 +15,14 @@
  */
 
 import {
-  createPlugin,
-  createRouteRef,
   createApiFactory,
-  discoveryApiRef,
-  createRoutableExtension,
   createComponentExtension,
+  createPlugin,
+  createRoutableExtension,
+  createRouteRef,
+  discoveryApiRef,
 } from '@backstage/core';
-import { jenkinsApiRef, JenkinsApi } from './api';
+import { JenkinsApi, jenkinsApiRef } from './api';
 
 export const rootRouteRef = createRouteRef({
   path: '',
@@ -31,6 +31,7 @@ export const rootRouteRef = createRouteRef({
 
 export const buildRouteRef = createRouteRef({
   path: 'run/:branch/:buildNumber',
+  params: ['branch', 'buildNumber'],
   title: 'Jenkins run',
 });
 


### PR DESCRIPTION
This PR is RFC. With react-router one is using `useParams` to access parameters in an URL. This PR introduce `useRouteRefParams` which gets a `RouteRef` passed to derive the available parameters in a route to provide static typing. This can be used whenever routes with parameters are used. First I tried to replace all existing places of useParams, but this won't work yet as most plugins aren't using the new `RouteRef`s yet.



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
