### PR TITLE
Adapt azure publish repo to new domain

### DIFF
--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.test.ts
@@ -180,7 +180,7 @@ describe('publish:azure', () => {
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
-      'https://dev.azure.com/organization/project/_git/repo',
+      'https://dev.azure.com/org/owner/_git/repo',
     );
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
@@ -107,9 +107,7 @@ export function createPublishAzureAction(options: {
         );
       }
 
-      // blam: Repo contents is serialized into the path,
-      // so it's just the base path I think
-      const repoContentsUrl = remoteUrl;
+      const repoContentsUrl = `https://${host}/${organization}/${owner}/_git/${repo}`;
 
       await initRepoAndPush({
         dir: ctx.workspacePath,


### PR DESCRIPTION
Signed-off-by: Bartosz Nadworny <bartosz.nadworny@gmail.com>

## Hey, I just made a Pull Request!

Changed the `publish:azure` action to support new domain as described in this bug: https://github.com/backstage/backstage/issues/5119

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
