### PR TITLE
fix techdocs landing page table wrong copied link

### DIFF
--- a/.changeset/techdocs-mean-humans-hammer.md
+++ b/.changeset/techdocs-mean-humans-hammer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix TechDocs landing page table wrong copied link

--- a/plugins/techdocs/src/home/components/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/DocsTable.tsx
@@ -76,7 +76,7 @@ export const DocsTable = ({
         <Tooltip title="Click to copy documentation link to clipboard">
           <IconButton
             onClick={() =>
-              copyToClipboard(`${window.location.origin}/${row.docsUrl}`)
+              copyToClipboard(`${window.location.href}/${row.docsUrl}`)
             }
           >
             <ShareIcon />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix incorrect link copied to clipboard for documentation reader pages (incorrect when custom landing page routing as recommended in How To is used)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ :heavy_check_mark: ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ NA ] Added or updated documentation
- [ NA ] Tests for new functionality and regression tests for bug fixes
- [ NA ] Screenshots attached (for UI changes)
- [ :heavy_check_mark:  ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
