### PR TITLE
Fix error handling in `LdapOrgReaderProcessor`, and support complex paging options

### DIFF
--- a/.changeset/afraid-rockets-yell.md
+++ b/.changeset/afraid-rockets-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix error handling in `LdapOrgReaderProcessor`, and support complex paging options

--- a/plugins/catalog-backend/src/ingestion/processors/LdapOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/LdapOrgReaderProcessor.ts
@@ -69,7 +69,11 @@ export class LdapOrgReaderProcessor implements CatalogProcessor {
     // Be lazy and create the client each time; even though it's pretty
     // inefficient, we usually only do this once per entire refresh loop and
     // don't have to worry about timeouts and reconnects etc.
-    const client = await LdapClient.create(provider.target, provider.bind);
+    const client = await LdapClient.create(
+      this.logger,
+      provider.target,
+      provider.bind,
+    );
     const { users, groups } = await readLdapOrg(
       client,
       provider.users,

--- a/plugins/catalog-backend/src/ingestion/processors/ldap/client.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/ldap/client.ts
@@ -75,10 +75,6 @@ export class LdapClient {
       return await new Promise<SearchEntry[]>((resolve, reject) => {
         const output: SearchEntry[] = [];
 
-        this.client.on('error', (err: ldap.Error) => {
-          reject(new Error(errorString(err)));
-        });
-
         this.client.search(dn, options, (err, res) => {
           if (err) {
             reject(new Error(errorString(err)));

--- a/plugins/catalog-backend/src/ingestion/processors/ldap/config.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/ldap/config.test.ts
@@ -105,7 +105,10 @@ describe('readLdapConfig', () => {
               scope: 'base',
               attributes: ['*'],
               filter: 'f',
-              paged: true,
+              paged: {
+                pageSize: 7,
+                pagePause: true,
+              },
             },
             set: { p: 'v' },
             map: {
@@ -153,7 +156,10 @@ describe('readLdapConfig', () => {
             scope: 'base',
             attributes: ['*'],
             filter: 'f',
-            paged: true,
+            paged: {
+              pageSize: 7,
+              pagePause: true,
+            },
           },
           set: { p: 'v' },
           map: {

--- a/plugins/catalog-backend/src/ingestion/processors/ldap/config.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/ldap/config.ts
@@ -180,11 +180,32 @@ export function readLdapConfig(config: Config): LdapProviderConfig[] {
     if (!c) {
       return {};
     }
+
+    const paged = readOptionsPagedConfig(c);
+
     return {
       scope: c.getOptionalString('scope') as SearchOptions['scope'],
       filter: formatFilter(c.getOptionalString('filter')),
       attributes: c.getOptionalStringArray('attributes'),
-      paged: c.getOptionalBoolean('paged'),
+      ...(paged !== undefined ? { paged } : undefined),
+    };
+  }
+
+  function readOptionsPagedConfig(c: Config): SearchOptions['paged'] {
+    const pagedConfig = c.getOptional('paged');
+    if (pagedConfig === undefined) {
+      return undefined;
+    }
+
+    if (pagedConfig === true || pagedConfig === false) {
+      return pagedConfig;
+    }
+
+    const pageSize = c.getOptionalNumber('paged.pageSize');
+    const pagePause = c.getOptionalBoolean('paged.pagePause');
+    return {
+      ...(pageSize !== undefined ? { pageSize } : undefined),
+      ...(pagePause !== undefined ? { pagePause } : undefined),
     };
   }
 
@@ -258,7 +279,7 @@ export function readLdapConfig(config: Config): LdapProviderConfig[] {
   }
 
   function formatFilter(filter?: string): string | undefined {
-    // Remove extra whitespaces between blocks to support multiline filters from the configuration
+    // Remove extra whitespace between blocks to support multiline filters from the configuration
     return filter?.replace(/\s*(\(|\))/g, '$1')?.trim();
   }
 


### PR DESCRIPTION
The paging options were documented and supported in the types - but the config reading code was broken and assumed only booleans.