### PR TITLE
Include the GraphiQL stylesheet

### DIFF
--- a/.changeset/light-insects-sort.md
+++ b/.changeset/light-insects-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Include the GraphiQL stylesheet

--- a/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/GraphQlDefinitionWidget/GraphQlDefinitionWidget.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import React, { Suspense } from 'react';
-import { buildSchema } from 'graphql';
-import { makeStyles } from '@material-ui/core/styles';
 import { Progress } from '@backstage/core';
 import { BackstageTheme } from '@backstage/theme';
+import { makeStyles } from '@material-ui/core/styles';
+import 'graphiql/graphiql.css';
+import { buildSchema } from 'graphql';
+import React, { Suspense } from 'react';
 
 const GraphiQL = React.lazy(() => import('graphiql'));
 


### PR DESCRIPTION
GraphiQL is broken when doing `npx @backstage/create-app` because it misses the stylesheets. This wasn't noticed before, because it works as soon as `plugin-graphiql` is installed because it [includes the import](https://github.com/backstage/backstage/blob/3bf4ea86eb9e49182de3937e447773dd327624f6/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.tsx#L19). Which is the case in the `example-app` and also on `demo.backstage.io`.

<img src="https://user-images.githubusercontent.com/720821/112686456-42076c80-8e76-11eb-894a-bae25a08de1c.png" width=600>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
