### PR TITLE
fix: include migrations in code-coverage-backend plugin

### DIFF
--- a/.changeset/pink-islands-help.md
+++ b/.changeset/pink-islands-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage-backend': patch
+---
+
+Include migrations

--- a/plugins/code-coverage-backend/package.json
+++ b/plugins/code-coverage-backend/package.json
@@ -44,6 +44,7 @@
     "xml2js": "^0.4.23"
   },
   "files": [
-    "dist"
+    "dist",
+    "migrations/**/*.{js,d.ts}"
   ]
 }


### PR DESCRIPTION
Signed-off-by: Erik Larsson <erik.larsson@schibsted.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Migrations must be included in the published code-coverage-backend plugin package or adopting backends will fail to start with the following error:

```
Backend failed to start up [Error: ENOENT: no such file or directory, scandir '.../backstage/node_modules/@backstage/plugin-code-coverage-backend/migrations'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: '.../backstage/node_modules/@backstage/plugin-code-coverage-backend/migrations'
}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
