### PR TITLE
Tech docs with s3-like services

### DIFF
--- a/.changeset/tricky-yaks-melt.md
+++ b/.changeset/tricky-yaks-melt.md
@@ -1,0 +1,6 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Adding optional config to enable S3-like API for tech-docs using s3ForcePathStyle option.
+This allows providers like LocalStack, Minio and Wasabi (+possibly others) to be used to host tech docs.

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -41,8 +41,10 @@ Kaewkasi
 Knex
 Leasot
 Lerna
+LocalStack
 Luxon
 Minikube
+Minio
 Mkdocs
 Monorepo
 Namespaces

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -78,6 +78,11 @@ techdocs:
       # https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
       endpoint: ${AWS_ENDPOINT}
 
+      # (Optional) Whether to use path style URLs when communicating with S3.
+      # Defaults to false.
+      # This allows providers like LocalStack, Minio and Wasabi (and possibly others) to be used to host tech docs.
+      s3ForcePathStyle: false
+
     # Required when techdocs.publisher.type is set to 'azureBlobStorage'. Skip otherwise.
 
     azureBlobStorage:

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -80,10 +80,17 @@ export class AwsS3Publish implements PublisherBase {
       'techdocs.publisher.awsS3.endpoint',
     );
 
+    // AWS forcePathStyle is an optional config. If missing, it defaults to false. Needs to be enabled for cases
+    // where endpoint url points to locally hosted S3 compatible storage like Localstack
+    const s3ForcePathStyle = config.getOptionalBoolean(
+      'techdocs.publisher.awsS3.s3ForcePathStyle',
+    );
+
     const storageClient = new aws.S3({
       credentials,
       ...(region && { region }),
       ...(endpoint && { endpoint }),
+      ...(s3ForcePathStyle && { s3ForcePathStyle }),
     });
 
     return new AwsS3Publish(storageClient, bucketName, logger);

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -90,6 +90,13 @@ export interface Config {
              * @visibility secret
              */
             endpoint?: string;
+            /**
+             * (Optional) Whether to use path style URLs when communicating with S3.
+             * Defaults to false.
+             * This allows providers like LocalStack, Minio and Wasabi (and possibly others) to be used to host tech docs.
+             * @visibility backend
+             */
+            endpoint?: string;
           };
         }
       | {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While adding end-to-end tests to our system I noticed that using alternative S3-like storage providers is not supported by tech docs. S3 API provides a simple boolean option to force path style discovery which is the style used in some of these S3-compliant-but-not-quite-the-same services. Some examples of these include Localstack, Minio and Wasabi. 

~Let me know if this is a worthy addition and I'll update the docs as well.~ Added docs to config options

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
