### PR TITLE
Tweak the `EntityListProvider` to do single-cycle updates.

### DIFF
--- a/.changeset/beige-garlics-doubt.md
+++ b/.changeset/beige-garlics-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Fix a bug in `MockStorageApi` where it unhelpfully returned new empty buckets every single time

--- a/.changeset/slimy-kids-attack.md
+++ b/.changeset/slimy-kids-attack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Tweak the `EntityListProvider` to do single-cycle updates

--- a/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.ts
+++ b/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.ts
@@ -23,6 +23,8 @@ import ObservableImpl from 'zen-observable';
 
 export type MockStorageBucket = { [key: string]: any };
 
+const bucketStorageApis = new Map<string, MockStorageApi>();
+
 export class MockStorageApi implements StorageApi {
   private readonly namespace: string;
   private readonly data: MockStorageBucket;
@@ -37,7 +39,13 @@ export class MockStorageApi implements StorageApi {
   }
 
   forBucket(name: string): StorageApi {
-    return new MockStorageApi(`${this.namespace}/${name}`, this.data);
+    if (!bucketStorageApis.has(name)) {
+      bucketStorageApis.set(
+        name,
+        new MockStorageApi(`${this.namespace}/${name}`, this.data),
+      );
+    }
+    return bucketStorageApis.get(name)!;
   }
 
   get<T>(key: string): T | undefined {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -157,6 +157,7 @@ describe('<EntityListProvider/>', () => {
         user: new UserListFilter('owned', mockUser, () => true),
       }),
     );
+    await waitFor(() => result.current.entities.length !== 2);
     expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(1);
     expect(result.current.entities.length).toBe(1);
   });

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.test.tsx
@@ -34,7 +34,7 @@ import {
   renderWithEffects,
   wrapInTestApp,
 } from '@backstage/test-utils';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { createComponentRouteRef } from '../../routes';
 import { CatalogPage } from './CatalogPage';
@@ -132,35 +132,38 @@ describe('CatalogPage', () => {
   // related to some theme issues in mui-table
   // https://github.com/mbrn/material-table/issues/1293
   it('should render', async () => {
-    const { getByText, getByTestId } = await renderWrapped(<CatalogPage />);
-    expect(getByText(/Owned \(1\)/)).toBeInTheDocument();
+    const { findByText, getByTestId } = await renderWrapped(<CatalogPage />);
+    await expect(findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
     fireEvent.click(getByTestId('user-picker-all'));
-    expect(getByText(/All \(2\)/)).toBeInTheDocument();
+    await expect(findByText(/All \(2\)/)).resolves.toBeInTheDocument();
   });
+
   it('should set initial filter correctly', async () => {
-    const { getByText } = await renderWrapped(
+    const { findByText } = await renderWrapped(
       <CatalogPage initiallySelectedFilter="all" />,
     );
-    expect(getByText(/All \(2\)/)).toBeInTheDocument();
+    await expect(findByText(/All \(2\)/)).resolves.toBeInTheDocument();
   });
-  // this test is for fixing the bug after favoriting an entity, the matching entities defaulting
-  // to "owned" filter and not based on the selected filter
-  it('should render the correct entities filtered on the selectedfilter', async () => {
-    const { getByText, findAllByTitle, getByTestId } = await renderWrapped(
-      <CatalogPage />,
-    );
-    expect(getByText(/Owned \(1\)/)).toBeInTheDocument();
-    expect(getByText(/Starred/)).toBeInTheDocument();
-    fireEvent.click(getByTestId('user-picker-starred'));
-    expect(getByText(/Starred \(0\)/)).toBeInTheDocument();
-    fireEvent.click(getByTestId('user-picker-all'));
-    expect(getByText(/All \(2\)/)).toBeInTheDocument();
 
-    const starredIcons = await findAllByTitle('Add to favorites');
+  // this test is for fixing the bug after favoriting an entity, the matching
+  // entities defaulting to "owned" filter and not based on the selected filter
+  it('should render the correct entities filtered on the selected filter', async () => {
+    await renderWrapped(<CatalogPage />);
+    await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('user-picker-starred'));
+    await expect(
+      screen.findByText(/Starred \(0\)/),
+    ).resolves.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('user-picker-all'));
+    await expect(screen.findByText(/All \(2\)/)).resolves.toBeInTheDocument();
+
+    const starredIcons = await screen.findAllByTitle('Add to favorites');
     fireEvent.click(starredIcons[0]);
-    expect(getByText(/All \(2\)/)).toBeInTheDocument();
+    await expect(screen.findByText(/All \(2\)/)).resolves.toBeInTheDocument();
 
-    fireEvent.click(getByTestId('user-picker-starred'));
-    waitFor(() => expect(getByText(/Starred \(1\)/)).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('user-picker-starred'));
+    await expect(
+      screen.findByText(/Starred \(1\)/),
+    ).resolves.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The old code had some "waterfalls" of things triggering other things. For example, the following could happen in succession based on a single filter changing:

- the filter contents changed
- the client side filtered entities changed
- a backend load was triggered
- the backend responded, which made both the client side filtered entities and the backend entities change

The proposed new code does all of the actual work in one single unit, applying all updates in one go.

Sadly this doesn't entirely address the slowness of the entities table. But it makes updates more consistent and less flickery, and less frequent.
