### PR TITLE
Fix dependency resolution for broken build

### DIFF
--- a/.changeset/fluffy-rice-push.md
+++ b/.changeset/fluffy-rice-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Fixing dependency resolution for problematic library graphql-language-service-interface

--- a/.changeset/fluffy-rice-push.md
+++ b/.changeset/fluffy-rice-push.md
@@ -2,4 +2,28 @@
 '@backstage/create-app': patch
 ---
 
-Fixing dependency resolution for problematic library graphql-language-service-interface
+Fixing dependency resolution for problematic library `graphql-language-service-interface`.
+
+This change might not have to be applied to your local installation, however if you run into this error:
+
+```
+Error: Failed to compile.
+/tmp/backstage-e2e-uMeycm/test-app/node_modules/graphql-language-service-interface/esm/GraphQLLanguageService.js 100:23
+Module parse failed: Unexpected token (100:23)
+You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
+|         }
+|         let customRules = null;
+>         if (extensions?.customValidationRules &&
+|             typeof extensions.customValidationRules === 'function') {
+|             customRules = extensions.customValidationRules(this._graphQLConfig);
+```
+
+You can fix it by adding the following to the root `package.json`.
+
+```json
+...
+"resolutions": {
+    "graphql-language-service-interface": "2.8.2"
+ },
+...
+```

--- a/.changeset/fluffy-rice-push.md
+++ b/.changeset/fluffy-rice-push.md
@@ -23,7 +23,8 @@ You can fix it by adding the following to the root `package.json`.
 ```json
 ...
 "resolutions": {
-    "graphql-language-service-interface": "2.8.2"
+  "graphql-language-service-interface": "2.8.2",
+  "graphql-language-service-parser": "1.9.0"
  },
 ...
 ```

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "**/@roadiehq/**/@backstage/core": "*",
     "**/@roadiehq/**/@backstage/plugin-catalog": "*",
     "**/@roadiehq/**/@backstage/catalog-model": "*",
-    "graphql-language-service-interface": "2.8.2"
+    "graphql-language-service-interface": "2.8.2",
+    "graphql-language-service-parser": "1.9.0"
   },
   "version": "1.0.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "resolutions": {
     "**/@roadiehq/**/@backstage/core": "*",
     "**/@roadiehq/**/@backstage/plugin-catalog": "*",
-    "**/@roadiehq/**/@backstage/catalog-model": "*"
+    "**/@roadiehq/**/@backstage/catalog-model": "*",
+    "graphql-language-service-interface": "2.8.2"
   },
   "version": "1.0.0",
   "devDependencies": {

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -22,6 +22,9 @@
     "create-plugin": "backstage-cli create-plugin --scope internal --no-private",
     "remove-plugin": "backstage-cli remove-plugin"
   },
+  "resolutions": {
+    "graphql-language-service-interface": "2.8.2"
+  },
   "workspaces": {
     "packages": [
       "packages/*",

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -23,7 +23,8 @@
     "remove-plugin": "backstage-cli remove-plugin"
   },
   "resolutions": {
-    "graphql-language-service-interface": "2.8.2"
+    "graphql-language-service-interface": "2.8.2",
+    "graphql-language-service-parser": "1.9.0"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -14492,7 +14492,7 @@ graphql-extensions@^0.12.8:
     apollo-server-env "^3.0.0"
     apollo-server-types "^0.6.3"
 
-graphql-language-service-interface@^2.8.2:
+graphql-language-service-interface@2.8.2, graphql-language-service-interface@^2.8.2:
   version "2.8.2"
   resolved "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-2.8.2.tgz#b3bb2aef7eaf0dff0b4ea419fa412c5f66fa268b"
   integrity sha512-otbOQmhgkAJU1QJgQkMztNku6SbJLu/uodoFOYOOtJsizTjrMs93vkYaHCcYnLA3oi1Goj27XcHjMnRCYQOZXQ==


### PR DESCRIPTION
This is a bit of a workaround for the library change in `graphql-language-service-interface` now producing `esnext` output in typescript which breaks webpack.

Looking at bumping to webpack5 but that could be a while, so this is a workaround in the meantime.

You might need to apply this change to your local installation if you run into issues with webpack failing with the following error: 

```
Error: Failed to compile.
/tmp/backstage-e2e-uMeycm/test-app/node_modules/graphql-language-service-interface/esm/GraphQLLanguageService.js 100:23
Module parse failed: Unexpected token (100:23)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|         }
|         let customRules = null;
>         if (extensions?.customValidationRules &&
|             typeof extensions.customValidationRules === 'function') {
|             customRules = extensions.customValidationRules(this._graphQLConfig);

```
