### PR TITLE
Jenkins: enable integration with multiple instances, based on the path defined in the catalog entity

### DIFF
--- a/.changeset/shiny-berries-cheer.md
+++ b/.changeset/shiny-berries-cheer.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-jenkins': patch
 ---
 
-allow proxying to different jenkins instances based on `backstage.io/jenkins-proxy-path` annotation in `catalog-info.yaml` of a given entity
+allow proxying to different Jenkins instances based on `backstage.io/jenkins-proxy-path` annotation in `catalog-info.yaml` of a given entity

--- a/.changeset/shiny-berries-cheer.md
+++ b/.changeset/shiny-berries-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins': patch
+---
+
+allow proxying to different jenkins instances based on `backstage.io/jenkins-proxy-path` annotation in `catalog-info.yaml` of a given entity

--- a/plugins/jenkins/src/api/JenkinsApi.ts
+++ b/plugins/jenkins/src/api/JenkinsApi.ts
@@ -39,8 +39,8 @@ type EntityOptions = {
    * Path to use for requests via the proxy from the entity catalog entry
    * defined by annotation: `backstage.io/jenkins-proxy-path`
    */
-   proxyPath?: string;
-}
+  proxyPath?: string;
+};
 
 export class JenkinsApi {
   private readonly discoveryApi: DiscoveryApi;
@@ -199,8 +199,8 @@ export class JenkinsApi {
   mapJenkinsBuildToCITable(
     jenkinsResult: any,
     jobScmInfo?: any,
-    options?: EntityOptions    
-    ): CITableBuildInfo {
+    options?: EntityOptions,
+  ): CITableBuildInfo {
     const source =
       jenkinsResult.actions
         .filter(

--- a/plugins/jenkins/src/components/useProxyPathFromEntity.ts
+++ b/plugins/jenkins/src/components/useProxyPathFromEntity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Spotify AB
+ * Copyright 2021 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,5 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const JENKINS_ANNOTATION = 'jenkins.io/github-folder';
-export const JENKINS_PROXYPATH_ANNOTATION = 'backstage.io/jenkins-proxy-path';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { JENKINS_PROXYPATH_ANNOTATION } from '../constants';
+
+export const useProxyPathFromEntity = () => {
+  const { entity } = useEntity();
+
+  return entity.metadata.annotations?.[JENKINS_PROXYPATH_ANNOTATION] ?? '';
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Different catalog entities *may* be built in different `jenkins` instances.
It will be great to be able to choose a particular `jenkins` instance to scrape based on where the component is built.
The component could refer to the `jenkins` path in its `catalog-info.yaml`.

Potential annotations for 2 components in their respective `catalog-info.yaml`:
component 1:
```yaml
metadata:
  annotations:
    jenkins.io/github-folder: 'org1/job1'
    backstage.io/jenkins-proxy-path: '/jenkins/instance1'
```

component 2:
```yaml
metadata:
  annotations:
    jenkins.io/github-folder: 'org2/job1'
    backstage.io/jenkins-proxy-path: '/jenkins/instance2'
```

corresponding `app-config.yaml`:
```yaml
proxy:
  '/jenkins/instance1':
    target: 'https://instance1.blah'
    headers:
      Authorization:
        $env: JENKINS_INSTANCE1_BASICAUTH_HEADER
  '/jenkins/instance2':
    target: 'https://instance2.blah'
    headers:
      Authorization:
        $env: JENKINS_INSTANCE2_BASICAUTH_HEADER
```

Similar change in `@roadiehq/backstage-plugin-argo-cd`: https://github.com/RoadieHQ/backstage-plugin-argo-cd/pull/27/files

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
