### PR TITLE
techdocs: reset scroll position on page navigate

### DIFF
--- a/.changeset/slimy-lies-tap.md
+++ b/.changeset/slimy-lies-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+TechDocs: links at sidebar and bottom reset scroll position to top

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -113,6 +113,7 @@ export const Reader = ({ entityId, onReady }: Props) => {
       addLinkClickListener({
         baseUrl: window.location.origin,
         onClick: (_: MouseEvent, url: string) => {
+          window.scroll({ top: 0 });
           const parsedUrl = new URL(url);
           if (parsedUrl.hash) {
             history.pushState(


### PR DESCRIPTION
Signed-off-by: Chongyang Adrian, Ke <ftt.adrian.ke@grabtaxi.com>

## Hey, I just made a Pull Request!

Bug:
  Expected behavior: clicking on navigation link in TechDocs reader goes to selected documentation page and resets screen position to the top.
  Current behavior: Screen position stays the same relative to before the click, i.e. no change in vertical scroll position
Fix:
  Reader page now resets to top on click on navigation links to another page within the documentation set.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ :heavy_check_mark:] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ NA ] Added or updated documentation
- [ NA ] Tests for new functionality and regression tests for bug fixes
- [ NA ] Screenshots attached (for UI changes)
- [ :heavy_check_mark: ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
