### PR TITLE
Tweaks to the v2 catalog ingestion

### DIFF
--- a/plugins/catalog-backend/migrationsv2/20210302150147_refresh_state.js
+++ b/plugins/catalog-backend/migrationsv2/20210302150147_refresh_state.js
@@ -83,10 +83,18 @@ exports.up = async function up(knex) {
       .inTable('refresh_state')
       .onDelete('CASCADE')
       .comment(
-        'Entity ID which correspond to the ID in the refresh_state table',
+        'Entity ID which corresponds to the ID in the refresh_state table',
       );
-    table.text('etag').notNullable().comment('Etag to be used for caching');
-    table.text('finalized_entity').notNullable().comment('The final entity');
+    table
+      .text('hash')
+      .notNullable()
+      .comment(
+        'Stable hash of the entity data, to be used for caching and avoiding redundant work',
+      );
+    table
+      .text('final_entity')
+      .notNullable()
+      .comment('The JSON encoded final entity');
     table.index('entity_id', 'final_entities_entity_id_idx');
   });
 

--- a/plugins/catalog-backend/src/next/NextEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/next/NextEntitiesCatalog.ts
@@ -37,7 +37,7 @@ export class NextEntitiesCatalog implements EntitiesCatalog {
       'final_entities',
     ).select();
 
-    const entities = dbResponse.map(e => JSON.parse(e.finalized_entity));
+    const entities = dbResponse.map(e => JSON.parse(e.final_entity));
 
     return {
       entities,

--- a/plugins/catalog-backend/src/next/search.test.ts
+++ b/plugins/catalog-backend/src/next/search.test.ts
@@ -152,8 +152,8 @@ describe('search', () => {
           key: 'metadata.namespace',
           value: ENTITY_DEFAULT_NAMESPACE,
         },
-        { entity_id: 'eid', key: 'relations', value: 't1:k:ns/a' },
-        { entity_id: 'eid', key: 'relations', value: 't2:k:ns/b' },
+        { entity_id: 'eid', key: 'relations.t1', value: 'k:ns/a' },
+        { entity_id: 'eid', key: 'relations.t2', value: 'k:ns/b' },
       ]);
     });
   });

--- a/plugins/catalog-backend/src/next/search.ts
+++ b/plugins/catalog-backend/src/next/search.ts
@@ -182,8 +182,8 @@ export function buildEntitySearch(
   // Visit relations
   for (const relation of entity.relations ?? []) {
     raw.push({
-      key: 'relations',
-      value: `${relation.type}:${stringifyEntityRef(relation.target)}`,
+      key: `relations.${relation.type}`,
+      value: stringifyEntityRef(relation.target),
     });
   }
 


### PR DESCRIPTION
Tweaks to the v2 catalog ingestion.

- Rename the `finalized_entity` column to `final_entity`
- Rename the `etag` column to `hash`, to clarify its purpose and detaching from the notion of `metadata.etag`
- Only replace `metadata.etag` with the hash if there wasn't one to begin with. This is a very premature fix that allows `POST` based entity store+source to manage their etags in any way that they see fit (to get atomicity checks in their API), separate from our hashing needs. We could do the same with `metadata.generation` now as well, if we store that in a column in the `final_entities` table.
- Make sure that the relations filters are on the form `relations.<type>=<kind>:<namespace>/<name>`