### PR TITLE
Update pagerduty token environment variable

### DIFF
--- a/plugins/pagerduty/README.md
+++ b/plugins/pagerduty/README.md
@@ -74,7 +74,7 @@ proxy:
 Then start the backend passing the token as an environment variable:
 
 ```bash
-$ PAGERDUTY_TOKEN='Token token=<TOKEN>' yarn start
+$ PAGERDUTY_TOKEN='<TOKEN>' yarn start
 ```
 
 This will proxy the request by adding `Authorization` header with the provided token.


### PR DESCRIPTION
As is the docs have "Token token=" in both the config and the environment variable, which will lead to requests looking like "Token token=Token token=<token>"

This removes the "Token token=" from the environment variable and requests will work.

- [ X] Added or updated documentation

Signed-off-by: Seth Howard <seth.howard@doordash.com>