### PR TITLE
Handle/log cache connection errors and allow integrators to pass custom handlers

### DIFF
--- a/.changeset/improbable-word-combination.md
+++ b/.changeset/improbable-word-combination.md
@@ -1,0 +1,16 @@
+---
+'@backstage/backend-common': patch
+---
+
+Plugin developers may now provide handlers for connection errors emitted by cache stores.
+
+```typescript
+// Providing an error handler
+const cacheClient = somePluginCache.getClient({
+  defaultTtl: 3600000,
+  onError: e => {
+    logger.error(`There was a cache connection problem: ${e.message}`);
+    execOtherErrorHandlingLogic();
+  },
+});
+```

--- a/.changeset/improbable-word-combination.md
+++ b/.changeset/improbable-word-combination.md
@@ -2,15 +2,16 @@
 '@backstage/backend-common': patch
 ---
 
-Plugin developers may now provide handlers for connection errors emitted by cache stores.
+All cache-related connection errors are now handled and logged by the cache manager. App Integrators may provide an optional error handler when instantiating the cache manager if custom error handling is needed.
 
 ```typescript
 // Providing an error handler
-const cacheClient = somePluginCache.getClient({
-  defaultTtl: 3600000,
+const cacheManager = CacheManager.fromConfig(config, {
   onError: e => {
-    logger.error(`There was a cache connection problem: ${e.message}`);
-    execOtherErrorHandlingLogic();
+    if (isSomehowUnrecoverable(e)) {
+      gracefullyShutThingsDown();
+      process.exit(1);
+    }
   },
 });
 ```

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -73,7 +73,7 @@ export interface CacheClient {
 // @public
 export class CacheManager {
     forPlugin(pluginId: string): PluginCacheManager;
-    static fromConfig(config: Config): CacheManager;
+    static fromConfig(config: Config, options?: CacheManagerOptions): CacheManager;
     }
 
 // @public (undocumented)

--- a/packages/backend-common/src/cache/CacheClient.ts
+++ b/packages/backend-common/src/cache/CacheClient.ts
@@ -92,7 +92,8 @@ export class DefaultCacheClient implements CacheClient {
     const wellFormedKey = Buffer.from(candidateKey).toString('base64');
 
     // Memcache in particular doesn't do well with keys > 250 bytes.
-    if (wellFormedKey.length < 250) {
+    // Padded because a plugin ID is also prepended to the key.
+    if (wellFormedKey.length < 200) {
       return wellFormedKey;
     }
 

--- a/packages/backend-common/src/cache/CacheManager.test.ts
+++ b/packages/backend-common/src/cache/CacheManager.test.ts
@@ -86,6 +86,17 @@ describe('CacheManager', () => {
       expect(client).toHaveBeenCalledTimes(1);
     });
 
+    it('attaches error handler to client', () => {
+      const pluginId = 'error-test';
+      const handler = jest.fn();
+      manager.forPlugin(pluginId).getClient({ onError: handler });
+
+      const client = DefaultCacheClient as jest.Mock;
+      const mockCalls = client.mock.calls.splice(-1);
+      const realClient = mockCalls[0][0].client as Keyv;
+      expect(realClient.on).toHaveBeenCalledWith('error', handler);
+    });
+
     it('provides different plugins different cache clients', async () => {
       const plugin1Id = 'test1';
       const plugin2Id = 'test2';

--- a/packages/backend-common/src/cache/CacheManager.ts
+++ b/packages/backend-common/src/cache/CacheManager.ts
@@ -65,7 +65,7 @@ export class CacheManager {
   }
 
   /**
-   * Generates a CacheManagerInstance for consumption by plugins.
+   * Generates a PluginCacheManager for consumption by plugins.
    *
    * @param pluginId The plugin that the cache manager should be created for. Plugin names should be unique.
    */

--- a/packages/backend-common/src/cache/CacheManager.ts
+++ b/packages/backend-common/src/cache/CacheManager.ts
@@ -73,6 +73,12 @@ export class CacheManager {
     return {
       getClient: (opts = {}): CacheClient => {
         const concreteClient = this.getClientWithTtl(pluginId, opts.defaultTtl);
+
+        // Attach error handler if provided.
+        if (typeof opts?.onError === 'function') {
+          concreteClient.on('error', opts.onError);
+        }
+
         return new DefaultCacheClient({
           client: concreteClient,
         });

--- a/packages/backend-common/src/cache/CacheManager.ts
+++ b/packages/backend-common/src/cache/CacheManager.ts
@@ -18,9 +18,15 @@ import { Config } from '@backstage/config';
 import Keyv from 'keyv';
 // @ts-expect-error
 import KeyvMemcache from 'keyv-memcache';
+import { Logger } from 'winston';
+import { getRootLogger } from '../logging';
 import { DefaultCacheClient, CacheClient } from './CacheClient';
 import { NoStore } from './NoStore';
-import { PluginCacheManager } from './types';
+import {
+  CacheManagerOptions,
+  OptionalOnError,
+  PluginCacheManager,
+} from './types';
 
 /**
  * Implements a Cache Manager which will automatically create new cache clients
@@ -38,8 +44,10 @@ export class CacheManager {
     none: this.getNoneClient,
   };
 
+  private readonly logger: Logger;
   private readonly store: keyof CacheManager['storeFactories'];
   private readonly connection: string;
+  private readonly errorHandler: OptionalOnError;
 
   /**
    * Creates a new CacheManager instance by reading from the `backend` config
@@ -47,21 +55,34 @@ export class CacheManager {
    *
    * @param config The loaded application configuration.
    */
-  static fromConfig(config: Config): CacheManager {
+  static fromConfig(
+    config: Config,
+    options: CacheManagerOptions = {},
+  ): CacheManager {
     // If no `backend.cache` config is provided, instantiate the CacheManager
     // with a "NoStore" cache client.
     const store = config.getOptionalString('backend.cache.store') || 'none';
     const connectionString =
       config.getOptionalString('backend.cache.connection') || '';
-    return new CacheManager(store, connectionString);
+    const logger = (options.logger || getRootLogger()).child({
+      type: 'cacheManager',
+    });
+    return new CacheManager(store, connectionString, logger, options.onError);
   }
 
-  private constructor(store: string, connectionString: string) {
+  private constructor(
+    store: string,
+    connectionString: string,
+    logger: Logger,
+    errorHandler: OptionalOnError,
+  ) {
     if (!this.storeFactories.hasOwnProperty(store)) {
       throw new Error(`Unknown cache store: ${store}`);
     }
+    this.logger = logger;
     this.store = store as keyof CacheManager['storeFactories'];
     this.connection = connectionString;
+    this.errorHandler = errorHandler;
   }
 
   /**
@@ -74,10 +95,16 @@ export class CacheManager {
       getClient: (opts = {}): CacheClient => {
         const concreteClient = this.getClientWithTtl(pluginId, opts.defaultTtl);
 
-        // Attach error handler if provided.
-        if (typeof opts?.onError === 'function') {
-          concreteClient.on('error', opts.onError);
-        }
+        // Always provide an error handler to avoid killing the process.
+        concreteClient.on('error', (err: Error) => {
+          // In all cases, just log the error.
+          this.logger.error(err);
+
+          // Invoke any custom error handler if provided.
+          if (typeof this.errorHandler === 'function') {
+            this.errorHandler(err);
+          }
+        });
 
         return new DefaultCacheClient({
           client: concreteClient,

--- a/packages/backend-common/src/cache/types.ts
+++ b/packages/backend-common/src/cache/types.ts
@@ -23,6 +23,12 @@ type ClientOptions = {
    * can be configured per entry at set-time).
    */
   defaultTtl?: number;
+
+  /**
+   * An optional handler for connection errors emitted from the underlying data
+   * store.
+   */
+  onError?: (err: Error) => void
 };
 
 /**

--- a/packages/backend-common/src/cache/types.ts
+++ b/packages/backend-common/src/cache/types.ts
@@ -28,7 +28,7 @@ type ClientOptions = {
    * An optional handler for connection errors emitted from the underlying data
    * store.
    */
-  onError?: (err: Error) => void
+  onError?: (err: Error) => void;
 };
 
 /**

--- a/packages/backend-common/src/cache/types.ts
+++ b/packages/backend-common/src/cache/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Logger } from 'winston';
 import { CacheClient } from './CacheClient';
 
 type ClientOptions = {
@@ -23,12 +24,21 @@ type ClientOptions = {
    * can be configured per entry at set-time).
    */
   defaultTtl?: number;
+};
+
+export type OptionalOnError = ((err: Error) => void) | undefined;
+
+export type CacheManagerOptions = {
+  /**
+   * An optional logger for use by the PluginCacheManager.
+   */
+  logger?: Logger;
 
   /**
    * An optional handler for connection errors emitted from the underlying data
    * store.
    */
-  onError?: (err: Error) => void;
+  onError?: OptionalOnError;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I was integrating the ✨✨✨  **_new cache manager_** ✨ ✨✨ in `@backstage/backend-common` into a plugin and doing some basic load tests on the whole system...  In the process, I ran into situations where the backend process would crash with socket connection issues.

The root cause of the crash is that `keyv` captures and re-emits `error` events when there are transient connection errors.  When no listeners are registered for `error` events on `EventEmitter`s, node just throws the error, prints the stack trace, and then exits.

This attaches a handler that just logs the error, but also gives ~~plugin developers~~ app integrators the option to handle errors more gracefully.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
