### PR TITLE
config-loader: fix include test on windows

### DIFF
--- a/packages/config-loader/src/lib/transform/include.test.ts
+++ b/packages/config-loader/src/lib/transform/include.test.ts
@@ -161,7 +161,7 @@ describe('includeTransform', () => {
     ).resolves.toEqual({
       applied: true,
       value: { foo: 'bar' },
-      newBaseDir: `/${mySubstitution}`,
+      newBaseDir: resolvePath(root, mySubstitution),
     });
   });
 });


### PR DESCRIPTION
Fixing Windows master build