### PR TITLE
change all `$env` to `${}`

### DIFF
--- a/.tugboat/tugboat.app-config.production.yaml
+++ b/.tugboat/tugboat.app-config.production.yaml
@@ -1,13 +1,10 @@
 app:
   title: Backstage Tugboat Preview
-  baseUrl:
-    $env: TUGBOAT_DEFAULT_SERVICE_URL
+  baseUrl: ${TUGBOAT_DEFAULT_SERVICE_URL}
 
 backend:
-  baseUrl:
-    $env: TUGBOAT_DEFAULT_SERVICE_URL
+  baseUrl: ${TUGBOAT_DEFAULT_SERVICE_URL}
   cors:
-    origin:
-      $env: TUGBOAT_DEFAULT_SERVICE_URL
+    origin: ${TUGBOAT_DEFAULT_SERVICE_URL}
     methods: [GET, POST, PUT, DELETE]
     credentials: true

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -40,47 +40,40 @@ proxy:
   '/circleci/api':
     target: https://circleci.com/api/v1.1
     headers:
-      Circle-Token:
-        $env: CIRCLECI_AUTH_TOKEN
+      Circle-Token: ${CIRCLECI_AUTH_TOKEN}
 
   '/jenkins/api':
     target: http://localhost:8080
     headers:
-      Authorization:
-        $env: JENKINS_BASIC_AUTH_HEADER
+      Authorization: ${JENKINS_BASIC_AUTH_HEADER}
 
   '/travisci/api':
     target: https://api.travis-ci.com
     changeOrigin: true
     headers:
-      Authorization:
-        $env: TRAVISCI_AUTH_TOKEN
+      Authorization: ${TRAVISCI_AUTH_TOKEN}
       travis-api-version: '3'
 
   '/newrelic/apm/api':
     target: https://api.newrelic.com/v2
     headers:
-      X-Api-Key:
-        $env: NEW_RELIC_REST_API_KEY
+      X-Api-Key: ${NEW_RELIC_REST_API_KEY}
 
   '/pagerduty':
     target: https://api.pagerduty.com
     headers:
-      Authorization:
-        $env: PAGERDUTY_TOKEN
+      Authorization: ${PAGERDUTY_TOKEN}
 
   '/buildkite/api':
     target: https://api.buildkite.com/v2/
     headers:
-      Authorization:
-        $env: BUILDKITE_TOKEN
+      Authorization: ${BUILDKITE_TOKEN}
 
   '/sentry/api':
     target: https://sentry.io/api/
     allowedMethods: ['GET']
     headers:
-      Authorization:
-        $env: SENTRY_TOKEN
+      Authorization: ${SENTRY_TOKEN}
 
 organization:
   name: My Company
@@ -124,36 +117,28 @@ kafka:
 integrations:
   github:
     - host: github.com
-      token:
-        $env: GITHUB_TOKEN
+      token: ${GITHUB_TOKEN}
     ### Example for how to add your GitHub Enterprise instance using the API:
     # - host: ghe.example.net
     #   apiBaseUrl: https://ghe.example.net/api/v3
-    #   token:
-    #     $env: GHE_TOKEN
+    #   token: ${GHE_TOKEN}
     ### Example for how to add your GitHub Enterprise instance using raw HTTP fetches (token is optional):
     # - host: ghe.example.net
     #   rawBaseUrl: https://ghe.example.net/raw
-    #   token:
-    #     $env: GHE_TOKEN
+    #   token: ${GHE_TOKEN}
   gitlab:
     - host: gitlab.com
-      token:
-        $env: GITLAB_TOKEN
+      token: ${GITLAB_TOKEN}
   bitbucket:
     - host: bitbucket.org
-      username:
-        $env: BITBUCKET_USERNAME
-      appPassword:
-        $env: BITBUCKET_APP_PASSWORD
+      username: ${BITBUCKET_USERNAME}
+      appPassword: ${BITBUCKET_APP_PASSWORD}
   azure:
     - host: dev.azure.com
-      token:
-        $env: AZURE_TOKEN
+      token: ${AZURE_TOKEN}
 #  googleGcs:
 #    clientEmail: 'example@example.com'
-#    privateKey:
-#      $env: GCS_PRIVATE_KEY
+#    privateKey: ${GCS_PRIVATE_KEY}
 
 catalog:
   rules:
@@ -172,21 +157,18 @@ catalog:
     githubOrg:
       providers:
         - target: https://github.com
-          token:
-            $env: GITHUB_TOKEN
+          token: ${GITHUB_TOKEN}
         #### Example for how to add your GitHub Enterprise instance using the API:
         # - target: https://ghe.example.net
         #   apiBaseUrl: https://ghe.example.net/api
-        #   token:
-        #     $env: GHE_TOKEN
+        #   token: ${GHE_TOKEN}
     ldapOrg:
       ### Example for how to add your enterprise LDAP server
       # providers:
       #   - target: ldaps://ds.example.net
       #     bind:
       #       dn: uid=ldap-reader-user,ou=people,ou=example,dc=example,dc=net
-      #       secret:
-      #         $env: LDAP_SECRET
+      #       secret: ${LDAP_SECRET}
       #     users:
       #       dn: ou=people,ou=example,dc=example,dc=net
       #       options:
