### PR TITLE
Use `RouteRef` to generate path to search page

### DIFF
--- a/.changeset/sixty-dragons-retire.md
+++ b/.changeset/sixty-dragons-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Use `RouteRef` to generate path to search page.

--- a/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
+++ b/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useCallback } from 'react';
+import { SidebarSearchField, useRouteRef } from '@backstage/core';
 import qs from 'qs';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { SidebarSearchField } from '@backstage/core';
+import { rootRouteRef } from '../../plugin';
 
 export const SidebarSearch = () => {
+  const searchRoute = useRouteRef(rootRouteRef);
   const navigate = useNavigate();
   const handleSearch = useCallback(
     (query: string): void => {
       const queryString = qs.stringify({ query }, { addQueryPrefix: true });
 
-      // TODO: Here the url to the search plugin is hardcoded. We need a way to query the route in the future.
-      // Maybe an API that I can just call from other places?
-      navigate(`/search${queryString}`);
+      navigate(`${searchRoute()}${queryString}`);
     },
-    [navigate],
+    [navigate, searchRoute],
   );
 
   return <SidebarSearchField onSearch={handleSearch} to="/search" />;


### PR DESCRIPTION
Just came across an old TODO comment of mine, now that the composability is in place, we can fix this.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
