### PR TITLE
Enable non unicode character in catalog import.

### DIFF
--- a/.changeset/old-spies-love.md
+++ b/.changeset/old-spies-love.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-import': patch
 ---
 
-When importing components you will now have the ability to use non unicode characters in the entity owner field
+When importing components you will now have the ability to use non Unicode characters in the entity owner field

--- a/.changeset/old-spies-love.md
+++ b/.changeset/old-spies-love.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+When importing components you will now have the ability to use non unicode characters in the entity owner field

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -43,6 +43,7 @@
     "@octokit/rest": "^18.0.12",
     "@types/react": "^16.9",
     "git-url-parse": "^11.4.4",
+    "js-base64": "^3.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-hook-form": "^6.15.4",

--- a/plugins/catalog-import/src/api/CatalogImportClient.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.test.ts
@@ -307,7 +307,7 @@ describe('CatalogImportClient', () => {
       await expect(
         catalogImportClient.submitPullRequest({
           repositoryUrl: 'https://github.com/backstage/backstage',
-          fileContent: 'some content',
+          fileContent: 'some content 🤖',
           title: 'A title/message',
           body: 'A body',
         }),
@@ -333,7 +333,7 @@ describe('CatalogImportClient', () => {
         repo: 'backstage',
         path: 'catalog-info.yaml',
         message: 'A title/message',
-        content: 'c29tZSBjb250ZW50',
+        content: 'c29tZSBjb250ZW50IPCfpJY=',
         branch: 'backstage-integration',
       });
       expect(

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -21,6 +21,7 @@ import {
   GitHubIntegrationConfig,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
+import { Base64 } from 'js-base64';
 import { Octokit } from '@octokit/rest';
 import { PartialEntity } from '../types';
 import { AnalyzeResult, CatalogImportApi } from './CatalogImportApi';
@@ -300,7 +301,7 @@ export class CatalogImportClient implements CatalogImportApi {
         repo,
         path: fileName,
         message: title,
-        content: btoa(fileContent),
+        content: Base64.encode(fileContent),
         branch: branchName,
       })
       .catch(e => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16882,6 +16882,11 @@ joycon@^2.2.5:
   resolved "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz#8d4cf4cbb2544d7b7583c216fcdfec19f6be1615"
   integrity sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==
 
+js-base64@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.npmjs.org/js-base64/-/js-base64-3.6.0.tgz#773e1de628f4f298d65a7e9842c50244751f5756"
+  integrity sha512-wVdUBYQeY2gY73RIlPrysvpYx+2vheGo8Y1SNQv/BzHToWpAZzJU7Z6uheKMAe+GLSBig5/Ps2nxg/8tRB73xg==
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"


### PR DESCRIPTION
replaced btoa with js-base64 so the code can gracefully handle non unicode characters.

Signed-off-by: Podge <padraig@padraigobrien.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