@@ -202,12 +184,9 @@ catalog:
       #providers:
       #  - target: https://graph.microsoft.com/v1.0
       #    authority: https://login.microsoftonline.com
-      #    tenantId:
-      #      $env: MICROSOFT_GRAPH_TENANT_ID
-      #    clientId:
-      #      $env: MICROSOFT_GRAPH_CLIENT_ID
-      #    clientSecret:
-      #      $env: MICROSOFT_GRAPH_CLIENT_SECRET_TOKEN
+      #    tenantId: ${MICROSOFT_GRAPH_TENANT_ID}
+      #    clientId: ${MICROSOFT_GRAPH_CLIENT_ID}
+      #    clientSecret: ${MICROSOFT_GRAPH_CLIENT_SECRET_TOKEN}
       #    userFilter: accountEnabled eq true and userType eq 'member'
       #    groupFilter: securityEnabled eq false and mailEnabled eq true and groupTypes/any(c:c+eq+'Unified')
 
@@ -255,27 +234,22 @@ catalog:
 
 scaffolder:
   github:
-    token:
-      $env: GITHUB_TOKEN
+    token: ${GITHUB_TOKEN}
     visibility: public # or 'internal' or 'private'
   gitlab:
     api:
       baseUrl: https://gitlab.com
-      token:
-        $env: GITLAB_TOKEN
+      token: ${GITLAB_TOKEN}
     visibility: public # or 'internal' or 'private'
   azure:
     baseUrl: https://dev.azure.com/{your-organization}
     api:
-      token:
-        $env: AZURE_TOKEN
+      token: ${AZURE_TOKEN}
   bitbucket:
     api:
       host: https://bitbucket.org
-      username:
-        $env: BITBUCKET_USERNAME
-      token:
-        $env: BITBUCKET_TOKEN
+      username: ${BITBUCKET_USERNAME}
+      token: ${BITBUCKET_TOKEN}
     visibility: public # or or 'private'
 
 auth:
@@ -286,89 +260,59 @@ auth:
   providers:
     google:
       development:
-        clientId:
-          $env: AUTH_GOOGLE_CLIENT_ID
-        clientSecret:
-          $env: AUTH_GOOGLE_CLIENT_SECRET
+        clientId: ${AUTH_GOOGLE_CLIENT_ID}
+        clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
     github:
       development:
-        clientId:
-          $env: AUTH_GITHUB_CLIENT_ID
-        clientSecret:
-          $env: AUTH_GITHUB_CLIENT_SECRET
-        enterpriseInstanceUrl:
-          $env: AUTH_GITHUB_ENTERPRISE_INSTANCE_URL
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+        enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
     gitlab:
       development:
-        clientId:
-          $env: AUTH_GITLAB_CLIENT_ID
-        clientSecret:
-          $env: AUTH_GITLAB_CLIENT_SECRET
-        audience:
-          $env: GITLAB_BASE_URL
+        clientId: ${AUTH_GITLAB_CLIENT_ID}
+        clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
+        audience: ${GITLAB_BASE_URL}
     saml:
       entryPoint: 'http://localhost:7001/'
       issuer: 'passport-saml'
     okta:
       development:
-        clientId:
-          $env: AUTH_OKTA_CLIENT_ID
-        clientSecret:
-          $env: AUTH_OKTA_CLIENT_SECRET
-        audience:
-          $env: AUTH_OKTA_AUDIENCE
+        clientId: ${AUTH_OKTA_CLIENT_ID}
+        clientSecret: ${AUTH_OKTA_CLIENT_SECRET}
+        audience: ${AUTH_OKTA_AUDIENCE}
     oauth2:
       development:
-        clientId:
-          $env: AUTH_OAUTH2_CLIENT_ID
-        clientSecret:
-          $env: AUTH_OAUTH2_CLIENT_SECRET
-        authorizationUrl:
-          $env: AUTH_OAUTH2_AUTH_URL
-        tokenUrl:
-          $env: AUTH_OAUTH2_TOKEN_URL
+        clientId: ${AUTH_OAUTH2_CLIENT_ID}
+        clientSecret: ${AUTH_OAUTH2_CLIENT_SECRET}
+        authorizationUrl: ${AUTH_OAUTH2_AUTH_URL}
+        tokenUrl: ${AUTH_OAUTH2_TOKEN_URL}
         ###
         # provide a list of scopes as needed for your OAuth2 Server:
         #
         # scope: saml-login-selector openid profile email
     oidc:
       development:
-        metadataUrl:
-          $env: AUTH_OIDC_METADATA_URL
-        clientId:
-          $env: AUTH_OIDC_CLIENT_ID
-        clientSecret:
-          $env: AUTH_OIDC_CLIENT_SECRET
-        authorizationUrl:
-          $env: AUTH_OIDC_AUTH_URL
-        tokenUrl:
-          $env: AUTH_OIDC_TOKEN_URL
-        tokenSignedResponseAlg:
-          $env: AUTH_OIDC_TOKEN_SIGNED_RESPONSE_ALG
+        metadataUrl: ${AUTH_OIDC_METADATA_URL}
+        clientId: ${AUTH_OIDC_CLIENT_ID}
+        clientSecret: ${AUTH_OIDC_CLIENT_SECRET}
+        authorizationUrl: ${AUTH_OIDC_AUTH_URL}
+        tokenUrl: ${AUTH_OIDC_TOKEN_URL}
+        tokenSignedResponseAlg: ${AUTH_OIDC_TOKEN_SIGNED_RESPONSE_ALG}
     auth0:
       development:
