### PR TITLE
Show number of older messages in AlertDisplay

### DIFF
--- a/.changeset/stale-gifts-push.md
+++ b/.changeset/stale-gifts-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Add count of older messages when multiple messages exist in AlertDisplay

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "immer": "^9.0.1",
     "lodash": "^4.17.15",
     "material-table": "^1.69.1",
+    "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "qs": "^6.9.4",
     "rc-progress": "^3.0.0",

--- a/packages/core/src/components/AlertDisplay/AlertDisplay.test.tsx
+++ b/packages/core/src/components/AlertDisplay/AlertDisplay.test.tsx
@@ -62,4 +62,46 @@ describe('<AlertDisplay />', () => {
 
     expect(queryByText(TEST_MESSAGE)).toBeInTheDocument();
   });
+
+  describe('with multiple messages', () => {
+    let apiRegistry: ApiRegistry;
+
+    beforeEach(() => {
+      apiRegistry = ApiRegistry.from([
+        [
+          alertApiRef,
+          {
+            post() {},
+            alert$() {
+              return Observable.of(
+                { message: 'message one' },
+                { message: 'message two' },
+                { message: 'message three' },
+              );
+            },
+          },
+        ],
+      ]);
+    });
+
+    it('renders first message', async () => {
+      const { queryByText } = await renderInTestApp(
+        <ApiProvider apis={apiRegistry}>
+          <AlertDisplay />
+        </ApiProvider>,
+      );
+
+      expect(queryByText('message one')).toBeInTheDocument();
+    });
+
+    it('renders a count of remaining messages', async () => {
+      const { queryByText } = await renderInTestApp(
+        <ApiProvider apis={apiRegistry}>
+          <AlertDisplay />
+        </ApiProvider>,
+      );
+
+      expect(queryByText('(2 older messages)')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/core/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core/src/components/AlertDisplay/AlertDisplay.tsx
@@ -19,6 +19,7 @@ import { Snackbar, IconButton } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import { Alert } from '@material-ui/lab';
 import { AlertMessage, useApi, alertApiRef } from '@backstage/core-api';
+import pluralize from 'pluralize';
 
 // TODO: improve on this and promote to a shared component for use by all apps.
 export const AlertDisplay = () => {
@@ -60,7 +61,15 @@ export const AlertDisplay = () => {
         }
         severity={firstMessage.severity}
       >
-        {firstMessage.message.toString()}
+        <span>
+          {firstMessage.message.toString()}
+          {messages.length > 1 && (
+            <em>{` (${messages.length - 1} older ${pluralize(
+              'message',
+              messages.length - 1,
+            )})`}</em>
+          )}
+        </span>
       </Alert>
     </Snackbar>
   );

--- a/packages/core/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core/src/components/AlertDisplay/AlertDisplay.tsx
@@ -46,11 +46,7 @@ export const AlertDisplay = () => {
   };
 
   return (
-    <Snackbar
-      open
-      message={firstMessage.message.toString()}
-      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-    >
+    <Snackbar open anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
       <Alert
         action={
           <IconButton


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #4850.

Adds "(n older messages)" suffix to the message contents in the core AlertDisplay when there are multiple messages to show. Some considerations that led to this:

* It seems like if we're going to show only one message, it should be the most recent message (which is the current behavior).
* Just showing a message count (e.g. '1/4', '4/4') seems open to interpretation about whether the count starts at the oldest or newest.

**With one message:**
![Screenshot 2021-05-10 at 09 47 49](https://user-images.githubusercontent.com/542836/117632627-34334f80-b175-11eb-9372-a42ff8cfe11c.png)

**With two messages:**
![Screenshot 2021-05-10 at 09 47 39](https://user-images.githubusercontent.com/542836/117632663-3bf2f400-b175-11eb-8ebd-fab879129735.png)

**With four messages:**
![Screenshot 2021-05-10 at 09 47 44](https://user-images.githubusercontent.com/542836/117632694-431a0200-b175-11eb-88e6-2c3668a8812e.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
