### PR TITLE
Fix setting the state with `useQueryParamState` makes inputs lose their focus

### DIFF
--- a/.changeset/short-bobcats-mate.md
+++ b/.changeset/short-bobcats-mate.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core': patch
+'@backstage/plugin-api-docs': patch
+---
+
+Fix setting the state with `useQueryParamState` makes inputs lose their focus.

--- a/packages/core/src/hooks/useQueryParamState.ts
+++ b/packages/core/src/hooks/useQueryParamState.ts
@@ -17,7 +17,7 @@
 import { isEqual } from 'lodash';
 import qs from 'qs';
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useDebounce } from 'react-use';
 
 function stringify(queryParams: any): string {
@@ -58,9 +58,7 @@ type SetQueryParams<T> = (params: T) => void;
 
 export function useQueryParamState<T>(
   stateName: string,
-  debounceTime: number = 100,
 ): [T | undefined, SetQueryParams<T>] {
-  const navigate = useNavigate();
   const location = useLocation();
   const [queryParamState, setQueryParamState] = useState<T>(
     extractState(location.search, stateName),
@@ -83,10 +81,16 @@ export function useQueryParamState<T>(
       );
 
       if (location.search !== queryString) {
-        navigate({ ...location, search: `?${queryString}` }, { replace: true });
+        // We fallback to the history API, as navigate from react-router causes
+        // input elements to loose focus.
+        history.replaceState(
+          undefined,
+          document.title,
+          `${location.pathname}?${queryString}`,
+        );
       }
     },
-    debounceTime,
+    100,
     [queryParamState],
   );
 

--- a/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerTable/ApiExplorerTable.tsx
@@ -156,7 +156,6 @@ export const ApiExplorerTable = ({
 }: ExplorerTableProps) => {
   const [queryParamState, setQueryParamState] = useQueryParamState<TableState>(
     'apiTable',
-    500,
   );
 
   if (error) {


### PR DESCRIPTION
There was already a try to fix this in #5267, however it is not possible to fix this issue by increasing the debounce time. Increasing the debounce time only makes the problem happen a little less often.

The problem is the `navigate` function by `react-router` that causes the focus loss. If one doesn't use it but use the underling history API directly, the focus on inputs stays.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
