### PR TITLE
docs: tweak docs for backstage.io/source-location

### DIFF
--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -92,12 +92,14 @@ view and edit links need changing.
 # Example:
 metadata:
   annotations:
-    backstage.io/source-location: github:https://github.com/my-org/my-service
+    backstage.io/source-location: url:https://github.com/my-org/my-service/
 ```
 
 A `Location` reference that points to the source code of the entity (typically a
 `Component`). Useful when catalog files do not get ingested from the source code
-repository itself.
+repository itself. If the URL points to a folder, it is important that it is
+suffixed with a `'/'` in order for relative path resolution to work
+consistently.
 
 ### jenkins.io/github-folder
 


### PR DESCRIPTION
The `github` location type is a thing of the past, so switched that to `url`.

It's also important that `source-location` URLs have a trailing `/` for folders, or relative path resolution won't work properly down the line. This is already the case in the implementation of the built-in processor though, so it's just a doc update.