### PR TITLE
Resolve the target for glob file locations correctly

### DIFF
--- a/.changeset/cyan-guests-burn.md
+++ b/.changeset/cyan-guests-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Resolve the `target` for glob `file` locations correctly

--- a/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.test.ts
@@ -79,6 +79,14 @@ describe('FileReaderProcessor', () => {
 
     expect(emit).toBeCalledTimes(2);
     expect(emit.mock.calls[0][0].entity).toEqual({ kind: 'Component' });
+    expect(emit.mock.calls[0][0].location).toEqual({
+      type: 'file',
+      target: expect.stringMatching(/^[^*]*$/),
+    });
     expect(emit.mock.calls[1][0].entity).toEqual({ kind: 'API' });
+    expect(emit.mock.calls[1][0].location).toEqual({
+      type: 'file',
+      target: expect.stringMatching(/^[^*]*$/),
+    });
   });
 });

--- a/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.ts
@@ -41,7 +41,10 @@ export class FileReaderProcessor implements CatalogProcessor {
         for (const fileMatch of fileMatches) {
           const data = await fs.readFile(fileMatch);
 
-          for (const parseResult of parseEntityYaml(data, location)) {
+          for (const parseResult of parseEntityYaml(data, {
+            type: 'file',
+            target: fileMatch,
+          })) {
             emit(parseResult);
           }
         }


### PR DESCRIPTION
Emit the correct location target when importing from a globbed `file` location.

We use this feature for `yarn dev` to have some local examples added. But when we import a scaffolder template by a glob like `./templates/*/template.yaml`, it crashes with an error: `2021-05-14T09:18:18.000Z Error: ENOENT: no such file or directory, stat '/Users/.../templates/*/{{ cookiecutter.project_name }}'`.

This fix emits the correct file location:
```diff
 src/ingestion/processors/__fixtures__/fileReaderProcessor/dir/api.yaml {
    type: 'entity',
    location: {
      type: 'file',
-     target: 'src/ingestion/processors/__fixtures__/fileReaderProcessor/**/*.yaml'
+     target: 'src/ingestion/processors/__fixtures__/fileReaderProcessor/dir/api.yaml'
    },
    entity: { kind: 'API' }
  }
```
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
