### PR TITLE
Feat/client url escape

### DIFF
--- a/.changeset/old-clouds-whisper.md
+++ b/.changeset/old-clouds-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Use `string` TypeScript type instead of `String`.

--- a/.changeset/tiny-games-hide.md
+++ b/.changeset/tiny-games-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Make sure the `CatalogClient` escapes URL parameters correctly.

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -42,10 +42,14 @@ export class CatalogClient implements CatalogApi {
   }
 
   async getLocationById(
-    id: String,
+    id: string,
     options?: CatalogRequestOptions,
   ): Promise<Location | undefined> {
-    return await this.requestOptional('GET', `/locations/${id}`, options);
+    return await this.requestOptional(
+      'GET',
+      `/locations/${encodeURIComponent(id)}`,
+      options,
+    );
   }
 
   async getEntities(
@@ -86,7 +90,9 @@ export class CatalogClient implements CatalogApi {
     const { kind, namespace = 'default', name } = compoundName;
     return this.requestOptional(
       'GET',
-      `/entities/by-name/${kind}/${namespace}/${name}`,
+      `/entities/by-name/${encodeURIComponent(kind)}/${encodeURIComponent(
+        namespace,
+      )}/${encodeURIComponent(name)}`,
       options,
     );
   }
@@ -171,14 +177,22 @@ export class CatalogClient implements CatalogApi {
     id: string,
     options?: CatalogRequestOptions,
   ): Promise<void> {
-    await this.requestIgnored('DELETE', `/locations/${id}`, options);
+    await this.requestIgnored(
+      'DELETE',
+      `/locations/${encodeURIComponent(id)}`,
+      options,
+    );
   }
 
   async removeEntityByUid(
     uid: string,
     options?: CatalogRequestOptions,
   ): Promise<void> {
-    await this.requestIgnored('DELETE', `/entities/by-uid/${uid}`, options);
+    await this.requestIgnored(
+      'DELETE',
+      `/entities/by-uid/${encodeURIComponent(uid)}`,
+      options,
+    );
   }
 
   //

--- a/packages/catalog-client/src/types.ts
+++ b/packages/catalog-client/src/types.ts
@@ -46,7 +46,7 @@ export interface CatalogApi {
 
   // Locations
   getLocationById(
-    id: String,
+    id: string,
     options?: CatalogRequestOptions,
   ): Promise<Location | undefined>;
   getOriginLocationByEntity(

--- a/plugins/catalog/src/CatalogClientWrapper.ts
+++ b/plugins/catalog/src/CatalogClientWrapper.ts
@@ -42,7 +42,7 @@ export class CatalogClientWrapper implements CatalogApi {
   }
 
   async getLocationById(
-    id: String,
+    id: string,
     options?: CatalogRequestOptions,
   ): Promise<Location | undefined> {
     return await this.client.getLocationById(id, {

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
@@ -21,7 +21,7 @@ import { AwsIamKubernetesAuthTranslator } from './AwsIamKubernetesAuthTranslator
 
 export class KubernetesAuthTranslatorGenerator {
   static getKubernetesAuthTranslatorInstance(
-    authProvider: String,
+    authProvider: string,
   ): KubernetesAuthTranslator {
     switch (authProvider) {
       case 'google': {

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -34,8 +34,8 @@ const mockFetch = (mock: jest.Mock) => {
 };
 
 function generateMockResourcesAndErrors(
-  serviceId: String,
-  clusterName: String,
+  serviceId: string,
+  clusterName: string,
 ) {
   if (clusterName === 'empty-cluster') {
     return {


### PR DESCRIPTION
Make sure the `CatalogClient` escapes URL parameters correctly. @freben noted that in another PR review. Also fixed some cases where the `String` type was accidentally used.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
