### PR TITLE
core-api: fixed confusion around wrong error thrown from routable extensions

### DIFF
--- a/.changeset/strong-houses-lick.md
+++ b/.changeset/strong-houses-lick.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-api': patch
+'@backstage/core': patch
+---
+
+Fixed a potentially confusing error being thrown about misuse of routable extensions where the error was actually something different.

--- a/packages/core-api/src/extensions/extensions.tsx
+++ b/packages/core-api/src/extensions/extensions.tsx
@@ -47,12 +47,15 @@ export function createRoutableExtension<
               // Validate that the routing is wired up correctly in the App.tsx
               try {
                 useRouteRef(mountPoint);
-              } catch {
-                throw new Error(
-                  `Routable extension component with mount point ${mountPoint} was not discovered in the app element tree. ` +
-                    'Routable extension components may not be rendered by other components and must be ' +
-                    'directly available as an element within the App provider component.',
-                );
+              } catch (error) {
+                if (error?.message.startsWith('No path for ')) {
+                  throw new Error(
+                    `Routable extension component with mount point ${mountPoint} was not discovered in the app element tree. ` +
+                      'Routable extension components may not be rendered by other components and must be ' +
+                      'directly available as an element within the App provider component.',
+                  );
+                }
+                throw error;
               }
               return <InnerComponent {...props} />;
             };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes the confusion around the error seen in https://github.com/alzafacon/standalone-plugin-bug-repro

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
