### PR TITLE
Support for an `allowedEndpoints` option for `plugin-proxy`.

### DIFF
--- a/.changeset/spotty-insects-heal.md
+++ b/.changeset/spotty-insects-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': minor
+---
+
+Support for an `allowedEndpoints` option for `plugin-proxy`.

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -132,7 +132,7 @@ export function buildMiddleware(
 
     if (fullConfig?.allowedEndpoints) {
       return (
-        fullConfig.allowedEndpoints?.[pathname]?.includes(req.method) === true
+        fullConfig.allowedEndpoints?.[pathname]?.includes(req.method!) === true
       );
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This enables restricting proxy requests to a specified set of endpoints and associated HTTP verbs.

As an example use case, currently plugins that rely on the proxy plugin (e.g. `plugin-pagerduty`) open up unfettered access to the server being proxied. Strict enforcement might involve a corresponding backend plugin rather than using the proxy at all, allow-listing can at least restrict users to a strict set of calls.

The current implementation is strict: The path must match exactly. No globs, no regex. Query params may vary, though.

Feedback welcome -- there are a few different ways the allow list could be represented and I chose one somewhat arbitrarily. :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
