### PR TITLE
fix: support auth in badge plugin

### DIFF
--- a/.changeset/eight-files-rhyme.md
+++ b/.changeset/eight-files-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-badges': minor
+'@backstage/plugin-badges-backend': patch
+---
+
+Support auth in badge plugin

--- a/plugins/badges-backend/src/service/router.test.ts
+++ b/plugins/badges-backend/src/service/router.test.ts
@@ -112,11 +112,14 @@ describe('createRouter', () => {
       expect(response.text).toEqual(JSON.stringify([badge], null, 2));
 
       expect(catalog.getEntityByName).toHaveBeenCalledTimes(1);
-      expect(catalog.getEntityByName).toHaveBeenCalledWith({
-        namespace: 'default',
-        kind: 'service',
-        name: 'test',
-      });
+      expect(catalog.getEntityByName).toHaveBeenCalledWith(
+        {
+          namespace: 'default',
+          kind: 'service',
+          name: 'test',
+        },
+        { token: undefined },
+      );
 
       expect(badgeBuilder.getBadges).toHaveBeenCalledTimes(1);
       expect(badgeBuilder.createBadgeJson).toHaveBeenCalledTimes(1);
@@ -148,11 +151,14 @@ describe('createRouter', () => {
       expect(response.body).toEqual(Buffer.from(image));
 
       expect(catalog.getEntityByName).toHaveBeenCalledTimes(1);
-      expect(catalog.getEntityByName).toHaveBeenCalledWith({
-        namespace: 'default',
-        kind: 'service',
-        name: 'test',
-      });
+      expect(catalog.getEntityByName).toHaveBeenCalledWith(
+        {
+          namespace: 'default',
+          kind: 'service',
+          name: 'test',
+        },
+        { token: undefined },
+      );
 
       expect(badgeBuilder.getBadges).toHaveBeenCalledTimes(0);
       expect(badgeBuilder.createBadgeSvg).toHaveBeenCalledTimes(1);

--- a/plugins/badges-backend/src/service/router.ts
+++ b/plugins/badges-backend/src/service/router.ts
@@ -46,7 +46,12 @@ export async function createRouter(
 
   router.get('/entity/:namespace/:kind/:name/badge-specs', async (req, res) => {
     const { namespace, kind, name } = req.params;
-    const entity = await catalog.getEntityByName({ namespace, kind, name });
+    const entity = await catalog.getEntityByName(
+      { namespace, kind, name },
+      {
+        token: getBearerToken(req.headers.authorization),
+      },
+    );
     if (!entity) {
       throw new NotFoundError(
         `No ${kind} entity in ${namespace} named "${name}"`,
@@ -81,7 +86,12 @@ export async function createRouter(
     '/entity/:namespace/:kind/:name/badge/:badgeId',
     async (req, res) => {
       const { namespace, kind, name, badgeId } = req.params;
-      const entity = await catalog.getEntityByName({ namespace, kind, name });
+      const entity = await catalog.getEntityByName(
+        { namespace, kind, name },
+        {
+          token: getBearerToken(req.headers.authorization),
+        },
+      );
       if (!entity) {
         throw new NotFoundError(
           `No ${kind} entity in ${namespace} named "${name}"`,
@@ -133,4 +143,8 @@ async function getBadgeUrl(
 ): Promise<string> {
   const baseUrl = await options.discovery.getExternalBaseUrl('badges');
   return `${baseUrl}/entity/${namespace}/${kind}/${name}/badge/${badgeId}`;
+}
+
+function getBearerToken(header?: string): string | undefined {
+  return header?.match(/Bearer\s+(\S+)/i)?.[1];
 }

--- a/plugins/badges/src/plugin.ts
+++ b/plugins/badges/src/plugin.ts
@@ -18,6 +18,7 @@ import {
   createComponentExtension,
   createPlugin,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core';
 import { badgesApiRef, BadgesClient } from './api';
 
@@ -26,8 +27,9 @@ export const badgesPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: badgesApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new BadgesClient({ discoveryApi }),
+      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
+      factory: ({ discoveryApi, identityApi }) =>
+        new BadgesClient({ discoveryApi, identityApi }),
     }),
   ],
 });


### PR DESCRIPTION
Signed-off-by: Erik Larsson <erik.larsson@schibsted.com>

## Hey, I just made a Pull Request!

The badge plugin does not support authorization of API requests (the client does not send an Authorization header and the backend does not forward said token on backend api requests), causing a 401 error when requiring api authentication. This PR fixes part of that, but the problem persists due to how badges work - see discussion in https://github.com/backstage/backstage/issues/5039.

Might be this PR is still worth it, to standardize backstage api requests?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
