### PR TITLE
TechDocs: Support configurable working directory as temp dir

### DIFF
--- a/.changeset/nasty-wasps-look.md
+++ b/.changeset/nasty-wasps-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+TechDocs: Support configurable working directory as temp dir

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { getRootLogger, loadBackendConfig } from '@backstage/backend-common';
 import {
   Entity,
   ENTITY_DEFAULT_NAMESPACE,
@@ -142,7 +143,12 @@ export class DocsBuilder {
     );
 
     // Create a temporary directory to store the generated files in.
-    const tmpdirPath = os.tmpdir();
+    const config = await loadBackendConfig({
+      argv: process.argv,
+      logger: getRootLogger(),
+    });
+    const workingDir = config.get('backend.workingDirectory');
+    const tmpdirPath = workingDir ? String(workingDir) : os.tmpdir();
     // Fixes a problem with macOS returning a path that is a symlink
     const tmpdirResolvedPath = fs.realpathSync(tmpdirPath);
     const outputDir = await fs.mkdtemp(

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -16,7 +16,7 @@
 import {
   Entity,
   ENTITY_DEFAULT_NAMESPACE,
-  serializeEntityRef,
+  stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { NotModifiedError } from '@backstage/errors';
 import {
@@ -75,7 +75,7 @@ export class DocsBuilder {
      */
 
     this.logger.info(
-      `Step 1 of 3: Preparing docs for entity ${serializeEntityRef(
+      `Step 1 of 3: Preparing docs for entity ${stringifyEntityRef(
         this.entity,
       )}`,
     );
@@ -116,7 +116,7 @@ export class DocsBuilder {
         // Set last check happened to now
         new BuildMetadataStorage(this.entity.metadata.uid).setLastUpdated();
         this.logger.debug(
-          `Docs for ${serializeEntityRef(
+          `Docs for ${stringifyEntityRef(
             this.entity,
           )} are unmodified. Using cache, skipping generate and prepare`,
         );
@@ -126,7 +126,7 @@ export class DocsBuilder {
     }
 
     this.logger.info(
-      `Prepare step completed for entity ${serializeEntityRef(
+      `Prepare step completed for entity ${stringifyEntityRef(
         this.entity,
       )}, stored at ${preparedDir}`,
     );
@@ -136,7 +136,7 @@ export class DocsBuilder {
      */
 
     this.logger.info(
-      `Step 2 of 3: Generating docs for entity ${serializeEntityRef(
+      `Step 2 of 3: Generating docs for entity ${stringifyEntityRef(
         this.entity,
       )}`,
     );
@@ -176,7 +176,7 @@ export class DocsBuilder {
      */
 
     this.logger.info(
-      `Step 3 of 3: Publishing docs for entity ${serializeEntityRef(
+      `Step 3 of 3: Publishing docs for entity ${stringifyEntityRef(
         this.entity,
       )}`,
     );

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -147,8 +147,8 @@ export class DocsBuilder {
       argv: process.argv,
       logger: getRootLogger(),
     });
-    const workingDir = config.get('backend.workingDirectory');
-    const tmpdirPath = workingDir ? String(workingDir) : os.tmpdir();
+    const workingDir = config.getOptionalString('backend.workingDirectory');
+    const tmpdirPath = workingDir || os.tmpdir();
     // Fixes a problem with macOS returning a path that is a symlink
     const tmpdirResolvedPath = fs.realpathSync(tmpdirPath);
     const outputDir = await fs.mkdtemp(

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -164,6 +164,7 @@ export async function createRouter({
       publisher,
       logger,
       entity,
+      config,
     });
     let foundDocs = false;
     switch (publisherType) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR fixes #3333 by using any `backend.workingDirectory` specified in [`app-config.yaml`](https://github.com/backstage/backstage/blob/dc7ac4076a0befce1a752c95de2ec2a84a03b633/app-config.yaml#L42) as a temporary directory for TechDocs before falling back to the OS default.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
