### PR TITLE
[TechDocs] Respect download attribute

### DIFF
--- a/.changeset/techdocs-keep-it-on-the-download.md
+++ b/.changeset/techdocs-keep-it-on-the-download.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+TechDocs now respects the `download` attribute on anchor tags in generated
+markup, allowing documentation authors to bundle downloadable files with their
+documentation.

--- a/plugins/techdocs/src/reader/transformers/addBaseUrl.test.ts
+++ b/plugins/techdocs/src/reader/transformers/addBaseUrl.test.ts
@@ -37,6 +37,7 @@ const fixture = `
     <body>
       <img src="test.jpg" />
       <script type="javascript" src="script.js"></script>
+      <a href="afile.pdf" download>Download Now</a>
     </body>
   </html>
 `;
@@ -75,6 +76,12 @@ describe('addBaseUrl', () => {
     expect(techdocsStorageApi.getBaseUrl).toHaveBeenNthCalledWith(
       3,
       'astyle.css',
+      mockEntityId,
+      '',
+    );
+    expect(techdocsStorageApi.getBaseUrl).toHaveBeenNthCalledWith(
+      4,
+      'afile.pdf',
       mockEntityId,
       '',
     );

--- a/plugins/techdocs/src/reader/transformers/addBaseUrl.ts
+++ b/plugins/techdocs/src/reader/transformers/addBaseUrl.ts
@@ -48,6 +48,7 @@ export const addBaseUrl = ({
     updateDom<HTMLImageElement>(dom.querySelectorAll('img'), 'src');
     updateDom<HTMLScriptElement>(dom.querySelectorAll('script'), 'src');
     updateDom<HTMLLinkElement>(dom.querySelectorAll('link'), 'href');
+    updateDom<HTMLAnchorElement>(dom.querySelectorAll('a[download]'), 'href');
 
     return dom;
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently, it's not possible to link directly to assets bundled with TechDocs sites. This opens up the possibility to do this by respecting the download attribute on anchor tags (by swapping out the `href` to point at the backend static docs proxy, rather than Backstage frontend).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
