### PR TITLE
packages: update outdated installation instructions

### DIFF
--- a/.changeset/long-jokes-end.md
+++ b/.changeset/long-jokes-end.md
@@ -1,0 +1,11 @@
+---
+'@backstage/cli': patch
+'@backstage/core-app-api': patch
+'@backstage/core-components': patch
+'@backstage/core-plugin-api': patch
+'@backstage/dev-utils': patch
+'@backstage/test-utils': patch
+'@backstage/theme': patch
+---
+
+Update installation instructions in README.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,13 +4,7 @@ This package provides a CLI for developing Backstage plugins and apps.
 
 ## Installation
 
-Install the package via npm or Yarn:
-
-```sh
-npm install --save @backstage/cli
-```
-
-or
+Install the package via Yarn:
 
 ```sh
 yarn add @backstage/cli

--- a/packages/core-app-api/README.md
+++ b/packages/core-app-api/README.md
@@ -4,16 +4,11 @@ This package provides the core API used by Backstage apps.
 
 ## Installation
 
-Install the package via Yarn or npm:
+Install the package via Yarn:
 
 ```sh
-$ yarn add @backstage/core-app-api
-```
-
-or
-
-```sh
-$ npm install --save @backstage/core-app-api
+cd packages/app
+yarn add @backstage/core-app-api
 ```
 
 ## Documentation

--- a/packages/core-components/README.md
+++ b/packages/core-components/README.md
@@ -4,16 +4,11 @@ This package provides the core components used by Backstage plugins and apps
 
 ## Installation
 
-Install the package via Yarn or npm:
+Install the package via Yarn:
 
 ```sh
-$ yarn add @backstage/core-components
-```
-
-or
-
-```sh
-$ npm install --save @backstage/core-components
+cd <package-dir> # if within a monorepo
+yarn add @backstage/core-components
 ```
 
 ## Documentation

--- a/packages/core-plugin-api/README.md
+++ b/packages/core-plugin-api/README.md
@@ -4,16 +4,11 @@ This package provides the core API used by Backstage plugins.
 
 ## Installation
 
-Install the package via Yarn or npm:
+Install the package via Yarn:
 
 ```sh
-$ yarn add @backstage/core-plugin-api
-```
-
-or
-
-```sh
-$ npm install --save @backstage/core-plugin-api
+cd <package-dir> # if within a monorepo
+yarn add @backstage/core-plugin-api
 ```
 
 ## Documentation

--- a/packages/dev-utils/README.md
+++ b/packages/dev-utils/README.md
@@ -6,15 +6,10 @@ This package provides utilities that help in developing plugins for Backstage, l
 
 ## Installation
 
-Install the package via npm or Yarn:
+Install the package via Yarn:
 
 ```sh
-npm install --save-dev @backstage/dev-utils
-```
-
-or
-
-```sh
+cd plugins/<plugin> # if within a monorepo
 yarn add -D @backstage/dev-utils
 ```
 

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -4,15 +4,10 @@ This package provides utilities that can be used to test plugins and apps for Ba
 
 ## Installation
 
-Install the package via npm or Yarn:
+Install the package via Yarn:
 
 ```sh
-npm install --save-dev @backstage/test-utils
-```
-
-or
-
-```sh
+cd <package-dir> # if within a monorepo
 yarn add -D @backstage/test-utils
 ```
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -4,15 +4,10 @@ This package provides the extended Material UI Theme(s) that power Backstage.
 
 ## Installation
 
-Install the package via npm or Yarn:
+Install the package via Yarn:
 
 ```sh
-npm install --save @backstage/theme
-```
-
-or
-
-```sh
+cd <package-dir> # if within a monorepo
 yarn add @backstage/theme
 ```
 


### PR DESCRIPTION
Some followup from #5825

Stopped recommending usage of NPM as it's incompatible with our tooling and default setup, even though it can be used if there's a requirement.

Also updated to include some form of hint towards running `yarn add` inside package dirs, as well as got rid of the `$` prefix that we stopped using long ago.