### PR TITLE
add debounce time for apis-docs

### DIFF
--- a/.changeset/tender-turtles-smash.md
+++ b/.changeset/tender-turtles-smash.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core': patch
+'@backstage/plugin-api-docs': patch
+---
+
+add debounce time attribute for apis-docs for search, giving more time to the users when they are typing.

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -13,6 +13,7 @@ Cloudformation
 Codecov
 Codehilite
 Config
+Debounce
 Discoverability
 Dockerfile
 Dockerize

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -112,6 +112,7 @@ cookiecutter
 css
 dataflow
 deadnaming
+debounce
 declaratively
 destructured
 dev

--- a/packages/core/src/hooks/useQueryParamState.ts
+++ b/packages/core/src/hooks/useQueryParamState.ts
@@ -58,6 +58,7 @@ type SetQueryParams<T> = (params: T) => void;
 
 export function useQueryParamState<T>(
   stateName: string,
+  debounceTime: number = 100,
 ): [T | undefined, SetQueryParams<T>] {
   const navigate = useNavigate();
   const location = useLocation();
@@ -85,7 +86,7 @@ export function useQueryParamState<T>(
         navigate({ ...location, search: `?${queryString}` }, { replace: true });
       }
     },
-    100,
+    debounceTime,
     [queryParamState],
   );
 

--- a/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
@@ -156,6 +156,7 @@ export const ApiExplorerTable = ({
 }: ExplorerTableProps) => {
   const [queryParamState, setQueryParamState] = useQueryParamState<TableState>(
     'apiTable',
+    500,
   );
 
   if (error) {


### PR DESCRIPTION
Signed-off-by: miguelrambalt <v-migueramirez@expediagroup.com>

## Hey, I just made a Pull Request!

API Filter text box loses focus when typing forcing the user to re-obtain focus to keep filtering. This, in practice, causes the user to add one letter at a time on the filter.

see more details on this [bug](https://github.com/backstage/backstage/issues/5266)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
