### PR TITLE
Should there be a redirects plugin?

### DIFF
--- a/plugins/redirect/.eslintrc.js
+++ b/plugins/redirect/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint')],
+};

--- a/plugins/redirect/README.md
+++ b/plugins/redirect/README.md
@@ -29,7 +29,7 @@ you wish to redirect from/to:
 redirects:
   patterns:
     - from: '/old-path'
-    - to: '/new-path'
+      to: '/new-path'
 ```
 
 If you wish to redirect all sub-paths from a given path, you can use the `*`
@@ -39,7 +39,7 @@ character at the end of both your `from` and `to` keys, like so:
 redirects:
   patterns:
     - from: '/docs/default/Component/solr-searcher/*'
-    - to: '/docs/default/Component/elastic-searcher/*'
+      to: '/docs/default/Component/elastic-searcher/*'
 ```
 
 You may also use route parameters in your redirect definition if, for example,
@@ -50,5 +50,5 @@ parameters.
 redirects:
   patterns:
     - from: '/catalog/:namespace/:kind/:name/diy-ci'
-    - to: '/catalog/:namespace/:kind/:name/circle-ci'
+      to: '/catalog/:namespace/:kind/:name/circle-ci'
 ```

--- a/plugins/redirect/README.md
+++ b/plugins/redirect/README.md
@@ -1,0 +1,54 @@
+# Redirects
+
+This plugin allows you to define basic, client-side redirects for your
+Backstage instance via app config. Redirects merely require a `from` and a `to`
+value, and values may contain route parameters as well as `*`.
+
+## Installation
+
+1. Use `yarn` or `npm` to install this plugin `@backstage/plugin-redirects`
+2. Import the `<Redirects />` component from this plugin in your `App.tsx` file
+   like so: `import { Redirects } from '@backstage/plugin-redirect';`
+3. Add the `<Redirects />` component as a child of `<AppRouter>`, and a sibling
+   of `<Root>`.
+4. Add redirect configurations to your `app-config.yaml`, like so:
+
+```yaml
+redirects:
+  patterns:
+    - from: '/old/path'
+      to: '/new/path'
+```
+
+## Usage
+
+For simple, single-page redirects, just set `from` and `to` as the exact paths
+you wish to redirect from/to:
+
+```yaml
+redirects:
+  patterns:
+    - from: '/old-path'
+    - to: '/new-path'
+```
+
+If you wish to redirect all sub-paths from a given path, you can use the `*`
+character at the end of both your `from` and `to` keys, like so:
+
+```yaml
+redirects:
+  patterns:
+    - from: '/docs/default/Component/solr-searcher/*'
+    - to: '/docs/default/Component/elastic-searcher/*'
+```
+
+You may also use route parameters in your redirect definition if, for example,
+you wish to redirect a single view for all instances of a given set of
+parameters.
+
+```yaml
+redirects:
+  patterns:
+    - from: '/catalog/:namespace/:kind/:name/diy-ci'
+    - to: '/catalog/:namespace/:kind/:name/circle-ci'
+```

--- a/plugins/redirect/config.d.ts
+++ b/plugins/redirect/config.d.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  redirects?: {
+    /**
+     * List of redirect patterns.
+     * @visibility frontend
+     */
+    patterns?: Array<{
+      /**
+       * The path/pattern to redirect from.
+       * @visibility frontend
+       */
+      from: string;
+      /**
+       * The path/target to redirect to.
+       * @visibility frontend
+       */
+      to: string;
+    }>;
+  };
+}

--- a/plugins/redirect/dev/index.tsx
+++ b/plugins/redirect/dev/index.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createDevApp } from '@backstage/dev-utils';
+import { redirectPlugin } from '../src/plugin';
+
+createDevApp().registerPlugin(redirectPlugin).render();

--- a/plugins/redirect/package.json
+++ b/plugins/redirect/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@backstage/plugin-redirect",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "configSchema": "config.d.ts",
+  "scripts": {
+    "build": "backstage-cli plugin:build",
+    "start": "backstage-cli plugin:serve",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test",
+    "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
+    "clean": "backstage-cli clean"
+  },
+  "dependencies": {
+    "@backstage/core": "^0.7.3",
+    "@backstage/theme": "^0.2.5",
+    "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "4.0.0-alpha.45",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-router": "6.0.0-beta.0",
+    "react-use": "^15.3.3"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.6.6",
+    "@backstage/dev-utils": "^0.1.13",
+    "@backstage/test-utils": "^0.1.9",
+    "@testing-library/jest-dom": "^5.10.1",
+    "@testing-library/react": "^11.2.5",
+    "@testing-library/user-event": "^12.0.7",
+    "@types/jest": "^26.0.7",
+    "@types/node": "^14.14.32",
+    "msw": "^0.21.2",
+    "cross-fetch": "^3.0.6"
+  },
+  "files": [
+    "dist",
+    "config.d.ts"
+  ]
+}

--- a/plugins/redirect/src/components/Redirects/Redirects.tsx
+++ b/plugins/redirect/src/components/Redirects/Redirects.tsx
@@ -42,9 +42,9 @@ export const Redirects = () => {
       {redirects.map(redirect => {
         return (
           <Route
-            key={redirect.get('from')}
-            path={redirect.get('from')}
-            element={<NavigateRedirect to={redirect.get('to')} />}
+            key={redirect.getString('from')}
+            path={redirect.getString('from')}
+            element={<NavigateRedirect to={redirect.getString('to')} />}
           />
         );
       })}

--- a/plugins/redirect/src/components/Redirects/Redirects.tsx
+++ b/plugins/redirect/src/components/Redirects/Redirects.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Navigate, Route, Routes, useParams } from 'react-router';
+import { configApiRef, useApi } from '@backstage/core';
+
+interface RedirectProps {
+  from: string;
+  to: string;
+}
+
+function NavigateRedirect({ to }: Pick<RedirectProps, 'to'>) {
+  const params = useParams();
+  let finalTo = to;
+
+  Object.entries(params).forEach(([name, value]) => {
+    finalTo = finalTo.replace(name === '*' ? name : `:${name}`, value);
+  });
+
+  return <Navigate replace to={finalTo} />;
+}
+
+export const Redirects = () => {
+  const redirects =
+    useApi(configApiRef).getOptionalConfigArray('redirects.patterns') || [];
+  return (
+    <Routes>
+      {redirects.map(redirect => {
+        return (
+          <Route
+            key={redirect.get('from')}
+            path={redirect.get('from')}
+            element={<NavigateRedirect to={redirect.get('to')} />}
+          />
+        );
+      })}
+    </Routes>
+  );
+};

--- a/plugins/redirect/src/components/Redirects/index.ts
+++ b/plugins/redirect/src/components/Redirects/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { Redirects } from './Redirects';

--- a/plugins/redirect/src/index.ts
+++ b/plugins/redirect/src/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { redirectPlugin } from './plugin';
+export { Redirects } from './components/Redirects';

--- a/plugins/redirect/src/plugin.test.ts
+++ b/plugins/redirect/src/plugin.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { redirectPlugin } from './plugin';
+
+describe('redirect', () => {
+  it('should export plugin', () => {
+    expect(redirectPlugin).toBeDefined();
+  });
+});

--- a/plugins/redirect/src/plugin.ts
+++ b/plugins/redirect/src/plugin.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createPlugin } from '@backstage/core';
+
+export const redirectPlugin = createPlugin({
+  id: 'redirect',
+});

--- a/plugins/redirect/src/setupTests.ts
+++ b/plugins/redirect/src/setupTests.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+import 'cross-fetch/polyfill';


### PR DESCRIPTION
**THIS IS JUST A PROPOSAL**

## Hey, I just made a Pull Request!

In sufficiently mature instances of Backstage, the need for redirects will become inevitable.  Some use-cases are already popping up in the wild (#4931).

Proposal here is to introduce a plugin that defines a configuration-based approach to redirects.  It exposes a `<Redirects />` routing component that Backstage adopters can mount in their app that handles all configured redirects on their behalf.

Maybe there ought to be a facility for plugins to declare redirects at some point, for backward compatibility, but I wonder if an App-level redirect system is more useful right now.

What do y'all think?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
