### PR TITLE
Draft: [Fixes #5536] Make CatalogTable configurable

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -20,6 +20,7 @@ import {
   FlatRoutes,
   OAuthRequestDialog,
   SignInPage,
+  TableColumn,
 } from '@backstage/core';
 import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';
 import {
@@ -56,6 +57,8 @@ import { Root } from './components/Root';
 import { entityPage } from './components/catalog/EntityPage';
 import { providers } from './identityProviders';
 import * as plugins from './plugins';
+import { EntityRow } from '../../catalog-model/src';
+import { EntityRefLink } from '@backstage/plugin-catalog-react';
 
 const app = createApp({
   apis,
@@ -94,6 +97,17 @@ const app = createApp({
 
 const AppProvider = app.getProvider();
 const AppRouter = app.getRouter();
+
+const columns: TableColumn<EntityRow>[] = [
+  {
+    title: 'Name',
+    field: 'resolved.name',
+    highlight: true,
+    render: ({ entity }) => (
+      <EntityRefLink entityRef={entity} defaultKind="Component" />
+    ),
+  },
+];
 
 const routes = (
   <FlatRoutes>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -20,7 +20,6 @@ import {
   FlatRoutes,
   OAuthRequestDialog,
   SignInPage,
-  TableColumn,
 } from '@backstage/core';
 import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';
 import {
@@ -57,8 +56,6 @@ import { Root } from './components/Root';
 import { entityPage } from './components/catalog/EntityPage';
 import { providers } from './identityProviders';
 import * as plugins from './plugins';
-import { EntityRow } from '../../catalog-model/src';
-import { EntityRefLink } from '@backstage/plugin-catalog-react';
 
 const app = createApp({
   apis,
@@ -97,17 +94,6 @@ const app = createApp({
 
 const AppProvider = app.getProvider();
 const AppRouter = app.getRouter();
-
-const columns: TableColumn<EntityRow>[] = [
-  {
-    title: 'Name',
-    field: 'resolved.name',
-    highlight: true,
-    render: ({ entity }) => (
-      <EntityRefLink entityRef={entity} defaultKind="Component" />
-    ),
-  },
-];
 
 const routes = (
   <FlatRoutes>

--- a/packages/catalog-model/src/types.ts
+++ b/packages/catalog-model/src/types.ts
@@ -16,6 +16,7 @@
 
 import { JsonValue } from '@backstage/config';
 import { JSONSchema7 } from 'json-schema';
+import { Entity } from './entity';
 
 export type JSONSchema = JSONSchema7 & { [key in string]?: JsonValue };
 
@@ -44,3 +45,14 @@ export type EntityRef =
       namespace?: string;
       name: string;
     };
+
+export type EntityRow = {
+  entity: Entity;
+  resolved: {
+    name: string;
+    partOfSystemRelationTitle?: string;
+    partOfSystemRelations: EntityName[];
+    ownedByRelationsTitle?: string;
+    ownedByRelations: EntityName[];
+  };
+};

--- a/packages/catalog-model/src/types.ts
+++ b/packages/catalog-model/src/types.ts
@@ -16,7 +16,6 @@
 
 import { JsonValue } from '@backstage/config';
 import { JSONSchema7 } from 'json-schema';
-import { Entity } from './entity';
 
 export type JSONSchema = JSONSchema7 & { [key in string]?: JsonValue };
 
@@ -45,14 +44,3 @@ export type EntityRef =
       namespace?: string;
       name: string;
     };
-
-export type EntityRow = {
-  entity: Entity;
-  resolved: {
-    name: string;
-    partOfSystemRelationTitle?: string;
-    partOfSystemRelations: EntityName[];
-    ownedByRelationsTitle?: string;
-    ownedByRelations: EntityName[];
-  };
-};

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -20,9 +20,11 @@ import {
   ContentHeader,
   errorApiRef,
   SupportButton,
+  TableColumn,
   useApi,
   useRouteRef,
 } from '@backstage/core';
+import { EntityRow } from '@backstage/catalog-model';
 import {
   catalogApiRef,
   isOwnerOf,
@@ -61,6 +63,7 @@ const useStyles = makeStyles(theme => ({
 
 export type CatalogPageProps = {
   initiallySelectedFilter?: string;
+  columns?: TableColumn<EntityRow>[];
 };
 
 const CatalogPageContents = (props: CatalogPageProps) => {
@@ -210,6 +213,7 @@ const CatalogPageContents = (props: CatalogPageProps) => {
           <CatalogTable
             titlePreamble={selectedSidebarItem?.label ?? ''}
             view={selectedTab}
+            columns={props.columns}
             entities={matchingEntities}
             loading={loading}
             error={error}

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -24,7 +24,6 @@ import {
   useApi,
   useRouteRef,
 } from '@backstage/core';
-import { EntityRow } from '@backstage/catalog-model';
 import {
   catalogApiRef,
   isOwnerOf,
@@ -44,6 +43,7 @@ import {
   CatalogFilterType,
 } from '../CatalogFilter/CatalogFilter';
 import { CatalogTable } from '../CatalogTable/CatalogTable';
+import { EntityRow } from '../CatalogTable/types';
 import { ResultsFilter } from '../ResultsFilter/ResultsFilter';
 import { useOwnUser } from '../useOwnUser';
 import CatalogLayout from './CatalogLayout';

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -15,26 +15,21 @@
  */
 import {
   Entity,
-  EntityName,
   RELATION_OWNED_BY,
   RELATION_PART_OF,
 } from '@backstage/catalog-model';
 import {
   CodeSnippet,
-  OverflowTooltip,
   Table,
   TableColumn,
   TableProps,
   WarningPanel,
 } from '@backstage/core';
 import {
-  EntityRefLink,
-  EntityRefLinks,
   formatEntityRefTitle,
   getEntityRelations,
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
-import { Chip } from '@material-ui/core';
 import Edit from '@material-ui/icons/Edit';
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import React from 'react';
@@ -46,88 +41,17 @@ import {
   favouriteEntityIcon,
   favouriteEntityTooltip,
 } from '../FavouriteEntity/FavouriteEntity';
+import * as columnFactories from './columns';
+import { EntityRow } from './types';
 
-type EntityRow = {
-  entity: Entity;
-  resolved: {
-    name: string;
-    partOfSystemRelationTitle?: string;
-    partOfSystemRelations: EntityName[];
-    ownedByRelationsTitle?: string;
-    ownedByRelations: EntityName[];
-  };
-};
-
-const columns: TableColumn<EntityRow>[] = [
-  {
-    title: 'Name',
-    field: 'resolved.name',
-    highlight: true,
-    render: ({ entity }) => (
-      <EntityRefLink entityRef={entity} defaultKind="Component" />
-    ),
-  },
-  {
-    title: 'System',
-    field: 'resolved.partOfSystemRelationTitle',
-    render: ({ resolved }) => (
-      <EntityRefLinks
-        entityRefs={resolved.partOfSystemRelations}
-        defaultKind="system"
-      />
-    ),
-  },
-  {
-    title: 'Owner',
-    field: 'resolved.ownedByRelationsTitle',
-    render: ({ resolved }) => (
-      <EntityRefLinks
-        entityRefs={resolved.ownedByRelations}
-        defaultKind="group"
-      />
-    ),
-  },
-  {
-    title: 'Type',
-    field: 'entity.spec.type',
-    hidden: true,
-  },
-  {
-    title: 'Lifecycle',
-    field: 'entity.spec.lifecycle',
-  },
-  {
-    title: 'Description',
-    field: 'entity.metadata.description',
-    render: ({ entity }) => (
-      <OverflowTooltip
-        text={entity.metadata.description}
-        placement="bottom-start"
-      />
-    ),
-    width: 'auto',
-  },
-  {
-    title: 'Tags',
-    field: 'entity.metadata.tags',
-    cellStyle: {
-      padding: '0px 16px 0px 20px',
-    },
-    render: ({ entity }) => (
-      <>
-        {entity.metadata.tags &&
-          entity.metadata.tags.map(t => (
-            <Chip
-              key={t}
-              label={t}
-              size="small"
-              variant="outlined"
-              style={{ marginBottom: '0px' }}
-            />
-          ))}
-      </>
-    ),
-  },
+const defaultColumns: TableColumn<EntityRow>[] = [
+  columnFactories.createNameColumn(),
+  columnFactories.createSystemColumn(),
+  columnFactories.createOwnerColumn(),
+  columnFactories.createSpecTypeColumn(),
+  columnFactories.createSpecLifecycleColumn(),
+  columnFactories.createMetadataDescriptionColumn(),
+  columnFactories.createTagsColumn(),
 ];
 
 type CatalogTableProps = {
@@ -136,6 +60,7 @@ type CatalogTableProps = {
   loading: boolean;
   error?: any;
   view?: string;
+  columns?: TableColumn<EntityRow>[];
 };
 
 export const CatalogTable = ({
@@ -144,6 +69,7 @@ export const CatalogTable = ({
   error,
   titlePreamble,
   view,
+  columns,
 }: CatalogTableProps) => {
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
 
@@ -224,7 +150,7 @@ export const CatalogTable = ({
     };
   });
 
-  const typeColumn = columns.find(c => c.title === 'Type');
+  const typeColumn = defaultColumns.find(c => c.title === 'Type');
   if (typeColumn) {
     typeColumn.hidden = view !== 'Other';
   }
@@ -232,7 +158,7 @@ export const CatalogTable = ({
   return (
     <Table<EntityRow>
       isLoading={loading}
-      columns={columns}
+      columns={columns || defaultColumns}
       options={{
         paging: true,
         pageSize: 20,
@@ -248,3 +174,5 @@ export const CatalogTable = ({
     />
   );
 };
+
+CatalogTable.columns = columnFactories;

--- a/plugins/catalog/src/components/CatalogTable/columns.tsx
+++ b/plugins/catalog/src/components/CatalogTable/columns.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { EntityRefLink, EntityRefLinks } from '@backstage/plugin-catalog-react';
+import { OverflowTooltip, TableColumn } from '@backstage/core';
+import { Chip } from '@material-ui/core';
+import { EntityRow } from './types';
+
+export function createNameColumn(): TableColumn<EntityRow> {
+  return {
+    title: 'Name',
+    field: 'resolved.name',
+    highlight: true,
+    render: ({ entity }) => (
+      <EntityRefLink entityRef={entity} defaultKind="Component" />
+    ),
+  };
+}
+
+export function createSystemColumn(): TableColumn<EntityRow> {
+  return {
+    title: 'System',
+    field: 'resolved.partOfSystemRelationTitle',
+    render: ({ resolved }) => (
+      <EntityRefLinks
+        entityRefs={resolved.partOfSystemRelations}
+        defaultKind="system"
+      />
+    ),
+  };
+}
+
+export function createOwnerColumn(): TableColumn<EntityRow> {
+  return {
+    title: 'Owner',
+    field: 'resolved.ownedByRelationsTitle',
+    render: ({ resolved }) => (
+      <EntityRefLinks
+        entityRefs={resolved.ownedByRelations}
+        defaultKind="group"
+      />
+    ),
+  };
+}
+
+export function createSpecTypeColumn(): TableColumn<EntityRow> {
+  return {
+    title: 'Type',
+    field: 'entity.spec.type',
+    hidden: true,
+  };
+}
+
+export function createSpecLifecycleColumn(): TableColumn<EntityRow> {
+  return {
+    title: 'Lifecycle',
+    field: 'entity.spec.lifecycle',
+  };
+}
+
+export function createMetadataDescriptionColumn(): TableColumn<EntityRow> {
+  return {
+    title: 'Description',
+    field: 'entity.metadata.description',
+    render: ({ entity }) => (
+      <OverflowTooltip
+        text={entity.metadata.description}
+        placement="bottom-start"
+      />
+    ),
+    width: 'auto',
+  };
+}
+
+export function createTagsColumn(): TableColumn<EntityRow> {
+  return {
+    title: 'Tags',
+    field: 'entity.metadata.tags',
+    cellStyle: {
+      padding: '0px 16px 0px 20px',
+    },
+    render: ({ entity }) => (
+      <>
+        {entity.metadata.tags &&
+          entity.metadata.tags.map(t => (
+            <Chip
+              key={t}
+              label={t}
+              size="small"
+              variant="outlined"
+              style={{ marginBottom: '0px' }}
+            />
+          ))}
+      </>
+    ),
+  };
+}

--- a/plugins/catalog/src/components/CatalogTable/index.ts
+++ b/plugins/catalog/src/components/CatalogTable/index.ts
@@ -13,22 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export { AboutCard } from './components/AboutCard';
-export { EntityLayout } from './components/EntityLayout';
-export { EntityPageLayout } from './components/EntityPageLayout';
-export { CatalogTable } from './components/CatalogTable';
-export * from './components/EntitySwitch';
-export { Router } from './components/Router';
-export {
-  CatalogEntityPage,
-  CatalogIndexPage,
-  catalogPlugin,
-  catalogPlugin as plugin,
-  EntityAboutCard,
-  EntityHasComponentsCard,
-  EntityHasSubcomponentsCard,
-  EntityHasSystemsCard,
-  EntityLinksCard,
-  EntitySystemDiagramCard,
-} from './plugin';
+export { CatalogTable } from './CatalogTable';

--- a/plugins/catalog/src/components/CatalogTable/types.ts
+++ b/plugins/catalog/src/components/CatalogTable/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Spotify AB
+ * Copyright 2021 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Entity, EntityName } from '@backstage/catalog-model';
 
-export * from './entity';
-export { EntityPolicies } from './EntityPolicies';
-export * from './kinds';
-export * from './location';
-export type { EntityName, EntityRef, JSONSchema, EntityRow } from './types';
-export * from './validation';
+export type EntityRow = {
+  entity: Entity;
+  resolved: {
+    name: string;
+    partOfSystemRelationTitle?: string;
+    partOfSystemRelations: EntityName[];
+    ownedByRelationsTitle?: string;
+    ownedByRelations: EntityName[];
+  };
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This fixes #5536, where we can now add a `columns` prop to the CatalogPage, which then is passed down to the CatalogTable. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
