### PR TITLE
TechDocs: Disable color transitions on links to avoid issues in dark mode

### DIFF
--- a/.changeset/techdocs-red-donkeys-share.md
+++ b/.changeset/techdocs-red-donkeys-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Disable color transitions on links to avoid issues in dark mode.

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -197,9 +197,20 @@ export const Reader = ({ entityId, onReady }: Props) => {
           }
           .md-nav--primary > .md-nav__title [for="none"] {
             padding-top: 0;
-          } 
+          }
         }
       `,
+      }),
+      injectCss({
+        // Disable CSS animations on link colors as they lead to issues in dark
+        // mode. The dark mode color theme is applied later and theirfore there
+        // is always an animation from light to dark mode when navigation
+        // between pages.
+        css: `
+        .md-nav__link, .md-typeset a, .md-typeset a::before, .md-typeset .headerlink {
+          transition: none;
+        }
+        `,
       }),
       injectCss({
         // Admonitions and others are using SVG masks to define icons. These


### PR DESCRIPTION
This issue is mostly visible in dark mode. 

Before (with animation speed reduced to 10% to make it more visible):

https://user-images.githubusercontent.com/648527/116107478-5cba4480-a6b3-11eb-9734-3c6a61c01b13.mov

After:

https://user-images.githubusercontent.com/648527/116107505-6348bc00-a6b3-11eb-8362-2216c0676335.mov

Reported as part of #5184

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
