### PR TITLE
Externalize repository processing for BitbucketDiscoveryProcessor

### DIFF
--- a/.changeset/stale-carpets-poke.md
+++ b/.changeset/stale-carpets-poke.md
@@ -1,0 +1,30 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Externalize repository processing for BitbucketDiscoveryProcessor.
+
+Add an extension point where you can customize how a matched Bitbucket repository should
+be processed. This can for example be used if you want to generate the catalog-info.yaml
+automatically based on other files in a repository, while taking advantage of the
+build-in repository crawling functionality.
+
+`BitbucketDiscoveryProcessor.fromConfig` now takes an optional parameter `options.parser` where
+you can customize the logic for each repository found. The default parser has the same
+behaviour as before, where it emits an optional location for the matched repository
+and lets the other processors take care of further processing.
+
+```typescript
+const customRepositoryParser: BitbucketRepositoryParser = async function* customRepositoryParser({
+  client,
+  repository,
+}) {
+  // Custom logic for interpret the matching repository.
+  // See defaultRepositoryParser for an example
+};
+
+const processor = BitbucketDiscoveryProcessor.fromConfig(env.config, {
+  parser: customRepositoryParser,
+  logger: env.logger,
+});
+```

--- a/docs/integrations/bitbucket/discovery.md
+++ b/docs/integrations/bitbucket/discovery.md
@@ -39,3 +39,29 @@ The target is composed of four parts:
 - The path within each repository to find the catalog YAML file. This will
   usually be `/catalog-info.yaml` or a similar variation for catalog files
   stored in the root directory of each repository.
+
+## Custom repository processing
+
+The Bitbucket Discovery Processor will by default emit a location for each
+matching repository for further processing by other processors. However, it is
+possible to override this functionality and take full control of how each
+matching repository is processed.
+
+`BitbucketDiscoveryProcessor.fromConfig` takes an optional parameter
+`options.parser` where you can set your own parser to be used for each matched
+repository.
+
+```typescript
+const customRepositoryParser: BitbucketRepositoryParser = async function* customRepositoryParser({
+  client,
+  repository,
+}) {
+  // Custom logic for interpret the matching repository.
+  // See defaultRepositoryParser for an example
+};
+
+const processor = BitbucketDiscoveryProcessor.fromConfig(env.config, {
+  parser: customRepositoryParser,
+  logger: env.logger,
+});
+```

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { defaultRepositoryParser } from './BitbucketRepositoryParser';
+import { Project, Repository } from './types';
+import { BitbucketClient } from './client';
+import { results } from '../index';
+
+describe('BitbucketRepositoryParser', () => {
+  describe('defaultRepositoryParser', () => {
+    it('emits location', async () => {
+      const browseUrl =
+        'https://bitbucket.mycompany.com/projects/project-key/repos/repo-slug/browse';
+      const path = '/catalog-info.yaml';
+      const expected = [
+        results.location(
+          {
+            type: 'url',
+            target: `${browseUrl}${path}`,
+          },
+          true,
+        ),
+      ];
+      const actual = await defaultRepositoryParser({
+        client: {} as BitbucketClient,
+        repository: {
+          project: {} as Project,
+          slug: 'repo-slug',
+          links: {
+            self: [{ href: browseUrl }],
+          },
+        } as Repository,
+        path: path,
+      });
+
+      let i = 0;
+      for await (const entity of actual) {
+        expect(entity).toStrictEqual(expected[i]);
+        i++;
+      }
+    });
+  });
+});

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Repository } from './types';
+import { CatalogProcessorResult } from '../types';
+import { results } from '../index';
+import { BitbucketClient } from './client';
+
+export type BitbucketRepositoryParser = (options: {
+  client: BitbucketClient;
+  repository: Repository;
+  path: string;
+}) => AsyncIterable<CatalogProcessorResult>;
+
+export const defaultRepositoryParser: BitbucketRepositoryParser = async function* defaultRepositoryParser({
+  repository,
+  path,
+}) {
+  yield results.location(
+    {
+      type: 'url',
+      target: `${repository.links.self[0].href}${path}`,
+    },
+    // Not all locations may actually exist, since the user defined them as a wildcard pattern.
+    // Thus, we emit them as optional and let the downstream processor find them while not outputting
+    // an error if it couldn't.
+    true,
+  );
+};

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/client.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/client.ts
@@ -41,6 +41,15 @@ export class BitbucketClient {
     );
   }
 
+  async getRaw(
+    projectKey: string,
+    repo: string,
+    path: string,
+  ): Promise<Response> {
+    const request = `${this.config.apiBaseUrl}/projects/${projectKey}/repos/${repo}/raw/${path}`;
+    return fetch(request, getBitbucketRequestOptions(this.config));
+  }
+
   private async pagedRequest(
     endpoint: string,
     options?: ListOptions,

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/types.ts
@@ -13,8 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { BitbucketClient, paginated } from './client';
-export type { PagedResponse } from './client';
-export * from './types';
-export type { BitbucketRepositoryParser } from './BitbucketRepositoryParser';
-export { defaultRepositoryParser } from './BitbucketRepositoryParser';
+export type Project = {
+  key: string;
+};
+
+export type Repository = {
+  project: Project;
+  slug: string;
+  links: Record<string, Link[]>;
+};
+
+export type Link = {
+  href: string;
+};


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

## Hey, I just made a Pull Request!

This pull request adds an extension point where you can take advantage of the built-in repository crawling functionality for Bitbucket but customize how each repository should be interpreted.

An example is where you want to fallback on auto-discover components by generating entities based on other files in a repository for those repositories that are missing a `catalog-info.yaml` file.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
