### PR TITLE
core-api: updated Observable type to support interop

### DIFF
--- a/.changeset/chatty-books-buy.md
+++ b/.changeset/chatty-books-buy.md
@@ -1,0 +1,13 @@
+---
+'@backstage/core-api': patch
+---
+
+Updated the `Observable` type to provide interoperability with `Symbol.observable`, making it compatible with at least `zen-observable` and `RxJS 7`.
+
+In cases where this change breaks tests that mocked the `Observable` type, the following addition to the mock should fix the breakage:
+
+```ts
+  [Symbol.observable]() {
+    return this;
+  },
+```

--- a/.changeset/sweet-colts-teach.md
+++ b/.changeset/sweet-colts-teach.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Updated `MockErrorApi` to work with new `Observable` type in `@backstage/core`.

--- a/packages/core-api/src/lib/subjects.ts
+++ b/packages/core-api/src/lib/subjects.ts
@@ -53,6 +53,10 @@ export class PublishSubject<T>
     ZenObservable.SubscriptionObserver<T>
   >();
 
+  [Symbol.observable]() {
+    return this;
+  }
+
   get closed() {
     return this.isClosed;
   }
@@ -147,6 +151,10 @@ export class BehaviorSubject<T>
   private readonly subscribers = new Set<
     ZenObservable.SubscriptionObserver<T>
   >();
+
+  [Symbol.observable]() {
+    return this;
+  }
 
   get closed() {
     return this.isClosed;

--- a/packages/core-api/src/types.ts
+++ b/packages/core-api/src/types.ts
@@ -39,7 +39,7 @@ export type Subscription = {
   /**
    * Value indicating whether the subscription is closed.
    */
-  readonly closed: Boolean;
+  readonly closed: boolean;
 };
 
 /**
@@ -51,12 +51,14 @@ export type Subscription = {
  * using many different observable implementations, such as zen-observable or RxJS 5.
  */
 export type Observable<T> = {
+  [Symbol.observable](): Observable<T>;
+
   /**
    * Subscribes to this observable to start receiving new values.
    */
   subscribe(observer: Observer<T>): Subscription;
   subscribe(
-    onNext: (value: T) => void,
+    onNext?: (value: T) => void,
     onError?: (error: Error) => void,
     onComplete?: () => void,
   ): Subscription;

--- a/packages/test-utils/src/testUtils/apis/ErrorApi/MockErrorApi.ts
+++ b/packages/test-utils/src/testUtils/apis/ErrorApi/MockErrorApi.ts
@@ -32,6 +32,10 @@ type Waiter = {
 
 const nullObservable = {
   subscribe: () => ({ unsubscribe: () => {}, closed: true }),
+
+  [Symbol.observable]() {
+    return this;
+  },
 };
 
 export class MockErrorApi implements ErrorApi {


### PR DESCRIPTION
This makes our `Observable` type from `@backstage/core` compatible with `zen-observable` and `RxJS 7`, meaning that it can be passed to `Observable.from()` or just `from()` in the case of `RxJS`.

Bit torn on whether we should make this a breaking change or not. Strictly speaking it definitely is, as any custom implementation of the observable interface would likely not include the `Symbol.observable` method. In practice it's implemented by libraries that are compatible with our observable type though, so the only breakage ends up being it tests that end up doing some pretty deep mocking.