### PR TITLE
Add Owner Field into TemplateCard and ownedBy & ownerOf relations for TemplateEntity

### DIFF
--- a/.changeset/fuzzy-ladybugs-drive.md
+++ b/.changeset/fuzzy-ladybugs-drive.md
@@ -1,6 +1,12 @@
 ---
 '@backstage/catalog-model': patch
 '@backstage/plugin-scaffolder': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
 Add Owner field in template card and new data distribution
+Add spec.owner as optional field into TemplateV1Alpha and TemplateV1Beta Schema
+Add relations ownedBy and ownerOf into Template entity
+Template documentation updated

--- a/.changeset/fuzzy-ladybugs-drive.md
+++ b/.changeset/fuzzy-ladybugs-drive.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-model': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Add Owner field in template card and new data distribution

--- a/.changeset/fuzzy-ladybugs-drive.md
+++ b/.changeset/fuzzy-ladybugs-drive.md
@@ -2,7 +2,6 @@
 '@backstage/catalog-model': patch
 '@backstage/plugin-scaffolder': patch
 '@backstage/plugin-catalog-backend': patch
-'@backstage/plugin-scaffolder': patch
 '@backstage/plugin-scaffolder-backend': patch
 ---
 

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -662,7 +662,7 @@ You can find out more about the `steps` key
 An [entity reference](#string-references) to the owner of the component, e.g.
 `artist-relations-team`. This field is required.
 
-In Backstage, the owner of an Template is the singular entity (commonly a team)
+In Backstage, the owner of a Template is the singular entity (commonly a team)
 that bears ultimate responsibility for the Template, and has the authority and
 capability to develop and maintain it. They will be the point of contact if
 something goes wrong, or if features are to be requested. The main purpose of

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -657,6 +657,25 @@ You can find out more about the `parameters` key
 You can find out more about the `steps` key
 [here](../software-templates/writing-templates.md)
 
+### `spec.owner` [optional]
+
+An [entity reference](#string-references) to the owner of the component, e.g.
+`artist-relations-team`. This field is required.
+
+In Backstage, the owner of an Template is the singular entity (commonly a team)
+that bears ultimate responsibility for the Template, and has the authority and
+capability to develop and maintain it. They will be the point of contact if
+something goes wrong, or if features are to be requested. The main purpose of
+this field is for display purposes in Backstage, so that people looking at
+catalog items can get an understanding of to whom this Template belongs. It is
+not to be used by automated processes to for example assign authorization in
+runtime systems. There may be others that also develop or otherwise touch the
+Template, but there will always be one ultimate owner.
+
+| [`kind`](#apiversion-and-kind-required)                | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                              |
+| ------------------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------- |
+| [`Group`](#kind-group) (default), [`User`](#kind-user) | Same as this entity, typically `default`   | [`ownerOf`, and reverse `ownedBy`](well-known-relations.md#ownedby-and-ownerof) |
+
 ## Kind: API
 
 Describes the following entity kind:

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -486,6 +486,7 @@ interface TemplateEntityV1alpha1 extends Entity {
         templater: string;
         path?: string;
         schema: JSONSchema;
+        owner: string;
     };
 }
 

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -486,7 +486,7 @@ interface TemplateEntityV1alpha1 extends Entity {
         templater: string;
         path?: string;
         schema: JSONSchema;
-        owner: string;
+        owner?: string;
     };
 }
 
@@ -520,6 +520,7 @@ export interface TemplateEntityV1beta2 extends Entity {
         output?: {
             [name: string]: string;
         };
+        owner?: string;
     };
 }
 

--- a/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.test.ts
@@ -91,4 +91,8 @@ describe('templateEntityV1alpha1Validator', () => {
     (entity as any).spec.templater = '';
     await expect(validator.check(entity)).rejects.toThrow(/templater/);
   });
+  it('accepts missing owner', async () => {
+    delete (entity as any).spec.owner;
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
 });

--- a/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.test.ts
@@ -48,7 +48,7 @@ describe('templateEntityV1alpha1Validator', () => {
             },
           },
         },
-        owner: 'example@email.com',
+        owner: 'team-a@example.com',
       },
     };
   });
@@ -94,5 +94,13 @@ describe('templateEntityV1alpha1Validator', () => {
   it('accepts missing owner', async () => {
     delete (entity as any).spec.owner;
     await expect(validator.check(entity)).resolves.toBe(true);
+  });
+  it('rejects empty owner', async () => {
+    (entity as any).spec.owner = '';
+    await expect(validator.check(entity)).rejects.toThrow(/owner/);
+  });
+  it('rejects wrong type owner', async () => {
+    (entity as any).spec.owner = 5;
+    await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 });

--- a/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.test.ts
@@ -48,6 +48,7 @@ describe('templateEntityV1alpha1Validator', () => {
             },
           },
         },
+        owner: 'example@email.com',
       },
     };
   });