-        clientId:
-          $env: AUTH_AUTH0_CLIENT_ID
-        clientSecret:
-          $env: AUTH_AUTH0_CLIENT_SECRET
-        domain:
-          $env: AUTH_AUTH0_DOMAIN
+        clientId: ${AUTH_AUTH0_CLIENT_ID}
+        clientSecret: ${AUTH_AUTH0_CLIENT_SECRET}
+        domain: ${AUTH_AUTH0_DOMAIN}
     microsoft:
       development:
-        clientId:
-          $env: AUTH_MICROSOFT_CLIENT_ID
-        clientSecret:
-          $env: AUTH_MICROSOFT_CLIENT_SECRET
-        tenantId:
-          $env: AUTH_MICROSOFT_TENANT_ID
+        clientId: ${AUTH_MICROSOFT_CLIENT_ID}
+        clientSecret: ${AUTH_MICROSOFT_CLIENT_SECRET}
+        tenantId: ${AUTH_MICROSOFT_TENANT_ID}
     onelogin:
       development:
-        clientId:
-          $env: AUTH_ONELOGIN_CLIENT_ID
-        clientSecret:
-          $env: AUTH_ONELOGIN_CLIENT_SECRET
-        issuer:
-          $env: AUTH_ONELOGIN_ISSUER
+        clientId: ${AUTH_ONELOGIN_CLIENT_ID}
+        clientSecret: ${AUTH_ONELOGIN_CLIENT_SECRET}
+        issuer: ${AUTH_ONELOGIN_ISSUER}
 costInsights:
   engineerCost: 200000
   products:

--- a/contrib/chart/backstage/values.yaml
+++ b/contrib/chart/backstage/values.yaml
@@ -127,68 +127,47 @@ appConfig:
         development:
           appOrigin: 'http://localhost:3000/'
           secure: false
-          clientId:
-            $env: AUTH_GOOGLE_CLIENT_ID
-          clientSecret:
-            $env: AUTH_GOOGLE_CLIENT_SECRET
+          clientId: ${AUTH_GOOGLE_CLIENT_ID}
+          clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
       github:
         development:
           appOrigin: 'http://localhost:3000/'
           secure: false
-          clientId:
-            $env: AUTH_GITHUB_CLIENT_ID
-          clientSecret:
-            $env: AUTH_GITHUB_CLIENT_SECRET
-          enterpriseInstanceUrl:
-            $env: AUTH_GITHUB_ENTERPRISE_INSTANCE_URL
+          clientId: ${AUTH_GITHUB_CLIENT_ID}
+          clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+          enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
       gitlab:
         development:
           appOrigin: 'http://localhost:3000/'
           secure: false
-          clientId:
-            $env: AUTH_GITLAB_CLIENT_ID
-          clientSecret:
-            $env: AUTH_GITLAB_CLIENT_SECRET
-          audience:
-            $env: GITLAB_BASE_URL
+          clientId: ${AUTH_GITLAB_CLIENT_ID}
+          clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
+          audience: ${GITLAB_BASE_URL}
       okta:
         development:
           appOrigin: 'http://localhost:3000/'
           secure: false
-          clientId:
-            $env: AUTH_OKTA_CLIENT_ID
-          clientSecret:
-            $env: AUTH_OKTA_CLIENT_SECRET
-          audience:
-            $env: AUTH_OKTA_AUDIENCE
+          clientId: ${AUTH_OKTA_CLIENT_ID}
+          clientSecret: ${AUTH_OKTA_CLIENT_SECRET}
+          audience: ${AUTH_OKTA_AUDIENCE}
       oauth2:
         development:
           appOrigin: 'http://localhost:3000/'
           secure: false
-          clientId:
-            $env: AUTH_OAUTH2_CLIENT_ID
-          clientSecret:
-            $env: AUTH_OAUTH2_CLIENT_SECRET
-          authorizationURL:
-            $env: AUTH_OAUTH2_AUTH_URL
-          tokenURL:
-            $env: AUTH_OAUTH2_TOKEN_URL
+          clientId: ${AUTH_OAUTH2_CLIENT_ID}
+          clientSecret: ${AUTH_OAUTH2_CLIENT_SECRET}
+          authorizationURL: ${AUTH_OAUTH2_AUTH_URL}
+          tokenURL: ${AUTH_OAUTH2_TOKEN_URL}
       auth0:
         development:
-          clientId:
-            $env: AUTH_AUTH0_CLIENT_ID
-          clientSecret:
-            $env: AUTH_AUTH0_CLIENT_SECRET
-          domain:
-            $env: AUTH_AUTH0_DOMAIN
+          clientId: ${AUTH_AUTH0_CLIENT_ID}
+          clientSecret: ${AUTH_AUTH0_CLIENT_SECRET}
+          domain: ${AUTH_AUTH0_DOMAIN}
       microsoft:
         development:
