### PR TITLE
Mention error handling on GitHub discovery docs

### DIFF
--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -37,6 +37,13 @@ The locations added through static configuration cannot be removed through the
 catalog locations API. To remove these locations, you must remove them from the
 configuration.
 
+Syntax errors or other types of errors present in `catalog-info.yaml` files will
+be logged for investigation. Errors do not cause processing to abort.
+
+When multiple `catalog-info.yaml` files with the same `metadata.name` property
+are discovered, one will be processed and all others will be skipped. This
+action is logged for further investigation.
+
 ### Integration Processors
 
 Integrations may simply provide a mechanism to handle `url` location type for an

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -52,3 +52,13 @@ Backstage to use the [github-apps plugin](../../plugins/github-apps.md).
 
 This is true for any method of adding GitHub entities to the catalog, but
 especially easy to hit with automatic discovery.
+
+## Error handling
+
+Syntax errors or other types of errors present in `catalog-info.yaml` files will
+be logged for investigation and the importer will continue. Errors do not cause
+the process to fail.
+
+When multiple `catalog-info.yaml` files with the same `metadata.name` property
+are discovered, one will be skipped and the process will continue. This action
+will be logged for later investication.

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -61,4 +61,4 @@ the process to fail.
 
 When multiple `catalog-info.yaml` files with the same `metadata.name` property
 are discovered, one will be skipped and the process will continue. This action
-will be logged for later investication.
+will be logged for later investigation.

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -52,13 +52,3 @@ Backstage to use the [github-apps plugin](../../plugins/github-apps.md).
 
 This is true for any method of adding GitHub entities to the catalog, but
 especially easy to hit with automatic discovery.
-
-## Error handling
-
-Syntax errors or other types of errors present in `catalog-info.yaml` files will
-be logged for investigation and the importer will continue. Errors do not cause
-the process to fail.
-
-When multiple `catalog-info.yaml` files with the same `metadata.name` property
-are discovered, one will be skipped and the process will continue. This action
-will be logged for later investigation.


### PR DESCRIPTION
I did some testing with error handling of the GitHub discovery and it may be useful to explain the results for others who are curious.

One other question that has come up is whether or not `Location` entities are imported by the discovery importer. I'll try to test that later and may add more notes to this page.

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
