### PR TITLE
scaffolder-backend: add file publisher for local testing

### DIFF
--- a/.changeset/slow-jeans-cheer.md
+++ b/.changeset/slow-jeans-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Added a `publish:file` action to use for local development. The action is not installed by default.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/file.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/file.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import { dirname } from 'path';
+import { InputError } from '@backstage/errors';
+import { createTemplateAction } from '../../createTemplateAction';
+
+/**
+ * This task is useful for local development and testing of both the scaffolder
+ * and scaffolder templates.
+ *
+ * This action is not installed by default and should not be installed in
+ * production, as it writes the files to the local filesystem of the scaffolder.
+ */
+export function createPublishFileAction() {
+  return createTemplateAction<{ path: string }>({
+    id: 'publish:file',
+    description: 'Writes contents of the workspace to a local directory',
+    schema: {
+      input: {
+        type: 'object',
+        required: ['path'],
+        properties: {
+          path: {
+            title: 'Path to a directory where the output will be written',
+            type: 'string',
+          },
+        },
+      },
+    },
+    async handler(ctx) {
+      const { path } = ctx.input;
+
+      const exists = await fs.pathExists(path);
+      if (exists) {
+        throw new InputError('Output path already exists');
+      }
+      await fs.ensureDir(dirname(path));
+      await fs.copy(ctx.workspacePath, path);
+    },
+  });
+}

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/index.ts
@@ -18,3 +18,4 @@ export { createPublishGithubAction } from './github';
 export { createPublishAzureAction } from './azure';
 export { createPublishGitlabAction } from './gitlab';
 export { createPublishBitbucketAction } from './bitbucket';
+export { createPublishFileAction } from './file';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Made this for a bit of debugging, figured it could be useful to have in the repo.

Also gave me the idea that it might be good to have a dry-run/debug publisher, which lets you browse the output. That'd be more useful for template authors in an organization.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
