### PR TITLE
cli: make create-github-app available and deprecate backend:build-image

### DIFF
--- a/.changeset/cool-poems-train.md
+++ b/.changeset/cool-poems-train.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Mark the `create-github-app` command as ready for use and reveal it in the command list.

--- a/.changeset/strong-mails-drum.md
+++ b/.changeset/strong-mails-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Deprecated the `backend:build-image` command, pointing to the newer `backend:bundle` command.

--- a/packages/cli/src/commands/backend/buildImage.ts
+++ b/packages/cli/src/commands/backend/buildImage.ts
@@ -15,6 +15,7 @@
  */
 
 import { Command } from 'commander';
+import { yellow } from 'chalk';
 import fs from 'fs-extra';
 import { join as joinPath, relative as relativePath } from 'path';
 import { createDistWorkspace } from '../../lib/packager';
@@ -30,6 +31,15 @@ export default async (cmd: Command) => {
     await run('docker', ['image', 'build', '--help']);
     return;
   }
+
+  console.warn(
+    yellow(`
+The backend:build-image command is deprecated and will be removed in the future.
+Please use the backend:bundle command instead along with your own Docker setup.
+
+  https://backstage.io/docs/deployment/docker
+`),
+  );
 
   const pkgPath = paths.resolveTarget(PKG_PATH);
   const pkg = await fs.readJson(pkgPath);

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -225,10 +225,8 @@ export function registerCommands(program: CommanderStatic) {
     .action(lazy(() => import('./buildWorkspace').then(m => m.default)));
 
   program
-    .command('create-github-app <github-org>', { hidden: true })
-    .description(
-      'Create new GitHub App in your organization. This command is experimental and may change in the future.',
-    )
+    .command('create-github-app <github-org>')
+    .description('Create new GitHub App in your organization.')
     .action(lazy(() => import('./create-github-app').then(m => m.default)));
 }
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -60,11 +60,7 @@ export function registerCommands(program: CommanderStatic) {
     .helpOption(', --backstage-cli-help') // Let docker handle --help
     .option('--build', 'Build packages before packing them into the image')
     .description(
-      // TODO: Add example use cases in Backstage documentation.
-      // For example, if a $NPM_TOKEN needs to be exposed, run `backend:build-image --secret
-      // id=NPM_TOKEN,src=/NPM_TOKEN.txt`.
-      'Bundles the package into a docker image. All extra args are forwarded to ' +
-        '`docker image build`.',
+      'Bundles the package into a docker image. This command is deprecated and will be removed.',
     )
     .action(lazy(() => import('./backend/buildImage').then(m => m.default)));
 


### PR DESCRIPTION
Some CLI housekeeping. The `backend:bundle` command has been around for a long time now and seen widespread use, so confident in deprecating the old `backend:build-image` command.

The `create-github-app` command has been around for a long time now, although hidden in the CLI help it's been documented and has likely seen use too, although afaik we don't have any clear feedback on it. If we want to rename it I feel we should do that now, and otherwise just ship as is.