### PR TITLE
fix(plugin-github-deployments): properly parse ghe hostnames

### DIFF
--- a/.changeset/tame-scissors-bow.md
+++ b/.changeset/tame-scissors-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-deployments': patch
+---
+
+Support GHE by properly parsing enterprise instance hosts

--- a/plugins/github-deployments/src/api/index.ts
+++ b/plugins/github-deployments/src/api/index.ts
@@ -28,21 +28,25 @@ const getBaseUrl = (
   }
 
   const location = parseLocationReference(host);
-  if (location.type !== 'github') {
+  if (location.type !== 'github' && location.type !== 'url') {
     return 'https://api.github.com';
   }
 
-  const config = scmIntegrationsApi.github.byHost(location.target);
+  const config = scmIntegrationsApi.github.byUrl(location.target);
 
   if (!config) {
     throw new InputError(
-      `No matching GitHub integration configuration for host ${host}, please check your integrations config`,
+      `No matching GitHub integration configuration for host ${
+        new URL(location.target).hostname
+      }, please check your integrations config`,
     );
   }
 
   if (!config.config.apiBaseUrl) {
     throw new InputError(
-      `No apiBaseUrl available for host ${host}, please check your integrations config`,
+      `No apiBaseUrl available for host ${
+        new URL(location.target).hostname
+      }, please check your integrations config`,
     );
   }
 

--- a/plugins/github-deployments/src/components/GithubDeploymentsCard.test.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsCard.test.tsx
@@ -250,7 +250,8 @@ describe('github-deployments', () => {
         entity = entityStub;
         entity.entity.metadata.annotations = {
           'github.com/project-slug': 'org/repo',
-          'backstage.io/source-location': 'github:my-github-1.com',
+          'backstage.io/source-location':
+            'github:https://my-github-1.com/org/repo/tree/master/',
         };
       });
 
@@ -271,7 +272,8 @@ describe('github-deployments', () => {
         entity = entityStub;
         entity.entity.metadata.annotations = {
           'github.com/project-slug': 'org/repo',
-          'backstage.io/managed-by-location': 'github:my-github-2.com',
+          'backstage.io/managed-by-location':
+            'github:https://my-github-2.com/org/repo/blob/master/catalog-info.yaml',
         };
       });
 
@@ -292,7 +294,8 @@ describe('github-deployments', () => {
         entity = entityStub;
         entity.entity.metadata.annotations = {
           'github.com/project-slug': 'org/repo',
-          'backstage.io/managed-by-location': 'github:my-github-3.com',
+          'backstage.io/managed-by-location':
+            'github:https://my-github-3.com/org/repo/blob/master/catalog-info.yaml',
         };
       });
 
@@ -305,7 +308,7 @@ describe('github-deployments', () => {
 
         expect(
           await rendered.findByText(
-            'Warning: No apiBaseUrl available for host github:my-github-3.com, please check your integrations config',
+            'Warning: No apiBaseUrl available for host my-github-3.com, please check your integrations config',
           ),
         ).toBeInTheDocument();
       });
@@ -317,7 +320,7 @@ describe('github-deployments', () => {
         entity.entity.metadata.annotations = {
           'github.com/project-slug': 'org/repo',
           'backstage.io/managed-by-location':
-            'github:my-github-unknown.com/org/repo',
+            'github:https://my-github-unknown.com/org/repo/blob/master/catalog-info.yaml',
         };
       });
 
@@ -330,7 +333,7 @@ describe('github-deployments', () => {
 
         expect(
           await rendered.findByText(
-            'Warning: No matching GitHub integration configuration for host github:my-github-unknown.com/org/repo, please check your integrations config',
+            'Warning: No matching GitHub integration configuration for host my-github-unknown.com, please check your integrations config',
           ),
         ).toBeInTheDocument();
       });
@@ -342,15 +345,15 @@ describe('github-deployments', () => {
         entity.entity.metadata.annotations = {
           'github.com/project-slug': 'org/repo',
           'backstage.io/source-location':
-            'url:my-favourite-url-location/org/repo',
+            'url:https://my-github-1.com/org/repo/tree/master/',
           'backstage.io/managed-by-location':
-            'url:my-favourite-url-location/org/repo',
+            'url:https://my-github-1.com/org/repo/blob/master/catalog-info.yaml',
         };
       });
 
-      it('displays fetched data using default github api', async () => {
+      it('should fetch data using custom api', async () => {
         worker.use(
-          GRAPHQL_GITHUB_API.query('deployments', (_, res, ctx) =>
+          GRAPHQL_CUSTOM_API_1.query('deployments', (_, res, ctx) =>
             res(ctx.data(responseStub)),
           ),
         );


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Properly parse the hostname from URLs. Also support `url` type locations since entities seem to be annotated with this location type by the catalog preprocessor based on my usage with GHE

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
