### PR TITLE
Adding Johan Haals as a maintainer and replacing 'Friends of' with 'Hall of Fame'

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -14,12 +14,13 @@ This page lists all active sponsors and maintainers.
 - Patrik Oldsberg ([rugvip](https://github.com/rugvip)) (Discord: @Rugvip)
 - Fredrik Adelöw ([freben](https://github.com/freben)) (Discord: @freben)
 - Ben Lambert ([benjdlambert](https://github.com/benjdlambert)) (Discord: @blam)
+- Johan Haals ([jhaals](https://github.com/jhaals)) (Discord: @jhaals)
 
 # Emeritus maintainers
 
 - Stefan Ålund ([stefanalund](https://github.com/stefanalund)) (Discord: @stalund)
 
-# Friends of Backstage
+# Hall of Fame
 
 People that have made significant contributions to the project and earned write access.
 


### PR DESCRIPTION
Signed-off-by: Lee Mills <leem@spotify.com>

## Hey, I just made a Pull Request!

Welcome Johan Haals to the Backstage Maintainers! 🎉

Updated Friends fo Backstage to be the Hall of Fame.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
