### PR TITLE
Configuration of the kubernetes-backend should be able to toggle TLS verification

### DIFF
--- a/.changeset/rude-items-bow.md
+++ b/.changeset/rude-items-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Kubernetes client TLS verification is now configurable and defaults to true

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -25,6 +25,7 @@ kubernetes:
         - url: http://127.0.0.1:9999
           name: minikube
           authProvider: 'serviceAccount'
+          skipTLSVerify: false
           serviceAccountToken:
             $env: K8S_MINIKUBE_TOKEN
         - url: http://127.0.0.2:9999
@@ -78,6 +79,11 @@ cluster. Valid values are:
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `serviceAccount` | This will use a Kubernetes [service account](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) to access the Kubernetes API. When this is used the `serviceAccountToken` field should also be set. |
 | `google`         | This will use a user's Google auth token from the [Google auth plugin](https://backstage.io/docs/auth/) to access the Kubernetes API.                                                                                             |
+
+##### `clusters.\*.skipTLSVerify`
+
+This determines whether or not the Kubernetes client verifies the TLS
+certificate presented by the API server.
 
 ##### `clusters.\*.serviceAccountToken` (optional)
 

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -82,7 +82,7 @@ cluster. Valid values are:
 ##### `clusters.\*.skipTLSVerify`
 
 This determines whether or not the Kubernetes client verifies the TLS
-certificate presented by the API server.
+certificate presented by the API server. Defaults to `false`.
 
 ##### `clusters.\*.serviceAccountToken` (optional)
 

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
@@ -52,6 +52,7 @@ describe('ConfigClusterLocator', () => {
         serviceAccountToken: undefined,
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
+        skipTLSVerify: false,
       },
     ]);
   });
@@ -64,11 +65,13 @@ describe('ConfigClusterLocator', () => {
           serviceAccountToken: 'token',
           url: 'http://localhost:8080',
           authProvider: 'serviceAccount',
+          skipTLSVerify: false,
         },
         {
           name: 'cluster2',
           url: 'http://localhost:8081',
           authProvider: 'google',
+          skipTLSVerify: true,
         },
       ],
     });
@@ -83,12 +86,14 @@ describe('ConfigClusterLocator', () => {
         serviceAccountToken: 'token',
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
+        skipTLSVerify: false,
       },
       {
         name: 'cluster2',
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
         authProvider: 'google',
+        skipTLSVerify: true,
       },
     ]);
   });

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -33,10 +33,7 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
           name: c.getString('name'),
           url: c.getString('url'),
           serviceAccountToken: c.getOptionalString('serviceAccountToken'),
-          skipTLSVerify:
-            c.getOptionalBoolean('skipTLSVerify') === undefined
-              ? false
-              : c.getOptionalBoolean('skipTLSVerify'),
+          skipTLSVerify: c.getOptionalBoolean('skipTLSVerify') ?? false,
           authProvider: c.getString('authProvider'),
         };
       }),

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -33,6 +33,10 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
           name: c.getString('name'),
           url: c.getString('url'),
           serviceAccountToken: c.getOptionalString('serviceAccountToken'),
+          skipTLSVerify:
+            c.getOptionalBoolean('skipTLSVerify') === undefined
+              ? false
+              : c.getOptionalBoolean('skipTLSVerify'),
           authProvider: c.getString('authProvider'),
         };
       }),

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -53,12 +53,14 @@ describe('getCombinedClusterDetails', () => {
         serviceAccountToken: 'token',
         url: 'http://localhost:8080',
         authProvider: 'serviceAccount',
+        skipTLSVerify: false,
       },
       {
         name: 'cluster2',
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
         authProvider: 'google',
+        skipTLSVerify: false,
       },
     ]);
   });

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.test.ts
@@ -34,6 +34,7 @@ describe('KubernetesClientProvider', () => {
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
       authProvider: 'serviceAccount',
+      skipTLSVerify: false,
     });
 
     expect(result.basePath).toBe('http://localhost:9999');
@@ -41,6 +42,7 @@ describe('KubernetesClientProvider', () => {
     const auth = (result as any).authentications.default;
     expect(auth.users[0].token).toBe('TOKEN');
     expect(auth.clusters[0].name).toBe('cluster-name');
+    expect(auth.clusters[0].skipTLSVerify).toBe(false);
 
     expect(mockGetKubeConfig.mock.calls.length).toBe(1);
   });
@@ -57,6 +59,7 @@ describe('KubernetesClientProvider', () => {
       url: 'http://localhost:9999',
       serviceAccountToken: 'TOKEN',
       authProvider: 'serviceAccount',
+      skipTLSVerify: false,
     });
 
     expect(result.basePath).toBe('http://localhost:9999');

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -30,8 +30,7 @@ export class KubernetesClientProvider {
     const cluster = {
       name: clusterDetails.name,
       server: clusterDetails.url,
-      // TODO configure this
-      skipTLSVerify: true,
+      skipTLSVerify: clusterDetails.skipTLSVerify,
     };
 
     // TODO configure

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -30,6 +30,7 @@ export interface ClusterDetails {
   url: string;
   authProvider: string;
   serviceAccountToken?: string | undefined;
+  skipTLSVerify?: boolean;
 }
 
 export interface KubernetesRequestBody {


### PR DESCRIPTION
Signed-off-by: Travis Truman <trumant@gmail.com>

## Hey, I just made a Pull Request!

Previously, when configuring the k8s plugin backend, the user was unable to decide whether or not
the kubernetes node client should verify the TLS cert presented by the kubernetes API server.

The default behavior was that the client **would not** verify the TLS cert which is an insecure default state.

This change defaults to a more secure state where absent explicit configuration the kubernetes client
**will verify the TLS cert** but also provides a configuration mechanism for users to choose to skip TLS verification.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
