### PR TITLE
test-utils: remove unnecessary wrapInTestApp wrapping that broke mount point discovery

### DIFF
--- a/.changeset/polite-cameras-sin.md
+++ b/.changeset/polite-cameras-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Remove unnecessary wrapping of elements rendered by `wrapInTestApp` and `renderInTestApp`, which was breaking mount discovery.

--- a/packages/test-utils/src/testUtils/appWrappers.tsx
+++ b/packages/test-utils/src/testUtils/appWrappers.tsx
@@ -120,11 +120,11 @@ export function wrapInTestApp(
     },
   });
 
-  let Wrapper: ComponentType;
+  let wrappedElement: React.ReactElement;
   if (Component instanceof Function) {
-    Wrapper = Component;
+    wrappedElement = <Component />;
   } else {
-    Wrapper = () => Component as React.ReactElement;
+    wrappedElement = Component as React.ReactElement;
   }
 
   const routeElements = Object.entries(options.mountedRoutes ?? {}).map(
@@ -153,7 +153,7 @@ export function wrapInTestApp(
         {routeElements}
         {/* The path of * here is needed to be set as a catch all, so it will render the wrapper element
          *  and work with nested routes if they exist too */}
-        <Route path="*" element={<Wrapper />} />
+        <Route path="*" element={wrappedElement} />
       </AppRouter>
     </AppProvider>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This make it tricky to test routable extensions using the test app wrapper.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
