### PR TITLE
Fix example data link

### DIFF
--- a/packages/catalog-model/examples/apis/spotify-api.yaml
+++ b/packages/catalog-model/examples/apis/spotify-api.yaml
@@ -14,4 +14,4 @@ spec:
   lifecycle: production
   owner: team-a
   definition:
-    $text: https://github.com/APIs-guru/openapi-directory/blob/master/APIs/spotify.com/v1/swagger.yaml
+    $text: https://github.com/APIs-guru/openapi-directory/blob/dab6854d4d599aafb0eb36e6c7ae1fe0c37509b7/APIs/spotify.com/2021.4.2/openapi.yaml


### PR DESCRIPTION
The old file was renamed. The new link points to an exact commit instead, so that it can't break again in the future.

Example data, no need for a changeset.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
