### PR TITLE
`GithubAppId` can be string or number for Environment Variables

### DIFF
--- a/.changeset/mean-tigers-brake.md
+++ b/.changeset/mean-tigers-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+GitHub App ID can be a string too for environment variables otherwise it will fail validation

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -89,9 +89,9 @@ export interface Config {
        */
       apps?: Array<{
         /**
-         * The numeric GitHub App ID
+         * The numeric GitHub App ID, string for environment variables
          */
-        appId: number;
+        appId: number | string;
         /**
          * The private key to use for auth against the app
          * @visibility secret


### PR DESCRIPTION
Fixes  #5140