### PR TITLE
core-api: add global definition of Symbol.observable

### DIFF
--- a/.changeset/old-pigs-happen.md
+++ b/.changeset/old-pigs-happen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-api': patch
+---
+
+Add a global type definition for `Symbol.observable`, fix type checking in projects that didn't already have it defined.

--- a/packages/core-api/src/types.ts
+++ b/packages/core-api/src/types.ts
@@ -42,6 +42,14 @@ export type Subscription = {
   readonly closed: boolean;
 };
 
+// Declares the global well-known Symbol.observable
+// We get the actual runtime polyfill from zen-observable
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
 /**
  * Observable sequence of values and errors, see TC39.
  *


### PR DESCRIPTION
@timbonicus discovered this issue once https://github.com/backstage/backstage/pull/5691 released. It's likely to affect any project that doesn't end up explicitly importing `zen-observable` anywhere. The issues is likely only surfaced if type checking is done with `skipLibCheck` disabled though.

The global type definition ends up being included in the types for `core-api`, so any project that imports `@backstage/core` will now have the type definitions available. It can also be redeclared any number of times, for example it's also declared in `zen-observable` and `rxjs`.