### PR TITLE
Fix api docs page theme

### DIFF
--- a/packages/core/src/layout/Header/Header.stories.tsx
+++ b/packages/core/src/layout/Header/Header.stories.tsx
@@ -53,38 +53,6 @@ export const Apis = () => (
   </Page>
 );
 
-export const Grpc = () => (
-  <Page themeId="grpc">
-    <Header title="Grpc catalogue" type="tool">
-      {labels}
-    </Header>
-  </Page>
-);
-
-export const AsyncApi = () => (
-  <Page themeId="asyncapi">
-    <Header title="Async API catalogue" type="tool">
-      {labels}
-    </Header>
-  </Page>
-);
-
-export const Graphql = () => (
-  <Page themeId="graphql">
-    <Header title="GraphQL API catalogue" type="tool">
-      {labels}
-    </Header>
-  </Page>
-);
-
-export const OpenApi = () => (
-  <Page themeId="openapi">
-    <Header title="OpenAPI catalogue" type="tool">
-      {labels}
-    </Header>
-  </Page>
-);
-
 export const Tool = () => (
   <Page themeId="tool">
     <Header title="Stand-alone tool" type="tool">

--- a/packages/theme/src/pageTheme.ts
+++ b/packages/theme/src/pageTheme.ts
@@ -63,5 +63,5 @@ export const pageTheme: Record<string, PageTheme> = {
   library: genPageTheme(colorVariants.rubyRed, shapes.wave),
   other: genPageTheme(colorVariants.darkGrey, shapes.wave),
   app: genPageTheme(colorVariants.toastyOrange, shapes.wave),
-  apis: genPageTheme(colorVariants.eveningSea, shapes.wave2),
+  apis: genPageTheme(colorVariants.teal, shapes.wave2),
 };


### PR DESCRIPTION
#5237 made the page theme of the api docs plugin configurable, but also introduced a new default color. I open to a new color, but the current choice makes the title hard to read. This PR restores it to the previous colors while keeping the configuration option.

![image](https://user-images.githubusercontent.com/648527/114673074-1d304780-9d06-11eb-8463-733b1e8fc820.png)


For a new color we [might need some input](https://github.com/backstage/backstage/pull/5237#discussion_r611846635) from @katz95. But to keep tomorrows release more stable, I would suggest to merge this before we get feedback. In case we merge this before the next release, we don't need a changeset here as the previous PR already includes one.

Also took the time to include this cleanup: https://github.com/backstage/backstage/pull/5237#discussion_r611794890


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
