### PR TITLE
config-loader resolve config from cwd

### DIFF
--- a/.changeset/four-jeans-tap.md
+++ b/.changeset/four-jeans-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Resolve the path to app-config.yaml from the current working directory. This will allow use of `yarn link` or running the CLI in other directories and improve the experience for local backstage development.

--- a/packages/config-loader/src/lib/schema/collect.ts
+++ b/packages/config-loader/src/lib/schema/collect.ts
@@ -124,7 +124,9 @@ export async function collectConfigSchemas(
     );
   }
 
-  await Promise.all(packageNames.map(name => processItem({ name })));
+  await Promise.all(
+    packageNames.map(name => processItem({ name, parentPath: currentDir })),
+  );
 
   const tsSchemas = compileTsSchemas(tsSchemaPaths);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adjusts the config-loader to look for config relative to the current working directory. It allows one to use `yarn link`, and a local copy of the backstage CLI to test changes on one's personal instance of backstage.

Prior to this change, the `require.resolve` would walk the tree up the `backstage/backstage` repo, and never find the `package.json` for your frontend app or plugins. This eventually lead to the error down the line where it would fail to find the app config information since `frontend` didn't exist.

```shell
❯ yarn start
yarn run v1.22.10
$ backstage-cli app:serve
Loaded config from app-config.yaml, app-config.local.yaml

Error: Missing required config value at 'app.baseUrl'

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
