### PR TITLE
Implemented dependsOn/dependencyOf support in catalog model.

### DIFF
--- a/.changeset/red-planets-hammer.md
+++ b/.changeset/red-planets-hammer.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/catalog-model': minor
-'@backstage/plugin-catalog-backend': minor
+'@backstage/catalog-model': patch
+'@backstage/plugin-catalog-backend': patch
 '@backstage/plugin-catalog': patch
 ---
 

--- a/.changeset/red-planets-hammer.md
+++ b/.changeset/red-planets-hammer.md
@@ -4,4 +4,10 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Implemented missing support for the dependsOn/dependencyOf relationships between Component and Resource catalog model objects. Added support for generating the relevant relationships to the BuiltinKindsEntityProcessor, and added simple support for fetching relationships between Components and Resources for rendering in the system diagram. All catalog-model changes backwards compatible.
+Implemented missing support for the dependsOn/dependencyOf relationships
+between `Component` and `Resource` catalog model objects.
+
+Added support for generating the relevant relationships to the
+`BuiltinKindsEntityProcessor`, and added simple support for fetching
+relationships between `Components` and `Resources` for rendering in the
+system diagram. All catalog-model changes backwards compatible.

--- a/.changeset/red-planets-hammer.md
+++ b/.changeset/red-planets-hammer.md
@@ -1,0 +1,7 @@
+---
+'@backstage/catalog-model': minor
+'@backstage/plugin-catalog-backend': minor
+'@backstage/plugin-catalog': patch
+---
+
+Implemented missing support for the dependsOn/dependencyOf relationships between Component and Resource catalog model objects. Added support for generating the relevant relationships to the BuiltinKindsEntityProcessor, and added simple support for fetching relationships between Components and Resources for rendering in the system diagram. All catalog-model changes backwards compatible.

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -521,12 +521,14 @@ consumed by the component, e.g. `artist-api`. This field is optional.
 
 ### `spec.dependsOn` [optional]
 
