### PR TITLE
Scaffolder: Enable branch protection on new repo

### DIFF
--- a/.changeset/thick-ads-smash.md
+++ b/.changeset/thick-ads-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Add branch protection for default branches of scaffolded GitHub repositories

--- a/.changeset/thick-ads-smash.md
+++ b/.changeset/thick-ads-smash.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
 Add branch protection for default branches of scaffolded GitHub repositories

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -235,7 +235,9 @@ export function createPublishGithubAction(options: {
           repoName: newRepo.name,
         });
       } catch (e) {
-        throw new Error(`Failed to add branch protection to '${name}', ${e}`);
+        throw new Error(
+          `Failed to add branch protection to '${newRepo.name}', ${e}`,
+        );
       }
 
       ctx.output('remoteUrl', remoteUrl);

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -29,6 +29,7 @@ import path from 'path';
 
 export type RepoVisibilityOptions = 'private' | 'internal' | 'public';
 
+/** @deprecated */
 export class GithubPublisher implements PublisherBase {
   static async fromConfig(
     config: GitHubIntegrationConfig,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -29,7 +29,7 @@ import path from 'path';
 
 export type RepoVisibilityOptions = 'private' | 'internal' | 'public';
 
-/** @deprecated */
+/** @deprecated use createPublishGithubAction instead */
 export class GithubPublisher implements PublisherBase {
   static async fromConfig(
     config: GitHubIntegrationConfig,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -110,9 +110,7 @@ export class GithubPublisher implements PublisherBase {
         repoName: name,
       });
     } catch (e) {
-      throw new Error(
-        `Failed to add branch protection to '${name}': ${e.message}`,
-      );
+      throw new Error(`Failed to add branch protection to '${name}', ${e}`);
     }
 
     return { remoteUrl, catalogInfoUrl };

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
@@ -89,16 +89,15 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
 
   try {
     await client.repos.updateBranchProtection({
-      headers: {
-        Accept:
-          /**
-           * 👇 we need this header because allowing a custom
-           * reviewer count on branch protection is a preview
-           * feature.
-           *
-           * More here: https://docs.github.com/en/rest/overview/api-previews#require-multiple-approving-reviews
-           */
-          'application/vnd.github.luke-cage-preview+json',
+      mediaType: {
+        /**
+         * 👇 we need this preview because allowing a custom
+         * reviewer count on branch protection is a preview
+         * feature.
+         *
+         * More here: https://docs.github.com/en/rest/overview/api-previews#require-multiple-approving-reviews
+         */
+        previews: ['luke-cage-preview'],
       },
       owner,
       repo: repoName,

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
@@ -109,9 +109,9 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
     if (!e.message.includes('Branch not found')) {
       throw e;
     }
-  }
 
-  // GitHub has eventual consistency. Fail silently, wait, and try again.
-  await new Promise(resolve => setTimeout(resolve, 600));
-  await tryOnce();
+    // GitHub has eventual consistency. Fail silently, wait, and try again.
+    await new Promise(resolve => setTimeout(resolve, 600));
+    await tryOnce();
+  }
 };

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
@@ -93,7 +93,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
         /**
          * 👇 we need this preview because allowing a custom
          * reviewer count on branch protection is a preview
-         * feature.
+         * feature
          *
          * More here: https://docs.github.com/en/rest/overview/api-previews#require-multiple-approving-reviews
          */

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
@@ -82,11 +82,6 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
   owner,
   isRetry = false,
 }: BranchProtectionOptions): Promise<void> => {
-  const { data: repo } = await client.repos.get({
-    owner,
-    repo: repoName,
-  });
-
   try {
     await client.repos.updateBranchProtection({
       mediaType: {
@@ -101,7 +96,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
       },
       owner,
       repo: repoName,
-      branch: repo.default_branch,
+      branch: 'master',
       required_status_checks: { strict: true, contexts: [] },
       restrictions: null,
       enforce_admins: true,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR fixes #2494 as it was missed in RFCs #2447 and #2771 by enabling branch protection on a newly scaffolded GitHub repo's default branch according to the constraints laid out in #2494.

It is not configurable right now, but _can be made configurable_ to meet our user needs in the future.

### Demo
![Kapture 2021-05-18 at 11 37 28](https://user-images.githubusercontent.com/9947422/118629828-41cc8300-b7ce-11eb-9d52-6ea38884b462.gif)

### Additional Changes
This PR deprecates a deprecated class according to https://github.com/backstage/backstage/pull/5709#pullrequestreview-662234871:

![image](https://user-images.githubusercontent.com/9947422/118680654-36458000-b7ff-11eb-9fe5-86c66e08f337.png)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation 
  - ⚠️ Not sure if or where to add this information to the docs.
- [ ] Tests for new functionality and regression tests for bug fixes
  - ⚠️ No new tests because this functionality is already covered by https://github.com/backstage/backstage/blob/99dddfb61001ee823e717047fc3e9e9954a86b04/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.test.ts#L77-L81
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
