### PR TITLE
docs: remove plugins from createApp examples + clarify app auth tutorial

### DIFF
--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -77,7 +77,6 @@ built-in providers:
 +
 const app = createApp({
   apis,
-  plugins: Object.values(plugins),
 +  components: {
 +    SignInPage: props => (
 +      <SignInPage
@@ -96,7 +95,6 @@ To also allow unauthenticated guest access, use the `providers` prop for
 ```diff
 const app = createApp({
   apis,
-  plugins: Object.values(plugins),
 +  components: {
 +    SignInPage: props => (
 +      <SignInPage

--- a/docs/tutorials/quickstart-app-auth.md
+++ b/docs/tutorials/quickstart-app-auth.md
@@ -329,12 +329,12 @@ above:
 
 ### 6. In the same file, modify createApp
 
-Remember to modify the provider information based on the table above.
+Remember to add or modify a `SignInPage` component for `createApp`, using
+provider information based on the table above.
 
 ```tsx
 const app = createApp({
   apis,
-  plugins: Object.values(plugins),
   components: {
     SignInPage: props => (
       <SignInPage


### PR DESCRIPTION
Plugins are removed from the `create-app` template, so let's remove them from the examples in docs.