### PR TITLE
[kubernetes-backend]: Add options to skip TLS verification for gke type clusters

### DIFF
--- a/.changeset/wild-moles-care.md
+++ b/.changeset/wild-moles-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Add possibility to configure TLS verification for `gke` type clusters

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -33,6 +33,7 @@ kubernetes:
     - type: 'gke'
       projectId: 'gke-clusters'
       region: 'europe-west1'
+      skipTLSVerify: true
 ```
 
 ### `serviceLocatorMethod`
@@ -128,6 +129,11 @@ The Google Cloud project to look for Kubernetes clusters in.
 
 The Google Cloud region to look for Kubernetes clusters in. Defaults to all
 regions.
+
+##### `skipTLSVerify`
+
+This determines whether or not the Kubernetes client verifies the TLS
+certificate presented by the API server. Defaults to `false`.
 
 ### `customResources` (optional)
 

--- a/plugins/kubernetes-backend/schema.d.ts
+++ b/plugins/kubernetes-backend/schema.d.ts
@@ -14,14 +14,43 @@
  * limitations under the License.
  */
 
-import { ClusterLocatorMethod, CustomResource } from './src/types';
-
 export interface Config {
   kubernetes?: {
     serviceLocatorMethod: {
       type: 'multiTenant';
     };
-    clusterLocatorMethods: ClusterLocatorMethod[];
-    customResources?: CustomResource[];
+    clusterLocatorMethods: Array<
+      | {
+          /** @visibility frontend */
+          type: 'gke';
+          /** @visibility frontend */
+          projectId: string;
+          /** @visibility frontend */
+          region?: string;
+          /** @visibility frontend */
+          skipTLSVerify?: boolean;
+        }
+      | {
+          /** @visibility frontend */
+          type: 'config';
+          clusters: Array<{
+            /** @visibility frontend */
+            url: string;
+            /** @visibility frontend */
+            name: string;
+            /** @visibility secret  */
+            serviceAccountToken?: string;
+            /** @visibility frontend */
+            authProvider: 'aws' | 'google' | 'serviceAccount';
+            /** @visibility frontend */
+            skipTLSVerify?: boolean;
+          }>;
+        }
+    >;
+    customResources?: Array<{
+      group: string;
+      apiVersion: string;
+      plural: string;
+    }>;
   };
 }

--- a/plugins/kubernetes-backend/src/cluster-locator/GkeClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/GkeClusterLocator.test.ts
@@ -106,6 +106,7 @@ describe('GkeClusterLocator', () => {
           authProvider: 'google',
           name: 'some-cluster',
           url: 'https://1.2.3.4',
+          skipTLSVerify: false,
         },
       ]);
       expect(mockedListClusters).toBeCalledTimes(1);
@@ -141,6 +142,7 @@ describe('GkeClusterLocator', () => {
           authProvider: 'google',
           name: 'some-cluster',
           url: 'https://1.2.3.4',
+          skipTLSVerify: false,
         },
       ]);
       expect(mockedListClusters).toBeCalledTimes(1);
@@ -181,11 +183,13 @@ describe('GkeClusterLocator', () => {
           authProvider: 'google',
           name: 'some-cluster',
           url: 'https://1.2.3.4',
+          skipTLSVerify: false,
         },
         {
           authProvider: 'google',
           name: 'some-other-cluster',
           url: 'https://6.7.8.9',
+          skipTLSVerify: false,
         },
       ]);
       expect(mockedListClusters).toBeCalledTimes(1);

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -19,50 +19,6 @@ import type {
   KubernetesFetchError,
 } from '@backstage/plugin-kubernetes-common';
 
-export type ClusterLocatorMethod =
-  | ConfigClusterLocatorMethod
-  | GKEClusterLocatorMethod;
-
-export interface ConfigClusterLocatorMethod {
-  /**
-   * @visibility frontend
-   */
-  type: 'config';
-  clusters: {
-    /**
-     * @visibility frontend
-     */
-    url: string;
-    /**
-     * @visibility frontend
-     */
-    name: string;
-    /**
-     * @visibility secret
-     */
-    serviceAccountToken: string | undefined;
-    /**
-     * @visibility frontend
-     */
-    authProvider: 'aws' | 'google' | 'serviceAccount';
-  }[];
-}
-
-export interface GKEClusterLocatorMethod {
-  /**
-   * @visibility frontend
-   */
-  type: 'gke';
-  /**
-   * @visibility frontend
-   */
-  projectId: string;
-  /**
-   * @visibility frontend
-   */
-  region?: string;
-}
-
 export interface CustomResource {
   group: string;
   apiVersion: string;


### PR DESCRIPTION
The possibility to skip the TLS client verification only exists for the `config` cluster locator method, and I needed it for the `gke` locator too.

I also noticed that the schema validation didn't pick up an error I made. Looking into it a bit further, it seemed that imports in `schema.d.ts` was somehow not properly processed, which I first thought was an issue with the import path being wrong. But even after fixing that it didn't validate the schema properly. After moving it to be inline in the `schema.d.ts` file it started behaving as expected.
Not sure if this is the correct approach, let me know if I should handle it in any other way.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
