### PR TITLE
add refresh to deployments plugin

### DIFF
--- a/.changeset/thirty-panthers-learn.md
+++ b/.changeset/thirty-panthers-learn.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-github-deployments': minor
+'@backstage/plugin-github-deployments': patch
 ---
 
 Add a button to reload the GitHub Deployments card

--- a/.changeset/thirty-panthers-learn.md
+++ b/.changeset/thirty-panthers-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-deployments': minor
+---
+
+add reload button and functionality

--- a/.changeset/thirty-panthers-learn.md
+++ b/.changeset/thirty-panthers-learn.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-github-deployments': minor
 ---
 
-add reload button and functionality
+Add a button to reload the GitHub Deployments card

--- a/plugins/github-deployments/package.json
+++ b/plugins/github-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-github-deployments",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-deployments/package.json
+++ b/plugins/github-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-github-deployments",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/github-deployments/src/components/GithubDeploymentsCard.test.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsCard.test.tsx
@@ -151,7 +151,7 @@ describe('github-deployments', () => {
         ),
       );
 
-      const refreshButton = await rendered.findByTitle('Refresh');
+      const refreshButton = await rendered.findByTitle('Reload');
       fireEvent.click(refreshButton);
 
       expect(

--- a/plugins/github-deployments/src/components/GithubDeploymentsCard.test.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsCard.test.tsx
@@ -24,12 +24,18 @@ import {
   OAuthApi,
 } from '@backstage/core';
 
+import { fireEvent } from '@testing-library/react';
 import { msw, renderInTestApp } from '@backstage/test-utils';
 import { GithubDeploymentsApiClient, githubDeploymentsApiRef } from '../api';
 import { githubDeploymentsPlugin } from '../plugin';
 import { GithubDeploymentsCard } from './GithubDeploymentsCard';
 
-import { entityStub, noDataResponseStub, responseStub } from '../mocks/mocks';
+import {
+  entityStub,
+  noDataResponseStub,
+  refreshedResponseStub,
+  responseStub,
+} from '../mocks/mocks';
 
 import { setupServer } from 'msw/node';
 import { graphql } from 'msw';
@@ -81,6 +87,9 @@ describe('github-deployments', () => {
         </ApiProvider>,
       );
 
+      expect(
+        await rendered.findByText('GitHub Deployments'),
+      ).toBeInTheDocument();
       expect(await rendered.findByText('active')).toBeInTheDocument();
       expect(await rendered.findByText('prd')).toBeInTheDocument();
       expect(await rendered.findByText('12345')).toHaveAttribute(
@@ -110,8 +119,45 @@ describe('github-deployments', () => {
       );
 
       expect(
+        await rendered.findByText('GitHub Deployments'),
+      ).toBeInTheDocument();
+      expect(
         await rendered.findByText('No deployments found for this entity.'),
       ).toBeInTheDocument();
+    });
+
+    it('should shows new data on reload', async () => {
+      worker.use(
+        graphql.query('deployments', (_, res, ctx) =>
+          res(ctx.data(responseStub)),
+        ),
+      );
+
+      const rendered = await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <GithubDeploymentsCard />
+        </ApiProvider>,
+      );
+
+      expect(
+        await rendered.findByText('GitHub Deployments'),
+      ).toBeInTheDocument();
+      expect(await rendered.findByText('pending')).toBeInTheDocument();
+
+      worker.resetHandlers();
+      worker.use(
+        graphql.query('deployments', (_, res, ctx) =>
+          res(ctx.data(refreshedResponseStub)),
+        ),
+      );
+
+      const refreshButton = await rendered.findByTitle('Refresh');
+      fireEvent.click(refreshButton);
+
+      expect(
+        await rendered.findByText('GitHub Deployments'),
+      ).toBeInTheDocument();
+      expect(await rendered.findByText('failure')).toBeInTheDocument();
     });
   });
 });

