### PR TITLE
Accessibility: Scaffolder Headings adjustments

### DIFF
--- a/packages/core/src/components/Lifecycle/Lifecycle.tsx
+++ b/packages/core/src/components/Lifecycle/Lifecycle.tsx
@@ -25,7 +25,7 @@ type Props = CSS.Properties & {
 
 const useStyles = makeStyles({
   alpha: {
-    color: '#d00150',
+    color: '#ffffff',
     fontFamily: 'serif',
     fontWeight: 'normal',
     fontStyle: 'italic',

--- a/packages/core/src/layout/ContentHeader/ContentHeader.tsx
+++ b/packages/core/src/layout/ContentHeader/ContentHeader.tsx
@@ -66,7 +66,12 @@ const DefaultTitle = ({
   title = 'Unknown page',
   className,
 }: DefaultTitleProps) => (
-  <Typography variant="h4" className={className} data-testid="header-title">
+  <Typography
+    variant="h4"
+    component="h2"
+    className={className}
+    data-testid="header-title"
+  >
     {title}
   </Typography>
 );

--- a/packages/core/src/layout/Header/Header.tsx
+++ b/packages/core/src/layout/Header/Header.tsx
@@ -140,7 +140,7 @@ const TypeFragment = ({
 
 const TitleFragment = ({ pageTitle, classes, tooltip }: TitleFragmentProps) => {
   const FinalTitle = (
-    <Typography className={classes.title} variant="h4">
+    <Typography className={classes.title} variant="h1">
       {pageTitle}
     </Typography>
   );
@@ -166,7 +166,11 @@ const SubtitleFragment = ({ classes, subtitle }: SubtitleFragmentProps) => {
   }
 
   return (
-    <Typography className={classes.subtitle} variant="subtitle2">
+    <Typography
+      className={classes.subtitle}
+      variant="subtitle2"
+      component="span"
+    >
       {subtitle}
     </Typography>
   );

--- a/packages/core/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core/src/layout/InfoCard/InfoCard.tsx
@@ -125,6 +125,7 @@ type Props = {
   actionsTopRight?: ReactNode;
   className?: string;
   noPadding?: boolean;
+  titleTypographyProps?: object;
 };
 
 export const InfoCard = ({
@@ -143,6 +144,7 @@ export const InfoCard = ({
   actionsTopRight,
   className,
   noPadding,
+  titleTypographyProps,
 }: Props): JSX.Element => {
   const classes = useStyles();
   /**
@@ -183,6 +185,7 @@ export const InfoCard = ({
             title={title}
             subheader={subheader}
             style={{ ...headerStyle }}
+            titleTypographyProps={titleTypographyProps}
             {...headerProps}
           />
         )}

--- a/packages/core/src/layout/ItemCard/ItemCardHeader.tsx
+++ b/packages/core/src/layout/ItemCard/ItemCardHeader.tsx
@@ -77,8 +77,16 @@ export const ItemCardHeader = (props: ItemCardHeaderProps) => {
   const classes = useStyles(props);
   return (
     <div className={classes.root}>
-      {subtitle && <Typography variant="subtitle2">{subtitle}</Typography>}
-      {title && <Typography variant="h6">{title}</Typography>}
+      {subtitle && (
+        <Typography variant="subtitle2" component="h3">
+          {subtitle}
+        </Typography>
+      )}
+      {title && (
+        <Typography variant="h6" component="h4">
+          {title}
+        </Typography>
+      )}
       {children}
     </div>
   );

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -71,10 +71,14 @@ export const MultistepJsonForm = ({
   return (
     <>
       <Stepper activeStep={activeStep} orientation="vertical">
-        {steps.map(({ title, schema, ...formProps }) => {
+        {steps.map(({ title, schema, ...formProps }, index) => {
           return (
             <StepUI key={title}>
-              <StepLabel>
+              <StepLabel
+                aria-label={`Step ${index + 1} ${title}`}
+                aria-disabled="false"
+                tabIndex={0}
+              >
                 <Typography variant="h6" component="h3">
                   {title}
                 </Typography>

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -75,7 +75,9 @@ export const MultistepJsonForm = ({
           return (
             <StepUI key={title}>
               <StepLabel>
-                <Typography variant="h6">{title}</Typography>
+                <Typography variant="h6" component="h3">
+                  {title}
+                </Typography>
               </StepLabel>
               <StepContent key={title}>
                 <Form

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -85,7 +85,7 @@ export const TemplateCard = ({
         <Box className={classes.description}>{description}</Box>
       </CardContent>
       <CardActions>
-        <Button color="primary" to={href}>
+        <Button color="primary" to={href} aria-label={`Choose ${title} `}>
           Choose
         </Button>
       </CardActions>

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -187,7 +187,11 @@ export const TemplatePage = () => {
       <Content>
         {loading && <LinearProgress data-testid="loading-progress" />}
         {schema && (
-          <InfoCard title={schema.title} noPadding>
+          <InfoCard
+            title={schema.title}
+            noPadding
+            titleTypographyProps={{ component: 'h2' }}
+          >
             <MultistepJsonForm
               formData={formState}
               fields={{ RepoUrlPicker, OwnerPicker }}


### PR DESCRIPTION
Hello guys! @miguelrambalt and I made some adjustments to the headings on the Scaffolder plugin so it can better follow accesibility guidelines and it's easier to navigate with a screen reader.

Here's some screenshots

**Create Page**

Headings
_Before_
![image](https://user-images.githubusercontent.com/7888169/114066146-0189f480-9861-11eb-9fd1-692f9bddea81.png)
_After_
![image](https://user-images.githubusercontent.com/7888169/114066286-3007cf80-9861-11eb-8472-6b4a84686829.png)

Form Control
_Before_
![image](https://user-images.githubusercontent.com/7888169/114058829-6d685f00-9859-11eb-9b61-8af6571dd585.png)
_After_
![image](https://user-images.githubusercontent.com/7888169/114058891-7822f400-9859-11eb-8f71-502780955ca6.png)

**Template Page**
Headings
_Before_
![image](https://user-images.githubusercontent.com/7888169/113939220-5118e380-97c1-11eb-8de2-ed4f7f6c9dc7.png)
_After_
![image](https://user-images.githubusercontent.com/7888169/114057316-13b36500-9858-11eb-948a-da606f51eae2.png)
This h5 comes from 
https://www.npmjs.com/package/@rjsf/material-ui
Any feedback on how to change, if possible, on our side is appreciated

We've also include a color correction for better visibility although this may need to be evaluated with the design team.
_Before_
![image](https://user-images.githubusercontent.com/7888169/114068460-91c93900-9863-11eb-90b9-485dbc94f7f6.png)
_After_
![image](https://user-images.githubusercontent.com/7888169/114068507-95f55680-9863-11eb-9747-63d3158ea44c.png)

Thanks!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
