### PR TITLE
fix(github-deployments): handle deployments without commits

### DIFF
--- a/.changeset/two-cameras-repeat.md
+++ b/.changeset/two-cameras-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-deployments': patch
+---
+
+Handle deployments without a commit

--- a/plugins/github-deployments/src/api/index.ts
+++ b/plugins/github-deployments/src/api/index.ts
@@ -60,7 +60,7 @@ export type GithubDeployment = {
   commit: {
     abbreviatedOid: string;
     commitUrl: string;
-  };
+  } | null;
   creator: {
     login: string;
   };

--- a/plugins/github-deployments/src/components/GithubDeploymentsTable/columns.tsx
+++ b/plugins/github-deployments/src/components/GithubDeploymentsTable/columns.tsx
@@ -66,11 +66,12 @@ export function createStatusColumn(): TableColumn<GithubDeployment> {
 export function createCommitColumn(): TableColumn<GithubDeployment> {
   return {
     title: 'Commit',
-    render: (row: GithubDeployment): JSX.Element => (
-      <Link to={row.commit.commitUrl} target="_blank" rel="noopener">
-        {row.commit.abbreviatedOid}
-      </Link>
-    ),
+    render: (row: GithubDeployment) =>
+      row.commit && (
+        <Link to={row.commit.commitUrl} target="_blank" rel="noopener">
+          {row.commit.abbreviatedOid}
+        </Link>
+      ),
   };
 }
 


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Fixes scenario where the commit field of the deployment response is `null` which throws a `TypeError` causing the page to break. 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