--- a/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.ts
@@ -33,7 +33,7 @@ export interface TemplateEntityV1alpha1 extends Entity {
     templater: string;
     path?: string;
     schema: JSONSchema;
-    owner: string;
+    owner?: string;
   };
 }
 

--- a/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1alpha1.ts
@@ -33,6 +33,7 @@ export interface TemplateEntityV1alpha1 extends Entity {
     templater: string;
     path?: string;
     schema: JSONSchema;
+    owner: string;
   };
 }
 

--- a/packages/catalog-model/src/kinds/TemplateEntityV1beta2.test.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1beta2.test.ts
@@ -59,6 +59,7 @@ describe('templateEntityV1beta2Validator', () => {
         output: {
           fetchUrl: '{{ steps.fetch.output.targetUrl }}',
         },
+        owner: 'example@email.com',
       },
     };
   });
@@ -120,5 +121,9 @@ describe('templateEntityV1beta2Validator', () => {
   it('rejects step with missing action', async () => {
     delete (entity as any).spec.steps[0].action;
     await expect(validator.check(entity)).rejects.toThrow(/action/);
+  });
+  it('accepts missing owner', async () => {
+    delete (entity as any).spec.owner;
+    await expect(validator.check(entity)).resolves.toBe(true);
   });
 });

--- a/packages/catalog-model/src/kinds/TemplateEntityV1beta2.test.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1beta2.test.ts
@@ -59,7 +59,7 @@ describe('templateEntityV1beta2Validator', () => {
         output: {
           fetchUrl: '{{ steps.fetch.output.targetUrl }}',
         },
-        owner: 'example@email.com',
+        owner: 'team-b@example.com',
       },
     };
   });
@@ -125,5 +125,13 @@ describe('templateEntityV1beta2Validator', () => {
   it('accepts missing owner', async () => {
     delete (entity as any).spec.owner;
     await expect(validator.check(entity)).resolves.toBe(true);
+  });
+  it('rejects empty owner', async () => {
+    (entity as any).spec.owner = '';
+    await expect(validator.check(entity)).rejects.toThrow(/owner/);
+  });
+  it('rejects wrong type owner', async () => {
+    (entity as any).spec.owner = 5;
+    await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 });

--- a/packages/catalog-model/src/kinds/TemplateEntityV1beta2.ts
+++ b/packages/catalog-model/src/kinds/TemplateEntityV1beta2.ts
@@ -41,6 +41,7 @@ export interface TemplateEntityV1beta2 extends Entity {
       parameters?: JsonObject;
     }>;
     output?: { [name: string]: string };
+    owner?: string;
   };
 }
 

--- a/packages/catalog-model/src/schema/kinds/Template.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Template.v1alpha1.schema.json
@@ -88,7 +88,8 @@
             },
             "owner": {
               "type": "string",
-              "description": "The user (or group) owner of the template"
+              "description": "The user (or group) owner of the template",
+              "minLength": 1
             }
           }
         }

--- a/packages/catalog-model/src/schema/kinds/Template.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Template.v1alpha1.schema.json
@@ -85,6 +85,10 @@
             "schema": {
               "type": "object",
               "description": "The JSONSchema describing the inputs for the template."
+            },
+            "owner": {
+              "type": "string",
+              "description": "The user (or group) owner of the template"
             }
           }
         }

--- a/packages/catalog-model/src/schema/kinds/Template.v1beta2.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Template.v1beta2.schema.json
@@ -171,7 +171,8 @@
             },
             "owner": {
               "type": "string",
-              "description": "The user (or group) owner of the template"
+              "description": "The user (or group) owner of the template",
+              "minLength": 1
             }
           }
         }

--- a/packages/catalog-model/src/schema/kinds/Template.v1beta2.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Template.v1beta2.schema.json
@@ -168,6 +168,10 @@
               "additionalProperties": {
                 "type": "string"
               }
+            },
+            "owner": {
+              "type": "string",
+              "description": "The user (or group) owner of the template"
             }
           }
         }

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
@@ -21,6 +21,7 @@ import {
   GroupEntity,
   ResourceEntity,
   SystemEntity,
+  TemplateEntity,
   UserEntity,
 } from '@backstage/catalog-model';
 import { BuiltinKindsEntityProcessor } from './BuiltinKindsEntityProcessor';
