### PR TITLE
Disable hot reloading in CI environments

### DIFF
--- a/.changeset/young-kids-remember.md
+++ b/.changeset/young-kids-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Disable hot reloading in CI environments.

--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -43,7 +43,7 @@ export async function serveBundle(options: ServeOptions) {
   const compiler = webpack(config);
 
   const server = new WebpackDevServer(compiler, {
-    hot: true,
+    hot: !process.env.CI,
     contentBase: paths.targetPublic,
     contentBasePublicPath: config.output?.publicPath,
     publicPath: config.output?.publicPath,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This disables hot reloading in CI environments. Critical for running the e2e tests in containers where you may bump up against file watcher limits, but not have access to the host machine to adjust them.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
