### PR TITLE
Expose the register-component route as an external route from the scaffolder

### DIFF
--- a/.changeset/loud-apricots-fix.md
+++ b/.changeset/loud-apricots-fix.md
@@ -1,0 +1,31 @@
+---
+'@backstage/create-app': patch
+'@backstage/plugin-scaffolder': minor
+---
+
+Expose the catalog-import route as an external route from the scaffolder.
+
+This will make it possible to hide the "Register Existing Component" button
+when you for example are running backstage with `catalog.readonly=true`.
+
+As a consequence of this change you need add a new binding to your createApp call to
+keep the button visible. However, if you instead want to hide the button you can safely
+ignore the following example.
+
+To bind the external route from the catalog-import plugin to the scaffolder template
+index page, make sure you have the appropriate imports and add the following
+to the createApp call:
+
+```typescript
+import { catalogImportPlugin } from '@backstage/plugin-catalog-import';
+
+const app = createApp({
+  // ...
+  bindRoutes({ bind }) {
+    // ...
+    bind(scaffolderPlugin.externalRoutes, {
+      registerComponent: catalogImportPlugin.routes.importPage,
+    });
+  },
+});
+```

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -27,7 +27,11 @@ import {
   CatalogIndexPage,
   catalogPlugin,
 } from '@backstage/plugin-catalog';
-import { CatalogImportPage } from '@backstage/plugin-catalog-import';
+
+import {
+  CatalogImportPage,
+  catalogImportPlugin,
+} from '@backstage/plugin-catalog-import';
 import {
   CostInsightsLabelDataflowInstructionsPage,
   CostInsightsPage,
@@ -81,6 +85,9 @@ const app = createApp({
     });
     bind(explorePlugin.externalRoutes, {
       catalogEntity: catalogPlugin.routes.catalogEntity,
+    });
+    bind(scaffolderPlugin.externalRoutes, {
+      registerComponent: catalogImportPlugin.routes.importPage,
     });
   },
 });

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -12,7 +12,7 @@ import {
   CatalogIndexPage,
   catalogPlugin,
 } from '@backstage/plugin-catalog';
-import { CatalogImportPage } from '@backstage/plugin-catalog-import';
+import {CatalogImportPage, catalogImportPlugin} from '@backstage/plugin-catalog-import';
 import { ScaffolderPage, scaffolderPlugin } from '@backstage/plugin-scaffolder';
 import { SearchPage } from '@backstage/plugin-search';
 import { TechRadarPage } from '@backstage/plugin-tech-radar';
@@ -32,6 +32,9 @@ const app = createApp({
     });
     bind(apiDocsPlugin.externalRoutes, {
       createComponent: scaffolderPlugin.routes.root,
+    });
+    bind(scaffolderPlugin.externalRoutes, {
+      registerComponent: catalogImportPlugin.routes.importPage,
     });
   },
 });

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -26,6 +26,7 @@ import {
   Progress,
   SupportButton,
   useApi,
+  useRouteRef,
   WarningPanel,
 } from '@backstage/core';
 import { useStarredEntities } from '@backstage/plugin-catalog-react';
@@ -39,6 +40,7 @@ import { ScaffolderFilter } from '../ScaffolderFilter';
 import { ButtonGroup } from '../ScaffolderFilter/ScaffolderFilter';
 import SearchToolbar from '../SearchToolbar/SearchToolbar';
 import { TemplateCard, TemplateCardProps } from '../TemplateCard';
+import { registerComponentRouteRef } from '../../routes';
 
 const useStyles = makeStyles(theme => ({
   contentWrapper: {
@@ -108,6 +110,8 @@ export const ScaffolderPageContents = () => {
     `${metadata.title}`.toLocaleUpperCase('en-US').includes(query) ||
     metadata.tags?.join('').toLocaleUpperCase('en-US').indexOf(query) !== -1;
 
+  const registerComponentLink = useRouteRef(registerComponentRouteRef);
+
   useEffect(() => {
     if (search.length === 0) {
       return setMatchingEntities(filteredEntities);
@@ -132,14 +136,16 @@ export const ScaffolderPageContents = () => {
       />
       <Content>
         <ContentHeader title="Available Templates">
-          <Button
-            variant="contained"
-            color="primary"
-            component={RouterLink}
-            to="/catalog-import"
-          >
-            Register Existing Component
-          </Button>
+          {registerComponentLink && (
+            <Button
+              component={RouterLink}
+              variant="contained"
+              color="primary"
+              to={registerComponentLink()}
+            >
+              Register Existing Component
+            </Button>
+          )}
           <SupportButton>
             Create new software components using standard templates. Different
             templates create different kinds of components (services, websites,

--- a/plugins/scaffolder/src/plugin.ts
+++ b/plugins/scaffolder/src/plugin.ts
@@ -23,7 +23,7 @@ import {
 } from '@backstage/core';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 import { scaffolderApiRef, ScaffolderClient } from './api';
-import { rootRouteRef } from './routes';
+import { rootRouteRef, registerComponentRouteRef } from './routes';
 
 export const scaffolderPlugin = createPlugin({
   id: 'scaffolder',
@@ -41,6 +41,9 @@ export const scaffolderPlugin = createPlugin({
   ],
   routes: {
     root: rootRouteRef,
+  },
+  externalRoutes: {
+    registerComponent: registerComponentRouteRef,
   },
 });
 

--- a/plugins/scaffolder/src/routes.ts
+++ b/plugins/scaffolder/src/routes.ts
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createRouteRef } from '@backstage/core';
+import { createExternalRouteRef, createRouteRef } from '@backstage/core';
+
+export const registerComponentRouteRef = createExternalRouteRef({
+  id: 'register-component',
+  optional: true,
+});
 
 export const rootRouteRef = createRouteRef({
   title: 'Create new entity',


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

## Hey, I just made a Pull Request!

This pull request will expose the link to the "Register Existing Component" button in the scaffolder plugin as an external route. This will make it possible to hide the button in cases where you do not want to let users to be able to register an existing component manuallt. e.g. when the `catalog.readonly=true`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
