### PR TITLE
Filtered archived repositories when discovering repos

### DIFF
--- a/.changeset/real-apples-visit.md
+++ b/.changeset/real-apples-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+GithubDiscoveryProcessor now excludes archived repositories so they won't be added to Backstage.

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
@@ -118,8 +118,16 @@ describe('GithubDiscoveryProcessor', () => {
       };
       mockGetOrganizationRepositories.mockResolvedValueOnce({
         repositories: [
-          { name: 'backstage', url: 'https://github.com/backstage/backstage' },
-          { name: 'demo', url: 'https://github.com/backstage/demo' },
+          {
+            name: 'backstage',
+            url: 'https://github.com/backstage/backstage',
+            isArchived: false,
+          },
+          {
+            name: 'demo',
+            url: 'https://github.com/backstage/demo',
+            isArchived: false,
+          },
         ],
       });
       const emitter = jest.fn();
@@ -153,14 +161,20 @@ describe('GithubDiscoveryProcessor', () => {
       };
       mockGetOrganizationRepositories.mockResolvedValueOnce({
         repositories: [
-          { name: 'backstage', url: 'https://github.com/backstage/backstage' },
+          {
+            name: 'backstage',
+            url: 'https://github.com/backstage/backstage',
+            isArchived: false,
+          },
           {
             name: 'techdocs-cli',
             url: 'https://github.com/backstage/techdocs-cli',
+            isArchived: false,
           },
           {
             name: 'techdocs-container',
             url: 'https://github.com/backstage/techdocs-container',
+            isArchived: false,
           },
         ],
       });
@@ -187,21 +201,32 @@ describe('GithubDiscoveryProcessor', () => {
         optional: true,
       });
     });
-    it('filter unrelated repositories', async () => {
+    it('filter unrelated and archived repositories', async () => {
       const location: LocationSpec = {
         type: 'github-discovery',
         target: 'https://github.com/backstage/test/blob/master/catalog.yaml',
       };
       mockGetOrganizationRepositories.mockResolvedValueOnce({
         repositories: [
-          { name: 'abstest', url: 'https://github.com/backstage/abctest' },
+          {
+            name: 'abstest',
+            url: 'https://github.com/backstage/abctest',
+            isArchived: false,
+          },
           {
             name: 'test',
             url: 'https://github.com/backstage/test',
+            isArchived: false,
+          },
+          {
+            name: 'test-archived',
+            url: 'https://github.com/backstage/test',
+            isArchived: true,
           },
           {
             name: 'testxyz',
             url: 'https://github.com/backstage/testxyz',
+            isArchived: false,
           },
         ],
       });

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
@@ -78,7 +78,9 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
     this.logger.info(`Reading GitHub repositories from ${location.target}`);
 
     const { repositories } = await getOrganizationRepositories(client, org);
-    const matching = repositories.filter(r => repoSearchPath.test(r.name));
+    const matching = repositories.filter(
+      r => !r.isArchived && repoSearchPath.test(r.name),
+    );
 
     const duration = ((Date.now() - startTimestamp) / 1000).toFixed(1);
     this.logger.debug(

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.test.ts
@@ -162,10 +162,12 @@ describe('github', () => {
               {
                 name: 'backstage',
                 url: 'https://github.com/backstage/backstage',
+                isArchived: false,
               },
               {
                 name: 'demo',
                 url: 'https://github.com/backstage/demo',
+                isArchived: true,
               },
             ],
             pageInfo: {
@@ -177,10 +179,15 @@ describe('github', () => {
 
       const output = {
         repositories: [
-          { name: 'backstage', url: 'https://github.com/backstage/backstage' },
+          {
+            name: 'backstage',
+            url: 'https://github.com/backstage/backstage',
+            isArchived: false,
+          },
           {
             name: 'demo',
             url: 'https://github.com/backstage/demo',
+            isArchived: true,
           },
         ],
       };

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.ts
@@ -56,6 +56,7 @@ export type Team = {
 export type Repository = {
   name: string;
   url: string;
+  isArchived: boolean;
 };
 
 export type Connection<T> = {
@@ -234,6 +235,7 @@ export async function getOrganizationRepositories(
         nodes {
           name
           url
+          isArchived
         }
         pageInfo {
           hasNextPage


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes #5239. Filtering of archived repositories so they won't be added to Backstage.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
