### PR TITLE
Correcting the path to the Root component in the plugin docs

### DIFF
--- a/docs/getting-started/configure-app-with-plugins.md
+++ b/docs/getting-started/configure-app-with-plugins.md
@@ -68,9 +68,9 @@ proxy:
 
 In a standard Backstage app created with
 [@backstage/create-app](./create-an-app.md), the sidebar is managed inside
-`packages/app/src/components/Root.tsx`. The file exports the entire `Sidebar`
-element of your app, which you can extend with additional entries by adding new
-`SidebarItem` elements.
+`packages/app/src/components/Root/Root.tsx`. The file exports the entire
+`Sidebar` element of your app, which you can extend with additional entries by
+adding new `SidebarItem` elements.
 
 For example, if you install the `api-docs` plugin, a matching `SidebarItem`
 could be something like this:


### PR DESCRIPTION
Signed-off-by: Travis Truman <trumant@gmail.com>

## Hey, I just made a Pull Request!

Fixes #5283

#### :heavy_check_mark: Checklist

- [X] Added or updated documentation
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
