### PR TITLE
fix(auth): Do not ask to log-in on every page refresh

### DIFF
--- a/.changeset/moody-beds-chew.md
+++ b/.changeset/moody-beds-chew.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Fix a bug where users are asked to log-in on every page refresh. This is specific to people with only one sign-in provider in their SignInPage component.

--- a/packages/core/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core/src/layout/SignInPage/SignInPage.tsx
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
+import { configApiRef, SignInPageProps, useApi } from '@backstage/core-api';
+import { Button, Grid, Typography } from '@material-ui/core';
 import React, { useEffect, useState } from 'react';
-import { Page } from '../Page';
-import { Header } from '../Header';
+import { Progress } from '../../components/Progress';
 import { Content } from '../Content/Content';
 import { ContentHeader } from '../ContentHeader/ContentHeader';
-import { Grid, Button, Typography } from '@material-ui/core';
-import { SignInPageProps, useApi, configApiRef } from '@backstage/core-api';
-import { useSignInProviders, getSignInProviders } from './providers';
-import { IdentityProviders, SignInProviderConfig } from './types';
-import { Progress } from '../../components/Progress';
-import { GridItem, useStyles } from './styles';
+import { Header } from '../Header';
 import { InfoCard } from '../InfoCard';
+import { Page } from '../Page';
+import { getSignInProviders, useSignInProviders } from './providers';
+import { GridItem, useStyles } from './styles';
+import { IdentityProviders, SignInProviderConfig } from './types';
 
 type MultiSignInPageProps = SignInPageProps & {
   providers: IdentityProviders;
@@ -81,7 +81,7 @@ export const MultiSignInPage = ({
 export const SingleSignInPage = ({
   onResult,
   provider,
-  auto,
+  auto = true,
 }: SingleSignInPageProps) => {
   const classes = useStyles();
   const authApi = useApi(provider.apiRef);
@@ -92,9 +92,7 @@ export const SingleSignInPage = ({
 
   useEffect(() => {
     const login = async () => {
-      const identity = await authApi.getBackstageIdentity({
-        instantPopup: true,
-      });
+      const identity = await authApi.getBackstageIdentity();
 
       const profile = await authApi.getProfile();
       onResult({

--- a/packages/core/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core/src/layout/SignInPage/SignInPage.tsx
@@ -98,7 +98,18 @@ export const SingleSignInPage = ({
   useEffect(() => {
     const login = async () => {
       try {
-        const identity = await authApi.getBackstageIdentity();
+        let identity;
+        // Do an initial check if any logged-in session exists
+        identity = await authApi.getBackstageIdentity({
+          optional: true,
+        });
+
+        // If no session exists, show the sign-in page
+        if (!identity) {
+          identity = await authApi.getBackstageIdentity({
+            instantPopup: true,
+          });
+        }
 
         const profile = await authApi.getProfile();
         onResult({
@@ -111,9 +122,6 @@ export const SingleSignInPage = ({
             await authApi.signOut();
           },
         });
-
-        // Don't show if login is successful
-        setShowLoginPage(false);
       } catch (err) {
         // User closed the sign-in modal
         setError(err);
@@ -162,7 +170,9 @@ export const SingleSignInPage = ({
         </Grid>
       </Content>
     </Page>
-  ) : null;
+  ) : (
+    <Progress />
+  );
 };
 
 export const SignInPage = (props: Props) => {


### PR DESCRIPTION
Closes https://github.com/backstage/backstage/issues/5109
Relates https://github.com/backstage/backstage/discussions/5389

The SingleSignInPage component is used when users add a custom `SignInPage` to their Backstage app with just one Sign In provider ([for example](https://backstage.io/docs/auth/#adding-the-provider-to-the-sign-in-page)). This is a different component than the `MultiSignInPage` which is used when there are more than one Sign In providers.

To fix the "user being logged out on every page refresh" bug, this PR makes the following changes to the `SingleSignInPage` component

1. Set the default value of `retry` state to be `true`. Without this, the Sign in page loads but makes no attempt to automatically log in the user if they have existing session.

2. Use a `autoShowPopup` state to determine whether or not to show log-in popup if the user is not signed in.

3. In the `login` function, perform a check beforehand to see if a session exists before requesting a new Backstage identity.

4. Use a `showLoginPage` state and a progress bar to prevent a glitch-like experience in case when the sign-in page is displayed for a split second when the user is already logged-in.