### PR TITLE
[Catalog] Expose BitbucketRepositoryParser

### DIFF
--- a/.changeset/khaki-rice-accept.md
+++ b/.changeset/khaki-rice-accept.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Expose `BitbucketRepositoryParser` introduced in [#5295](https://github.com/backstage/backstage/pull/5295)

--- a/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
@@ -22,7 +22,7 @@ import {
 } from '@backstage/integration';
 import { LocationSpec } from '@backstage/catalog-model';
 import {
-  Repository,
+  Bitbucket,
   BitbucketRepositoryParser,
   BitbucketClient,
   defaultRepositoryParser,
@@ -159,5 +159,5 @@ function escapeRegExp(str: string): RegExp {
 
 type Result = {
   scanned: number;
-  matches: Repository[];
+  matches: Bitbucket.Repository[];
 };

--- a/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
@@ -22,11 +22,11 @@ import {
 } from '@backstage/integration';
 import { LocationSpec } from '@backstage/catalog-model';
 import {
-  Bitbucket,
   BitbucketRepositoryParser,
   BitbucketClient,
   defaultRepositoryParser,
   paginated,
+  BitbucketRepository,
 } from './bitbucket';
 import { CatalogProcessor, CatalogProcessorEmit } from './types';
 
@@ -66,20 +66,19 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
       return false;
     }
 
-    const bitbucketConfig = this.integrations.bitbucket.byUrl(location.target)
-      ?.config;
-    if (!bitbucketConfig) {
+    const integration = this.integrations.bitbucket.byUrl(location.target);
+    if (!integration) {
       throw new Error(
         `There is no Bitbucket integration that matches ${location.target}. Please add a configuration entry for it under integrations.bitbucket`,
       );
-    } else if (bitbucketConfig.host === 'bitbucket.org') {
+    } else if (integration.config.host === 'bitbucket.org') {
       throw new Error(
         `Component discovery for Bitbucket Cloud is not yet supported`,
       );
     }
 
     const client = new BitbucketClient({
-      config: bitbucketConfig,
+      config: integration.config,
     });
     const startTimestamp = Date.now();
     this.logger.info(`Reading Bitbucket repositories from ${location.target}`);
@@ -90,9 +89,9 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
 
     for (const repository of result.matches) {
       for await (const entity of this.parser({
-        client: client,
-        repository: repository,
-        path: catalogPath,
+        integration: integration,
+        target: `${repository.links.self[0]}${catalogPath}`,
+        logger: this.logger,
       })) {
         emit(entity);
       }
@@ -159,5 +158,5 @@ function escapeRegExp(str: string): RegExp {
 
 type Result = {
   scanned: number;
-  matches: Bitbucket.Repository[];
+  matches: BitbucketRepository[];
 };

--- a/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
@@ -90,7 +90,7 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
     for (const repository of result.matches) {
       for await (const entity of this.parser({
         integration: integration,
-        target: `${repository.links.self[0]}${catalogPath}`,
+        target: `${repository.links.self[0].href}${catalogPath}`,
         logger: this.logger,
       })) {
         emit(entity);

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import { defaultRepositoryParser } from './BitbucketRepositoryParser';
-import { Bitbucket } from './types';
-import { BitbucketClient } from './client';
 import { results } from '../index';
+import { getVoidLogger } from '@backstage/backend-common';
+import { BitbucketIntegration } from '@backstage/integration';
 
 describe('BitbucketRepositoryParser', () => {
   describe('defaultRepositoryParser', () => {
@@ -34,15 +34,9 @@ describe('BitbucketRepositoryParser', () => {
         ),
       ];
       const actual = await defaultRepositoryParser({
-        client: {} as BitbucketClient,
-        repository: {
-          project: {} as Bitbucket.Project,
-          slug: 'repo-slug',
-          links: {
-            self: [{ href: browseUrl }],
-          },
-        } as Bitbucket.Repository,
-        path: path,
+        integration: {} as BitbucketIntegration,
+        target: `${browseUrl}${path}`,
+        logger: getVoidLogger(),
       });
 
       let i = 0;

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { defaultRepositoryParser } from './BitbucketRepositoryParser';
-import { Project, Repository } from './types';
+import { Bitbucket } from './types';
 import { BitbucketClient } from './client';
 import { results } from '../index';
 
@@ -36,12 +36,12 @@ describe('BitbucketRepositoryParser', () => {
       const actual = await defaultRepositoryParser({
         client: {} as BitbucketClient,
         repository: {
-          project: {} as Project,
+          project: {} as Bitbucket.Project,
           slug: 'repo-slug',
           links: {
             self: [{ href: browseUrl }],
           },
-        } as Repository,
+        } as Bitbucket.Repository,
         path: path,
       });
 

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.ts
@@ -13,25 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Bitbucket } from './types';
 import { CatalogProcessorResult } from '../types';
 import { results } from '../index';
-import { BitbucketClient } from './client';
+import { Logger } from 'winston';
+import { BitbucketIntegration } from '@backstage/integration';
 
 export type BitbucketRepositoryParser = (options: {
-  client: BitbucketClient;
-  repository: Bitbucket.Repository;
-  path: string;
+  integration: BitbucketIntegration;
+  target: string;
+  logger: Logger;
 }) => AsyncIterable<CatalogProcessorResult>;
 
 export const defaultRepositoryParser: BitbucketRepositoryParser = async function* defaultRepositoryParser({
-  repository,
-  path,
+  target,
 }) {
   yield results.location(
     {
       type: 'url',
-      target: `${repository.links.self[0].href}${path}`,
+      target: target,
     },
     // Not all locations may actually exist, since the user defined them as a wildcard pattern.
     // Thus, we emit them as optional and let the downstream processor find them while not outputting

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Repository } from './types';
+import { Bitbucket } from './types';
 import { CatalogProcessorResult } from '../types';
 import { results } from '../index';
 import { BitbucketClient } from './client';
 
 export type BitbucketRepositoryParser = (options: {
   client: BitbucketClient;
-  repository: Repository;
+  repository: Bitbucket.Repository;
   path: string;
 }) => AsyncIterable<CatalogProcessorResult>;
 

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/client.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/client.ts
@@ -41,15 +41,6 @@ export class BitbucketClient {
     );
   }
 
-  async getRaw(
-    projectKey: string,
-    repo: string,
-    path: string,
-  ): Promise<Response> {
-    const request = `${this.config.apiBaseUrl}/projects/${projectKey}/repos/${repo}/raw/${path}`;
-    return fetch(request, getBitbucketRequestOptions(this.config));
-  }
-
   private async pagedRequest(
     endpoint: string,
     options?: ListOptions,

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/index.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 export { BitbucketClient, paginated } from './client';
-export type { PagedResponse } from './client';
-export * from './types';
-export type { BitbucketRepositoryParser } from './BitbucketRepositoryParser';
 export { defaultRepositoryParser } from './BitbucketRepositoryParser';
+export type { PagedResponse } from './client';
+export type { BitbucketRepository } from './types';
+export type { BitbucketRepositoryParser } from './BitbucketRepositoryParser';

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/types.ts
@@ -13,18 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export namespace Bitbucket {
-  export type Project = {
+export type BitbucketRepository = {
+  project: {
     key: string;
   };
-
-  export type Repository = {
-    project: Project;
-    slug: string;
-    links: Record<string, Link[]>;
-  };
-
-  export type Link = {
-    href: string;
-  };
-}
+  slug: string;
+  links: Record<
+    string,
+    {
+      href: string;
+    }[]
+  >;
+};

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/types.ts
@@ -13,16 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type Project = {
-  key: string;
-};
+export namespace Bitbucket {
+  export type Project = {
+    key: string;
+  };
 
-export type Repository = {
-  project: Project;
-  slug: string;
-  links: Record<string, Link[]>;
-};
+  export type Repository = {
+    project: Project;
+    slug: string;
+    links: Record<string, Link[]>;
+  };
 
-export type Link = {
-  href: string;
-};
+  export type Link = {
+    href: string;
+  };
+}

--- a/plugins/catalog-backend/src/ingestion/processors/index.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/index.ts
@@ -35,3 +35,7 @@ export * from './types';
 export { UrlReaderProcessor } from './UrlReaderProcessor';
 export { parseEntityYaml } from './util/parse';
 export { results };
+
+export * from './bitbucket/types';
+export { BitbucketClient } from './bitbucket';
+export type { BitbucketRepositoryParser } from './bitbucket';

--- a/plugins/catalog-backend/src/ingestion/processors/index.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/index.ts
@@ -36,6 +36,5 @@ export { UrlReaderProcessor } from './UrlReaderProcessor';
 export { parseEntityYaml } from './util/parse';
 export { results };
 
-export * from './bitbucket/types';
 export { BitbucketClient } from './bitbucket';
-export type { BitbucketRepositoryParser } from './bitbucket';
+export type { BitbucketRepositoryParser, Bitbucket } from './bitbucket';

--- a/plugins/catalog-backend/src/ingestion/processors/index.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/index.ts
@@ -36,5 +36,4 @@ export { UrlReaderProcessor } from './UrlReaderProcessor';
 export { parseEntityYaml } from './util/parse';
 export { results };
 
-export { BitbucketClient } from './bitbucket';
-export type { BitbucketRepositoryParser, Bitbucket } from './bitbucket';
+export type { BitbucketRepositoryParser } from './bitbucket';


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

## Hey, I just made a Pull Request!

When introducing the `BitbucketRepositoryParser` in #5295 exposing the parser function and some related types were missed. This pull request exposes the necessary types.

The change also includes wrapping the Bitbucket API types into a separate namespace for better isolation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
