### PR TITLE
[Fixes 5420] Update component example in documentation

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -77,7 +77,7 @@ This is the same entity as returned in JSON from the software catalog API:
     "etag": "ZjU2MWRkZWUtMmMxZS00YTZiLWFmMWMtOTE1NGNiZDdlYzNk",
     "generation": 1,
     "labels": {
-      "backstage.io/custom": "ValueStuff"
+      "example.com/custom": "custom_label_value"
     },
     "links": [{
       "url": "https://admin.example-org.com",

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -44,7 +44,7 @@ metadata:
   name: artist-web
   description: The place to be, for great artists
   labels:
-    backstage.io/custom: ValueStuff
+    example.com/custom: custom_label_value
   annotations:
     example.com/service-discovery: artistweb
     circleci.com/project-slug: github/example-org/artist-website

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -44,7 +44,7 @@ metadata:
   name: artist-web
   description: The place to be, for great artists
   labels:
-    system: public-websites
+    backstage.io/custom: ValueStuff
   annotations:
     example.com/service-discovery: artistweb
     circleci.com/project-slug: github/example-org/artist-website
@@ -58,6 +58,7 @@ spec:
   type: website
   lifecycle: production
   owner: artist-relations-team
+  system: public-websites
 ```
 
 This is the same entity as returned in JSON from the software catalog API:
@@ -76,7 +77,7 @@ This is the same entity as returned in JSON from the software catalog API:
     "etag": "ZjU2MWRkZWUtMmMxZS00YTZiLWFmMWMtOTE1NGNiZDdlYzNk",
     "generation": 1,
     "labels": {
-      "system": "public-websites"
+      "backstage.io/custom": "ValueStuff"
     },
     "links": [{
       "url": "https://admin.example-org.com",
@@ -90,7 +91,8 @@ This is the same entity as returned in JSON from the software catalog API:
   "spec": {
     "lifecycle": "production",
     "owner": "artist-relations-team",
-    "type": "website"
+    "type": "website",
+    "system": "public-websites"
   }
 }
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Currently the entity component example towards the top of the page
has metadata.labels.system set
https://github.com/backstage/backstage/blame/master/docs/features/software-catalog/descriptor-format.md#L47
but further down on the page it's spec.system
https://github.com/backstage/backstage/blame/master/docs/features/software-catalog/descriptor-format.md#L423.

This updates them to both use the correct spec.system key/value,
as well as add an example label to get a sense for what labels
look like as well

Signed-off-by: jrusso1020 <jrusso@brex.com>

Fixes #5420 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
<img width="980" alt="Screen Shot 2021-04-22 at 9 29 43 AM" src="https://user-images.githubusercontent.com/7664106/115741882-2486cf00-a35e-11eb-85f1-d6ed2f0b3580.png">

<img width="1002" alt="Screen Shot 2021-04-22 at 9 29 49 AM" src="https://user-images.githubusercontent.com/7664106/115741813-1173ff00-a35e-11eb-9f07-755bec562d5a.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

