### PR TITLE
Fix owner references to guest user

### DIFF
--- a/.changeset/thirty-humans-knock.md
+++ b/.changeset/thirty-humans-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Improve owner example value in `MissingAnnotationEmptyState`.

--- a/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -30,7 +30,7 @@ metadata:
 spec:
   type: website
   lifecycle: production
-  owner: guest`;
+  owner: user:guest`;
 
 type Props = {
   annotation: string;

--- a/plugins/catalog-backend/src/ingestion/processors/util/parse.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/util/parse.test.ts
@@ -38,7 +38,7 @@ describe('parseEntityYaml', () => {
       spec:
         type: website
         lifecycle: production
-        owner: guest
+        owner: user:guest
     `,
           'utf8',
         ),
@@ -60,7 +60,7 @@ describe('parseEntityYaml', () => {
         spec: {
           type: 'website',
           lifecycle: 'production',
-          owner: 'guest',
+          owner: 'user:guest',
         },
       }),
     ]);

--- a/plugins/github-actions/README.md
+++ b/plugins/github-actions/README.md
@@ -30,7 +30,7 @@ TBD
    spec:
      type: website
      lifecycle: production
-     owner: guest
+     owner: user:guest
    ```
 
 ### Standalone app requirements

--- a/plugins/github-actions/examples/sample.yaml
+++ b/plugins/github-actions/examples/sample.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: website
   lifecycle: production
-  owner: guest
+  owner: user:guest

--- a/plugins/kubernetes-backend/examples/dice-roller/catalog-info.yaml
+++ b/plugins/kubernetes-backend/examples/dice-roller/catalog-info.yaml
@@ -10,4 +10,4 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: guest
+  owner: user:guest

--- a/plugins/scaffolder-backend/sample-templates/pull-request/template/catalog-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/pull-request/template/catalog-info.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   type: website
   lifecycle: experimental
-  owner: guest
+  owner: user:guest


### PR DESCRIPTION
If the user guest is used as an example value of the `owner` field, we should make sure to specify it as `user:guest` instead, as the default is `group`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
