### PR TITLE
Whitelist files for Vale

### DIFF
--- a/.github/workflows/docs-quality-checker.yml
+++ b/.github/workflows/docs-quality-checker.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: documentation quality check
         uses: errata-ai/vale-action@v1.3.0
+        # Whitelist excluding ADOPTERS, CHANGELOG and OWNERS (no exclude flag exists)
         with:
-            files: '[".changeset", "contrib", "docs", "microsite", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "GOVERNANCE.md", "README.md"]'
+          files: '[".changeset", ".github", "contrib", "docs", "microsite", "packages", "plugins", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "GOVERNANCE.md", "README.md"]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-quality-checker.yml
+++ b/.github/workflows/docs-quality-checker.yml
@@ -14,5 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: documentation quality check
         uses: errata-ai/vale-action@v1.3.0
+        with:
+            files: '[".changeset", "contrib", "docs", "microsite", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "GOVERNANCE.md", "README.md"]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/check-docs-quality.js
+++ b/scripts/check-docs-quality.js
@@ -40,6 +40,7 @@ const getFilesToLint = () => {
     command = `git ls-files | .\\node_modules\\.bin\\shx grep ".md"`;
   }
 
+  // Note this ignore list only applies locally, CI runs `.github/workflows/docs-quality-checker.yml`
   const ignored = ['', 'ADOPTERS.md', 'OWNERS.md'];
   return execSync(command, {
     stdio: ['ignore', 'pipe', 'inherit'],


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

The GitHub Action runs from the YAML/vale-action rather than the local script. There doesn't seem to be an exclusion option for the action or vale.ini. Whitelist instead?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
