### PR TITLE
Don't declare registry in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-registry=https://registry.npmjs.org/
 engine-strict=true


### PR DESCRIPTION
## Hey, I just made a Pull Request!
I am not sure what the reason to include the public npm registry in `.npmrc` is, but it seems unnecessary, and it also prevents `npm install` from working by default when in an enterprise environment with no access to public registry.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
