### PR TITLE
Export SignInConfig type

### DIFF
--- a/.changeset/moody-pigs-repeat.md
+++ b/.changeset/moody-pigs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Exported SignInProviderConfig to strongly type SignInPage providers

--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -58,7 +58,7 @@ the local `auth.environment` setting will be selected.
 After configuring an authentication provider, the `app` frontend package needs a
 small update to show this provider as a login option. The `SignInPage` component
 handles this, and takes either a `provider` or `providers` (array) prop of
-`SignInConfig` definitions.
+`SignInProviderConfig` definitions.
 
 These reference the [ApiRef](../reference/utility-apis/README.md) exported by
 the provider. Again, an example using GitHub that can be adapted to any of the
@@ -66,9 +66,9 @@ built-in providers:
 
 ```diff
 # packages/app/src/App.tsx
-+ import { githubAuthApiRef, SignInConfig, SignInPage } from '@backstage/core';
++ import { githubAuthApiRef, SignInProviderConfig, SignInPage } from '@backstage/core';
 
-+ const githubProvider: SignInConfig = {
++ const githubProvider: SignInProviderConfig = {
 +  id: 'github-auth-provider',
 +  title: 'GitHub',
 +  message: 'Sign in using GitHub',

--- a/packages/core/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core/src/layout/SignInPage/SignInPage.tsx
@@ -22,7 +22,7 @@ import { ContentHeader } from '../ContentHeader/ContentHeader';
 import { Grid, Button, Typography } from '@material-ui/core';
 import { SignInPageProps, useApi, configApiRef } from '@backstage/core-api';
 import { useSignInProviders, getSignInProviders } from './providers';
-import { IdentityProviders, SignInConfig } from './types';
+import { IdentityProviders, SignInProviderConfig } from './types';
 import { Progress } from '../../components/Progress';
 import { GridItem, useStyles } from './styles';
 import { InfoCard } from '../InfoCard';
@@ -34,7 +34,7 @@ type MultiSignInPageProps = SignInPageProps & {
 };
 
 type SingleSignInPageProps = SignInPageProps & {
-  provider: SignInConfig;
+  provider: SignInProviderConfig;
   auto?: boolean;
 };
 

--- a/packages/core/src/layout/SignInPage/commonProvider.tsx
+++ b/packages/core/src/layout/SignInPage/commonProvider.tsx
@@ -21,13 +21,13 @@ import {
   ProviderComponent,
   ProviderLoader,
   SignInProvider,
-  SignInConfig,
+  SignInProviderConfig,
 } from './types';
 import { useApi, errorApiRef } from '@backstage/core-api';
 import { GridItem } from './styles';
 
 const Component: ProviderComponent = ({ config, onResult }) => {
-  const { apiRef, title, message } = config as SignInConfig;
+  const { apiRef, title, message } = config as SignInProviderConfig;
   const authApi = useApi(apiRef);
   const errorApi = useApi(errorApiRef);
 

--- a/packages/core/src/layout/SignInPage/index.ts
+++ b/packages/core/src/layout/SignInPage/index.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
+export type { SignInConfig } from './types';
 export { SignInPage } from './SignInPage';

--- a/packages/core/src/layout/SignInPage/index.ts
+++ b/packages/core/src/layout/SignInPage/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export type { SignInConfig } from './types';
+export type { SignInProviderConfig } from './types';
 export { SignInPage } from './SignInPage';

--- a/packages/core/src/layout/SignInPage/providers.tsx
+++ b/packages/core/src/layout/SignInPage/providers.tsx
@@ -22,7 +22,11 @@ import {
   useApiHolder,
   errorApiRef,
 } from '@backstage/core-api';
-import { SignInConfig, IdentityProviders, SignInProvider } from './types';
+import {
+  IdentityProviders,
+  SignInProvider,
+  SignInProviderConfig,
+} from './types';
 import { commonProvider } from './commonProvider';
 import { guestProvider } from './guestProvider';
 import { customProvider } from './customProvider';
@@ -33,7 +37,7 @@ export type SignInProviderType = {
   [key: string]: {
     components: SignInProvider;
     id: string;
-    config?: SignInConfig;
+    config?: SignInProviderConfig;
   };
 };
 
@@ -62,7 +66,7 @@ export function getSignInProviders(
         return acc;
       }
 
-      const { id } = config as SignInConfig;
+      const { id } = config as SignInProviderConfig;
       validateIDs(id, acc);
 
       acc[id] = { components: signInProviders.common, id, config };

--- a/packages/core/src/layout/SignInPage/types.ts
+++ b/packages/core/src/layout/SignInPage/types.ts
@@ -25,17 +25,17 @@ import {
   SessionApi,
 } from '@backstage/core-api';
 
-export type SignInConfig = {
+export type SignInProviderConfig = {
   id: string;
   title: string;
   message: string;
   apiRef: ApiRef<ProfileInfoApi & BackstageIdentityApi & SessionApi>;
 };
 
-export type IdentityProviders = ('guest' | 'custom' | SignInConfig)[];
+export type IdentityProviders = ('guest' | 'custom' | SignInProviderConfig)[];
 
 export type ProviderComponent = ComponentType<
-  SignInPageProps & { config: SignInConfig }
+  SignInPageProps & { config: SignInProviderConfig }
 >;
 
 export type ProviderLoader = (


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

Fixes #5270.

I included `SignInConfig` in the docs to strongly-type what we expect users to pass in to `SignInPage` props. This is not exported.

Alternatively, I can amend the docs - but seems preferable to have these strongly typed so any later API changes are compile-time caught by implementors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
