### PR TITLE
Skip adding entries to the entities_search table if their key exceeds a length limit.

### DIFF
--- a/.changeset/shaggy-melons-destroy.md
+++ b/.changeset/shaggy-melons-destroy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Skip adding entries to the `entities_search` table if their `key` exceeds a length limit.

--- a/plugins/catalog-backend/src/database/search.test.ts
+++ b/plugins/catalog-backend/src/database/search.test.ts
@@ -101,6 +101,12 @@ describe('search', () => {
       expect(output).toEqual([{ entity_id: 'eid', key: 'foo', value: 'bar' }]);
     });
 
+    it('skips very large keys', () => {
+      const input = [{ key: 'a'.repeat(10000), value: 'foo' }];
+      const output = mapToRows(input, 'eid');
+      expect(output).toEqual([]);
+    });
+
     it('skips very large values', () => {
       const input = [{ key: 'foo', value: 'a'.repeat(10000) }];
       const output = mapToRows(input, 'eid');

--- a/plugins/catalog-backend/src/database/search.ts
+++ b/plugins/catalog-backend/src/database/search.ts
@@ -31,6 +31,7 @@ const SPECIAL_KEYS = [
 // The maximum length allowed for search values. These columns are indexed, and
 // database engines do not like to index on massive values. For example,
 // postgres will balk after 8191 byte line sizes.
+const MAX_KEY_LENGTH = 200;
 const MAX_VALUE_LENGTH = 200;
 
 type Kv = {
@@ -136,7 +137,7 @@ export function mapToRows(
       result.push({ entity_id: entityId, key, value: null });
     } else {
       const value = String(rawValue).toLowerCase();
-      if (value.length <= MAX_VALUE_LENGTH) {
+      if (key.length <= MAX_KEY_LENGTH && value.length <= MAX_VALUE_LENGTH) {
         result.push({ entity_id: entityId, key, value });
       }
     }

--- a/plugins/catalog-backend/src/next/search.test.ts
+++ b/plugins/catalog-backend/src/next/search.test.ts
@@ -104,6 +104,12 @@ describe('search', () => {
       expect(output).toEqual([{ entity_id: 'eid', key: 'foo', value: 'bar' }]);
     });
 
+    it('skips very large keys', () => {
+      const input = [{ key: 'a'.repeat(10000), value: 'foo' }];
+      const output = mapToRows(input, 'eid');
+      expect(output).toEqual([]);
+    });
+
     it('skips very large values', () => {
       const input = [{ key: 'foo', value: 'a'.repeat(10000) }];
       const output = mapToRows(input, 'eid');

--- a/plugins/catalog-backend/src/next/search.ts
+++ b/plugins/catalog-backend/src/next/search.ts
@@ -43,6 +43,7 @@ const SPECIAL_KEYS = [
 // The maximum length allowed for search values. These columns are indexed, and
 // database engines do not like to index on massive values. For example,
 // postgres will balk after 8191 byte line sizes.
+const MAX_KEY_LENGTH = 200;
 const MAX_VALUE_LENGTH = 200;
 
 type Kv = {
@@ -145,7 +146,7 @@ export function mapToRows(input: Kv[], entityId: string): DbSearchRow[] {
       result.push({ entity_id: entityId, key, value: null });
     } else {
       const value = String(rawValue).toLocaleLowerCase('en-US');
-      if (value.length <= MAX_VALUE_LENGTH) {
+      if (key.length <= MAX_KEY_LENGTH && value.length <= MAX_VALUE_LENGTH) {
         result.push({ entity_id: entityId, key, value });
       }
     }


### PR DESCRIPTION
The values of `entities_search` table are generated from the entity definition. The special array logic concatenates the value into the key, but it length-checks only the resulting value. This could lead to the following error:

```
{"error":{"name":"error","message":"insert into \"entities_search\" (\"entity_id\", \"key\", \"value\") values ($1, $2, $3), ($4, $5, $6), ($7, $8, $9), ($10, $11, $12), ($13, $14, $15), ($16, $17, $18), ($19, $20, $21), ($22, $23, $24), ($25, $26, $27), ($28, $29, $30), ($31, $32, $33), ($34, $35, $36), ($37, $38, $39), ($40, $41, $42), ($43, $44, $45), ($46, $47, $48), ($49, $50, $51), ($52, $53, $54), ($55, $56, $57), ($58, $59, $60), ($61, $62, $63), ($64, $65, $66), ($67, $68, $69), ($70, $71, $72), ($73, $74, $75), ($76, $77, $78), ($79, $80, $81), ($82, $83, $84), ($85, $86, $87), ($88, $89, $90), ($91, $92, $93), ($94, $95, $96), ($97, $98, $99), ($100, $101, $102), ($103, $104, $105), ($106, $107, $108), ($109, $110, $111), ($112, $113, $114), ($115, $116, $117), ($118, $119, $120), ($121, $122, $123), ($124, $125, $126), ($127, $128, $129), ($130, $131, $132) - value too long for type character varying(255)","length":99,"severity":"ERROR","code":"22001","file":"varchar.c","line":"636","routine":"varchar","level":"error","service":"backstage"},"request":{"method":"POST","url":"/locations?dryRun=true"},"response":{"statusCode":500}}
```

This PR also discards values that have a too-long `key` entry.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
