### PR TITLE
Update nginx deployment to use 1.19 features

### DIFF
--- a/contrib/docker/frontend-with-nginx/Dockerfile.dockerbuild
+++ b/contrib/docker/frontend-with-nginx/Dockerfile.dockerbuild
@@ -51,9 +51,8 @@ FROM nginx:mainline
 RUN apt-get update && apt-get -y install jq && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/packages/app/dist /usr/share/nginx/html
-COPY docker/default.conf.template /etc/nginx/conf.d/default.conf.template
-COPY docker/run.sh /usr/local/bin/run.sh
+COPY docker/default.conf.template /etc/nginx/templates/default.conf.template
 
-CMD run.sh
+COPY docker/inject-config.sh /docker-entrypoint.d/40-inject-config.sh
 
 ENV PORT 80

--- a/contrib/docker/frontend-with-nginx/Dockerfile.hostbuild
+++ b/contrib/docker/frontend-with-nginx/Dockerfile.hostbuild
@@ -33,9 +33,9 @@ FROM nginx:mainline
 RUN apt-get update && apt-get -y install jq && rm -rf /var/lib/apt/lists/*
 
 COPY packages/app/dist /usr/share/nginx/html
-COPY docker/default.conf.template /etc/nginx/conf.d/default.conf.template
-COPY docker/run.sh /usr/local/bin/run.sh
+COPY docker/default.conf.template /etc/nginx/templates/default.conf.template
 
-CMD run.sh
+COPY docker/inject-config.sh /docker-entrypoint.d/40-inject-config.sh
 
 ENV PORT 80
+

--- a/contrib/docker/frontend-with-nginx/docker/inject-config.sh
+++ b/contrib/docker/frontend-with-nginx/docker/inject-config.sh
@@ -2,13 +2,6 @@
 
 set -Eeuo pipefail
 
-# Run nginx as root
-sed -i 's/user  nginx.*$//' /etc/nginx/nginx.conf
-
-# Write selected env vars to nginx config
-envsubst '$PORT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
-
-# Inject runtime config into the client
 function inject_config() {
   # Read runtime config from env in the same way as the @backstage/config-loader package
   local config
@@ -41,4 +34,3 @@ function inject_config() {
 
 inject_config
 
-exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Given that the nginx frontend example makes use of `nginx:mainline` I thought I'd update it to use some of the newer _features_  available. 

- There is no need to override the `CMD` on the base image to get the custom scripts to run. This can be done simply by adding the custom configuration script to the `/docker-entrypoint.d` folder. See https://github.com/nginxinc/docker-nginx/blob/master/mainline/debian/docker-entrypoint.sh.
- With the above change made, we can now also reap the benefit of support for `envsubst` having been added in 1.19 -  as long as the config is placed in the folder `/etc/nginx/templates/`. See https://github.com/docker-library/docs/tree/master/nginx#using-environment-variables-in-nginx-configuration-new-in-119 and https://github.com/nginxinc/docker-nginx/blob/master/mainline/debian/20-envsubst-on-templates.sh for more info.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info]())
