### PR TITLE
[chart] Update default docker image

### DIFF
--- a/contrib/chart/backstage/templates/backend-deployment.yaml
+++ b/contrib/chart/backstage/templates/backend-deployment.yaml
@@ -26,6 +26,13 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Chart.Name }}-backend
+          command: ["node"]
+          args:
+            - "packages/backend"
+            - "--config"
+            - "app-config.yaml"
+            - "--config"
+            - {{ printf "/usr/src/app/%s" (include "backstage.appConfigFilename" .) | quote }}
           image: {{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           ports:

--- a/contrib/chart/backstage/templates/frontend-deployment.yaml
+++ b/contrib/chart/backstage/templates/frontend-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.frontend.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,7 +47,6 @@ spec:
       {{- if .Values.global.nodeSelector }}
       nodeSelector: {{- toYaml .Values.global.nodeSelector | nindent 8 }}
       {{- end }}
-{{- if .Values.frontend.enabled }}
 ---
 apiVersion: v1
 kind: Service

--- a/contrib/chart/backstage/values.yaml
+++ b/contrib/chart/backstage/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 frontend:
-  enabled: true
+  enabled: false
   replicaCount: 1
   image:
     repository: martinaif/backstage-k8s-demo-frontend
@@ -23,7 +23,7 @@ backend:
   replicaCount: 1
   image:
     repository: martinaif/backstage-k8s-demo-backend
-    tag: test1
+    tag: 20210423T1550
     pullPolicy: IfNotPresent
   containerPort: 7000
   resources:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Update the docker image used by default in the chart
- Disable the frontend deployment and use the single backend-frontend image that is now built by default in the monorepo with `yarn run docker-build`


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
