### PR TITLE
Wrap EmptyState in a Card

### DIFF
--- a/.changeset/empty-lizards-doubt.md
+++ b/.changeset/empty-lizards-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-actions': patch
+---
+
+Wrap EmptyState in Card

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -25,14 +25,7 @@ import {
 } from '@backstage/core';
 import { readGitHubIntegrationConfigs } from '@backstage/integration';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Divider,
-  Link,
-} from '@material-ui/core';
+import { Button, Link } from '@material-ui/core';
 import React, { useEffect } from 'react';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
 import { GITHUB_ACTIONS_ANNOTATION } from '../useProjectName';
@@ -82,26 +75,22 @@ export const RecentWorkflowRunsCard = ({
   const githubHost = hostname || 'github.com';
 
   return !runs.length ? (
-    <Card>
-      <CardHeader title="Recent Workflow Runs" />
-      <Divider />
-      <CardContent>
-        <EmptyState
-          missing="data"
-          title="No Workflow Data"
-          description="This component has GitHub Actions enabled, but no data was found. Have you created any Workflows? Click the button below to create a new Workflow."
-          action={
-            <Button
-              variant="contained"
-              color="primary"
-              href={`https://${githubHost}/${owner}/${repo}/actions/new`}
-            >
-              Create new Workflow
-            </Button>
-          }
-        />
-      </CardContent>
-    </Card>
+    <InfoCard title="Recent Workflow Runs" variant={variant}>
+      <EmptyState
+        missing="data"
+        title="No Workflow Data"
+        description="This component has GitHub Actions enabled, but no data was found. Have you created any Workflows? Click the button below to create a new Workflow."
+        action={
+          <Button
+            variant="contained"
+            color="primary"
+            href={`https://${githubHost}/${owner}/${repo}/actions/new`}
+          >
+            Create new Workflow
+          </Button>
+        }
+      />
+    </InfoCard>
   ) : (
     <InfoCard
       title="Recent Workflow Runs"

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -16,21 +16,21 @@
 import { Entity } from '@backstage/catalog-model';
 import {
   configApiRef,
-  EmptyState,
   errorApiRef,
   InfoCard,
   InfoCardVariants,
+  Link,
   Table,
   useApi,
 } from '@backstage/core';
 import { readGitHubIntegrationConfigs } from '@backstage/integration';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { Button, Link } from '@material-ui/core';
 import React, { useEffect } from 'react';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
 import { GITHUB_ACTIONS_ANNOTATION } from '../useProjectName';
 import { useWorkflowRuns } from '../useWorkflowRuns';
 import { WorkflowRunStatus } from '../WorkflowRunStatus';
+import { Typography } from '@material-ui/core';
 
 const firstLine = (message: string): string => message.split('\n')[0];
 
@@ -74,56 +74,53 @@ export const RecentWorkflowRunsCard = ({
 
   const githubHost = hostname || 'github.com';
 
-  return !runs.length ? (
-    <InfoCard title="Recent Workflow Runs" variant={variant}>
-      <EmptyState
-        missing="data"
-        title="No Workflow Data"
-        description="This component has GitHub Actions enabled, but no data was found. Have you created any Workflows? Click the button below to create a new Workflow."
-        action={
-          <Button
-            variant="contained"
-            color="primary"
-            href={`https://${githubHost}/${owner}/${repo}/actions/new`}
-          >
-            Create new Workflow
-          </Button>
-        }
-      />
-    </InfoCard>
-  ) : (
+  return (
     <InfoCard
       title="Recent Workflow Runs"
       subheader={branch ? `Branch: ${branch}` : 'All Branches'}
       noPadding
       variant={variant}
     >
-      <Table
-        isLoading={loading}
-        options={{
-          search: false,
-          paging: false,
-          padding: dense ? 'dense' : 'default',
-          toolbar: false,
-        }}
-        columns={[
-          {
-            title: 'Commit Message',
-            field: 'message',
-            render: data => (
-              <Link
-                component={RouterLink}
-                to={generatePath('./ci-cd/:id', { id: data.id! })}
-              >
-                {firstLine(data.message)}
-              </Link>
-            ),
-          },
-          { title: 'Branch', field: 'source.branchName' },
-          { title: 'Status', field: 'status', render: WorkflowRunStatus },
-        ]}
-        data={runs}
-      />
+      {!runs.length ? (
+        <div style={{ textAlign: 'center' }}>
+          <Typography variant="body1">
+            This component has GitHub Actions enabled, but no workflows were
+            found.
+          </Typography>
+          <Typography variant="body2">
+            <Link to={`https://${githubHost}/${owner}/${repo}/actions/new`}>
+              Create a new workflow
+            </Link>
+          </Typography>
+        </div>
+      ) : (
+        <Table
+          isLoading={loading}
+          options={{
+            search: false,
+            paging: false,
+            padding: dense ? 'dense' : 'default',
+            toolbar: false,
+          }}
+          columns={[
+            {
+              title: 'Commit Message',
+              field: 'message',
+              render: data => (
+                <Link
+                  component={RouterLink}
+                  to={generatePath('./ci-cd/:id', { id: data.id! })}
+                >
+                  {firstLine(data.message)}
+                </Link>
+              ),
+            },
+            { title: 'Branch', field: 'source.branchName' },
+            { title: 'Status', field: 'status', render: WorkflowRunStatus },
+          ]}
+          data={runs}
+        />
+      )}
     </InfoCard>
   );
 };

--- a/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
+++ b/plugins/github-actions/src/components/Cards/RecentWorkflowRunsCard.tsx
@@ -25,7 +25,14 @@ import {
 } from '@backstage/core';
 import { readGitHubIntegrationConfigs } from '@backstage/integration';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { Button, Link } from '@material-ui/core';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  Link,
+} from '@material-ui/core';
 import React, { useEffect } from 'react';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
 import { GITHUB_ACTIONS_ANNOTATION } from '../useProjectName';
@@ -75,20 +82,26 @@ export const RecentWorkflowRunsCard = ({
   const githubHost = hostname || 'github.com';
 
   return !runs.length ? (
-    <EmptyState
-      missing="data"
-      title="No Workflow Data"
-      description="This component has GitHub Actions enabled, but no data was found. Have you created any Workflows? Click the button below to create a new Workflow."
-      action={
-        <Button
-          variant="contained"
-          color="primary"
-          href={`https://${githubHost}/${owner}/${repo}/actions/new`}
-        >
-          Create new Workflow
-        </Button>
-      }
-    />
+    <Card>
+      <CardHeader title="Recent Workflow Runs" />
+      <Divider />
+      <CardContent>
+        <EmptyState
+          missing="data"
+          title="No Workflow Data"
+          description="This component has GitHub Actions enabled, but no data was found. Have you created any Workflows? Click the button below to create a new Workflow."
+          action={
+            <Button
+              variant="contained"
+              color="primary"
+              href={`https://${githubHost}/${owner}/${repo}/actions/new`}
+            >
+              Create new Workflow
+            </Button>
+          }
+        />
+      </CardContent>
+    </Card>
   ) : (
     <InfoCard
       title="Recent Workflow Runs"


### PR DESCRIPTION
This prevents it overflowing onto subsequent content

## Hey, I just made a Pull Request!

When there are no actions defined for a project, the EmptyState component content overflowed on top of the next component (a README in this case:
![Screenshot 2021-04-19 at 14 05 01](https://user-images.githubusercontent.com/57419/115271260-0c803700-a135-11eb-8921-d0a066e0195f.png)

~~This PR wraps it in a Card which cuts the bottom of the image off~~

This PR removes the use of EmptyState and just includes the info in text in the InfoCard
<img width="784" alt="Screenshot 2021-04-26 at 18 03 16" src="https://user-images.githubusercontent.com/57419/116122610-eec54b80-a6b9-11eb-822f-59e7643e540e.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
