### PR TITLE
Filter returned fields in apis explorer

### DIFF
--- a/.changeset/kind-suns-melt.md
+++ b/.changeset/kind-suns-melt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Added fields filtering in get API entities to avoid the requesting of unused data

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
@@ -34,7 +34,19 @@ export const ApiExplorerPage = () => {
   const createComponentLink = useRouteRef(createComponentRouteRef);
   const catalogApi = useApi(catalogApiRef);
   const { loading, error, value: catalogResponse } = useAsync(() => {
-    return catalogApi.getEntities({ filter: { kind: 'API' } });
+    return catalogApi.getEntities({
+      filter: { kind: 'API' },
+      fields: [
+        'apiVersion',
+        'kind',
+        'metadata',
+        'relations',
+        'spec.lifecycle',
+        'spec.owner',
+        'spec.type',
+        'spec.system',
+      ],
+    });
   }, [catalogApi]);
 
   return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed return of unused `spec.definition` on API explorer page

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
