### PR TITLE
feat: allow custom directory to be specified for github publish action

### DIFF
--- a/.changeset/bright-lions-camp.md
+++ b/.changeset/bright-lions-camp.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Allow custom directory to be specified for github publish action
+Allow custom directory to be specified for GitHub publish action

--- a/.changeset/bright-lions-camp.md
+++ b/.changeset/bright-lions-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Allow custom directory to be specified for github publish action

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
@@ -19,7 +19,7 @@ import { ScmIntegrationRegistry } from '@backstage/integration';
 import { initRepoAndPush } from '../../../stages/publish/helpers';
 import { GitRepositoryCreateOptions } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { getPersonalAccessTokenHandler, WebApi } from 'azure-devops-node-api';
-import { parseRepoUrl } from './util';
+import { getRepoSourceDirectory, parseRepoUrl } from './util';
 import { createTemplateAction } from '../../createTemplateAction';
 
 export function createPublishAzureAction(options: {
@@ -30,6 +30,7 @@ export function createPublishAzureAction(options: {
   return createTemplateAction<{
     repoUrl: string;
     description?: string;
+    sourcePath?: string;
   }>({
     id: 'publish:azure',
     description:
@@ -45,6 +46,11 @@ export function createPublishAzureAction(options: {
           },
           description: {
             title: 'Repository Description',
+            type: 'string',
+          },
+          sourcePath: {
+            title:
+              'Path within the workspace that will be used as the repository root. If omitted, the entire workspace will be published as the respository.',
             type: 'string',
           },
         },
@@ -112,7 +118,7 @@ export function createPublishAzureAction(options: {
       const repoContentsUrl = remoteUrl;
 
       await initRepoAndPush({
-        dir: ctx.workspacePath,
+        dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
         remoteUrl,
         auth: {
           username: 'notempty',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
@@ -20,7 +20,7 @@ import {
   ScmIntegrationRegistry,
 } from '@backstage/integration';
 import { initRepoAndPush } from '../../../stages/publish/helpers';
-import { parseRepoUrl } from './util';
+import { getRepoSourceDirectory, parseRepoUrl } from './util';
 import fetch from 'cross-fetch';
 import { createTemplateAction } from '../../createTemplateAction';
 
@@ -165,6 +165,7 @@ export function createPublishBitbucketAction(options: {
     repoUrl: string;
     description: string;
     repoVisibility: 'private' | 'public';
+    sourcePath?: string;
   }>({
     id: 'publish:bitbucket',
     description:
@@ -186,6 +187,11 @@ export function createPublishBitbucketAction(options: {
             title: 'Repository Visiblity',
             type: 'string',
             enum: ['private', 'public'],
+          },
+          sourcePath: {
+            title:
+              'Path within the workspace that will be used as the repository root. If omitted, the entire workspace will be published as the respository.',
+            type: 'string',
           },
         },
       },
@@ -233,7 +239,7 @@ export function createPublishBitbucketAction(options: {
       });
 
       await initRepoAndPush({
-        dir: ctx.workspacePath,
+        dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
         remoteUrl,
         auth: {
           username: integrationConfig.config.username

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -40,7 +40,7 @@ export function createPublishGithubAction(options: {
     repoUrl: string;
     description?: string;
     access?: string;
-    repoPath?: string;
+    sourcePath?: string;
     repoVisibility: 'private' | 'internal' | 'public';
   }>({
     id: 'publish:github',
@@ -68,7 +68,7 @@ export function createPublishGithubAction(options: {
             type: 'string',
             enum: ['private', 'public', 'internal'],
           },
-          repoPath: {
+          sourcePath: {
             title: 'Repository Path',
             type: 'string',
           },
@@ -163,8 +163,8 @@ export function createPublishGithubAction(options: {
 
       const remoteUrl = data.clone_url;
       const repoContentsUrl = `${data.html_url}/blob/master`;
-      const outputPath = ctx.input.repoPath
-        ? resolvePath(ctx.workspacePath, ctx.input.repoPath)
+      const outputPath = ctx.input.sourcePath
+        ? resolvePath(ctx.workspacePath, ctx.input.sourcePath)
         : ctx.workspacePath;
 
       await initRepoAndPush({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { resolve as resolvePath } from 'path';
 import { InputError } from '@backstage/errors';
 import {
   GithubCredentialsProvider,
@@ -40,6 +40,7 @@ export function createPublishGithubAction(options: {
     repoUrl: string;
     description?: string;
     access?: string;
+    repoPath?: string;
     repoVisibility: 'private' | 'internal' | 'public';
   }>({
     id: 'publish:github',
@@ -66,6 +67,10 @@ export function createPublishGithubAction(options: {
             title: 'Repository Visiblity',
             type: 'string',
             enum: ['private', 'public', 'internal'],
+          },
+          repoPath: {
+            title: 'Repository Path',
+            type: 'string',
           },
         },
       },
@@ -158,9 +163,12 @@ export function createPublishGithubAction(options: {
 
       const remoteUrl = data.clone_url;
       const repoContentsUrl = `${data.html_url}/blob/master`;
+      const outputPath = ctx.input.repoPath
+        ? resolvePath(ctx.workspacePath, ctx.input.repoPath)
+        : ctx.workspacePath;
 
       await initRepoAndPush({
-        dir: ctx.workspacePath,
+        dir: outputPath,
         remoteUrl,
         auth: {
           username: 'x-access-token',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -18,7 +18,7 @@ import { InputError } from '@backstage/errors';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { Gitlab } from '@gitbeaker/node';
 import { initRepoAndPush } from '../../../stages/publish/helpers';
-import { parseRepoUrl } from './util';
+import { getRepoSourceDirectory, parseRepoUrl } from './util';
 import { createTemplateAction } from '../../createTemplateAction';
 
 export function createPublishGitlabAction(options: {
@@ -29,6 +29,7 @@ export function createPublishGitlabAction(options: {
   return createTemplateAction<{
     repoUrl: string;
     repoVisibility: 'private' | 'internal' | 'public';
+    sourcePath?: string;
   }>({
     id: 'publish:gitlab',
     description:
@@ -46,6 +47,11 @@ export function createPublishGitlabAction(options: {
             title: 'Repository Visiblity',
             type: 'string',
             enum: ['private', 'public', 'internal'],
+          },
+          sourcePath: {
+            title:
+              'Path within the workspace that will be used as the repository root. If omitted, the entire workspace will be published as the respository.',
+            type: 'string',
           },
         },
       },
@@ -106,7 +112,7 @@ export function createPublishGitlabAction(options: {
       const repoContentsUrl = `${remoteUrl}/-/blob/master`;
 
       await initRepoAndPush({
-        dir: ctx.workspacePath,
+        dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
         remoteUrl: http_url_to_repo as string,
         auth: {
           username: 'oauth2',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.ts
@@ -15,6 +15,21 @@
  */
 
 import { InputError } from '@backstage/errors';
+import { join as joinPath, normalize as normalizePath } from 'path';
+
+export const getRepoSourceDirectory = (
+  workspacePath: string,
+  sourcePath: string | undefined,
+) => {
+  if (sourcePath) {
+    const safeSuffix = normalizePath(sourcePath).replace(
+      /^(\.\.(\/|\\|$))+/,
+      '',
+    );
+    return joinPath(workspacePath, safeSuffix);
+  }
+  return workspacePath;
+};
 
 export const parseRepoUrl = (repoUrl: string) => {
   let parsed;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Allows custom directory to be specified for the GitHub publish task. This is useful if you have a Template that is generating/scaffolding multiple templates and pushing them to separate repositories. 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
