### PR TITLE
Remove unintended paragraph in the scaffolder template migration document

### DIFF
--- a/docs/features/software-templates/migrating-from-v1alpha1-to-v1beta2.md
+++ b/docs/features/software-templates/migrating-from-v1alpha1-to-v1beta2.md
@@ -14,12 +14,11 @@ steps which was pretty hard to extend and add new functionality to, difficult to
 re-use logic between templates. There used to be a fixed pipeline of
 `preparers`, `templaters`, and `publishers`, which were defined by the backend
 and needed to be run for each template. This is now changed, to give the
-template total control over what
-
-should be executed as part of the templating run. This makes templates a little
-more declarative as you can now register different `actions` or `functions` with
-the `scaffolder-backend` which you then can decide how, and in what order, to
-run using the template definition YAML file.
+template total control over what should be executed as part of the templating
+run. This makes templates a little more declarative as you can now register
+different `actions` or `functions` with the `scaffolder-backend` which you then
+can decide how, and in what order, to run using the template definition YAML
+file.
 
 We've also made some improvements, and added some helpers to work with
 cookiecutter. The skeleton for a template can now be stored in a different place


### PR DESCRIPTION
This looks wrong:

![image](https://user-images.githubusercontent.com/720821/118840799-057d4d80-b8c8-11eb-92e0-edca837c275f.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
