### PR TITLE
fix: displays name from jwt instead of using email address

### DIFF
--- a/.changeset/forty-ladybugs-move.md
+++ b/.changeset/forty-ladybugs-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+When using OAuth2 authentication the name is now taken from the name property of the JWT instead of the email property

--- a/plugins/auth-backend/src/lib/passport/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/lib/passport/PassportStrategyHelper.ts
@@ -30,7 +30,7 @@ export const makeProfileInfo = (
   profile: passport.Profile,
   idToken?: string,
 ): ProfileInfo => {
-  const { displayName } = profile;
+  let { displayName } = profile;
 
   let email: string | undefined = undefined;
   if (profile.emails && profile.emails.length > 0) {
@@ -44,7 +44,7 @@ export const makeProfileInfo = (
     picture = firstPhoto.value;
   }
 
-  if ((!email || !picture) && idToken) {
+  if ((!email || !picture || !displayName) && idToken) {
     try {
       const decoded: Record<string, string> = jwtDecoder(idToken);
       if (!email && decoded.email) {
@@ -52,6 +52,9 @@ export const makeProfileInfo = (
       }
       if (!picture && decoded.picture) {
         picture = decoded.picture;
+      }
+      if (!displayName && decoded.name) {
+        displayName = decoded.name;
       }
     } catch (e) {
       throw new Error(`Failed to parse id token and get profile info, ${e}`);


### PR DESCRIPTION
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This change to the OAuth2 backend makes it so that the name of a user will be taken from the `name` attribute of a JWT, instead of using the email address and deriving it from that.

> I used to email of the company I work for, teun.willems@theapsgroup.com
Before

![image](https://user-images.githubusercontent.com/3589281/113292496-e2d1ae00-92f4-11eb-925d-4eaba463a831.png)

After:

![image](https://user-images.githubusercontent.com/3589281/113292422-ca619380-92f4-11eb-8d05-4a5835f7e56b.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
  - There weren't any tests to check this before, should I add these to the existing tests?
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
