### PR TITLE
Upgrade 3 roadie plugins in sample app (Fixes bug in master)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -41,7 +41,7 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@octokit/rest": "^18.5.3",
-    "@roadiehq/backstage-plugin-buildkite": "^1.0.0",
+    "@roadiehq/backstage-plugin-buildkite": "^1.0.3",
     "@roadiehq/backstage-plugin-github-insights": "^1.1.11",
     "@roadiehq/backstage-plugin-github-pull-requests": "^1.0.0",
     "@roadiehq/backstage-plugin-travis-ci": "^1.0.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,7 +42,7 @@
     "@material-ui/icons": "^4.9.1",
     "@octokit/rest": "^18.5.3",
     "@roadiehq/backstage-plugin-buildkite": "^1.0.0",
-    "@roadiehq/backstage-plugin-github-insights": "^1.1.10",
+    "@roadiehq/backstage-plugin-github-insights": "^1.1.11",
     "@roadiehq/backstage-plugin-github-pull-requests": "^1.0.0",
     "@roadiehq/backstage-plugin-travis-ci": "^1.0.0",
     "history": "^5.0.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,7 +43,7 @@
     "@octokit/rest": "^18.5.3",
     "@roadiehq/backstage-plugin-buildkite": "^1.0.3",
     "@roadiehq/backstage-plugin-github-insights": "^1.1.11",
-    "@roadiehq/backstage-plugin-github-pull-requests": "^1.0.0",
+    "@roadiehq/backstage-plugin-github-pull-requests": "^1.0.5",
     "@roadiehq/backstage-plugin-travis-ci": "^1.0.0",
     "history": "^5.0.0",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,20 +1693,6 @@
     uuid "^8.0.0"
     yup "^0.29.3"
 
-"@backstage/catalog-model@^0.7.7":
-  version "0.8.0"
-  dependencies:
-    "@backstage/config" "^0.1.5"
-    "@backstage/errors" "^0.1.1"
-    "@types/json-schema" "^7.0.5"
-    "@types/yup" "^0.29.8"
-    ajv "^7.0.3"
-    json-schema "^0.3.0"
-    lodash "^4.17.15"
-    typescript-json-schema "^0.49.0"
-    uuid "^8.0.0"
-    yup "^0.29.3"
-
 "@backstage/catalog-model@^0.7.9":
   version "0.8.0"
   dependencies:
@@ -1721,7 +1707,7 @@
     uuid "^8.0.0"
     yup "^0.29.3"
 
-"@backstage/plugin-catalog-react@^0.1.4", "@backstage/plugin-catalog-react@^0.1.5":
+"@backstage/plugin-catalog-react@^0.1.4":
   version "0.1.6"
   resolved "https://registry.npmjs.org/@backstage/plugin-catalog-react/-/plugin-catalog-react-0.1.6.tgz#1d72756cce22b880987c30ac27e23af8efa22843"
   integrity sha512-/60GIrcFfyAiKn3bylXegwtHf1NQxQa4PcXD7nSIB5ISCuot2mkI32LMjciEvNHR7efGA5Yv6yWelFSFdvbcKQ==
@@ -4362,14 +4348,14 @@
     react-router-dom "6.0.0-beta.0"
     react-use "^15.3.6"
 
-"@roadiehq/backstage-plugin-github-insights@^1.1.10":
-  version "1.1.10"
-  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-github-insights/-/backstage-plugin-github-insights-1.1.10.tgz#0af8ae29cab6d92985079a1d8f92ede2e50bf247"
-  integrity sha512-XeWnPOgLI1BWgRwGqrnGTk79gpjd9bQtzGLzpTAjecFQWMnp6eeCOpIq1xTQcFHnFOSaJhQLp2JOWtiM4ZUAXw==
+"@roadiehq/backstage-plugin-github-insights@^1.1.11":
+  version "1.1.11"
+  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-github-insights/-/backstage-plugin-github-insights-1.1.11.tgz#6f716a0864b7e3a7255d7ec97c92a68a99874025"
+  integrity sha512-fDW92aCGXJtZ36TLgEkHiLCZgNKh5lqRFSmStd+58o4QRMiJp852Tcbi2ySrtf03SnGKn7rvD2CqThx/VcwPwg==
   dependencies:
-    "@backstage/catalog-model" "^0.7.7"
-    "@backstage/core" "^0.7.8"
-    "@backstage/plugin-catalog-react" "^0.1.5"
+    "@backstage/catalog-model" "^0.8.0"
+    "@backstage/core" "^0.7.11"
+    "@backstage/plugin-catalog-react" "^0.2.0"
     "@backstage/theme" "^0.2.7"
     "@date-io/core" "2.10.7"
     "@material-ui/core" "^4.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4165,7 +4165,7 @@
     node-fetch "^2.6.1"
     universal-user-agent "^6.0.0"
 
-"@octokit/rest@^18.1.0", "@octokit/rest@^18.1.1", "@octokit/rest@^18.5.3":
+"@octokit/rest@^18.1.0", "@octokit/rest@^18.5.3":
   version "18.5.3"
   resolved "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.3.tgz#6a2e6006a87ebbc34079c419258dd29ec9ff659d"
   integrity sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==
@@ -4368,17 +4368,17 @@
     react-router "^6.0.0-beta.0"
     react-use "^17.2.4"
 