-          clientId:
-            $env: AUTH_MICROSOFT_CLIENT_ID
-          clientSecret:
-            $env: AUTH_MICROSOFT_CLIENT_SECRET
-          tenantId:
-            $env: AUTH_MICROSOFT_TENANT_ID
+          clientId: ${AUTH_MICROSOFT_CLIENT_ID}
+          clientSecret: ${AUTH_MICROSOFT_CLIENT_SECRET}
+          tenantId: ${AUTH_MICROSOFT_TENANT_ID}
 
 auth:
   google:

--- a/docs/auth/auth-backend-classes.md
+++ b/docs/auth/auth-backend-classes.md
@@ -95,40 +95,27 @@ auth:
   providers:
     google:
       development:
-        clientId:
-          $env: AUTH_GOOGLE_CLIENT_ID
-        clientSecret:
-          $env: AUTH_GOOGLE_CLIENT_SECRET
+        clientId: ${AUTH_GOOGLE_CLIENT_ID}
+        clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
     github:
       development:
-        clientId:
-          $env: AUTH_GITHUB_CLIENT_ID
-        clientSecret:
-          $env: AUTH_GITHUB_CLIENT_SECRET
-        enterpriseInstanceUrl:
-          $env: AUTH_GITHUB_ENTERPRISE_INSTANCE_URL
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+        enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
     gitlab:
       development:
-        clientId:
-          $env:
+        clientId: ${AUTH_GITLAB_CLIENT_ID}
     oauth2:
       development:
-        clientId:
-          $env: AUTH_OAUTH2_CLIENT_ID
-        clientSecret:
-          $env: AUTH_OAUTH2_CLIENT_SECRET
-        authorizationUrl:
-          $env: AUTH_OAUTH2_AUTH_URL
-        tokenUrl:
-          $env: AUTH_OAUTH2_TOKEN_URL
-        scope:
-          $env: AUTH_OAUTH2_SCOPE
+        clientId: ${AUTH_OAUTH2_CLIENT_ID}
+        clientSecret: ${AUTH_OAUTH2_CLIENT_SECRET}
+        authorizationUrl: ${AUTH_OAUTH2_AUTH_URL}
+        tokenUrl: ${AUTH_OAUTH2_TOKEN_URL}
+        scope: ${AUTH_OAUTH2_SCOPE}
     saml:
-      entryPoint:
-        $env: AUTH_SAML_ENTRY_POINT
-      issuer:
-        $env: AUTH_SAML_ISSUER
-            ...
+      entryPoint: ${AUTH_SAML_ENTRY_POINT}
+      issuer: ${AUTH_SAML_ISSUER}
+    ...
 ```
 
 ## Implementing Your Own Auth Wrapper

--- a/docs/conf/writing.md
+++ b/docs/conf/writing.md
@@ -129,6 +129,9 @@ variable.
 $env: MY_SECRET
 ```
 
