### PR TITLE
Adjust rendering of backend errors

### DIFF
--- a/.changeset/nasty-zebras-worry.md
+++ b/.changeset/nasty-zebras-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Make UI errors friendlier when importing existing components

--- a/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
+++ b/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
@@ -108,7 +108,7 @@ export const StepInitAnalyzeUrl = ({
           }
         }
       } catch (e) {
-        setError(e.message);
+        setError(e.data?.error?.message ?? e.message);
         setSubmitted(false);
       }
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes #4199 by rendering a backend error message with a bit more information. Specifically,

- if the error implements the [`ErrorResponse`](https://github.com/backstage/backstage/blob/c729b520bb992a292d6302d4b9102f7c5a5dc4d6/packages/errors/src/serialization/response.ts#L22-L39) interface, then it expands the error message, providing more meaningful information to a user than it does right now.
- If it's a generic JavaScript `Error`, it displays only the message.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/9947422/118819584-c2b27a00-b8b5-11eb-8c90-bc597d0b0169.png)|![image](https://user-images.githubusercontent.com/9947422/118819510-b3333100-b8b5-11eb-9909-c36b74bc0f21.png)|

As an _extra mile_, we might add a function to map backend errors like `Malformed envelope, /metadata/name should be string` to something more meaningful to a user, like `This path looks incorrect. Please adjust it.` or similar, but I'm not sure if it's worth it at this stage. If there's a general consensus for something like this, I'd be happy to implement it.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
