### PR TITLE
System diagram improvements

### DIFF
--- a/.changeset/healthy-stingrays-shout.md
+++ b/.changeset/healthy-stingrays-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+SystemDiagramCard UI improvements

--- a/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.test.tsx
+++ b/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.test.tsx
@@ -62,9 +62,9 @@ describe('<SystemDiagramCard />', () => {
     );
 
     expect(queryByText(/System Diagram/)).toBeInTheDocument();
-    expect(queryByText(/system:my-namespace2\/my-system2/)).toBeInTheDocument();
+    expect(queryByText(/my-namespace2\/my-system2/)).toBeInTheDocument();
     expect(
-      queryByText(/component:my-namespace\/my-entity/),
+      queryByText(/my-namespace\/my-entity/),
     ).not.toBeInTheDocument();
   });
 
@@ -118,7 +118,7 @@ describe('<SystemDiagramCard />', () => {
     );
 
     expect(getByText('System Diagram')).toBeInTheDocument();
-    expect(getByText('system:my-namespace/my-system')).toBeInTheDocument();
-    expect(getByText('component:my-namespace/my-entity')).toBeInTheDocument();
+    expect(getByText('my-namespace/my-system')).toBeInTheDocument();
+    expect(getByText('my-namespace/my-entity')).toBeInTheDocument();
   });
 });

--- a/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.test.tsx
+++ b/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.test.tsx
@@ -19,6 +19,7 @@ import {
   catalogApiRef,
   CatalogApi,
   EntityProvider,
+  entityRouteRef,
 } from '@backstage/plugin-catalog-react';
 import { Entity, RELATION_PART_OF } from '@backstage/catalog-model';
 import { renderInTestApp } from '@backstage/test-utils';
@@ -59,6 +60,11 @@ describe('<SystemDiagramCard />', () => {
           <SystemDiagramCard />
         </EntityProvider>
       </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
     );
 
     expect(queryByText(/System Diagram/)).toBeInTheDocument();
@@ -113,6 +119,11 @@ describe('<SystemDiagramCard />', () => {
           <SystemDiagramCard />
         </EntityProvider>
       </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
     );
 
     expect(getByText('System Diagram')).toBeInTheDocument();

--- a/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.test.tsx
+++ b/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.test.tsx
@@ -63,9 +63,7 @@ describe('<SystemDiagramCard />', () => {
 
     expect(queryByText(/System Diagram/)).toBeInTheDocument();
     expect(queryByText(/my-namespace2\/my-system2/)).toBeInTheDocument();
-    expect(
-      queryByText(/my-namespace\/my-entity/),
-    ).not.toBeInTheDocument();
+    expect(queryByText(/my-namespace\/my-entity/)).not.toBeInTheDocument();
   });
 
   it('shows related systems', async () => {

--- a/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
+++ b/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
@@ -25,7 +25,7 @@ import {
 } from '@backstage/catalog-model';
 import {
   catalogApiRef,
-  entityRoute,
+  entityRouteRef,
   getEntityRelations,
   useEntity,
 } from '@backstage/plugin-catalog-react';
@@ -37,13 +37,13 @@ import {
   useApi,
   ResponseErrorPanel,
   Link,
+  useRouteRef,
 } from '@backstage/core';
 import { Box, makeStyles, Typography } from '@material-ui/core';
 import ZoomOutMap from '@material-ui/icons/ZoomOutMap';
 import React from 'react';
 import { useAsync } from 'react-use';
 import { BackstageTheme } from '@backstage/theme';
-import { generatePath } from 'react-router';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   domainNode: {
@@ -86,6 +86,7 @@ function readableEntityName(
 
 function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
   const classes = useStyles();
+  const catalogEntityRoute = useRouteRef(entityRouteRef);
   const kind = props.node.kind || 'Component';
   const ref = parseEntityRef(props.node.id);
   let nodeClass = classes.componentNode;
@@ -114,7 +115,7 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
     <g>
       <rect width={200} height={100} rx={20} className={nodeClass} />
       <Link
-        to={generatePath(`/catalog/${entityRoute.path}`, {
+        to={catalogEntityRoute({
           kind: kind,
           namespace: ref.namespace,
           name: ref.name,

--- a/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
+++ b/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
@@ -20,6 +20,7 @@ import {
   RELATION_PROVIDES_API,
   RELATION_PART_OF,
   serializeEntityRef,
+  ENTITY_DEFAULT_NAMESPACE,
 } from '@backstage/catalog-model';
 import {
   catalogApiRef,
@@ -71,7 +72,10 @@ export function SystemDiagramCard() {
     return catalogApi.getEntities({
       filter: {
         kind: ['Component', 'API', 'Resource', 'System', 'Domain'],
-        'spec.system': currentSystemName,
+        'spec.system': [
+          currentSystemName,
+          `${ENTITY_DEFAULT_NAMESPACE}/${currentSystemName}`,
+        ],
       },
     });
   }, [catalogApi, currentSystemName]);


### PR DESCRIPTION
## :wave:  Hey, I just made a Pull Request!

In this PR, I address an issue preventing the `SystemDiagramCard` from displaying the full diagram of a system when the system and its component are defined in different namespaces, and updated the diagram itself to have different node colors based on the entity type as well as making the node name link to the entity it represents.

Here is an example of how it looks like:

![Screenshot_2021-04-17 warf-system Diagram Backstage](https://user-images.githubusercontent.com/66958/115128882-3cb6c100-9fe1-11eb-9287-61b26b617d39.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
