### PR TITLE
Allow backend builds without emitting types

### DIFF
--- a/packages/cli/src/commands/backend/build.ts
+++ b/packages/cli/src/commands/backend/build.ts
@@ -13,11 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { Command } from 'commander';
 import { buildPackage, Output } from '../../lib/builder';
 
-export default async () => {
+export default async (cmd: Command) => {
+  const disableTypes = cmd.opts().disableTypes;
+  const outputs = new Set([Output.cjs]);
+  if (!disableTypes) {
+    outputs.add(Output.types);
+  }
   await buildPackage({
-    outputs: new Set([Output.cjs, Output.types]),
+    outputs,
   });
 };

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -41,6 +41,11 @@ export function registerCommands(program: CommanderStatic) {
 
   program
     .command('backend:build')
+    .option(
+      '--disable-types',
+      'do not output types as a part of the build',
+      false,
+    )
     .description('Build a backend plugin')
     .action(lazy(() => import('./backend/build').then(m => m.default)));
 


### PR DESCRIPTION
The `backend:build` command by default, sets `Output.types` when calling `buildPackage`.
For backend Node JS builds, especially when building for production, types are superfluous as the
code is transpiled to Javascript and types are erased.
Despite types being not used, this lack of flexibility makes it necessary to emit types, that adds
a lot of accidental complexity.
Optionally disable emitting types if a `--no-types` flag is passed (`false` by default)

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
