### PR TITLE
Close eventstreams upon completion

### DIFF
--- a/.changeset/tame-masks-juggle.md
+++ b/.changeset/tame-masks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Close eventSource upon completion of a scaffolder task

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -214,6 +214,7 @@ export class ScaffolderClient implements ScaffolderApi {
                 subscriber.error(ex);
               }
             }
+            eventSource.close();
             subscriber.complete();
           });
           eventSource.addEventListener('error', event => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Previously we were not closing eventSource's upon completion which
lead to stale eventstream calls persisting across a session in the
scaffolder. This calls eventSource.close() properly in order to
clean up an eventStream once we get completion event

Signed-off-by: jrusso1020 <jrusso@brex.com>


### Note
This only fixes part of our issues, we are still encountering `net::ERR_HTTP2_PROTOCOL_ERROR 200` which resets the stream and then the new stream's changes don't show up in the UI but with this change we no longer have multiple stale eventstreams laying around

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