-An array of [entity references](#string-references) to the Resources that the
-component depends on, e.g. `artists-db`. This field is optional.
+An array of [entity references](#string-references) to the components and
+resources that the component depends on, e.g. `artists-db`. This field is
+optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                            |
 | --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| [`Resource`](#kind-resource) (default)  | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
+| [`Component`](#kind-component)          | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
+| [`Resource`](#kind-resource)            | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
 
 ## Kind: Template
 
@@ -1010,14 +1012,16 @@ belongs to, e.g. `artist-engagement-portal`. This field is optional.
 | --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
 | [`System`](#kind-system) (default)      | Same as this entity, typically `default`   | [`partOf`, and reverse `hasPart`](well-known-relations.md#partof-and-haspart) |
 
-### `spec.dependencyOf` [optional]
+### `spec.dependsOn` [optional]
 
-An array of [entity references](#string-references) to the Components that the
-resource is a dependency of, e.g. `artist-lookup`. This field is optional.
+An array of [entity references](#string-references) to the components and
+resources that the resource depends on, e.g. `artist-lookup`. This field is
+optional.
 
-| [`kind`](#apiversion-and-kind-required)  | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                            |
-| ---------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| [`Component`](#kind-component) (default) | Same as this entity, typically `default`   | [`dependencyOf`, and reverse `dependsOn`](well-known-relations.md#dependson-and-dependencyof) |
+| [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                            |
+| --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| [`Component`](#kind-component)          | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
+| [`Resource`](#kind-resource)            | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
 
 ## Kind: System
 

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -519,6 +519,15 @@ consumed by the component, e.g. `artist-api`. This field is optional.
 | --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------- |
 | [`API`](#kind-api) (default)            | Same as this entity, typically `default`   | [`consumesApi`, and reverse `apiConsumedBy`](well-known-relations.md#consumesapi-and-apiconsumedby) |
 
+### `spec.dependsOn` [optional]
+
+An array of [entity references](#string-references) to the Resources that the
+component depends on, e.g. `artists-db`. This field is optional.
+
+| [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                            |
+| --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| [`Resource`](#kind-resource) (default)  | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
+
 ## Kind: Template
 
 The following describes the following entity kind:
@@ -1000,6 +1009,15 @@ belongs to, e.g. `artist-engagement-portal`. This field is optional.
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                            |
 | --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
 | [`System`](#kind-system) (default)      | Same as this entity, typically `default`   | [`partOf`, and reverse `hasPart`](well-known-relations.md#partof-and-haspart) |
+
+### `spec.dependencyOf` [optional]
+
+An array of [entity references](#string-references) to the Components that the
+resource is a dependency of, e.g. `artist-lookup`. This field is optional.
+
+| [`kind`](#apiversion-and-kind-required)  | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                            |
+| ---------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| [`Component`](#kind-component) (default) | Same as this entity, typically `default`   | [`dependencyOf`, and reverse `dependsOn`](well-known-relations.md#dependson-and-dependencyof) |
 
 ## Kind: System
 

--- a/packages/catalog-model/examples/components/artist-lookup-component.yaml
+++ b/packages/catalog-model/examples/components/artist-lookup-component.yaml
@@ -32,6 +32,4 @@ spec:
   type: service
   lifecycle: experimental
   owner: team-a
-  dependsOn:
-    - artists-db
   system: artist-engagement-portal

--- a/packages/catalog-model/examples/components/artist-lookup-component.yaml
+++ b/packages/catalog-model/examples/components/artist-lookup-component.yaml
@@ -32,4 +32,6 @@ spec:
   type: service
   lifecycle: experimental
   owner: team-a
+  dependsOn:
+    - artists-db
   system: artist-engagement-portal

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
@@ -36,7 +36,7 @@ describe('ComponentV1alpha1Validator', () => {
         subcomponentOf: 'monolith',
         providesApis: ['api-0'],
         consumesApis: ['api-0'],
-        dependsOn: ['resource-0'],
+        dependsOn: ['resource:resource-0', 'component:component-0'],
         system: 'system',
       },
     };

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
@@ -36,6 +36,7 @@ describe('ComponentV1alpha1Validator', () => {
         subcomponentOf: 'monolith',
         providesApis: ['api-0'],
         consumesApis: ['api-0'],
+        dependsOn: ['resource-0'],
         system: 'system',
       },
     };
@@ -157,6 +158,26 @@ describe('ComponentV1alpha1Validator', () => {
 
   it('accepts no consumesApis', async () => {
     (entity as any).spec.consumesApis = [];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts missing dependsOn', async () => {
+    delete (entity as any).spec.dependsOn;
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty dependsOn', async () => {
+    (entity as any).spec.dependsOn = [''];
+    await expect(validator.check(entity)).rejects.toThrow(/dependsOn/);
+  });
+
+  it('rejects undefined dependsOn', async () => {
+    (entity as any).spec.dependsOn = [undefined];
+    await expect(validator.check(entity)).rejects.toThrow(/dependsOn/);
+  });
+
+  it('accepts no dependsOn', async () => {
+    (entity as any).spec.dependsOn = [];
     await expect(validator.check(entity)).resolves.toBe(true);
   });
 

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
@@ -34,6 +34,7 @@ export interface ComponentEntityV1alpha1 extends Entity {
     subcomponentOf?: string;
     providesApis?: string[];
     consumesApis?: string[];
+    dependsOn?: string[];
     system?: string;
   };
 }

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.test.ts
@@ -32,7 +32,7 @@ describe('ResourceV1alpha1Validator', () => {
       spec: {
         type: 'database',
         owner: 'me',
-        dependencyOf: ['component-0'],
+        dependsOn: ['component:component-0', 'resource:resource-0'],
         system: 'system',
       },
     };
@@ -87,23 +87,23 @@ describe('ResourceV1alpha1Validator', () => {
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 
-  it('accepts missing dependencyOf', async () => {
-    delete (entity as any).spec.dependencyOf;
+  it('accepts missing dependsOn', async () => {
+    delete (entity as any).spec.dependsOn;
     await expect(validator.check(entity)).resolves.toBe(true);
   });
 
-  it('rejects empty dependencyOf', async () => {
-    (entity as any).spec.dependencyOf = [''];
-    await expect(validator.check(entity)).rejects.toThrow(/dependencyOf/);
+  it('rejects empty dependsOn', async () => {
+    (entity as any).spec.dependsOn = [''];
+    await expect(validator.check(entity)).rejects.toThrow(/dependsOn/);
   });
 
-  it('rejects undefined dependencyOf', async () => {
-    (entity as any).spec.dependencyOf = [undefined];
-    await expect(validator.check(entity)).rejects.toThrow(/dependencyOf/);
+  it('rejects undefined dependsOn', async () => {
+    (entity as any).spec.dependsOn = [undefined];
+    await expect(validator.check(entity)).rejects.toThrow(/dependsOn/);
   });
 
-  it('accepts no dependencyOf', async () => {
-    (entity as any).spec.dependencyOf = [];
+  it('accepts no dependsOn', async () => {
+    (entity as any).spec.dependsOn = [];
     await expect(validator.check(entity)).resolves.toBe(true);
   });
 

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.test.ts
@@ -32,6 +32,7 @@ describe('ResourceV1alpha1Validator', () => {
       spec: {
         type: 'database',
         owner: 'me',
+        dependencyOf: ['component-0'],
         system: 'system',
       },
     };
@@ -84,6 +85,26 @@ describe('ResourceV1alpha1Validator', () => {
   it('rejects empty owner', async () => {
     (entity as any).spec.owner = '';
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
+  });
+
+  it('accepts missing dependencyOf', async () => {
+    delete (entity as any).spec.dependencyOf;
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty dependencyOf', async () => {
+    (entity as any).spec.dependencyOf = [''];
+    await expect(validator.check(entity)).rejects.toThrow(/dependencyOf/);
+  });
+
+  it('rejects undefined dependencyOf', async () => {
+    (entity as any).spec.dependencyOf = [undefined];
+    await expect(validator.check(entity)).rejects.toThrow(/dependencyOf/);
+  });
+
+  it('accepts no dependencyOf', async () => {
+    (entity as any).spec.dependencyOf = [];
+    await expect(validator.check(entity)).resolves.toBe(true);
   });
 
   it('accepts missing system', async () => {

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
@@ -30,7 +30,7 @@ export interface ResourceEntityV1alpha1 extends Entity {
   spec: {
     type: string;
     owner: string;
-    dependencyOf?: string[];
+    dependsOn?: string[];
     system?: string;
   };
 }

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
@@ -30,6 +30,7 @@ export interface ResourceEntityV1alpha1 extends Entity {
   spec: {
     type: string;
     owner: string;
+    dependencyOf?: string[];
     system?: string;
   };
 }

--- a/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
@@ -87,7 +87,7 @@
             },
             "dependsOn": {
               "type": "array",
-              "description": "An array of entity references to the resources that the component depends on.",
+              "description": "An array of references to other entities that the component depends on to function.",
               "items": {
                 "type": "string",
                 "minLength": 1

--- a/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
@@ -84,6 +84,14 @@
                 "type": "string",
                 "minLength": 1
               }
+            },
+            "dependsOn": {
+              "type": "array",
+              "description": "An array of entity references to the resources that the component depends on.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           }
         }

--- a/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
@@ -47,7 +47,7 @@
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
             },
-            "dependencyOf": {
+            "dependsOn": {
               "type": "array",
               "description": "An array of entity references to the components that the resource is a dependency of.",
               "items": {

--- a/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
@@ -47,6 +47,14 @@
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
             },
+            "dependencyOf": {
+              "type": "array",
+              "description": "An array of entity references to the components that the resource is a dependency of.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
             "system": {
               "type": "string",
               "description": "An entity reference to the system that the resource belongs to.",

--- a/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
@@ -49,7 +49,7 @@
             },
             "dependsOn": {
               "type": "array",
-              "description": "An array of entity references to the components that the resource is a dependency of.",
+              "description": "An array of references to other entities that the resource depends on to function.",
               "items": {
                 "type": "string",
                 "minLength": 1

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
@@ -45,13 +45,14 @@ describe('BuiltinKindsEntityProcessor', () => {
           lifecycle: 'l',
           providesApis: ['b'],
           consumesApis: ['c'],
+          dependsOn: ['r'],
           system: 's',
         },
       };
 
       await processor.postProcessEntity(entity, location, emit);
 
-      expect(emit).toBeCalledTimes(10);
+      expect(emit).toBeCalledTimes(12);
       expect(emit).toBeCalledWith({
         type: 'relation',
         relation: {
@@ -98,6 +99,22 @@ describe('BuiltinKindsEntityProcessor', () => {
           source: { kind: 'Component', namespace: 'default', name: 'n' },
           type: 'consumesApi',
           target: { kind: 'API', namespace: 'default', name: 'c' },
+        },
+      });
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'r' },
+          type: 'dependencyOf',
+          target: { kind: 'Component', namespace: 'default', name: 'n' },
+        },
+      });
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Component', namespace: 'default', name: 'n' },
+          type: 'dependsOn',
+          target: { kind: 'Resource', namespace: 'default', name: 'r' },
         },
       });
       expect(emit).toBeCalledWith({
@@ -193,13 +210,14 @@ describe('BuiltinKindsEntityProcessor', () => {
         spec: {
           type: 'database',
           owner: 'o',
+          dependencyOf: ['c'],
           system: 's',
         },
       };
 
       await processor.postProcessEntity(entity, location, emit);
 
-      expect(emit).toBeCalledTimes(4);
+      expect(emit).toBeCalledTimes(6);
       expect(emit).toBeCalledWith({
         type: 'relation',
         relation: {
@@ -214,6 +232,22 @@ describe('BuiltinKindsEntityProcessor', () => {
           source: { kind: 'Resource', namespace: 'default', name: 'n' },
           type: 'ownedBy',
           target: { kind: 'Group', namespace: 'default', name: 'o' },
+        },
+      });
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'n' },
+          type: 'dependencyOf',
+          target: { kind: 'Component', namespace: 'default', name: 'c' },
+        },
+      });
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Component', namespace: 'default', name: 'c' },
+          type: 'dependsOn',
+          target: { kind: 'Resource', namespace: 'default', name: 'n' },
         },
       });
       expect(emit).toBeCalledWith({

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
@@ -186,7 +186,7 @@ describe('BuiltinKindsEntityProcessor', () => {
       await expect(
         processor.postProcessEntity(entity, location, emit),
       ).rejects.toThrowError(
-        'Entity reference kind is undefined and has no default',
+        'Entity reference "r" did not specify a kind (e.g. starting with "Component:"), and has no default',
       );
     });
 
@@ -334,14 +334,14 @@ describe('BuiltinKindsEntityProcessor', () => {
         spec: {
           type: 'database',
           owner: 'o',
-          dependsOn: ['r'],
+          dependsOn: ['c'],
           system: 's',
         },
       };
       await expect(
         processor.postProcessEntity(entity, location, emit),
       ).rejects.toThrowError(
-        'Entity reference kind is undefined and has no default',
+        'Entity reference "c" did not specify a kind (e.g. starting with "Component:"), and has no default',
       );
     });
 

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
@@ -32,6 +32,8 @@ import {
   RELATION_API_PROVIDED_BY,
   RELATION_CHILD_OF,
   RELATION_CONSUMES_API,
+  RELATION_DEPENDENCY_OF,
+  RELATION_DEPENDS_ON,
   RELATION_HAS_MEMBER,
   RELATION_HAS_PART,
   RELATION_MEMBER_OF,
@@ -147,6 +149,12 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_API_CONSUMED_BY,
       );
       doEmit(
+        component.spec.dependsOn,
+        { defaultKind: 'Resource', defaultNamespace: selfRef.namespace },
+        RELATION_DEPENDS_ON,
+        RELATION_DEPENDENCY_OF,
+      );
+      doEmit(
         component.spec.system,
         { defaultKind: 'System', defaultNamespace: selfRef.namespace },
         RELATION_PART_OF,
@@ -185,6 +193,12 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         { defaultKind: 'Group', defaultNamespace: selfRef.namespace },
         RELATION_OWNED_BY,
         RELATION_OWNER_OF,
+      );
+      doEmit(
+        resource.spec.dependencyOf,
+        { defaultKind: 'Component', defaultNamespace: selfRef.namespace },
+        RELATION_DEPENDENCY_OF,
+        RELATION_DEPENDS_ON,
       );
       doEmit(
         resource.spec.system,

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
@@ -103,7 +103,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         const targetRef = parseEntityRef(target, context);
         if (targetRef.kind === undefined) {
           throw new Error(
-            'Entity reference kind is undefined and has no default',
+            `Entity reference "${target}" did not specify a kind (e.g. starting with "Component:"), and has no default`,
           );
         }
         emit(

--- a/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
+++ b/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
@@ -16,6 +16,7 @@
 
 import {
   Entity,
+  RELATION_DEPENDS_ON,
   RELATION_PROVIDES_API,
   RELATION_PART_OF,
   serializeEntityRef,
@@ -124,12 +125,23 @@ export function SystemDiagramCard() {
         catalogItem,
         RELATION_PROVIDES_API,
       );
-
       catalogItemRelations_providesApi.forEach(foundRelation =>
         systemEdges.push({
           from: simplifiedEntityName(catalogItem),
           to: simplifiedEntityName(foundRelation),
           label: 'provides API',
+        }),
+      );
+
+      const catalogItemRelations_dependsOn = getEntityRelations(
+        catalogItem,
+        RELATION_DEPENDS_ON,
+      );
+      catalogItemRelations_dependsOn.forEach(foundRelation =>
+        systemEdges.push({
+          from: simplifiedEntityName(catalogItem),
+          to: simplifiedEntityName(foundRelation),
+          label: 'depends on',
         }),
       );
     }


### PR DESCRIPTION
Added support for the dependsOn property to the Component kind in the catalog model and schema, plus tests.
Added support for the dependencyOf property to the Resource kind in the catalog model and schema, plus tests.
Added support for generating relationships from these new properties via the BuiltinKindsEntityProcessor, plus tests.
Added support for fetching dependsOn relationships between components in the system to render the System Diagram.

Closes #4505 