### PR TITLE
cli: added config:docs command

### DIFF
--- a/.changeset/fair-carrots-tell.md
+++ b/.changeset/fair-carrots-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add `config:docs` command that opens up reference documentation for the local configuration schema in a browser.

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -44,6 +44,7 @@ clean                    Delete cache directories
 create-plugin            Creates a new plugin in the current repository
 remove-plugin            Removes plugin in the current repository
 
+config:docs              Browse the configuration reference documentation
 config:print             Print the app configuration for the current package
 config:check             Validate that the given configuration loads and matches schema
 config:schema            Dump the app configuration schema
@@ -445,6 +446,25 @@ Usage: backstage-cli test [options]
 
 Options:
   --backstage-cli-help    display help for command
+```
+
+## config:docs
+
+Scope: `root`
+
+This commands opens up the reference documentation of your apps local
+configuration schema in the browser. This is useful to get an overview of what
+configuration values are available to use, a description of what they do and
+their format, and where they get sent.
+
+```text
+Usage: backstage-cli config:docs [options]
+
+Browse the configuration reference documentation
+
+Options:
+  --package <name>  Only include the schema that applies to the given package
+  -h, --help        display help for command
 ```
 
 ## config:print

--- a/packages/cli/src/commands/config/docs.ts
+++ b/packages/cli/src/commands/config/docs.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/config';
+import { mergeConfigSchemas } from '@backstage/config-loader';
+import { Command } from 'commander';
+import { JSONSchema7 as JSONSchema } from 'json-schema';
+import openBrowser from 'react-dev-utils/openBrowser';
+import { loadCliConfig } from '../../lib/config';
+
+const DOCS_URL = 'https://config.backstage.io';
+
+export default async (cmd: Command) => {
+  const { schema: appSchemas } = await loadCliConfig({
+    args: [],
+    fromPackage: cmd.package,
+    mockEnv: true,
+  });
+
+  const schema = mergeConfigSchemas(
+    (appSchemas.serialize().schemas as JsonObject[]).map(
+      _ => _.value as JSONSchema,
+    ),
+  );
+
+  openBrowser(`${DOCS_URL}#schema=${JSON.stringify(schema)}`);
+};

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -141,6 +141,15 @@ export function registerCommands(program: CommanderStatic) {
     .action(lazy(() => import('./testCommand').then(m => m.default)));
 
   program
+    .command('config:docs')
+    .option(
+      '--package <name>',
+      'Only include the schema that applies to the given package',
+    )
+    .description('Browse the configuration reference documentation')
+    .action(lazy(() => import('./config/docs').then(m => m.default)));
+
+  program
     .command('config:print')
     .option(
       '--package <name>',


### PR DESCRIPTION
Signed-off-by: Patrik Oldsberg <poldsberg@gmail.com>

## Hey, I just made a Pull Request!

This wires up the config-schema plugin deployed through https://github.com/backstage/config-schema-viewer and makes it available via the `backstage-cli config:docs` command. Running the `config:docs` command opens up the docs for the local schema in the browser.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
