### PR TITLE
Add link to Bitbucket Discovery, fix capitalization

### DIFF
--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -211,7 +211,7 @@ integrations:
         $env: GITLAB_TOKEN
 ```
 
-#### BitBucket
+#### Bitbucket
 
 For Bitbucket there are two authentication methods supported. Either `token` or
 a combination of `appPassword` and `username`. It looks like either of the

--- a/docs/features/techdocs/README.md
+++ b/docs/features/techdocs/README.md
@@ -43,7 +43,7 @@ providers are used.
 | ---------------------------- | -------------- |
 | GitHub                       | Yes ✅         |
 | GitHub Enterprise            | Yes ✅         |
-| BitBucket                    | Yes ✅         |
+| Bitbucket                    | Yes ✅         |
 | Azure DevOps                 | Yes ✅         |
 | GitLab                       | Yes ✅         |
 | GitLab Enterprise            | Yes ✅         |

--- a/docs/integrations/bitbucket/locations.md
+++ b/docs/integrations/bitbucket/locations.md
@@ -7,7 +7,7 @@ description:
 ---
 
 The Bitbucket integration supports loading catalog entities from bitbucket.org
-or a self-hosted BitBucket. Entities can be added to
+or a self-hosted Bitbucket. Entities can be added to
 [static catalog configuration](../../features/software-catalog/configuration.md),
 or registered with the
 [catalog-import](https://github.com/backstage/backstage/tree/master/plugins/catalog-import)
@@ -17,7 +17,6 @@ plugin.
 integrations:
   bitbucket:
     - host: bitbucket.org
-      username: ${BITBUCKET_USERNAME}
       token: ${BITBUCKET_TOKEN}
 ```
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -8,7 +8,7 @@ description:
 ---
 
 Integrations allow Backstage to read or publish data using external providers
-such as GitHub, GitLab, BitBucket, LDAP, or cloud providers.
+such as GitHub, GitLab, Bitbucket, LDAP, or cloud providers.
 
 ## Configuration
 
@@ -17,7 +17,7 @@ integrations are used by many Backstage core features and other plugins.
 
 Each key under `integrations` is a separate configuration for a single external
 provider. Providers each have different configuration; here's an example of
-configuration to use both GitHub and BitBucket:
+configuration to use both GitHub and Bitbucket:
 
 ```yaml
 integrations:

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -113,8 +113,11 @@
       },
       {
         "type": "subcategory",
-        "label": "BitBucket",
-        "ids": ["integrations/bitbucket/locations"]
+        "label": "Bitbucket",
+        "ids": [
+          "integrations/bitbucket/locations",
+          "integrations/bitbucket/discovery"
+        ]
       },
       {
         "type": "subcategory",


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

A Bitbucket discovery processor was added in #5149 but not linked in the sidebar. I also noticed in that PR the correction from `BitBucket` to `Bitbucket` - updated that a few more places.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
