### PR TITLE
Apply more deliberate validation of the entities throughout processing

### DIFF
--- a/.changeset/slimy-toys-fetch.md
+++ b/.changeset/slimy-toys-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Only validate the envelope for emitted entities, and defer full validation to when they get processed later on.

--- a/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { stringifyEntityRef } from '@backstage/catalog-model';
+import {
+  Entity,
+  entityEnvelopeSchemaValidator,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 import { serializeError } from '@backstage/errors';
 import { Logger } from 'winston';
 import { ProcessingDatabase } from './database/types';
@@ -28,6 +32,8 @@ import {
 } from './types';
 
 class Connection implements EntityProviderConnection {
+  readonly validateEntityEnvelope = entityEnvelopeSchemaValidator();
+
   constructor(
     private readonly config: {
       processingDatabase: ProcessingDatabase;
@@ -37,7 +43,9 @@ class Connection implements EntityProviderConnection {
 
   async applyMutation(mutation: EntityProviderMutation): Promise<void> {
     const db = this.config.processingDatabase;
+
     if (mutation.type === 'full') {
+      this.check(mutation.entities);
       await db.transaction(async tx => {
         await db.replaceUnprocessedEntities(tx, {
           sourceKey: this.config.id,
@@ -47,6 +55,9 @@ class Connection implements EntityProviderConnection {
       });
       return;
     }
+
+    this.check(mutation.added);
+    this.check(mutation.removed);
     await db.transaction(async tx => {
       await db.replaceUnprocessedEntities(tx, {
         sourceKey: this.config.id,
@@ -55,6 +66,16 @@ class Connection implements EntityProviderConnection {
         removed: mutation.removed,
       });
     });
+  }
+
+  private check(entities: Entity[]) {
+    for (const entity of entities) {
+      try {
+        this.validateEntityEnvelope(entity);
+      } catch (e) {
+        throw new TypeError(`Malformed entity envelope, ${e}`);
+      }
+    }
   }
 }
 
@@ -113,14 +134,18 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
     // TODO: replace Promise.all with something more sophisticated for parallel processing.
     await Promise.all(
       items.map(async item => {
-        const { id, state, unprocessedEntity } = item;
+        const { id, state, unprocessedEntity, entityRef } = item;
         const result = await this.orchestrator.process({
           entity: unprocessedEntity,
           state,
         });
 
         for (const error of result.errors) {
-          this.logger.warn(error.message);
+          // TODO(freben): Try to extract the location out of the unprocessed
+          // entity and add as meta to the log lines
+          this.logger.warn(error.message, {
+            entity: entityRef,
+          });
         }
         const errorsString = JSON.stringify(
           result.errors.map(e => serializeError(e)),

--- a/plugins/catalog-backend/src/next/Stitcher.ts
+++ b/plugins/catalog-backend/src/next/Stitcher.ts
@@ -176,7 +176,7 @@ export class Stitcher {
             statusItems = parsedErrors.map(e => ({
               type: ENTITY_STATUS_CATALOG_PROCESSING_TYPE,
               level: 'error',
-              message: e.toString(),
+              message: `${e.name}: ${e.message}`,
               error: e,
             }));
           }

--- a/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
@@ -14,24 +14,22 @@
  * limitations under the License.
  */
 
-import { ConflictError, NotFoundError } from '@backstage/errors';
-import { stringifyEntityRef, Entity } from '@backstage/catalog-model';
-import { Knex } from 'knex';
-import { Transaction } from '../../database';
-import lodash from 'lodash';
-
-import {
-  ProcessingDatabase,
-  AddUnprocessedEntitiesOptions,
-  UpdateProcessedEntityOptions,
-  GetProcessableEntitiesResult,
-  ReplaceUnprocessedEntitiesOptions,
-  RefreshStateItem,
-} from './types';
-import type { Logger } from 'winston';
-
-import { v4 as uuid } from 'uuid';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import { JsonObject } from '@backstage/config';
+import { ConflictError, NotFoundError } from '@backstage/errors';
+import { Knex } from 'knex';
+import lodash from 'lodash';
+import { v4 as uuid } from 'uuid';
+import type { Logger } from 'winston';
+import { Transaction } from '../../database';
+import {
+  AddUnprocessedEntitiesOptions,
+  GetProcessableEntitiesResult,
+  ProcessingDatabase,
+  RefreshStateItem,
+  ReplaceUnprocessedEntitiesOptions,
+  UpdateProcessedEntityOptions,
+} from './types';
 
 export type DbRefreshStateRow = {
   entity_id: string;

--- a/plugins/catalog-backend/src/next/types.ts
+++ b/plugins/catalog-backend/src/next/types.ts
@@ -16,9 +16,9 @@
 
 import {
   Entity,
-  LocationSpec,
-  Location,
   EntityRelationSpec,
+  Location,
+  LocationSpec,
 } from '@backstage/catalog-model';
 import { JsonObject } from '@backstage/config';
 


### PR DESCRIPTION
This is still not at all perfect but a step in the right direction. For example `Processor.preProcessEntity` may not want to take an `Entity` input but rather `EntityEnvelope`, but we're postponing those kinds of API changes. There's also more testing to be done to see that all relevant error conditions land properly in the `status` field in the end. At least a lot of them do, with this change, after some manual tests.

Example state:

```json
    "status": {
      "items": [
        {
          "type": "backstage.io/catalog-processing",
          "level": "error",
          "message": "InputError: Processor BuiltinKindsEntityProcessor threw an error while validating the entity; caused by TypeError: /spec should have required property 'type' - missingProperty: type",
          "error": {
            "name": "InputError",
            "message": "Processor BuiltinKindsEntityProcessor threw an error while validating the entity; caused by TypeError: /spec should have required property 'type' - missingProperty: type",
            "cause": {
              "name": "TypeError",
              "message": "/spec should have required property 'type' - missingProperty: type",
              "stack": "TypeError: /spec should have required property 'type' - missingProperty: type\n    at throwAjvError (webpack-internal:///../catalog-model/src/validation/ajv.ts:56:9)\n    at eval (webpack-internal:///../catalog-model/src/validation/entityKindSchemaValidator.ts:83:69)\n    at Object.check (webpack-internal:///../catalog-model/src/kinds/util.ts:31:14)\n    at BuiltinKindsEntityProcessor.validateEntityKind (webpack-internal:///../../plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts:41:39)\n    at async DefaultCatalogProcessingOrchestrator.processSingleEntity (webpack-internal:///../../plugins/catalog-backend/src/next/DefaultCatalogProcessingOrchestrator.ts:188:27)\n    at async eval (webpack-internal:///../../plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts:138:24)\n    at async Promise.all (index 0)\n    at async DefaultCatalogProcessingEngine.process (webpack-internal:///../../plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts:135:5)\n    at async DefaultCatalogProcessingEngine.run (webpack-internal:///../../plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts:111:9)"
            }
          }
        }
      ]
    }
```

Example log message:

![Screenshot 2021-06-02 at 14 56 07](https://user-images.githubusercontent.com/3097461/120485289-3c695e00-c3b4-11eb-8e37-99abd819b033.png)
