### PR TITLE
Correctly respect namespace when routing and filtering group members

### DIFF
--- a/.changeset/cuddly-buses-complain.md
+++ b/.changeset/cuddly-buses-complain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Correctly route to namespaced group members

--- a/.changeset/flat-meals-behave.md
+++ b/.changeset/flat-meals-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Correctly include group members via matching namespace relation

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -164,6 +164,7 @@ monorepo
 monorepos
 msw
 namespace
+namespaced
 namespaces
 namespacing
 neuro

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -72,6 +72,33 @@ describe('MemberTab Test', () => {
               memberOf: ['team-d'],
             },
           },
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'User',
+            metadata: {
+              name: 'sara.macgovern',
+              namespace: 'default',
+              uid: 'a5gerth57',
+            },
+            relations: [
+              {
+                type: 'memberOf',
+                target: {
+                  kind: 'group',
+                  name: 'team-d',
+                  namespace: 'foo-bar',
+                },
+              },
+            ],
+            spec: {
+              profile: {
+                displayName: 'Sara MacGovern',
+                email: 'sara-macgovern@example.com',
+                picture: 'https://example.com/staff/sara.jpeg',
+              },
+              memberOf: ['foo-bar/team-d'],
+            },
+          },
         ] as Entity[],
       }),
   };
@@ -101,5 +128,7 @@ describe('MemberTab Test', () => {
       'href',
       '/catalog/foo-bar/user/tara.macgovern',
     );
+
+    expect(rendered.getByText('Members (1)')).toBeInTheDocument();
   });
 });

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -47,10 +47,10 @@ describe('MemberTab Test', () => {
         items: [
           {
             apiVersion: 'backstage.io/v1alpha1',
-            kind: 'Group',
+            kind: 'User',
             metadata: {
               name: 'tara.macgovern',
-              namespace: 'default',
+              namespace: 'foo-bar',
               uid: 'a5gerth56',
             },
             relations: [
@@ -99,7 +99,7 @@ describe('MemberTab Test', () => {
     ).toBeInTheDocument();
     expect(rendered.getByText('Tara MacGovern')).toHaveAttribute(
       'href',
-      '/catalog/default/user/tara.macgovern',
+      '/catalog/foo-bar/user/tara.macgovern',
     );
   });
 });

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -97,7 +97,7 @@ const MemberComponent = ({
                 component={RouterLink}
                 to={generatePath(
                   `/catalog/:namespace/user/${metaName}`,
-                  entityRouteParams(groupEntity),
+                  entityRouteParams(member),
                 )}
               >
                 {displayName}

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {
-  Entity,
+  ENTITY_DEFAULT_NAMESPACE,
   GroupEntity,
   RELATION_MEMBER_OF,
   UserEntity,
@@ -59,13 +59,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-const MemberComponent = ({
-  member,
-  groupEntity,
-}: {
-  member: UserEntity;
-  groupEntity: Entity;
-}) => {
+const MemberComponent = ({ member }: { member: UserEntity }) => {
   const classes = useStyles();
   const {
     metadata: { name: metaName },
@@ -117,12 +111,14 @@ export const MembersListCard = (_props: {
 }) => {
   const { entity: groupEntity } = useEntity<GroupEntity>();
   const {
-    metadata: { name: groupName },
+    metadata: { name: groupName, namespace: grpNamespace },
     spec: { profile },
   } = groupEntity;
   const catalogApi = useApi(catalogApiRef);
 
   const displayName = profile?.displayName ?? groupName;
+
+  const groupNamespace = grpNamespace || ENTITY_DEFAULT_NAMESPACE;
 
   const { loading, error, value: members } = useAsync(async () => {
     const membersList = await catalogApi.getEntities({
@@ -134,7 +130,9 @@ export const MembersListCard = (_props: {
           r =>
             r.type === RELATION_MEMBER_OF &&
             r.target.name.toLocaleLowerCase('en-US') ===
-              groupName.toLocaleLowerCase('en-US'),
+              groupName.toLocaleLowerCase('en-US') &&
+            r.target.namespace.toLocaleLowerCase('en-US') ===
+              groupNamespace.toLocaleLowerCase('en-US'),
         ),
     );
     return groupMembersList;
@@ -155,11 +153,7 @@ export const MembersListCard = (_props: {
         <Grid container spacing={3}>
           {members && members.length > 0 ? (
             members.map(member => (
-              <MemberComponent
-                member={member}
-                groupEntity={groupEntity}
-                key={member.metadata.uid}
-              />
+              <MemberComponent member={member} key={member.metadata.uid} />
             ))
           ) : (
             <Box p={2}>


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Correct the routing to group members when they exist in a different namespace from the group entity.
Correctly filter group members while respecting the target namespace in the relation.
Previously if you were a member of a group in a certain namespace, every duplicate group in other namespaces will include you in their membership list.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
