### PR TITLE
GitlabUrlReader to check for modified with SHA of only commits that modify filepath

### DIFF
--- a/.changeset/short-ears-attend.md
+++ b/.changeset/short-ears-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Change GitlabUrlReader to SHA timestamp compare using only commits that modify given file path, if file path given

--- a/packages/backend-common/src/reading/GitlabUrlReader.ts
+++ b/packages/backend-common/src/reading/GitlabUrlReader.ts
@@ -108,14 +108,16 @@ export class GitlabUrlReader implements UrlReader {
 
     // Fetch the latest commit that modifies the the filepath in the provided or default branch
     // to compare against the provided sha.
-    const branchQuery = `ref_name=${branch}`;
-    const pathQuery = !!filepath ? `&path=${filepath}` : '';
-
+    const commitsReqParams = new URLSearchParams();
+    commitsReqParams.set('ref_name', branch);
+    if (!!filepath) {
+      commitsReqParams.set('path', filepath);
+    }
     const commitsGitlabResponse = await fetch(
       new URL(
         `${this.integration.config.apiBaseUrl}/projects/${encodeURIComponent(
           full_name,
-        )}/repository/commits?${branchQuery}${pathQuery}`,
+        )}/repository/commits?${commitsReqParams.toString()}`,
       ).toString(),
       getGitLabRequestOptions(this.integration.config),
     );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Original logic in `readTree` in GitlabUrlReader always compares the SHA of the last commit of the branch when checking if there have been modifications, but this is inaccurate for cases where a specified path within the branch is also given, as the last commit of the whole branch may not have any changes within the specified path.

This patch makes `readTree' perform the SHA comparison with the last of only commits that affect the specified path.

Only GitlabUrlReader is updated here as I'm not sure if I correctly understand what GithubUrlReader is doing, and I don't have an example of the other Git repositiory types to test with. 

#### :heavy_check_mark: Checklist

- [ :heavy_check_mark: ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ NA ] Added or updated documentation
- [  :heavy_check_mark: ] Tests for new functionality and regression tests for bug fixes
- [ NA ] Screenshots attached (for UI changes)
- [  :heavy_check_mark: ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
