### PR TITLE
[TechDocs]Add a test id to the shadow root element of the Reader to access it easily in e2e tests

### DIFF
--- a/.changeset/techdocs-swift-mugs-invent.md
+++ b/.changeset/techdocs-swift-mugs-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Add a test id to the shadow root element of the Reader to access it easily in e2e tests

--- a/plugins/techdocs/src/reader/components/Reader.test.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiProvider, ApiRegistry } from '@backstage/core';
+import { wrapInTestApp } from '@backstage/test-utils';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { TechDocsStorageApi, techdocsStorageApiRef } from '../../api';
+import { Reader } from './Reader';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: jest.fn(),
+  };
+});
+
+const { useParams }: { useParams: jest.Mock } = jest.requireMock(
+  'react-router-dom',
+);
+
+describe('<Reader />', () => {
+  it('should render Reader content', async () => {
+    useParams.mockReturnValue({
+      entityId: 'Component::backstage',
+    });
+
+    const techdocsStorageApi: Partial<TechDocsStorageApi> = {};
+
+    const apiRegistry = ApiRegistry.from([
+      [techdocsStorageApiRef, techdocsStorageApi],
+    ]);
+
+    await act(async () => {
+      const rendered = render(
+        wrapInTestApp(
+          <ApiProvider apis={apiRegistry}>
+            <Reader
+              entityId={{
+                kind: 'Component',
+                namespace: 'default',
+                name: 'example',
+              }}
+            />
+          </ApiProvider>,
+        ),
+      );
+      expect(
+        rendered.getByTestId('techdocs-content-shadowroot'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -17,10 +17,10 @@ import { EntityName } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core';
 import { BackstageTheme } from '@backstage/theme';
 import { useTheme } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAsync } from 'react-use';
-import React, { useEffect, useRef, useState } from 'react';
-import { Alert } from '@material-ui/lab';
 import { techdocsStorageApiRef } from '../../api';
 import transformer, {
   addBaseUrl,
@@ -343,7 +343,7 @@ export const Reader = ({ entityId, onReady }: Props) => {
       {docLoading || (docLoadError && syncInProgress) ? (
         <TechDocsProgressBar />
       ) : null}
-      <div ref={shadowDomRef} />
+      <div data-testid="techdocs-content-shadowroot" ref={shadowDomRef} />
     </>
   );
 };


### PR DESCRIPTION
While the parent element in the [`TechDocsPage`](https://github.com/backstage/backstage/blob/826d50e033648c3c6950f778dac6667d053f7b36/plugins/techdocs/src/reader/components/TechDocsPage.tsx#L60) already contains a `testid`, the [`EntityPageDocs`](https://github.com/backstage/backstage/blob/826d50e033648c3c6950f778dac6667d053f7b36/plugins/techdocs/src/EntityPageDocs.tsx#L23) doesn't. To be able to test both cases consistently with e2e tests, I prefer to add it to the element in the `Reader`. Example: Cypress needs to find the element [prior to entering the shadow dom](https://docs.cypress.io/api/commands/shadow), i.e. `cy.get("[data-testid=techdocs-content-shadowroot]").shadow().`

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
