### PR TITLE
Export `ReadTreeResponseFile` and `SearchResponseFile`

### DIFF
--- a/.changeset/tender-steaks-roll.md
+++ b/.changeset/tender-steaks-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Export `ReadTreeResponseFile` and `SearchResponseFile`.

--- a/packages/backend-common/src/reading/index.ts
+++ b/packages/backend-common/src/reading/index.ts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
-export type { UrlReader, ReadTreeResponse, SearchResponse } from './types';
-export { UrlReaders } from './UrlReaders';
 export { AzureUrlReader } from './AzureUrlReader';
 export { BitbucketUrlReader } from './BitbucketUrlReader';
 export { GithubUrlReader } from './GithubUrlReader';
 export { GitlabUrlReader } from './GitlabUrlReader';
+export type {
+  ReadTreeResponse,
+  ReadTreeResponseFile,
+  SearchResponse,
+  SearchResponseFile,
+  UrlReader,
+} from './types';
+export { UrlReaders } from './UrlReaders';


### PR DESCRIPTION
I would like to pass them to functions in my processor.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
