### PR TITLE
badges: Add icon to menu and reformat dialog

### DIFF
--- a/.changeset/calm-mugs-jog.md
+++ b/.changeset/calm-mugs-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-badges': patch
+---
+
+Update badge dialog formatting

--- a/.changeset/silly-crabs-press.md
+++ b/.changeset/silly-crabs-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Add icon for entity badge menu

--- a/plugins/badges/src/components/EntityBadgesDialog.test.tsx
+++ b/plugins/badges/src/components/EntityBadgesDialog.test.tsx
@@ -55,7 +55,7 @@ describe('EntityBadgesDialog', () => {
     );
 
     await expect(
-      rendered.findByText('testbadge badge'),
+      rendered.findByText('![test: badge](http://127.0.0.1/catalog/...)'),
     ).resolves.toBeInTheDocument();
   });
 });

--- a/plugins/badges/src/components/EntityBadgesDialog.tsx
+++ b/plugins/badges/src/components/EntityBadgesDialog.tsx
@@ -71,10 +71,10 @@ export const EntityBadgesDialog = ({ open, onClose, entity }: Props) => {
       <DialogTitle>Entity Badges</DialogTitle>
 
       <DialogContent>
-        <Typography>
+        <DialogContentText>
           Embed badges in other web sites that link back to this entity. Copy
           the relevant snippet of Markdown code to use the badge.
-        </Typography>
+        </DialogContentText>
         {loading && <Progress />}
         {error && <ResponseErrorPanel error={error} />}
         {content}

--- a/plugins/badges/src/components/EntityBadgesDialog.tsx
+++ b/plugins/badges/src/components/EntityBadgesDialog.tsx
@@ -29,7 +29,6 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  Typography,
   useMediaQuery,
   useTheme,
 } from '@material-ui/core';

--- a/plugins/badges/src/components/EntityBadgesDialog.tsx
+++ b/plugins/badges/src/components/EntityBadgesDialog.tsx
@@ -33,7 +33,6 @@ import {
   useMediaQuery,
   useTheme,
 } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 import { useAsync } from 'react-use';
 import { badgesApiRef } from '../api';
@@ -43,14 +42,6 @@ type Props = {
   onClose?: () => any;
   entity: Entity;
 };
-
-const useStyles = makeStyles({
-  codeBlock: {
-    '& code': {
-      whiteSpace: 'pre-wrap',
-    },
-  },
-});
 
 export const EntityBadgesDialog = ({ open, onClose, entity }: Props) => {
   const theme = useTheme();

--- a/plugins/badges/src/components/EntityBadgesDialog.tsx
+++ b/plugins/badges/src/components/EntityBadgesDialog.tsx
@@ -22,6 +22,7 @@ import {
   useApi,
 } from '@backstage/core';
 import {
+  Box,
   Button,
   Dialog,
   DialogActions,
@@ -55,7 +56,6 @@ export const EntityBadgesDialog = ({ open, onClose, entity }: Props) => {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const badgesApi = useApi(badgesApiRef);
-  const classes = useStyles();
 
   const { value: badges, loading, error } = useAsync(async () => {
     if (open) {
@@ -67,18 +67,11 @@ export const EntityBadgesDialog = ({ open, onClose, entity }: Props) => {
 
   const content = (badges || []).map(
     ({ badge: { description }, id, url, markdown }) => (
-      <div key={id}>
-        <DialogContentText>
-          {description || `${id} badge`}
-          <br />
-          <img alt={description || id} src={url} />
-        </DialogContentText>
-        <Typography component="div" className={classes.codeBlock}>
-          Copy the following snippet of markdown code for the badge:
-          <CodeSnippet language="markdown" text={markdown} showCopyCodeButton />
-        </Typography>
-        <hr />
-      </div>
+      <DialogContentText>
+        <Box m={4} />
+        <img alt={description || id} src={url} />
+        <CodeSnippet language="markdown" text={markdown} showCopyCodeButton />
+      </DialogContentText>
     ),
   );
 
@@ -87,6 +80,10 @@ export const EntityBadgesDialog = ({ open, onClose, entity }: Props) => {
       <DialogTitle>Entity Badges</DialogTitle>
 
       <DialogContent>
+        <Typography>
+          Embed badges in other web sites that link back to this entity. Copy
+          the relevant snippet of Markdown code to use the badge.
+        </Typography>
         {loading && <Progress />}
         {error && <ResponseErrorPanel error={error} />}
         {content}

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -24,6 +24,7 @@ import {
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import Cancel from '@material-ui/icons/Cancel';
+import BadgeIcon from '@material-ui/icons/CallToAction';
 import MoreVert from '@material-ui/icons/MoreVert';
 import React, { useState } from 'react';
 
@@ -81,6 +82,9 @@ export const EntityContextMenu = ({
                 onShowBadgesDialog();
               }}
             >
+              <ListItemIcon>
+                <BadgeIcon fontSize="small" />
+              </ListItemIcon>
               <Typography variant="inherit">Badges</Typography>
             </MenuItem>
           )}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Minor tweaks for dialog usage.

1. Addition of an icon to the entity context menu

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33203301/112085421-ddd86600-8b60-11eb-815e-a40aa3df70af.png) | ![image](https://user-images.githubusercontent.com/33203301/112085293-a23d9c00-8b60-11eb-901d-eb1a72dc2b5f.png) |

2. Reformatting of the dialog, hopefully to simplify and make it easier to read. Removed the descriptive headings as I think it may be obvious, _but_ welcome feedback/adjustments for other opinions.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33203301/112085487-ff395200-8b60-11eb-878c-394a2688611d.png) |  ![image](https://user-images.githubusercontent.com/33203301/112085345-bc777a00-8b60-11eb-848c-2c4cde3010e9.png) |


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
