### PR TITLE
fix(cost-insights): null groups in urls

### DIFF
--- a/.changeset/cost-insights-smooth-toes-draw.md
+++ b/.changeset/cost-insights-smooth-toes-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+fix for query parameters with null groups

--- a/plugins/cost-insights/src/utils/history.test.ts
+++ b/plugins/cost-insights/src/utils/history.test.ts
@@ -63,6 +63,7 @@ describe.each`
   ${'?foo=bar'}                                       | ${{}}
   ${'?group'}                                         | ${{ group: null }}
   ${'?project'}                                       | ${{ project: null }}
+  ${'?project&group'}                                 | ${{ group: null, project: null }}
   ${'?group=some-group'}                              | ${{ group: 'some-group' }}
   ${'?group=some-group&project'}                      | ${{ group: 'some-group', project: null }}
   ${'?group=some-group&project=some-project'}         | ${{ group: 'some-group', project: 'some-project' }}

--- a/plugins/cost-insights/src/utils/history.test.ts
+++ b/plugins/cost-insights/src/utils/history.test.ts
@@ -61,6 +61,7 @@ describe.each`
   params                                              | expected
   ${''}                                               | ${{}}
   ${'?foo=bar'}                                       | ${{}}
+  ${'?group'}                                         | ${{ group: null }}
   ${'?project'}                                       | ${{ project: null }}
   ${'?group=some-group'}                              | ${{ group: 'some-group' }}
   ${'?group=some-group&project'}                      | ${{ group: 'some-group', project: null }}
@@ -70,11 +71,5 @@ describe.each`
   it(`should validate ${params}`, async () => {
     const pageFilters = await validate(params);
     expect(pageFilters).toMatchObject(expected);
-  });
-});
-
-describe('invalidate', () => {
-  it("should throw an error if param values don't match schema", async () => {
-    await expect(validate('?group')).rejects.toThrowError();
   });
 });

--- a/plugins/cost-insights/src/utils/history.ts
+++ b/plugins/cost-insights/src/utils/history.ts
@@ -23,7 +23,7 @@ import { ConfigContextProps } from '../hooks/useConfig';
 const schema = yup
   .object()
   .shape({
-    group: yup.string(),
+    group: yup.string().nullable(),
     project: yup.string().nullable(),
   })
   .required();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allows null groups in cost insights urls. e.g `backstage/cost-insights?group`

### Rationale
Users may not be a member of any group. Cost Insights currently handles this case by displaying some friendly fallback UI but if a user enters this url manually, or there is some change to the user identity state which results in no groups -  `yup` will fail schema validation. 

Since null groups is a valid state, the url for null groups should also be valid.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
