### PR TITLE
improve credential loading for AWS IAM translator

### DIFF
--- a/.changeset/sharp-flowers-prove.md
+++ b/.changeset/sharp-flowers-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Load credentials properly for AWS Kubernetes Auth Translator

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.test.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.test.ts
@@ -46,6 +46,8 @@ describe('AwsIamKubernetesAuthTranslator tests', () => {
       url: '',
       authProvider: 'aws',
     });
-    await expect(promise).rejects.toThrow('no AWS credentials found.');
+    await expect(promise).rejects.toThrow(
+      'Could not load credentials from any providers',
+    );
   });
 });

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.ts
@@ -32,7 +32,16 @@ const makeUrlSafe = pipe([replace('+', '-'), replace('/', '_')]);
 export class AwsIamKubernetesAuthTranslator
   implements KubernetesAuthTranslator {
   async getBearerToken(clusterName: string): Promise<string> {
-    const credentials = AWS.config.credentials;
+    const credentials = await new Promise((resolve, reject) => {
+      AWS.config.getCredentials(err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(AWS.config.credentials);
+        }
+      });
+    });
+
     if (!(credentials instanceof Credentials)) {
       throw new Error('no AWS credentials found.');
     }


### PR DESCRIPTION
Signed-off-by: Jonah Back <jonah@jonahback.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
Improve loading of AWS credentials to remove need for manually setting AWS.config.credentials
<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
