### PR TITLE
Remove co-located entities that are added by the same origin location

### DIFF
--- a/.changeset/swift-crews-protect.md
+++ b/.changeset/swift-crews-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Remove co-located entities that are added by the same origin location

--- a/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
@@ -20,6 +20,7 @@ import {
   generateUpdatedEntity,
   getEntityName,
   LOCATION_ANNOTATION,
+  ORIGIN_LOCATION_ANNOTATION,
   serializeEntityRef,
 } from '@backstage/catalog-model';
 import { ConflictError, NotFoundError } from '@backstage/errors';
@@ -91,13 +92,15 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
       }
 
       const location =
-        entityResponse.entity.metadata.annotations?.[LOCATION_ANNOTATION];
+        entityResponse.entity.metadata.annotations?.[
+          ORIGIN_LOCATION_ANNOTATION
+        ];
 
       const colocatedEntities = location
         ? (
             await this.database.entities(tx, {
               filter: basicEntityFilter({
-                [`metadata.annotations.${LOCATION_ANNOTATION}`]: location,
+                [`metadata.annotations.${ORIGIN_LOCATION_ANNOTATION}`]: location,
               }),
             })
           ).entities


### PR DESCRIPTION
The catalog backend should remove the same entities that the `UnregisterEntityDialog` previews. The dialog is based on the _origin location_ while the delete logic on the _location_. This problem occurs when someone registers a `Location` that links to the actual resources (e.g. via glob). Then the two annotations doesn't match and the entities don't get removed though the Dialog previewed that.

If the old behavior was intended, an alternative would be to update the Dialog to only show the entities from the `backstage.io/managed-by-location` as they are the only ones that are removed currently.

I also added a happy-path test for the `removeEntityByUid` function.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
