### PR TITLE
[Search] Conditionally pull catalog entities from local catalog if configured

### DIFF
--- a/.changeset/long-shirts-dress.md
+++ b/.changeset/long-shirts-dress.md
@@ -1,0 +1,8 @@
+---
+'example-backend': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-search': patch
+---
+
+The `DefaultCatalogCollator` now conditionally uses a pre-configured, local catalog client when deployed in the same process as the catalog. #5316

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -19,16 +19,14 @@ import { IndexBuilder } from '@backstage/plugin-search-backend-node';
 import { PluginEnvironment } from '../types';
 import { DefaultCatalogCollator } from '@backstage/plugin-catalog-backend';
 
-export default async function createPlugin({
-  logger,
-  discovery,
-}: PluginEnvironment) {
+export default async function createPlugin(env: PluginEnvironment) {
+  const { logger } = env;
   const indexBuilder = new IndexBuilder({ logger });
 
   indexBuilder.addCollator({
     type: 'software-catalog',
     defaultRefreshIntervalSeconds: 600,
-    collator: new DefaultCatalogCollator(discovery),
+    collator: await DefaultCatalogCollator.fromEnv(env),
   });
 
   // TODO: Move refresh loop logic into the builder.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Aims to provide a reasonable interim solution to #5207 until there's consensus on #5210...

Not sure of what, if any, implications there are of building a completely separate instance of the catalog (but with identical configs).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
