### PR TITLE
[Fixes #5520] yarn build does not have --lax option exposed

### DIFF
--- a/.changeset/nice-shirts-fetch.md
+++ b/.changeset/nice-shirts-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added lax option to backstage-cli app:build command

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -111,6 +111,7 @@ Usage: backstage-cli app:build
 
 Options:
   --stats          Write bundle stats to output directory
+  --lax            Do not require environment variables to be set
   --config &lt;path&gt;  Config files to load instead of app-config.yaml (default: [])
   -h, --help       display help for command
 ```
@@ -486,6 +487,7 @@ Usage: backstage-cli config:print [options]
 
 Options:
   --package &lt;name&gt;   Only load config schema that applies to the given package
+  --lax              Do not require environment variables to be set
   --frontend         Print only the frontend configuration
   --with-secrets     Include secrets in the printed configuration
   --format &lt;format&gt;  Format to print the configuration in, either json or yaml [yaml]
@@ -506,6 +508,7 @@ Usage: backstage-cli config:check [options]
 
 Options:
   --package &lt;name&gt;  Only load config schema that applies to the given package
+  --lax                   Do not require environment variables to be set
   --config &lt;path&gt;   Config files to load instead of app-config.yaml (default: [])
   -h, --help        display help for command
 ```

--- a/packages/cli/src/commands/app/build.ts
+++ b/packages/cli/src/commands/app/build.ts
@@ -30,6 +30,7 @@ export default async (cmd: Command) => {
     ...(await loadCliConfig({
       args: cmd.config,
       fromPackage: name,
+      mockEnv: cmd.lax,
     })),
   });
 };

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -29,6 +29,7 @@ export function registerCommands(program: CommanderStatic) {
     .command('app:build')
     .description('Build an app for a production release')
     .option('--stats', 'Write bundle stats to output directory')
+    .option('--lax', 'Do not require environment variables to be set')
     .option(...configOption)
     .action(lazy(() => import('./app/build').then(m => m.default)));
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This fixes https://github.com/backstage/backstage/issues/5520 by adding the `--lax` option to `backstage-cli app:build`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
