### PR TITLE
catalog/next: Set Entity next_update_at to 100s

### DIFF
--- a/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
@@ -376,8 +376,8 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       .update({
         next_update_at:
           tx.client.config.client === 'sqlite3'
-            ? tx.raw(`datetime('now', ?)`, [`10 seconds`]) // TODO: test this in sqlite3
-            : tx.raw(`now() + interval '30 seconds'`),
+            ? tx.raw(`datetime('now', ?)`, [`100 seconds`])
+            : tx.raw(`now() + interval '100 seconds'`),
       });
 
     return {


### PR DESCRIPTION
Signed-off-by: Johan Haals <johan.haals@gmail.com>

## Hey, I just made a Pull Request!

Refresh entities every 100s to be able to do a fair comparison with the current and new catalog before cacheable processing is introduced.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
