### PR TITLE
Add optional skipIfExists to builtin action github:publish

### DIFF
--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -43,7 +43,7 @@ export function createPublishGithubAction(options: {
     description?: string;
     access?: string;
     sourcePath?: string;
-    skipIfExists?: string;
+    skipIfExists?: boolean;
     repoVisibility: 'private' | 'internal' | 'public';
     collaborators: Collaborator[];
   }>({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -43,6 +43,7 @@ export function createPublishGithubAction(options: {
     description?: string;
     access?: string;
     sourcePath?: string;
+    skipIfExists?: string;
     repoVisibility: 'private' | 'internal' | 'public';
     collaborators: Collaborator[];
   }>({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -19,10 +19,7 @@ import {
   ScmIntegrationRegistry,
 } from '@backstage/integration';
 import { Octokit } from '@octokit/rest';
-import {
-  initRepoAndPush,
-  checkIfRepoExists,
-} from '../../../stages/publish/helpers';
+import { initRepoAndPush } from '../../../stages/publish/helpers';
 import { getRepoSourceDirectory, parseRepoUrl } from './util';
 import { createTemplateAction } from '../../createTemplateAction';
 
@@ -46,7 +43,6 @@ export function createPublishGithubAction(options: {
     description?: string;
     access?: string;
     sourcePath?: string;
-    skipIfExists?: boolean;
     repoVisibility: 'private' | 'internal' | 'public';
     collaborators: Collaborator[];
   }>({
@@ -79,11 +75,6 @@ export function createPublishGithubAction(options: {
             title:
               'Path within the workspace that will be used as the repository root. If omitted, the entire workspace will be published as the respository.',
             type: 'string',
-          },
-          skipIfExists: {
-            title:
-              'If the repository exists, skip this action without failing.',
-            type: 'boolean',
           },
           collaborators: {
             title: 'Collaborators',
@@ -223,29 +214,15 @@ export function createPublishGithubAction(options: {
       const remoteUrl = data.clone_url;
       const repoContentsUrl = `${data.html_url}/blob/master`;
 
-      let exists = false;
-      if (ctx.input.skipIfExists) {
-        exists = await checkIfRepoExists({
-          remoteUrl,
-          auth: {
-            username: 'x-access-token',
-            password: token,
-          },
-          logger: ctx.logger,
-        });
-      }
-
-      if (!exists) {
-        await initRepoAndPush({
-          dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
-          remoteUrl,
-          auth: {
-            username: 'x-access-token',
-            password: token,
-          },
-          logger: ctx.logger,
-        });
-      }
+      await initRepoAndPush({
+        dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
+        remoteUrl,
+        auth: {
+          username: 'x-access-token',
+          password: token,
+        },
+        logger: ctx.logger,
+      });
 
       ctx.output('remoteUrl', remoteUrl);
       ctx.output('repoContentsUrl', repoContentsUrl);

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
@@ -67,3 +67,29 @@ export async function initRepoAndPush({
     remote: 'origin',
   });
 }
+
+export async function checkIfRepoExists({
+  remoteUrl,
+  auth,
+  logger,
+}: {
+  remoteUrl: string;
+  auth: { username: string; password: string };
+  logger: Logger;
+}): Promise<boolean> {
+  const git = Git.fromAuth({
+    username: auth.username,
+    password: auth.password,
+    logger,
+  });
+  try {
+    await git.clone({ url: remoteUrl, dir: 'testClone' });
+    // no error - repository exists
+    return true;
+  } catch (error) {
+    if (error.data.statusCode === 404) {
+      return false;
+    }
+    throw error;
+  }
+}

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
@@ -67,29 +67,3 @@ export async function initRepoAndPush({
     remote: 'origin',
   });
 }
-
-export async function checkIfRepoExists({
-  remoteUrl,
-  auth,
-  logger,
-}: {
-  remoteUrl: string;
-  auth: { username: string; password: string };
-  logger: Logger;
-}): Promise<boolean> {
-  const git = Git.fromAuth({
-    username: auth.username,
-    password: auth.password,
-    logger,
-  });
-  try {
-    await git.clone({ url: remoteUrl, dir: 'testClone' });
-    // no error - repository exists
-    return true;
-  } catch (error) {
-    if (error.data.statusCode === 404) {
-      return false;
-    }
-    throw error;
-  }
-}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added an optional parameter to the github:publish builtin action called skipIfExists. This allows the action to check if the repository already exists before attempting to create it. If the user desires the job to fail if the repository already exists, they can leave this option blank, or set it false.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
