### PR TITLE
catalog/next: Fix postgres type error when deleting entries

### DIFF
--- a/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
@@ -185,7 +185,7 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
         ),
         -- All the nodes that can be reached upwards from the descendants
         ancestors(root_id, via_entity_ref, to_entity_ref) AS (
-          SELECT NULL, entity_ref, entity_ref
+          SELECT CAST(NULL as INT), entity_ref, entity_ref
           FROM descendants
           UNION
           SELECT
@@ -235,7 +235,7 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
               .withRecursive('ancestors', function ancestors(outer) {
                 return outer
                   .select({
-                    root_id: tx.raw('NULL', []),
+                    root_id: tx.raw('CAST(NULL as INT)', []),
                     via_entity_ref: 'entity_ref',
                     to_entity_ref: 'entity_ref',
                   })


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes typecast error in postgres when deleting entites.

```
2021-05-07 08:30:04.790 UTC [1118] ERROR:  recursive query "ancestors" column 1 has type text in non-recursive term but type integer overall at character 510
2021-05-07 08:30:04.790 UTC [1118] HINT:  Cast the output of the non-recursive term to the correct type.
2021-05-07 08:30:04.790 UTC [1118] STATEMENT:  delete from "refresh_state" where "entity_ref" in (with recursive "descendants" as (select "id" as "root_id", "target_entity_ref" as "entity_ref" from "refresh_state_references" where "source_key" = $1 and "target_entity_ref" in ($2) union select "descendants"."root_id" as "root_id", "refresh_state_references"."target_entity_ref" as "entity_ref" from "descendants" inner join "refresh_state_references" on "descendants"."entity_ref" = "refresh_state_references"."source_entity_ref"), "ancestors" as (select NULL as "root_id", "entity_ref" as "via_entity_ref", "entity_ref" as "to_entity_ref" from "descendants" union select CASE WHEN source_key IS NOT NULL THEN id ELSE NULL END as "root_id", "source_entity_ref" as "via_entity_ref", "ancestors"."to_entity_ref" as "to_entity_ref" from "ancestors" inner join "refresh_state_references" on "target_entity_ref" = "ancestors"."via_entity_ref") select "descendants"."entity_ref" from "descendants" left outer join "ancestors" on "ancestors"."to_entity_ref" = "descendants"."entity_ref" and "ancestors"."root_id" is not null and "ancestors"."root_id" != "descendants"."root_id" where "ancestors"."root_id" is null)
```

Tested in postgres and sqlite.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
