### PR TITLE
Fix MembersList not updating when group changes

### DIFF
--- a/.changeset/selfish-items-dream.md
+++ b/.changeset/selfish-items-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fixed MembersList showing members from a previous group when navigating to a new group

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -135,7 +135,7 @@ export const MembersListCard = (_props: {
         ),
     );
     return groupMembersList;
-  }, [catalogApi]);
+  }, [catalogApi, groupEntity]);
 
   if (loading) {
     return <Progress />;


### PR DESCRIPTION
Fixes #5108

Signed-off-by: Tim Hansen <timbonicus@gmail.com>

Missing dependency for `useAsync` caused members to remain when the group was changed. I couldn't figure out how to update the `useEntity` React context during a test to write a regression test. 🤔  Any pointers?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
