### PR TITLE
cost insights: make change.ratio optional

### DIFF
--- a/.changeset/cost-insights-five-baboons-attack.md
+++ b/.changeset/cost-insights-five-baboons-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': minor
+---
+
+make change ratio optional

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowth.test.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowth.test.tsx
@@ -46,6 +46,7 @@ describe.each`
   engineerCost | ratio           | amount     | expected
   ${200_000}   | ${0}            | ${0}       | ${'Negligible'}
   ${200_000}   | ${0}            | ${8_333}   | ${'Negligible'}
+  ${200_000}   | ${undefined}    | ${10_000}  | ${`~1 ${engineers.unit}`}
   ${200_000}   | ${0.000000001}  | ${8_334}   | ${`0% or ~1 ${engineers.unit}`}
   ${200_000}   | ${-0.000000001} | ${10_000}  | ${`0% or ~1 ${engineers.unit}`}
   ${200_000}   | ${-0.8}         | ${10_000}  | ${`80% or ~1 ${engineers.unit}`}
@@ -65,6 +66,9 @@ describe.each`
   engineerCost | ratio           | amount     | expected
   ${200_000}   | ${0}            | ${0}       | ${'Negligible'}
   ${200_000}   | ${0}            | ${8_333}   | ${'Negligible'}
+  ${200_000}   | ${undefined}    | ${-1_000}  | ${'Negligible'}
+  ${200_000}   | ${undefined}    | ${1_000}   | ${'Negligible'}
+  ${200_000}   | ${undefined}    | ${10_000}  | ${'~$10,000'}
   ${200_000}   | ${0.000000001}  | ${8_334}   | ${'0% or ~$8,334'}
   ${200_000}   | ${-0.000000001} | ${10_000}  | ${'0% or ~$10,000'}
   ${200_000}   | ${-0.8}         | ${10_000}  | ${'80% or ~$10,000'}
@@ -84,6 +88,8 @@ describe.each`
   engineerCost | ratio           | amount     | expected
   ${200_000}   | ${0}            | ${0}       | ${'Negligible'}
   ${200_000}   | ${0}            | ${8_333}   | ${'Negligible'}
+  ${200_000}   | ${undefined}    | ${1_000}   | ${'Negligible'}
+  ${200_000}   | ${undefined}    | ${10_000}  | ${`~2,857 ${carbon.unit}s`}
   ${200_000}   | ${0.000000001}  | ${8_334}   | ${`0% or ~2,381 ${carbon.unit}s`}
   ${200_000}   | ${-0.000000001} | ${10_000}  | ${`0% or ~2,857 ${carbon.unit}s`}
   ${200_000}   | ${-0.8}         | ${10_000}  | ${`80% or ~2,857 ${carbon.unit}s`}

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.test.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.test.tsx
@@ -21,8 +21,6 @@ import { ChangeThreshold, EngineerThreshold } from '../../types';
 
 describe.each`
   ratio                           | amount                     | ariaLabel
-  ${-0.1}                         | ${undefined}               | ${'savings'}
-  ${0.01}                         | ${undefined}               | ${'excess'}
   ${ChangeThreshold.lower}        | ${EngineerThreshold}       | ${'savings'}
   ${ChangeThreshold.lower - 0.01} | ${EngineerThreshold}       | ${'savings'}
   ${ChangeThreshold.lower - 0.01} | ${EngineerThreshold + 0.1} | ${'savings'}
