### PR TITLE
feat(errors): Reuse ResponseErrorList for non ResponseErrors

### DIFF
--- a/.changeset/shy-owls-grab.md
+++ b/.changeset/shy-owls-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Reuse ResponseErrorList for non ResponseErrors

--- a/packages/core/src/components/ResponseErrorPanel/ResponseErrorPanel.tsx
+++ b/packages/core/src/components/ResponseErrorPanel/ResponseErrorPanel.tsx
@@ -39,6 +39,78 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+type ResponseErrorListProps = {
+  error: string;
+  message: string;
+  request?: string;
+  stack?: string;
+  json?: string;
+};
+
+const ResponseErrorList = ({
+  error,
+  request,
+  message,
+  stack,
+  json,
+}: ResponseErrorListProps) => {
+  const classes = useStyles();
+
+  return (
+    <List dense>
+      <ListItem alignItems="flex-start">
+        <ListItemText
+          classes={{ secondary: classes.text }}
+          primary="Error"
+          secondary={error}
+        />
+        <CopyTextButton text={error} />
+      </ListItem>
+      <ListItem alignItems="flex-start">
+        <ListItemText
+          classes={{ secondary: classes.text }}
+          primary="Message"
+          secondary={message}
+        />
+        <CopyTextButton text={message} />
+      </ListItem>
+      {request && (
+        <ListItem alignItems="flex-start">
+          <ListItemText
+            classes={{ secondary: classes.text }}
+            primary="Request"
+            secondary={request}
+          />
+          <CopyTextButton text={request} />
+        </ListItem>
+      )}
+      {stack && (
+        <ListItem alignItems="flex-start">
+          <ListItemText
+            classes={{ secondary: classes.text }}
+            primary="Stack Trace"
+            secondary={stack}
+          />
+          <CopyTextButton text={stack} />
+        </ListItem>
+      )}
+      {json && (
+        <>
+          <Divider component="li" className={classes.divider} />
+          <ListItem alignItems="flex-start">
+            <ListItemText
+              classes={{ secondary: classes.text }}
+              primary="Full Error as JSON"
+              secondary={<CodeSnippet language="json" text={json} />}
+            />
+            <CopyTextButton text={json} />
+          </ListItem>
+        </>
+      )}
+    </List>
+  );
+};
+
 type Props = {
   error: Error;
 };
@@ -50,13 +122,13 @@ type Props = {
  * server-provided information about what happened.
  */
 export const ResponseErrorDetails = ({ error }: Props) => {
-  const classes = useStyles();
-
   if (error.name !== 'ResponseError') {
     return (
-      <List dense>
-        <ListItemText primary="Message" secondary={error.message} />
-      </List>
+      <ResponseErrorList
+        error={error.name}
+        message={error.message}
+        stack={error.stack}
+      />
     );
   }
 
@@ -70,53 +142,13 @@ export const ResponseErrorDetails = ({ error }: Props) => {
   const jsonString = JSON.stringify(data, undefined, 2);
 
   return (
-    <List dense>
-      <ListItem alignItems="flex-start">
-        <ListItemText
-          classes={{ secondary: classes.text }}
-          primary="Error"
-          secondary={errorString}
-        />
-        <CopyTextButton text={errorString} />
-      </ListItem>
-      <ListItem alignItems="flex-start">
-        <ListItemText
-          classes={{ secondary: classes.text }}
-          primary="Message"
-          secondary={messageString}
-        />
-        <CopyTextButton text={messageString} />
-      </ListItem>
-      {requestString && (
-        <ListItem alignItems="flex-start">
-          <ListItemText
-            classes={{ secondary: classes.text }}
-            primary="Request"
-            secondary={requestString}
-          />
-          <CopyTextButton text={requestString} />
-        </ListItem>
-      )}
-      {stackString && (
-        <ListItem alignItems="flex-start">
-          <ListItemText
-            classes={{ secondary: classes.text }}
-            primary="Stack Trace"
-            secondary={stackString}
-          />
-          <CopyTextButton text={stackString} />
-        </ListItem>
-      )}
-      <Divider component="li" className={classes.divider} />
-      <ListItem alignItems="flex-start">
-        <ListItemText
-          classes={{ secondary: classes.text }}
-          primary="Full Error as JSON"
-          secondary={<CodeSnippet language="json" text={jsonString} />}
-        />
-        <CopyTextButton text={jsonString} />
-      </ListItem>
-    </List>
+    <ResponseErrorList
+      error={errorString}
+      message={messageString}
+      request={requestString}
+      stack={stackString}
+      json={jsonString}
+    />
   );
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Basically, makes the error component display the same information even if it's not a ResponseError.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