@@ -517,6 +518,48 @@ describe('BuiltinKindsEntityProcessor', () => {
           source: { kind: 'Group', namespace: 'default', name: 'n' },
           type: 'hasMember',
           target: { kind: 'User', namespace: 'default', name: 'm' },
+        },
+      });
+    });
+    it('generates relations for template entities', async () => {
+      const entity: TemplateEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Template',
+        metadata: { name: 'n' },
+        spec: {
+          schema: {
+            properties: {
+              description: {
+                title: 'd',
+                type: 'string',
+                description: 'des',
+              },
+            },
+          },
+          templater: 'cookiecutter',
+          path: '.',
+          type: 'service',
+          owner: 'o',
+        },
+      };
+
+      await processor.postProcessEntity(entity, location, emit);
+
+      expect(emit).toBeCalledTimes(2);
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Group', namespace: 'default', name: 'o' },
+          type: 'ownerOf',
+          target: { kind: 'Template', namespace: 'default', name: 'n' },
+        },
+      });
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Template', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'o' },
         },
       });
     });

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
@@ -46,6 +46,7 @@ import {
   resourceEntityV1alpha1Validator,
   SystemEntity,
   systemEntityV1alpha1Validator,
+  TemplateEntity,
   templateEntityV1alpha1Validator,
   templateEntityV1beta2Validator,
   UserEntity,
@@ -129,6 +130,19 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
           }),
         );
       }
