### PR TITLE
dev-utils: fix for scm integrations API factory not being provided

### DIFF
--- a/.changeset/strong-nails-do.md
+++ b/.changeset/strong-nails-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/dev-utils': patch
+---
+
+Fix a bug where an instance of the SCM integrations API wasn't being provided properly to the dev app.

--- a/packages/dev-utils/src/devApp/render.tsx
+++ b/packages/dev-utils/src/devApp/render.tsx
@@ -154,7 +154,7 @@ class DevAppBuilder {
     }
 
     const app = createApp({
-      apis: this.apis,
+      apis,
       plugins: this.plugins,
       bindRoutes: ({ bind }) => {
         for (const plugin of this.plugins ?? []) {


### PR DESCRIPTION
Ran across this the other day