### PR TITLE
changesets: fix bump level for catalog-model change

### DIFF
--- a/.changeset/little-starfishes-whisper.md
+++ b/.changeset/little-starfishes-whisper.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/catalog-model': minor
+'@backstage/catalog-model': patch
 ---
 
 Added `stringifyEntityRef`, which always creates a string representation of an entity reference. Also deprecated `serializeEntityRef`, as `stringifyEntityRef` should be used instead.


### PR DESCRIPTION
#5186 was a minor bump from the beginning but was reduced to patch