### PR TITLE
Set logo assets to absolute URLs

### DIFF
--- a/docs/overview/logos.md
+++ b/docs/overview/logos.md
@@ -6,37 +6,37 @@ description: Guidelines for how to use the Backstage logos and icons
 ---
 
 Guidelines for how to use the Backstage logo and icon can be found
-[here](/logo_assets/Backstage_Identity_Assets_Overview.pdf). The assets below
-are all in `.svg` format. Other formats are available in the
+[here](https://backstage.io/logo_assets/Backstage_Identity_Assets_Overview.pdf).
+The assets below are all in `.svg` format. Other formats are available in the
 [repository](https://github.com/backstage/backstage/tree/master/microsite/static/logo_assets).
 
 ## Backstage logo
 
-<a href="/logo_assets/svg/Logo_White.svg">
-  <img src="/logo_assets/svg/Logo_White.svg" width="600" />
+<a href="https://backstage.io/logo_assets/svg/Logo_White.svg">
+  <img src="https://backstage.io/logo_assets/svg/Logo_White.svg" width="600" />
 </a>
 
-<a href="/logo_assets/svg/Logo_Teal.svg">
-  <img src="/logo_assets/svg/Logo_Teal.svg" width="600" />
+<a href="https://backstage.io/logo_assets/svg/Logo_Teal.svg">
+  <img src="https://backstage.io/logo_assets/svg/Logo_Teal.svg" width="600" />
 </a>
 
-<a href="/logo_assets/svg/Logo_Black.svg">
-  <img src="/logo_assets/svg/Logo_Black.svg" width="600" style="background-color:white" />
+<a href="https://backstage.io/logo_assets/svg/Logo_Black.svg">
+  <img src="https://backstage.io/logo_assets/svg/Logo_Black.svg" width="600" style="background-color:white" />
 </a>
 
 ## Backstage icon
 
 <div>
-  <a href="/logo_assets/svg/Icon_White.svg">
-    <img src="/logo_assets/svg/Icon_White.svg" width="180" height="180" />
+  <a href="https://backstage.io/logo_assets/svg/Icon_White.svg">
+    <img src="https://backstage.io/logo_assets/svg/Icon_White.svg" width="180" height="180" />
   </a>
-  <a href="/logo_assets/svg/Icon_Teal.svg">
-    <img src="/logo_assets/svg/Icon_Teal.svg" width="180" height="180" />
+  <a href="https://backstage.io/logo_assets/svg/Icon_Teal.svg">
+    <img src="https://backstage.io/logo_assets/svg/Icon_Teal.svg" width="180" height="180" />
   </a>
-  <a href="/logo_assets/svg/Icon_Gradient.svg">
-    <img src="/logo_assets/svg/Icon_Gradient.svg" width="180" height="180" />
+  <a href="https://backstage.io/logo_assets/svg/Icon_Gradient.svg">
+    <img src="https://backstage.io/logo_assets/svg/Icon_Gradient.svg" width="180" height="180" />
   </a>
-  <a href="/logo_assets/svg/Icon_Black.svg">
-    <img src="/logo_assets/svg/Icon_Black.svg" width="180" height="180" style="background-color:white" />
+  <a href="https://backstage.io/logo_assets/svg/Icon_Black.svg">
+    <img src="https://backstage.io/logo_assets/svg/Icon_Black.svg" width="180" height="180" style="background-color:white" />
   </a>
 </div>


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

Fixes https://github.com/backstage/demo/issues/22

Sets logo assets in the documentation to absolute URLs. I considered moving these to `docs/assets`, but they are referenced outside of docs in the microsite.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
