### PR TITLE
Add options attribute to catalog locations config

### DIFF
--- a/.changeset/large-items-study.md
+++ b/.changeset/large-items-study.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-model': minor
+'@backstage/plugin-catalog-backend': minor
+---
+
+Add options attribute to catalog locations config

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -304,6 +304,7 @@ export type LocationSpec = {
     type: string;
     target: string;
     presence?: 'optional' | 'required';
+    options?: object;
 };
 
 // @public (undocumented)

--- a/packages/catalog-model/src/location/types.ts
+++ b/packages/catalog-model/src/location/types.ts
@@ -21,6 +21,7 @@ export type LocationSpec = {
   // This flag is then set to indicate that the file can be not present.
   // default value: 'required'.
   presence?: 'optional' | 'required';
+  options?: object;
 };
 
 export type Location = {

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
@@ -15,13 +15,16 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import { LocationSpec } from '@backstage/catalog-model';
 import {
   GitHubIntegration,
   ScmIntegrations,
   ScmIntegrationsGroup,
 } from '@backstage/integration';
-import { GithubOrgReaderProcessor, parseUrl } from './GithubOrgReaderProcessor';
+import {
+  GitHubOrgLocationSpec,
+  GithubOrgReaderProcessor,
+  parseUrl,
+} from './GithubOrgReaderProcessor';
 
 describe('GithubOrgReaderProcessor', () => {
   describe('parseUrl', () => {
@@ -59,7 +62,7 @@ describe('GithubOrgReaderProcessor', () => {
         integrations,
         logger: getVoidLogger(),
       });
-      const location: LocationSpec = {
+      const location: GitHubOrgLocationSpec = {
         type: 'not-github-org',
         target: 'https://github.com',
       };
@@ -79,7 +82,7 @@ describe('GithubOrgReaderProcessor', () => {
         integrations,
         logger: getVoidLogger(),
       });
-      const location: LocationSpec = {
+      const location: GitHubOrgLocationSpec = {
         type: 'github-org',
         target: 'https://not.github.com/apa',
       };
@@ -96,7 +99,7 @@ describe('GithubOrgReaderProcessor', () => {
         integrations,
         logger: getVoidLogger(),
       });
-      const location: LocationSpec = {
+      const location: GitHubOrgLocationSpec = {
         type: 'github-org',
         target: 'https://not.github.com/apa',
       };

--- a/plugins/catalog-backend/src/ingestion/processors/StaticLocationProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/StaticLocationProcessor.ts
@@ -27,7 +27,13 @@ export class StaticLocationProcessor implements StaticLocationProcessor {
     for (const lConfig of lConfigs) {
       const type = lConfig.getString('type');
       const target = lConfig.getString('target');
-      locations.push({ type, target });
+
+      let options = {};
+      if (lConfig.has('options')) {
+        options = lConfig.get('options');
+      }
+
+      locations.push({ type, target, options });
     }
 
     return new StaticLocationProcessor(locations);

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.test.ts
@@ -67,6 +67,44 @@ describe('github', () => {
 
       await expect(getOrganizationUsers(graphql, 'a')).resolves.toEqual(output);
     });
+
+    it('reads members when fetchEmail is false', async () => {
+      const input: QueryResponse = {
+        organization: {
+          membersWithRole: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                login: 'a',
+                name: 'b',
+                bio: 'c',
+                avatarUrl: 'e',
+              },
+            ],
+          },
+        },
+      };
+
+      const output = {
+        users: [
+          expect.objectContaining({
+            metadata: expect.objectContaining({ name: 'a', description: 'c' }),
+            spec: {
+              profile: { displayName: 'b', picture: 'e' },
+              memberOf: [],
+            },
+          }),
+        ],
+      };
+
+      server.use(
+        graphqlMsw.query('users', (_req, res, ctx) => res(ctx.data(input))),
+      );
+
+      await expect(getOrganizationUsers(graphql, 'a', false)).resolves.toEqual(
+        output,
+      );
+    });
   });
 
   describe('getOrganizationTeams', () => {

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.ts
@@ -77,13 +77,20 @@ export type Connection<T> = {
 export async function getOrganizationUsers(
   client: typeof graphql,
   org: string,
+  email: boolean = true,
 ): Promise<{ users: UserEntity[] }> {
   const query = `
-    query users($org: String!, $cursor: String) {
+    query users($org: String!, $email: Boolean!, $cursor: String) {
       organization(login: $org) {
         membersWithRole(first: 100, after: $cursor) {
           pageInfo { hasNextPage, endCursor }
-          nodes { avatarUrl, bio, email, login, name }
+          nodes { 
+            avatarUrl
+            bio
+            login
+            name
+            email @include(if: $email)
+          }
         }
       }
     }`;
@@ -119,7 +126,7 @@ export async function getOrganizationUsers(
     query,
     r => r.organization?.membersWithRole,
     mapper,
-    { org },
+    { org, email },
   );
 
   return { users };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is meant to resolve the problem defined in #5680. When using the `github-org` location, and a user has a private email on your org, the GraphQL query fails. For organizations where this is happening, you can now define the following configuration to ignore `email` on GraphQL. This prevents emails from being loaded for _all_ users of the organization, which is why I chose to use an `opt-in` option.

```yaml
catalog:
  locations:
    - type: github-org
      target: https://github.com/your-org
      options:
        fetchEmail: false # this disables the email fetching
      rules:
        - allow: [Group, User]
```

I have also updated the `LocationSpec` type to have an optional `options` attribute. This may be useful for other location types, but for now this would be the only type using this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