+    }
+
+    /*
+     * Emit relations for the Template kind
+     */
+    if (entity.kind === 'Template') {
+      const template = entity as TemplateEntity;
+      doEmit(
+        template.spec.owner,
+        { defaultKind: 'Group', defaultNamespace: selfRef.namespace },
+        RELATION_OWNED_BY,
+        RELATION_OWNER_OF,
+      );
     }
 
     /*

--- a/plugins/scaffolder-backend/src/scaffolder/jobs/processor.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/jobs/processor.test.ts
@@ -60,6 +60,7 @@ describe('JobProcessor', () => {
           },
         },
       },
+      owner: 'example@email.com',
     },
   };
 

--- a/plugins/scaffolder-backend/src/scaffolder/stages/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/helpers.test.ts
@@ -55,7 +55,7 @@ describe('Helpers', () => {
               },
             },
           },
-          owner: 'example@email.com',
+          owner: 'team-d@example.com',
         },
       };
 
@@ -104,7 +104,7 @@ describe('Helpers', () => {
               },
             },
           },
-          owner: 'example@email.com',
+          owner: 'team-b@example.com',
         },
       };
 
@@ -153,7 +153,7 @@ describe('Helpers', () => {
               },
             },
           },
-          owner: 'example@email.com',
+          owner: 'team-a@example.com',
         },
       };
 
@@ -201,7 +201,7 @@ describe('Helpers', () => {
               },
             },
           },
-          owner: 'example@email.com',
+          owner: 'team-b@example.com',
         },
       };
 
@@ -247,7 +247,7 @@ describe('Helpers', () => {
               },
             },
           },
-          owner: 'example@email.com',
+          owner: 'team-c@example.com',
         },
       };
 

--- a/plugins/scaffolder-backend/src/scaffolder/stages/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/helpers.test.ts
@@ -55,6 +55,7 @@ describe('Helpers', () => {
               },
             },
           },
+          owner: 'example@email.com',
         },
       };
 
@@ -103,6 +104,7 @@ describe('Helpers', () => {
               },
             },
           },
+          owner: 'example@email.com',
         },
       };
 
@@ -151,6 +153,7 @@ describe('Helpers', () => {
               },
             },
           },
+          owner: 'example@email.com',
         },
       };
 
@@ -198,6 +201,7 @@ describe('Helpers', () => {
               },
             },
           },
+          owner: 'example@email.com',
         },
       };
 
@@ -243,6 +247,7 @@ describe('Helpers', () => {
               },
             },
           },
+          owner: 'example@email.com',
         },
       };
 

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -23,6 +23,7 @@ import {
   CardMedia,
   Chip,
   makeStyles,
+  Typography,
   useTheme,
 } from '@material-ui/core';
 import React from 'react';
@@ -31,21 +32,32 @@ import { rootRouteRef } from '../../routes';
 import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 import { FavouriteTemplate } from '../FavouriteTemplate/FavouriteTemplate';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   cardHeader: {
     position: 'relative',
   },
   title: {
     backgroundImage: ({ backgroundImage }: any) => backgroundImage,
   },
-  description: {
+  box: {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     display: '-webkit-box',
     '-webkit-line-clamp': 10,
     '-webkit-box-orient': 'vertical',
+    paddingBottom: '0.8em',
   },
-});
+  label: {
+    color: theme.palette.text.secondary,
+    textTransform: 'uppercase',
+    fontSize: '10px',
+    fontWeight: 'bold',
+    letterSpacing: 0.5,
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    paddingBottom: '0.2rem',
+  },
+}));
 
 export type TemplateCardProps = {
   template: TemplateEntityV1alpha1;
@@ -57,6 +69,7 @@ type TemplateProps = {
   title: string;
   type: string;
   name: string;
+  owner: string;
 };
 
 const getTemplateCardProps = (
@@ -68,6 +81,7 @@ const getTemplateCardProps = (
     title: `${(template.metadata.title || template.metadata.name) ?? ''}`,
     type: template.spec.type ?? '',
     description: template.metadata.description ?? '-',
+    owner: template.spec.owner ?? '-',
     tags: (template.metadata?.tags as string[]) ?? [],
   };
 };
@@ -94,13 +108,27 @@ export const TemplateCard = ({ template }: TemplateCardProps) => {
           classes={{ root: classes.title }}
         />
       </CardMedia>
-      <CardContent>
+      <CardContent style={{ display: 'grid' }}>
+        <Box className={classes.box}>
+          <Typography variant="body2" className={classes.label}>
+            Description
+          </Typography>
+          {templateProps.description}
+        </Box>
+        <Box className={classes.box}>
+          <Typography variant="body2" className={classes.label}>
+            Owner
+          </Typography>
+          <Typography variant="inherit">{templateProps.owner}</Typography>
+        </Box>
         <Box>
+          <Typography variant="body2" className={classes.label}>
+            Tags
+          </Typography>
           {templateProps.tags?.map(tag => (
             <Chip size="small" label={tag} key={tag} />
           ))}
         </Box>
-        <Box className={classes.description}>{templateProps.description}</Box>
       </CardContent>
       <CardActions>
         <Button

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -58,11 +58,10 @@ const useStyles = makeStyles(theme => ({
   label: {
     color: theme.palette.text.secondary,
     textTransform: 'uppercase',
-    fontSize: '10px',
+    fontSize: '0.65rem',
     fontWeight: 'bold',
     letterSpacing: 0.5,
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
+    lineHeight: 1,
     paddingBottom: '0.2rem',
   },
 }));

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -29,8 +29,16 @@ import {
 import React from 'react';
 import { generatePath } from 'react-router';
 import { rootRouteRef } from '../../routes';
-import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
+import {
+  TemplateEntityV1alpha1,
+  Entity,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
 import { FavouriteTemplate } from '../FavouriteTemplate/FavouriteTemplate';
+import {
+  getEntityRelations,
+  EntityRefLinks,
+} from '@backstage/plugin-catalog-react';
 
 const useStyles = makeStyles(theme => ({
   cardHeader: {
@@ -69,7 +77,6 @@ type TemplateProps = {
   title: string;
   type: string;
   name: string;
-  owner: string;
 };
 
 const getTemplateCardProps = (
@@ -81,7 +88,6 @@ const getTemplateCardProps = (
     title: `${(template.metadata.title || template.metadata.name) ?? ''}`,
     type: template.spec.type ?? '',
     description: template.metadata.description ?? '-',
-    owner: template.spec.owner ?? '-',
     tags: (template.metadata?.tags as string[]) ?? [],
   };
 };
@@ -90,7 +96,10 @@ export const TemplateCard = ({ template }: TemplateCardProps) => {
   const backstageTheme = useTheme<BackstageTheme>();
   const rootLink = useRouteRef(rootRouteRef);
   const templateProps = getTemplateCardProps(template);
-
+  const ownedByRelations = getEntityRelations(
+    template as Entity,
+    RELATION_OWNED_BY,
+  );
   const themeId = pageTheme[templateProps.type] ? templateProps.type : 'other';
   const theme = backstageTheme.getPageTheme({ themeId });
   const classes = useStyles({ backgroundImage: theme.backgroundImage });
@@ -119,7 +128,7 @@ export const TemplateCard = ({ template }: TemplateCardProps) => {
           <Typography variant="body2" className={classes.label}>
             Owner
           </Typography>
-          <Typography variant="inherit">{templateProps.owner}</Typography>
+          <EntityRefLinks entityRefs={ownedByRelations} defaultKind="Group" />
         </Box>
         <Box>
           <Typography variant="body2" className={classes.label}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
New data distribution in `TemplateCard`
Add owner field in `TemplateCard`
Add `spec.owner` on Template Schema
Create `ownedBy` and `ownerOf` relations for TemplateEntity using `spec.owner` 

**Screenshot**
![Screen Shot 2021-05-05 at 15 23 37](https://user-images.githubusercontent.com/17731032/117204395-ddfd8f80-adb5-11eb-971f-fbcf326e2a0b.png)

![Screen Shot 2021-05-05 at 15 23 01](https://user-images.githubusercontent.com/17731032/117204320-c920fc00-adb5-11eb-9dd2-868fb79cbf30.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
