### PR TITLE
fix: forward auth on todo backend requests

### DIFF
--- a/.changeset/quick-falcons-happen.md
+++ b/.changeset/quick-falcons-happen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-todo-backend': patch
+---
+
+Forward authorization on todo backend requests

--- a/plugins/todo-backend/src/service/TodoReaderService.test.ts
+++ b/plugins/todo-backend/src/service/TodoReaderService.test.ts
@@ -89,7 +89,9 @@ describe('TodoReaderService', () => {
       offset: 0,
       limit: 10,
     });
-    expect(catalogClient.getEntityByName).toHaveBeenCalledWith(entityName);
+    expect(catalogClient.getEntityByName).toHaveBeenCalledWith(entityName, {
+      token: undefined,
+    });
   });
 
   it('should list, order, and filter todos', async () => {
@@ -298,7 +300,9 @@ describe('TodoReaderService', () => {
         message: 'Entity not found, Component:default/my-component',
       }),
     );
-    expect(catalogClient.getEntityByName).toHaveBeenCalledWith(entityName);
+    expect(catalogClient.getEntityByName).toHaveBeenCalledWith(entityName, {
+      token: undefined,
+    });
   });
 
   it('should throw if entity does not have a location', async () => {

--- a/plugins/todo-backend/src/service/TodoReaderService.ts
+++ b/plugins/todo-backend/src/service/TodoReaderService.ts
@@ -56,11 +56,17 @@ export class TodoReaderService implements TodoService {
     this.defaultPageSize = options.defaultPageSize ?? DEFAULT_DEFAULT_PAGE_SIZE;
   }
 
-  async listTodos(req: ListTodosRequest): Promise<ListTodosResponse> {
+  async listTodos(
+    req: ListTodosRequest,
+    options?: { token?: string },
+  ): Promise<ListTodosResponse> {
     if (!req.entity) {
       throw new InputError('Entity filter is required to list TODOs');
     }
-    const entity = await this.catalogClient.getEntityByName(req.entity);
+    const token = options?.token;
+    const entity = await this.catalogClient.getEntityByName(req.entity, {
+      token,
+    });
     if (!entity) {
       throw new NotFoundError(
         `Entity not found, ${serializeEntityRef(req.entity)}`,

--- a/plugins/todo-backend/src/service/router.test.ts
+++ b/plugins/todo-backend/src/service/router.test.ts
@@ -69,11 +69,32 @@ describe('createRouter', () => {
       const response = await request(app).get('/v1/todos');
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(mockListBody);
-      expect(mockService.listTodos).toHaveBeenCalledWith({
-        entity: undefined,
-        offset: undefined,
-        limit: undefined,
-      });
+      expect(mockService.listTodos).toHaveBeenCalledWith(
+        {
+          entity: undefined,
+          offset: undefined,
+          limit: undefined,
+        },
+        { token: undefined },
+      );
+    });
+
+    it('forwards auth token', async () => {
+      mockService.listTodos.mockResolvedValueOnce(mockListBody);
+
+      const response = await request(app)
+        .get('/v1/todos')
+        .set('Authorization', 'Bearer secret');
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(mockListBody);
+      expect(mockService.listTodos).toHaveBeenCalledWith(
+        {
+          entity: undefined,
+          offset: undefined,
+          limit: undefined,
+        },
+        { token: 'secret' },
+      );
     });
 
     it('forwards pagination query', async () => {
@@ -82,11 +103,14 @@ describe('createRouter', () => {
       const response = await request(app).get('/v1/todos?offset=5&limit=3');
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(mockListBody);
-      expect(mockService.listTodos).toHaveBeenCalledWith({
-        entity: undefined,
-        offset: 5,
-        limit: 3,
-      });
+      expect(mockService.listTodos).toHaveBeenCalledWith(
+        {
+          entity: undefined,
+          offset: 5,
+          limit: 3,
+        },
+        { token: undefined },
+      );
     });
 
     it('forwards entity query', async () => {
@@ -97,15 +121,18 @@ describe('createRouter', () => {
       );
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(mockListBody);
-      expect(mockService.listTodos).toHaveBeenCalledWith({
-        entity: {
-          name: 'my-component',
-          kind: 'component',
-          namespace: 'default',
+      expect(mockService.listTodos).toHaveBeenCalledWith(
+        {
+          entity: {
+            name: 'my-component',
+            kind: 'component',
+            namespace: 'default',
+          },
+          offset: undefined,
+          limit: undefined,
         },
-        offset: undefined,
-        limit: undefined,
-      });
+        { token: undefined },
+      );
     });
 
     it('rejects invalid queries', async () => {

--- a/plugins/todo-backend/src/service/router.ts
+++ b/plugins/todo-backend/src/service/router.ts
@@ -59,13 +59,18 @@ export async function createRouter(
       }
     }
 
-    const todos = await todoService.listTodos({
-      entity,
-      offset,
-      limit,
-      orderBy,
-      filters,
-    });
+    const todos = await todoService.listTodos(
+      {
+        entity,
+        offset,
+        limit,
+        orderBy,
+        filters,
+      },
+      {
+        token: getBearerToken(req.headers.authorization),
+      },
+    );
     res.json(todos);
   });
 
@@ -156,4 +161,8 @@ export function parseFilterParam<T extends readonly string[]>(
   }
 
   return filters;
+}
+
+function getBearerToken(header?: string): string | undefined {
+  return header?.match(/Bearer\s+(\S+)/i)?.[1];
 }

--- a/plugins/todo-backend/src/service/types.ts
+++ b/plugins/todo-backend/src/service/types.ts
@@ -42,5 +42,8 @@ export type ListTodosResponse = {
 };
 
 export interface TodoService {
-  listTodos(req: ListTodosRequest): Promise<ListTodosResponse>;
+  listTodos(
+    req: ListTodosRequest,
+    options?: { token?: string },
+  ): Promise<ListTodosResponse>;
 }


### PR DESCRIPTION
Signed-off-by: Erik Larsson <erik.larsson@schibsted.com>

## Hey, I just made a Pull Request!

The todo backend does not forward the authorization header from the client when making backend requests to the catalog API, causing a 401 error when requiring api authentication. This PR fixes that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
