### PR TITLE
Allow `/` characters in app configuration environment variables

### DIFF
--- a/.changeset/clean-chefs-speak.md
+++ b/.changeset/clean-chefs-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Allow for `/` characters in app configuration environment variables

--- a/packages/config-loader/src/lib/env.test.ts
+++ b/packages/config-loader/src/lib/env.test.ts
@@ -70,6 +70,27 @@ describe('readEnvConfig', () => {
     ]);
   });
 
+  it('should accept keys with /', () => {
+    expect(
+      readEnvConfig({
+        'APP_CONFIG_proxy_/foo': 'http://localhost:1337',
+        'APP_CONFIG_proxy_/bar/v1_target': 'http://localhost:1337',
+      }),
+    ).toEqual([
+      {
+        data: {
+          proxy: {
+            '/foo': 'http://localhost:1337',
+            '/bar/v1': {
+              target: 'http://localhost:1337',
+            },
+          },
+        },
+        context: 'env',
+      },
+    ]);
+  });
+
   it('should accept complex objects', () => {
     expect(
       readEnvConfig({
@@ -91,7 +112,6 @@ describe('readEnvConfig', () => {
     ['APP_CONFIG__foo'],
     ['APP_CONFIG_foo_'],
     ['APP_CONFIG_fo_0'],
-    ['APP_CONFIG_fo/o'],
     ['APP_CONFIG_fo o'],
     ['APP_CONFIG_foo_(foo)_foo'],
   ])('should reject invalid key %p', key => {

--- a/packages/config-loader/src/lib/env.ts
+++ b/packages/config-loader/src/lib/env.ts
@@ -19,7 +19,7 @@ import { AppConfig, JsonObject } from '@backstage/config';
 const ENV_PREFIX = 'APP_CONFIG_';
 
 // Update the same pattern in config package if this is changed
-const CONFIG_KEY_PART_PATTERN = /^[a-z][a-z0-9]*(?:[-_][a-z][a-z0-9]*)*$/i;
+const CONFIG_KEY_PART_PATTERN = /^[a-z/][a-z0-9/]*(?:[-_/][a-z][a-z0-9]*)*$/i;
 
 /**
  * Read runtime configuration from the environment.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adjusts the `CONFIG_KEY_PART_PATTERN` regex with `config-loader` to _better_ cater for the requirements of the `proxy-backend` plugin.

At present `/` characters within the app config environment variables are currently treated as invalid by the `config-loader` package. This prevents users from applying configuration for the `backend-proxy` via environment variables as these must currently be prefixed with a `/` (and may even contain multiple `/` characters). E.g. `APP_CONFIG_proxy_/foo/bar_target: http://localhost:1337` will currently fail. Whilst this change doesn't cater for the full range of characters allowed in a URL is does open up the possibility of supplying basic configuration for the `proxy-backend` configuration via environment variables.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
