### PR TITLE
Support multiline LDAP query filters

### DIFF
--- a/.changeset/green-otters-grin.md
+++ b/.changeset/green-otters-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add support for configure an LDAP query filter on multiple lines.

--- a/plugins/catalog-backend/src/ingestion/processors/ldap/config.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/ldap/config.test.ts
@@ -172,4 +172,35 @@ describe('readLdapConfig', () => {
     ];
     expect(actual).toEqual(expected);
   });
+
+  it('supports multiline ldap query filter', () => {
+    const config = {
+      providers: [
+        {
+          target: 'target',
+          users: {
+            dn: 'udn',
+            options: {
+              filter: `
+              (| 
+                (cn=foo bar) 
+                (cn=bar) 
+              )
+              `,
+            },
+          },
+          groups: {
+            dn: 'gdn',
+            options: {
+              filter: 'f',
+            },
+          },
+        },
+      ],
+    };
+    const actual = readLdapConfig(new ConfigReader(config));
+
+    const expected = '(|(cn=foo bar)(cn=bar))';
+    expect(actual[0].users.options.filter).toEqual(expected);
+  });
 });

--- a/plugins/catalog-backend/src/ingestion/processors/ldap/config.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/ldap/config.ts
@@ -182,7 +182,7 @@ export function readLdapConfig(config: Config): LdapProviderConfig[] {
     }
     return {
       scope: c.getOptionalString('scope') as SearchOptions['scope'],
-      filter: c.getOptionalString('filter'),
+      filter: formatFilter(c.getOptionalString('filter')),
       attributes: c.getOptionalStringArray('attributes'),
       paged: c.getOptionalBoolean('paged'),
     };
@@ -258,6 +258,11 @@ export function readLdapConfig(config: Config): LdapProviderConfig[] {
       set: readSetConfig(c.getOptionalConfigArray('set')),
       map: readGroupMapConfig(c.getOptionalConfig('map')),
     };
+  }
+
+  function formatFilter(filter?: string): string | undefined {
+    // Remove extra whitespaces between blocks to support multiline filters from the configuration
+    return filter?.replace(/\s*(\(|\))/g, '$1')?.trim();
   }
 
   const providerConfigs = config.getOptionalConfigArray('providers') ?? [];


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

## Hey, I just made a Pull Request!

This pull request will add support for configure you ldap query filters on multiple lines for easier readability.

e.g.

```yaml
catalog:
  processors:
    ldapOrg:
      providers:
      - target: ldaps://mycompany.com
         users:
           options:
             filter: >
               (|
                 (cn=foo)
                 (cn=bar)
               )
```

The multiline filter will be formated into a single line when the configuration is read.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
