### PR TITLE
fixed backstage clone url instruction in the contributors page

### DIFF
--- a/docs/getting-started/contributors.md
+++ b/docs/getting-started/contributors.md
@@ -15,7 +15,7 @@ your own GitHub account and clone that code to your local machine or you can
 grab the one for the origin like so:
 
 ```bash
-git clone git@github.com/backstage/backstage --depth 1
+git clone git@github.com:backstage/backstage --depth 1
 ```
 
 If you cloned a fork, you can add the upstream dependency like so:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

![image](https://user-images.githubusercontent.com/51252/112822972-8d8d6680-9080-11eb-827e-68b35aad8fe7.png)

![image](https://user-images.githubusercontent.com/51252/112823021-a0a03680-9080-11eb-9a60-6fe049fe24de.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
