### PR TITLE
[code-coverage] fix so tests work in windows

### DIFF
--- a/.changeset/rotten-cups-bow.md
+++ b/.changeset/rotten-cups-bow.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-code-coverage': patch
+'@backstage/plugin-code-coverage-backend': patch
+---
+
+Update tests to function in windows

--- a/plugins/code-coverage-backend/src/service/converter/cobertura.test.ts
+++ b/plugins/code-coverage-backend/src/service/converter/cobertura.test.ts
@@ -15,6 +15,7 @@
  */
 import { parseString } from 'xml2js';
 import fs from 'fs';
+import path from 'path';
 import { Cobertura } from './cobertura';
 import { CoberturaXML } from './types';
 import { getVoidLogger } from '@backstage/backend-common';
@@ -27,7 +28,12 @@ describe('convert cobertura', () => {
     let fixture: CoberturaXML;
     parseString(
       fs.readFileSync(
-        `${__dirname}/../__fixtures__/cobertura-testdata-${idx}.xml`,
+        path.resolve(
+          __dirname,
+          '..',
+          '__fixtures__',
+          `cobertura-testdata-${idx}.xml`,
+        ),
       ),
       (_e, r) => {
         fixture = r;
@@ -36,13 +42,23 @@ describe('convert cobertura', () => {
     const expected = JSON.parse(
       fs
         .readFileSync(
-          `${__dirname}/../__fixtures__/cobertura-jsoncoverage-files-${idx}.json`,
+          path.resolve(
+            __dirname,
+            '..',
+            '__fixtures__',
+            `cobertura-jsoncoverage-files-${idx}.json`,
+          ),
         )
         .toString(),
     );
     const scmFiles = fs
       .readFileSync(
-        `${__dirname}/../__fixtures__/cobertura-sourcefiles-${idx}.txt`,
+        path.resolve(
+          __dirname,
+          '..',
+          '__fixtures__',
+          `cobertura-sourcefiles-${idx}.txt`,
+        ),
       )
       .toString()
       .split('\n');

--- a/plugins/code-coverage-backend/src/service/converter/cobertura.ts
+++ b/plugins/code-coverage-backend/src/service/converter/cobertura.ts
@@ -62,7 +62,9 @@ export class Cobertura implements Converter {
         }
       });
 
-      const currentFile = scmFiles.find(f => f.endsWith(packageAndFilename));
+      const currentFile = scmFiles
+        .map(f => f.trimEnd())
+        .find(f => f.endsWith(packageAndFilename));
       this.logger.debug(`matched ${packageAndFilename} to ${currentFile}`);
       if (
         scmFiles.length === 0 ||

--- a/plugins/code-coverage-backend/src/service/converter/jacoco.test.ts
+++ b/plugins/code-coverage-backend/src/service/converter/jacoco.test.ts
@@ -15,6 +15,7 @@
  */
 import { parseString } from 'xml2js';
 import fs from 'fs';
+import path from 'path';
 import { Jacoco } from './jacoco';
 import { JacocoXML } from './types';
 import { getVoidLogger } from '@backstage/backend-common';
@@ -25,7 +26,9 @@ describe('convert jacoco', () => {
   const converter = new Jacoco(getVoidLogger());
   let fixture: JacocoXML;
   parseString(
-    fs.readFileSync(`${__dirname}/../__fixtures__/jacoco-testdata-1.xml`),
+    fs.readFileSync(
+      path.resolve(`${__dirname}/../__fixtures__/jacoco-testdata-1.xml`),
+    ),
     (_e, r) => {
       fixture = r;
     },
@@ -33,12 +36,16 @@ describe('convert jacoco', () => {
   const expected = JSON.parse(
     fs
       .readFileSync(
-        `${__dirname}/../__fixtures__/jacoco-jsoncoverage-files-1.json`,
+        path.resolve(
+          `${__dirname}/../__fixtures__/jacoco-jsoncoverage-files-1.json`,
+        ),
       )
       .toString(),
   );
   const scmFiles = fs
-    .readFileSync(`${__dirname}/../__fixtures__/jacoco-sourcefiles-1.txt`)
+    .readFileSync(
+      path.resolve(`${__dirname}/../__fixtures__/jacoco-sourcefiles-1.txt`),
+    )
     .toString()
     .split('\n');
 

--- a/plugins/code-coverage-backend/src/service/converter/jacoco.ts
+++ b/plugins/code-coverage-backend/src/service/converter/jacoco.ts
@@ -63,7 +63,9 @@ export class Jacoco implements Converter {
         });
 
         const packageAndFilename = `${packageName}/${fileName}`;
-        const currentFile = scmFiles.find(f => f.endsWith(packageAndFilename));
+        const currentFile = scmFiles
+          .map(f => f.trimEnd())
+          .find(f => f.endsWith(packageAndFilename));
         this.logger.debug(`matched ${packageAndFilename} to ${currentFile}`);
         if (Object.keys(lineHits).length > 0 && currentFile) {
           jscov.push({


### PR DESCRIPTION
Use path.resolve, and trim end of scmFiles

Signed-off-by: alde <r.dybeck@gmail.com>

## Hey, I just made a Pull Request!

Fixed so codeCoverage plugin tests don't fail on windows

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
