### PR TITLE
feat(techradar-plugin): add markdown support in techradar entry 

### DIFF
--- a/.changeset/witty-hotels-know.md
+++ b/.changeset/witty-hotels-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Add markdown support for tech radar entry description

--- a/plugins/tech-radar/src/components/RadarDescription/RadarDescription.tsx
+++ b/plugins/tech-radar/src/components/RadarDescription/RadarDescription.tsx
@@ -19,6 +19,7 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { Button, DialogActions, DialogContent } from '@material-ui/core';
 import LinkIcon from '@material-ui/icons/Link';
+import { MarkdownContent } from '@backstage/core';
 
 export type Props = {
   open: boolean;
@@ -43,7 +44,9 @@ const RadarDescription = (props: Props): JSX.Element => {
       <DialogTitle data-testid="radar-description-dialog-title">
         {title}
       </DialogTitle>
-      <DialogContent dividers>{description}</DialogContent>
+      <DialogContent dividers>
+        <MarkdownContent content={description} />
+      </DialogContent>
       {url && (
         <DialogActions>
           <Button

--- a/plugins/tech-radar/src/sampleData.ts
+++ b/plugins/tech-radar/src/sampleData.ts
@@ -50,7 +50,7 @@ entries.push({
   title: 'JavaScript',
   quadrant: 'languages',
   description:
-    'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
+    'Excepteur **sint** occaecat *cupidatat* non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
 });
 entries.push({
   timeline: [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

add markdown support in techradar entry description

Here is how it looks for the following markdown

`Excepteur **sint** occaecat *cupidatat* non proident, sunt in culpa qui officia deserunt mollit anim id est laborum`

![image](https://user-images.githubusercontent.com/17722640/114292307-be8a8400-9ae1-11eb-80e0-45bdfb6d228d.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
