### PR TITLE
[DOCS/CLI] Removes ADD in favor of COPY

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -190,10 +190,13 @@ output of `backstage-cli backend:bundle` into an image:
 FROM node:14-buster-slim
 WORKDIR /app
 
-ADD yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
+COPY yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
+RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
+
 RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
 
-ADD packages/backend/dist/bundle.tar.gz app-config.yaml ./
+COPY packages/backend/dist/bundle.tar.gz app-config.yaml ./
+RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
 CMD ["node", "packages/backend"]
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I spent a good 4 hours trying to understand why the images would build correctly locally but when built in jenkins/kaniko they would miss the `dist` folders.

Turns out ADD is too magical, and in some occasions it would not untar.  See: https://github.com/moby/moby/issues/3050

This small doc change can save a bunch of time

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
