### PR TITLE
Add `catalog.processors.microsoftGraphOrg.ignoreGroupIds`

### DIFF
--- a/.changeset/warm-files-notice.md
+++ b/.changeset/warm-files-notice.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add optional `catalog.processors.microsoftGraphOrg.ignoreGroupIds` configuration
+option to be able to prevent certain groups from being imported into Backstage.

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -408,6 +408,12 @@ export interface Config {
            * E.g. "securityEnabled eq false and mailEnabled eq true"
            */
           groupFilter?: string;
+          /**
+           * Skip importing groups by id. 
+           * 
+           * This doesn't affect the users that are part of the group.
+           */
+          ignoreGroupIds?: string[];
         }>;
       };
     };

--- a/plugins/catalog-backend/src/ingestion/processors/MicrosoftGraphOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/MicrosoftGraphOrgReaderProcessor.ts
@@ -79,6 +79,7 @@ export class MicrosoftGraphOrgReaderProcessor implements CatalogProcessor {
       {
         userFilter: provider.userFilter,
         groupFilter: provider.groupFilter,
+        ignoreGroupIds: provider.ignoreGroupIds,
       },
     );
 

--- a/plugins/catalog-backend/src/ingestion/processors/microsoftGraph/config.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/microsoftGraph/config.ts
@@ -57,6 +57,12 @@ export type MicrosoftGraphProviderConfig = {
    * E.g. "securityEnabled eq false and mailEnabled eq true"
    */
   groupFilter?: string;
+  /**
+   * Skip importing groups by id.
+   * 
+   * This doesn't affect the users that are part of the group.
+   */
+  ignoreGroupIds?: string[];
 };
 
 export function readMicrosoftGraphConfig(
@@ -75,6 +81,9 @@ export function readMicrosoftGraphConfig(
     const clientSecret = providerConfig.getString('clientSecret');
     const userFilter = providerConfig.getOptionalString('userFilter');
     const groupFilter = providerConfig.getOptionalString('groupFilter');
+    const ignoreGroupIds = providerConfig.getOptionalStringArray(
+      'ignoreGroupIds',
+    );
 
     providers.push({
       target,
@@ -84,6 +93,7 @@ export function readMicrosoftGraphConfig(
       clientSecret,
       userFilter,
       groupFilter,
+      ignoreGroupIds,
     });
   }
 

--- a/plugins/catalog-backend/src/ingestion/processors/microsoftGraph/read.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/microsoftGraph/read.test.ts
@@ -172,6 +172,12 @@ describe('read microsoft graph', () => {
           description: 'Group Description',
           mail: 'group@example.com',
         };
+        yield {
+          id: 'ignore-groupid',
+          displayName: 'Ignore Group Name',
+          description: 'Ignore Group Description',
+          mail: 'ignore-group@example.com',
+        };
       }
 
       async function* getExampleGroupMembers(): AsyncIterable<GroupMember> {
@@ -202,6 +208,7 @@ describe('read microsoft graph', () => {
         rootGroup,
       } = await readMicrosoftGraphGroups(client, 'tenantid', {
         groupFilter: 'securityEnabled eq false',
+        ignoreGroupIds: ['ignore-groupid'],
       });
 
       const expectedRootGroup = group({

--- a/plugins/catalog-backend/src/ingestion/processors/microsoftGraph/read.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/microsoftGraph/read.ts
@@ -126,7 +126,7 @@ export async function readMicrosoftGraphOrganization(
 export async function readMicrosoftGraphGroups(
   client: MicrosoftGraphClient,
   tenantId: string,
-  options?: { groupFilter?: string },
+  options?: { groupFilter?: string; ignoreGroupIds?: string[] },
 ): Promise<{
   groups: GroupEntity[]; // With all relations empty
   rootGroup: GroupEntity | undefined; // With all relations empty
@@ -149,6 +149,10 @@ export async function readMicrosoftGraphGroups(
     select: ['id', 'displayName', 'description', 'mail', 'mailNickname'],
   })) {
     if (!group.id || !group.displayName) {
+      continue;
+    }
+
+    if (options?.ignoreGroupIds && options.ignoreGroupIds.includes(group.id)) {
       continue;
     }
 
@@ -321,7 +325,11 @@ export function resolveRelations(
 export async function readMicrosoftGraphOrg(
   client: MicrosoftGraphClient,
   tenantId: string,
-  options?: { userFilter?: string; groupFilter?: string },
+  options?: {
+    userFilter?: string;
+    groupFilter?: string;
+    ignoreGroupIds?: string[];
+  },
 ): Promise<{ users: UserEntity[]; groups: GroupEntity[] }> {
   const { users } = await readMicrosoftGraphUsers(client, {
     userFilter: options?.userFilter,
@@ -333,6 +341,7 @@ export async function readMicrosoftGraphOrg(
     groupMemberOf,
   } = await readMicrosoftGraphGroups(client, tenantId, {
     groupFilter: options?.groupFilter,
+    ignoreGroupIds: options?.ignoreGroupIds,
   });
 
   resolveRelations(rootGroup, groups, users, groupMember, groupMemberOf);


### PR DESCRIPTION
Now that the new group page in the explore plugin shows the available groups nicely, we have to problem that we have a lot of garbage groups that we don't want to show. While we already have the `groupFilter` option, we can't build a filter that allows to exclude them. Even a filter that just excludes them by id is not implemented by the graph API, even though the syntax would support it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