-"@roadiehq/backstage-plugin-github-pull-requests@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-github-pull-requests/-/backstage-plugin-github-pull-requests-1.0.0.tgz#5103d9ff65ed38a752ceb8ac1c7369fd0724388f"
-  integrity sha512-HAi3X0kto/xMNaMzy9f4t142MGvxwuxDfiLN+bZUsWwta4iI3CgK/9fZAd5kU9+E04EFxkRXmg72FXxG64H6Zg==
+"@roadiehq/backstage-plugin-github-pull-requests@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-github-pull-requests/-/backstage-plugin-github-pull-requests-1.0.5.tgz#7b71823b1c39dbcb89276a5725815c15a0e27943"
+  integrity sha512-be+buEb4tkMfVB1qFn3OwFc4pq9/Nu+5C5LsdEwhRnJHN7eLcOBMnhH5l0zAYkHErpF3zbI3xngbap+TATbm0Q==
   dependencies:
-    "@backstage/catalog-model" "^0.7.4"
-    "@backstage/core" "^0.7.3"
-    "@backstage/plugin-catalog-react" "^0.1.4"
+    "@backstage/catalog-model" "^0.8.0"
+    "@backstage/core" "^0.7.11"
+    "@backstage/plugin-catalog-react" "^0.2.0"
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
-    "@octokit/rest" "^18.1.1"
+    "@octokit/rest" "^18.5.3"
     "@octokit/types" "^5.0.1"
     "@types/node-fetch" "^2.5.7"
     history "^5.0.0"
@@ -4387,7 +4387,7 @@
     react "^16.13.1"
     react-dom "^16.13.1"
     react-router "6.0.0-beta.0"
-    react-use "^15.3.6"
+    react-use "^17.2.4"
 
 "@roadiehq/backstage-plugin-travis-ci@^1.0.0":
   version "1.0.0"
@@ -22467,7 +22467,7 @@ react-use@^12.2.0:
     ts-easing "^0.2.0"
     tslib "^1.10.0"
 
-react-use@^15.3.3, react-use@^15.3.6:
+react-use@^15.3.3:
   version "15.3.8"
   resolved "https://registry.npmjs.org/react-use/-/react-use-15.3.8.tgz#ca839ac7fb3d696e5ccbeabbc8dadc2698969d30"
   integrity sha512-GeGcrmGuUvZrY5wER3Lnph9DSYhZt5nEjped4eKDq8BRGr2CnLf9bDQWG9RFc7oCPphnscUUdOovzq0E5F2c6Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4326,27 +4326,26 @@
   resolved "https://registry.npmjs.org/@rjsf/material-ui/-/material-ui-2.5.1.tgz#b93ac9f1f4a909e2aae729616859c2d72557e53e"
   integrity sha512-ooKxQJO12+i1xCGtknMZDxWSbVlSEgQ5U1I7lJ+uI/MvwAg3Rz9wb2cTEF3ErBczT7EEW+j1lR19rxBjFd78MA==
 
-"@roadiehq/backstage-plugin-buildkite@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-buildkite/-/backstage-plugin-buildkite-1.0.0.tgz#0c00352eb7a204ac45f55bc5dd4c17c9c1cfdf9e"
-  integrity sha512-R6pxMSOeTK+4OBBhSktEEEIkaVTcOWTsgnpB5FEZ748YZ3Ul4dp4H2S3bup2OnMIL79xY2oAxYt1iRmAe69Bng==
+"@roadiehq/backstage-plugin-buildkite@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-buildkite/-/backstage-plugin-buildkite-1.0.3.tgz#d865da83380e1cdcec5825f856597446f5652f53"
+  integrity sha512-HMDworpWRgwhmQETAe2DUX3cxddP+N1q8bTWxAQwOHO6mecF08uvZDGA1VdWabXSPpJwFUiZEi9OLlNYkl32GA==
   dependencies:
-    "@backstage/catalog-model" "^0.7.4"
-    "@backstage/core" "^0.7.3"
-    "@backstage/plugin-catalog" "^0.5.1"
-    "@backstage/plugin-catalog-react" "^0.1.4"
-    "@backstage/theme" "^0.2.5"
+    "@backstage/catalog-model" "^0.8.0"
+    "@backstage/core" "^0.7.11"
+    "@backstage/plugin-catalog-react" "^0.2.0"
+    "@backstage/theme" "^0.2.7"
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
     "@material-ui/lab" "4.0.0-alpha.45"
     history "^5.0.0"
-    moment "^2.27.0"
+    moment "^2.29.1"
     react "^16.13.1"
     react-dom "^16.13.1"
     react-lazylog "^4.5.2"
     react-router "6.0.0-beta.0"
     react-router-dom "6.0.0-beta.0"
-    react-use "^15.3.6"
+    react-use "^17.2.4"
 
 "@roadiehq/backstage-plugin-github-insights@^1.1.11":
   version "1.1.11"


### PR DESCRIPTION
An incompatibility between the GitHub Insights plugin and Backstage is currently breaking the sample app entity page in the master branch. A fix was previously released for the GitHub insights plugin, this PR uptakes the new version.

I decided to tack on a few versions bumps for other roadie plugins. I haven't upgraded travis-ci because the `yarn.lock` diff looks oddly big and I don't want to delay the GitHub Insights fix.

No changeset is required because it's all in packages/app.

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
