### PR TITLE
Add documentation for readonly catalog

### DIFF
--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -91,3 +91,28 @@ the catalog:
 catalog:
   rules: []
 ```
+
+## Readonly mode
+
+Processors provides a good way to automate ingestion of entities when combined
+with [Static Location Configuration](#static-location-configuration) or a
+discovery processor like
+[GitHub Discovery](../../integrations/github/discovery.md). To enforce usage of
+processors to locate entities we can configure the catalog into `readonly` mode.
+This configuration disables the mutating backend catalog APIs and disallows
+users from registering new entities at run-time.
+
+```yaml
+catalog:
+  readonly: true
+```
+
+> **Note that any plugin relying on the catalog API for creating, updating and
+> deleting entities will not work in this mode.**
+
+A common use case for this configuration is when organizations have a remote
+source that should be mirrored into backstage. If we want backstage to be a
+mirror of this remote source we cannot allow users to also register entities
+with e.g.
+[catalog-import](https://github.com/backstage/backstage/tree/master/plugins/catalog-import)
+plugin.


### PR DESCRIPTION
This change contains documentation for the readonly configuration of the catalog introduced in #5034.

This is part of the #3348 feature request.

Let me know if anything is unclear or need additional explanations.

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
