### PR TITLE
core-api: remove apiHolder creation check

### DIFF
--- a/packages/core-api/src/app/App.tsx
+++ b/packages/core-api/src/app/App.tsx
@@ -306,9 +306,6 @@ export class PrivateAppImpl implements BackstageApp {
         this.verifyPlugins(this.plugins);
 
         // Initialize APIs once all plugins are available
-        if (this.apiHolder) {
-          throw new Error('Plugin holder was initialized too soon');
-        }
         this.getApiHolder();
 
         return result;


### PR DESCRIPTION
Was causing trouble with hot reloads, and there's no current codepath that's gonna be hitting this anyway, so removing the check.

Thanks to @dhenneke for reporting 👍 

Relying on the existing changeset https://github.com/backstage/backstage/blob/master/.changeset/quiet-badgers-cheer.md