### PR TITLE
Auth types fix + GitLab audience is optional

### DIFF
--- a/.changeset/light-zoos-wonder.md
+++ b/.changeset/light-zoos-wonder.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+The `auth` config types now properly accept any declared auth environment. Previously only `development` was accepted.
+
+The `audience` configuration is no longer required for GitLab auth; this will default to `https://gitlab.com`

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -36,13 +36,13 @@ export interface Config {
      */
     providers?: {
       google?: {
-        development: { [key: string]: string };
+        [authEnv: string]: { [key: string]: string };
       };
       github?: {
-        development: { [key: string]: string };
+        [authEnv: string]: { [key: string]: string };
       };
       gitlab?: {
-        development: { [key: string]: string };
+        [authEnv: string]: { [key: string]: string };
       };
       saml?: {
         entryPoint: string;
@@ -55,10 +55,10 @@ export interface Config {
         digestAlgorithm?: string;
       };
       okta?: {
-        development: { [key: string]: string };
+        [authEnv: string]: { [key: string]: string };
       };
       oauth2?: {
-        development: {
+        [authEnv: string]: {
           clientId: string;
           clientSecret: string;
           authorizationUrl: string;
@@ -67,16 +67,16 @@ export interface Config {
         };
       };
       oidc?: {
-        development: { [key: string]: string };
+        [authEnv: string]: { [key: string]: string };
       };
       auth0?: {
-        development: { [key: string]: string };
+        [authEnv: string]: { [key: string]: string };
       };
       microsoft?: {
-        development: { [key: string]: string };
+        [authEnv: string]: { [key: string]: string };
       };
       onelogin?: {
-        development: { [key: string]: string };
+        [authEnv: string]: { [key: string]: string };
       };
       awsalb?: {
         issuer?: string;

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -122,7 +122,7 @@ export const createGitlabProvider = (
     OAuthEnvironmentHandler.mapConfig(config, envConfig => {
       const clientId = envConfig.getString('clientId');
       const clientSecret = envConfig.getString('clientSecret');
-      const audience = envConfig.getString('audience');
+      const audience = envConfig.getOptionalString('audience');
       const baseUrl = audience || 'https://gitlab.com';
       const callbackUrl = `${globalConfig.baseUrl}/${providerId}/handler/frame`;
 


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

Minor fix to auth config types, `development` was hard-coded as the only auth environment. Also makes GitLab `audience` optional, since it's defaulted in the auth-backend code. Working on documentation that I can update with the change.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
