### PR TITLE
Adding close button on Support menu

### DIFF
--- a/.changeset/stale-chefs-retire.md
+++ b/.changeset/stale-chefs-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': minor
+---
+
+Adding close button on support menu

--- a/.changeset/stale-chefs-retire.md
+++ b/.changeset/stale-chefs-retire.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/core': minor
+'@backstage/core': patch
 ---
 
 Adding close button on support menu

--- a/packages/core/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core/src/components/SupportButton/SupportButton.tsx
@@ -16,6 +16,7 @@
 
 import { HelpIcon, useApp } from '@backstage/core-api';
 import {
+  Box,
   Button,
   List,
   ListItem,
@@ -127,6 +128,11 @@ export const SupportButton = ({ children }: PropsWithChildren<Props>) => {
           {items &&
             items.map((item, i) => <SupportListItem item={item} key={i} />)}
         </List>
+        <Box display="flex" justifyContent="flex-end">
+          <Button color="primary" onClick={popoverCloseHandler}>
+            Close
+          </Button>
+        </Box>
       </Popover>
     </Fragment>
   );

--- a/packages/core/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core/src/components/SupportButton/SupportButton.tsx
@@ -16,8 +16,8 @@
 
 import { HelpIcon, useApp } from '@backstage/core-api';
 import {
-  Box,
   Button,
+  DialogActions,
   List,
   ListItem,
   ListItemIcon,
@@ -128,11 +128,11 @@ export const SupportButton = ({ children }: PropsWithChildren<Props>) => {
           {items &&
             items.map((item, i) => <SupportListItem item={item} key={i} />)}
         </List>
-        <Box display="flex" justifyContent="flex-end">
+        <DialogActions>
           <Button color="primary" onClick={popoverCloseHandler}>
             Close
           </Button>
-        </Box>
+        </DialogActions>
       </Popover>
     </Fragment>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Adding a close button in Support menu, to be align with a11y guideline. Please check this [issue](https://github.com/backstage/backstage/issues/5243) to get more information .

Fixes #5243.

<img width="480" alt="Screen Shot 2021-04-07 at 14 34 05" src="https://user-images.githubusercontent.com/40499017/113930335-60426600-97ae-11eb-8bfd-46bf8adb3567.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
