### PR TITLE
Added 'where' support in catalog client calls

### DIFF
--- a/.changeset/strange-gifts-promise.md
+++ b/.changeset/strange-gifts-promise.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-client': patch
+'@backstage/plugin-org': patch
+---
+
+Added support for a 'where' clause in calls to the catalog client

--- a/packages/catalog-client/src/types.ts
+++ b/packages/catalog-client/src/types.ts
@@ -23,7 +23,7 @@ export type CatalogEntitiesRequestWhereOne = {
 
 export type CatalogEntitiesRequestWhereMany = {
   operator: 'in' | 'not-in';
-  operand: Array<string> | Array<number> | Array<boolean>;
+  operand: Array<string>;
 };
 
 export type CatalogEntitiesRequestWhere =

--- a/packages/catalog-client/src/types.ts
+++ b/packages/catalog-client/src/types.ts
@@ -16,9 +16,24 @@
 
 import { Entity, EntityName, Location } from '@backstage/catalog-model';
 
+export type CatalogEntitiesRequestWhereOne = {
+  operator: 'equal' | 'not-equal';
+  operand: string | number | boolean;
+};
+
+export type CatalogEntitiesRequestWhereMany = {
+  operator: 'in' | 'not-in';
+  operand: Array<string> | Array<number> | Array<boolean>;
+};
+
+export type CatalogEntitiesRequestWhere =
+  | CatalogEntitiesRequestWhereOne
+  | CatalogEntitiesRequestWhereMany;
+
 export type CatalogEntitiesRequest = {
   filter?: Record<string, string | string[]> | undefined;
   fields?: string[] | undefined;
+  where?: Record<string, CatalogEntitiesRequestWhere>;
 };
 
 export type CatalogListResponse<T> = {

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -17,6 +17,7 @@ import {
   ENTITY_DEFAULT_NAMESPACE,
   GroupEntity,
   RELATION_MEMBER_OF,
+  stringifyEntityRef,
   UserEntity,
 } from '@backstage/catalog-model';
 import {
@@ -44,7 +45,7 @@ import React from 'react';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
 import { useAsync } from 'react-use';
 
-const useStyles = makeStyles((theme: Theme) =>
+const useStyles = makeStyles(theme =>
   createStyles({
     card: {
       border: `1px solid ${theme.palette.divider}`,
@@ -123,6 +124,12 @@ export const MembersListCard = (_props: {
   const { loading, error, value: members } = useAsync(async () => {
     const membersList = await catalogApi.getEntities({
       filter: { kind: 'User' },
+      where: {
+        [RELATION_MEMBER_OF]: {
+          operator: 'equal',
+          operand: stringifyEntityRef({ kind: 'group', name: groupName }),
+        },
+      },
     });
     const groupMembersList = (membersList.items as UserEntity[]).filter(
       member =>

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -45,7 +45,7 @@ import React from 'react';
 import { generatePath, Link as RouterLink } from 'react-router-dom';
 import { useAsync } from 'react-use';
 
-const useStyles = makeStyles(theme =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     card: {
       border: `1px solid ${theme.palette.divider}`,

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
+import {
+  Entity,
+  RELATION_OWNED_BY,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 import {
   InfoCard,
   InfoCardVariants,
@@ -156,6 +160,12 @@ export const OwnershipCard = ({
         'spec.type',
         'relations',
       ],
+      where: {
+        [RELATION_OWNED_BY]: {
+          operator: 'equal',
+          operand: stringifyEntityRef(entity),
+        },
+      },
     });
 
     const ownedEntitiesList = entitiesList.items.filter(component =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
