### PR TITLE
Remove backend dependency in the techdocs plugin

### DIFF
--- a/.changeset/plenty-years-deny.md
+++ b/.changeset/plenty-years-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Remove the `@backstage/techdocs-common` dependency to not pull in backend config schemas in the frontend.

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -37,7 +37,6 @@
     "@backstage/plugin-catalog-react": "^0.1.3",
     "@backstage/test-utils": "^0.1.9",
     "@backstage/theme": "^0.2.5",
-    "@backstage/techdocs-common": "^0.4.5",
     "@backstage/errors": "^0.1.1",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The frontend plugin should not reference a backend plugin (or in this case a backend-package).

Similar to #5113. The config system keeps crashing on building apps when it discovers some required config properties that doesn't make sense in the frontend.

Would be cool to have a custom lint rule that is based on the naming pattern for plugins.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
