### PR TITLE
Add height of md-tabs on sidebar position

### DIFF
--- a/.changeset/stupid-balloons-change.md
+++ b/.changeset/stupid-balloons-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Bug fix on sidebar position when Tab-Bar is enabled

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -89,12 +89,17 @@ export const Reader = ({ entityId, onReady }: Props) => {
   useEffect(() => {
     const updateSidebarPosition = () => {
       if (!!shadowDomRef.current && !!sidebars) {
+        const mdTabs = shadowDomRef.current!.querySelector(
+          '.md-container > .md-tabs',
+        );
         sidebars!.forEach(sidebar => {
           const newTop = Math.max(
             shadowDomRef.current!.getBoundingClientRect().top,
             0,
           );
-          sidebar.style.top = `${newTop}px`;
+          sidebar.style.top = mdTabs
+            ? `${newTop + mdTabs.getBoundingClientRect().height}px`
+            : `${newTop}px`;
         });
       }
     };
@@ -318,8 +323,11 @@ export const Reader = ({ entityId, onReady }: Props) => {
           // set sidebar height so they don't initially render in wrong position
           const docTopPosition = (dom as HTMLElement).getBoundingClientRect()
             .top;
+          const mdTabs = dom.querySelector('.md-container > .md-tabs');
           sideDivs!.forEach(sidebar => {
-            sidebar.style.top = `${docTopPosition}px`;
+            sidebar.style.top = mdTabs
+              ? `${docTopPosition + mdTabs.getBoundingClientRect().height}px`
+              : `${docTopPosition}px`;
           });
         },
       }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!
The sidebars on the documentation page overlap the tab-bar. 
Adding the height of the tab-bar to the position of the sidebars to fix that
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

![1620748296972](https://user-images.githubusercontent.com/3040347/117846254-8cf00e80-b281-11eb-8bc9-255d71a77ade.png)
