### PR TITLE
cli: context for version:bump about version change

### DIFF
--- a/.changeset/beige-cheetahs-jog.md
+++ b/.changeset/beige-cheetahs-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add context for versions:bump on what version it was bumped to. Updated tests for the same.

--- a/packages/cli/src/commands/versions/bump.test.ts
+++ b/packages/cli/src/commands/versions/bump.test.ts
@@ -136,7 +136,7 @@ describe('bump', () => {
       'bumping @backstage/theme in b to ^2.0.0',
       'Running yarn install to install new versions',
       '⚠️  The following packages may have breaking changes:',
-      '  @backstage/theme',
+      '  @backstage/theme : 1.0.0 ~> 2.0.0',
       '    https://github.com/backstage/backstage/blob/master/packages/theme/CHANGELOG.md',
       'Version bump complete!',
     ]);

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -195,8 +195,14 @@ export default async () => {
       );
       console.log();
 
-      for (const name of Array.from(breakingUpdates.keys()).sort()) {
-        console.log(`  ${chalk.yellow(name)}`);
+      for (const [name, { from, to }] of [
+        ...breakingUpdates.entries(),
+      ].sort()) {
+        console.log(
+          `  ${chalk.yellow(name)} : ${chalk.yellow(from)} ~> ${chalk.yellow(
+            to,
+          )}`,
+        );
 
         let path;
         if (name.startsWith('@backstage/plugin-')) {

--- a/packages/cli/src/commands/versions/bump.ts
+++ b/packages/cli/src/commands/versions/bump.ts
@@ -195,9 +195,9 @@ export default async () => {
       );
       console.log();
 
-      for (const [name, { from, to }] of [
-        ...breakingUpdates.entries(),
-      ].sort()) {
+      for (const [name, { from, to }] of Array.from(
+        breakingUpdates.entries(),
+      ).sort()) {
         console.log(
           `  ${chalk.yellow(name)} : ${chalk.yellow(from)} ~> ${chalk.yellow(
             to,


### PR DESCRIPTION
Closes #5565 

This PR adds context for versions:bump on what version it was bumped to. Updated the tests for the same.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
