### PR TITLE
Feature/pre substitute transforms

### DIFF
--- a/.changeset/fair-geese-yell.md
+++ b/.changeset/fair-geese-yell.md
@@ -1,0 +1,9 @@
+---
+'@backstage/config-loader': minor
+---
+
+Add support for environment variable substitution in `$include` transform values.
+
+This change allows for including dynamic paths, such as environment specific secrets by using the same environment variable substitution already supported outside of the `$include` transform (`${..}`).
+
+If you are currently using the syntax `${...}` in your `$include` values, you will need to escape the substitution by using `$${...}` instead.

--- a/.changeset/fair-geese-yell.md
+++ b/.changeset/fair-geese-yell.md
@@ -2,8 +2,13 @@
 '@backstage/config-loader': minor
 ---
 
-Add support for environment variable substitution in `$include` transform values.
+Add support for environment variable substitution in `$include`, `$file` and
+`$env` transform values.
 
-This change allows for including dynamic paths, such as environment specific secrets by using the same environment variable substitution already supported outside of the `$include` transform (`${..}`).
+This change allows for including dynamic paths, such as environment specific
+secrets by using the same environment variable substitution (`${..}`) already
+supported outside of the various include transforms.
 
-If you are currently using the syntax `${...}` in your `$include` values, you will need to escape the substitution by using `$${...}` instead.
+If you are currently using the syntax `${...}` in your include transform values,
+you will need to escape the substitution by using `$${...}` instead to maintain
+the same behavior.

--- a/.changeset/fair-geese-yell.md
+++ b/.changeset/fair-geese-yell.md
@@ -2,13 +2,14 @@
 '@backstage/config-loader': minor
 ---
 
+Fix bug where `$${...}` was not being escaped to `${...}`
+
 Add support for environment variable substitution in `$include`, `$file` and
 `$env` transform values.
 
-This change allows for including dynamic paths, such as environment specific
-secrets by using the same environment variable substitution (`${..}`) already
-supported outside of the various include transforms.
-
-If you are currently using the syntax `${...}` in your include transform values,
-you will need to escape the substitution by using `$${...}` instead to maintain
-the same behavior.
+- This change allows for including dynamic paths, such as environment specific
+  secrets by using the same environment variable substitution (`${..}`) already
+  supported outside of the various include transforms.
+- If you are currently using the syntax `${...}` in your include transform values,
+  you will need to escape the substitution by using `$${...}` instead to maintain
+  the same behavior.

--- a/docs/conf/writing.md
+++ b/docs/conf/writing.md
@@ -177,3 +177,31 @@ configuration value will evaluate to `undefined`.
 
 The substitution syntax can be escaped using `$${...}`, which will be resolved
 as `${...}`.
+
+## Combining Includes and Environment Variable Substitution
+
+The Includes and Environment Variable Substitutions can be combined to do
+something like read a secrets configuration for a specific environment. For
+example:
+
+```yaml
+integrations:
+  github:
+    - host: github.com
+      apps:
+        - $include: secrets.${BACKSTAGE_ENVIRONMENT}.yaml
+```
+
+Example `secrets.prod.yaml`:
+
+```yaml
+appId: 1
+webhookUrl: https://smee.io/foo
+clientId: someGithubAppClientId
+clientSecret: someGithubAppClientSecret
+webhookSecret: someWebhookSecret
+privateKey: |
+  -----BEGIN RSA PRIVATE KEY-----
+  SomeRsaPrivateKey
+  -----END RSA PRIVATE KEY-----
+```

