### PR TITLE
feat: use main for default git branch

### DIFF
--- a/.changeset/mighty-trainers-sip.md
+++ b/.changeset/mighty-trainers-sip.md
@@ -1,0 +1,7 @@
+---
+'@backstage/backend-common': minor
+'@backstage/integration': minor
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+add defaultBranch config for github

--- a/packages/backend-common/src/scm/git.ts
+++ b/packages/backend-common/src/scm/git.ts
@@ -150,12 +150,19 @@ export class Git {
     });
   }
 
-  async init({ dir }: { dir: string }): Promise<void> {
+  async init({
+    dir,
+    defaultBranch,
+  }: {
+    dir: string;
+    defaultBranch?: string;
+  }): Promise<void> {
     this.config.logger?.info(`Init git repository {dir=${dir}}`);
 
     return git.init({
       fs,
       dir,
+      defaultBranch,
     });
   }
 

--- a/packages/integration/src/github/config.ts
+++ b/packages/integration/src/github/config.ts
@@ -65,6 +65,13 @@ export type GitHubIntegrationConfig = {
    * If no apps are specified, token or anonymous is used.
    */
   apps?: GithubAppConfig[];
+
+  /**
+   * The default branch for scaffolded repositories.
+   *
+   * If no branch is specified, master is used.
+   */
+  defaultBranch?: string;
 };
 
 /**

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/github.ts
@@ -45,6 +45,7 @@ export class GithubPublisher implements PublisherBase {
       credentialsProvider,
       repoVisibility,
       apiBaseUrl: config.apiBaseUrl,
+      defaultBranch: config.defaultBranch,
     });
   }
 
@@ -53,6 +54,7 @@ export class GithubPublisher implements PublisherBase {
       credentialsProvider: GithubCredentialsProvider;
       repoVisibility: RepoVisibilityOptions;
       apiBaseUrl: string | undefined;
+      defaultBranch: string | undefined;
     },
   ) {}
 
@@ -62,6 +64,7 @@ export class GithubPublisher implements PublisherBase {
     logger,
   }: PublisherOptions): Promise<PublisherResult> {
     const { owner, name } = parseGitUrl(values.storePath);
+    const { defaultBranch = 'master' } = this.config;
 
     const { token } = await this.config.credentialsProvider.getCredentials({
       url: values.storePath,
@@ -97,11 +100,12 @@ export class GithubPublisher implements PublisherBase {
         password: token,
       },
       logger,
+      defaultBranch,
     });
 
     const catalogInfoUrl = remoteUrl.replace(
       /\.git$/,
-      '/blob/master/catalog-info.yaml',
+      `/blob/${defaultBranch}/catalog-info.yaml`,
     );
 
     try {
@@ -110,6 +114,7 @@ export class GithubPublisher implements PublisherBase {
         client,
         repoName: name,
         logger,
+        defaultBranch,
       });
     } catch (e) {
       throw new Error(`Failed to add branch protection to '${name}', ${e}`);

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
@@ -24,11 +24,13 @@ export async function initRepoAndPush({
   remoteUrl,
   auth,
   logger,
+  defaultBranch = 'master',
 }: {
   dir: string;
   remoteUrl: string;
   auth: { username: string; password: string };
   logger: Logger;
+  defaultBranch?: string;
 }): Promise<void> {
   const git = Git.fromAuth({
     username: auth.username,
@@ -38,6 +40,7 @@ export async function initRepoAndPush({
 
   await git.init({
     dir,
+    defaultBranch,
   });
 
   const paths = await globby(['./**', './**/.*', '!.git'], {
@@ -74,6 +77,7 @@ type BranchProtectionOptions = {
   owner: string;
   repoName: string;
   logger: Logger;
+  defaultBranch: string;
 };
 
 export const enableBranchProtectionOnDefaultRepoBranch = async ({
@@ -81,6 +85,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
   client,
   owner,
   logger,
+  defaultBranch,
 }: BranchProtectionOptions): Promise<void> => {
   const tryOnce = async () => {
     try {
@@ -97,7 +102,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
         },
         owner,
         repo: repoName,
-        branch: 'master',
+        branch: defaultBranch,
         required_status_checks: { strict: true, contexts: [] },
         restrictions: null,
         enforce_admins: true,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It has become common practice to use `main` as the default branch when initializing a Git repository. This updates the GitHub integration to expose the `defaultBranch` config property. If not provided, `master` will still be used. For example:

```
integrations:
  github:
    - host: github.com
      defaultBranch: main
      apps:
        - $include: github-credentials.yaml
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
