### PR TITLE
catalog: Display warning when entity is orphan 

### DIFF
--- a/.changeset/wise-mugs-sell.md
+++ b/.changeset/wise-mugs-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Display warning when Entity has orphan annotation.

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -40,6 +40,7 @@ import {
   isComponentType,
   isKind,
   EntityHasResourcesCard,
+  EntityOrphanWarning,
 } from '@backstage/plugin-catalog';
 import {
   EntityCircleCIContent,
@@ -214,7 +215,10 @@ const errorsContent = (
 
 const overviewContent = (
   <Grid container spacing={3} alignItems="stretch">
-    <Grid item md={6}>
+    <Grid item xs={12}>
+      <EntityOrphanWarning />
+    </Grid>
+    <Grid item md={8} xs={12}>
       <EntityAboutCard variant="gridItem" />
     </Grid>
 
@@ -226,7 +230,7 @@ const overviewContent = (
       </EntitySwitch.Case>
     </EntitySwitch>
 
-    <Grid item md={4} sm={6}>
+    <Grid item md={4} xs={12}>
       <EntityLinksCard />
     </Grid>
 
@@ -260,7 +264,7 @@ const overviewContent = (
       </EntitySwitch.Case>
     </EntitySwitch>
 
-    <Grid item md={6}>
+    <Grid item md={8} xs={12}>
       <EntityHasSubcomponentsCard variant="gridItem" />
     </Grid>
   </Grid>

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -41,6 +41,7 @@ import {
   isKind,
   EntityHasResourcesCard,
   EntityOrphanWarning,
+  isOrphan,
 } from '@backstage/plugin-catalog';
 import {
   EntityCircleCIContent,
@@ -215,9 +216,14 @@ const errorsContent = (
 
 const overviewContent = (
   <Grid container spacing={3} alignItems="stretch">
-    <Grid item xs={12}>
-      <EntityOrphanWarning />
-    </Grid>
+    <EntitySwitch>
+      <EntitySwitch.Case if={isOrphan}>
+        <Grid item xs={12}>
+          <EntityOrphanWarning />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
+
     <Grid item md={8} xs={12}>
       <EntityAboutCard variant="gridItem" />
     </Grid>

--- a/plugins/catalog/src/components/EntityOrphanWarning/DeleteEntityDialog.test.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/DeleteEntityDialog.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { DeleteEntityDialog } from './DeleteEntityDialog';
+import { ORIGIN_LOCATION_ANNOTATION } from '@backstage/catalog-model';
+import {
+  AlertApi,
+  alertApiRef,
+  ApiProvider,
+  ApiRegistry,
+} from '@backstage/core';
+import { CatalogApi } from '@backstage/catalog-client';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { screen, waitFor } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+
+describe('DeleteEntityDialog', () => {
+  const alertApi: jest.Mocked<AlertApi> = {
+    post: jest.fn(),
+    alert$: jest.fn(),
+  };
+
+  const catalogClient: jest.Mocked<CatalogApi> = {
+    removeEntityByUid: jest.fn(),
+  } as any;
+  const apis = ApiRegistry.with(catalogApiRef, catalogClient).with(
+    alertApiRef,
+    alertApi,
+  );
+
+  const entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      uid: '123',
+      name: 'n',
+      namespace: 'ns',
+      annotations: {
+        [ORIGIN_LOCATION_ANNOTATION]: 'url:http://example.com',
+      },
+    },
+    spec: {},
+  };
+
+  const Wrapper = ({ children }: { children?: React.ReactNode }) => (
+    <ApiProvider apis={apis}>{children}</ApiProvider>
+  );
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('can cancel', async () => {
+    const onClose = jest.fn();
+
+    await renderInTestApp(
+      <Wrapper>
+        <DeleteEntityDialog
+          open
+          onClose={onClose}
+          onConfirm={() => {}}
+          entity={entity}
+        />
+      </Wrapper>,
+    );
+
+    userEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => {
+      expect(onClose).toBeCalled();
+    });
+  });
+
+  it('can delete', async () => {
+    const onConfirm = jest.fn();
+
+    await renderInTestApp(
+      <Wrapper>
+        <DeleteEntityDialog
+          open
+          onClose={() => {}}
+          onConfirm={onConfirm}
+          entity={entity}
+        />
+      </Wrapper>,
+    );
+
+    userEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(catalogClient.removeEntityByUid).toBeCalledWith('123');
+      expect(onConfirm).toBeCalled();
+    });
+  });
+
+  it('handles error', async () => {
+    const onConfirm = jest.fn();
+
+    await renderInTestApp(
+      <Wrapper>
+        <DeleteEntityDialog
+          open
+          onClose={() => {}}
+          onConfirm={onConfirm}
+          entity={entity}
+        />
+      </Wrapper>,
+    );
+
+    catalogClient.removeEntityByUid.mockRejectedValue(new Error('no no no'));
+    userEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(catalogClient.removeEntityByUid).toBeCalledWith('123');
+      expect(alertApi.post).toBeCalledWith({ message: 'no no no' });
+    });
+  });
+});

--- a/plugins/catalog/src/components/EntityOrphanWarning/DeleteEntityDialog.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/DeleteEntityDialog.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { alertApiRef, useApi } from '@backstage/core';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { Button, Dialog, DialogActions, DialogTitle } from '@material-ui/core';
+import React, { useState } from 'react';
+
+type Props = {
+  open: boolean;
+  onClose: () => any;
+  onConfirm: () => any;
+  entity: Entity;
+};
+
+export const DeleteEntityDialog = ({
+  open,
+  onClose,
+  onConfirm,
+  entity,
+}: Props) => {
+  const [busy, setBusy] = useState(false);
+  const catalogApi = useApi(catalogApiRef);
+  const alertApi = useApi(alertApiRef);
+
+  const onDelete = async () => {
+    setBusy(true);
+    try {
+      const uid = entity.metadata.uid;
+      await catalogApi.removeEntityByUid(uid!);
+      onConfirm();
+    } catch (err) {
+      alertApi.post({ message: err.message });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle id="responsive-dialog-title">
+        Are you sure you want to delete this entity?
+      </DialogTitle>
+      <DialogActions>
+        <Button
+          variant="contained"
+          color="secondary"
+          disabled={busy}
+          onClick={onDelete}
+        >
+          Delete
+        </Button>
+        <Button onClick={onClose} color="primary">
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiProvider, ApiRegistry, ConfigReader } from '@backstage/core';
+import {
+  ScmIntegrationsApi,
+  scmIntegrationsApiRef,
+} from '@backstage/integration-react';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { renderInTestApp } from '@backstage/test-utils';
+import React from 'react';
+import { EntityOrphanWarning } from './EntityOrphanWarning';
+
+describe('<EntityOrphanWarning />', () => {
+  it('renders EntityOrphanWarning if the entity is orphan', async () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+        description: 'This is the description',
+        annotations: { 'backstage.io/orphan': 'true' },
+      },
+
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const apis = ApiRegistry.with(
+      scmIntegrationsApiRef,
+      ScmIntegrationsApi.fromConfig(
+        new ConfigReader({
+          integrations: {},
+        }),
+      ),
+    );
+
+    const { getByText } = await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <EntityProvider entity={entity}>
+          <EntityOrphanWarning />
+        </EntityProvider>
+      </ApiProvider>,
+    );
+    expect(
+      getByText(
+        'This entity is not referenced by any location and is therefore not receiving updates. Click here to unregister.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render EntityOrphanWarning if the entity is not orphan', async () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+        description: 'This is the description',
+      },
+
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const apis = ApiRegistry.with(
+      scmIntegrationsApiRef,
+      ScmIntegrationsApi.fromConfig(
+        new ConfigReader({
+          integrations: {},
+        }),
+      ),
+    );
+
+    const { queryByText } = await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <EntityProvider entity={entity}>
+          <EntityOrphanWarning />
+        </EntityProvider>
+      </ApiProvider>,
+    );
+    expect(
+      queryByText(
+        'This entity is not referenced by any location and is therefore not receiving updates. Click here to unregister.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
@@ -61,34 +61,4 @@ describe('<EntityOrphanWarning />', () => {
       ),
     ).toBeInTheDocument();
   });
-
-  it('does not render EntityOrphanWarning if the entity is not orphan', async () => {
-    const entity = {
-      apiVersion: 'v1',
-      kind: 'Component',
-      metadata: {
-        name: 'software',
-        description: 'This is the description',
-      },
-
-      spec: {
-        owner: 'guest',
-        type: 'service',
-        lifecycle: 'production',
-      },
-    };
-
-    const { queryByText } = await renderInTestApp(
-      <ApiProvider apis={apis}>
-        <EntityProvider entity={entity}>
-          <EntityOrphanWarning />
-        </EntityProvider>
-      </ApiProvider>,
-    );
-    expect(
-      queryByText(
-        'This entity is not referenced by any location and is therefore not receiving updates. Click here to delete.',
-      ),
-    ).not.toBeInTheDocument();
-  });
 });

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
@@ -14,17 +14,23 @@
  * limitations under the License.
  */
 
-import { ApiProvider, ApiRegistry, ConfigReader } from '@backstage/core';
+import { ApiProvider, ApiRegistry } from '@backstage/core';
+
 import {
-  ScmIntegrationsApi,
-  scmIntegrationsApiRef,
-} from '@backstage/integration-react';
-import { EntityProvider } from '@backstage/plugin-catalog-react';
+  CatalogApi,
+  catalogApiRef,
+  EntityProvider,
+} from '@backstage/plugin-catalog-react';
 import { renderInTestApp } from '@backstage/test-utils';
 import React from 'react';
 import { EntityOrphanWarning } from './EntityOrphanWarning';
 
 describe('<EntityOrphanWarning />', () => {
+  const catalogClient: jest.Mocked<CatalogApi> = {
+    removeEntityByUid: jest.fn(),
+  } as any;
+  const apis = ApiRegistry.with(catalogApiRef, catalogClient);
+
   it('renders EntityOrphanWarning if the entity is orphan', async () => {
     const entity = {
       apiVersion: 'v1',
@@ -41,14 +47,6 @@ describe('<EntityOrphanWarning />', () => {
         lifecycle: 'production',
       },
     };
-    const apis = ApiRegistry.with(
-      scmIntegrationsApiRef,
-      ScmIntegrationsApi.fromConfig(
-        new ConfigReader({
-          integrations: {},
-        }),
-      ),
-    );
 
     const { getByText } = await renderInTestApp(
       <ApiProvider apis={apis}>
@@ -59,7 +57,7 @@ describe('<EntityOrphanWarning />', () => {
     );
     expect(
       getByText(
-        'This entity is not referenced by any location and is therefore not receiving updates. Click here to unregister.',
+        'This entity is not referenced by any location and is therefore not receiving updates. Click here to delete.',
       ),
     ).toBeInTheDocument();
   });
@@ -79,14 +77,6 @@ describe('<EntityOrphanWarning />', () => {
         lifecycle: 'production',
       },
     };
-    const apis = ApiRegistry.with(
-      scmIntegrationsApiRef,
-      ScmIntegrationsApi.fromConfig(
-        new ConfigReader({
-          integrations: {},
-        }),
-      ),
-    );
 
     const { queryByText } = await renderInTestApp(
       <ApiProvider apis={apis}>
@@ -97,7 +87,7 @@ describe('<EntityOrphanWarning />', () => {
     );
     expect(
       queryByText(
-        'This entity is not referenced by any location and is therefore not receiving updates. Click here to unregister.',
+        'This entity is not referenced by any location and is therefore not receiving updates. Click here to delete.',
       ),
     ).not.toBeInTheDocument();
   });

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiProvider, ApiRegistry, createRouteRef } from '@backstage/core';
+import { ApiProvider, ApiRegistry } from '@backstage/core';
 
 import {
   CatalogApi,

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.test.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { ApiProvider, ApiRegistry } from '@backstage/core';
+import { ApiProvider, ApiRegistry, createRouteRef } from '@backstage/core';
 
 import {
   CatalogApi,
   catalogApiRef,
+  catalogRouteRef,
   EntityProvider,
 } from '@backstage/plugin-catalog-react';
 import { renderInTestApp } from '@backstage/test-utils';
@@ -54,6 +55,11 @@ describe('<EntityOrphanWarning />', () => {
           <EntityOrphanWarning />
         </EntityProvider>
       </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/create': catalogRouteRef,
+        },
+      },
     );
     expect(
       getByText(

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+import { Entity } from '@backstage/catalog-model';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { Alert } from '@material-ui/lab';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { DeleteEntityDialog } from './DeleteEntityDialog';
+
+export const isOrphan = (entity: Entity) =>
+  entity?.metadata?.annotations?.['backstage.io/orphan'] === 'true';
 
 /**
  * Displays a warning alert if the entity is marked as orphan with the ability to delete said entity.
@@ -28,7 +32,7 @@ export const EntityOrphanWarning = () => {
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
 
   const { entity } = useEntity();
-  if (entity.metadata?.annotations?.['backstage.io/orphan'] !== 'true') {
+  if (entity?.metadata?.annotations?.['backstage.io/orphan'] !== 'true') {
     return null;
   }
 

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { Alert } from '@material-ui/lab';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router';
+import { UnregisterEntityDialog } from '../UnregisterEntityDialog/UnregisterEntityDialog';
+
+/**
+ * Displays a warning alert if the entity is marked as orphan with the ability to delete said entity.
+ */
+export const EntityOrphanWarning = () => {
+  const navigate = useNavigate();
+  const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
+
+  const { entity } = useEntity();
+  if (
+    !entity.metadata?.annotations ||
+    entity.metadata?.annotations['backstage.io/orphan'] !== 'true'
+  ) {
+    return null;
+  }
+
+  const cleanUpAfterRemoval = async () => {
+    setConfirmationDialogOpen(false);
+    navigate('/');
+  };
+
+  return (
+    <>
+      <Alert severity="warning" onClick={() => setConfirmationDialogOpen(true)}>
+        This entity is not referenced by any location and is therefore not
+        receiving updates. Click here to unregister.
+      </Alert>
+      <UnregisterEntityDialog
+        open={confirmationDialogOpen}
+        entity={entity!}
+        onConfirm={cleanUpAfterRemoval}
+        onClose={() => setConfirmationDialogOpen(false)}
+      />
+    </>
+  );
+};

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
@@ -18,7 +18,7 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import { Alert } from '@material-ui/lab';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router';
-import { UnregisterEntityDialog } from '../UnregisterEntityDialog/UnregisterEntityDialog';
+import { DeleteEntityDialog } from './DeleteEntityDialog';
 
 /**
  * Displays a warning alert if the entity is marked as orphan with the ability to delete said entity.
@@ -28,10 +28,7 @@ export const EntityOrphanWarning = () => {
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
 
   const { entity } = useEntity();
-  if (
-    !entity.metadata?.annotations ||
-    entity.metadata?.annotations['backstage.io/orphan'] !== 'true'
-  ) {
+  if (entity.metadata?.annotations?.['backstage.io/orphan'] !== 'true') {
     return null;
   }
 
@@ -44,9 +41,9 @@ export const EntityOrphanWarning = () => {
     <>
       <Alert severity="warning" onClick={() => setConfirmationDialogOpen(true)}>
         This entity is not referenced by any location and is therefore not
-        receiving updates. Click here to unregister.
+        receiving updates. Click here to delete.
       </Alert>
-      <UnregisterEntityDialog
+      <DeleteEntityDialog
         open={confirmationDialogOpen}
         entity={entity!}
         onConfirm={cleanUpAfterRemoval}

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
@@ -30,11 +30,7 @@ export const isOrphan = (entity: Entity) =>
 export const EntityOrphanWarning = () => {
   const navigate = useNavigate();
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
-
   const { entity } = useEntity();
-  if (entity?.metadata?.annotations?.['backstage.io/orphan'] !== 'true') {
-    return null;
-  }
 
   const cleanUpAfterRemoval = async () => {
     setConfirmationDialogOpen(false);

--- a/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
+++ b/plugins/catalog/src/components/EntityOrphanWarning/EntityOrphanWarning.tsx
@@ -15,7 +15,8 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import { useRouteRef } from '@backstage/core';
+import { catalogRouteRef, useEntity } from '@backstage/plugin-catalog-react';
 import { Alert } from '@material-ui/lab';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -29,12 +30,13 @@ export const isOrphan = (entity: Entity) =>
  */
 export const EntityOrphanWarning = () => {
   const navigate = useNavigate();
+  const catalogLink = useRouteRef(catalogRouteRef);
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
   const { entity } = useEntity();
 
   const cleanUpAfterRemoval = async () => {
     setConfirmationDialogOpen(false);
-    navigate('/');
+    navigate(catalogLink());
   };
 
   return (

--- a/plugins/catalog/src/components/EntityOrphanWarning/index.ts
+++ b/plugins/catalog/src/components/EntityOrphanWarning/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { EntityOrphanWarning } from './EntityOrphanWarning';
+export { EntityOrphanWarning, isOrphan } from './EntityOrphanWarning';

--- a/plugins/catalog/src/components/EntityOrphanWarning/index.ts
+++ b/plugins/catalog/src/components/EntityOrphanWarning/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { EntityOrphanWarning } from './EntityOrphanWarning';

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -35,3 +35,4 @@ export {
   EntityLinksCard,
   EntitySystemDiagramCard,
 } from './plugin';
+export * from './components/EntityOrphanWarning';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Displays warning when the entity has the orphan annotation. This is only displayed for entities in the catalog that's currently being worked on.
This also updates the grid layout to add up to 12 for the About, Subcomponent and Link card.


<img width="1297" alt="Screenshot 2021-05-18 at 11 29 31" src="https://user-images.githubusercontent.com/68980/118628329-ccac7e00-b7cc-11eb-9560-8d05837c09a1.png">
<img width="1260" alt="Screenshot 2021-05-18 at 16 42 45" src="https://user-images.githubusercontent.com/68980/118672163-53c31b80-b7f8-11eb-9cca-d8e98e765706.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
