### PR TITLE
Don't use a drag & drop cursor when clicking on disabled `IconLinkVertical`

### DIFF
--- a/.changeset/wicked-mirrors-scream.md
+++ b/.changeset/wicked-mirrors-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Don't use a drag & drop cursor when clicking on disabled `IconLinkVertical`.

--- a/packages/core/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
+++ b/packages/core/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
@@ -35,12 +35,10 @@ const useIconStyles = makeStyles(theme => ({
     justifyItems: 'center',
     gridGap: 4,
     textAlign: 'center',
-    '&:active': {
-      cursor: 'grabbing',
-    },
   },
   disabled: {
     color: 'gray',
+    cursor: 'default',
   },
   primary: {
     color: theme.palette.primary.main,


### PR DESCRIPTION
This is something that puzzles me for a long time 😆 . Previously, a drag and drop hand was displayed when clicking on a disabled `IconLinkVertical`, for example in the about card. This behavior is kind of strange, as there isn't anything to drag and drop, it is even disabled. Not it shows a normal arrow, as you would have for a disabled button.

Normally I would include a screenshot, but I couldn't manage to include the cursor in them 😆 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
