### PR TITLE
Support parsing `mkdocs.yml` files that are using custom yaml tags

### DIFF
--- a/.changeset/techdocs-nice-forks-flow.md
+++ b/.changeset/techdocs-nice-forks-flow.md
@@ -1,0 +1,6 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Support parsing `mkdocs.yml` files that are using custom yaml tags like
+`!!python/name:materialx.emoji.twemoji`.

--- a/packages/techdocs-common/src/stages/generate/__fixtures__/mkdocs_with_extensions.yml
+++ b/packages/techdocs-common/src/stages/generate/__fixtures__/mkdocs_with_extensions.yml
@@ -1,0 +1,7 @@
+site_name: Test site name
+site_description: Test site description
+
+markdown_extensions:
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
#5748 introduced an issue in `techdocs-cli` if one is using "special" YAML features. MkDocs is relying on these special features, for example:

```yaml
site_name: Test site name
site_description: Test site description

markdown_extensions:
  - pymdownx.emoji:
      emoji_index: !!python/name:materialx.emoji.twemoji
      emoji_generator: !!python/name:materialx.emoji.to_svg
```

This enables additional emojis by using a custom YAML tag. The Python YAML parser of MkDocs supports them, but the one used for validation in #5748 doesn't (`js-yaml`). This introduces a workaround by adding a custom tag that catches all tags to be able to parse the file correctly. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
