### PR TITLE
Remove extra bottom padding in InfoCard content

### DIFF
--- a/.changeset/khaki-singers-perform.md
+++ b/.changeset/khaki-singers-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/theme': patch
+---
+
+Remove extra bottom padding in InfoCard content

--- a/packages/theme/src/baseTheme.ts
+++ b/packages/theme/src/baseTheme.ts
@@ -257,6 +257,9 @@ export function createThemeOverrides(theme: BackstageTheme): Overrides {
         // etc) end up at the bottom of the card instead of just below the body
         // contents.
         flexGrow: 1,
+        '&:last-child': {
+          paddingBottom: undefined,
+        },
       },
     },
     MuiCardActions: {


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Fixes #5396 by overriding padding-bottom to undefined for MuiCardContent in rootTheme.ts. I took a look at how it affects the InfoCard with and without titles and actions:

### No title or action:

Looks more balanced, as discussed in #5396.

#### Before
![before](https://user-images.githubusercontent.com/542836/117131060-d380cd00-ad98-11eb-9a82-d256b022ca83.png)
#### After 
![after](https://user-images.githubusercontent.com/542836/117131057-d2e83680-ad98-11eb-836b-bbc530add4a1.png)

### With title

Not explicitly discussed in the original issue - to me it looks sensible both before and after. This side effect of fixing the no-title case seems reasonable to me, but we could instead explore applying the change _only_ when there's no title if folks feel like the after state here is worse.

#### Before
![with-title-before](https://user-images.githubusercontent.com/542836/117131270-22c6fd80-ad99-11eb-8c6c-862dc01f9854.png)

#### After
![with-title-after](https://user-images.githubusercontent.com/542836/117131264-2195d080-ad99-11eb-8527-385523061ef8.png)

### With actions

No changes, since the extra padding is only applied to the card content if it's the last child.

#### Before
![with-title-and-action-before](https://user-images.githubusercontent.com/542836/117131211-0925b600-ad99-11eb-9fc5-b6af9da47efb.png)

#### After
![with-title-and-action-after](https://user-images.githubusercontent.com/542836/117131218-0b881000-ad99-11eb-869a-88ce8cb9367e.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
