### PR TITLE
Fix custom-actions source link

### DIFF
--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -57,7 +57,7 @@ export const createNewFileAction = () => {
 So let's break this down. The `createNewFileAction` is a function that returns a
 `createTemplateAction`, and it's a good place to pass in dependencies which
 close over the `TemplateAction`. Take a look at our
-[built-in actions](https://github.com/backstage/backstage/blob/7f5716081f45a41dc8a4246134b50c893e15c5e1/../plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts)
+[built-in actions](https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/src/scaffolder/actions/builtin)
 for reference.
 
 We set the type generic to `{ contents: string, filename: string}` which is


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

This source link was hitting a 404; updated to `master` and to link to the builtin actions folder more generically.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
