### PR TITLE
Set techdocs admonition font size to 1rem

### DIFF
--- a/.changeset/shiny-keys-dream.md
+++ b/.changeset/shiny-keys-dream.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Set admonition font size to 1rem in TechDocs to align with the rest of the document's font sizes.
+Fixes #5448 and #5541.

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -183,21 +183,24 @@ export const Reader = ({ entityId, onReady }: Props) => {
           border-bottom: 1px solid ${theme.palette.text.primary};
         }
         .md-typeset table:not([class]) th { font-weight: bold; }
+        .md-typeset .admonition, .md-typeset details {
+          font-size: 1rem;
+        }
         @media screen and (max-width: 76.1875em) {
-          .md-nav { 
-            background-color: ${theme.palette.background.default}; 
+          .md-nav {
+            background-color: ${theme.palette.background.default};
             transition: none !important
           }
           .md-sidebar--secondary { display: none; }
           .md-sidebar--primary { left: 72px; width: 10rem }
           .md-content { margin-left: 10rem; max-width: calc(100% - 10rem); }
           .md-content__inner { font-size: 0.9rem }
-          .md-footer { 
-            position: static; 
-            margin-left: 10rem; 
-            width: calc(100% - 10rem); 
+          .md-footer {
+            position: static;
+            margin-left: 10rem;
+            width: calc(100% - 10rem);
           }
-          .md-nav--primary .md-nav__title {  
+          .md-nav--primary .md-nav__title {
             white-space: normal;
             height: auto;
             line-height: 1rem;


### PR DESCRIPTION
Currently admonitions in TechDocs are rendered with font size 0.64rem which is much smaller than the rest of the text. This makes admontions hard to read and further "undo"s the attention they are here to provide.

This change adds a style overide, like we do with tables that sets the size to 1rem for bot collapsable and expanded admonitions.

Some trailing whitespace in the CSS styles is removed as well.

Fixes #5448 and #5541.

This change is done the same as #5281 due to the same limitations as described in #3998.

### Before

![before](https://user-images.githubusercontent.com/6881694/119191450-f2f94480-ba7e-11eb-93f8-d0d680496990.png)

### After

![after](https://user-images.githubusercontent.com/6881694/119191456-f4c30800-ba7e-11eb-98ea-3aebaec8b832.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
