### PR TITLE
Fix/4208

### DIFF
--- a/.changeset/odd-toys-kiss.md
+++ b/.changeset/odd-toys-kiss.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Bitbucket server needs username to be set as well as the token or appPassword for the publishing process to work.
+
+```yaml
+integrations:
+  bitbucket:
+    - host: bitbucket.mycompany.com
+      apiBaseUrl: https://bitbucket.mycompany.com/rest/api/1.0
+      token: token
+      username: username
+```

--- a/docs/integrations/bitbucket/locations.md
+++ b/docs/integrations/bitbucket/locations.md
@@ -38,3 +38,6 @@ a structure with up to four elements:
 - `apiBaseUrl` (optional): The URL of the Bitbucket API. For self-hosted
   installations, it is commonly at `https://<host>/rest/api/1.0`. For
   bitbucket.org, this configuration is not needed as it can be inferred.
+
+> Note: If you are using Bitbucket server you MUST set the username as well as
+> the token or appPassword.

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.test.ts
@@ -97,6 +97,19 @@ describe('Bitbucket Publisher', () => {
   });
 
   describe('publish: createRemoteInBitbucketServer', () => {
+    it('should throw an error if no username present', async () => {
+      await expect(
+        BitbucketPublisher.fromConfig(
+          {
+            host: 'bitbucket.mycompany.com',
+            token: 'fake-token',
+          },
+          { repoVisibility: 'private' },
+        ),
+      ).rejects.toThrow(
+        'Bitbucket server requires the username to be set in your config',
+      );
+    });
     it('should create repo in bitbucket server', async () => {
       server.use(
         rest.post(
@@ -128,6 +141,7 @@ describe('Bitbucket Publisher', () => {
       const publisher = await BitbucketPublisher.fromConfig(
         {
           host: 'bitbucket.mycompany.com',
+          username: 'foo',
           token: 'fake-token',
         },
         { repoVisibility: 'private' },
@@ -151,7 +165,7 @@ describe('Bitbucket Publisher', () => {
       expect(initRepoAndPush).toHaveBeenCalledWith({
         dir: resultPath,
         remoteUrl: 'https://bitbucket.mycompany.com/scm/project/repo',
-        auth: { username: 'x-token-auth', password: 'fake-token' },
+        auth: { username: 'foo', password: 'fake-token' },
         logger: logger,
       });
     });

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
@@ -32,6 +32,11 @@ export class BitbucketPublisher implements PublisherBase {
     config: BitbucketIntegrationConfig,
     { repoVisibility }: { repoVisibility: RepoVisibilityOptions },
   ) {
+    if (config.host !== 'bitbucket.org' && !config.username)
+      throw new Error(
+        'Bitbucket server requires the username to be set in your config',
+      );
+
     return new BitbucketPublisher({
       host: config.host,
       token: config.token,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/publishers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/publishers.test.ts
@@ -76,7 +76,9 @@ describe('Publishers', () => {
     const publishers = await Publishers.fromConfig(
       new ConfigReader({
         integrations: {
-          bitbucket: [{ host: 'bitbucket.com', token: 'blob' }],
+          bitbucket: [
+            { host: 'bitbucket.com', username: 'foo', token: 'blob' },
+          ],
         },
       }),
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4236,7 +4236,7 @@
   dependencies:
     "@octokit/openapi-types" "^5.3.2"
 
-"@octokit/types@^6.13.0":
+"@octokit/types@^6.13.0", "@octokit/types@^6.8.2":
   version "6.13.0"
   resolved "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz#779e5b7566c8dde68f2f6273861dd2f0409480d0"
   integrity sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes #4208  the bitbucket integration not pushing the files unless username is present.
`x-auth-token` only seems to work with bitbucket.org, see the discussion here: https://community.atlassian.com/t5/Bitbucket-questions/How-do-you-clone-a-repository-from-Bit-Bucket-server-using-a/qaq-p/751179

Username + either token or appPassword must be set 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] n/a Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
