### PR TITLE
Add auth0 to DefaultProviderSettings

### DIFF
--- a/.changeset/tricky-lions-press.md
+++ b/.changeset/tricky-lions-press.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Adds Auth0 to the default Authentication Providers settings page

--- a/plugins/user-settings/src/components/AuthProviders/DefaultProviderSettings.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/DefaultProviderSettings.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+  auth0AuthApiRef,
   githubAuthApiRef,
   gitlabAuthApiRef,
   googleAuthApiRef,
@@ -60,6 +61,14 @@ export const DefaultProviderSettings = ({ configuredProviders }: Props) => (
         title="GitLab"
         description="Provides authentication towards GitLab APIs"
         apiRef={gitlabAuthApiRef}
+        icon={Star}
+      />
+    )}
+    {configuredProviders.includes('auth0') && (
+      <ProviderSettingsItem
+        title="Auth0"
+        description="Provides authentication towards Auth0 APIs"
+        apiRef={auth0AuthApiRef}
         icon={Star}
       />
     )}


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

## Hey, look at me!

Adds the included Auth0 provider to the DefaultProviderSettings component, so it will appear on the Authentication Provider user settings pane when enabled.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
