### PR TITLE
Expose the list of default catalog processors

### DIFF
--- a/.changeset/fuzzy-cheetahs-drop.md
+++ b/.changeset/fuzzy-cheetahs-drop.md
@@ -1,0 +1,24 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Expose a list of the default processors to enable fine-grained configuration
+
+You can now use the exposed method `defaultProcessors(env:CatalogEnvironment):CatalogProcessor[]`
+when you need to configure one of the default catalog processors, but still want
+to enable all default processors without explicitly initiate them.
+
+```typescript
+const builder = new CatalogBuilder(env);
+const processors = defaultProcessors(env);
+
+// Replace or change one or several of the default processors
+
+builder.replaceProcessors(processors);
+// ...
+const {
+  entitiesCatalog,
+  locationsCatalog,
+  higherOrderOperation,
+} = await builder.build();
+```

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -282,8 +282,7 @@ export class CatalogBuilder {
   }
 
   private buildProcessors(): CatalogProcessor[] {
-    const { config, logger, reader } = this.env;
-    const integrations = ScmIntegrations.fromConfig(config);
+    const { config, reader } = this.env;
 
     this.checkDeprecatedReaderProcessors();
 
@@ -303,18 +302,7 @@ export class CatalogBuilder {
 
     // These are only added unless the user replaced them all
     if (!this.processorsReplace) {
-      processors.push(
-        new FileReaderProcessor(),
-        BitbucketDiscoveryProcessor.fromConfig(config, { logger }),
-        GithubDiscoveryProcessor.fromConfig(config, { logger }),
-        GithubOrgReaderProcessor.fromConfig(config, { logger }),
-        LdapOrgReaderProcessor.fromConfig(config, { logger }),
-        MicrosoftGraphOrgReaderProcessor.fromConfig(config, { logger }),
-        new UrlReaderProcessor({ reader, logger }),
-        CodeOwnersProcessor.fromConfig(config, { logger, reader }),
-        new LocationEntityProcessor({ integrations }),
-        new AnnotateLocationEntityProcessor({ integrations }),
-      );
+      processors.push(...defaultProcessors(this.env));
     }
 
     // Add the ones (if any) that the user added
@@ -348,4 +336,25 @@ export class CatalogBuilder {
       );
     }
   }
+}
+
+export function defaultProcessors(env: CatalogEnvironment): CatalogProcessor[] {
+  const { config, logger, reader } = env;
+  const integrations = ScmIntegrations.fromConfig(config);
+
+  const processors: CatalogProcessor[] = [];
+  processors.push(
+    new FileReaderProcessor(),
+    BitbucketDiscoveryProcessor.fromConfig(config, { logger }),
+    GithubDiscoveryProcessor.fromConfig(config, { logger }),
+    GithubOrgReaderProcessor.fromConfig(config, { logger }),
+    LdapOrgReaderProcessor.fromConfig(config, { logger }),
+    MicrosoftGraphOrgReaderProcessor.fromConfig(config, { logger }),
+    new UrlReaderProcessor({ reader, logger }),
+    CodeOwnersProcessor.fromConfig(config, { logger, reader }),
+    new LocationEntityProcessor({ integrations }),
+    new AnnotateLocationEntityProcessor({ integrations }),
+  );
+
+  return processors;
 }

--- a/plugins/catalog-backend/src/service/index.ts
+++ b/plugins/catalog-backend/src/service/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { CatalogBuilder } from './CatalogBuilder';
+export { CatalogBuilder, defaultProcessors } from './CatalogBuilder';
 export { createRouter } from './router';
 export type { RouterOptions } from './router';


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

## Hey, I just made a Pull Request!
This pull request exposes the list of default catalog processors for further fine-grained configuration.

```typescript
const builder = new CatalogBuilder(env);
const processors = defaultProcessors(env);

// Replace or change one or several of the default processors

builder.replaceProcessors(processors);
// ...
const {
  entitiesCatalog,
  locationsCatalog,
  higherOrderOperation,
} = await builder.build();
```

Fixes #5388

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