+Note however, that it's often more convenient to use
+[environment variable substitution](#environment-variable-substitution) instead.
+
 ### File Includes
 
 This reads a string value from the entire contents of a text file. The file path

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -25,8 +25,7 @@ kubernetes:
         - url: http://127.0.0.1:9999
           name: minikube
           authProvider: 'serviceAccount'
-          serviceAccountToken:
-            $env: K8S_MINIKUBE_TOKEN
+          serviceAccountToken: ${K8S_MINIKUBE_TOKEN}
         - url: http://127.0.0.2:9999
           name: aws-cluster-1
           authProvider: 'aws'

--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -189,8 +189,7 @@ public within the enterprise.
 integrations:
   github:
     - host: github.com
-      token:
-        $env: GITHUB_TOKEN
+      token: ${GITHUB_TOKEN}
 
 scaffolder:
   github:
@@ -207,8 +206,7 @@ instance:
 integrations:
   gitlab:
     - host: gitlab.com
-      token:
-        $env: GITLAB_TOKEN
+      token: ${GITLAB_TOKEN}
 ```
 
 #### Bitbucket
@@ -221,8 +219,7 @@ following:
 integrations:
   bitbucket:
     - host: bitbucket.org
-      token:
-        $env: BITBUCKET_TOKEN
+      token: ${BITBUCKET_TOKEN}
 ```
 
 or
@@ -231,10 +228,8 @@ or
 integrations:
   bitbucket:
     - host: bitbucket.org
-      appPassword:
-        $env: BITBUCKET_APP_PASSWORD
-      username:
-        $env: BITBUCKET_USERNAME
+      appPassword: ${BITBUCKET_APP_PASSWORD}
+      username: ${BITBUCKET_USERNAME}
 ```
 
 #### Azure DevOps
@@ -249,8 +244,7 @@ verified.
 integrations:
   azure:
     - host: dev.azure.com
-      token:
-        $env: AZURE_TOKEN
+      token: ${AZURE_TOKEN}
 ```
 
 ### Running the Backend

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -65,22 +65,18 @@ techdocs:
       # https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html
       # https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-shared.html
       credentials:
-        accessKeyId:
-          $env: TECHDOCS_AWSS3_ACCESS_KEY_ID_CREDENTIAL
-        secretAccessKey:
-          $env: TECHDOCS_AWSS3_SECRET_ACCESS_KEY_CREDENTIAL
+        accessKeyId: ${TECHDOCS_AWSS3_ACCESS_KEY_ID_CREDENTIAL}
+        secretAccessKey: ${TECHDOCS_AWSS3_SECRET_ACCESS_KEY_CREDENTIAL}
 
       # (Optional) AWS Region of the bucket.
       # If not set, AWS_REGION environment variable or aws config file will be used.
       # https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html
-      region:
-        $env: AWS_REGION
+      region: ${AWS_REGION}
 
       # (Optional) Endpoint URI to send requests to.
       # If not set, the default endpoint is built from the configured region.
       # https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
-      endpoint:
-        $env: AWS_ENDPOINT
+      endpoint: ${AWS_ENDPOINT}
 
     # Required when techdocs.publisher.type is set to 'azureBlobStorage'. Skip otherwise.
 
@@ -91,13 +87,11 @@ techdocs:
       # (Required) An account name is required to write to a storage blob container.
       # https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
       credentials:
-        accountName:
-          $env: TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_NAME
+        accountName: ${TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_NAME}
         # (Optional) An account key is required to write to a storage container.
         # If missing,AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET environment variable will be used.
         # https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json
-        accountKey:
-          $env: TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_KEY
+        accountKey: ${TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_KEY}
 
   # (Optional and Legacy) TechDocs makes API calls to techdocs-backend using this URL. e.g. get docs of an entity, get metadata, etc.
   # You don't have to specify this anymore.

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -95,8 +95,7 @@ techdocs:
     type: 'googleGcs'
     googleGcs:
       bucketName: 'name-of-techdocs-storage-bucket'
-      credentials:
-        $env: GOOGLE_APPLICATION_CREDENTIALS
+      credentials: ${GOOGLE_APPLICATION_CREDENTIALS}
 ```
 
 **4. That's it!**
@@ -179,13 +178,10 @@ techdocs:
     type: 'awsS3'
     awsS3:
       bucketName: 'name-of-techdocs-storage-bucket'
-      region:
-        $env: AWS_REGION
+      region: ${AWS_REGION}
       credentials:
-        accessKeyId:
-          $env: AWS_ACCESS_KEY_ID
-        secretAccessKey:
-          $env: AWS_SECRET_ACCESS_KEY
+        accessKeyId: ${AWS_ACCESS_KEY_ID}
+        secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
 ```
 
 Refer to the
@@ -202,8 +198,7 @@ techdocs:
     type: 'awsS3'
     awsS3:
       bucketName: 'name-of-techdocs-storage-bucket'
-      region:
-        $env: AWS_REGION
+      region: ${AWS_REGION}
       credentials:
         roleArn: arn:aws:iam::123456789012:role/my-backstage-role
 ```
@@ -276,8 +271,7 @@ techdocs:
     azureBlobStorage:
       containerName: 'name-of-techdocs-storage-bucket'
       credentials:
-        accountName:
-          $env: TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_NAME
+        accountName: ${TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_NAME}
 ```
 
 **3b. Authentication using app-config.yaml**
@@ -297,10 +291,8 @@ techdocs:
     azureBlobStorage:
       containerName: 'name-of-techdocs-storage-bucket'
       credentials:
-        accountName:
-          $env: TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_NAME
-        accountKey:
-          $env: TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_KEY
+        accountName: ${TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_NAME}
+        accountKey: ${TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_KEY}
 ```
 
 **4. That's it!**
@@ -361,20 +353,13 @@ techdocs:
     openStackSwift:
       containerName: 'name-of-techdocs-storage-bucket'
       credentials:
-        userName:
-          $env: OPENSTACK_SWIFT_STORAGE_USERNAME
-        password:
-          $env: OPENSTACK_SWIFT_STORAGE_PASSWORD
-      authUrl:
-        $env: OPENSTACK_SWIFT_STORAGE_AUTH_URL
-      keystoneAuthVersion:
-        $env: OPENSTACK_SWIFT_STORAGE_AUTH_VERSION
-      domainId:
-        $env: OPENSTACK_SWIFT_STORAGE_DOMAIN_ID
-      domainName:
-        $env: OPENSTACK_SWIFT_STORAGE_DOMAIN_NAME
-      region:
-        $env: OPENSTACK_SWIFT_STORAGE_REGION
+        userName: ${OPENSTACK_SWIFT_STORAGE_USERNAME}
+        password: ${OPENSTACK_SWIFT_STORAGE_PASSWORD}
+      authUrl: ${OPENSTACK_SWIFT_STORAGE_AUTH_URL}
+      keystoneAuthVersion: ${OPENSTACK_SWIFT_STORAGE_AUTH_VERSION}
+      domainId: ${OPENSTACK_SWIFT_STORAGE_DOMAIN_ID}
+      domainName: ${OPENSTACK_SWIFT_STORAGE_DOMAIN_NAME}
+      region: ${OPENSTACK_SWIFT_STORAGE_REGION}
 ```
 
 **4. That's it!**

--- a/docs/getting-started/configure-app-with-plugins.md
+++ b/docs/getting-started/configure-app-with-plugins.md
@@ -60,8 +60,7 @@ proxy:
   '/circleci/api':
     target: https://circleci.com/api/v1.1
     headers:
-      Circle-Token:
-        $env: CIRCLECI_AUTH_TOKEN
+      Circle-Token: ${CIRCLECI_AUTH_TOKEN}
 ```
 
 ### Adding a plugin page to the Sidebar

--- a/docs/integrations/google-cloud-storage/locations.md
+++ b/docs/integrations/google-cloud-storage/locations.md
@@ -24,10 +24,8 @@ Explicit credentials can be set in the following format:
 ```yaml
 integrations:
   googleGcs:
-    clientEmail:
-      $env: GCS_CLIENT_EMAIL
-    privateKey:
-      $env: GCS_PRIVATE_KEY
+    clientEmail: ${GCS_CLIENT_EMAIL}
+    privateKey: ${GCS_PRIVATE_KEY}
 ```
 
 Then make sure the environment variables `GCS_CLIENT_EMAIL` and

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -40,8 +40,9 @@ proxy:
   '/larger-example/v1':
     target: http://larger.example.com:8080/svc.v1
     headers:
-      Authorization:
-        $env: EXAMPLE_AUTH_HEADER
+      Authorization: ${EXAMPLE_AUTH_HEADER}
+      # ...or interpolating a value into part of a string,
+      # Authorization: Bearer ${EXAMPLE_AUTH_TOKEN}
 ```
 
 Each key under the proxy configuration entry is a route to match, below the

--- a/docs/tutorials/quickstart-app-auth.md
+++ b/docs/tutorials/quickstart-app-auth.md
@@ -79,13 +79,10 @@ auth:
   providers:
     github:
       development:
-        clientId:
-          $env: AUTH_GITHUB_CLIENT_ID
-        clientSecret:
-          $env: AUTH_GITHUB_CLIENT_SECRET
-        ## uncomment the following two lines if using enterprise
-        # enterpriseInstanceUrl:
-        #  $env: AUTH_GITHUB_ENTERPRISE_INSTANCE_URL
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+        ## uncomment the following line if using enterprise
+        # enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
 ```
 
 ### 2. Generate a GitHub client ID and secret
@@ -122,10 +119,8 @@ auth:
   providers:
     gitlab:
       development:
-        clientId:
-          $env: AUTH_GITLAB_CLIENT_ID
-        clientSecret:
-          $env: AUTH_GITLAB_CLIENT_SECRET
+        clientId: ${AUTH_GITLAB_CLIENT_ID}
+        clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
         audience: https://gitlab.com # Or your self-hosted GitLab instance URL
 ```
 
@@ -172,10 +167,8 @@ auth:
   providers:
     google:
       development:
-        clientId:
-          $env: AUTH_GOOGLE_CLIENT_ID
-        clientSecret:
-          $env: AUTH_GOOGLE_CLIENT_SECRET
+        clientId: ${AUTH_GOOGLE_CLIENT_ID}
+        clientSecret: ${AUTH_GOOGLE_CLIENT_SECRET}
 ```
 
 ### 2. Generate Google Credentials in Google Cloud console
@@ -216,12 +209,9 @@ auth:
   providers:
     microsoft:
       development:
-        clientId:
-          $env: AUTH_MICROSOFT_CLIENT_ID
-        clientSecret:
-          $env: AUTH_MICROSOFT_CLIENT_SECRET
-        tenantId:
-          $env: AUTH_MICROSOFT_TENANT_ID
+        clientId: ${AUTH_MICROSOFT_CLIENT_ID}
+        clientSecret: ${AUTH_MICROSOFT_CLIENT_SECRET}
+        tenantId: ${AUTH_MICROSOFT_TENANT_ID}
 ```
 
 ### 2. Create a Microsoft App Registration in Microsoft Portal
@@ -264,12 +254,9 @@ auth:
   providers:
     auth0:
       development:
-        clientId:
-          $env: AUTH_AUTH0_CLIENT_ID
-        clientSecret:
-          $env: AUTH_AUTH0_CLIENT_SECRET
-        domain:
-          $env: AUTH_AUTH0_DOMAIN_ID
+        clientId: ${AUTH_AUTH0_CLIENT_ID}
+        clientSecret: ${AUTH_AUTH0_CLIENT_SECRET}
+        domain: ${AUTH_AUTH0_DOMAIN_ID}
 ```
 
 ### 2. Create an Auth0 application in the Auth0 management console

--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -38,14 +38,10 @@ backend:
 +    # config options: https://node-postgres.com/api/client
 +    client: pg
 +    connection:
-+      host:
-+        $env: POSTGRES_HOST
-+      port:
-+        $env: POSTGRES_PORT
-+      user:
-+        $env: POSTGRES_USER
-+      password:
-+        $env: POSTGRES_PASSWORD
++      host: ${POSTGRES_HOST}
++      port: ${POSTGRES_PORT}
++      user: ${POSTGRES_USER}
++      password: ${POSTGRES_PASSWORD}
 +      # https://node-postgres.com/features/ssl
 +      #ssl: require # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
 +        #ca: # if you have a CA file and want to verify it you can uncomment this section
@@ -53,9 +49,9 @@ backend:
 
 ```
 
-If you have a `app-config.local.yaml` for local development, a similar update
+If you have an `app-config.local.yaml` for local development, a similar update
 should be made there. You can set the `POSTGRES_` environment variables prior to
-launching Backstage, or remove the $env keys and simply set values directly for
-development.
+launching Backstage, or remove the `${...}` values and simply set actual values
+directly for development.
 
 The Backstage App is now ready to start up with a PostgreSQL backing database.

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -25,14 +25,10 @@ backend:
   database:
     client: pg
     connection:
-      host:
-        $env: POSTGRES_HOST
-      port:
-        $env: POSTGRES_PORT
-      user:
-        $env: POSTGRES_USER
-      password:
-        $env: POSTGRES_PASSWORD
+      host: ${POSTGRES_HOST}
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}
+      password: ${POSTGRES_PASSWORD}
       # https://node-postgres.com/features/ssl
       #ssl: require # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
         #ca: # if you have a CA file and want to verify it you can uncomment this section
