### PR TITLE
config-loader: workaround for config schema parsing in typescript 4.3

### DIFF
--- a/.changeset/selfish-turtles-deliver.md
+++ b/.changeset/selfish-turtles-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Fixed configuration schema parsing when using TypeScript `4.3`.

--- a/packages/config-loader/src/lib/schema/collect.ts
+++ b/packages/config-loader/src/lib/schema/collect.ts
@@ -168,6 +168,23 @@ function compileTsSchemas(paths: string[]) {
         },
         [path.split(sep).join('/')], // Unix paths are expected for all OSes here
       ) as JsonObject | null;
+
+      // This is a workaround for an API change in TypeScript 4.3 where doc comments no
+      // longer are represented by a single string, but instead an array of objects.
+      // This isn't handled by typescript-json-schema so we do the conversion here instead.
+      value = JSON.parse(JSON.stringify(value), (key, prop) => {
+        if (key === 'visibility' && Array.isArray(prop)) {
+          const text = prop[0]?.text;
+          if (!text) {
+            const propStr = JSON.stringify(prop);
+            throw new Error(
+              `Failed conversion of visibility schema, got ${propStr}`,
+            );
+          }
+          return text;
+        }
+        return prop;
+      });
     } catch (error) {
       if (error.message !== 'type Config not found') {
         throw error;


### PR DESCRIPTION
This fixes the broken e2e tests where it's complaining about invalid config schema.

The TypeScript 4.3 release is a bit weird, it went straight to 4.3.2 and there's no announcement so I'm not sure if it's intended. Seems like this change is coming either way though so lets get a workaround in place.