--- a/plugins/github-deployments/src/components/GithubDeploymentsCard.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsCard.tsx
@@ -38,7 +38,7 @@ const GithubDeploymentsComponent = ({
   const api = useApi(githubDeploymentsApiRef);
   const [owner, repo] = projectSlug.split('/');
 
-  const { loading, value, error, retry } = useAsyncRetry(
+  const { loading, value, error, retry: reload } = useAsyncRetry(
     async () => await api.listDeployments({ owner, repo, last }),
   );
 
@@ -50,7 +50,7 @@ const GithubDeploymentsComponent = ({
     <GithubDeploymentsTable
       deployments={value || []}
       isLoading={loading}
-      retry={retry}
+      reload={reload}
     />
   );
 };

--- a/plugins/github-deployments/src/components/GithubDeploymentsCard.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsCard.tsx
@@ -15,13 +15,11 @@
  */
 import React from 'react';
 import {
-  InfoCard,
   MissingAnnotationEmptyState,
-  Progress,
   ResponseErrorPanel,
   useApi,
 } from '@backstage/core';
-import { useAsync } from 'react-use';
+import { useAsyncRetry } from 'react-use';
 import { githubDeploymentsApiRef } from '../api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import {
@@ -40,22 +38,21 @@ const GithubDeploymentsComponent = ({
   const api = useApi(githubDeploymentsApiRef);
   const [owner, repo] = projectSlug.split('/');
 
-  const { loading, value, error } = useAsync(
+  const { loading, value, error, retry } = useAsyncRetry(
     async () => await api.listDeployments({ owner, repo, last }),
   );
 
-  if (loading) {
-    return (
-      <InfoCard title="GitHub Deployments">
-        <Progress />
-      </InfoCard>
-    );
-  }
   if (error) {
     return <ResponseErrorPanel error={error} />;
   }
 
-  return <GithubDeploymentsTable deployments={value || []} />;
+  return (
+    <GithubDeploymentsTable
+      deployments={value || []}
+      isLoading={loading}
+      retry={retry}
+    />
+  );
 };
 
 export const GithubDeploymentsCard = ({ last }: { last?: number }) => {

--- a/plugins/github-deployments/src/components/GithubDeploymentsTable/GithubDeploymentsTable.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsTable/GithubDeploymentsTable.tsx
@@ -85,13 +85,13 @@ const columns: TableColumn<GithubDeployment>[] = [
 type GithubDeploymentsTableProps = {
   deployments: GithubDeployment[];
   isLoading: boolean;
-  retry: () => void;
+  reload: () => void;
 };
 
 const GithubDeploymentsTable = ({
   deployments,
   isLoading,
-  retry,
+  reload,
 }: GithubDeploymentsTableProps) => {
   const classes = useStyles();
 
@@ -105,9 +105,9 @@ const GithubDeploymentsTable = ({
       actions={[
         {
           icon: () => <SyncIcon />,
-          tooltip: 'Refresh',
+          tooltip: 'Reload',
           isFreeAction: true,
-          onClick: () => retry(),
+          onClick: () => reload(),
         },
       ]}
       emptyContent={

--- a/plugins/github-deployments/src/components/GithubDeploymentsTable/GithubDeploymentsTable.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsTable/GithubDeploymentsTable.tsx
@@ -26,6 +26,7 @@ import {
 import { GithubDeployment } from '../../api';
 import { DateTime } from 'luxon';
 import { Box, Typography, Link, makeStyles } from '@material-ui/core';
+import SyncIcon from '@material-ui/icons/Sync';
 
 const useStyles = makeStyles(theme => ({
   empty: {
@@ -83,10 +84,14 @@ const columns: TableColumn<GithubDeployment>[] = [
 
 type GithubDeploymentsTableProps = {
   deployments: GithubDeployment[];
+  isLoading: boolean;
+  retry: () => void;
 };
 
 const GithubDeploymentsTable = ({
   deployments,
+  isLoading,
+  retry,
 }: GithubDeploymentsTableProps) => {
   const classes = useStyles();
 
@@ -96,6 +101,15 @@ const GithubDeploymentsTable = ({
       options={{ padding: 'dense', paging: true, search: false, pageSize: 5 }}
       title="GitHub Deployments"
       data={deployments}
+      isLoading={isLoading}
+      actions={[
+        {
+          icon: () => <SyncIcon />,
+          tooltip: 'Refresh',
+          isFreeAction: true,
+          onClick: () => retry(),
+        },
+      ]}
       emptyContent={
         <div className={classes.empty}>
           <Typography variant="body1">

--- a/plugins/github-deployments/src/mocks/mocks.ts
+++ b/plugins/github-deployments/src/mocks/mocks.ts
@@ -64,4 +64,31 @@ export const responseStub: QueryResponse = {
   },
 };
 
+export const refreshedResponseStub: QueryResponse = {
+  repository: {
+    deployments: {
+      nodes: [
+        {
+          state: 'active',
+          environment: 'prd',
+          updatedAt: '2021-03-25T12:08:45Z',
+          commit: {
+            commitUrl: 'https://exampleapi.com/123456789',
+            abbreviatedOid: '12345',
+          },
+        },
+        {
+          state: 'failure',
+          environment: 'lab',
+          updatedAt: '2021-03-25T12:09:47Z',
+          commit: {
+            commitUrl: 'https://exampleapi.com/543212345',
+            abbreviatedOid: '54321',
+          },
+        },
+      ],
+    },
+  },
+};
+
 export const noDataResponseStub: QueryResponse = {};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a refresh button + functionality to the GithubDeploymentsPlugin.

## Screenshots

<img width="775" alt="Screenshot 2021-03-31 at 16 48 27" src="https://user-images.githubusercontent.com/57673895/113177037-03422f80-9245-11eb-9118-e837cbbd04b3.png">

<img width="778" alt="Screenshot 2021-03-31 at 16 48 08" src="https://user-images.githubusercontent.com/57673895/113177045-050bf300-9245-11eb-8369-1c02a38f05cd.png">

## Issues

Issues: At the moment there seems to be a flakey test caused by the small time frame in which loading = true. Trying to figure out how to ensure this doesn't happen.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
