### PR TITLE
Add nebula-preview header for Octokit publishing

### DIFF
--- a/.changeset/thin-coins-compete.md
+++ b/.changeset/thin-coins-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Added the `nebula-preview` preview to `Octokit` for repository visibility.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -149,6 +149,7 @@ export function createPublishGithubAction(options: {
       const client = new Octokit({
         auth: token,
         baseUrl: integrationConfig.config.apiBaseUrl,
+        previews: ['nebula-preview'],
       });
 
       const user = await client.users.getByUsername({

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -72,6 +72,7 @@ export class GithubPublisher implements PublisherBase {
     const client = new Octokit({
       auth: token,
       baseUrl: this.config.apiBaseUrl,
+      previews: ['nebula-preview'],
     });
 
     const description = values.description as string;


### PR DESCRIPTION
Signed-off-by: Tim Hansen <timbonicus@gmail.com>

## Hey, I just made a Pull Request!

Fixes #5488.

The Github API appears to [require a preview header](https://docs.github.com/en/rest/overview/api-previews#new-visibility-parameter-for-the-repositories-api) for the repo visibility parameter. It's a bit unclear why this worked before, perhaps an oversight on the Github API side?

Verified that I saw the error locally with the scaffolder and that this made it go away.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
