### PR TITLE
Cost insights custom alert titles

### DIFF
--- a/.changeset/cost-insights-fuzzy-boats-float.md
+++ b/.changeset/cost-insights-fuzzy-boats-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': minor
+---
+
+support jsx in alert titles

--- a/plugins/cost-insights/src/components/ActionItems/ActionItemCard.test.tsx
+++ b/plugins/cost-insights/src/components/ActionItems/ActionItemCard.test.tsx
@@ -43,4 +43,22 @@ describe('<ActionItemCard/>', () => {
     expect(rendered.getByText(alert.title)).toBeInTheDocument();
     expect(rendered.getByText(alert.subtitle)).toBeInTheDocument();
   });
+
+  it('renders custom title elements', async () => {
+    const rendered = await renderInTestApp(
+      <MockScrollProvider>
+        <ActionItemCard
+          alert={{
+            ...alert,
+            title: <span>Foo</span>,
+            subtitle: <span>Bar</span>,
+          }}
+          avatar={<div>1</div>}
+        />
+      </MockScrollProvider>,
+    );
+
+    expect(rendered.getByText('Foo')).toBeInTheDocument();
+    expect(rendered.getByText('Bar')).toBeInTheDocument();
+  });
 });

--- a/plugins/cost-insights/src/components/AlertInsights/AlertInsightsSection.test.tsx
+++ b/plugins/cost-insights/src/components/AlertInsights/AlertInsightsSection.test.tsx
@@ -41,8 +41,8 @@ describe('<AlertInsightsSection/>', () => {
         onAccept={jest.fn()}
       />,
     );
-    expect(getByText(mockAlert.title)).toBeInTheDocument();
-    expect(getByText(mockAlert.subtitle)).toBeInTheDocument();
+    expect(getByText(mockAlert.title as string)).toBeInTheDocument();
+    expect(getByText(mockAlert.subtitle as string)).toBeInTheDocument();
     expect(getByText('View Instructions')).toBeInTheDocument();
     expect(queryByText('Snooze')).not.toBeInTheDocument();
     expect(queryByText('Accept')).not.toBeInTheDocument();

--- a/plugins/cost-insights/src/components/AlertInsights/AlertInsightsSection.test.tsx
+++ b/plugins/cost-insights/src/components/AlertInsights/AlertInsightsSection.test.tsx
@@ -49,6 +49,25 @@ describe('<AlertInsightsSection/>', () => {
     expect(queryByText('Dismiss')).not.toBeInTheDocument();
   });
 
+  it('renders custom title elements', () => {
+    const { getByText } = renderInContext(
+      <AlertInsightsSection
+        alert={{
+          ...mockAlert,
+          title: <span>Foo</span>,
+          subtitle: <span>Bar</span>,
+        }}
+        number={1}
+        onSnooze={jest.fn()}
+        onDismiss={jest.fn()}
+        onAccept={jest.fn()}
+      />,
+    );
+
+    expect(getByText('Foo')).toBeInTheDocument();
+    expect(getByText('Bar')).toBeInTheDocument();
+  });
+
   it('Hides instructions button if url is not provided', () => {
     const alert: Alert = {
       ...mockAlert,

--- a/plugins/cost-insights/src/components/AlertInsights/AlertStatusSummary.test.tsx
+++ b/plugins/cost-insights/src/components/AlertInsights/AlertStatusSummary.test.tsx
@@ -50,8 +50,8 @@ describe('<AlertStatusSummary />', () => {
       </MockScrollProvider>,
     );
     [mockSnoozed, mockAccepted, mockDismissed].forEach(a => {
-      expect(getByText(a.title)).toBeInTheDocument();
-      expect(getByText(a.subtitle)).toBeInTheDocument();
+      expect(getByText(a.title as string)).toBeInTheDocument();
+      expect(getByText(a.subtitle as string)).toBeInTheDocument();
       expect(getByRole('img', { name: a.status })).toBeInTheDocument();
     });
   });

--- a/plugins/cost-insights/src/example/alerts/KubernetesMigrationAlert.tsx
+++ b/plugins/cost-insights/src/example/alerts/KubernetesMigrationAlert.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import pluralize from 'pluralize';
 import { KubernetesMigrationAlertCard } from '../components';
+import { Lifecycle } from '@backstage/core';
 import { CostInsightsApi } from '../../api';
 import {
   Alert,
@@ -87,11 +88,13 @@ export class KubernetesMigrationAlert implements KubernetesMigrationApi {
   }
 
   get title() {
-    return `Consider migrating ${pluralize(
-      'service',
-      this.data.services.length,
-      true,
-    )} to Kubernetes.`;
+    return (
+      <span>
+        Consider migrating{' '}
+        {pluralize('service', this.data.services.length, true)} to Kubernetes{' '}
+        <Lifecycle shorthand />
+      </span>
+    );
   }
 
   get element() {

--- a/plugins/cost-insights/src/types/Alert.ts
+++ b/plugins/cost-insights/src/types/Alert.ts
@@ -34,8 +34,8 @@ import { Maybe } from './Maybe';
  */
 
 export type Alert = {
-  title: string;
-  subtitle: string;
+  title: string | JSX.Element;
+  subtitle: string | JSX.Element;
   element?: JSX.Element;
   status?: AlertStatus;
   url?: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds support for rendering custom elements in alert titles.

### Action Item List Item
<img width="640" alt="Screen Shot 2021-05-07 at 3 19 42 PM" src="https://user-images.githubusercontent.com/3030003/117498345-ad4d5f80-af47-11eb-9bb9-6d0d868365fc.png">

### Action Item Section
<img width="1092" alt="Screen Shot 2021-05-07 at 3 17 23 PM" src="https://user-images.githubusercontent.com/3030003/117498105-5778b780-af47-11eb-9c01-44a8f62758ca.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
