### PR TITLE
Support `gridItem` variant for `EntityLinksCard`

### DIFF
--- a/.changeset/small-snakes-shake.md
+++ b/.changeset/small-snakes-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Support `gridItem` variant for `EntityLinksCard`.

--- a/plugins/catalog/src/components/EntityLinksCard/EntityLinksCard.tsx
+++ b/plugins/catalog/src/components/EntityLinksCard/EntityLinksCard.tsx
@@ -27,9 +27,10 @@ type Props = {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: Entity;
   cols?: ColumnBreakpoints | number;
+  variant?: 'gridItem';
 };
 
-export const EntityLinksCard = ({ cols = undefined }: Props) => {
+export const EntityLinksCard = ({ cols = undefined, variant }: Props) => {
   const { entity } = useEntity();
   const app = useApp();
 
@@ -39,7 +40,7 @@ export const EntityLinksCard = ({ cols = undefined }: Props) => {
   const links = entity?.metadata?.links;
 
   return (
-    <InfoCard title="Links">
+    <InfoCard title="Links" variant={variant}>
       {!links || links.length === 0 ? (
         <EntityLinksEmptyState />
       ) : (


### PR DESCRIPTION
This makes it similar to other cards.

Signed-off-by: Oliver Sand <oliver.sand@sda-se.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
