### PR TITLE
unify how the owner and lifecycle labels are made

### DIFF
--- a/.changeset/sour-boxes-travel.md
+++ b/.changeset/sour-boxes-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+unify how the owner and lifecycle header labels are made

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Entity, ENTITY_DEFAULT_NAMESPACE } from '@backstage/catalog-model';
+import {
+  Entity,
+  ENTITY_DEFAULT_NAMESPACE,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
 import {
   Content,
   Header,
@@ -26,6 +30,8 @@ import {
 } from '@backstage/core';
 import {
   EntityContext,
+  EntityRefLinks,
+  getEntityRelations,
   useEntityCompoundName,
 } from '@backstage/plugin-catalog-react';
 import { Box } from '@material-ui/core';
@@ -73,6 +79,29 @@ const headerProps = (
       return t;
     })(),
   };
+};
+
+const EntityLabels = ({ entity }: { entity: Entity }) => {
+  const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
+  return (
+    <>
+      {ownedByRelations.length > 0 && (
+        <HeaderLabel
+          label="Owner"
+          value={
+            <EntityRefLinks
+              entityRefs={ownedByRelations}
+              defaultKind="Group"
+              color="inherit"
+            />
+          }
+        />
+      )}
+      {entity.spec?.lifecycle && (
+        <HeaderLabel label="Lifecycle" value={entity.spec.lifecycle} />
+      )}
+    </>
+  );
 };
 
 // NOTE(freben): Intentionally not exported at this point, since it's part of
@@ -133,17 +162,9 @@ export const EntityLayout = ({
         pageTitleOverride={headerTitle}
         type={headerType}
       >
-        {/* TODO: fix after catalog page customization is added */}
-        {entity && kind !== 'user' && (
+        {entity && (
           <>
-            <HeaderLabel
-              label="Owner"
-              value={entity.spec?.owner || 'unknown'}
-            />
-            <HeaderLabel
-              label="Lifecycle"
-              value={entity.spec?.lifecycle || 'unknown'}
-            />
+            <EntityLabels entity={entity} />
             <EntityContextMenu
               UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
               onUnregisterEntity={showRemovalDialog}

--- a/plugins/catalog/src/components/EntityPageLayout/EntityPageLayout.tsx
+++ b/plugins/catalog/src/components/EntityPageLayout/EntityPageLayout.tsx
@@ -22,12 +22,12 @@ import {
   Content,
   Header,
   HeaderLabel,
+  IconComponent,
   Link,
   Page,
   Progress,
   ResponseErrorPanel,
   WarningPanel,
-  IconComponent,
 } from '@backstage/core';
 import {
   EntityContext,
@@ -58,14 +58,17 @@ const EntityPageTitle = ({
 
 const EntityLabels = ({ entity }: { entity: Entity }) => {
   const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
-
   return (
     <>
       {ownedByRelations.length > 0 && (
         <HeaderLabel
           label="Owner"
           value={
-            <EntityRefLinks entityRefs={ownedByRelations} color="inherit" />
+            <EntityRefLinks
+              entityRefs={ownedByRelations}
+              defaultKind="Group"
+              color="inherit"
+            />
           }
         />
       )}


### PR DESCRIPTION
The old and new layouts had different behaviours.

Now it handles users and groups properly, and only shows them when there is any data to show.

![Screenshot 2021-03-26 at 08 56 26](https://user-images.githubusercontent.com/3097461/112601075-4ac65700-8e12-11eb-96f1-a42bc0929790.png)

![Screenshot 2021-03-26 at 08 56 16](https://user-images.githubusercontent.com/3097461/112601071-47cb6680-8e12-11eb-9eca-7946b30391c5.png)
