### PR TITLE
Microsite Homepage: Fix typo in Kubernetes section

### DIFF
--- a/microsite/pages/en/index.js
+++ b/microsite/pages/en/index.js
@@ -431,7 +431,7 @@ class Index extends React.Component {
               <Block.SmallTitle small>Pick a cloud, any cloud</Block.SmallTitle>
               <Block.Paragraph>
                 Since Backstage uses the Kubernetes API, it's cloud agnostic —
-                so it works no matter which cloud provide or managed Kubernetes
+                so it works no matter which cloud provider or managed Kubernetes
                 service you use, and even works in multi-cloud orgs
               </Block.Paragraph>
             </Block.TextBox>


### PR DESCRIPTION
Signed-off-by: Alexandra Wei alexandrawei@spotify.com

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

[microsite] typo update in Kubernetes section of home page. Should read as "provider" instead of "provide".

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

![Screen Shot 2021-05-06 at 11 22 39 AM](https://user-images.githubusercontent.com/64219471/117324058-6edb7600-ae5d-11eb-8dd3-50c18b20f318.png)
