### PR TITLE
Add validation to prevent docs_dir from being an absolute path

### DIFF
--- a/.changeset/gold-kings-jog.md
+++ b/.changeset/gold-kings-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Adding validation to mkdocs.yml parsing to prevent directory tree traversing

--- a/packages/techdocs-common/src/stages/generate/__fixtures__/mkdocs_invalid_doc_dir.yml
+++ b/packages/techdocs-common/src/stages/generate/__fixtures__/mkdocs_invalid_doc_dir.yml
@@ -1,0 +1,3 @@
+site_name: Test site name
+site_description: Test site description
+docs_dir: /etc

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -24,6 +24,7 @@ import {
   patchMkdocsYmlPreBuild,
   runCommand,
   storeEtagMetadata,
+  validateMkdocsYaml,
 } from './helpers';
 import { GeneratorBase, GeneratorRunOptions } from './types';
 
@@ -79,13 +80,16 @@ export class TechdocsGenerator implements GeneratorBase {
     // TODO: In future mkdocs.yml can be mkdocs.yaml. So, use a config variable here to find out
     // the correct file name.
     // Do some updates to mkdocs.yml before generating docs e.g. adding repo_url
+    const mkdocsYmlPath = path.join(inputDir, 'mkdocs.yml');
     if (parsedLocationAnnotation) {
       await patchMkdocsYmlPreBuild(
-        path.join(inputDir, 'mkdocs.yml'),
+        mkdocsYmlPath,
         this.logger,
         parsedLocationAnnotation,
       );
     }
+
+    await validateMkdocsYaml(mkdocsYmlPath);
 
     // Directories to bind on container
     const mountDirs = {


### PR DESCRIPTION

## Hey, I just made a Pull Request!

* Adds a new validation function to helpers to prevent generation when mkdocs.yml is not present or is invalid
* Handles vulnerability where docs_dir can be put in as an absolute path which copies and exposes the files from that absolute path in the file system

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
