### PR TITLE
Add support for non-organization accounts in GitHub Discovery

### DIFF
--- a/.changeset/stupid-feet-reply.md
+++ b/.changeset/stupid-feet-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add support for non-organization accounts in GitHub Discovery

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.test.ts
@@ -156,7 +156,7 @@ describe('github', () => {
   describe('getOrganizationRepositories', () => {
     it('read repositories', async () => {
       const input: QueryResponse = {
-        organization: {
+        repositoryOwner: {
           repositories: {
             nodes: [
               {


### PR DESCRIPTION
Signed-off-by: Simon Knittel <hallo@simonknittel.de>

## Hey, I just made a Pull Request!

This PR adds support for non-organization accounts in GitHub Discovery. This isn't possible at the moment since the `organization` endpoint in GitHub's GraphQL API only returns repositories of actual organization accounts. Closes #5544

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
