### PR TITLE
Fix typo in basic k8s example

### DIFF
--- a/contrib/kubernetes/basic_kubernetes_example_with_helm/backstage/templates/service.yaml
+++ b/contrib/kubernetes/basic_kubernetes_example_with_helm/backstage/templates/service.yaml
@@ -16,7 +16,7 @@ spec:
     app.kubernetes.io/name: {{ include "backstage.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-{{- if .Values.app.enabled }}
+{{- if .Values.backend.enabled }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Simple typo fix - backend service should be conditionally enabled based on `.Values.backend.enabled` not `.Values.app.enabled`.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
