### PR TITLE
Make GitHub workflow run source.commit.url optional

### DIFF
--- a/.changeset/little-doors-smell.md
+++ b/.changeset/little-doors-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-actions': patch
+---
+
+Fixed GitHub workflows not appearing when the originating repository for a workflow run was deleted.

--- a/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
@@ -50,7 +50,7 @@ export type WorkflowRun = {
     branchName: string;
     commit: {
       hash: string;
-      url: string;
+      url?: string;
     };
   };
   status: string;

--- a/plugins/github-actions/src/components/useWorkflowRuns.ts
+++ b/plugins/github-actions/src/components/useWorkflowRuns.ts
@@ -43,53 +43,48 @@ export function useWorkflowRuns({
   const { loading, value: runs, retry, error } = useAsyncRetry<
     WorkflowRun[]
   >(async () => {
-    return (
-      api
-        // GitHub API pagination count starts from 1
-        .listWorkflowRuns({
-          hostname,
-          owner,
-          repo,
-          pageSize,
-          page: page + 1,
-          branch,
-        })
-        .then((workflowRunsData): WorkflowRun[] => {
-          setTotal(workflowRunsData.total_count);
-          // Transformation here
-          return workflowRunsData.workflow_runs.map(run => ({
-            workflowName: run.name,
-            message: run.head_commit.message,
-            id: `${run.id}`,
-            onReRunClick: async () => {
-              try {
-                await api.reRunWorkflow({
-                  hostname,
-                  owner,
-                  repo,
-                  runId: run.id,
-                });
-              } catch (e) {
-                errorApi.post(e);
-              }
-            },
-            source: {
-              branchName: run.head_branch,
-              commit: {
-                hash: run.head_commit.id,
-                url: run.head_repository.branches_url.replace(
-                  '{/branch}',
-                  run.head_branch,
-                ),
-              },
-            },
-            status: run.status,
-            conclusion: run.conclusion,
-            url: run.url,
-            githubUrl: run.html_url,
-          }));
-        })
-    );
+    // GitHub API pagination count starts from 1
+    const workflowRunsData = await api.listWorkflowRuns({
+      hostname,
+      owner,
+      repo,
+      pageSize,
+      page: page + 1,
+      branch,
+    });
+    setTotal(workflowRunsData.total_count);
+    // Transformation here
+    return workflowRunsData.workflow_runs.map(run => ({
+      workflowName: run.name,
+      message: run.head_commit.message,
+      id: `${run.id}`,
+      onReRunClick: async () => {
+        try {
+          await api.reRunWorkflow({
+            hostname,
+            owner,
+            repo,
+            runId: run.id,
+          });
+        } catch (e) {
+          errorApi.post(e);
+        }
+      },
+      source: {
+        branchName: run.head_branch,
+        commit: {
+          hash: run.head_commit.id,
+          url: run.head_repository?.branches_url?.replace(
+            '{/branch}',
+            run.head_branch,
+          ),
+        },
+      },
+      status: run.status,
+      conclusion: run.conclusion,
+      url: run.url,
+      githubUrl: run.html_url,
+    }));
   }, [page, pageSize, repo, owner]);
 
   return [


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

The [demo component](https://demo.backstage.io/catalog/default/component/demo/ci-cd) on the demo site is not showing GitHub workflow runs after we merged https://github.com/backstage/demo/pull/24.

This is because the `head_repository` field on a workflow run is nullable if the repository was deleted, as in this case where I nuked my fork shortly after. The derived `source.commit.url` field isn't used in the frontend currently, but should be optional for this reason.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
