### PR TITLE
core-api: fix a bug where resolving routes beneath a mount point would fail

### DIFF
--- a/.changeset/neat-lions-peel.md
+++ b/.changeset/neat-lions-peel.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-api': patch
+'@backstage/core': patch
+---
+
+Fixed a bug with `useRouteRef` where navigating from routes beneath a mount point would often fail.

--- a/packages/core-api/src/routing/collectors.test.tsx
+++ b/packages/core-api/src/routing/collectors.test.tsx
@@ -90,13 +90,26 @@ function sortedEntries<T>(map: Map<RouteRef, T>): [RouteRef, T][] {
   );
 }
 
-function routeObj(path: string, refs: RouteRef[], children: any[] = []) {
+function routeObj(
+  path: string,
+  refs: RouteRef[],
+  children: any[] = [],
+  type: 'mounted' | 'gathered' = 'mounted',
+) {
   return {
     path: path,
     caseSensitive: false,
-    element: null,
+    element: type,
     routeRefs: new Set(refs),
-    children: children,
+    children: [
+      {
+        path: '/*',
+        caseSensitive: false,
+        element: 'match-all',
+        routeRefs: new Set(),
+      },
+      ...children,
+    ],
   };
 }
 
@@ -266,8 +279,12 @@ describe('discovery', () => {
       [ref5, ref3],
     ]);
     expect(routeObjects).toEqual([
-      routeObj('/foo', [ref1, ref2]),
-      routeObj('/bar', [ref3], [routeObj('/baz', [ref4, ref5])]),
+      routeObj('/foo', [ref1, ref2], [], 'gathered'),
+      routeObj(
+        '/bar',
+        [ref3],
+        [routeObj('/baz', [ref4, ref5], [], 'gathered')],
+      ),
     ]);
   });
 
@@ -321,6 +338,7 @@ describe('discovery', () => {
             '/bar',
             [ref2, ref5],
             [routeObj('/baz', [ref3], [routeObj('/blop', [ref4])])],
+            'gathered',
           ),
         ],
       ),

--- a/packages/core-api/src/routing/collectors.tsx
+++ b/packages/core-api/src/routing/collectors.tsx
@@ -109,6 +109,17 @@ export const routeParentCollector = createCollector(
   },
 );
 
+// We always add a child that matches all subroutes but without any route refs. This makes
+// sure that we're always able to match each route no matter how deep the navigation goes.
+// The route resolver then takes care of selecting the most specific match in order to find
+// mount points that are as deep in the routing tree as possible.
+export const MATCH_ALL_ROUTE: BackstageRouteObject = {
+  caseSensitive: false,
+  path: '/*',
+  element: 'match-all', // These elements aren't used, so we add in a bit of debug information
+  routeRefs: new Set(),
+};
+
 export const routeObjectCollector = createCollector(
   () => Array<BackstageRouteObject>(),
   (acc, node, parent, parentObj: BackstageRouteObject | undefined) => {
@@ -126,9 +137,9 @@ export const routeObjectCollector = createCollector(
         const newObject: BackstageRouteObject = {
           caseSensitive,
           path,
-          element: null,
+          element: 'mounted',
           routeRefs: new Set([routeRef]),
-          children: [],
+          children: [MATCH_ALL_ROUTE],
         };
         parentChildren.push(newObject);
         return newObject;
@@ -148,9 +159,9 @@ export const routeObjectCollector = createCollector(
       const newObject: BackstageRouteObject = {
         caseSensitive,
         path,
-        element: null,
+        element: 'gathered',
         routeRefs: new Set(),
-        children: [],
+        children: [MATCH_ALL_ROUTE],
       };
       parentChildren.push(newObject);
       return newObject;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Couple of bugs showing up now that we're getting more usage of the new routing API :grin:

Thanks to @Fox32 for reporting this one

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
