### PR TITLE
Add support for fullHeight variant

### DIFF
--- a/.changeset/tidy-garlics-decide.md
+++ b/.changeset/tidy-garlics-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Add support for fullHeight variant to the AboutCard

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -23,6 +23,7 @@ import {
 import {
   HeaderIconLinkRow,
   IconLinkVerticalProps,
+  InfoCardVariants,
   useApi,
 } from '@backstage/core';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
@@ -50,7 +51,15 @@ const useStyles = makeStyles({
     height: 'calc(100% - 10px)', // for pages without content header
     marginBottom: '10px',
   },
+  fullHeightCard: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
   gridItemCardContent: {
+    flex: 1,
+  },
+  fullHeightCardContent: {
     flex: 1,
   },
 });
@@ -58,7 +67,7 @@ const useStyles = makeStyles({
 type AboutCardProps = {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: Entity;
-  variant?: 'gridItem';
+  variant?: InfoCardVariants;
 };
 
 export function AboutCard({ variant }: AboutCardProps) {
@@ -103,8 +112,22 @@ export function AboutCard({ variant }: AboutCardProps) {
     href: 'api',
   };
 
+  let cardClass = '';
+  if (variant === 'gridItem') {
+    cardClass = classes.gridItemCard;
+  } else if (variant === 'fullHeight') {
+    cardClass = classes.fullHeightCard;
+  }
+
+  let cardContentClass = '';
+  if (variant === 'gridItem') {
+    cardContentClass = classes.gridItemCardContent;
+  } else if (variant === 'fullHeight') {
+    cardContentClass = classes.fullHeightCardContent;
+  }
+
   return (
-    <Card className={variant === 'gridItem' ? classes.gridItemCard : ''}>
+    <Card className={cardClass}>
       <CardHeader
         title="About"
         action={
@@ -124,9 +147,7 @@ export function AboutCard({ variant }: AboutCardProps) {
         }
       />
       <Divider />
-      <CardContent
-        className={variant === 'gridItem' ? classes.gridItemCardContent : ''}
-      >
+      <CardContent className={cardContentClass}>
         <AboutContent entity={entity} />
       </CardContent>
     </Card>


### PR DESCRIPTION
Signed-off-by: Rob Long <Robert.Long@lv.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This change adds support for the `fullHeight` variant to the InfoCard, which currently only supports `gridItem`. The `gridItem` variant stretches the card  to100% of the available height, minus 10px, but `fullHeight` uses all the available height. Using `fullHeight` you can make neater grids, while retaining the default behaviour.

Before the change there is additional space under the AboutCard and the SonarQubeCard, both of which use InfoCard with variant support:
![image](https://user-images.githubusercontent.com/14176917/114697659-190c2600-9d16-11eb-9f40-12eed705cbf0.png)


With `fullHeight` support everything lines up nicely:
![image](https://user-images.githubusercontent.com/14176917/114697511-e95d1e00-9d15-11eb-8c5b-8874c0b885a0.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
