### PR TITLE
adjust source map devtools filename template to point to source

### DIFF
--- a/.changeset/brown-lobsters-enjoy.md
+++ b/.changeset/brown-lobsters-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Adjust the Webpack `devtool` module filename template to correctly resolve via the source maps to the source files.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -197,6 +197,15 @@ export async function createConfig(
       chunkFilename: isDev
         ? '[name].chunk.js'
         : 'static/[name].[chunkhash:8].chunk.js',
+      ...(isDev
+        ? {
+            devtoolModuleFilenameTemplate: info =>
+              `file:///${resolvePath(info.absoluteResourcePath).replace(
+                /\\/g,
+                '/',
+              )}`,
+          }
+        : {}),
     },
     plugins,
   };
@@ -281,7 +290,11 @@ export async function createBackendConfig(
         : '[name].[chunkhash:8].chunk.js',
       ...(isDev
         ? {
-            devtoolModuleFilenameTemplate: 'file:///[absolute-resource-path]',
+            devtoolModuleFilenameTemplate: info =>
+              `file:///${resolvePath(info.absoluteResourcePath).replace(
+                /\\/g,
+                '/',
+              )}`,
           }
         : {}),
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To improve the debugging experience, we adjusted the `devtoolModuleFilenameTemplate` in webpack to help debug tools correctly resolve and point to the source files. This closes #5840.

### Example of an `app` error before the change:

![app original-error](https://user-images.githubusercontent.com/2019387/119904593-2cfb9800-bf10-11eb-8273-191fcd5be9cf.png)

### Example of an `app` error after the change

![app new-error](https://user-images.githubusercontent.com/2019387/119904638-413f9500-bf10-11eb-903b-a5e02a85b443.png)

Clicking on the file, note that nothing is transformed (including the jsx).

![image](https://user-images.githubusercontent.com/2019387/119904749-75b35100-bf10-11eb-90f6-df3b04ffb9a7.png)

### Example of a `backend` error before the change

![backend original-error](https://user-images.githubusercontent.com/2019387/119904672-50bede00-bf10-11eb-9b55-e08e4e59f9c6.png)


### Example of a `backend` error after the change

![backend new-error](https://user-images.githubusercontent.com/2019387/119904691-59171900-bf10-11eb-8b62-a3957c7ccaf3.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
