### PR TITLE
SignInPage: Minor improvements as follow up of #5702

### DIFF
--- a/.changeset/lazy-gorillas-remain.md
+++ b/.changeset/lazy-gorillas-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+SignInPage: Show login page while pop-up is being displayed when `auto` prop is set.

--- a/packages/core/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core/src/layout/SignInPage/SignInPage.tsx
@@ -110,6 +110,7 @@ export const SingleSignInPage = ({
         if (!identity && autoShowPopup) {
           // Unless auto is set to true, this step should not happen.
           // When user intentionally clicks the Sign In button, autoShowPopup is set to true
+          setShowLoginPage(true);
           identity = await authApi.getBackstageIdentity({
             instantPopup: true,
           });

--- a/packages/core/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core/src/layout/SignInPage/SignInPage.tsx
@@ -89,7 +89,7 @@ export const SingleSignInPage = ({
 
   const [autoShowPopup, setAutoShowPopup] = useState<boolean>(auto ?? false);
   // Defaults to true so that an initial check for existing user session is made
-  const [retry, setRetry] = useState<{} | boolean | undefined>(true);
+  const [retry, setRetry] = useState<{} | boolean | undefined>(undefined);
   const [error, setError] = useState<Error>();
 
   // The SignIn component takes some time to decide whether the user is logged-in or not.
@@ -139,9 +139,7 @@ export const SingleSignInPage = ({
       }
     };
 
-    if (retry) {
-      login();
-    }
+    login();
   }, [onResult, authApi, retry, autoShowPopup]);
 
   return showLoginPage ? (


### PR DESCRIPTION
Couple of follow-ups from https://github.com/backstage/backstage/pull/5702

1. Render login page instead of a blank page when auto prop is set
2. Remove unnecessary if block