### PR TITLE
Prevent uncaught exception in download of Techdocs Azure Blob Storage publisher

### DIFF
--- a/.changeset/six-rocks-allow.md
+++ b/.changeset/six-rocks-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Gracefully handle HTTP request failures in download method of AzureBlobStorage publisher.

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
@@ -221,7 +221,8 @@ export class AzureBlobStoragePublish implements PublisherBase {
             .on('end', () => {
               resolve(Buffer.concat(fileStreamChunks));
             });
-        });
+        })
+        .catch(reject);
     });
   }
 


### PR DESCRIPTION
Signed-off-by: Taras <tarasm@gmail.com>

## Hey, I just made a Pull Request!

We implemented the mechanism that @Fox32 [described](https://discord.com/channels/687207715902193673/714754240933003266/832299521487798292) that allows to automatically populates `backstage.io/techdocs-ref` when docs for a component are available in the storage container. 

We're using Azure Storage Blog and we found that calling the metadata endpoint caused the process to crash due to an unhandled exception. I'm not sure how to reproduce it in the tests. The problem occurs because Azure Blog Storage client reports 404 different than a content error. The download function rejects the promise when it encounters an error while reading the content but it didn't handle a scenario where content could not be read because the content didn't exist. I added a catch to the promise chain with the `reject` callback. 

The current test harness in techdocs-common doesn't make testing particularly easy. It's not obvious how to get Jest mocks to induce this specific scenario without digging further into Azure Blob Storage client. There is another approach to testing that I could use to test this, but it would require adding a test harness to techdocs-backend. I could test it in the following way,

1. Add a test harness to techdocs-backend that starts the service in a separate process
2. Configure the service to start with AzureBlobStorage
3. Interrupt HTTP request that goes out to AzureBlobStorage and return a 404
4. This should trigger an unhandled exception

I'm not sure if other plugins test this way. If you're open to this solution then I can set it up. It's a lot of work for a 1 line PR but it'll be worth it in the long run because it'll make it easier to test this service and could provide a pattern for other services.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
