### PR TITLE
Changed the signature of createRoutableExtension to include null

### DIFF
--- a/.changeset/chilled-flies-speak.md
+++ b/.changeset/chilled-flies-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-api': patch
+---
+
+Changed the signature of `createRoutableExtension` to include null

--- a/packages/core-api/src/extensions/extensions.tsx
+++ b/packages/core-api/src/extensions/extensions.tsx
@@ -27,8 +27,11 @@ type ComponentLoader<T> =
       sync: T;
     };
 
+// We do not use ComponentType as the return type, since it doesn't let us convey the children prop.
+// ComponentType inserts children as an optional prop whether the inner component accepts it or not,
+// making it impossible to make the usage of children type safe.
 export function createRoutableExtension<
-  T extends (props: any) => JSX.Element
+  T extends (props: any) => JSX.Element | null
 >(options: {
   component: () => Promise<T>;
   mountPoint: RouteRef;
@@ -70,6 +73,9 @@ export function createComponentExtension<
   return createReactExtension({ component });
 }
 
+// We do not use ComponentType as the return type, since it doesn't let us convey the children prop.
+// ComponentType inserts children as an optional prop whether the inner component accepts it or not,
+// making it impossible to make the usage of children type safe.
 export function createReactExtension<
   T extends (props: any) => JSX.Element | null
 >(options: {


### PR DESCRIPTION
Signed-off-by: Brian Leathem <bleathem@netflix.com>

## Hey, I just made a Pull Request!

#4843 omitted the return type change for createRoutableExtension.  This PR includes it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
