### PR TITLE
fix: Support auth by sending cookies in scaffolder eventstream request

### DIFF
--- a/.changeset/mighty-bats-nail.md
+++ b/.changeset/mighty-bats-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Support auth by sending cookies in eventstream request

--- a/.changeset/mighty-bats-nail.md
+++ b/.changeset/mighty-bats-nail.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Support auth by sending cookies in eventstream request
+Support auth by sending cookies in event stream request

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -196,7 +196,7 @@ export class ScaffolderClient implements ScaffolderApi {
           const url = `${baseUrl}/v2/tasks/${encodeURIComponent(
             taskId,
           )}/eventstream`;
-          const eventSource = new EventSource(url);
+          const eventSource = new EventSource(url, { withCredentials: true });
           eventSource.addEventListener('log', (event: any) => {
             if (event.data) {
               try {


### PR DESCRIPTION
Signed-off-by: Erik Larsson <erik.larsson@schibsted.com>

## Hey, I just made a Pull Request!

The scaffolder plugin does not support authorization of API requests (the client does not send an Authorization header), causing a 401 error when asking for the task event stream (no task updates are seen on client). This PR solves that by asking that cookies be sent, using the token cookie specified in https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md to authenticate the eventstreaam request.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
