### PR TITLE
WIP: Reduce CVEs by using alpine container instead of Ubuntu

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -22,7 +22,7 @@ RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
 
 # Then copy the rest of the backend bundle, along with any other files we might want.
-ADD packages/backend/dist/bundle.tar.gz app-config.yaml ./
+COPY packages/backend/dist/bundle.tar.gz app-config.yaml ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -25,4 +25,6 @@ RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -
 COPY packages/backend/dist/bundle.tar.gz app-config.yaml ./
 RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
-CMD ["node", "packages/backend", "--config", "app-config.yaml"]
+WORKDIR /app/packages/backend
+
+CMD ["node", ".", "--config", "../../app-config.yaml"]

--- a/packages/catalog-model/package.json
+++ b/packages/catalog-model/package.json
@@ -46,6 +46,7 @@
     "yaml": "^1.9.2"
   },
   "files": [
-    "dist"
+    "dist",
+    "examples"
   ]
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ubuntu has lots of unresolved CVEs. I ran [trivy](https://github.com/aquasecurity/trivy) on the image generated with the latest version of master and it produced the following report.

<details><summary>Debian 10.9 - total: 95 (UNKNOWN: 0, LOW: 65, MEDIUM: 8, HIGH: 20, CRITICAL: 2)</summary>

```xterm
docker.io/library/example-backend (debian 10.9)
===============================================
Total: 95 (UNKNOWN: 0, LOW: 65, MEDIUM: 8, HIGH: 20, CRITICAL: 2)

+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
|    LIBRARY     |  VULNERABILITY ID   | SEVERITY | INSTALLED VERSION | FIXED VERSION |                           TITLE                            |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| apt            | CVE-2011-3374       | LOW      | 1.8.2.2           |               | It was found that apt-key in apt,                          |
|                |                     |          |                   |               | all versions, do not correctly...                          |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2011-3374                       |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| bash           | CVE-2019-18276      |          | 5.0-4             |               | bash: when effective UID is not                            |
|                |                     |          |                   |               | equal to its real UID the...                               |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-18276                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | TEMP-0841856-B18BAF |          |                   |               | -->security-tracker.debian.org/tracker/TEMP-0841856-B18BAF |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| coreutils      | CVE-2016-2781       |          | 8.30-3            |               | coreutils: Non-privileged                                  |
|                |                     |          |                   |               | session can escape to the                                  |
|                |                     |          |                   |               | parent session in chroot                                   |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2016-2781                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2017-18018      |          |                   |               | coreutils: race condition                                  |
|                |                     |          |                   |               | vulnerability in chown and chgrp                           |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-18018                      |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| gcc-8-base     | CVE-2018-12886      | HIGH     | 8.3.0-6           |               | gcc: spilling of stack                                     |
|                |                     |          |                   |               | protection address in cfgexpand.c                          |
|                |                     |          |                   |               | and function.c leads to...                                 |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-12886                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-15847      |          |                   |               | gcc: POWER9 "DARN" RNG intrinsic                           |
|                |                     |          |                   |               | produces repeated output                                   |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-15847                      |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| gpgv           | CVE-2019-14855      | LOW      | 2.2.12-1+deb10u1  |               | gnupg2: OpenPGP Key Certification                          |
|                |                     |          |                   |               | Forgeries with SHA-1                                       |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-14855                      |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libapt-pkg5.0  | CVE-2011-3374       |          | 1.8.2.2           |               | It was found that apt-key in apt,                          |
|                |                     |          |                   |               | all versions, do not correctly...                          |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2011-3374                       |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libc-bin       | CVE-2020-1751       | HIGH     | 2.28-10           |               | glibc: array overflow in                                   |
|                |                     |          |                   |               | backtrace functions for powerpc                            |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-1751                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-1752       |          |                   |               | glibc: use-after-free in glob()                            |
|                |                     |          |                   |               | function when expanding ~user                              |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-1752                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2021-3326       |          |                   |               | glibc: Assertion failure in                                |
|                |                     |          |                   |               | ISO-2022-JP-3 gconv module                                 |
|                |                     |          |                   |               | related to combining characters                            |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3326                       |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2019-25013      | MEDIUM   |                   |               | glibc: buffer over-read in                                 |
|                |                     |          |                   |               | iconv when processing invalid                              |
|                |                     |          |                   |               | multi-byte input sequences in...                           |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-25013                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-10029      |          |                   |               | glibc: stack corruption                                    |
|                |                     |          |                   |               | from crafted input in cosl,                                |
|                |                     |          |                   |               | sinl, sincosl, and tanl...                                 |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-10029                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-27618      |          |                   |               | glibc: iconv when processing                               |
|                |                     |          |                   |               | invalid multi-byte input                                   |
|                |                     |          |                   |               | sequences fails to advance the...                          |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-27618                      |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2010-4051       | LOW      |                   |               | CVE-2010-4052 glibc: De-recursivise                        |
|                |                     |          |                   |               | regular expression engine                                  |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4051                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2010-4052       |          |                   |               | CVE-2010-4051 CVE-2010-4052                                |
|                |                     |          |                   |               | glibc: De-recursivise                                      |
|                |                     |          |                   |               | regular expression engine                                  |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4052                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2010-4756       |          |                   |               | glibc: glob implementation                                 |
|                |                     |          |                   |               | can cause excessive CPU and                                |
|                |                     |          |                   |               | memory consumption due to...                               |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4756                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2016-10228      |          |                   |               | glibc: iconv program can hang                              |
|                |                     |          |                   |               | when invoked with the -c option                            |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2016-10228                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2018-20796      |          |                   |               | glibc: uncontrolled recursion in                           |
|                |                     |          |                   |               | function check_dst_limits_calc_pos_1                       |
|                |                     |          |                   |               | in posix/regexec.c                                         |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-20796                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-1010022    |          |                   |               | glibc: stack guard protection bypass                       |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010022                    |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-1010023    |          |                   |               | glibc: running ldd on malicious ELF                        |
|                |                     |          |                   |               | leads to code execution because of...                      |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010023                    |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-1010024    |          |                   |               | glibc: ASLR bypass using                                   |
|                |                     |          |                   |               | cache of thread stack and heap                             |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010024                    |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-1010025    |          |                   |               | glibc: information disclosure of heap                      |
|                |                     |          |                   |               | addresses of pthread_created thread                        |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010025                    |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-19126      |          |                   |               | glibc: LD_PREFER_MAP_32BIT_EXEC                            |
|                |                     |          |                   |               | not ignored in setuid binaries                             |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-19126                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-9192       |          |                   |               | glibc: uncontrolled recursion in                           |
|                |                     |          |                   |               | function check_dst_limits_calc_pos_1                       |
|                |                     |          |                   |               | in posix/regexec.c                                         |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-9192                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-6096       |          |                   |               | glibc: signed comparison                                   |
|                |                     |          |                   |               | vulnerability in the                                       |
|                |                     |          |                   |               | ARMv7 memcpy function                                      |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-6096                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2021-27645      |          |                   |               | glibc: Use-after-free in                                   |
|                |                     |          |                   |               | addgetnetgrentX function                                   |
|                |                     |          |                   |               | in netgroupcache.c                                         |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-27645                      |
+----------------+---------------------+----------+                   +---------------+------------------------------------------------------------+
| libc6          | CVE-2020-1751       | HIGH     |                   |               | glibc: array overflow in                                   |
|                |                     |          |                   |               | backtrace functions for powerpc                            |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-1751                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-1752       |          |                   |               | glibc: use-after-free in glob()                            |
|                |                     |          |                   |               | function when expanding ~user                              |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-1752                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2021-3326       |          |                   |               | glibc: Assertion failure in                                |
|                |                     |          |                   |               | ISO-2022-JP-3 gconv module                                 |
|                |                     |          |                   |               | related to combining characters                            |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3326                       |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2019-25013      | MEDIUM   |                   |               | glibc: buffer over-read in                                 |
|                |                     |          |                   |               | iconv when processing invalid                              |
|                |                     |          |                   |               | multi-byte input sequences in...                           |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-25013                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-10029      |          |                   |               | glibc: stack corruption                                    |
|                |                     |          |                   |               | from crafted input in cosl,                                |
|                |                     |          |                   |               | sinl, sincosl, and tanl...                                 |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-10029                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-27618      |          |                   |               | glibc: iconv when processing                               |
|                |                     |          |                   |               | invalid multi-byte input                                   |
|                |                     |          |                   |               | sequences fails to advance the...                          |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-27618                      |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2010-4051       | LOW      |                   |               | CVE-2010-4052 glibc: De-recursivise                        |
|                |                     |          |                   |               | regular expression engine                                  |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4051                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2010-4052       |          |                   |               | CVE-2010-4051 CVE-2010-4052                                |
|                |                     |          |                   |               | glibc: De-recursivise                                      |
|                |                     |          |                   |               | regular expression engine                                  |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4052                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2010-4756       |          |                   |               | glibc: glob implementation                                 |
|                |                     |          |                   |               | can cause excessive CPU and                                |
|                |                     |          |                   |               | memory consumption due to...                               |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2010-4756                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2016-10228      |          |                   |               | glibc: iconv program can hang                              |
|                |                     |          |                   |               | when invoked with the -c option                            |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2016-10228                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2018-20796      |          |                   |               | glibc: uncontrolled recursion in                           |
|                |                     |          |                   |               | function check_dst_limits_calc_pos_1                       |
|                |                     |          |                   |               | in posix/regexec.c                                         |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-20796                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-1010022    |          |                   |               | glibc: stack guard protection bypass                       |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010022                    |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-1010023    |          |                   |               | glibc: running ldd on malicious ELF                        |
|                |                     |          |                   |               | leads to code execution because of...                      |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010023                    |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-1010024    |          |                   |               | glibc: ASLR bypass using                                   |
|                |                     |          |                   |               | cache of thread stack and heap                             |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010024                    |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-1010025    |          |                   |               | glibc: information disclosure of heap                      |
|                |                     |          |                   |               | addresses of pthread_created thread                        |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-1010025                    |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-19126      |          |                   |               | glibc: LD_PREFER_MAP_32BIT_EXEC                            |
|                |                     |          |                   |               | not ignored in setuid binaries                             |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-19126                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-9192       |          |                   |               | glibc: uncontrolled recursion in                           |
|                |                     |          |                   |               | function check_dst_limits_calc_pos_1                       |
|                |                     |          |                   |               | in posix/regexec.c                                         |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-9192                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-6096       |          |                   |               | glibc: signed comparison                                   |
|                |                     |          |                   |               | vulnerability in the                                       |
|                |                     |          |                   |               | ARMv7 memcpy function                                      |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-6096                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2021-27645      |          |                   |               | glibc: Use-after-free in                                   |
|                |                     |          |                   |               | addgetnetgrentX function                                   |
|                |                     |          |                   |               | in netgroupcache.c                                         |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-27645                      |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libgcc1        | CVE-2018-12886      | HIGH     | 8.3.0-6           |               | gcc: spilling of stack                                     |
|                |                     |          |                   |               | protection address in cfgexpand.c                          |
|                |                     |          |                   |               | and function.c leads to...                                 |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-12886                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-15847      |          |                   |               | gcc: POWER9 "DARN" RNG intrinsic                           |
|                |                     |          |                   |               | produces repeated output                                   |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-15847                      |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libgcrypt20    | CVE-2019-13627      | MEDIUM   | 1.8.4-5           |               | libgcrypt: ECDSA timing attack                             |
|                |                     |          |                   |               | allowing private key leak                                  |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-13627                      |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2018-6829       | LOW      |                   |               | libgcrypt: ElGamal implementation                          |
|                |                     |          |                   |               | doesn't have semantic security due                         |
|                |                     |          |                   |               | to incorrectly encoded plaintexts...                       |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-6829                       |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libgnutls30    | CVE-2021-20231      | CRITICAL | 3.6.7-4+deb10u6   |               | gnutls: Use after free in                                  |
|                |                     |          |                   |               | client key_share extension                                 |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-20231                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2021-20232      |          |                   |               | gnutls: Use after free                                     |
|                |                     |          |                   |               | in client_send_params in                                   |
|                |                     |          |                   |               | lib/ext/pre_shared_key.c                                   |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-20232                      |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2020-24659      | HIGH     |                   |               | gnutls: Heap buffer                                        |
|                |                     |          |                   |               | overflow in handshake with                                 |
|                |                     |          |                   |               | no_renegotiation alert sent                                |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-24659                      |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2011-3389       | LOW      |                   |               | HTTPS: block-wise chosen-plaintext                         |
|                |                     |          |                   |               | attack against SSL/TLS (BEAST)                             |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2011-3389                       |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libhogweed4    | CVE-2021-20305      | HIGH     | 3.4.1-1           |               | nettle: Out of bounds memory                               |
|                |                     |          |                   |               | access in signature verification                           |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-20305                      |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libidn2-0      | CVE-2019-12290      |          | 2.0.5-1+deb10u1   |               | GNU libidn2 before 2.2.0                                   |
|                |                     |          |                   |               | fails to perform the roundtrip                             |
|                |                     |          |                   |               | checks specified in...                                     |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-12290                      |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| liblz4-1       | CVE-2019-17543      | LOW      | 1.8.3-1           |               | lz4: heap-based buffer                                     |
|                |                     |          |                   |               | overflow in LZ4_write32                                    |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-17543                      |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libnettle6     | CVE-2021-20305      | HIGH     | 3.4.1-1           |               | nettle: Out of bounds memory                               |
|                |                     |          |                   |               | access in signature verification                           |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-20305                      |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libpcre3       | CVE-2020-14155      | MEDIUM   | 2:8.39-12         |               | pcre: integer overflow in libpcre                          |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-14155                      |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2017-11164      | LOW      |                   |               | pcre: OP_KETRMAX feature in the                            |
|                |                     |          |                   |               | match function in pcre_exec.c                              |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-11164                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2017-16231      |          |                   |               | pcre: self-recursive call                                  |
|                |                     |          |                   |               | in match() in pcre_exec.c                                  |
|                |                     |          |                   |               | leads to denial of service...                              |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-16231                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2017-7245       |          |                   |               | pcre: stack-based buffer overflow                          |
|                |                     |          |                   |               | write in pcre32_copy_substring                             |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-7245                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2017-7246       |          |                   |               | pcre: stack-based buffer overflow                          |
|                |                     |          |                   |               | write in pcre32_copy_substring                             |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2017-7246                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-20838      |          |                   |               | pcre: buffer over-read in                                  |
|                |                     |          |                   |               | JIT when UTF is disabled                                   |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-20838                      |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libseccomp2    | CVE-2019-9893       |          | 2.3.3-4           |               | libseccomp: incorrect generation                           |
|                |                     |          |                   |               | of syscall filters in libseccomp                           |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-9893                       |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libstdc++6     | CVE-2018-12886      | HIGH     | 8.3.0-6           |               | gcc: spilling of stack                                     |
|                |                     |          |                   |               | protection address in cfgexpand.c                          |
|                |                     |          |                   |               | and function.c leads to...                                 |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-12886                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-15847      |          |                   |               | gcc: POWER9 "DARN" RNG intrinsic                           |
|                |                     |          |                   |               | produces repeated output                                   |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-15847                      |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libsystemd0    | CVE-2019-3843       |          | 241-7~deb10u7     |               | systemd: services with DynamicUser                         |
|                |                     |          |                   |               | can create SUID/SGID binaries                              |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-3843                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-3844       |          |                   |               | systemd: services with DynamicUser                         |
|                |                     |          |                   |               | can get new privileges and                                 |
|                |                     |          |                   |               | create SGID binaries...                                    |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-3844                       |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2013-4392       | LOW      |                   |               | systemd: TOCTOU race condition                             |
|                |                     |          |                   |               | when updating file permissions                             |
|                |                     |          |                   |               | and SELinux security contexts...                           |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2013-4392                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-20386      |          |                   |               | systemd: memory leak in button_open()                      |
|                |                     |          |                   |               | in login/logind-button.c when                              |
|                |                     |          |                   |               | udev events are received...                                |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-20386                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-13776      |          |                   |               | systemd: Mishandles numerical                              |
|                |                     |          |                   |               | usernames beginning with decimal                           |
|                |                     |          |                   |               | digits or 0x followed by...                                |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-13776                      |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| libtasn1-6     | CVE-2018-1000654    |          | 4.13-3            |               | libtasn1: Infinite loop in                                 |
|                |                     |          |                   |               | _asn1_expand_object_id(ptree)                              |
|                |                     |          |                   |               | leads to memory exhaustion                                 |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-1000654                    |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+
| libudev1       | CVE-2019-3843       | HIGH     | 241-7~deb10u7     |               | systemd: services with DynamicUser                         |
|                |                     |          |                   |               | can create SUID/SGID binaries                              |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-3843                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-3844       |          |                   |               | systemd: services with DynamicUser                         |
|                |                     |          |                   |               | can get new privileges and                                 |
|                |                     |          |                   |               | create SGID binaries...                                    |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-3844                       |
+                +---------------------+----------+                   +---------------+------------------------------------------------------------+
|                | CVE-2013-4392       | LOW      |                   |               | systemd: TOCTOU race condition                             |
|                |                     |          |                   |               | when updating file permissions                             |
|                |                     |          |                   |               | and SELinux security contexts...                           |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2013-4392                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-20386      |          |                   |               | systemd: memory leak in button_open()                      |
|                |                     |          |                   |               | in login/logind-button.c when                              |
|                |                     |          |                   |               | udev events are received...                                |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-20386                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2020-13776      |          |                   |               | systemd: Mishandles numerical                              |
|                |                     |          |                   |               | usernames beginning with decimal                           |
|                |                     |          |                   |               | digits or 0x followed by...                                |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-13776                      |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| login          | CVE-2007-5686       |          | 1:4.5-1.1         |               | initscripts in rPath Linux 1                               |
|                |                     |          |                   |               | sets insecure permissions for                              |
|                |                     |          |                   |               | the /var/log/btmp file,...                                 |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2007-5686                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2013-4235       |          |                   |               | shadow-utils: TOCTOU race                                  |
|                |                     |          |                   |               | conditions by copying and                                  |
|                |                     |          |                   |               | removing directory trees                                   |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2013-4235                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2018-7169       |          |                   |               | shadow-utils: newgidmap                                    |
|                |                     |          |                   |               | allows unprivileged user to                                |
|                |                     |          |                   |               | drop supplementary groups                                  |
|                |                     |          |                   |               | potentially allowing privilege...                          |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-7169                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-19882      |          |                   |               | shadow-utils: local users can                              |
|                |                     |          |                   |               | obtain root access because setuid                          |
|                |                     |          |                   |               | programs are misconfigured...                              |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-19882                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | TEMP-0628843-DBAD28 |          |                   |               | -->security-tracker.debian.org/tracker/TEMP-0628843-DBAD28 |
+----------------+---------------------+          +                   +---------------+------------------------------------------------------------+
| passwd         | CVE-2007-5686       |          |                   |               | initscripts in rPath Linux 1                               |
|                |                     |          |                   |               | sets insecure permissions for                              |
|                |                     |          |                   |               | the /var/log/btmp file,...                                 |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2007-5686                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2013-4235       |          |                   |               | shadow-utils: TOCTOU race                                  |
|                |                     |          |                   |               | conditions by copying and                                  |
|                |                     |          |                   |               | removing directory trees                                   |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2013-4235                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2018-7169       |          |                   |               | shadow-utils: newgidmap                                    |
|                |                     |          |                   |               | allows unprivileged user to                                |
|                |                     |          |                   |               | drop supplementary groups                                  |
|                |                     |          |                   |               | potentially allowing privilege...                          |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-7169                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-19882      |          |                   |               | shadow-utils: local users can                              |
|                |                     |          |                   |               | obtain root access because setuid                          |
|                |                     |          |                   |               | programs are misconfigured...                              |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-19882                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | TEMP-0628843-DBAD28 |          |                   |               | -->security-tracker.debian.org/tracker/TEMP-0628843-DBAD28 |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| perl-base      | CVE-2011-4116       |          | 5.28.1-6+deb10u1  |               | perl: File::Temp insecure                                  |
|                |                     |          |                   |               | temporary file handling                                    |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2011-4116                       |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| sysvinit-utils | TEMP-0517018-A83CE6 |          | 2.93-8            |               | -->security-tracker.debian.org/tracker/TEMP-0517018-A83CE6 |
+----------------+---------------------+          +-------------------+---------------+------------------------------------------------------------+
| tar            | CVE-2005-2541       |          | 1.30+dfsg-6       |               | Tar 1.15.1 does not                                        |
|                |                     |          |                   |               | properly warn the user when                                |
|                |                     |          |                   |               | extracting setuid or...                                    |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2005-2541                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2019-9923       |          |                   |               | tar: null-pointer dereference                              |
|                |                     |          |                   |               | in pax_decode_header in sparse.c                           |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2019-9923                       |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | CVE-2021-20193      |          |                   |               | tar: Memory leak in                                        |
|                |                     |          |                   |               | read_header() in list.c                                    |
|                |                     |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-20193                      |
+                +---------------------+          +                   +---------------+------------------------------------------------------------+
|                | TEMP-0290435-0B57B5 |          |                   |               | -->security-tracker.debian.org/tracker/TEMP-0290435-0B57B5 |
+----------------+---------------------+----------+-------------------+---------------+------------------------------------------------------------+

app/yarn.lock
=============
Total: 27 (UNKNOWN: 0, LOW: 1, MEDIUM: 8, HIGH: 17, CRITICAL: 1)

+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
|          LIBRARY          |  VULNERABILITY ID   | SEVERITY | INSTALLED VERSION |         FIXED VERSION          |                    TITLE                     |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| @graphql-tools/git-loader | CVE-2021-23326      | HIGH     | 6.2.4             | 6.2.6                          | graphql-tools/git-loader:                    |
|                           |                     |          |                   |                                | exec and execSync in                         |
|                           |                     |          |                   |                                | packages/loaders/git/src/load-git.ts         |
|                           |                     |          |                   |                                | allows arbitrary command injection.          |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-23326        |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| axios                     | CVE-2020-28168      | MEDIUM   | 0.20.0            | 0.21.1                         | nodejs-axios: allows an attacker to          |
|                           |                     |          |                   |                                | bypass a proxy by providing a URL...         |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-28168        |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| date-and-time             | CVE-2020-26289      | HIGH     | 0.6.3             | 0.14.2                         | nodejs-date-and-time: ReDoS                  |
|                           |                     |          |                   |                                | in parsing via date.compile                  |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-26289        |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| debug                     | CVE-2017-16137      | MEDIUM   | 2.2.0             | 3.1.0, 2.6.9                   | nodejs-debug: Regular                        |
|                           |                     |          |                   |                                | expression Denial of Service                 |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2017-16137        |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| diff                      | GHSA-h6ch-v84p-w6p9 | HIGH     | 1.4.0             | 3.5.0                          | Regular Expression Denial of Service (ReDoS) |
|                           |                     |          |                   |                                | -->github.com/advisories/GHSA-h6ch-v84p-w6p9 |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| growl                     | CVE-2017-16042      | CRITICAL | 1.9.2             | 1.10.0                         | nodejs-growl: Does not                       |
|                           |                     |          |                   |                                | properly sanitize input                      |
|                           |                     |          |                   |                                | before passing it to exec                    |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2017-16042        |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| immer                     | CVE-2020-28477      | HIGH     | 1.10.0            | 8.0.1                          | nodejs-immer: prototype pollution may        |
|                           |                     |          |                   |                                | lead to DoS or remote code execution         |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-28477        |
+---------------------------+---------------------+          +-------------------+--------------------------------+----------------------------------------------+
| is-svg                    | CVE-2021-28092      |          | 3.0.0             | 4.2.2                          | nodejs-is-svg: ReDoS                         |
|                           |                     |          |                   |                                | via malicious string                         |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-28092        |
+---------------------------+---------------------+          +-------------------+--------------------------------+----------------------------------------------+
| jspdf                     | CVE-2021-23353      |          | 2.1.0             | 2.3.1                          | Regular Expression                           |
|                           |                     |          |                   |                                | Denial of Service (ReDoS)                    |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-23353        |
+---------------------------+---------------------+          +-------------------+--------------------------------+----------------------------------------------+
| lodash                    | CVE-2020-8203       |          | 4.17.15           | 4.17.19                        | nodejs-lodash: prototype pollution           |
|                           |                     |          |                   |                                | in zipObjectDeep function                    |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-8203         |
+                           +---------------------+          +                   +--------------------------------+----------------------------------------------+
|                           | NSWG-ECO-516        |          |                   | >=4.17.19                      | Allocation of Resources                      |
|                           |                     |          |                   |                                | Without Limits or Throttling                 |
|                           |                     |          |                   |                                | -->www.npmjs.com/advisories/1523             |
+---------------------------+---------------------+          +-------------------+--------------------------------+----------------------------------------------+
| minimatch                 | CVE-2016-10540      |          | 0.3.0             | 3.0.2                          | Regular Expression Denial                    |
|                           |                     |          |                   |                                | of Service in minimatch                      |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2016-10540        |
+                           +---------------------+          +                   +--------------------------------+----------------------------------------------+
|                           | NSWG-ECO-118        |          |                   | >=3.0.2                        | Regular Expression Denial of                 |
|                           |                     |          |                   |                                | Service                                      |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| minimist                  | CVE-2020-7598       | MEDIUM   | 0.0.8             | 1.2.3, 0.2.1                   | nodejs-minimist: prototype                   |
|                           |                     |          |                   |                                | pollution allows adding                      |
|                           |                     |          |                   |                                | or modifying properties of                   |
|                           |                     |          |                   |                                | Object.prototype using a...                  |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-7598         |
+                           +---------------------+          +                   +--------------------------------+----------------------------------------------+
|                           | GHSA-7fhm-mqm4-2wp7 |          |                   | 0.2.1                          | Withdrawn: ESLint dependencies are           |
|                           |                     |          |                   |                                | vulnerable (ReDoS and Prototype Pollution)   |
|                           |                     |          |                   |                                | -->github.com/advisories/GHSA-7fhm-mqm4-2wp7 |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| node-forge                | CVE-2020-7720       | HIGH     | 0.8.5             | 0.10.0                         | nodejs-node-forge:                           |
|                           |                     |          |                   |                                | prototype pollution via                      |
|                           |                     |          |                   |                                | the util.setPath function                    |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-7720         |
+---------------------------+---------------------+          +-------------------+--------------------------------+----------------------------------------------+
| prismjs                   | CVE-2021-23341      |          | 1.22.0            | 1.23.0                         | nodejs-prismjs: Regular                      |
|                           |                     |          |                   |                                | expression denial of service                 |
|                           |                     |          |                   |                                | via prism-asciidoc prism-rest                |
|                           |                     |          |                   |                                | prism-tap and prism-eiffel...                |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-23341        |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| react-dev-utils           | CVE-2021-24033      | MEDIUM   | 10.2.1            | 11.0.4                         | nodejs-react-dev-utils: function             |
|                           |                     |          |                   |                                | getProcessForPort concatenates               |
|                           |                     |          |                   |                                | input argument into a command string         |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-24033        |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| serialize-javascript      | CVE-2020-7660       | HIGH     | 2.1.2             | 3.1.0                          | npm-serialize-javascript:                    |
|                           |                     |          |                   |                                | allows remote attackers to                   |
|                           |                     |          |                   |                                | inject arbitrary code via the                |
|                           |                     |          |                   |                                | function deleteFunctions...                  |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-7660         |
+---------------------------+---------------------+          +-------------------+--------------------------------+----------------------------------------------+
| ssri                      | CVE-2021-27290      |          | 6.0.1             | 8.0.1, 6.0.2                   | nodejs-ssri: Regular expression              |
|                           |                     |          |                   |                                | DoS (ReDoS) when parsing                     |
|                           |                     |          |                   |                                | malicious SRI in strict mode...              |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-27290        |
+                           +                     +          +-------------------+                                +                                              +
|                           |                     |          | 8.0.0             |                                |                                              |
|                           |                     |          |                   |                                |                                              |
|                           |                     |          |                   |                                |                                              |
|                           |                     |          |                   |                                |                                              |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| xmldom                    | CVE-2021-21366      | MEDIUM   | 0.1.27            | 0.5.0                          | Misinterpretation of                         |
|                           |                     |          |                   |                                | malicious XML input                          |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2021-21366        |
+                           +                     +          +-------------------+                                +                                              +
|                           |                     |          | 0.4.0             |                                |                                              |
|                           |                     |          |                   |                                |                                              |
|                           |                     |          |                   |                                |                                              |
+                           +                     +          +-------------------+                                +                                              +
|                           |                     |          | 0.1.31            |                                |                                              |
|                           |                     |          |                   |                                |                                              |
|                           |                     |          |                   |                                |                                              |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| y18n                      | CVE-2020-7774       | HIGH     | 3.2.1             | 5.0.5, 4.0.1, 3.2.2            | nodejs-y18n: prototype                       |
|                           |                     |          |                   |                                | pollution vulnerability                      |
|                           |                     |          |                   |                                | -->avd.aquasec.com/nvd/cve-2020-7774         |
+                           +                     +          +-------------------+                                +                                              +
|                           |                     |          | 4.0.0             |                                |                                              |
|                           |                     |          |                   |                                |                                              |
|                           |                     |          |                   |                                |                                              |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
| yargs-parser              | GHSA-p9pc-299p-vxgp | LOW      | 3.2.0             | 5.0.0-security.0, 13.1.2,      | Prototype Pollution in yargs-parser          |
|                           |                     |          |                   | 18.1.2, 15.0.1                 | -->github.com/advisories/GHSA-p9pc-299p-vxgp |
+---------------------------+---------------------+----------+-------------------+--------------------------------+----------------------------------------------+
```

</details>

You can reproduce these results by running the following commands in the backstage repository. You need [trivy](https://github.com/aquasecurity/trivy) installed locally.

```sh
git checkout master
yarn
yarn docker-build
trivy docker.io/library/example-backend
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
