### PR TITLE
fix(create-app,example): Move system diagram to system page

### DIFF
--- a/.changeset/sour-plums-enjoy.md
+++ b/.changeset/sour-plums-enjoy.md
@@ -1,0 +1,7 @@
+---
+'@backstage/create-app': patch
+---
+
+Fix system diagram card to be on the system page
+
+To apply the same fix to an existing application, in `EntityPage.tsx` simply move the `<EntityLayout.route>` for the `/diagram` path from the `groupPage` down into the `systemPage` element.

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -441,10 +441,6 @@ const groupPage = (
         </Grid>
       </Grid>
     </EntityLayout.Route>
-
-    <EntityLayout.Route path="/diagram" title="Diagram">
-      <EntitySystemDiagramCard />
-    </EntityLayout.Route>
   </EntityLayoutWrapper>
 );
 
@@ -462,6 +458,9 @@ const systemPage = (
           <EntityHasApisCard variant="gridItem" />
         </Grid>
       </Grid>
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/diagram" title="Diagram">
+      <EntitySystemDiagramCard />
     </EntityLayout.Route>
   </EntityLayoutWrapper>
 );

--- a/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
@@ -208,10 +208,6 @@ const groupPage = (
         </Grid>
       </Grid>
     </EntityLayout.Route>
-
-    <EntityLayout.Route path="/diagram" title="Diagram">
-      <EntitySystemDiagramCard />
-    </EntityLayout.Route>
   </EntityLayout>
 );
 
@@ -229,6 +225,9 @@ const systemPage = (
           <EntityHasApisCard variant="gridItem" />
         </Grid>
       </Grid>
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/diagram" title="Diagram">
+      <EntitySystemDiagramCard />
     </EntityLayout.Route>
   </EntityLayout>
 );


### PR DESCRIPTION
Signed-off-by: Adam Harvey <adaharve@cisco.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The system diagram tab was mistakenly moved to the group page via #4822.  This PR fixes it both in the example app and the create-app tool so it will show up on the system page.

| Current | Fixed |
| --- | --- |
| <img width="1111" alt="image" src="https://user-images.githubusercontent.com/33203301/114957353-d722d300-9e2e-11eb-8c52-3ba2a2c883eb.png">  | <img width="1066" alt="image" src="https://user-images.githubusercontent.com/33203301/114957405-f91c5580-9e2e-11eb-853b-43b2cb38f263.png"> |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
