### PR TITLE
core-api: Add cloud icon to system icon list

### DIFF
--- a/.changeset/stupid-queens-rest.md
+++ b/.changeset/stupid-queens-rest.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-api': patch
+---
+
+Adds a cloud icon to the system icon list.
+
+This icon is then displayed with components such as the `EntityLinksCard`.

--- a/packages/core-api/src/icons/icons.tsx
+++ b/packages/core-api/src/icons/icons.tsx
@@ -26,6 +26,7 @@ import MuiPeopleIcon from '@material-ui/icons/People';
 import MuiPersonIcon from '@material-ui/icons/Person';
 import MuiWarningIcon from '@material-ui/icons/Warning';
 import MuiDocsIcon from '@material-ui/icons/Description';
+import MuiCloudIcon from '@material-ui/icons/Cloud';
 
 import React from 'react';
 import { useApp } from '../app/AppContext';
@@ -44,6 +45,7 @@ export const defaultSystemIcons: IconComponentMap = {
   user: MuiPersonIcon,
   warning: MuiWarningIcon,
   docs: MuiDocsIcon,
+  cloud: MuiCloudIcon,
 };
 
 const overridableSystemIcon = (key: SystemIconKey): IconComponent => {
@@ -65,3 +67,4 @@ export const HelpIcon = overridableSystemIcon('help');
 export const UserIcon = overridableSystemIcon('user');
 export const WarningIcon = overridableSystemIcon('warning');
 export const DocsIcon = overridableSystemIcon('docs');
+export const CloudIcon = overridableSystemIcon('cloud');

--- a/packages/core-api/src/icons/types.ts
+++ b/packages/core-api/src/icons/types.ts
@@ -27,7 +27,8 @@ export type SystemIconKey =
   | 'help'
   | 'user'
   | 'warning'
-  | 'docs';
+  | 'docs'
+  | 'cloud';
 
 export type IconComponent = ComponentType<SvgIconProps>;
 export type IconKey = SystemIconKey | string;


### PR DESCRIPTION
Signed-off-by: Adam Harvey <adaharve@cisco.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Adds a cloud icon to the core system icons list. As a feature request, this cloud icon is now available throughout the system.

I noticed this because of the sample data. This essentially fixes some sample entity metadata which displays in the Links card saying it has a cloud icon, even though it defaults back to web site.

| Before | After |
| --- | --- |
| <img width="416" alt="image" src="https://user-images.githubusercontent.com/33203301/115452674-b8d12480-a1ec-11eb-8b4f-1ddaba2d9ea6.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/33203301/115452637-a8b94500-a1ec-11eb-8df0-b0c82de43d73.png"> |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