@@ -43,13 +39,11 @@ backend:
 integrations:
   github:
     - host: github.com
-      token:
-        $env: GITHUB_TOKEN
+      token: ${GITHUB_TOKEN}
     ### Example for how to add your GitHub Enterprise instance using the API:
     # - host: ghe.example.net
     #   apiBaseUrl: https://ghe.example.net/api/v3
-    #   token:
-    #     $env: GHE_TOKEN
+    #   token: ${GHE_TOKEN}
 
 proxy:
   '/test':
@@ -73,8 +67,7 @@ auth:
 
 scaffolder:
   github:
-    token:
-      $env: GITHUB_TOKEN
+    token: ${GITHUB_TOKEN}
     visibility: public # or 'internal' or 'private'
 
 catalog:

--- a/plugins/bitrise/README.md
+++ b/plugins/bitrise/README.md
@@ -55,8 +55,7 @@ proxy:
     target: 'https://api.bitrise.io/v0.1'
     allowedMethods: ['GET']
     headers:
-      Authorization:
-        $env: BITRISE_AUTH_TOKEN
+      Authorization: ${BITRISE_AUTH_TOKEN}
 ```
 
 Learn on https://devcenter.bitrise.io/api/authentication how to create a new Bitrise token.

--- a/plugins/circleci/README.md
+++ b/plugins/circleci/README.md
@@ -43,8 +43,7 @@ proxy:
   '/circleci/api':
     target: https://circleci.com/api/v1.1
     headers:
-      Circle-Token:
-        $env: CIRCLECI_AUTH_TOKEN
+      Circle-Token: ${CIRCLECI_AUTH_TOKEN}
 ```
 
 5. Get and provide `CIRCLECI_AUTH_TOKEN` as env variable (https://circleci.com/docs/api/#add-an-api-token)

--- a/plugins/fossa/README.md
+++ b/plugins/fossa/README.md
@@ -50,9 +50,7 @@ proxy:
     target: https://app.fossa.io/api
     allowedMethods: ['GET']
     headers:
-      Authorization:
-        # Content: 'token <your-fossa-api-token>'
-        $env: FOSSA_AUTH_HEADER
+      Authorization: token ${FOSSA_API_TOKEN}
 
 # if you have a fossa organization, configure your id here
 fossa:

--- a/plugins/jenkins/README.md
+++ b/plugins/jenkins/README.md
@@ -29,15 +29,13 @@ proxy:
     target: 'http://localhost:8080' # your Jenkins URL
     changeOrigin: true
     headers:
-      Authorization:
-        $env: JENKINS_BASIC_AUTH_HEADER
+      Authorization: Basic ${JENKINS_BASIC_AUTH_HEADER}
 ```
 
 4. Add an environment variable which contains the Jenkins credentials, (note: use an API token not your password). Here user is the name of the user created in Jenkins.
 
 ```shell
-HEADER=$(echo -n user:api-token | base64)
-export JENKINS_BASIC_AUTH_HEADER="Basic $HEADER"
+export JENKINS_BASIC_AUTH_HEADER=$(echo -n user:api-token | base64)
 ```
 
 5. Run app with `yarn start`

--- a/plugins/newrelic/README.md
+++ b/plugins/newrelic/README.md
@@ -15,8 +15,7 @@ proxy:
   '/newrelic/apm/api':
     target: https://api.newrelic.com/v2
     headers:
-      X-Api-Key:
-        $env: NEW_RELIC_REST_API_KEY
+      X-Api-Key: ${NEW_RELIC_REST_API_KEY}
 ```
 
 In your production deployment of Backstage, you would also need to ensure that

--- a/plugins/rollbar-backend/README.md
+++ b/plugins/rollbar-backend/README.md
@@ -8,8 +8,7 @@ The following values are read from the configuration file.
 
 ```yaml
 rollbar:
-  accountToken:
-    $env: ROLLBAR_ACCOUNT_TOKEN
+  accountToken: ${ROLLBAR_ACCOUNT_TOKEN}
 ```
 
 _NOTE: The `ROLLBAR_ACCOUNT_TOKEN` environment variable must be set to a read

--- a/plugins/rollbar/README.md
+++ b/plugins/rollbar/README.md
@@ -45,8 +45,7 @@ const ServiceEntityPage = ({ entity }: { entity: Entity }) => (
 rollbar:
   organization: organization-name
   # used by rollbar-backend
-  accountToken:
-    $env: ROLLBAR_ACCOUNT_TOKEN
+  accountToken: ${ROLLBAR_ACCOUNT_TOKEN}
 ```
 
 6. Annotate entities with the rollbar project slug

--- a/plugins/sentry/README.md
+++ b/plugins/sentry/README.md
@@ -70,9 +70,7 @@ proxy:
     target: https://sentry.io/api/
     allowedMethods: ['GET']
     headers:
-      Authorization:
-        # Content: 'Bearer <your-sentry-token>'
-        $env: SENTRY_TOKEN
+      Authorization: Bearer ${SENTRY_TOKEN}
 
 sentry:
   organization: <your-organization>

--- a/plugins/sonarqube/README.md
+++ b/plugins/sonarqube/README.md
@@ -54,10 +54,9 @@ proxy:
     target: https://sonarcloud.io/api
     allowedMethods: ['GET']
     headers:
-      Authorization:
-        # Content: 'Basic base64("<api-key>:")' <-- note the trailing ':'
-        # Example: Basic bXktYXBpLWtleTo=
-        $env: SONARQUBE_AUTH_HEADER
+      Authorization: Basic ${SONARQUBE_AUTH}
+      # Content: 'base64("<api-key>:")' <-- note the trailing ':'
+      # Example: bXktYXBpLWtleTo=
 ```
 
 **SonarQube**
@@ -70,20 +69,19 @@ proxy:
     target: https://your.sonarqube.instance.com/api
     allowedMethods: ['GET']
     headers:
-      Authorization:
-        # Environmental variable: SONARQUBE_AUTH_HEADER
-        # Value: 'Basic base64("<sonar-auth-token>:")'
-        # Encode the "<sonar-auth-token>:" string using base64 encoder.
-        # Note the trailing colon (:) at the end of the token.
-        # Example environmental config: SONARQUBE_AUTH_HEADER=Basic bXktYXBpLWtleTo=
-        # Fetch the sonar-auth-token from https://sonarcloud.io/account/security/
-        $env: SONARQUBE_AUTH_HEADER
+      Authorization: Basic ${SONARQUBE_AUTH}
+      # Environmental variable: SONARQUBE_AUTH
+      # Value: 'base64("<sonar-auth-token>:")'
+      # Encode the "<sonar-auth-token>:" string using base64 encoder.
+      # Note the trailing colon (:) at the end of the token.
+      # Example environmental config: SONARQUBE_AUTH=bXktYXBpLWtleTo=
+      # Fetch the sonar-auth-token from https://sonarcloud.io/account/security/
 
 sonarQube:
   baseUrl: https://your.sonarqube.instance.com
 ```
 
-5. Get and provide `SONARQUBE_AUTH_HEADER` as env variable (https://sonarcloud.io/account/security or https://docs.sonarqube.org/latest/user-guide/user-token/)
+5. Get and provide `SONARQUBE_AUTH` as an env variable (https://sonarcloud.io/account/security or https://docs.sonarqube.org/latest/user-guide/user-token/)
 
 6. Run the following commands in the root folder of the project to install and compile the changes.
 

--- a/plugins/splunk-on-call/README.md
+++ b/plugins/splunk-on-call/README.md
@@ -50,7 +50,7 @@ import {
 
 In order to be able to perform certain action (create-acknowledge-resolve an action), you need to provide a REST Endpoint.
 
-To enable the REST Endpoint integration you can go on https://portal.victorops.com/ inside Integrations > 3rd Party Integrations > REST – Generic.  
+To enable the REST Endpoint integration you can go on https://portal.victorops.com/ inside Integrations > 3rd Party Integrations > REST – Generic.
 You can now copy the URL to notify: `<SPLUNK_ON_CALL_REST_ENDPOINT>/$routing_key`
 
 In `app-config.yaml`:
@@ -69,10 +69,8 @@ proxy:
   '/splunk-on-call':
     target: https://api.victorops.com/api-public
     headers:
-      X-VO-Api-Id:
-        $env: SPLUNK_ON_CALL_API_ID
-      X-VO-Api-Key:
-        $env: SPLUNK_ON_CALL_API_KEY
+      X-VO-Api-Id: ${SPLUNK_ON_CALL_API_ID}
+      X-VO-Api-Key: ${SPLUNK_ON_CALL_API_KEY}
 ```
 
 In addition, to make certain API calls (trigger-resolve-acknowledge an incident) you need to add the `PATCH` method to the backend `cors` methods list: `[GET, POST, PUT, DELETE, PATCH]`.

--- a/plugins/user-settings/src/components/AuthProviders/EmptyProviders.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/EmptyProviders.tsx
@@ -22,10 +22,8 @@ const EXAMPLE = `auth:
   providers:
     google:
       development:
-        clientId:
-          $env: AUTH_GOOGLE_CLIENT_ID
-        clientSecret:
-          $env: AUTH_GOOGLE_CLIENT_SECRET
+        clientId: \${AUTH_GOOGLE_CLIENT_ID}
+        clientSecret: \${AUTH_GOOGLE_CLIENT_SECRET}
 `;
 
 export const EmptyProviders = () => (


### PR DESCRIPTION
Signed-off-by: Fredrik Adelöw <freben@gmail.com>

In a few places where it made sense, I have replaced e.g. `$env: X_AUTH_HEADER` with `Basic ${X_AUTH}`, but mostly in docs - I left them untouched in app-config for now, we can clean those up to simplify at a later point. It'd be kind of a breaking change for devs I guess :)