### PR TITLE
feat: Add catalog base page for customizations

### DIFF
--- a/.changeset/long-scissors-divide.md
+++ b/.changeset/long-scissors-divide.md
@@ -1,0 +1,16 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Allows the customization of catalog pages by providing a "base" catalog page
+which lets users specify their own table components and filters.
+
+```typescript
+// You can specify the base page like so:
+<CatalogIndexBasePage
+  showHeaderTabs={false}
+  showManagedFilters
+  showSupportButton
+  TableComponent={CustomTable}
+/>
+```

--- a/plugins/catalog/dev/CustomTable.tsx
+++ b/plugins/catalog/dev/CustomTable.tsx
@@ -15,6 +15,8 @@
  */
 
 import React from 'react';
+import { useAsync } from 'react-use';
+import { Chip } from '@material-ui/core';
 import {
   catalogApiRef,
   EntityRefLink,
@@ -22,8 +24,6 @@ import {
   formatEntityRefTitle,
   getEntityRelations,
 } from '@backstage/plugin-catalog-react';
-import { Chip } from '@material-ui/core';
-import { EntityRow } from '../src/components/CatalogTable/CatalogTable';
 import { RELATION_OWNED_BY, RELATION_PART_OF } from '@backstage/catalog-model';
 import {
   CodeSnippet,
@@ -34,7 +34,8 @@ import {
   useApi,
   WarningPanel,
 } from '@backstage/core';
-import { useAsync } from 'react-use';
+import { EntityRow } from '../src/components/CatalogTable/types';
+import {CatalogBaseTableProps} from '../src/components/CatalogPage/CatalogPageBase';
 
 const columns: TableColumn<EntityRow>[] = [
   {
@@ -111,7 +112,9 @@ const filters: TableFilter[] = [
   },
 ];
 
-export const CustomTable = ({ useBuiltInFilters = true }) => {
+type CustomTableProps = CatalogBaseTableProps & { useBuiltInFilters?: boolean };
+
+export const CustomTable = ({ useBuiltInFilters = true }: CustomTableProps) => {
   const catalogApi = useApi(catalogApiRef);
   const { loading, error, value: matchingEntities } = useAsync(() => {
     return catalogApi.getEntities({ filter: { kind: 'Component' } });

--- a/plugins/catalog/dev/CustomTable.tsx
+++ b/plugins/catalog/dev/CustomTable.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  catalogApiRef,
+  EntityRefLink,
+  EntityRefLinks,
+  formatEntityRefTitle,
+  getEntityRelations,
+} from '@backstage/plugin-catalog-react';
+import { Chip } from '@material-ui/core';
+import { EntityRow } from '../src/components/CatalogTable/CatalogTable';
+import { RELATION_OWNED_BY, RELATION_PART_OF } from '@backstage/catalog-model';
+import {
+  CodeSnippet,
+  OverflowTooltip,
+  Table,
+  TableColumn,
+  TableFilter,
+  useApi,
+  WarningPanel,
+} from '@backstage/core';
+import { useAsync } from 'react-use';
+
+const columns: TableColumn<EntityRow>[] = [
+  {
+    title: 'Name',
+    field: 'resolved.name',
+    highlight: true,
+    render: ({ entity }) => (
+      <EntityRefLink entityRef={entity} defaultKind="Component" />
+    ),
+  },
+  {
+    title: 'Owner',
+    field: 'resolved.ownedByRelationsTitle',
+    render: ({ resolved }) => (
+      <EntityRefLinks
+        entityRefs={resolved.ownedByRelations}
+        defaultKind="group"
+      />
+    ),
+  },
+  {
+    title: 'Lifecycle',
+    field: 'entity.spec.lifecycle',
+  },
+  {
+    title: 'Description',
+    field: 'entity.metadata.description',
+    render: ({ entity }) => (
+      <OverflowTooltip
+        text={entity.metadata.description}
+        placement="bottom-start"
+      />
+    ),
+    width: 'auto',
+  },
+  {
+    title: 'Tags',
+    field: 'entity.metadata.tags',
+    cellStyle: {
+      padding: '0px 16px 0px 20px',
+    },
+    render: ({ entity }) => (
+      <>
+        {entity.metadata.tags &&
+          entity.metadata.tags.map(t => (
+            <Chip
+              key={t}
+              label={t}
+              size="small"
+              variant="outlined"
+              style={{ marginBottom: '0px' }}
+            />
+          ))}
+      </>
+    ),
+  },
+];
+const filters: TableFilter[] = [
+  {
+    column: 'Owner',
+    type: 'select',
+  },
+  {
+    column: 'Type',
+    type: 'multiple-select',
+  },
+  {
+    column: 'Lifecycle',
+    type: 'multiple-select',
+  },
+  {
+    column: 'Tags',
+    type: 'checkbox-tree',
+  },
+];
+
+export const CustomTable = ({ useBuiltInFilters = true }) => {
+  const catalogApi = useApi(catalogApiRef);
+  const { loading, error, value: matchingEntities } = useAsync(() => {
+    return catalogApi.getEntities({ filter: { kind: 'Component' } });
+  }, [catalogApi]);
+
+  if (error) {
+    <WarningPanel severity="error" title="Could not fetch catalog entities.">
+      <CodeSnippet language="text" text={error.toString()} />
+    </WarningPanel>;
+  }
+
+  const rows =
+    matchingEntities?.items.map(entity => {
+      const partOfSystemRelations = getEntityRelations(
+        entity,
+        RELATION_PART_OF,
+        {
+          kind: 'system',
+        },
+      );
+      const ownedByRelations = getEntityRelations(entity, RELATION_OWNED_BY);
+
+      return {
+        entity,
+        resolved: {
+          name: formatEntityRefTitle(entity, {
+            defaultKind: 'Component',
+          }),
+          ownedByRelationsTitle: ownedByRelations
+            .map(r => formatEntityRefTitle(r, { defaultKind: 'group' }))
+            .join(', '),
+          ownedByRelations,
+          partOfSystemRelationTitle: partOfSystemRelations
+            .map(r =>
+              formatEntityRefTitle(r, {
+                defaultKind: 'system',
+              }),
+            )
+            .join(', '),
+          partOfSystemRelations,
+        },
+      };
+    }) ?? [];
+
+  return (
+    <Table<EntityRow>
+      isLoading={loading}
+      options={{
+        paging: false,
+        actionsColumnIndex: -1,
+        loadingType: 'linear',
+        showEmptyDataSourceMessage: !loading,
+        padding: 'dense',
+      }}
+      data={rows}
+      columns={columns}
+      filters={useBuiltInFilters ? filters : undefined}
+    />
+  );
+};

--- a/plugins/catalog/dev/index.tsx
+++ b/plugins/catalog/dev/index.tsx
@@ -19,9 +19,11 @@ import { createDevApp } from '@backstage/dev-utils';
 import {
   catalogPlugin,
   CatalogIndexPage,
+  CatalogIndexBasePage,
   CatalogEntityPage,
   EntityLayout,
 } from '../src';
+import { CustomTable } from './CustomTable';
 
 createDevApp()
   .registerPlugin(catalogPlugin)
@@ -39,6 +41,18 @@ createDevApp()
           <h1>Overview</h1>
         </EntityLayout.Route>
       </EntityLayout>
+    ),
+  })
+  .addPage({
+    path: '/custom-catalog',
+    title: 'Custom Catalog',
+    element: (
+      <CatalogIndexBasePage
+        showHeaderTabs={false}
+        showManagedFilters
+        showSupportButton
+        TableComponent={CustomTable}
+      />
     ),
   })
   .render();

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -56,6 +56,7 @@
     "@backstage/dev-utils": "^0.1.14",
     "@backstage/test-utils": "^0.1.11",
     "@microsoft/microsoft-graph-types": "^1.25.0",
+    "@testing-library/dom": "^7.31.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^11.2.5",
     "@testing-library/react-hooks": "^3.3.0",

--- a/plugins/catalog/src/components/CatalogPage/CatalogPageBase.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPageBase.test.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { CatalogApi } from '@backstage/catalog-client';
+import {
+  Entity,
+  RELATION_MEMBER_OF,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
+import {
+  ApiProvider,
+  ApiRegistry,
+  IdentityApi,
+  identityApiRef,
+  ProfileInfo,
+  storageApiRef,
+} from '@backstage/core';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { MockStorageApi, wrapInTestApp } from '@backstage/test-utils';
+import { fireEvent, Matcher, render, waitFor } from '@testing-library/react';
+import { within, screen } from '@testing-library/dom';
+import { EntityFilterGroupsProvider } from '../../filter';
+import { createComponentRouteRef } from '../../routes';
+import { CatalogBasePage } from './CatalogPageBase';
+import { CustomTable } from '../../../dev/CustomTable';
+
+describe('CatalogPage', () => {
+  const catalogApi: Partial<CatalogApi> = {
+    getEntities: () =>
+      Promise.resolve({
+        items: [
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'Entity1',
+            },
+            spec: {
+              owner: 'tools@example.com',
+              type: 'service',
+            },
+            relations: [
+              {
+                type: RELATION_OWNED_BY,
+                target: { kind: 'Group', name: 'tools', namespace: 'default' },
+              },
+            ],
+          },
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'Entity2',
+            },
+            spec: {
+              owner: 'not-tools@example.com',
+              type: 'service',
+            },
+            relations: [
+              {
+                type: RELATION_OWNED_BY,
+                target: {
+                  kind: 'Group',
+                  name: 'not-tools',
+                  namespace: 'default',
+                },
+              },
+            ],
+          },
+        ] as Entity[],
+      }),
+    getLocationByEntity: () =>
+      Promise.resolve({ id: 'id', type: 'github', target: 'url' }),
+    getEntityByName: async entityName => {
+      return {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        metadata: { name: entityName.name },
+        relations: [
+          {
+            type: RELATION_MEMBER_OF,
+            target: { namespace: 'default', kind: 'Group', name: 'tools' },
+          },
+        ],
+      };
+    },
+  };
+  const testProfile: Partial<ProfileInfo> = {
+    displayName: 'Display Name',
+  };
+  const identityApi: Partial<IdentityApi> = {
+    getUserId: () => 'tools@example.com',
+    getProfile: () => testProfile,
+  };
+
+  const renderWrapped = (children: React.ReactNode) =>
+    render(
+      wrapInTestApp(
+        <ApiProvider
+          apis={ApiRegistry.from([
+            [catalogApiRef, catalogApi],
+            [identityApiRef, identityApi],
+            [storageApiRef, MockStorageApi.create()],
+          ])}
+        >
+          <EntityFilterGroupsProvider>{children}</EntityFilterGroupsProvider>,
+        </ApiProvider>,
+        {
+          mountedRoutes: {
+            '/create': createComponentRouteRef,
+          },
+        },
+      ),
+    );
+
+  it('should render a custom table with working managed filters', async () => {
+    const { findByText, getByText } = renderWrapped(
+      <CatalogBasePage
+        showHeaderTabs={false}
+        showSupportButton
+        showManagedFilters
+        TableComponent={() => <CustomTable useBuiltInFilters={false} />}
+      />,
+    );
+    expect(await findByText(/Owned/)).toBeInTheDocument();
+    fireEvent.click(getByText(/All/));
+    expect(await findByText(/All/)).toBeInTheDocument();
+  });
+
+  it('should set initial filter correctly when managed filters are enabled', async () => {
+    const { findByText } = renderWrapped(
+      <CatalogBasePage
+        showHeaderTabs={false}
+        showManagedFilters
+        showSupportButton
+        initiallySelectedFilter="all"
+        TableComponent={() => <CustomTable useBuiltInFilters={false} />}
+      />,
+    );
+    expect(await findByText(/All/)).toBeInTheDocument();
+  });
+
+  it('should render the correct entities filtered on the selectedfilter', async () => {
+    const findInside = (filterElement: HTMLElement, regex: RegExp) =>
+      within(filterElement).getByText(
+        (((_: string, node: Element) =>
+          node?.textContent?.match(regex)) as unknown) as Matcher,
+        { selector: 'li' },
+      );
+    const { findByText, getByText } = await renderWrapped(
+      <CatalogBasePage
+        showHeaderTabs={false}
+        showManagedFilters
+        showSupportButton
+        TableComponent={() => <CustomTable useBuiltInFilters={false} />}
+      />,
+    );
+
+    const filters = screen.getByText('Personal').parentElement as HTMLElement;
+    // wait for table to render
+    await findByText('Entity1');
+
+    expect(findInside(filters, /Owned.*1/)).toBeInTheDocument();
+    expect(findInside(filters, /Starred.*0/)).toBeInTheDocument();
+
+    fireEvent.click(getByText(/All/));
+    expect(findInside(filters, /All.*2/)).toBeInTheDocument();
+  });
+});

