### PR TITLE
Optimize data fetched for the `OwnershipCard`

### DIFF
--- a/.changeset/stale-geese-rule.md
+++ b/.changeset/stale-geese-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Optimize data fetched for the `OwnershipCard`.

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GroupEntity } from '@backstage/catalog-model';
+import { ApiProvider, ApiRegistry } from '@backstage/core';
+import {
+  CatalogApi,
+  catalogApiRef,
+  EntityProvider,
+} from '@backstage/plugin-catalog-react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { queryByText } from '@testing-library/react';
+import React from 'react';
+import { OwnershipCard } from './OwnershipCard';
+
+describe('OwnershipCard', () => {
+  const userEntity: GroupEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Group',
+    metadata: {
+      name: 'my-team',
+    },
+    spec: {
+      type: 'team',
+      children: [],
+    },
+    relations: [
+      {
+        type: 'memberOf',
+        target: {
+          kind: 'group',
+          name: 'ExampleGroup',
+          namespace: 'default',
+        },
+      },
+    ],
+  };
+
+  it('displays entity counts', async () => {
+    const catalogApi: jest.Mocked<CatalogApi> = {
+      getEntities: jest.fn(),
+    } as any;
+
+    catalogApi.getEntities.mockResolvedValue({
+      items: [
+        {
+          kind: 'API',
+          metadata: {
+            name: 'my-api',
+          },
+          spec: {
+            type: 'openapi',
+          },
+          relations: [
+            {
+              type: 'ownedBy',
+              target: {
+                name: 'my-team',
+                namespace: 'default',
+                kind: 'Group',
+              },
+            },
+          ],
+        },
+        {
+          kind: 'Component',
+          metadata: {
+            name: 'my-service',
+          },
+          spec: {
+            type: 'service',
+          },
+          relations: [
+            {
+              type: 'ownedBy',
+              target: {
+                name: 'my-team',
+                namespace: 'default',
+                kind: 'Group',
+              },
+            },
+          ],
+        },
+        {
+          kind: 'Component',
+          metadata: {
+            name: 'my-library',
+            namespace: 'other-namespace',
+          },
+          spec: {
+            type: 'library',
+          },
+          relations: [
+            {
+              type: 'ownedBy',
+              target: {
+                name: 'my-team',
+                namespace: 'default',
+                kind: 'Group',
+              },
+            },
+          ],
+        },
+      ] as any,
+    });
+
+    const { getByText } = await renderInTestApp(
+      <ApiProvider apis={ApiRegistry.with(catalogApiRef, catalogApi)}>
+        <EntityProvider entity={userEntity}>
+          <OwnershipCard />
+        </EntityProvider>
+      </ApiProvider>,
+    );
+
+    expect(getByText('Services')).toBeInTheDocument();
+    expect(
+      queryByText(getByText('Services').parentElement!, '1'),
+    ).toBeInTheDocument();
+    expect(getByText('Documentation')).toBeInTheDocument();
+    expect(
+      queryByText(getByText('Documentation').parentElement!, '0'),
+    ).toBeInTheDocument();
+    expect(getByText('APIs')).toBeInTheDocument();
+    expect(
+      queryByText(getByText('APIs').parentElement!, '1'),
+    ).toBeInTheDocument();
+    expect(getByText('Libraries')).toBeInTheDocument();
+    expect(
+      queryByText(getByText('Libraries').parentElement!, '1'),
+    ).toBeInTheDocument();
+    expect(getByText('Websites')).toBeInTheDocument();
+    expect(
+      queryByText(getByText('Websites').parentElement!, '0'),
+    ).toBeInTheDocument();
+    expect(getByText('Tools')).toBeInTheDocument();
+    expect(
+      queryByText(getByText('Tools').parentElement!, '0'),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -144,7 +144,20 @@ export const OwnershipCard = ({
     error,
     value: componentsWithCounters,
   } = useAsync(async () => {
-    const entitiesList = await catalogApi.getEntities();
+    const kinds = ['Component', 'API'];
+    const entitiesList = await catalogApi.getEntities({
+      filter: {
+        kind: kinds,
+      },
+      fields: [
+        'kind',
+        'metadata.name',
+        'metadata.namespace',
+        'spec.type',
+        'relations',
+      ],
+    });
+
     const ownedEntitiesList = entitiesList.items.filter(component =>
       isOwnerOf(entity, component),
     );


### PR DESCRIPTION
I noticed that it takes a lot of time to evaluate this because all entities are fetched. Now we only fetch what we need. Also used this to add a test.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
