### PR TITLE
Move dependency to `@microsoft/microsoft-graph-types`

### DIFF
--- a/.changeset/thin-cougars-cheer.md
+++ b/.changeset/thin-cougars-cheer.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Move dependency to `@microsoft/microsoft-graph-types` from `@backstage/plugin-catalog`
+to `@backstage/plugin-catalog-backend`.

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -38,6 +38,7 @@
     "@backstage/integration": "^0.5.4",
     "@backstage/plugin-search-backend-node": "^0.1.4",
     "@backstage/search-common": "^0.1.1",
+    "@microsoft/microsoft-graph-types": "^1.25.0",
     "@octokit/graphql": "^4.5.8",
     "@types/express": "^4.17.6",
     "@types/ldapjs": "^1.0.9",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -56,7 +56,6 @@
     "@backstage/cli": "^0.6.13",
     "@backstage/dev-utils": "^0.1.16",
     "@backstage/test-utils": "^0.1.12",
-    "@microsoft/microsoft-graph-types": "^1.25.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^11.2.5",
     "@testing-library/react-hooks": "^3.3.0",


### PR DESCRIPTION
While working on something else I noticed that the dependency is in the wrong package. I actually wonder why this wasn't an issue yet, or why the linter didn't noticed it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
