### PR TITLE
Don't run the vale linter in CI/CD on changesets

### DIFF
--- a/.github/workflows/docs-quality-checker.yml
+++ b/.github/workflows/docs-quality-checker.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
     paths:
       - '**.md'
+      - '!.changeset/**.md'
 
 jobs:
   check-all-files:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While errata-ai/vale-action#33 is a thing, this will at least unblock merging of PRs where the only `.md` file is a changeset.  ...Do we even need to run this on changesets to begin with?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
