### PR TITLE
feat: document method to set token cookie

### DIFF
--- a/contrib/docs/tutorials/authenticate-api-requests.md
+++ b/contrib/docs/tutorials/authenticate-api-requests.md
@@ -128,7 +128,7 @@ function msUntilExpiry(token) {
 
 // Calls the specified url regularly using an auth token to set a token cookie
 // to authorize regular HTTP requests when loading techdocs
-async function setAuthCookie(url, getIdToken) {
+async function setTokenCookie(url, getIdToken) {
   const token = await getIdToken();
   const response = await fetch(url, {
     mode: 'cors',
@@ -141,7 +141,7 @@ async function setAuthCookie(url, getIdToken) {
   const ms = msUntilExpiry(token) - 4 * 60 * 1000;
   setTimeout(
     () => {
-      setAuthCookie(url, getIdToken);
+      setTokenCookie(url, getIdToken);
     },
     ms > 0 ? ms : 10000,
   );
@@ -161,7 +161,7 @@ const app = createApp({
           align="center"
           onResult={async result => {
             // When logged in, set a token cookie
-            setAuthCookie(
+            setTokenCookie(
               await discoveryApi.getBaseUrl('cookie'),
               result.getIdToken,
             );

--- a/contrib/docs/tutorials/authenticate-api-requests.md
+++ b/contrib/docs/tutorials/authenticate-api-requests.md
@@ -99,10 +99,7 @@ async function main() {
 ```typescript
 // packages/app/src/App.tsx from a create-app deployment
 
-import {
-  discoveryApiRef,
-  useApi,
-} from '@backstage/core';
+import { discoveryApiRef, useApi } from '@backstage/core';
 
 // ...
 
@@ -151,7 +148,6 @@ async function setAuthCookie(url, getIdToken) {
 }
 
 const app = createApp({
-
   // ...
 
   components: {
@@ -176,4 +172,9 @@ const app = createApp({
       );
     },
   },
+
+  // ...
+});
+
+// ...
 ```


### PR DESCRIPTION
Signed-off-by: Erik Larsson <erik.larsson@schibsted.com>

## Hey, I just made a Pull Request!

Added documentation on how one can trigger setting a token cookie used for authorization when reading techdocs

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
