### PR TITLE
TechDocs: Handle URLs with a `#hash` correctly when rewriting link URLs

### DIFF
--- a/.changeset/techdocs-lemon-cooks-drum.md
+++ b/.changeset/techdocs-lemon-cooks-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Handle URLs with a `#hash` correctly when rewriting link URLs.

--- a/plugins/techdocs/src/reader/transformers/rewriteDocLinks.test.ts
+++ b/plugins/techdocs/src/reader/transformers/rewriteDocLinks.test.ts
@@ -16,6 +16,7 @@
 
 import { createTestShadowDom, getSample } from '../../test-utils';
 import { rewriteDocLinks } from '../transformers';
+import { normalizeUrl } from './rewriteDocLinks';
 
 describe('rewriteDocLinks', () => {
   it('should not do anything', () => {
@@ -54,5 +55,19 @@ describe('rewriteDocLinks', () => {
       'http://localhost/example-docs',
       'http://localhost/example-docs/example-page',
     ]);
+  });
+});
+
+describe('normalizeUrl', () => {
+  it.each([
+    ['http://example.org', 'http://example.org/'],
+    ['http://example.org/', 'http://example.org/'],
+    ['http://example.org/folder', 'http://example.org/folder/'],
+    ['http://example.org/folder/', 'http://example.org/folder/'],
+    ['http://example.org/folder#intro', 'http://example.org/folder/#intro'],
+    ['http://example.org/folder/#intro', 'http://example.org/folder/#intro'],
+    ['http://example.org/folder#', 'http://example.org/folder/#'],
+  ])('should handle %s', (url, expected) => {
+    expect(normalizeUrl(url)).toEqual(expected);
   });
 });

--- a/plugins/techdocs/src/reader/transformers/rewriteDocLinks.ts
+++ b/plugins/techdocs/src/reader/transformers/rewriteDocLinks.ts
@@ -31,9 +31,7 @@ export const rewriteDocLinks = (): Transformer => {
             if (elemAttribute.match(/^https?:\/\//i)) {
               elem.setAttribute('target', '_blank');
             }
-            const normalizedWindowLocation = window.location.href.endsWith('/')
-              ? window.location.href
-              : `${window.location.href}/`;
+            const normalizedWindowLocation = normalizeUrl(window.location.href);
 
             elem.setAttribute(
               attributeName,
@@ -48,3 +46,14 @@ export const rewriteDocLinks = (): Transformer => {
     return dom;
   };
 };
+
+/** Make sure that the input url always ends with a '/' */
+export function normalizeUrl(input: string): string {
+  const url = new URL(input);
+
+  if (!url.pathname.endsWith('/')) {
+    url.pathname += '/';
+  }
+
+  return url.toString();
+}


### PR DESCRIPTION
Sometimes when sending links around, e.g. via Slack, we end up with links that have a `#hash` at the end. If you only have a hash, but no trailing slash before it, techdocs creates broken links between pages. The broken links later crash tech docs.

To fix this we can use the URL class, instead of doing URLs operations on a string level.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
