### PR TITLE
Document create-github-app CLI command

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -54,6 +54,8 @@ versions:check           Check Backstage package versioning
 prepack                  Prepares a package for packaging before publishing
 postpack                 Restores the changes made by the prepack command
 
+create-github-app        Create new GitHub App in your organization (experimental)
+
 help [command]           display help for command
 ```
 
@@ -608,4 +610,19 @@ the resulting archive in the target `workspace-dir`.
 
 ```text
 Usage: backstage-cli build-workspace [options] &lt;workspace-dir&gt;
+```
+
+## create-github-app
+
+Scope: `root`
+
+Creates a GitHub App in your GitHub organization. This is an alternative to
+token-based [GitHub integration](../integrations/github/locations.md). See
+[GitHub Apps for Backstage Authentication](../plugins/github-apps.md).
+
+Launches a browser to create the App through GitHub and saves the result as a
+YAML file that can be referenced in the GitHub integration configuration.
+
+```text
+Usage: backstage-cli create-github-app &lt;github-org&gt;
 ```


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

The `create-github-app` CLI command is linked from the [GitHub Apps plugin doc](https://backstage.io/docs/plugins/github-apps#using-the-cli-public-github-only), but didn't exist on the CLI page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
