### PR TITLE
Configurable CatalogLayout header title and subtitle

### DIFF
--- a/.changeset/cool-scissors-invite.md
+++ b/.changeset/cool-scissors-invite.md
@@ -1,0 +1,17 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Add the option to define custom header title and/or subtitle for the catalog layout page that would replace the greetings in random languages.
+
+```js
+<Route
+  path="/catalog"
+  element={
+    <CatalogIndexPage
+      customHeaderTitle="MyCompany Service Catalog"
+      customHeaderSubtitle="Some subtitle text"
+    />
+  }
+/>
+```

--- a/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
@@ -26,10 +26,16 @@ import React from 'react';
 import { getTimeBasedGreeting } from './utils/timeUtil';
 
 type Props = {
-  children?: React.ReactNode;
+  children?: React.ReactNode;;
+  customHeaderTitle?: string;
+  customHeaderSubtitle?: string;
 };
 
-const CatalogLayout = ({ children }: Props) => {
+const CatalogLayout = ({ 
+    children,
+    customHeaderTitle,
+    customHeaderSubtitle, 
+  }: Props) => {
   const greeting = getTimeBasedGreeting();
   const profile = useApi(identityApiRef).getProfile();
   const userId = useApi(identityApiRef).getUserId();
@@ -38,9 +44,9 @@ const CatalogLayout = ({ children }: Props) => {
   return (
     <Page themeId="home">
       <Header
-        title={`${greeting.greeting}, ${profile.displayName || userId}!`}
-        subtitle={`${orgName || 'Backstage'} Service Catalog`}
-        tooltip={greeting.language}
+        title={customHeaderTitle ?? `${greeting.greeting}, ${profile.displayName || userId}!`}
+        subtitle={customHeaderSubtitle ?? `${orgName || 'Backstage'} Service Catalog`}
+        tooltip={customHeaderTitle ? undefined : greeting.language}
         pageTitleOverride="Home"
       >
         <HomepageTimer />

--- a/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
@@ -26,16 +26,16 @@ import React from 'react';
 import { getTimeBasedGreeting } from './utils/timeUtil';
 
 type Props = {
-  children?: React.ReactNode;;
+  children?: React.ReactNode;
   customHeaderTitle?: string;
   customHeaderSubtitle?: string;
 };
 
-const CatalogLayout = ({ 
-    children,
-    customHeaderTitle,
-    customHeaderSubtitle, 
-  }: Props) => {
+const CatalogLayout = ({
+  children,
+  customHeaderTitle,
+  customHeaderSubtitle,
+}: Props) => {
   const greeting = getTimeBasedGreeting();
   const profile = useApi(identityApiRef).getProfile();
   const userId = useApi(identityApiRef).getUserId();
@@ -44,8 +44,13 @@ const CatalogLayout = ({
   return (
     <Page themeId="home">
       <Header
-        title={customHeaderTitle ?? `${greeting.greeting}, ${profile.displayName || userId}!`}
-        subtitle={customHeaderSubtitle ?? `${orgName || 'Backstage'} Service Catalog`}
+        title={
+          customHeaderTitle ??
+          `${greeting.greeting}, ${profile.displayName || userId}!`
+        }
+        subtitle={
+          customHeaderSubtitle ?? `${orgName || 'Backstage'} Service Catalog`
+        }
         tooltip={customHeaderTitle ? undefined : greeting.language}
         pageTitleOverride="Home"
       >

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
@@ -142,7 +142,7 @@ describe('CatalogPage', () => {
   });
   it('should set custom titles correctly', async () => {
     const { findByText } = renderWrapped(
-      <CatalogPage customHeaderTitle="title" customHeaderSubitle="subtitle" />,
+      <CatalogPage customHeaderTitle="title" customHeaderSubtitle="subtitle" />,
     );
     expect(await findByText(/title \(2\)/)).toBeInTheDocument();
     expect(await findByText(/subtitle \(2\)/)).toBeInTheDocument();

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
@@ -142,10 +142,10 @@ describe('CatalogPage', () => {
   });
   it('should set custom titles correctly', async () => {
     const { findByText } = renderWrapped(
-      <CatalogPage customHeaderTitle="title" customHeaderSubtitle="subtitle" />,
+      <CatalogPage customHeaderTitle="text1" customHeaderSubtitle="text2" />,
     );
-    expect(await findByText(/title \(2\)/)).toBeInTheDocument();
-    expect(await findByText(/subtitle \(2\)/)).toBeInTheDocument();
+    expect(await findByText(/text1/)).toBeInTheDocument();
+    expect(await findByText(/text2/)).toBeInTheDocument();
   });
   // this test is for fixing the bug after favoriting an entity, the matching entities defaulting
   // to "owned" filter and not based on the selected filter

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
@@ -140,6 +140,13 @@ describe('CatalogPage', () => {
     );
     expect(await findByText(/All \(2\)/)).toBeInTheDocument();
   });
+  it('should set custom titles correctly', async () => {
+    const { findByText } = renderWrapped(
+      <CatalogPage customHeaderTitle="title" customHeaderSubitle="subtitle" />,
+    );
+    expect(await findByText(/title \(2\)/)).toBeInTheDocument();
+    expect(await findByText(/subtitle \(2\)/)).toBeInTheDocument();
+  });
   // this test is for fixing the bug after favoriting an entity, the matching entities defaulting
   // to "owned" filter and not based on the selected filter
   it('should render the correct entities filtered on the selectedfilter', async () => {

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -60,7 +60,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export type CatalogPageProps = {
-  initiallySelectedFilter?: string;;
+  initiallySelectedFilter?: string;
   customHeaderTitle?: string;
   customHeaderSubtitle?: string;
 };
@@ -169,7 +169,7 @@ const CatalogPageContents = (props: CatalogPageProps) => {
     configApi.has('catalog.exampleEntityLocations') && isCatalogEmpty;
 
   return (
-    <Catalog
+    <CatalogLayout
       customHeaderTitle={props.customHeaderTitle}
       customHeaderSubtitle={props.customHeaderSubtitle}
     >

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -60,7 +60,9 @@ const useStyles = makeStyles(theme => ({
 }));
 
 export type CatalogPageProps = {
-  initiallySelectedFilter?: string;
+  initiallySelectedFilter?: string;;
+  customHeaderTitle?: string;
+  customHeaderSubtitle?: string;
 };
 
 const CatalogPageContents = (props: CatalogPageProps) => {
@@ -167,7 +169,10 @@ const CatalogPageContents = (props: CatalogPageProps) => {
     configApi.has('catalog.exampleEntityLocations') && isCatalogEmpty;
 
   return (
-    <CatalogLayout>
+    <Catalog
+      customHeaderTitle={props.customHeaderTitle}
+      customHeaderSubtitle={props.customHeaderSubtitle}
+    >
       <CatalogTabs
         tabs={tabs}
         onChange={({ label }) => setSelectedTab(label)}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is my very first GitHub PR 😵 I want to make the Header Title and Subtitle configurable, so instead of users seeing a greeting in foreign languages, they will see a static custom title like "MyCompany Service Catalog".
![image](https://user-images.githubusercontent.com/37385472/112511380-a5b86980-8d92-11eb-88a2-f0049ea2337b.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
