### PR TITLE
Fix scaffolder backend bug with visibility for github org

### DIFF
--- a/.changeset/blue-sheep-act.md
+++ b/.changeset/blue-sheep-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Update visibility for create in repo function

--- a/.changeset/blue-sheep-act.md
+++ b/.changeset/blue-sheep-act.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Update visibility for create in repo function
+Fixes bug in the `github:publish` action causing repositories to be set as private even if the visibility is set to internal

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -126,7 +126,7 @@ export function createPublishGithubAction(options: {
           ? client.repos.createInOrg({
               name: repo,
               org: owner,
-              private: repoVisibility !== 'public',
+              private: repoVisibility === 'private',
               visibility: repoVisibility,
               description: description,
             })


### PR DESCRIPTION
Signed-off-by: ebarrios <esteban.barrios@trivago.com>

## Hey, I just made a Pull Request!

This fixed a bug on the repo creation for create in org. Based on #5007 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