--- a/packages/config-loader/src/lib/transform/include.test.ts
+++ b/packages/config-loader/src/lib/transform/include.test.ts
@@ -31,7 +31,16 @@ const env = jest.fn(async (name: string) => {
 
 const substitute = async (
   value: JsonValue,
-): Promise<{ applied: boolean; value?: JsonValue }> => {
+): Promise<
+  | {
+      applied: false;
+    }
+  | {
+      applied: true;
+      value: JsonValue | undefined;
+      newBaseDir?: string | undefined;
+    }
+> => {
   if (typeof value !== 'string') {
     return { applied: false };
   }

--- a/packages/config-loader/src/lib/transform/include.test.ts
+++ b/packages/config-loader/src/lib/transform/include.test.ts
@@ -18,6 +18,7 @@ import { JsonValue } from '@backstage/config';
 import * as os from 'os';
 import { resolve as resolvePath } from 'path';
 import { createIncludeTransform } from './include';
+import { TransformFunc } from './types';
 
 const root = os.platform() === 'win32' ? 'C:\\' : '/';
 const substituteMe = '${MY_SUBSTITUTION}';
@@ -29,18 +30,7 @@ const env = jest.fn(async (name: string) => {
   } as { [name: string]: string })[name];
 });
 
-const substitute = async (
-  value: JsonValue,
-): Promise<
-  | {
-      applied: false;
-    }
-  | {
-      applied: true;
-      value: JsonValue | undefined;
-      newBaseDir?: string | undefined;
-    }
-> => {
+const substitute: TransformFunc = async value => {
   if (typeof value !== 'string') {
     return { applied: false };
   }

--- a/packages/config-loader/src/lib/transform/include.test.ts
+++ b/packages/config-loader/src/lib/transform/include.test.ts
@@ -29,23 +29,21 @@ const env = jest.fn(async (name: string) => {
   } as { [name: string]: string })[name];
 });
 
-const substitute = jest.fn(
-  async (
-    value: JsonValue,
-  ): Promise<{ applied: boolean; value?: JsonValue }> => {
-    if (typeof value !== 'string') {
-      return { applied: false };
-    }
-    if (value.includes(substituteMe)) {
-      return {
-        applied: true,
-        value: value.replace(substituteMe, mySubstitution),
-      };
-    }
-
+const substitute = async (
+  value: JsonValue,
+): Promise<{ applied: boolean; value?: JsonValue }> => {
+  if (typeof value !== 'string') {
     return { applied: false };
-  },
-);
+  }
+  if (value.includes(substituteMe)) {
+    return {
+      applied: true,
+      value: value.replace(substituteMe, mySubstitution),
+    };
+  }
+
+  return { applied: false };
+};
 
 const readFile = jest.fn(async (path: string) => {
   const content = ({

--- a/packages/config-loader/src/lib/transform/include.test.ts
+++ b/packages/config-loader/src/lib/transform/include.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { JsonValue } from '@backstage/config';
 import * as os from 'os';
 import { resolve as resolvePath } from 'path';
 import { createIncludeTransform } from './include';

--- a/packages/config-loader/src/lib/transform/include.ts
+++ b/packages/config-loader/src/lib/transform/include.ts
@@ -35,6 +35,7 @@ const includeFileParser: {
 export function createIncludeTransform(
   env: EnvFunc,
   readFile: ReadFileFunc,
+  substitute: TransformFunc,
 ): TransformFunc {
   return async (input: JsonValue, baseDir: string) => {
     if (!isObject(input)) {
@@ -53,7 +54,11 @@ export function createIncludeTransform(
       return { applied: false };
     }
 
-    const includeValue = input[includeKey];
+    const rawIncludedValue = input[includeKey];
+    const substituteResults = await substitute(rawIncludedValue!, baseDir);
+    const includeValue = substituteResults.applied
+      ? substituteResults.value
+      : rawIncludedValue;
     if (typeof includeValue !== 'string') {
       throw new Error(`${includeKey} include value is not a string`);
     }

--- a/packages/config-loader/src/lib/transform/include.ts
+++ b/packages/config-loader/src/lib/transform/include.ts
@@ -55,12 +55,18 @@ export function createIncludeTransform(
     }
 
     const rawIncludedValue = input[includeKey];
-    const substituteResults = await substitute(rawIncludedValue!, baseDir);
+    if (typeof rawIncludedValue !== 'string') {
+      throw new Error(`${includeKey} include value is not a string`);
+    }
+
+    const substituteResults = await substitute(rawIncludedValue, baseDir);
     const includeValue = substituteResults.applied
       ? substituteResults.value
       : rawIncludedValue;
-    if (typeof includeValue !== 'string') {
-      throw new Error(`${includeKey} include value is not a string`);
+
+    // The second string check is needed for Typescript to know this is a string.
+    if (includeValue === undefined || typeof includeValue !== 'string') {
+      throw new Error(`${includeKey} substitution value was undefined`);
     }
 
     switch (includeKey) {

--- a/packages/config-loader/src/lib/transform/substitution.test.ts
+++ b/packages/config-loader/src/lib/transform/substitution.test.ts
@@ -57,6 +57,12 @@ describe('substituteTransform', () => {
       value: undefined,
     });
     await expect(
+      substituteTransform('empty substitute ${}', '/'),
+    ).resolves.toEqual({
+      applied: true,
+      value: undefined,
+    });
+    await expect(
       substituteTransform('foo ${MISSING} ${SECRET}', '/'),
     ).resolves.toEqual({ applied: true, value: undefined });
     await expect(
@@ -65,5 +71,11 @@ describe('substituteTransform', () => {
     await expect(
       substituteTransform('foo ${SECRET} $$${ESCAPE_ME}', '/'),
     ).resolves.toEqual({ applied: true, value: 'foo my-secret $${ESCAPE_ME}' });
+    await expect(
+      substituteTransform('foo $${ESCAPE_ME} $$${ESCAPE_ME_TOO} $${}', '/'),
+    ).resolves.toEqual({
+      applied: true,
+      value: 'foo ${ESCAPE_ME} $${ESCAPE_ME_TOO} ${}',
+    });
   });
 });

--- a/packages/config-loader/src/lib/transform/substitution.test.ts
+++ b/packages/config-loader/src/lib/transform/substitution.test.ts
@@ -51,7 +51,7 @@ describe('substituteTransform', () => {
     });
     await expect(
       substituteTransform('${SECRET      } $${} ${TOKEN }', '/'),
-    ).resolves.toEqual({ applied: true, value: 'my-secret $${} my-token' });
+    ).resolves.toEqual({ applied: true, value: 'my-secret ${} my-token' });
     await expect(substituteTransform('foo ${MISSING}', '/')).resolves.toEqual({
       applied: true,
       value: undefined,
@@ -62,5 +62,8 @@ describe('substituteTransform', () => {
     await expect(
       substituteTransform('foo ${SECRET} ${SECRET}', '/'),
     ).resolves.toEqual({ applied: true, value: 'foo my-secret my-secret' });
+    await expect(
+      substituteTransform('foo ${SECRET} $$${ESCAPE_ME}', '/'),
+    ).resolves.toEqual({ applied: true, value: 'foo my-secret $${ESCAPE_ME}' });
   });
 });

--- a/packages/config-loader/src/lib/transform/substitution.ts
+++ b/packages/config-loader/src/lib/transform/substitution.ts
@@ -28,15 +28,16 @@ export function createSubstitutionTransform(env: EnvFunc): TransformFunc {
       return { applied: false };
     }
 
-    const parts: (string | undefined)[] = input.split(/(?<!\$)\$\{([^{}]+)\}/);
-    for (let i = 0; i < parts.length; i++) {
-      if (i % 2 === 0) {
-        parts[i] = parts[i]!.replace(/\$\${(.*?)\}/, '${$1}');
-      }
-      if (i % 2 === 1) {
-        parts[i] = await env(parts[i]!.trim());
+    const parts: (string | undefined)[] = input.split(/(\$?\$\{[^{}]*\})/);
+    for (let i = 1; i < parts.length; i += 2) {
+      const part = parts[i]!;
+      if (part.startsWith('$$')) {
+        parts[i] = part.slice(1);
+      } else {
+        parts[i] = await env(part.slice(2, -1).trim());
       }
     }
+
     if (parts.some(part => part === undefined)) {
       return { applied: true, value: undefined };
     }

--- a/packages/config-loader/src/lib/transform/substitution.ts
+++ b/packages/config-loader/src/lib/transform/substitution.ts
@@ -29,8 +29,13 @@ export function createSubstitutionTransform(env: EnvFunc): TransformFunc {
     }
 
     const parts: (string | undefined)[] = input.split(/(?<!\$)\$\{([^{}]+)\}/);
-    for (let i = 1; i < parts.length; i += 2) {
-      parts[i] = await env(parts[i]!.trim());
+    for (let i = 0; i < parts.length; i++) {
+      if (i % 2 === 0) {
+        parts[i] = parts[i]!.replace(/\$\${(.*?)\}/, '${$1}');
+      }
+      if (i % 2 === 1) {
+        parts[i] = await env(parts[i]!.trim());
+      }
     }
     if (parts.some(part => part === undefined)) {
       return { applied: true, value: undefined };

--- a/packages/config-loader/src/lib/transform/types.ts
+++ b/packages/config-loader/src/lib/transform/types.ts
@@ -23,13 +23,8 @@ export type ReadFileFunc = (path: string) => Promise<string>;
 export type TransformFunc = (
   value: JsonValue,
   baseDir: string,
-) => Promise<
-  | {
-      applied: false;
-    }
-  | {
-      applied: true;
-      value: JsonValue | undefined;
-      newBaseDir?: string | undefined;
-    }
->;
+) => Promise<{
+  applied: boolean;
+  value?: JsonValue;
+  newBaseDir?: string;
+}>;

--- a/packages/config-loader/src/lib/transform/types.ts
+++ b/packages/config-loader/src/lib/transform/types.ts
@@ -23,8 +23,13 @@ export type ReadFileFunc = (path: string) => Promise<string>;
 export type TransformFunc = (
   value: JsonValue,
   baseDir: string,
-) => Promise<{
-  applied: boolean;
-  value?: JsonValue;
-  newBaseDir?: string;
-}>;
+) => Promise<
+  | {
+      applied: false;
+    }
+  | {
+      applied: true;
+      value: JsonValue | undefined;
+      newBaseDir?: string | undefined;
+    }
+>;

--- a/packages/config-loader/src/loader.ts
+++ b/packages/config-loader/src/loader.ts
@@ -75,9 +75,10 @@ export async function loadConfig(
         fs.readFile(resolvePath(dir, path), 'utf8');
 
       const input = yaml.parse(await readFile(configPath));
+      const substitutionTransform = createSubstitutionTransform(env);
       const data = await applyConfigTransforms(dir, input, [
-        createIncludeTransform(env, readFile),
-        createSubstitutionTransform(env),
+        createIncludeTransform(env, readFile, substitutionTransform),
+        substitutionTransform,
       ]);
 
       configs.push({ data, context: basename(configPath) });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* Fixed bug where `$${...}` was not being escaped to `${...}` as per the docs
* Added support for using Environment Variable Substitution in the includes transforms, to support the below config:

```yaml
integrations:
  github:
    - host: github.com
      apps:
        - $include: secrets.${BACKSTAGE_ENVIRONMENT}.yaml
```

Resolves #5142.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
