### PR TITLE
core-api: improve error message and component naming for routable extension mounting errorsr

### DIFF
--- a/.changeset/funny-donkeys-jam.md
+++ b/.changeset/funny-donkeys-jam.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-api': patch
+'@backstage/core': patch
+---
+
+Improved error messaging for routable extension errors, making it easier to identify the component and mount point that caused the error.

--- a/packages/core-api/src/extensions/extensions.tsx
+++ b/packages/core-api/src/extensions/extensions.tsx
@@ -41,20 +41,28 @@ export function createRoutableExtension<
     component: {
       lazy: () =>
         component().then(InnerComponent => {
-          const RoutableExtensionWrapper = ((props: any) => {
+          const RoutableExtensionWrapper: any = (props: any) => {
             // Validate that the routing is wired up correctly in the App.tsx
             try {
               useRouteRef(mountPoint);
             } catch {
               throw new Error(
-                'Routable extension component was not discovered in the app element tree. ' +
+                `Routable extension component with mount point ${mountPoint} was not discovered in the app element tree. ` +
                   'Routable extension components may not be rendered by other components and must be ' +
                   'directly available as an element within the App provider component.',
               );
             }
             return <InnerComponent {...props} />;
-          }) as T;
-          return RoutableExtensionWrapper;
+          };
+
+          const componentName =
+            (InnerComponent as { displayName?: string }).displayName ||
+            InnerComponent.name ||
+            'LazyComponent';
+
+          RoutableExtensionWrapper.displayName = `RoutableExtension(${componentName})`;
+
+          return RoutableExtensionWrapper as T;
         }),
     },
     data: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Making it a bit easier to track down errors

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
