### PR TITLE
Use Tugboat for E2E Tests for ReadTree

### DIFF
--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:3000",
+  "baseUrl": "http://localhost:7000",
   "integrationFolder": "./src/integration",
   "supportFile": "./src/support",
   "fixturesFolder": "./src/fixures",

--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:7000",
+  "baseUrl": "http://localhost:3000",
   "integrationFolder": "./src/integration",
   "supportFile": "./src/support",
   "fixturesFolder": "./src/fixures",

--- a/cypress/src/integration/integrations.ts
+++ b/cypress/src/integration/integrations.ts
@@ -18,33 +18,59 @@ import 'os';
 
 describe('Integrations', () => {
   describe('ReadTree', () => {
-    // it('should work for azure', () => {
-    //   cy.loginAsGuest();
-
-    //   cy.visit('/catalog-import');
-
-    //   cy.get('input[name=url]').type(
-    //     'https://dev.azure.com/backstage-verification/_git/test-repo?path=%2Fnested%2F*',
-    //   );
-
-    //   cy.contains('Analyze').click();
-    // });
-
     it('should work for github', () => {
       cy.loginAsGuest();
 
-      cy.visit('/catalog-import');
-
-      cy.get('input[name=url]').type(
-        'https://github.com/backstage-verification/test-repo',
-      );
-      cy.request('/api/catalog/locations', {
+      cy.request('POST', '/api/catalog/locations', {
         target:
           'https://github.com/backstage-verification/test-repo/blob/main/**/*',
         type: 'url',
       });
 
-      cy.contains('Analyze').click();
+      cy.visit('/catalog');
+      cy.contains('All').click();
+      cy.get('table').should('contain', 'github-repo');
+      cy.get('table').should('contain', 'github-repo-nested');
+    });
+
+    // it('should work for azure', () => {
+    //   cy.loginAsGuest();
+
+    //   cy.request('POST', '/api/catalog/locations', {
+    //     target:
+    //       'https://dev.azure.com/backstage-verification/_git/test-repo?path=*',
+    //     type: 'url',
+    //   });
+    // });
+
+    it('should work for gitlab', () => {
+      cy.loginAsGuest();
+
+      cy.request('POST', '/api/catalog/locations', {
+        target:
+          'https://gitlab.com/backstage-verification/test-repo/-/tree/master/**/*',
+        type: 'url',
+      });
+
+      cy.visit('/catalog');
+      cy.contains('All').click();
+      cy.get('table').should('contain', 'gitlab-repo');
+      cy.get('table').should('contain', 'gitlab-repo-nested');
+    });
+
+    it('should work for bitbucket', () => {
+      cy.loginAsGuest();
+
+      cy.request('POST', '/api/catalog/locations', {
+        target:
+          'https://bitbucket.org/backstage-verification/test-repo/src/master/**/*',
+        type: 'url',
+      });
+
+      cy.visit('/catalog');
+      cy.contains('All').click();
+      cy.get('table').should('contain', 'bitbucket-repo');
+      cy.get('table').should('contain', 'bitbucket-repo-nested');
     });
   });
 });

--- a/cypress/src/integration/integrations.ts
+++ b/cypress/src/integration/integrations.ts
@@ -38,6 +38,11 @@ describe('Integrations', () => {
       cy.get('input[name=url]').type(
         'https://github.com/backstage-verification/test-repo',
       );
+      cy.request('/api/catalog/locations', {
+        target:
+          'https://github.com/backstage-verification/test-repo/blob/main/**/*',
+        type: 'url',
+      });
 
       cy.contains('Analyze').click();
     });

--- a/cypress/src/integration/integrations.ts
+++ b/cypress/src/integration/integrations.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/// <reference types="cypress" />
+import 'os';
+
+describe('Integrations', () => {
+  describe('ReadTree', () => {
+    // it('should work for azure', () => {
+    //   cy.loginAsGuest();
+
+    //   cy.visit('/catalog-import');
+
+    //   cy.get('input[name=url]').type(
+    //     'https://dev.azure.com/backstage-verification/_git/test-repo?path=%2Fnested%2F*',
+    //   );
+
+    //   cy.contains('Analyze').click();
+    // });
+
+    it('should work for github', () => {
+      cy.loginAsGuest();
+
+      cy.visit('/catalog-import');
+
+      cy.get('input[name=url]').type(
+        'https://github.com/backstage-verification/test-repo',
+      );
+
+      cy.contains('Analyze').click();
+    });
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

So in order to reduce a little of the complexity around the tests that we had commented out, I thought it would be useful to just test it in a broader scope. 

What happens here is that the Tugboat will spin up the backstage PR, and then try to POST locations with `**/*` as the path so it will use `readTree` indirectly by grabbing the zip/tar of the entire repo and scanning for catalog-info files.

I added the repo to each of the providers so we have some tests, and then the test will check that they are loaded into the catalog after the post request is done.

Only one I couldn't get working however is Azure. @freben, I seem to remember you implemented the URL globbing for `catalog-info.yaml` files for the providers, can you point me in the right direction and I can see if I can fix it part of this PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
