### PR TITLE
microsite: Fix typo in Kubernetes section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Which will look something like the following in the repo;
 ```
 Awesome commit message
 
-Signed-off-by: Jane Smith jane.smith@example.com
+Signed-off-by: Jane Smith <jane.smith@example.com>
 ```
 
 - In case you forgot to add it to the most recent commit, use `git commit --amend --signoff`

--- a/microsite/pages/en/index.js
+++ b/microsite/pages/en/index.js
@@ -431,7 +431,7 @@ class Index extends React.Component {
               <Block.SmallTitle small>Pick a cloud, any cloud</Block.SmallTitle>
               <Block.Paragraph>
                 Since Backstage uses the Kubernetes API, it's cloud agnostic —
-                so it works no matter which cloud provide or managed Kubernetes
+                so it works no matter which cloud provider or managed Kubernetes
                 service you use, and even works in multi-cloud orgs
               </Block.Paragraph>
             </Block.TextBox>


### PR DESCRIPTION
Follow up of https://github.com/backstage/backstage/pull/5603/