### PR TITLE
chore: Use the same version of react-hook-form across packages

### DIFF
--- a/.changeset/fuzzy-dancers-complain.md
+++ b/.changeset/fuzzy-dancers-complain.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core': patch
+'@backstage/plugin-catalog-import': patch
+---
+
+Bump react-hook-form version to be the same for the entire project.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-helmet": "6.1.0",
-    "react-hook-form": "^6.6.0",
+    "react-hook-form": "^6.15.4",
     "react-markdown": "^5.0.2",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",

--- a/plugins/register-component/package.json
+++ b/plugins/register-component/package.json
@@ -39,7 +39,7 @@
     "@material-ui/lab": "4.0.0-alpha.45",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-hook-form": "^6.6.0",
+    "react-hook-form": "^6.15.4",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^15.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22074,7 +22074,7 @@ react-helmet@6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-hook-form@^6.15.4, react-hook-form@^6.6.0:
+react-hook-form@^6.15.4:
   version "6.15.4"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.4.tgz#328003e1ccc096cd158899ffe7e3b33735a9b024"
   integrity sha512-K+Sw33DtTMengs8OdqFJI3glzNl1wBzSefD/ksQw/hJf9CnOHQAU6qy82eOrh0IRNt2G53sjr7qnnw1JDjvx1w==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use the same version of react-hook-form across packages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
