### PR TITLE
Introduce attachment store to catalog

### DIFF
--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -29,6 +29,8 @@ const discoveryApi: DiscoveryApi = {
   },
 };
 
+// TODO: Add tests for attachment endpoints
+
 describe('CatalogClient', () => {
   let client: CatalogClient;
 

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -218,8 +218,9 @@ describe('CatalogClient', () => {
       );
       const blob = await attachment.blob();
 
-      expect(blob.type).toBe('text/plain');
-      expect(await blob.text()).toBe('Hello World');
+      expect(blob).toBeDefined();
+      expect(blob!.type).toBe('text/plain');
+      expect(await blob!.text()).toBe('Hello World');
     });
 
     it('should load attachment as blob, without token', async () => {
@@ -239,8 +240,28 @@ describe('CatalogClient', () => {
       );
       const blob = await attachment.blob();
 
-      expect(blob.type).toBe('text/plain');
-      expect(await blob.text()).toBe('Hello World');
+      expect(blob).toBeDefined();
+      expect(blob!.type).toBe('text/plain');
+      expect(await blob!.text()).toBe('Hello World');
+    });
+
+    it('should load attachment as blob, return undefined if attachment does not exist', async () => {
+      server.use(
+        rest.get(
+          `${mockBaseUrl}/entities/by-name/my-kind/my-namespace/my-name/attachments/backstage.io%2Fattachment-key`,
+          (_, res, ctx) => {
+            return res(ctx.status(404));
+          },
+        ),
+      );
+
+      const attachment = await client.getAttachment(
+        { kind: 'my-kind', name: 'my-name', namespace: 'my-namespace' },
+        'backstage.io/attachment-key',
+      );
+      const blob = await attachment.blob();
+
+      expect(blob).toBeUndefined();
     });
 
     it('should load attachment as text', async () => {
@@ -259,6 +280,24 @@ describe('CatalogClient', () => {
       const text = await attachment.text();
 
       expect(text).toBe('Hello World');
+    });
+
+    it('should load attachment as text, return undefined if attachment does not exist', async () => {
+      server.use(
+        rest.get(
+          `${mockBaseUrl}/entities/by-name/my-kind/my-namespace/my-name/attachments/backstage.io%2Fattachment-key`,
+          (_, res, ctx) => res(ctx.status(404)),
+        ),
+      );
+
+      const attachment = await client.getAttachment(
+        { kind: 'my-kind', name: 'my-name', namespace: 'my-namespace' },
+        'backstage.io/attachment-key',
+        { token },
+      );
+      const text = await attachment.text();
+
+      expect(text).toBeUndefined();
     });
 
     // TODO: This test doesn't work as the Blob return from fetch doesn't seem

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -119,9 +119,9 @@ export class CatalogClient implements CatalogApi {
   }
 
   async getAttachmentUrl(name: EntityName, key: string): Promise<string> {
-    return `${await this.discoveryApi.getBaseUrl(
-      'catalog',
-    )}/attachments/by-name/${name.kind}/${name.namespace}/${name.name}/${key}`;
+    return `${await this.discoveryApi.getBaseUrl('catalog')}/entities/by-name/${
+      name.kind
+    }/${name.namespace}/${name.name}/attachments/${key}`;
   }
 
   async addLocation(

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -107,13 +107,17 @@ export class CatalogClient implements CatalogApi {
     );
   }
 
-  // TODO: These need tests!
   async getAttachment(
     name: EntityName,
     key: string,
+    options?: CatalogRequestOptions,
   ): Promise<CatalogAttachmentResponse> {
     const url = await this.getAttachmentUrl(name, key);
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      headers: {
+        ...(options?.token && { Authorization: `Bearer ${options?.token}` }),
+      },
+    });
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -106,6 +106,24 @@ export class CatalogClient implements CatalogApi {
     );
   }
 
+  // TODO: These need tests!
+  async getAttachment(name: EntityName, key: string): Promise<Blob> {
+    const url = await this.getAttachmentUrl(name, key);
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw await ResponseError.fromResponse(response);
+    }
+
+    return await response.blob();
+  }
+
+  async getAttachmentUrl(name: EntityName, key: string): Promise<string> {
+    return `${await this.discoveryApi.getBaseUrl(
+      'catalog',
+    )}/attachments/by-name/${name.kind}/${name.namespace}/${name.name}/${key}`;
+  }
+
   async addLocation(
     { type = 'url', target, dryRun, presence }: AddLocationRequest,
     options?: CatalogRequestOptions,

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -28,6 +28,7 @@ import {
   AddLocationRequest,
   AddLocationResponse,
   CatalogApi,
+  CatalogAttachmentResponse,
   CatalogEntitiesRequest,
   CatalogListResponse,
   CatalogRequestOptions,
@@ -107,7 +108,10 @@ export class CatalogClient implements CatalogApi {
   }
 
   // TODO: These need tests!
-  async getAttachment(name: EntityName, key: string): Promise<Blob> {
+  async getAttachment(
+    name: EntityName,
+    key: string,
+  ): Promise<CatalogAttachmentResponse> {
     const url = await this.getAttachmentUrl(name, key);
     const response = await fetch(url);
 
@@ -115,13 +119,15 @@ export class CatalogClient implements CatalogApi {
       throw await ResponseError.fromResponse(response);
     }
 
-    return await response.blob();
+    return { data: await response.blob() };
   }
 
   async getAttachmentUrl(name: EntityName, key: string): Promise<string> {
-    return `${await this.discoveryApi.getBaseUrl('catalog')}/entities/by-name/${
-      name.kind
-    }/${name.namespace}/${name.name}/attachments/${key}`;
+    return `${await this.discoveryApi.getBaseUrl(
+      'catalog',
+    )}/entities/by-name/${encodeURIComponent(name.kind)}/${encodeURIComponent(
+      name.namespace,
+    )}/${encodeURIComponent(name.name)}/attachments/${encodeURIComponent(key)}`;
   }
 
   async addLocation(

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -149,9 +149,9 @@ export class CatalogClient implements CatalogApi {
           // In case a token is used, we have to fallback to a workaround, as a
           // simple URL won't work with tokens provided in headers. This is less
           // efficient, but also only used in that case.
-          // Instead of returning an URL where the called can request the attachment
-          // from, we return the attachmend directly as a base64 URL. Returning blob
-          // URLs might be more efficient, but requires to release them afterwars.
+          // Instead of returning a URL where the caller can request the attachment
+          // from, we return the attachment directly as a base64 URL. Returning blob
+          // URLs might be more efficient, but requires to release them afterwards.
           const blob = await fetchBlob();
           const reader = new FileReader();
 

--- a/packages/catalog-client/src/index.ts
+++ b/packages/catalog-client/src/index.ts
@@ -19,6 +19,7 @@ export type {
   AddLocationRequest,
   AddLocationResponse,
   CatalogApi,
+  CatalogAttachmentResponse,
   CatalogEntitiesRequest,
   CatalogListResponse,
 } from './types';

--- a/packages/catalog-client/src/types.ts
+++ b/packages/catalog-client/src/types.ts
@@ -33,7 +33,9 @@ export type CatalogRequestOptions = {
 };
 
 export type CatalogAttachmentResponse = {
-  data: Blob;
+  blob(): Promise<Blob>;
+  text(): Promise<string>;
+  url(): Promise<string>;
 };
 
 export interface CatalogApi {
@@ -57,7 +59,6 @@ export interface CatalogApi {
     key: string,
     options?: CatalogRequestOptions,
   ): Promise<CatalogAttachmentResponse>;
-  getAttachmentUrl(name: EntityName, key: string): Promise<string>;
 
   // Locations
   getLocationById(

--- a/packages/catalog-client/src/types.ts
+++ b/packages/catalog-client/src/types.ts
@@ -55,6 +55,7 @@ export interface CatalogApi {
   getAttachment(
     name: EntityName,
     key: string,
+    options?: CatalogRequestOptions,
   ): Promise<CatalogAttachmentResponse>;
   getAttachmentUrl(name: EntityName, key: string): Promise<string>;
 

--- a/packages/catalog-client/src/types.ts
+++ b/packages/catalog-client/src/types.ts
@@ -47,6 +47,10 @@ export interface CatalogApi {
     options?: CatalogRequestOptions,
   ): Promise<void>;
 
+  // Attachments
+  getAttachment(name: EntityName, key: string): Promise<Blob>;
+  getAttachmentUrl(name: EntityName, key: string): Promise<string>;
+
   // Locations
   getLocationById(
     id: string,

--- a/packages/catalog-client/src/types.ts
+++ b/packages/catalog-client/src/types.ts
@@ -33,8 +33,8 @@ export type CatalogRequestOptions = {
 };
 
 export type CatalogAttachmentResponse = {
-  blob(): Promise<Blob>;
-  text(): Promise<string>;
+  blob(): Promise<Blob | undefined>;
+  text(): Promise<string | undefined>;
   url(): Promise<string>;
 };
 

--- a/packages/catalog-client/src/types.ts
+++ b/packages/catalog-client/src/types.ts
@@ -32,6 +32,10 @@ export type CatalogRequestOptions = {
   token?: string;
 };
 
+export type CatalogAttachmentResponse = {
+  data: Blob;
+};
+
 export interface CatalogApi {
   // Entities
   getEntities(
@@ -48,7 +52,10 @@ export interface CatalogApi {
   ): Promise<void>;
 
   // Attachments
-  getAttachment(name: EntityName, key: string): Promise<Blob>;
+  getAttachment(
+    name: EntityName,
+    key: string,
+  ): Promise<CatalogAttachmentResponse>;
   getAttachmentUrl(name: EntityName, key: string): Promise<string>;
 
   // Locations

--- a/packages/catalog-model/examples/apis/spotify-api.yaml
+++ b/packages/catalog-model/examples/apis/spotify-api.yaml
@@ -13,5 +13,4 @@ spec:
   type: openapi
   lifecycle: production
   owner: team-a
-  definition:
-    $text: https://github.com/APIs-guru/openapi-directory/blob/dab6854d4d599aafb0eb36e6c7ae1fe0c37509b7/APIs/spotify.com/2021.4.2/openapi.yaml
+  definitionLocation: url:https://github.com/APIs-guru/openapi-directory/blob/dab6854d4d599aafb0eb36e6c7ae1fe0c37509b7/APIs/spotify.com/2021.4.2/openapi.yaml

--- a/packages/catalog-model/examples/apis/spotify-api.yaml
+++ b/packages/catalog-model/examples/apis/spotify-api.yaml
@@ -6,9 +6,6 @@ metadata:
   tags:
     - spotify
     - rest
-  annotations:
-    # The annotation is deprecated, we use placeholders (see below) instead, remove it later.
-    backstage.io/definition-at-location: 'url:https://raw.githubusercontent.com/APIs-guru/openapi-directory/master/APIs/spotify.com/v1/swagger.yaml'
 spec:
   type: openapi
   lifecycle: production

--- a/packages/catalog-model/src/kinds/ApiEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ApiEntityV1alpha1.ts
@@ -31,7 +31,10 @@ export interface ApiEntityV1alpha1 extends Entity {
     type: string;
     lifecycle: string;
     owner: string;
-    definition: string;
+    // TODO: We need to adjust tests and documentation for this change.
+    // TODO: Think about a migration strategy!
+    definition?: string;
+    definitionLocation: string;
     system?: string;
   };
 }

--- a/packages/catalog-model/src/schema/kinds/API.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/API.v1alpha1.schema.json
@@ -41,7 +41,7 @@
         },
         "spec": {
           "type": "object",
-          "required": ["type", "lifecycle", "owner", "definition"],
+          "required": ["type", "lifecycle", "owner"],
           "properties": {
             "type": {
               "type": "string",
@@ -69,6 +69,11 @@
             "definition": {
               "type": "string",
               "description": "The definition of the API, based on the format defined by the type.",
+              "minLength": 1
+            },
+            "definitionLocation": {
+              "type": "string",
+              "description": "The location reference to the definition of the API.",
               "minLength": 1
             }
           }

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -14,11 +14,18 @@
  * limitations under the License.
  */
 
-import { ApiEntity } from '@backstage/catalog-model';
-import { CardTab, TabbedCard, useApi } from '@backstage/core';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import { ApiEntity, getEntityName } from '@backstage/catalog-model';
+import {
+  CardTab,
+  Progress,
+  ResponseErrorPanel,
+  TabbedCard,
+  useApi,
+} from '@backstage/core';
+import { catalogApiRef, useEntity } from '@backstage/plugin-catalog-react';
 import { Alert } from '@material-ui/lab';
 import React from 'react';
+import { useAsync } from 'react-use';
 import { apiDocsConfigRef } from '../../config';
 import { PlainApiDefinitionWidget } from '../PlainApiDefinitionWidget';
 
@@ -30,7 +37,23 @@ type Props = {
 export const ApiDefinitionCard = (_: Props) => {
   const { entity } = useEntity<ApiEntity>();
   const config = useApi(apiDocsConfigRef);
+  const catalogClient = useApi(catalogApiRef);
   const { getApiDefinitionWidget } = config;
+  const { value: definition, loading, error } = useAsync(async () => {
+    if (!entity) {
+      return undefined;
+    }
+
+    if (entity.spec.definition) {
+      return entity.spec.definition;
+    }
+
+    const data = await catalogClient.getAttachment(
+      getEntityName(entity),
+      'definition',
+    );
+    return await data.text();
+  }, [catalogClient, entity]);
 
   if (!entity) {
     return <Alert severity="error">Could not fetch the API</Alert>;
@@ -38,15 +61,23 @@ export const ApiDefinitionCard = (_: Props) => {
 
   const definitionWidget = getApiDefinitionWidget(entity);
 
+  if (error) {
+    return <ResponseErrorPanel error={error} />;
+  }
+
+  if (loading || !definition) {
+    return <Progress />;
+  }
+
   if (definitionWidget) {
     return (
       <TabbedCard title={entity.metadata.name}>
         <CardTab label={definitionWidget.title} key="widget">
-          {definitionWidget.component(entity.spec.definition)}
+          {definitionWidget.component(definition)}
         </CardTab>
         <CardTab label="Raw" key="raw">
           <PlainApiDefinitionWidget
-            definition={entity.spec.definition}
+            definition={definition}
             language={definitionWidget.rawLanguage || entity.spec.type}
           />
         </CardTab>
@@ -61,7 +92,7 @@ export const ApiDefinitionCard = (_: Props) => {
         // Has to be an array, otherwise typescript doesn't like that this has only a single child
         <CardTab label={entity.spec.type} key="raw">
           <PlainApiDefinitionWidget
-            definition={entity.spec.definition}
+            definition={definition}
             language={entity.spec.type}
           />
         </CardTab>,

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -50,11 +50,11 @@ export const ApiDefinitionCard = (_: Props) => {
 
     // TODO: Move to catalog model
     const ATTACHMENT_API_DEFINITION = 'backstage.io/api-definition';
-    const response = await catalogClient.getAttachment(
+    const attachment = await catalogClient.getAttachment(
       getEntityName(entity),
       ATTACHMENT_API_DEFINITION,
     );
-    return await response.data.text();
+    return await attachment.text();
   }, [catalogClient, entity]);
 
   if (!entity) {

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -48,11 +48,11 @@ export const ApiDefinitionCard = (_: Props) => {
       return entity.spec.definition;
     }
 
-    const data = await catalogClient.getAttachment(
+    const response = await catalogClient.getAttachment(
       getEntityName(entity),
       'definition',
     );
-    return await data.text();
+    return await response.data.text();
   }, [catalogClient, entity]);
 
   if (!entity) {

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -48,9 +48,11 @@ export const ApiDefinitionCard = (_: Props) => {
       return entity.spec.definition;
     }
 
+    // TODO: Move to catalog model
+    const ATTACHMENT_API_DEFINITION = 'backstage.io/api-definition';
     const response = await catalogClient.getAttachment(
       getEntityName(entity),
-      'definition',
+      ATTACHMENT_API_DEFINITION,
     );
     return await response.data.text();
   }, [catalogClient, entity]);

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -29,7 +29,6 @@ describe('CatalogIdentityClient', () => {
     getLocationByEntity: jest.fn(),
     removeEntityByUid: jest.fn(),
     getAttachment: jest.fn(),
-    getAttachmentUrl: jest.fn(),
   };
 
   afterEach(() => jest.resetAllMocks());

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -28,6 +28,8 @@ describe('CatalogIdentityClient', () => {
     getOriginLocationByEntity: jest.fn(),
     getLocationByEntity: jest.fn(),
     removeEntityByUid: jest.fn(),
+    getAttachment: jest.fn(),
+    getAttachmentUrl: jest.fn(),
   };
 
   afterEach(() => jest.resetAllMocks());

--- a/plugins/auth-backend/src/providers/aws-alb/provider.test.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.test.ts
@@ -77,7 +77,6 @@ describe('AwsALBAuthProvider', () => {
     removeEntityByUid: jest.fn(),
     getEntityByName: jest.fn(),
     getAttachment: jest.fn(),
-    getAttachmentUrl: jest.fn(),
   };
 
   const mockRequest = ({

--- a/plugins/auth-backend/src/providers/aws-alb/provider.test.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.test.ts
@@ -16,9 +16,8 @@
 import { getVoidLogger } from '@backstage/backend-common';
 import express from 'express';
 import { JWT } from 'jose';
-
-import { AwsAlbAuthProvider } from './provider';
 import { AuthResponse } from '../types';
+import { AwsAlbAuthProvider } from './provider';
 
 const jwtMock = JWT as jest.Mocked<any>;
 
@@ -77,6 +76,8 @@ describe('AwsALBAuthProvider', () => {
     getLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
     getEntityByName: jest.fn(),
+    getAttachment: jest.fn(),
+    getAttachmentUrl: jest.fn(),
   };
 
   const mockRequest = ({

--- a/plugins/badges-backend/src/service/router.test.ts
+++ b/plugins/badges-backend/src/service/router.test.ts
@@ -67,7 +67,6 @@ describe('createRouter', () => {
       removeLocationById: jest.fn(),
       removeEntityByUid: jest.fn(),
       getAttachment: jest.fn(),
-      getAttachmentUrl: jest.fn(),
     };
 
     config = new ConfigReader({

--- a/plugins/badges-backend/src/service/router.test.ts
+++ b/plugins/badges-backend/src/service/router.test.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import express from 'express';
-import request from 'supertest';
 import {
   PluginEndpointDiscovery,
   SingleHostDiscovery,
@@ -23,8 +21,10 @@ import {
 import { CatalogApi } from '@backstage/catalog-client';
 import type { Entity } from '@backstage/catalog-model';
 import { Config, ConfigReader } from '@backstage/config';
-import { createRouter } from './router';
+import express from 'express';
+import request from 'supertest';
 import { BadgeBuilder } from '../lib';
+import { createRouter } from './router';
 
 describe('createRouter', () => {
   let app: express.Express;
@@ -66,6 +66,8 @@ describe('createRouter', () => {
       getLocationById: jest.fn(),
       removeLocationById: jest.fn(),
       removeEntityByUid: jest.fn(),
+      getAttachment: jest.fn(),
+      getAttachmentUrl: jest.fn(),
     };
 
     config = new ConfigReader({

--- a/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
+++ b/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
@@ -45,9 +45,7 @@ exports.up = async function up(knex) {
     table
       .string('etag')
       .notNullable()
-      .comment(
-        'A hash of the attachment and its metadata.',
-      );
+      .comment('A hash of the attachment and its metadata.');
     table.primary(['originating_entity_id', 'key']);
   });
 };
@@ -56,5 +54,9 @@ exports.up = async function up(knex) {
  * @param {import('knex').Knex} knex
  */
 exports.down = async function down(knex) {
+  await knex.schema.alterTable('entities_attachments', table => {
+    table.dropIndex(['originating_entity_id', 'key']);
+    table.dropIndex([], 'originating_entity_id_idx');
+  });
   await knex.schema.dropTable('entities_attachments');
 };

--- a/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
+++ b/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
@@ -42,7 +42,12 @@ exports.up = async function up(knex) {
       .text('content_type')
       .notNullable()
       .comment('The content type of the attachment for serving over HTTP');
-    // TODO: Store etag?
+    table
+      .string('etag')
+      .notNullable()
+      .comment(
+        'An opaque string that changes for each update operation to the content of the attachment.',
+      );
     table.primary(['originating_entity_id', 'key']);
   });
 };

--- a/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
+++ b/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
@@ -23,14 +23,15 @@ exports.up = async function up(knex) {
   await knex.schema.createTable('entities_attachments', table => {
     table.comment('Binary attachments to a entity');
     table
-      .string('originating_entity_id')
+      .text('originating_entity_id')
       .references('id')
       .inTable('entities')
       .onDelete('CASCADE')
       .notNullable()
+      .index('originating_entity_id_idx')
       .comment('The uid of the related entity');
     table
-      .string('key')
+      .text('key')
       .notNullable()
       .comment('The name of the attachment, unique for a single entity');
     table
@@ -38,7 +39,7 @@ exports.up = async function up(knex) {
       .notNullable()
       .comment('The binary data of the attachment');
     table
-      .string('content_type')
+      .text('content_type')
       .notNullable()
       .comment('The content type of the attachment for serving over HTTP');
     // TODO: Store etag?

--- a/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
+++ b/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
@@ -46,7 +46,7 @@ exports.up = async function up(knex) {
       .string('etag')
       .notNullable()
       .comment(
-        'An opaque string that changes for each update operation to the content of the attachment.',
+        'A hash of the attachment and its metadata.',
       );
     table.primary(['originating_entity_id', 'key']);
   });

--- a/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
+++ b/plugins/catalog-backend/migrations/20210408154713_add_attachments.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('entities_attachments', table => {
+    table.comment('Binary attachments to a entity');
+    table
+      .string('originating_entity_id')
+      .references('id')
+      .inTable('entities')
+      .onDelete('CASCADE')
+      .notNullable()
+      .comment('The uid of the related entity');
+    table
+      .string('key')
+      .notNullable()
+      .comment('The name of the attachment, unique for a single entity');
+    table
+      .binary('data')
+      .notNullable()
+      .comment('The binary data of the attachment');
+    table
+      .string('content_type')
+      .notNullable()
+      .comment('The content type of the attachment for serving over HTTP');
+    // TODO: Store etag?
+    table.primary(['originating_entity_id', 'key']);
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.dropTable('entities_attachments');
+};

--- a/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.test.ts
@@ -21,6 +21,8 @@ import { basicEntityFilter } from '../service/request';
 import { DatabaseEntitiesCatalog } from './DatabaseEntitiesCatalog';
 import { EntityUpsertRequest } from './types';
 
+// TODO: Tests...
+
 describe('DatabaseEntitiesCatalog', () => {
   let db: jest.Mocked<Database>;
   let transaction: jest.Mocked<Transaction>;

--- a/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/catalog/DatabaseEntitiesCatalog.ts
@@ -35,6 +35,7 @@ import {
   EntitiesRequest,
   EntitiesResponse,
   EntityAttachment,
+  EntityAttachmentFilter,
   EntityUpsertRequest,
   EntityUpsertResponse,
 } from './types';
@@ -87,9 +88,15 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
   async attachment(
     uid: string,
     key: string,
+    filter?: EntityAttachmentFilter,
   ): Promise<EntityAttachment | undefined> {
     return await this.database.transaction(async tx => {
-      const response = await this.database.attachmentByUidAndKey(tx, uid, key);
+      const response = await this.database.attachmentByUidAndKey(
+        tx,
+        uid,
+        key,
+        filter,
+      );
 
       if (!response) {
         return undefined;
@@ -99,6 +106,7 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
         key: response.key,
         data: response.data,
         contentType: response.contentType,
+        etag: response.etag,
       };
     });
   }
@@ -319,10 +327,9 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
         locationId,
         entity,
         relations,
-        attachments: attachments.map(({ key, data, contentType }) => ({
+        attachments: attachments.map(({ key, content }) => ({
           key,
-          data,
-          contentType,
+          content,
         })),
       })),
     );
@@ -385,10 +392,9 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
           locationId,
           entity: updated,
           relations,
-          attachments: attachments.map(({ key, data, contentType }) => ({
+          attachments: attachments.map(({ key, content }) => ({
             key,
-            data,
-            contentType,
+            content,
           })),
         },
         existing.entity.metadata.etag,
@@ -400,10 +406,9 @@ export class DatabaseEntitiesCatalog implements EntitiesCatalog {
           locationId,
           entity,
           relations,
-          attachments: attachments.map(({ key, data, contentType }) => ({
+          attachments: attachments.map(({ key, content }) => ({
             key,
-            data,
-            contentType,
+            content,
           })),
         },
       ]);

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -41,9 +41,19 @@ export type EntitiesResponse = {
   pageInfo: PageInfo;
 };
 
+// TODO: Think a bit more about this type! We might want to split it into
+// metadata and the actual data. For reading we might only want to return the
+// metadata except the data itself is requested explicitly!
+export type EntityAttachment = {
+  key: string;
+  data: Buffer;
+  contentType: string;
+};
+
 export type EntityUpsertRequest = {
   entity: Entity;
   relations: EntityRelationSpec[];
+  attachments: EntityAttachment[];
 };
 
 export type EntityUpsertResponse = {
@@ -58,6 +68,13 @@ export type EntitiesCatalog = {
    * @param request Request options
    */
   entities(request?: EntitiesRequest): Promise<EntitiesResponse>;
+
+  /**
+   * Get a single entity attachment
+   *
+   * @param uid
+   */
+  attachment(uid: string, key: string): Promise<EntityAttachment | undefined>;
 
   /**
    * Removes a single entity.

--- a/plugins/catalog-backend/src/database/CommonDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.test.ts
@@ -34,6 +34,8 @@ const bootstrapLocation = {
   timestamp: null,
 };
 
+// TODO: Tests...
+
 describe('CommonDatabase', () => {
   let db: Database;
   let entityRequest: DbEntityRequest;

--- a/plugins/catalog-backend/src/database/CommonDatabase.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.ts
@@ -414,7 +414,7 @@ export class CommonDatabase implements Database {
       entityUid: result.originating_entity_id,
       contentType: result.content_type,
       // knex returns null, make sure we use undefined instead
-      data: result.dataOrNull ? result.dataOrNull : undefined,
+      data: result.dataOrNull ?? undefined,
       etag: result.etag,
     };
   }

--- a/plugins/catalog-backend/src/database/CommonDatabase.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.ts
@@ -26,7 +26,6 @@ import {
   parseEntityName,
 } from '@backstage/catalog-model';
 import { ConflictError, InputError, NotFoundError } from '@backstage/errors';
-import { createHash } from 'crypto';
 import { Knex } from 'knex';
 import lodash from 'lodash';
 import type { Logger } from 'winston';
@@ -54,6 +53,7 @@ import {
   EntityPagination,
   Transaction,
 } from './types';
+import { generateAttachmentEtag } from './utils';
 
 // The number of items that are sent per batch to the database layer, when
 // doing .batchInsert calls to knex. This needs to be low enough to not cause
@@ -693,11 +693,4 @@ function deduplicateRelations(
     rows,
     r => `${r.source_full_name}:${r.target_full_name}:${r.type}`,
   );
-}
-
-function generateAttachmentEtag(data: Buffer, contentType: string): string {
-  return createHash('sha256')
-    .update(data)
-    .update(contentType, 'utf8')
-    .digest('base64');
 }

--- a/plugins/catalog-backend/src/database/CommonDatabase.ts
+++ b/plugins/catalog-backend/src/database/CommonDatabase.ts
@@ -140,7 +140,7 @@ export class CommonDatabase implements Database {
       entityRows.push(this.toEntityRow(locationId, newEntity));
       relationRows.push(...this.toRelationRows(uid, relations));
       searchRows.push(...buildEntitySearch(uid, newEntity));
-      attachmentRows.push(...this.toAttachmendRows(uid, attachments));
+      attachmentRows.push(...this.toAttachmentRows(uid, attachments));
     }
 
     await tx.batchInsert('entities', entityRows, BATCH_SIZE);
@@ -211,7 +211,7 @@ export class CommonDatabase implements Database {
       .where({ originating_entity_id: uid })
       .whereNotIn('key', attachmentKeys)
       .del();
-    const attachmentRows = this.toAttachmendRows(
+    const attachmentRows = this.toAttachmentRows(
       uid,
       request.attachments.filter(({ content }) => content),
     );
@@ -573,7 +573,7 @@ export class CommonDatabase implements Database {
     return deduplicateRelations(rows);
   }
 
-  private toAttachmendRows(
+  private toAttachmentRows(
     originatingEntityId: string,
     attachments: DbAttachmentRequest[],
   ): DbAttachmentRow[] {

--- a/plugins/catalog-backend/src/database/index.ts
+++ b/plugins/catalog-backend/src/database/index.ts
@@ -18,6 +18,10 @@ export { CommonDatabase } from './CommonDatabase';
 export { DatabaseManager } from './DatabaseManager';
 export type {
   Database,
+  DbAttachmentRequest,
+  DbAttachmentRequestContent,
+  DbAttachmentMetadataResponse,
+  DbAttachmentResponse,
   DbEntityRequest,
   DbEntityResponse,
   EntitiesSearchFilter,

--- a/plugins/catalog-backend/src/database/types.ts
+++ b/plugins/catalog-backend/src/database/types.ts
@@ -34,6 +34,7 @@ export type DbEntityRequest = {
   locationId?: string;
   entity: Entity;
   relations: EntityRelationSpec[];
+  attachments: DbAttachmentRequest[];
 };
 
 export type DbEntitiesRequest = {
@@ -97,6 +98,26 @@ export type DatabaseLocationUpdateLogEvent = {
   entity_name: string;
   created_at?: string;
   message?: string;
+};
+
+export type DbAttachmentRequest = {
+  key: string;
+  data?: Buffer;
+  contentType: string;
+};
+
+export type DbAttachmentResponse = {
+  entityUid: string;
+  key: string;
+  data: Buffer;
+  contentType: string;
+};
+
+export type DbAttachmentRow = {
+  originating_entity_id: string;
+  key: string;
+  data: Buffer;
+  content_type: string;
 };
 
 /**
@@ -214,6 +235,12 @@ export type Database = {
   ): Promise<DbEntityResponse | undefined>;
 
   removeEntityByUid(tx: Transaction, uid: string): Promise<void>;
+
+  attachmentByUidAndKey(
+    tx: Transaction,
+    entityUid: string,
+    key: string,
+  ): Promise<DbAttachmentResponse | undefined>;
 
   /**
    * Remove current relations for the entity and replace them with the new

--- a/plugins/catalog-backend/src/database/types.ts
+++ b/plugins/catalog-backend/src/database/types.ts
@@ -101,23 +101,58 @@ export type DatabaseLocationUpdateLogEvent = {
 };
 
 export type DbAttachmentRequest = {
+  /** Key of the entity attachment, has to be unique inside an entity. */
   key: string;
-  data?: Buffer;
-  contentType: string;
+  /**
+   * Optional content of the attachment, including data and content type. If no
+   * content is provided, the current content is kept.
+   */
+  content?: DbAttachmentRequestContent;
 };
 
-export type DbAttachmentResponse = {
-  entityUid: string;
-  key: string;
+export type DbAttachmentRequestContent = {
+  /** Data to be stored in the attachment. */
   data: Buffer;
+  /** Mime type of the data. */
   contentType: string;
 };
 
-export type DbAttachmentRow = {
+export type DbAttachmentMetadataResponse = {
+  /** Unique id of the entity that this attachment belongs to. */
+  entityUid: string;
+  /** Key of the entity attachment, has to be unique inside an entity. */
+  key: string;
+  /**
+   * An opaque string that changes for each update operation to the content of
+   * the attachment.
+   */
+  etag: string;
+  /** Mime type of the data. */
+  contentType: string;
+};
+
+export type DbAttachmentResponse = DbAttachmentMetadataResponse & {
+  /**
+   * Data that is stored in the attachment. Might be empty, if it matches the
+   * requested etag.
+   */
+  data?: Buffer;
+};
+
+export type DbAttachmentFilter = {
+  /** Return data in the attachment only if the provided etag doesn't match. */
+  ifNotMatchEtag?: string;
+};
+
+export type DbAttachmentMetadataRow = {
   originating_entity_id: string;
   key: string;
-  data: Buffer;
+  etag: string;
   content_type: string;
+};
+
+export type DbAttachmentRow = DbAttachmentMetadataRow & {
+  dataOrNull?: Buffer;
 };
 
 /**
@@ -236,10 +271,29 @@ export type Database = {
 
   removeEntityByUid(tx: Transaction, uid: string): Promise<void>;
 
+  /**
+   * Query metadata on all attachments of an entity.
+   *
+   * @param tx An ongoing transaction
+   * @param entityUid The entity uid
+   */
+  attachmentsByUid(
+    tx: Transaction,
+    entityUid: string,
+  ): Promise<DbAttachmentMetadataResponse[]>;
+
+  /**
+   * Query metadata and content of an attachment of an entity.
+   *
+   * @param tx An ongoing transaction
+   * @param entityUid The entity uid
+   * @param key The key of the attachment
+   */
   attachmentByUidAndKey(
     tx: Transaction,
     entityUid: string,
     key: string,
+    filter?: DbAttachmentFilter,
   ): Promise<DbAttachmentResponse | undefined>;
 
   /**

--- a/plugins/catalog-backend/src/database/utils.test.ts
+++ b/plugins/catalog-backend/src/database/utils.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { generateAttachmentEtag } from './utils';
+
+describe('generateAttachmentEtag', () => {
+  it('should generate stable etag', () => {
+    const buffer = Buffer.from('Hello World');
+    expect(generateAttachmentEtag(buffer, 'text/plain')).toEqual(
+      'EAT0d0ctWMREHR8j9pp7TjTWNh7/UilaEjqh8cNWMcs=',
+    );
+  });
+
+  it('changing data should change etag', () => {
+    const buffer = Buffer.from('Hallo Welt');
+    expect(generateAttachmentEtag(buffer, 'text/plain')).toEqual(
+      'jCCaQrktTdmyQmaRpwrdvH8ixr8+v5I8/H2W9o7Z3iA=',
+    );
+  });
+
+  it('changing content type should change etag', () => {
+    const buffer = Buffer.from('Hello World');
+    expect(generateAttachmentEtag(buffer, 'application/json')).toEqual(
+      'X4mJrhwvCjyxLfx4KmBBaohcjXB2w/qomM/xcZt4ExM=',
+    );
+  });
+});

--- a/plugins/catalog-backend/src/database/utils.ts
+++ b/plugins/catalog-backend/src/database/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Spotify AB
+ * Copyright 2021 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { createHash } from 'crypto';
 
-export { CommonDatabase } from './CommonDatabase';
-export { DatabaseManager } from './DatabaseManager';
-export type {
-  Database,
-  DbAttachmentMetadataResponse,
-  DbAttachmentRequest,
-  DbAttachmentRequestContent,
-  DbAttachmentResponse,
-  DbEntityRequest,
-  DbEntityResponse,
-  EntitiesSearchFilter,
-  EntityFilter,
-  EntityPagination,
-  Transaction,
-} from './types';
-export { generateAttachmentEtag } from './utils';
+export function generateAttachmentEtag(
+  data: Buffer,
+  contentType: string,
+): string {
+  return createHash('sha256')
+    .update(data)
+    .update(contentType, 'utf8')
+    .digest('base64');
+}

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.test.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.test.ts
@@ -357,7 +357,7 @@ describe('HigherOrderOperations', () => {
         { currentStatus: locationStatus, data: location },
       ]);
       locationReader.read.mockResolvedValue({
-        entities: [{ entity: desc, location, relations: [] }],
+        entities: [{ entity: desc, location, relations: [], attachments: [] }],
         errors: [],
       });
       entitiesCatalog.entities.mockResolvedValue({

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.test.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.test.ts
@@ -33,6 +33,7 @@ describe('HigherOrderOperations', () => {
       entities: jest.fn(),
       removeEntityByUid: jest.fn(),
       batchAddOrUpdateEntities: jest.fn(),
+      attachment: jest.fn(),
     };
     locationsCatalog = {
       addLocation: jest.fn(),
@@ -120,6 +121,7 @@ describe('HigherOrderOperations', () => {
             location,
             entity,
             relations: [],
+            attachments: [],
           },
         ],
         errors: [],
@@ -201,7 +203,7 @@ describe('HigherOrderOperations', () => {
 
       locationsCatalog.locations.mockResolvedValue([]);
       locationReader.read.mockResolvedValue({
-        entities: [{ entity, location, relations: [] }],
+        entities: [{ entity, location, relations: [], attachments: [] }],
         errors: [{ error: new Error('abcd'), location }],
       });
 
@@ -238,6 +240,7 @@ describe('HigherOrderOperations', () => {
             location,
             entity,
             relations: [],
+            attachments: [],
           },
         ],
         errors: [],
@@ -304,7 +307,7 @@ describe('HigherOrderOperations', () => {
         { currentStatus: locationStatus, data: location },
       ]);
       locationReader.read.mockResolvedValue({
-        entities: [{ entity: desc, location, relations: [] }],
+        entities: [{ entity: desc, location, relations: [], attachments: [] }],
         errors: [],
       });
       entitiesCatalog.batchAddOrUpdateEntities.mockResolvedValue([

--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -92,10 +92,7 @@ export class LocationReaders implements LocationReader {
                 } else if (emitResult.type === 'attachment') {
                   attachments.push({
                     key: emitResult.key,
-                    content: {
-                      data: emitResult.data,
-                      contentType: emitResult.contentType,
-                    },
+                    content: emitResult.content,
                   });
                   return;
                 }

--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -37,7 +37,7 @@ import {
   CatalogProcessorParser,
   CatalogProcessorResult,
 } from './processors/types';
-import { LocationReader, ReadLocationResult } from './types';
+import { EntityAttachment, LocationReader, ReadLocationResult } from './types';
 
 // The max amount of nesting depth of generated work items
 const MAX_DEPTH = 10;
@@ -81,12 +81,20 @@ export class LocationReaders implements LocationReader {
         } else if (item.type === 'entity') {
           if (rulesEnforcer.isAllowed(item.entity, item.location)) {
             const relations = Array<EntityRelationSpec>();
+            const attachments = Array<EntityAttachment>();
 
             const entity = await this.handleEntity(
               item,
               emitResult => {
                 if (emitResult.type === 'relation') {
                   relations.push(emitResult.relation);
+                  return;
+                } else if (emitResult.type === 'attachment') {
+                  attachments.push({
+                    key: emitResult.key,
+                    data: emitResult.data,
+                    contentType: emitResult.contentType,
+                  });
                   return;
                 }
                 emit(emitResult);
@@ -99,6 +107,7 @@ export class LocationReaders implements LocationReader {
                 entity,
                 location: item.location,
                 relations,
+                attachments,
               });
             }
           } else {

--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -92,8 +92,10 @@ export class LocationReaders implements LocationReader {
                 } else if (emitResult.type === 'attachment') {
                   attachments.push({
                     key: emitResult.key,
-                    data: emitResult.data,
-                    contentType: emitResult.contentType,
+                    content: {
+                      data: emitResult.data,
+                      contentType: emitResult.contentType,
+                    },
                   });
                   return;
                 }

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
@@ -25,6 +25,8 @@ import {
 } from '@backstage/catalog-model';
 import { BuiltinKindsEntityProcessor } from './BuiltinKindsEntityProcessor';
 
+// TODO: Add tests for emitting attachments
+
 describe('BuiltinKindsEntityProcessor', () => {
   describe('postProcessEntity', () => {
     const processor = new BuiltinKindsEntityProcessor();

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
@@ -212,7 +212,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
       // but for api definitions plain should be a fine choice.
       const contentType = 'text/plain';
 
-      emit(result.attachment(ATTACHMENT_API_DEFINITION, data, contentType));
+      emit(result.attachment(ATTACHMENT_API_DEFINITION, { data, contentType }));
 
       // TODO: How to migrate from "definition" to "definition?", it's a breaking change?
       delete api.spec.definition;
@@ -274,7 +274,9 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         // TODO: Move to catalog model
         const ATTACHMENT_PROFILE_PICTURE = 'backstage.io/profile-picture';
 
-        emit(result.attachment(ATTACHMENT_PROFILE_PICTURE, data, contentType));
+        emit(
+          result.attachment(ATTACHMENT_PROFILE_PICTURE, { data, contentType }),
+        );
 
         user.spec.profile.picture = stringifyLocationReference({
           type: 'attachment',

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
@@ -288,6 +288,8 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
       // TODO: Property name could be better... like pictureLocation...
 
       if (user.spec.profile?.picture) {
+        // TODO: This should use UrlReader instead, but UrlReader provides no
+        // access to the content type of the response.
         const response = await fetch(user.spec.profile?.picture);
         const buffer = await response.arrayBuffer();
         const data = Buffer.from(buffer);

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
@@ -44,6 +44,7 @@ import {
   RELATION_PROVIDES_API,
   ResourceEntity,
   resourceEntityV1alpha1Validator,
+  stringifyLocationReference,
   SystemEntity,
   systemEntityV1alpha1Validator,
   templateEntityV1alpha1Validator,
@@ -176,7 +177,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     }
 
     /*
-     * Emit relations for the API kind
+     * Emit relations and attachments for the API kind
      */
 
     if (entity.kind === 'API') {
@@ -193,6 +194,29 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_PART_OF,
         RELATION_HAS_PART,
       );
+
+      // TODO: Consider building a helper around this, but it's a bit difficult
+      // with "deleting" the previous field.
+
+      // TODO: Emitting the attachment from the definition field for now. That
+      // still requires that the definition is filled with the full data and we
+      // we can do any special caching around it for now. Later we can read it
+      // form a definitionLocation field instead.
+      const key = 'definition';
+      // TODO: Also support directly reading from a location in the future, this
+      // avoid that we bload our memory with all definitions.
+      const data = Buffer.from(api.spec.definition!, 'utf8');
+      // TODO: Actually a hard question, depends either on the use case or data,
+      // but for api definitions plain should be a fine choice.
+      const contentType = 'text/plain';
+      emit(result.attachment('definition', data, contentType));
+
+      // TODO: How to migrate from "definition" to "definition?", it's a breaking change?
+      delete api.spec.definition;
+      api.spec.definitionLocation = stringifyLocationReference({
+        type: 'attachment',
+        target: key,
+      });
     }
 
     /*
@@ -233,6 +257,8 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_MEMBER_OF,
         RELATION_HAS_MEMBER,
       );
+
+      // TODO: Create an attachment for the photo by downloading the URL.
     }
 
     /*
@@ -259,6 +285,8 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_HAS_MEMBER,
         RELATION_MEMBER_OF,
       );
+
+      // TODO: Create an attachment for the photo by downloading the URL.
     }
 
     /*

--- a/plugins/catalog-backend/src/ingestion/processors/results.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/results.ts
@@ -20,7 +20,10 @@ import {
   LocationSpec,
 } from '@backstage/catalog-model';
 import { InputError, NotFoundError } from '@backstage/errors';
-import { CatalogProcessorResult } from './types';
+import {
+  CatalogProcessorAttachmentContentResult,
+  CatalogProcessorResult,
+} from './types';
 
 export function notFoundError(
   atLocation: LocationSpec,
@@ -69,13 +72,16 @@ export function relation(spec: EntityRelationSpec): CatalogProcessorResult {
   return { type: 'relation', relation: spec };
 }
 
+/**
+ * Emits a entity attachment.
+ * @param key Required key for the attachment, has to be unqiue inside an
+ *            entity.
+ * @param content Optional content of the attachment. Content can be omitted, if
+ *                the previous content should be kept.
+ */
 export function attachment(
   key: string,
-  data: Buffer,
-  contentType: string,
+  content?: CatalogProcessorAttachmentContentResult,
 ): CatalogProcessorResult {
-  // TODO: Consider allowing to pass an optional etag to configure caching
-  // We could also make it required in CatalogProcessorResult and generate a
-  // fallback here (e.g. sha256)
-  return { type: 'attachment', key, data, contentType };
+  return { type: 'attachment', key, content };
 }

--- a/plugins/catalog-backend/src/ingestion/processors/results.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/results.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { InputError, NotFoundError } from '@backstage/errors';
 import {
   Entity,
   EntityRelationSpec,
   LocationSpec,
 } from '@backstage/catalog-model';
+import { InputError, NotFoundError } from '@backstage/errors';
 import { CatalogProcessorResult } from './types';
 
 export function notFoundError(
@@ -67,4 +67,15 @@ export function entity(
 
 export function relation(spec: EntityRelationSpec): CatalogProcessorResult {
   return { type: 'relation', relation: spec };
+}
+
+export function attachment(
+  key: string,
+  data: Buffer,
+  contentType: string,
+): CatalogProcessorResult {
+  // TODO: Consider allowing to pass an optional etag to configure caching
+  // We could also make it required in CatalogProcessorResult and generate a
+  // fallback here (e.g. sha256)
+  return { type: 'attachment', key, data, contentType };
 }

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -133,6 +133,13 @@ export type CatalogProcessorRelationResult = {
   entityRef?: string;
 };
 
+export type CatalogProcessorAttachmentResult = {
+  type: 'attachment';
+  key: string;
+  data: Buffer;
+  contentType: string;
+};
+
 export type CatalogProcessorErrorResult = {
   type: 'error';
   error: Error;
@@ -143,4 +150,5 @@ export type CatalogProcessorResult =
   | CatalogProcessorLocationResult
   | CatalogProcessorEntityResult
   | CatalogProcessorRelationResult
+  | CatalogProcessorAttachmentResult
   | CatalogProcessorErrorResult;

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -133,11 +133,15 @@ export type CatalogProcessorRelationResult = {
   entityRef?: string;
 };
 
+export type CatalogProcessorAttachmentContentResult = {
+  data: Buffer;
+  contentType: string;
+};
+
 export type CatalogProcessorAttachmentResult = {
   type: 'attachment';
   key: string;
-  data: Buffer;
-  contentType: string;
+  content?: CatalogProcessorAttachmentContentResult;
 };
 
 export type CatalogProcessorErrorResult = {

--- a/plugins/catalog-backend/src/ingestion/types.ts
+++ b/plugins/catalog-backend/src/ingestion/types.ts
@@ -54,6 +54,16 @@ export type LocationReader = {
   read(location: LocationSpec): Promise<ReadLocationResult>;
 };
 
+// TODO: Is this a candidate for the catalog model? I don't think so because it contains both metadata (but not all metadata) and the content itself!
+export type EntityAttachment = {
+  key: string;
+  // Alternative: we could use a callback here instead of the value itself.
+  // We could pass an etag to that callback and the callback can either return a
+  // buffer or some other value if unchanged.
+  data: Buffer;
+  contentType: string;
+};
+
 export type ReadLocationResult = {
   entities: ReadLocationEntity[];
   errors: ReadLocationError[];
@@ -63,6 +73,7 @@ export type ReadLocationEntity = {
   location: LocationSpec;
   entity: Entity;
   relations: EntityRelationSpec[];
+  attachments: EntityAttachment[];
 };
 
 export type ReadLocationError = {

--- a/plugins/catalog-backend/src/ingestion/types.ts
+++ b/plugins/catalog-backend/src/ingestion/types.ts
@@ -55,13 +55,14 @@ export type LocationReader = {
 };
 
 // TODO: Is this a candidate for the catalog model? I don't think so because it contains both metadata (but not all metadata) and the content itself!
-export type EntityAttachment = {
-  key: string;
-  // Alternative: we could use a callback here instead of the value itself.
-  // We could pass an etag to that callback and the callback can either return a
-  // buffer or some other value if unchanged.
+export type EntityAttachmentContent = {
   data: Buffer;
   contentType: string;
+};
+
+export type EntityAttachment = {
+  key: string;
+  content?: EntityAttachmentContent;
 };
 
 export type ReadLocationResult = {

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -298,7 +298,7 @@ export class CatalogBuilder {
     const processors: CatalogProcessor[] = [
       StaticLocationProcessor.fromConfig(config),
       new PlaceholderProcessor({ resolvers: placeholderResolvers, reader }),
-      new BuiltinKindsEntityProcessor(),
+      new BuiltinKindsEntityProcessor({ reader }),
     ];
 
     // These are only added unless the user replaced them all

--- a/plugins/catalog-backend/src/service/router.test.ts
+++ b/plugins/catalog-backend/src/service/router.test.ts
@@ -26,6 +26,8 @@ import { HigherOrderOperation } from '../ingestion/types';
 import { createRouter } from './router';
 import { basicEntityFilter } from './request';
 
+// TODO: Include tests for the two new routes!
+
 describe('createRouter readonly disabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
   let locationsCatalog: jest.Mocked<LocationsCatalog>;

--- a/plugins/catalog-backend/src/service/router.test.ts
+++ b/plugins/catalog-backend/src/service/router.test.ts
@@ -26,8 +26,6 @@ import { HigherOrderOperation } from '../ingestion/types';
 import { createRouter } from './router';
 import { basicEntityFilter } from './request';
 
-// TODO: Include tests for the two new routes!
-
 describe('createRouter readonly disabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
   let locationsCatalog: jest.Mocked<LocationsCatalog>;

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -150,7 +150,7 @@ export async function createRouter(
 
         if (!attachment) {
           throw new NotFoundError(
-            `No attachment with key '${key}' found for entity with uid ${uid}, with kind '${kind}' in namespace '${namespace}'`,
+            `No attachment with key '${key}' found for entity with uid ${uid}'`,
           );
         }
 

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -143,7 +143,6 @@ export async function createRouter(
         }
         res.status(200).json(entities[0]);
       })
-
       .get('/entities/by-uid/:uid/attachments/:key', async (req, res) => {
         const { uid, key } = req.params;
         const attachment = await entitiesCatalog.attachment(uid, key, {
@@ -168,7 +167,6 @@ export async function createRouter(
           .contentType(attachment.contentType)
           .send(attachment.data);
       })
-
       .get(
         '/entities/by-name/:kind/:namespace/:name/attachments/:key',
         async (req, res) => {

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -15,11 +15,13 @@
  */
 
 import { errorHandler } from '@backstage/backend-common';
-import type { Entity } from '@backstage/catalog-model';
 import {
+  Entity,
+  stringifyEntityRef,
   analyzeLocationSchema,
   locationSpecSchema,
 } from '@backstage/catalog-model';
+
 import { Config } from '@backstage/config';
 import { NotFoundError } from '@backstage/errors';
 import express from 'express';
@@ -138,7 +140,11 @@ export async function createRouter(
         });
         if (!entities.length) {
           throw new NotFoundError(
-            `No entity named '${name}' found, with kind '${kind}' in namespace '${namespace}'`,
+            `No entity named '${stringifyEntityRef({
+              kind,
+              namespace,
+              name,
+            })}' found`,
           );
         }
         res.status(200).json(entities[0]);
@@ -180,7 +186,11 @@ export async function createRouter(
           });
           if (!entities.length) {
             throw new NotFoundError(
-              `No entity named '${name}' found, with kind '${kind}' in namespace '${namespace}'`,
+              `No entity named '${stringifyEntityRef({
+                kind,
+                namespace,
+                name,
+              })}' found`,
             );
           }
 
@@ -194,7 +204,9 @@ export async function createRouter(
 
           if (!attachment) {
             throw new NotFoundError(
-              `No attachment with key '${key}' found for entity named '${name}', with kind '${kind}' in namespace '${namespace}'`,
+              `No attachment with key '${key}' found for entity named '${stringifyEntityRef(
+                { kind, namespace, name },
+              )}'`,
             );
           }
 

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -146,7 +146,9 @@ export async function createRouter(
 
       .get('/entities/by-uid/:uid/attachments/:key', async (req, res) => {
         const { uid, key } = req.params;
-        const attachment = await entitiesCatalog.attachment(uid, key);
+        const attachment = await entitiesCatalog.attachment(uid, key, {
+          ifNotMatchEtag: req.header('if-none-match'),
+        });
 
         if (!attachment) {
           throw new NotFoundError(
@@ -154,7 +156,12 @@ export async function createRouter(
           );
         }
 
-        // TODO: Include etag for caching
+        res.header('ETag', attachment.etag);
+
+        if (!attachment.data) {
+          res.status(304).send();
+          return;
+        }
 
         res
           .status(200)
@@ -182,6 +189,9 @@ export async function createRouter(
           const attachment = await entitiesCatalog.attachment(
             entities[0].metadata.uid!,
             key,
+            {
+              ifNotMatchEtag: req.header('if-none-match'),
+            },
           );
 
           if (!attachment) {
@@ -190,7 +200,12 @@ export async function createRouter(
             );
           }
 
-          // TODO: Include etag for caching
+          res.header('ETag', attachment.etag);
+
+          if (!attachment.data) {
+            res.status(304).send();
+            return;
+          }
 
           res
             .status(200)

--- a/plugins/catalog-import/src/api/CatalogImportClient.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.test.ts
@@ -102,7 +102,6 @@ describe('CatalogImportClient', () => {
     getLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
     getAttachment: jest.fn(),
-    getAttachmentUrl: jest.fn(),
   };
 
   let catalogImportClient: CatalogImportClient;

--- a/plugins/catalog-import/src/api/CatalogImportClient.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.test.ts
@@ -101,6 +101,8 @@ describe('CatalogImportClient', () => {
     getLocationByEntity: jest.fn(),
     getLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
+    getAttachment: jest.fn(),
+    getAttachmentUrl: jest.fn(),
   };
 
   let catalogImportClient: CatalogImportClient;

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -42,7 +42,6 @@ describe('<StepPrepareCreatePullRequest />', () => {
     removeLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
     getAttachment: jest.fn(),
-    getAttachmentUrl: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -41,6 +41,8 @@ describe('<StepPrepareCreatePullRequest />', () => {
     getLocationById: jest.fn(),
     removeLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
+    getAttachment: jest.fn(),
+    getAttachmentUrl: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/catalog/src/CatalogClientWrapper.test.ts
+++ b/plugins/catalog/src/CatalogClientWrapper.test.ts
@@ -146,35 +146,4 @@ describe('CatalogClientWrapper', () => {
       expect(catalogClient.getAttachment).toHaveBeenCalledTimes(1);
     });
   });
-
-  describe('getAttachmentUrl', () => {
-    const name = {
-      kind: 'kind',
-      namespace: 'namespace',
-      name: 'name',
-    };
-    const key = 'backstage.io/attachment-key';
-
-    it('injects authorization token', async () => {
-      catalogClient.getAttachment.mockResolvedValue({
-        data: new Blob(['Test'], { type: 'text/plain' }),
-      });
-      const url = await client.getAttachmentUrl(name, key);
-
-      expect(url).toMatch(/^data\:text\/plain;base64,/);
-      expect(catalogClient.getAttachment).toHaveBeenCalledWith(name, key, {
-        token: 'fake-id-token',
-      });
-      expect(catalogClient.getAttachment).toHaveBeenCalledTimes(1);
-      expect(catalogClient.getAttachmentUrl).toHaveBeenCalledTimes(0);
-    });
-
-    it('fallback to default implementation', async () => {
-      identityApi.getIdToken.mockResolvedValue(undefined);
-      await client.getAttachmentUrl(name, key);
-
-      expect(catalogClient.getAttachmentUrl).toHaveBeenCalledWith(name, key);
-      expect(catalogClient.getAttachmentUrl).toHaveBeenCalledTimes(1);
-    });
-  });
 });

--- a/plugins/catalog/src/CatalogClientWrapper.ts
+++ b/plugins/catalog/src/CatalogClientWrapper.ts
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-import { Entity, EntityName, Location } from '@backstage/catalog-model';
 import {
   AddLocationRequest,
   AddLocationResponse,
   CatalogApi,
+  CatalogAttachmentResponse,
+  CatalogClient,
   CatalogEntitiesRequest,
   CatalogListResponse,
-  CatalogClient,
 } from '@backstage/catalog-client';
+import { Entity, EntityName, Location } from '@backstage/catalog-model';
 import { IdentityApi } from '@backstage/core';
 
 type CatalogRequestOptions = {
@@ -68,7 +69,10 @@ export class CatalogClientWrapper implements CatalogApi {
     });
   }
 
-  async getAttachment(name: EntityName, key: string): Promise<Blob> {
+  async getAttachment(
+    name: EntityName,
+    key: string,
+  ): Promise<CatalogAttachmentResponse> {
     // TODO: Here we could set the header, but I think most of the use cases
     // won't use the function, e.g. if I embed the url into an image like
     // <img src={getAttachmentUrl(...)} ...

--- a/plugins/catalog/src/CatalogClientWrapper.ts
+++ b/plugins/catalog/src/CatalogClientWrapper.ts
@@ -68,6 +68,19 @@ export class CatalogClientWrapper implements CatalogApi {
     });
   }
 
+  async getAttachment(name: EntityName, key: string): Promise<Blob> {
+    // TODO: Here we could set the header, but I think most of the use cases
+    // won't use the function, e.g. if I embed the url into an image like
+    // <img src={getAttachmentUrl(...)} ...
+    return await this.client.getAttachment(name, key);
+  }
+
+  async getAttachmentUrl(name: EntityName, key: string): Promise<string> {
+    // TODO: Auth headers doesn't work well together with these urls...
+    // cookies would be better here. For now we skip this topic completly.
+    return await this.client.getAttachmentUrl(name, key);
+  }
+
   async addLocation(
     request: AddLocationRequest,
     options?: CatalogRequestOptions,

--- a/plugins/catalog/src/CatalogClientWrapper.ts
+++ b/plugins/catalog/src/CatalogClientWrapper.ts
@@ -79,33 +79,6 @@ export class CatalogClientWrapper implements CatalogApi {
     });
   }
 
-  async getAttachmentUrl(name: EntityName, key: string): Promise<string> {
-    const token = await this.identityApi.getIdToken();
-
-    if (token) {
-      // In case a token is used, we have to fallback to a workaround, as a
-      // simple URL won't work with tokens provided in headers. This is less
-      // efficient, but also only used in that case.
-      // Instead of returning an URL where the called can request the attachment
-      // from, we return the attachmend directly as a base64 URL. Returning blob
-      // URLs might be more efficient, but requires to release them afterwars.
-      const attachment = await this.getAttachment(name, key);
-      const reader = new FileReader();
-
-      return new Promise<string>((resolve, reject) => {
-        reader.onload = e => {
-          if (e.target && typeof e.target.result === 'string') {
-            resolve(e.target.result);
-          }
-        };
-        reader.onerror = reject;
-        reader.readAsDataURL(attachment.data);
-      });
-    }
-
-    return await this.client.getAttachmentUrl(name, key);
-  }
-
   async addLocation(
     request: AddLocationRequest,
     options?: CatalogRequestOptions,

--- a/plugins/catalog/src/filter/useEntityFilterGroup.test.tsx
+++ b/plugins/catalog/src/filter/useEntityFilterGroup.test.tsx
@@ -39,7 +39,6 @@ describe('useEntityFilterGroup', () => {
       removeEntityByUid: jest.fn(),
       getEntityByName: jest.fn(),
       getAttachment: jest.fn(),
-      getAttachmentUrl: jest.fn(),
     };
     const apis = ApiRegistry.with(catalogApiRef, catalogApi).with(
       storageApiRef,

--- a/plugins/catalog/src/filter/useEntityFilterGroup.test.tsx
+++ b/plugins/catalog/src/filter/useEntityFilterGroup.test.tsx
@@ -38,6 +38,8 @@ describe('useEntityFilterGroup', () => {
       removeLocationById: jest.fn(),
       removeEntityByUid: jest.fn(),
       getEntityByName: jest.fn(),
+      getAttachment: jest.fn(),
+      getAttachmentUrl: jest.fn(),
     };
     const apis = ApiRegistry.with(catalogApiRef, catalogApi).with(
       storageApiRef,

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -34,7 +34,6 @@ describe('<DomainExplorerContent />', () => {
     removeEntityByUid: jest.fn(),
     getEntityByName: jest.fn(),
     getAttachment: jest.fn(),
-    getAttachmentUrl: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -33,6 +33,8 @@ describe('<DomainExplorerContent />', () => {
     removeLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
     getEntityByName: jest.fn(),
+    getAttachment: jest.fn(),
+    getAttachmentUrl: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/fossa/src/components/FossaPage/FossaPage.test.tsx
+++ b/plugins/fossa/src/components/FossaPage/FossaPage.test.tsx
@@ -32,6 +32,7 @@ describe('<FossaPage />', () => {
     getOriginLocationByEntity: jest.fn(),
     removeEntityByUid: jest.fn(),
     removeLocationById: jest.fn(),
+    getAttachment: jest.fn(),
   };
   const fossaApi: jest.Mocked<FossaApi> = {
     getFindingSummary: jest.fn(),

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
@@ -63,12 +63,15 @@ export const UserProfileCard = ({
   const { entity: user } = useEntity<UserEntity>();
   const catalogApi = useApi(catalogApiRef);
   const { value: picture, loading } = useAsync(async () => {
-    return user
-      ? await catalogApi.getAttachmentUrl(
-          getEntityName(user),
-          ATTACHMENT_PROFILE_PICTURE,
-        )
-      : undefined;
+    if (user) {
+      const attachment = await catalogApi.getAttachment(
+        getEntityName(user),
+        ATTACHMENT_PROFILE_PICTURE,
+      );
+      return attachment.url();
+    }
+
+    return undefined;
   }, [catalogApi, user]);
 
   if (!user) {

--- a/plugins/register-component/src/components/RegisterComponentPage/RegisterComponentPage.test.tsx
+++ b/plugins/register-component/src/components/RegisterComponentPage/RegisterComponentPage.test.tsx
@@ -42,6 +42,8 @@ const catalogApi: jest.Mocked<typeof catalogApiRef.T> = {
   removeLocationById: jest.fn(),
   removeEntityByUid: jest.fn(),
   getEntityByName: jest.fn(),
+  getAttachment: jest.fn(),
+  getAttachmentUrl: jest.fn(),
 };
 
 const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/register-component/src/components/RegisterComponentPage/RegisterComponentPage.test.tsx
+++ b/plugins/register-component/src/components/RegisterComponentPage/RegisterComponentPage.test.tsx
@@ -43,7 +43,6 @@ const catalogApi: jest.Mocked<typeof catalogApiRef.T> = {
   removeEntityByUid: jest.fn(),
   getEntityByName: jest.fn(),
   getAttachment: jest.fn(),
-  getAttachmentUrl: jest.fn(),
 };
 
 const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/scaffolder/src/filter/useEntityFilterGroup.test.tsx
+++ b/plugins/scaffolder/src/filter/useEntityFilterGroup.test.tsx
@@ -39,7 +39,6 @@ describe('useEntityFilterGroup', () => {
       removeEntityByUid: jest.fn(),
       getEntityByName: jest.fn(),
       getAttachment: jest.fn(),
-      getAttachmentUrl: jest.fn(),
     };
     const apis = ApiRegistry.with(catalogApiRef, catalogApi).with(
       storageApiRef,

--- a/plugins/scaffolder/src/filter/useEntityFilterGroup.test.tsx
+++ b/plugins/scaffolder/src/filter/useEntityFilterGroup.test.tsx
@@ -38,6 +38,8 @@ describe('useEntityFilterGroup', () => {
       removeLocationById: jest.fn(),
       removeEntityByUid: jest.fn(),
       getEntityByName: jest.fn(),
+      getAttachment: jest.fn(),
+      getAttachmentUrl: jest.fn(),
     };
     const apis = ApiRegistry.with(catalogApiRef, catalogApi).with(
       storageApiRef,

--- a/plugins/todo-backend/src/service/TodoReaderService.test.ts
+++ b/plugins/todo-backend/src/service/TodoReaderService.test.ts
@@ -50,6 +50,8 @@ function mockCatalogClient(entity?: Entity): jest.Mocked<CatalogApi> {
     getLocationById: jest.fn(),
     removeLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
+    getAttachment: jest.fn(),
+    getAttachmentUrl: jest.fn(),
   };
   if (entity) {
     mock.getEntityByName.mockReturnValue(entity);

--- a/plugins/todo-backend/src/service/TodoReaderService.test.ts
+++ b/plugins/todo-backend/src/service/TodoReaderService.test.ts
@@ -51,7 +51,6 @@ function mockCatalogClient(entity?: Entity): jest.Mocked<CatalogApi> {
     removeLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
     getAttachment: jest.fn(),
-    getAttachmentUrl: jest.fn(),
   };
   if (entity) {
     mock.getEntityByName.mockReturnValue(entity);


### PR DESCRIPTION
This is my initial draft on an attachment store to the catalog, to keep bigger assets that are part of the entity separate from the stored entity. This should increase scalability at the API. See #4007 for more details.

This is a draft. There is still a lot to do, think about some implementations, tests, broken build, ... but I would happy to receive some initial feedback on the design.
I'm also interested in some ideas how we go about introducing this into Backstage. This is a bigger change and contains some breaking changes, e.g. around the API entity. My current idea is to split out the changes to actual entities into later PRs and only provide the groundwork for the catalog plugin here. I will probably also create some other PRs to prepare this one and keep it small.

Closes #4007

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