--- a/plugins/catalog/src/components/CatalogPage/CatalogPageBase.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPageBase.test.tsx
@@ -31,14 +31,14 @@ import {
 } from '@backstage/core';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { MockStorageApi, wrapInTestApp } from '@backstage/test-utils';
-import { fireEvent, Matcher, render, waitFor } from '@testing-library/react';
+import { fireEvent, Matcher, render } from '@testing-library/react';
 import { within, screen } from '@testing-library/dom';
 import { EntityFilterGroupsProvider } from '../../filter';
 import { createComponentRouteRef } from '../../routes';
 import { CatalogBasePage } from './CatalogPageBase';
 import { CustomTable } from '../../../dev/CustomTable';
 
-describe('CatalogPage', () => {
+describe('CatalogBasePage', () => {
   const catalogApi: Partial<CatalogApi> = {
     getEntities: () =>
       Promise.resolve({
@@ -134,7 +134,7 @@ describe('CatalogPage', () => {
         showSupportButton
         showManagedFilters
         TableComponent={() => <CustomTable useBuiltInFilters={false} />}
-      />,
+     />,
     );
     expect(await findByText(/Owned/)).toBeInTheDocument();
     fireEvent.click(getByText(/All/));

--- a/plugins/catalog/src/components/CatalogPage/CatalogPageBase.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPageBase.tsx
@@ -61,7 +61,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export type CatalogBaseTableProps = Pick<CatalogTableProps, 'error' | 'view'>;
+export type CatalogBaseTableProps = Partial<CatalogTableProps>;
 
 export type CatalogBasePageProps = {
   initiallySelectedFilter?: string;

--- a/plugins/catalog/src/components/CatalogPage/CatalogPageBase.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPageBase.tsx
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import { Button, makeStyles } from '@material-ui/core';
+import SettingsIcon from '@material-ui/icons/Settings';
+import StarIcon from '@material-ui/icons/Star';
+import {
+  configApiRef,
+  Content,
+  ContentHeader,
+  errorApiRef,
+  SupportButton,
+  useApi,
+  useRouteRef,
+} from '@backstage/core';
+import {
+  catalogApiRef,
+  isOwnerOf,
+  useStarredEntities,
+} from '@backstage/plugin-catalog-react';
+import CatalogLayout from './CatalogLayout';
+import { CatalogTabs, LabeledComponentType } from './CatalogTabs';
+import {
+  ButtonGroup,
+  CatalogFilter,
+  CatalogFilterType,
+} from '../CatalogFilter/CatalogFilter';
+import { useOwnUser } from '../useOwnUser';
+import { ResultsFilter } from '../ResultsFilter/ResultsFilter';
+import { CatalogTableProps } from '../CatalogTable/CatalogTable';
+import { EntityFilterGroupsProvider, useFilteredEntities } from '../../filter';
+import { createComponentRouteRef } from '../../routes';
+
+const useStyles = makeStyles(theme => ({
+  contentWrapper: {
+    display: 'grid',
+    gridTemplateAreas: "'filters' 'table'",
+    gridTemplateColumns: '250px 1fr',
+    gridColumnGap: theme.spacing(2),
+  },
+  contentWrapperWithoutFilterGroups: {
+    display: 'block',
+  },
+  buttonSpacing: {
+    marginLeft: theme.spacing(2),
+  },
+}));
+
+export type CatalogBaseTableProps = Pick<CatalogTableProps, 'error' | 'view'>;
+
+export type CatalogBasePageProps = {
+  initiallySelectedFilter?: string;
+  selectedTab?: string;
+  onHeaderTabChange?: Function;
+  onSidebarSelectionChange?: Function;
+  createComponentLinkText?: string;
+  supportButtonText?: string;
+  showHeaderTabs: boolean;
+  showManagedFilters: boolean;
+  showSupportButton: boolean;
+  LayoutComponent?: React.ReactType<any>;
+  TableComponent: React.ReactType<CatalogBaseTableProps>;
+};
+
+export const CatalogBasePageContents = ({
+  initiallySelectedFilter,
+  selectedTab,
+  onHeaderTabChange,
+  onSidebarSelectionChange,
+  createComponentLinkText,
+  supportButtonText,
+  showHeaderTabs,
+  showManagedFilters,
+  showSupportButton,
+  LayoutComponent = CatalogLayout,
+  TableComponent,
+}: CatalogBasePageProps) => {
+  const styles = useStyles();
+  const { reload, availableTags, isCatalogEmpty } = useFilteredEntities();
+  const configApi = useApi(configApiRef);
+  const catalogApi = useApi(catalogApiRef);
+  const errorApi = useApi(errorApiRef);
+  const { isStarredEntity } = useStarredEntities();
+  const [selectedSidebarItem] = useState<CatalogFilterType>();
+
+  const orgName = configApi.getOptionalString('organization.name') ?? 'Company';
+  const initiallySelectedFilterValue =
+    selectedSidebarItem?.id ?? initiallySelectedFilter ?? 'owned';
+
+  const createComponentLink = useRouteRef(createComponentRouteRef);
+  const addMockData = useCallback(async () => {
+    try {
+      const promises: Promise<unknown>[] = [];
+      const root = configApi.getConfig('catalog.exampleEntityLocations');
+      for (const type of root.keys()) {
+        for (const target of root.getStringArray(type)) {
+          promises.push(catalogApi.addLocation({ target }));
+        }
+      }
+      await Promise.all(promises);
+      await reload();
+    } catch (err) {
+      errorApi.post(err);
+    }
+  }, [catalogApi, configApi, errorApi, reload]);
+
+  const tabs = useMemo<LabeledComponentType[]>(
+    () => [
+      {
+        id: 'service',
+        label: 'Services',
+      },
+      {
+        id: 'website',
+        label: 'Websites',
+      },
+      {
+        id: 'library',
+        label: 'Libraries',
+      },
+      {
+        id: 'documentation',
+        label: 'Documentation',
+      },
+      {
+        id: 'other',
+        label: 'Other',
+      },
+    ],
+    [],
+  );
+
+  const { value: user } = useOwnUser();
+
+  const filterGroups = useMemo<ButtonGroup[]>(
+    () => [
+      {
+        name: 'Personal',
+        items: [
+          {
+            id: 'owned',
+            label: 'Owned',
+            icon: SettingsIcon,
+            filterFn: entity => user !== undefined && isOwnerOf(user, entity),
+          },
+          {
+            id: 'starred',
+            label: 'Starred',
+            icon: StarIcon,
+            filterFn: isStarredEntity,
+          },
+        ],
+      },
+      {
+        name: orgName,
+        items: [
+          {
+            id: 'all',
+            label: 'All',
+            filterFn: () => true,
+          },
+        ],
+      },
+    ],
+    [isStarredEntity, orgName, user],
+  );
+
+  const showAddExampleEntities =
+    configApi.has('catalog.exampleEntityLocations') && isCatalogEmpty;
+
+  return (
+    <LayoutComponent>
+      {showHeaderTabs && (
+        <CatalogTabs
+          tabs={tabs}
+          onChange={({ label }) =>
+            onHeaderTabChange && onHeaderTabChange(label)
+          }
+        />
+      )}
+      <Content>
+        <ContentHeader title={selectedTab ?? ''}>
+          {createComponentLink && (
+            <Button
+              component={RouterLink}
+              variant="contained"
+              color="primary"
+              to={createComponentLink()}
+            >
+              {createComponentLinkText ?? 'Create Component'}
+            </Button>
+          )}
+          {showAddExampleEntities && (
+            <Button
+              className={styles.buttonSpacing}
+              variant="outlined"
+              color="primary"
+              onClick={addMockData}
+            >
+              Add example components
+            </Button>
+          )}
+          {showSupportButton && (
+            <SupportButton>{supportButtonText ?? 'All your software catalog entities'}</SupportButton>
+          )}
+        </ContentHeader>
+        <div
+          className={
+            showManagedFilters
+              ? styles.contentWrapper
+              : styles.contentWrapperWithoutFilterGroups
+          }
+        >
+          {showManagedFilters && (
+            <div>
+              <CatalogFilter
+                buttonGroups={filterGroups}
+                onChange={({ label, id }) =>
+                  onSidebarSelectionChange &&
+                  onSidebarSelectionChange({ label, id })
+                }
+                initiallySelected={initiallySelectedFilterValue}
+              />
+              <ResultsFilter availableTags={availableTags} />
+            </div>
+          )}
+          <TableComponent />
+        </div>
+      </Content>
+    </LayoutComponent>
+  );
+};
+
+export const CatalogBasePage = (props: CatalogBasePageProps) => (
+  <EntityFilterGroupsProvider>
+    <CatalogBasePageContents {...props} />
+  </EntityFilterGroupsProvider>
+);

--- a/plugins/catalog/src/components/CatalogPage/index.ts
+++ b/plugins/catalog/src/components/CatalogPage/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { CatalogPage } from './CatalogPage';
+export { CatalogBasePage } from './CatalogPageBase';

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -54,7 +54,7 @@ const defaultColumns: TableColumn<EntityRow>[] = [
   columnFactories.createTagsColumn(),
 ];
 
-type CatalogTableProps = {
+export type CatalogTableProps = {
   entities: Entity[];
   titlePreamble: string;
   loading: boolean;

--- a/plugins/catalog/src/components/useOwnUser.ts
+++ b/plugins/catalog/src/components/useOwnUser.ts
@@ -30,12 +30,12 @@ export function useOwnUser(): AsyncState<UserEntity | undefined> {
   // TODO: get the full entity (or at least the full entity name) from the
   // identityApi
   return useAsync(
-    () =>
-      catalogApi.getEntityByName({
+    async () =>
+      await catalogApi.getEntityByName({
         kind: 'User',
         namespace: 'default',
         name: identityApi.getUserId(),
-      }) as Promise<UserEntity | undefined>,
+      }) as UserEntity | undefined,
     [catalogApi, identityApi],
   );
 }

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -23,6 +23,7 @@ export { Router } from './components/Router';
 export {
   CatalogEntityPage,
   CatalogIndexPage,
+  CatalogIndexBasePage,
   catalogPlugin,
   catalogPlugin as plugin,
   EntityAboutCard,

--- a/plugins/catalog/src/plugin.ts
+++ b/plugins/catalog/src/plugin.ts
@@ -61,6 +61,14 @@ export const CatalogIndexPage = catalogPlugin.provide(
   }),
 );
 
+export const CatalogIndexBasePage = catalogPlugin.provide(
+  createRoutableExtension({
+    component: () =>
+      import('./components/CatalogPage').then(m => m.CatalogBasePage),
+    mountPoint: catalogRouteRef,
+  }),
+);
+
 export const CatalogEntityPage = catalogPlugin.provide(
   createRoutableExtension({
     component: () =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5587,6 +5587,20 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
+"@testing-library/dom@^7.31.0":
+  version "7.31.0"
+  resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.0.tgz#938451abd3ca27e1b69bb395d4a40759fd7f5b3b"
+  integrity sha512-0X7ACg4YvTRDFMIuTOEj6B4NpN7i3F/4j5igOcTI5NC5J+N4TribNdErCHOZF1LBWhhcyfwxelVwvoYNMUXTOA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
 "@testing-library/jest-dom@^5.10.1":
   version "5.11.9"
   resolved "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz#e6b3cd687021f89f261bd53cbe367041fbd3e975"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Following up on some of the [advice](https://github.com/backstage/backstage/pull/4845#discussion_r597591980) from #4845, this PR offers a way of letting
users customize the catalog pages by offering a "base" catalog page with the
option of passing in a custom table component with whatever columns that users
may want to render. The new base catalog page component is meant to be used in
other plugins, such as `api-docs`, as a way to avoid having separate
implementations of the catalog page and table components. #4845 includes a
proof-of-concept implementation for the `api-docs` plugin that replaces its
catalog page and table with ones from this PR. An example of a custom catalog
page and table that can be rendered as a result of this work looks like the
following:


<img width="1850" alt="113224971-2f17e200-9252-11eb-81ed-a648894f86a5" src="https://user-images.githubusercontent.com/218873/119007392-ccd88500-b956-11eb-81b4-c9fc8d88352a.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

