### PR TITLE
Add readonly mode to catalog-backend

### DIFF
--- a/.changeset/rich-birds-reply.md
+++ b/.changeset/rich-birds-reply.md
@@ -1,14 +1,13 @@
 ---
-'example-backend': minor
 '@backstage/plugin-catalog-backend': minor
 ---
 
 Add `readonly` mode to catalog backend
 
-This change adds a `catalog.mode` field in `app-config.yaml` that can be used to configure the catalog in readonly mode which effectively disables the possibility of adding new components to the catalog after startup.
+This change adds a `catalog.readonly` field in `app-config.yaml` that can be used to configure the catalog in readonly mode which effectively disables the possibility of adding new components to the catalog after startup.
 
 When in `readonly` mode only locations configured in `catalog.locations` are loaded and served.
-By default the mode is `readwrite` which represents the current functionality where locations can be added at run-time.
+By default `readonly` is disabled which represents the current functionality where locations can be added at run-time.
 
 This change requires the config API in the router which requires a change to `createRouter`.
 

--- a/.changeset/rich-birds-reply.md
+++ b/.changeset/rich-birds-reply.md
@@ -5,7 +5,7 @@
 
 Add `readonly` mode to catalog backend
 
-This change adds a `catalog.mode` field in `app-config.yaml` that can be used to configure the catalog in readonly mode which effectively disables the possibilty of adding new components to the catalog after startup.
+This change adds a `catalog.mode` field in `app-config.yaml` that can be used to configure the catalog in readonly mode which effectively disables the possibility of adding new components to the catalog after startup.
 
 When in `readonly` mode only locations configured in `catalog.locations` are loaded and served.
 By default the mode is `readwrite` which represents the current functionality where locations can be added at run-time.

--- a/.changeset/rich-birds-reply.md
+++ b/.changeset/rich-birds-reply.md
@@ -1,0 +1,24 @@
+---
+'example-backend': minor
+'@backstage/plugin-catalog-backend': minor
+---
+
+Add `readonly` mode to catalog backend
+
+This change adds a `catalog.mode` field in `app-config.yaml` that can be used to configure the catalog in readonly mode which effectively disables the possibilty of adding new components to the catalog after startup.
+
+When in `readonly` mode only locations configured in `catalog.locations` are loaded and served.
+By default the mode is `readwrite` which represents the current functionality where locations can be added at run-time.
+
+This change requires the config API in the router which requires a change to `createRouter`.
+
+```diff
+   return await createRouter({
+     entitiesCatalog,
+     locationsCatalog,
+     higherOrderOperation,
+     locationAnalyzer,
+     logger: env.logger,
++    config: env.config,
+   });
+```

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -70,6 +70,7 @@ Protobuf
 Proxying
 Raghunandan
 Readme
+readonly
 rebase
 Recharts
 Redash

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -45,5 +45,6 @@ export default async function createPlugin(
     higherOrderOperation,
     locationAnalyzer,
     logger: env.logger,
+    config: env.config,
   });
 }

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/catalog.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/catalog.ts
@@ -27,5 +27,6 @@ export default async function createPlugin(env: PluginEnvironment): Promise<Rout
     higherOrderOperation,
     locationAnalyzer,
     logger: env.logger,
+    config: env.config,
   });
 }

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -16,8 +16,6 @@
 
 import { JsonValue } from '@backstage/config';
 
-export type Mode = 'readonly' | 'readwrite';
-
 export interface Config {
   /**
    * Configuration options for the catalog plugin.
@@ -45,18 +43,18 @@ export interface Config {
     }>;
 
     /**
-     * Mode defines the overall behaviour mode of the catalog.
+     * Readonly defines whether the catalog allows writes after startup.
      *
-     * Setting the mode to 'readwrite' you allow users to register their own
-     * components. This is the default value.
+     * Setting 'readonly=false' allows users to register their own components.
+     * This is the default value.
      *
-     * Setting the mode to 'readonly' configures catalog to only allow reads.
-     * This can be used in combination with static locations to only serve
-     * operator provided locations. Effectively this removes the ability to
-     * register new components to a running backstage instance.
+     * Setting 'readonly=true' configures catalog to only allow reads. This can
+     * be used in combination with static locations to only serve operator
+     * provided locations. Effectively this removes the ability to register new
+     * components to a running backstage instance.
      *
      */
-    mode?: Mode;
+    readonly?: boolean;
 
     /**
      * A set of static locations that the catalog shall always keep itself

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -16,6 +16,8 @@
 
 import { JsonValue } from '@backstage/config';
 
+export type Mode = 'readonly' | 'readwrite';
+
 export interface Config {
   /**
    * Configuration options for the catalog plugin.
@@ -41,6 +43,20 @@ export interface Config {
        */
       allow: Array<string>;
     }>;
