### PR TITLE
Updated documentation for sonarcloud plugin

### DIFF
--- a/plugins/sonarqube/README.md
+++ b/plugins/sonarqube/README.md
@@ -71,8 +71,12 @@ proxy:
     allowedMethods: ['GET']
     headers:
       Authorization:
-        # Content: 'Basic base64("<api-key>:")' <-- note the trailing ':'
-        # Example: Basic bXktYXBpLWtleTo=
+        # Environmental variable: SONARQUBE_AUTH_HEADER
+        # Value: 'Basic base64("<sonar-auth-token>:")'
+        # Encode the "<sonar-auth-token>:" string using base64 encoder.
+        # Note the trailing colon (:) at the end of the token.
+        # Example environmental config: SONARQUBE_AUTH_HEADER=Basic bXktYXBpLWtleTo=
+        # Fetch the sonar-auth-token from https://sonarcloud.io/account/security/
         $env: SONARQUBE_AUTH_HEADER
 
 sonarQube:
@@ -81,7 +85,14 @@ sonarQube:
 
 5. Get and provide `SONARQUBE_AUTH_HEADER` as env variable (https://sonarcloud.io/account/security or https://docs.sonarqube.org/latest/user-guide/user-token/)
 
-6. Add the `sonarqube.org/project-key` annotation to your catalog-info.yaml file:
+6. Run the following commands in the root folder of the project to install and compile the changes.
+
+```yaml
+yarn install
+yarn tsc
+```
+
+7. Add the `sonarqube.org/project-key` annotation to the catalog-info.yaml file of the target repo for which code quality analysis is needed.
 
 ```yaml
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For a new react developer working with backstage, he gets blocked while installing the sonarcloud plugin in backstage app. He faces the following [issue](https://github.com/backstage/backstage/issues/5141) after following the steps mentioned in the [plugin documentation](https://github.com/backstage/backstage/tree/master/plugins/sonarqube).

- Hence, this commit adds `yarn install` and `yarn tsc` commands to be run.
- Also, it adds additional information on how to set the SONARQUBE_AUTH_HEADER environmental header.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
