### PR TITLE
Bitbucket Server apiBaseUrl

### DIFF
--- a/.changeset/forty-pumpkins-agree.md
+++ b/.changeset/forty-pumpkins-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+The apiBaseUrl setting for Bitbucket Server integrations will now be used when it is set. Otherwise, it will default back to the host setting.

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
@@ -42,6 +42,7 @@ export class BitbucketPublisher implements PublisherBase {
       token: config.token,
       appPassword: config.appPassword,
       username: config.username,
+      apiBaseUrl: config.apiBaseUrl,
       repoVisibility,
     });
   }
@@ -52,6 +53,7 @@ export class BitbucketPublisher implements PublisherBase {
       token?: string;
       appPassword?: string;
       username?: string;
+      apiBaseUrl?: string;
       repoVisibility: RepoVisibilityOptions;
     },
   ) {}
@@ -181,10 +183,11 @@ export class BitbucketPublisher implements PublisherBase {
     };
 
     try {
-      response = await fetch(
-        `https://${this.config.host}/rest/api/1.0/projects/${project}/repos`,
-        options,
-      );
+      const baseUrl = this.config.apiBaseUrl
+        ? this.config.apiBaseUrl
+        : `https://${this.config.host}/rest/api/1.0`;
+
+      response = await fetch(`${baseUrl}/projects/${project}/repos`, options);
     } catch (e) {
       throw new Error(`Unable to create repository, ${e}`);
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Setting the `apiBaseUrl` for Bitbucket Server did not work, even though it is mentioned in the [documentation](https://backstage.io/docs/integrations/bitbucket/locations).
As mentioned in [this issue](https://github.com/backstage/backstage/issues/5577), it was not possible to configure Bitbucket Server if it was running under a different path.

This Pull Request proposes a solution in which the `apiBaseUrl` is used, if set, and it falls back to the default path with the `host` setting otherwise.

Closes #5577 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