+
+    /**
+     * Mode defines the overall behaviour mode of the catalog.
+     *
+     * Setting the mode to 'readwrite' you allow users to register their own
+     * components. This is the default value.
+     *
+     * Setting the mode to 'readonly' configures catalog to only allow reads.
+     * This can be used in combination with static locations to only serve
+     * operator provided locations. Effectively this removes the ability to
+     * register new components to a running backstage instance.
+     *
+     */
+    mode?: Mode;
 
     /**
      * A set of static locations that the catalog shall always keep itself

--- a/plugins/catalog-backend/src/service/router.test.ts
+++ b/plugins/catalog-backend/src/service/router.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
 import { NotFoundError } from '@backstage/errors';
 import type { Entity, LocationSpec } from '@backstage/catalog-model';
 import express from 'express';
@@ -25,7 +26,7 @@ import { HigherOrderOperation } from '../ingestion/types';
 import { createRouter } from './router';
 import { basicEntityFilter } from './request';
 
-describe('createRouter', () => {
+describe('createRouter readwrite mode', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
   let locationsCatalog: jest.Mocked<LocationsCatalog>;
   let higherOrderOperation: jest.Mocked<HigherOrderOperation>;
@@ -55,6 +56,7 @@ describe('createRouter', () => {
       locationsCatalog,
       higherOrderOperation,
       logger: getVoidLogger(),
+      config: new ConfigReader(undefined),
     });
     app = express().use(router);
   });
@@ -323,6 +325,158 @@ describe('createRouter', () => {
           location: { id: 'a', ...spec },
         }),
       );
+    });
+
+    it('supports dry run', async () => {
+      const spec: LocationSpec = {
+        type: 'b',
+        target: 'c',
+      };
+
+      higherOrderOperation.addLocation.mockResolvedValue({
+        location: { id: 'a', ...spec },
+        entities: [],
+      });
+
+      const response = await request(app)
+        .post('/locations?dryRun=true')
+        .send(spec);
+
+      expect(higherOrderOperation.addLocation).toHaveBeenCalledTimes(1);
+      expect(higherOrderOperation.addLocation).toHaveBeenCalledWith(spec, {
+        dryRun: true,
+      });
+      expect(response.status).toEqual(201);
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          location: { id: 'a', ...spec },
+        }),
+      );
+    });
+  });
+});
+
+describe('createRouter readonly mode', () => {
+  let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
+  let locationsCatalog: jest.Mocked<LocationsCatalog>;
+  let higherOrderOperation: jest.Mocked<HigherOrderOperation>;
+  let app: express.Express;
+
+  beforeAll(async () => {
+    entitiesCatalog = {
+      entities: jest.fn(),
+      removeEntityByUid: jest.fn(),
+      batchAddOrUpdateEntities: jest.fn(),
+    };
+    locationsCatalog = {
+      addLocation: jest.fn(),
+      removeLocation: jest.fn(),
+      locations: jest.fn(),
+      location: jest.fn(),
+      locationHistory: jest.fn(),
+      logUpdateSuccess: jest.fn(),
+      logUpdateFailure: jest.fn(),
+    };
+    higherOrderOperation = {
+      addLocation: jest.fn(),
+      refreshAllLocations: jest.fn(),
+    };
+    const router = await createRouter({
+      entitiesCatalog,
+      locationsCatalog,
+      higherOrderOperation,
+      logger: getVoidLogger(),
+      config: new ConfigReader({
+        catalog: {
+          mode: 'readonly',
+        },
+      }),
+    });
+    app = express().use(router);
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('GET /entities', () => {
+    it('happy path: lists entities', async () => {
+      const entities: Entity[] = [
+        { apiVersion: 'a', kind: 'b', metadata: { name: 'n' } },
+      ];
+
+      entitiesCatalog.entities.mockResolvedValueOnce({
+        entities: [entities[0]],
+        pageInfo: { hasNextPage: false },
+      });
+
+      const response = await request(app).get('/entities');
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(entities);
+    });
+  });
+
+  describe('POST /entities', () => {
+    it('is not allowed', async () => {
+      const entity: Entity = {
+        apiVersion: 'a',
+        kind: 'b',
+        metadata: {
+          name: 'c',
+          namespace: 'd',
+        },
+      };
+
+      const response = await request(app)
+        .post('/entities')
+        .set('Content-Type', 'application/json')
+        .send(entity);
+
+      expect(entitiesCatalog.batchAddOrUpdateEntities).not.toHaveBeenCalled();
+      expect(response.status).toEqual(403);
+      expect(response.text).toMatch(/readwrite/);
+    });
+  });
+
+  describe('DELETE /entities/by-uid/:uid', () => {
+    it('is not allowed', async () => {
+      const response = await request(app).delete('/entities/by-uid/apa');
+
+      expect(response.status).toEqual(403);
+      expect(response.text).toMatch(/readwrite/);
+    });
+  });
+
+  describe('GET /locations', () => {
+    it('happy path: lists locations', async () => {
+      const locations: LocationResponse[] = [
+        {
+          currentStatus: { timestamp: '', status: '', message: '' },
+          data: { id: 'a', type: 'b', target: 'c' },
+        },
+      ];
+      locationsCatalog.locations.mockResolvedValueOnce(locations);
+
+      const response = await request(app).get('/locations');
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(locations);
+    });
+  });
+
+  describe('POST /locations', () => {
+    it('is not allowed', async () => {
+      const spec: LocationSpec = {
+        type: 'b',
+        target: 'c',
+      };
+
+      const response = await request(app).post('/locations').send(spec);
+
+      expect(higherOrderOperation.addLocation).not.toHaveBeenCalled();
+      expect(response.status).toEqual(403);
+      expect(response.text).toMatch(/readwrite/);
     });
 
     it('supports dry run', async () => {

--- a/plugins/catalog-backend/src/service/router.test.ts
+++ b/plugins/catalog-backend/src/service/router.test.ts
@@ -26,7 +26,7 @@ import { HigherOrderOperation } from '../ingestion/types';
 import { createRouter } from './router';
 import { basicEntityFilter } from './request';
 
-describe('createRouter readwrite mode', () => {
+describe('createRouter readonly disabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
   let locationsCatalog: jest.Mocked<LocationsCatalog>;
   let higherOrderOperation: jest.Mocked<HigherOrderOperation>;
@@ -356,7 +356,7 @@ describe('createRouter readwrite mode', () => {
   });
 });
 
-describe('createRouter readonly mode', () => {
+describe('createRouter readonly enabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
   let locationsCatalog: jest.Mocked<LocationsCatalog>;
   let higherOrderOperation: jest.Mocked<HigherOrderOperation>;
@@ -388,7 +388,7 @@ describe('createRouter readonly mode', () => {
       logger: getVoidLogger(),
       config: new ConfigReader({
         catalog: {
-          mode: 'readonly',
+          readonly: true,
         },
       }),
     });
@@ -435,7 +435,7 @@ describe('createRouter readonly mode', () => {
 
       expect(entitiesCatalog.batchAddOrUpdateEntities).not.toHaveBeenCalled();
       expect(response.status).toEqual(403);
-      expect(response.text).toMatch(/readwrite/);
+      expect(response.text).toMatch(/not allowed in readonly/);
     });
   });
 
@@ -444,7 +444,7 @@ describe('createRouter readonly mode', () => {
       const response = await request(app).delete('/entities/by-uid/apa');
 
       expect(response.status).toEqual(403);
-      expect(response.text).toMatch(/readwrite/);
+      expect(response.text).toMatch(/not allowed in readonly/);
     });
   });
 
@@ -476,7 +476,7 @@ describe('createRouter readonly mode', () => {
 
       expect(higherOrderOperation.addLocation).not.toHaveBeenCalled();
       expect(response.status).toEqual(403);
-      expect(response.text).toMatch(/readwrite/);
+      expect(response.text).toMatch(/not allowed in readonly/);
     });
 
     it('supports dry run', async () => {

--- a/plugins/catalog-backend/src/service/router.test.ts
+++ b/plugins/catalog-backend/src/service/router.test.ts
@@ -440,11 +440,13 @@ describe('createRouter readonly enabled', () => {
   });
 
   describe('DELETE /entities/by-uid/:uid', () => {
-    it('is not allowed', async () => {
+    // this delete is allowed as there is no other way to remove entities
+    it('is allowed', async () => {
       const response = await request(app).delete('/entities/by-uid/apa');
 
-      expect(response.status).toEqual(403);
-      expect(response.text).toMatch(/not allowed in readonly/);
+      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
+      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa');
+      expect(response.status).toEqual(204);
     });
   });
 

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -123,8 +123,6 @@ export async function createRouter(
         res.status(200).json(entities[0]);
       })
       .delete('/entities/by-uid/:uid', async (req, res) => {
-        disallowReadonlyMode(readonlyEnabled);
-
         const { uid } = req.params;
         await entitiesCatalog.removeEntityByUid(uid);
         res.status(204).end();

--- a/plugins/catalog-backend/src/service/standaloneServer.ts
+++ b/plugins/catalog-backend/src/service/standaloneServer.ts
@@ -61,6 +61,7 @@ export async function startStandaloneServer(
     locationsCatalog,
     higherOrderOperation,
     logger,
+    config,
   });
   const service = createServiceBuilder(module)
     .enableCors({ origin: 'http://localhost:3000' })

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { InputError } from '@backstage/errors';
+import { InputError, NotAllowedError } from '@backstage/errors';
 import { Request } from 'express';
 import lodash from 'lodash';
 import yup from 'yup';
+import { Mode } from '../../config';
 
 export async function requireRequestBody(req: Request): Promise<unknown> {
   const contentType = req.header('content-type');
@@ -53,4 +54,10 @@ export async function validateRequestBody<T>(
   }
 
   return (body as unknown) as T;
+}
+
+export function requireReadWriteMode(mode: Mode) {
+  if (mode !== 'readwrite') {
+    throw new NotAllowedError('This operation requires readwrite mode');
+  }
 }

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -18,7 +18,6 @@ import { InputError, NotAllowedError } from '@backstage/errors';
 import { Request } from 'express';
 import lodash from 'lodash';
 import yup from 'yup';
-import { Mode } from '../../config';
 
 export async function requireRequestBody(req: Request): Promise<unknown> {
   const contentType = req.header('content-type');
@@ -56,8 +55,8 @@ export async function validateRequestBody<T>(
   return (body as unknown) as T;
 }
 
-export function requireReadWriteMode(mode: Mode) {
-  if (mode !== 'readwrite') {
-    throw new NotAllowedError('This operation requires readwrite mode');
+export function disallowReadonlyMode(readonly: boolean) {
+  if (readonly) {
+    throw new NotAllowedError('This operation not allowed in readonly mode');
   }
 }


### PR DESCRIPTION
This change includes a new `readonly` configuration field for the catalog backend. This gives us the handle to configure catalog into `readonly` mode as discussed in #3348.

The new `catalog.readonly` field configures the catalog as:

- `readonly=false` is the current mode that allows users to register components at startup through `catalog.locations` and with eg. plugin `catalog-import`
- `readonly=true` is the new mode which, for now, disables the mutating `location` APIs

#### Questions

1. Should we make an effort to ensure users cannot use both `readonly` mode and eg. `catalog-import`?
1. Is there any documentation that needs updating as well?

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