@@ -32,7 +30,7 @@ describe.each`
 `('growthOf', ({ ratio, amount, ariaLabel }) => {
   it(`should display the correct indicator for ${ariaLabel}`, async () => {
     const { getByLabelText } = await renderInTestApp(
-      <CostGrowthIndicator ratio={ratio} amount={amount} />,
+      <CostGrowthIndicator change={{ ratio, amount }} />,
     );
     expect(getByLabelText(ariaLabel)).toBeInTheDocument();
   });
@@ -40,7 +38,8 @@ describe.each`
 
 describe.each`
   ratio                           | amount
-  ${0}                            | ${undefined}
+  ${undefined}                    | ${0}
+  ${0}                            | ${0}
   ${ChangeThreshold.lower}        | ${0}
   ${ChangeThreshold.lower + 0.01} | ${EngineerThreshold}
   ${ChangeThreshold.lower + 0.01} | ${EngineerThreshold + 0.1}
@@ -49,7 +48,7 @@ describe.each`
 `('growthOf', ({ ratio, amount }) => {
   it('should display the correct indicator for negligible growth', async () => {
     const { queryByLabelText } = await renderInTestApp(
-      <CostGrowthIndicator ratio={ratio} amount={amount} />,
+      <CostGrowthIndicator change={{ ratio, amount }} />,
     );
     expect(queryByLabelText('savings')).not.toBeInTheDocument();
     expect(queryByLabelText('excess')).not.toBeInTheDocument();

--- a/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.tsx
+++ b/plugins/cost-insights/src/components/CostGrowth/CostGrowthIndicator.tsx
@@ -20,49 +20,33 @@ import { Typography, TypographyProps } from '@material-ui/core';
 import { default as ArrowDropUp } from '@material-ui/icons/ArrowDropUp';
 import { default as ArrowDropDown } from '@material-ui/icons/ArrowDropDown';
 import { growthOf } from '../../utils/change';
-import { GrowthType } from '../../types';
+import { ChangeStatistic, GrowthType, Maybe } from '../../types';
 import { useCostGrowthStyles as useStyles } from '../../utils/styles';
 
 export type CostGrowthIndicatorProps = TypographyProps & {
-  ratio: number;
-  amount?: number;
-  formatter?: (amount: number) => string;
+  change: ChangeStatistic;
+  formatter?: (change: ChangeStatistic) => Maybe<string>;
 };
 
 export const CostGrowthIndicator = ({
-  ratio,
-  amount,
+  change,
   formatter,
   className,
   ...props
 }: CostGrowthIndicatorProps) => {
   const classes = useStyles();
-  const growth = growthOf(ratio, amount);
+  const growth = growthOf(change);
 
   const classNames = classnames(classes.indicator, className, {
-    [classes.savings]: growth === GrowthType.Savings,
     [classes.excess]: growth === GrowthType.Excess,
+    [classes.savings]: growth === GrowthType.Savings,
   });
 
-  // Display cost as a factor of engineer cost growth and percentage growth
-  if (typeof amount === 'number') {
-    return (
-      <Typography className={classNames} component="span" {...props}>
-        {formatter ? formatter(amount) : amount}
-        {growth === GrowthType.Savings && (
-          <ArrowDropDown aria-label="savings" />
-        )}
-        {growth === GrowthType.Excess && <ArrowDropUp aria-label="excess" />}
-      </Typography>
-    );
-  }
-
-  // Display cost as a factor of percent change
   return (
     <Typography className={classNames} component="span" {...props}>
-      {formatter ? formatter(ratio) : ratio}
-      {ratio < 0 && <ArrowDropDown aria-label="savings" />}
-      {ratio > 0 && <ArrowDropUp aria-label="excess" />}
+      {formatter ? formatter(change) : change.ratio}
+      {growth === GrowthType.Excess && <ArrowDropUp aria-label="excess" />}
+      {growth === GrowthType.Savings && <ArrowDropDown aria-label="savings" />}
     </Typography>
   );
 };

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewLegend.test.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewLegend.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { wrapInTestApp } from '@backstage/test-utils';
+import { CostOverviewLegend } from './CostOverviewLegend';
+import {
+  MockBillingDateProvider,
+  MockConfigProvider,
+  MockFilterProvider,
+  MockCurrencyProvider,
+} from '../../testUtils';
+
+function renderInTestApp(children: JSX.Element) {
+  return render(
+    wrapInTestApp(
+      <MockConfigProvider>
+        <MockCurrencyProvider>
+          <MockBillingDateProvider>
+            <MockFilterProvider>{children}</MockFilterProvider>
+          </MockBillingDateProvider>
+        </MockCurrencyProvider>
+      </MockConfigProvider>,
+    ),
+  );
+}
+
+describe('<CostOverviewLegend />', () => {
+  it('displays the legend without exploding', async () => {
+    const { findByText } = renderInTestApp(
+      <CostOverviewLegend
+        metric={{
+          kind: 'msc',
+          name: 'MSC',
+          default: false,
+        }}
+        metricData={{
+          id: 'msc',
+          format: 'number',
+          aggregation: [],
+          change: {
+            ratio: 0,
+            amount: 0,
+          },
+        }}
+        dailyCostData={{
+          id: 'mock-id',
+          aggregation: [],
+          change: {
+            amount: 0,
+          },
+        }}
+      />,
+    );
+
+    expect(await findByText('Cost Trend')).toBeInTheDocument();
+    expect(await findByText('MSC Trend')).toBeInTheDocument();
+  });
+
+  it('does not display metric legend if metric data is not provided', async () => {
+    const { findByText, queryByText } = renderInTestApp(
+      <CostOverviewLegend
+        metric={{
+          kind: 'msc',
+          name: 'MSC',
+          default: false,
+        }}
+        metricData={null}
+        dailyCostData={{
+          id: 'mock-id',
+          aggregation: [],
+          change: {
+            amount: 0,
+          },
+        }}
+      />,
+    );
+
+    expect(await findByText('Cost Trend')).toBeInTheDocument();
+    expect(queryByText('MSC Trend')).not.toBeInTheDocument();
+  });
+});
+
+describe.each`
+  ratio        | amount    | title   | expected
+  ${undefined} | ${1_000}  | ${'∞'}  | ${'Your Excess'}
+  ${undefined} | ${-1_000} | ${'-∞'} | ${'Your Savings'}
+`('<CostOverviewLegend />', ({ ratio, amount, title, expected }) => {
+  it('displays the correct legend if ratio cannot be calculated and costs are within time period', async () => {
+    const { findByText, findAllByText } = renderInTestApp(
+      <CostOverviewLegend
+        metric={{
+          kind: 'msc',
+          name: 'MSC',
+          default: false,
+        }}
+        metricData={{
+          id: 'msc',
+          format: 'number',
+          change: {
+            ratio: ratio,
+            amount: amount,
+          },
+          aggregation: [
+            {
+              date: '2020-01-01',
+              amount: 0,
+            },
+            {
+              date: '2020-07-01', // within default P90D period
+              amount: amount,
+            },
+          ],
+        }}
+        dailyCostData={{
+          id: 'mock-id',
+          change: {
+            ratio,
+            amount,
+          },
+          aggregation: [
+            {
+              date: '2020-01-01',
+              amount: 0,
+            },
+            {
+              date: '2020-07-01', // within default P90D period
+              amount: amount,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(await findByText('Cost Trend')).toBeInTheDocument();
+    expect(await findByText('MSC Trend')).toBeInTheDocument();
+    expect(await findAllByText(title).then(res => res.length)).toBe(2);
+    expect(await findByText(expected)).toBeInTheDocument();
+  });
+});

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewLegend.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewLegend.tsx
@@ -30,8 +30,6 @@ import { mapFiltersToProps } from './selector';
 import { formatChange } from '../../utils/formatters';
 import { CostGrowth } from '../CostGrowth';
 
-import { notEmpty } from '../../utils/assert';
-
 type CostOverviewLegendProps = {
   metric: Maybe<Metric>;
   metricData: Maybe<MetricData>;

--- a/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewLegend.tsx
+++ b/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewLegend.tsx
@@ -25,10 +25,12 @@ import {
   Metric,
 } from '../../types';
 import { useLastCompleteBillingDate, useFilters } from '../../hooks';
-import { getComparedChange } from '../../utils/change';
+import { getComparedChange, choose } from '../../utils/change';
 import { mapFiltersToProps } from './selector';
-import { formatPercent } from '../../utils/formatters';
+import { formatChange } from '../../utils/formatters';
 import { CostGrowth } from '../CostGrowth';
+
+import { notEmpty } from '../../utils/assert';
 
 type CostOverviewLegendProps = {
   metric: Maybe<Metric>;
@@ -42,9 +44,8 @@ export const CostOverviewLegend = ({
   metricData,
 }: PropsWithChildren<CostOverviewLegendProps>) => {
   const theme = useTheme<CostInsightsTheme>();
-
-  const lastCompleteBillingDate = useLastCompleteBillingDate();
   const { duration } = useFilters(mapFiltersToProps);
+  const lastCompleteBillingDate = useLastCompleteBillingDate();
 
   const comparedChange = metricData
     ? getComparedChange(
@@ -57,23 +58,25 @@ export const CostOverviewLegend = ({
 
   return (
     <Box display="flex" flexDirection="row">
-      <Box mr={2}>
-        <LegendItem title="Cost Trend" markerColor={theme.palette.blue}>
-          {formatPercent(dailyCostData.change!.ratio)}
-        </LegendItem>
-      </Box>
-      {metric && metricData && comparedChange && (
+      {dailyCostData.change && (
+        <Box mr={2}>
+          <LegendItem title="Cost Trend" markerColor={theme.palette.blue}>
+            {formatChange(dailyCostData.change)}
+          </LegendItem>
+        </Box>
+      )}
+      {metricData && metric && comparedChange && (
         <>
           <Box mr={2}>
             <LegendItem
               title={`${metric.name} Trend`}
               markerColor={theme.palette.magenta}
             >
-              {formatPercent(metricData.change.ratio)}
+              {formatChange(metricData.change)}
             </LegendItem>
           </Box>
           <LegendItem
-            title={comparedChange.ratio <= 0 ? 'Your Savings' : 'Your Excess'}
+            title={choose(['Your Savings', 'Your Excess'], comparedChange)}
           >
             <CostGrowth change={comparedChange} duration={duration} />
           </LegendItem>

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityTable.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityTable.tsx
@@ -22,7 +22,6 @@ import { costFormatter, formatChange } from '../../utils/formatters';
 import { useEntityDialogStyles as useStyles } from '../../utils/styles';
 import { CostGrowthIndicator } from '../CostGrowth';
 import { BarChartOptions, ChangeStatistic, Entity } from '../../types';
-import { isUndefined } from '../../utils/assert';
 
 export type ProductEntityTableOptions = Partial<
   Pick<BarChartOptions, 'previousName' | 'currentName'>

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityTable.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductEntityTable.tsx
@@ -18,10 +18,11 @@ import React from 'react';
 import classnames from 'classnames';
 import { Table, TableColumn } from '@backstage/core';
 import { Typography } from '@material-ui/core';
-import { costFormatter, formatPercent } from '../../utils/formatters';
+import { costFormatter, formatChange } from '../../utils/formatters';
 import { useEntityDialogStyles as useStyles } from '../../utils/styles';
 import { CostGrowthIndicator } from '../CostGrowth';
-import { BarChartOptions, Entity } from '../../types';
+import { BarChartOptions, ChangeStatistic, Entity } from '../../types';
+import { isUndefined } from '../../utils/assert';
 
 export type ProductEntityTableOptions = Partial<
   Pick<BarChartOptions, 'previousName' | 'currentName'>
@@ -32,7 +33,7 @@ type RowData = {
   label: string;
   previous: number;
   current: number;
-  ratio: number;
+  change: ChangeStatistic;
 };
 
 function createRenderer(col: keyof RowData, classes: Record<string, string>) {
@@ -41,7 +42,7 @@ function createRenderer(col: keyof RowData, classes: Record<string, string>) {
     const rowStyles = classnames(classes.row, {
       [classes.rowTotal]: row.id === 'total',
       [classes.colFirst]: col === 'label',
-      [classes.colLast]: col === 'ratio',
+      [classes.colLast]: col === 'change',
     });
 
     switch (col) {
@@ -52,12 +53,12 @@ function createRenderer(col: keyof RowData, classes: Record<string, string>) {
             {costFormatter.format(row[col])}
           </Typography>
         );
-      case 'ratio':
+      case 'change':
         return (
           <CostGrowthIndicator
             className={rowStyles}
-            ratio={row.ratio}
-            formatter={amount => formatPercent(Math.abs(amount))}
+            change={row.change}
+            formatter={formatChange}
           />
         );
       default:
@@ -75,10 +76,15 @@ function createSorter(field?: keyof Omit<RowData, 'id'>) {
     if (a.id === 'total') return 1;
     if (b.id === 'total') return 1;
     if (field === 'label') return a.label.localeCompare(b.label);
+    if (field === 'change') {
+      if (formatChange(a[field]) === '∞' || formatChange(b[field]) === '-∞')
+        return 1;
+      if (formatChange(a[field]) === '-∞' || formatChange(b[field]) === '∞')
+        return -1;
+      return a[field].ratio! - b[field].ratio!;
+    }
 
-    return field
-      ? a[field] - b[field]
-      : b.previous + b.current - (a.previous + a.current);
+    return b.previous + b.current - (a.previous + a.current);
   };
 }
 
@@ -134,11 +140,11 @@ export const ProductEntityTable = ({
       customSort: createSorter('current'),
     },
     {
-      field: 'ratio',
+      field: 'change',
       title: <Typography className={lastColClasses}>Change</Typography>,
       align: 'right',
-      render: createRenderer('ratio', classes),
-      customSort: createSorter('ratio'),
+      render: createRenderer('change', classes),
+      customSort: createSorter('change'),
     },
   ];
 
@@ -148,14 +154,14 @@ export const ProductEntityTable = ({
       label: e.id || 'Unknown',
       previous: e.aggregation[0],
       current: e.aggregation[1],
-      ratio: e.change.ratio,
+      change: e.change,
     }))
     .concat({
       id: 'total',
       label: 'Total',
       previous: entity.aggregation[0],
       current: entity.aggregation[1],
-      ratio: entity.change.ratio,
+      change: entity.change,
     })
     .sort(createSorter());
 

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsChart.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsChart.tsx
@@ -40,7 +40,7 @@ import {
   findAnyKey,
   assertAlways,
 } from '../../utils/assert';
-import { formatPeriod, formatPercent } from '../../utils/formatters';
+import { formatPeriod, formatChange } from '../../utils/formatters';
 import {
   titleOf,
   tooltipItemOf,
@@ -54,6 +54,7 @@ import {
   useBarChartLayoutStyles as useLayoutStyles,
 } from '../../utils/styles';
 import { Duration, Entity, Maybe } from '../../types';
+import { choose } from '../../utils/change';
 
 export type ProductInsightsChartProps = {
   billingDate: string;
@@ -86,7 +87,6 @@ export const ProductInsightsChart = ({
     return breakdowns.length > 0;
   }, [entities, activeLabel]);
 
-  const legendTitle = `Cost ${entity.change.ratio <= 0 ? 'Savings' : 'Growth'}`;
   const costStart = entity.aggregation[0];
   const costEnd = entity.aggregation[1];
   const resources = entities.map(resourceOf);
@@ -136,7 +136,6 @@ export const ProductInsightsChart = ({
     const items = payload.map(tooltipItemOf).filter(notEmpty);
 
     const activeEntity = findAlways(entities, e => e.id === id);
-    const ratio = activeEntity.change.ratio;
     const breakdowns = Object.keys(activeEntity.entities);
 
     if (breakdowns.length) {
@@ -148,11 +147,13 @@ export const ProductInsightsChart = ({
           title={title}
           subtitle={subtitle}
           topRight={
-            <CostGrowthIndicator
-              className={classes.indicator}
-              ratio={ratio}
-              formatter={formatPercent}
-            />
+            !!activeEntity.change.ratio && (
+              <CostGrowthIndicator
+                formatter={formatChange}
+                change={activeEntity.change}
+                className={classes.indicator}
+              />
+            )
           }
           actions={
             <Box className={classes.actions}>
@@ -173,11 +174,13 @@ export const ProductInsightsChart = ({
       <BarChartTooltip
         title={title}
         topRight={
-          <CostGrowthIndicator
-            className={classes.indicator}
-            ratio={ratio}
-            formatter={formatPercent}
-          />
+          !!activeEntity.change.ratio && (
+            <CostGrowthIndicator
+              formatter={formatChange}
+              change={activeEntity.change}
+              className={classes.indicator}
+            />
+          )
         }
         content={
           id
@@ -197,7 +200,9 @@ export const ProductInsightsChart = ({
   return (
     <Box className={layoutClasses.wrapper}>
       <BarChartLegend costStart={costStart} costEnd={costEnd} options={options}>
-        <LegendItem title={legendTitle}>
+        <LegendItem
+          title={choose(['Cost Savings', 'Cost Excess'], entity.change)}
+        >
           <CostGrowth change={entity.change} duration={duration} />
         </LegendItem>
       </BarChartLegend>

--- a/plugins/cost-insights/src/testUtils/mockData.ts
+++ b/plugins/cost-insights/src/testUtils/mockData.ts
@@ -294,7 +294,6 @@ export const MockBigQueryInsights: Entity = {
         id: 'dataset-c',
         aggregation: [0, 10_000],
         change: {
-          ratio: 10_000,
           amount: 10_000,
         },
         entities: {},
@@ -415,7 +414,6 @@ export const MockCloudDataflowInsights: Entity = {
         id: 'pipeline-c',
         aggregation: [0, 10_000],
         change: {
-          ratio: 10_000,
           amount: 10_000,
         },
         entities: {},
@@ -503,7 +501,6 @@ export const MockCloudStorageInsights: Entity = {
               id: 'Mock SKU C',
               aggregation: [2_000, 0],
               change: {
-                ratio: -1,
                 amount: -2000,
               },
               entities: {},
@@ -515,7 +512,6 @@ export const MockCloudStorageInsights: Entity = {
         id: 'bucket-c',
         aggregation: [0, 0],
         change: {
-          ratio: 0,
           amount: 0,
         },
         entities: {},
@@ -655,7 +651,6 @@ export const MockComputeEngineInsights: Entity = {
         id: 'service-c',
         aggregation: [0, 10_000],
         change: {
-          ratio: 10_000,
           amount: 10_000,
         },
         entities: {},

--- a/plugins/cost-insights/src/testUtils/testUtils.ts
+++ b/plugins/cost-insights/src/testUtils/testUtils.ts
@@ -93,10 +93,16 @@ export function changeOf(aggregation: DateAggregation[]): ChangeStatistic {
   const lastAmount = aggregation.length
     ? aggregation[aggregation.length - 1].amount
     : 0;
-  const ratio =
-    firstAmount !== 0 ? (lastAmount - firstAmount) / firstAmount : 0;
+
+  // if either the first or last amounts are zero, the rate of increase/decrease is infinite
+  if (!firstAmount || !lastAmount) {
+    return {
+      amount: lastAmount - firstAmount,
+    };
+  }
+
   return {
-    ratio: ratio,
+    ratio: (lastAmount - firstAmount) / firstAmount,
     amount: lastAmount - firstAmount,
   };
 }

--- a/plugins/cost-insights/src/types/ChangeStatistic.ts
+++ b/plugins/cost-insights/src/types/ChangeStatistic.ts
@@ -16,7 +16,9 @@
 
 export interface ChangeStatistic {
   // The ratio of change from one duration to another, expressed as: (newSum - oldSum) / oldSum
-  ratio: number;
+  // If a ratio cannot be calculated - such as when a new or old sum is zero,
+  // the ratio can be omitted and where applicable, ∞ or -∞ will display based on amount.
+  ratio?: number;
   // The actual USD change between time periods (can be negative if costs decreased)
   amount: number;
 }

--- a/plugins/cost-insights/src/utils/assert.ts
+++ b/plugins/cost-insights/src/utils/assert.ts
@@ -20,7 +20,7 @@ export function notEmpty<TValue>(
   return !isNull(value) && !isUndefined(value);
 }
 
-export function isUndefined(value: any): boolean {
+export function isUndefined(value: any): value is undefined {
   return value === undefined;
 }
 

--- a/plugins/cost-insights/src/utils/change.test.ts
+++ b/plugins/cost-insights/src/utils/change.test.ts
@@ -32,23 +32,23 @@ const GrowthMap = {
 
 describe.each`
   ratio                           | amount                     | expected
-  ${0.0}                          | ${undefined}               | ${GrowthType.Negligible}
+  ${undefined}                    | ${0}                       | ${GrowthType.Negligible}
+  ${0.0}                          | ${0}                       | ${GrowthType.Negligible}
   ${0.0}                          | ${EngineerThreshold}       | ${GrowthType.Negligible}
   ${ChangeThreshold.lower}        | ${0}                       | ${GrowthType.Negligible}
-  ${ChangeThreshold.lower + 0.01} | ${undefined}               | ${GrowthType.Negligible}
+  ${ChangeThreshold.lower + 0.01} | ${0}                       | ${GrowthType.Negligible}
   ${ChangeThreshold.lower + 0.01} | ${EngineerThreshold}       | ${GrowthType.Negligible}
   ${ChangeThreshold.lower + 0.01} | ${EngineerThreshold + 0.1} | ${GrowthType.Negligible}
   ${ChangeThreshold.lower - 0.01} | ${EngineerThreshold - 0.1} | ${GrowthType.Negligible}
-  ${ChangeThreshold.upper - 0.01} | ${undefined}               | ${GrowthType.Negligible}
+  ${ChangeThreshold.lower - 0.01} | ${0}                       | ${GrowthType.Negligible}
+  ${ChangeThreshold.upper}        | ${0}                       | ${GrowthType.Negligible}
+  ${ChangeThreshold.upper - 0.01} | ${0}                       | ${GrowthType.Negligible}
   ${ChangeThreshold.upper + 0.01} | ${EngineerThreshold - 0.1} | ${GrowthType.Negligible}
-  ${ChangeThreshold.lower}        | ${undefined}               | ${GrowthType.Savings}
+  ${ChangeThreshold.upper + 0.01} | ${0}                       | ${GrowthType.Negligible}
   ${ChangeThreshold.lower}        | ${EngineerThreshold}       | ${GrowthType.Savings}
-  ${ChangeThreshold.lower - 0.01} | ${undefined}               | ${GrowthType.Savings}
   ${ChangeThreshold.lower - 0.01} | ${EngineerThreshold}       | ${GrowthType.Savings}
   ${ChangeThreshold.lower - 0.01} | ${EngineerThreshold + 0.1} | ${GrowthType.Savings}
-  ${ChangeThreshold.upper}        | ${undefined}               | ${GrowthType.Excess}
   ${ChangeThreshold.upper}        | ${EngineerThreshold}       | ${GrowthType.Excess}
-  ${ChangeThreshold.upper + 0.01} | ${undefined}               | ${GrowthType.Excess}
   ${ChangeThreshold.upper + 0.01} | ${EngineerThreshold}       | ${GrowthType.Excess}
   ${ChangeThreshold.upper + 0.01} | ${EngineerThreshold + 0.1} | ${GrowthType.Excess}
 `(
@@ -63,7 +63,7 @@ describe.each`
     expected: GrowthType;
   }) => {
     it(`should display ${GrowthMap[expected]}`, () => {
-      expect(growthOf(ratio, amount)).toBe(expected);
+      expect(growthOf({ ratio, amount })).toBe(expected);
     });
   },
 );

--- a/plugins/cost-insights/src/utils/formatters.ts
+++ b/plugins/cost-insights/src/utils/formatters.ts
@@ -16,8 +16,9 @@
 
 import moment from 'moment';
 import pluralize from 'pluralize';
-import { Duration } from '../types';
+import { ChangeStatistic, Duration } from '../types';
 import { inclusiveEndDateOf, inclusiveStartDateOf } from '../utils/duration';
+import { notEmpty } from './assert';
 
 export type Period = {
   periodStart: string;
@@ -76,6 +77,13 @@ export function formatCurrency(amount: number, currency?: string): string {
   const numString = numberFormatter.format(n);
 
   return currency ? `${numString} ${pluralize(currency, n)}` : numString;
+}
+
+export function formatChange(change: ChangeStatistic): string {
+  if (notEmpty(change.ratio)) {
+    return formatPercent(Math.abs(change.ratio));
+  }
+  return change.amount >= 0 ? '∞' : '-∞';
 }
 
 export function formatPercent(n: number): string {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Makes `ChangeStatistic.ratio` optional.

Reasoning: Often an entity can incur costs in one period but not in another - such as when a new service is started or decommissioned. This results in either the first or last sum of a change aggregation being zero and growth being technically infinite.

This PR makes `ChangeStatistic.ratio` optional. Where a ratio is omitted, growth is considered infinite and cost insights will use the `ChangeStatistic.amount` (which is required) to determine if growth is positive or negative and render the corresponding UI.

### Cost Overview Chart
<img width="1128" alt="Screen Shot 2021-04-22 at 2 20 28 PM" src="https://user-images.githubusercontent.com/3030003/115772764-7ee35800-a37d-11eb-946e-3a64dfbfbb96.png">
<img width="1124" alt="Screen Shot 2021-04-22 at 2 20 06 PM" src="https://user-images.githubusercontent.com/3030003/115772783-86a2fc80-a37d-11eb-98f7-ffc84fc41e7b.png">

### Product Insights Card
#### Cost Growth Indicator omitted
<img width="1089" alt="Screen Shot 2021-04-22 at 2 15 22 PM" src="https://user-images.githubusercontent.com/3030003/115772902-a9cdac00-a37d-11eb-9ede-d0137fffbcdc.png">

### Product Entity Table
<img width="1168" alt="Screen Shot 2021-04-22 at 2 08 02 PM" src="https://user-images.githubusercontent.com/3030003/115773830-c3232800-a37e-11eb-868e-5c5668ccfa62.png">

<img width="1168" alt="Screen Shot 2021-04-22 at 2 15 14 PM" src="https://user-images.githubusercontent.com/3030003/115773124-ee594780-a37d-11eb-9566-c6a3209ca85a.png">

#### Sorts infinite values
![infinite-growth-sorting](https://user-images.githubusercontent.com/3030003/115773394-4132ff00-a37e-11eb-90e8-71eefd017477.gif)

#### Zero percent growth means zero percent growth 
<img width="1162" alt="Screen Shot 2021-04-22 at 2 14 40 PM" src="https://user-images.githubusercontent.com/3030003/115773702-9ff87880-a37e-11eb-987d-8b26af4222be.png">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
