### PR TITLE
allow the configuration of the refresh loop period

### DIFF
--- a/.changeset/metal-wasps-return.md
+++ b/.changeset/metal-wasps-return.md
@@ -1,0 +1,6 @@
+---
+'example-backend': patch
+'@backstage/create-app': patch
+---
+
+allow the configuration of the refresh loop period

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -34,9 +34,15 @@ export default async function createPlugin(
     locationAnalyzer,
   } = await builder.build();
 
+  const refreshLoopMs =
+    env.config.getOptionalNumber('backend.refreshLoopMs') || 100000;
+
   useHotCleanup(
     module,
-    runPeriodically(() => higherOrderOperation.refreshAllLocations(), 100000),
+    runPeriodically(
+      () => higherOrderOperation.refreshAllLocations(),
+      refreshLoopMs,
+    ),
   );
 
   return await createRouter({

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/catalog.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/catalog.ts
@@ -16,9 +16,15 @@ export default async function createPlugin(env: PluginEnvironment): Promise<Rout
     locationAnalyzer,
   } = await builder.build();
 
+  const refreshLoopMs =
+    env.config.getOptionalNumber('backend.refreshLoopMs') || 100000;
+
   useHotCleanup(
     module,
-    runPeriodically(() => higherOrderOperation.refreshAllLocations(), 100000),
+    runPeriodically(
+      () => higherOrderOperation.refreshAllLocations(),
+      refreshLoopMs,
+    ),
   );
 
   return await createRouter({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change enables the ability to configure the refresh period
as suggested by the documentation for github discovery

  https://backstage.io/docs/integrations/github/discovery

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
