### PR TITLE
Make sure that Group  is taken into account when filling out an org hierarchy

### DIFF
--- a/.changeset/old-hounds-doubt.md
+++ b/.changeset/old-hounds-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Make sure that Group `spec.members` is taken into account when filling out an org hierarchy

--- a/plugins/catalog-backend/src/ingestion/processors/util/org.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/util/org.test.ts
@@ -73,4 +73,22 @@ describe('buildMemberOf', () => {
     buildMemberOf(groups, [u]);
     expect(u.spec.memberOf).toEqual(expect.arrayContaining(['a', 'b', 'c']));
   });
+
+  it('takes group spec.members into account', () => {
+    const a = g('a', undefined, []);
+    const b = g('b', 'a', []);
+    const c = g('c', 'b', []);
+    c.spec.members = ['n'];
+    const u: UserEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: { name: 'n' },
+      spec: { profile: {}, memberOf: [] },
+    };
+
+    const groups = [a, b, c];
+    buildOrgHierarchy(groups);
+    buildMemberOf(groups, [u]);
+    expect(u.spec.memberOf).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+  });
 });

--- a/plugins/catalog-backend/src/ingestion/processors/util/org.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/util/org.ts
@@ -57,7 +57,13 @@ export function buildMemberOf(groups: GroupEntity[], users: UserEntity[]) {
   users.forEach(user => {
     const transitiveMemberOf = new Set<string>();
 
-    const todo = [...user.spec.memberOf];
+    const todo = [
+      ...user.spec.memberOf,
+      ...groups
+        .filter(g => g.spec.members?.includes(user.metadata.name))
+        .map(g => g.metadata.name),
+    ];
+
     for (;;) {
       const current = todo.pop();
       if (!current) {


### PR DESCRIPTION
This is not necessarily the most efficient code. But the dataset is so small and it's only done "offline", that it's not worth rewriting right now.