### PR TITLE
allow import from HTTP repositories

### DIFF
--- a/.changeset/giant-onions-obey.md
+++ b/.changeset/giant-onions-obey.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+allow import from HTTP repositories

--- a/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.test.tsx
+++ b/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.test.tsx
@@ -127,7 +127,9 @@ describe('<StepInitAnalyzeUrl />', () => {
     expect(catalogImportApi.analyzeUrl).toBeCalledTimes(0);
     expect(onAnalysisFn).toBeCalledTimes(0);
     expect(errorApi.post).toBeCalledTimes(0);
-    expect(getByText('Must start with https://.')).toBeInTheDocument();
+    expect(
+      getByText('Must start with http:// or https://.'),
+    ).toBeInTheDocument();
   });
 
   it('should analyze single location', async () => {

--- a/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
+++ b/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
@@ -132,8 +132,8 @@ export const StepInitAnalyzeUrl = ({
           validate: {
             httpsValidator: (value: any) =>
               (typeof value === 'string' &&
-                value.match(/^https:\/\//) !== null) ||
-              'Must start with https://.',
+                value.match(/^http[s]?:\/\//) !== null) ||
+              'Must start with http:// or https://.',
           },
         })}
         required


### PR DESCRIPTION
## Allow importing from http git repositories

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

We use a private instance of Gitlab which is not yet protected by the HTTPS protocol. By changing this line, it is possible to import from these instances.

![image](https://user-images.githubusercontent.com/7511692/115472190-c055f500-a20f-11eb-97e3-18099391de71.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
