### PR TITLE
nit: make entity page contents fill width of page

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -208,42 +208,42 @@ const EntityPageLayoutWrapper = (props: { children?: React.ReactNode }) => {
 
 const ComponentOverviewContent = ({ entity }: { entity: Entity }) => (
   <Grid container spacing={3} alignItems="stretch">
-    <Grid item md={6}>
+    <Grid item xs={12} md={6}>
       <AboutCard entity={entity} variant="gridItem" />
     </Grid>
     {isPagerDutyAvailable(entity) && (
-      <Grid item md={6}>
+      <Grid item xs={12} md={6}>
         <EntityProvider entity={entity}>
           <PagerDutyCard />
         </EntityProvider>
       </Grid>
     )}
-    <Grid item md={4} sm={6}>
+    <Grid item xs={12} md={6}>
       <EntityLinksCard entity={entity} />
     </Grid>
     <RecentCICDRunsSwitcher entity={entity} />
     {isGitHubAvailable(entity) && (
       <>
-        <Grid item md={6}>
+        <Grid item xs={12} md={6}>
           <LanguagesCard entity={entity} />
           <ReleasesCard entity={entity} />
         </Grid>
-        <Grid item md={6}>
+        <Grid item xs={12} md={6}>
           <ReadMeCard entity={entity} maxHeight={350} />
         </Grid>
       </>
     )}
     {isLighthouseAvailable(entity) && (
-      <Grid item sm={4}>
+      <Grid item xs={12} sm={4}>
         <LastLighthouseAuditCard variant="gridItem" />
       </Grid>
     )}
     {isPullRequestsAvailable(entity) && (
-      <Grid item sm={4}>
+      <Grid item xs={12} sm={4}>
         <PullRequestsStatsCard entity={entity} />
       </Grid>
     )}
-    <Grid item md={6}>
+    <Grid item xs={12} md={6}>
       <EntityHasSubcomponentsCard variant="gridItem" />
     </Grid>
   </Grid>
@@ -251,10 +251,10 @@ const ComponentOverviewContent = ({ entity }: { entity: Entity }) => (
 
 const ComponentApisContent = ({ entity }: { entity: Entity }) => (
   <Grid container spacing={3} alignItems="stretch">
-    <Grid item md={6}>
+    <Grid item xs={12} md={6}>
       <ProvidedApisCard entity={entity} />
     </Grid>
-    <Grid item md={6}>
+    <Grid item xs={12} md={6}>
       <ConsumedApisCard entity={entity} />
     </Grid>
   </Grid>


### PR DESCRIPTION
it was bugging me that the contents of the entity pages of the default app weren't making use of the screen space.

Before:
![Screenshot 2021-03-26 at 10 43 07](https://user-images.githubusercontent.com/3097461/112613225-27a2a400-8e20-11eb-8a7c-b92e3e2a4048.png)

After:
![Screenshot 2021-03-26 at 10 42 54](https://user-images.githubusercontent.com/3097461/112613243-2b362b00-8e20-11eb-917c-c5dfc52d5e0f.png)
