### PR TITLE
Don't merge with previous from state on form changes

### DIFF
--- a/.changeset/eighty-rabbits-fail.md
+++ b/.changeset/eighty-rabbits-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Don't merge with previous from state on form changes.

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.test.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.test.tsx
@@ -17,12 +17,13 @@ import { ApiProvider, ApiRegistry, errorApiRef } from '@backstage/core';
 import { renderInTestApp, renderWithEffects } from '@backstage/test-utils';
 import { lightTheme } from '@backstage/theme';
 import { ThemeProvider } from '@material-ui/core';
+import { fireEvent, within } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter, Route } from 'react-router';
 import { ScaffolderApi, scaffolderApiRef } from '../../api';
 import { rootRouteRef } from '../../routes';
-import { TemplatePage, createValidator } from './TemplatePage';
+import { createValidator, TemplatePage } from './TemplatePage';
 
 jest.mock('react-router-dom', () => {
   return {
@@ -122,6 +123,78 @@ describe('TemplatePage', () => {
       rendered.queryByText('Create a New Component'),
     ).not.toBeInTheDocument();
     expect(rendered.queryByText('This is root')).toBeInTheDocument();
+  });
+
+  it('display template with oneOf', async () => {
+    scaffolderApiMock.getTemplateParameterSchema.mockResolvedValue({
+      title: 'my-schema',
+      steps: [
+        {
+          title: 'Fill in some steps',
+          schema: {
+            oneOf: [
+              {
+                title: 'First',
+                properties: {
+                  name: {
+                    title: 'Name',
+                    type: 'string',
+                  },
+                },
+                required: ['name'],
+              },
+              {
+                title: 'Second',
+                properties: {
+                  something: {
+                    title: 'Something',
+                    type: 'string',
+                  },
+                },
+                required: ['something'],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const {
+      findByText,
+      findByLabelText,
+      findAllByRole,
+      findByRole,
+    } = await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <TemplatePage />
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/create/actions': rootRouteRef,
+        },
+      },
+    );
+
+    expect(await findByText('Fill in some steps')).toBeInTheDocument();
+
+    // Fill the first option
+    fireEvent.change(await findByLabelText('Name', { exact: false }), {
+      target: { value: 'my-name' },
+    });
+
+    // Switch to second option
+    fireEvent.mouseDown((await findAllByRole('button'))[0]);
+    const listbox = within(await findByRole('listbox'));
+    fireEvent.click(listbox.getByText(/Second/i));
+
+    // Fill the second option
+    fireEvent.change(await findByLabelText('Something', { exact: false }), {
+      target: { value: 'my-something' },
+    });
+
+    // Go to the final page
+    fireEvent.click(await findByText('Next step'));
+    expect(await findByText('Reset')).toBeInTheDocument();
   });
 });
 

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -150,8 +150,8 @@ export const TemplatePage = () => {
   const handleFormReset = () => setFormState({});
 
   const handleChange = useCallback(
-    (e: IChangeEvent) => setFormState({ ...formState, ...e.formData }),
-    [setFormState, formState],
+    (e: IChangeEvent) => setFormState(e.formData),
+    [setFormState],
   );
 
   const handleCreate = async () => {


### PR DESCRIPTION
I'm trying to build a more complex workflow with the scaffolder and running into issues with the input form. If I use a `anyOf` or `oneOf` I have the problem that values aren't reseted when switching between two options.

For example, let's consider the following template

```yaml
apiVersion: backstage.io/v1beta2
kind: Template
metadata:
  name: v1beta2-demo
  title: Test Action template
  description: scaffolder v1beta2 template demo publishing to github
spec:
  owner: backstage/techdocs-core
  type: service

  parameters:
    - title: Fill in some steps
      oneOf:
      - title: First Option
        properties:
          name:
            title: Name
            type: string
          owner:
            title: Owner
            type: string
        required: 
        - name
        - owner
      - title: Second Option
        properties:
          name:
            title: Name
            type: string
          something:
            title: Someting
            type: string
        required: 
        - name
        - something
  steps:
     …
```

In this template I would expect the user to fill in either a name and owner OR a name and the something field. The user has a select to switch between the two views:

![image](https://user-images.githubusercontent.com/648527/119816947-a33ad300-beed-11eb-81ff-f755fe693161.png)

As the code is merging the form data on every change with the previous form data, you are unable to delete fields. For my example I would expect to have a result like:

```json
{
  "name": "sdsdsd",
  "something": "sdsdsd"
}
```

But get the merged result instead, which fails the JSON schema validation as it has to many fields (none of the two options matches):

```json

{
  "name": "sdsdsd",
  "owner": "sdsdsd",
  "something": "sdsdsd"
}
```

The solution is to skip merging the form data with the previous state. There is no need to do that, as that behavior is already done internally in `react-jsonschema-form` and the full object is returned on change.

~~I didn't added a test as it would be quite complicated scenario to test, but it would be possible. If there is a desire for a test, I can implement one.~~

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
