### PR TITLE
Catalog-model: Add getEntitySourceLocation helper

### DIFF
--- a/.changeset/metal-foxes-speak.md
+++ b/.changeset/metal-foxes-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Add getEntitySourceLocation helper

--- a/packages/catalog-model/src/location/helpers.test.ts
+++ b/packages/catalog-model/src/location/helpers.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { parseLocationReference, stringifyLocationReference } from './helpers';
+import {
+  getEntitySourceLocation,
+  parseLocationReference,
+  stringifyLocationReference,
+} from './helpers';
 
 describe('parseLocationReference', () => {
   it('works for the simple case', () => {
@@ -66,5 +70,50 @@ describe('stringifyLocationReference', () => {
     expect(() =>
       stringifyLocationReference({ type: 'hello', target: '' }),
     ).toThrow('Unable to stringify location reference, empty target');
+  });
+});
+
+describe('getEntitySourceLocation', () => {
+  it('returns the source-location', () => {
+    expect(
+      getEntitySourceLocation({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Location',
+        metadata: {
+          name: 'test',
+          namespace: 'default',
+          annotations: {
+            'backstage.io/source-location': 'url:https://backstage.io/foo.yaml',
+            'backstage.io/managed-by-location': 'url:https://spotify.com',
+          },
+        },
+      }),
+    ).toEqual({ target: 'https://backstage.io/foo.yaml', type: 'url' });
+  });
+
+  it('returns the managed-by-location', () => {
+    expect(
+      getEntitySourceLocation({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Location',
+        metadata: {
+          name: 'test',
+          namespace: 'default',
+          annotations: {
+            'backstage.io/managed-by-location': 'url:https://spotify.com',
+          },
+        },
+      }),
+    ).toEqual({ target: 'https://spotify.com', type: 'url' });
+  });
+
+  it('rejects missing location annotation', () => {
+    expect(() =>
+      getEntitySourceLocation({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Location',
+        metadata: { name: 'test', namespace: 'default' },
+      }),
+    ).toThrow(`Entity 'location:default/test' is missing location`);
   });
 });

--- a/packages/catalog-model/src/location/helpers.ts
+++ b/packages/catalog-model/src/location/helpers.ts
@@ -85,7 +85,7 @@ export function stringifyLocationReference(ref: {
 }
 
 /**
- * Returns the source code location of the Entity, to the extend which one exists.
+ * Returns the source code location of the Entity, to the extent that one exists.
  *
  * If the returned location type is of type 'url', the target should be readable at least
  * using the UrlReader from @backstage/backend-common. If it is not of type 'url', the caller

--- a/packages/catalog-model/src/location/helpers.ts
+++ b/packages/catalog-model/src/location/helpers.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { Entity, stringifyEntityRef } from '../entity';
+import { LOCATION_ANNOTATION, SOURCE_LOCATION_ANNOTATION } from './annotation';
+
 /**
  * Parses a string form location reference.
  *
@@ -79,4 +82,27 @@ export function stringifyLocationReference(ref: {
   }
 
   return `${type}:${target}`;
+}
+
+/**
+ * Returns the source code location of the Entity, to the extend which one exists.
+ *
+ * If the returned location type is of type 'url', the target should be readable at least
+ * using the UrlReader from @backstage/backend-common. If it is not of type 'url', the caller
+ * needs to have explicit handling of each location type or signal that it is not supported.
+ */
+export function getEntitySourceLocation(
+  entity: Entity,
+): { type: string; target: string } {
+  const locationRef =
+    entity.metadata?.annotations?.[SOURCE_LOCATION_ANNOTATION] ??
+    entity.metadata?.annotations?.[LOCATION_ANNOTATION];
+
+  if (!locationRef) {
+    throw new Error(
+      `Entity '${stringifyEntityRef(entity)}' is missing location`,
+    );
+  }
+
+  return parseLocationReference(locationRef);
 }

--- a/packages/catalog-model/src/location/index.ts
+++ b/packages/catalog-model/src/location/index.ts
@@ -19,7 +19,11 @@ export {
   ORIGIN_LOCATION_ANNOTATION,
   SOURCE_LOCATION_ANNOTATION,
 } from './annotation';
-export { parseLocationReference, stringifyLocationReference } from './helpers';
+export {
+  parseLocationReference,
+  stringifyLocationReference,
+  getEntitySourceLocation,
+} from './helpers';
 export type { Location, LocationSpec } from './types';
 export {
   analyzeLocationSchema,


### PR DESCRIPTION
Co-authored-by: Patrik Oldsberg <poldsberg@gmail.com>
Signed-off-by: Johan Haals <johan.haals@gmail.com>

## Hey, I just made a Pull Request!

Adds a small helper to get the entity source location.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
