### PR TITLE
Fix wrong yaml indention in docs

### DIFF
--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -222,17 +222,17 @@ You can see it in the above full example which is a separate step and it looks a
 little like this:
 
 ```yaml
-    - title: Choose a location
-      required:
-        - repoUrl
-      properties:
-        repoUrl:
-          title: Repository Location
-          type: string
-          ui:field: RepoUrlPicker
-          ui:options:
-            allowedHosts:
-              - github.com
+- title: Choose a location
+  required:
+    - repoUrl
+  properties:
+    repoUrl:
+      title: Repository Location
+      type: string
+      ui:field: RepoUrlPicker
+      ui:options:
+        allowedHosts:
+          - github.com
 ```
 
 The `allowedHosts` part should be set to where you wish to enable this template

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -222,7 +222,7 @@ You can see it in the above full example which is a separate step and it looks a
 little like this:
 
 ```yaml
-   - title: Choose a location
+    - title: Choose a location
       required:
         - repoUrl
       properties:


### PR DESCRIPTION
No changeset needed. The indention was wrong, I fixed it but prettier doesn't like it, so I removed it completely.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
