### PR TITLE
Add CLI output and README how to start app after create-app CLI

### DIFF
--- a/.changeset/seven-ligers-watch.md
+++ b/.changeset/seven-ligers-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Add CLI output and README how to start app after create-app CLI

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -9,14 +9,14 @@ You can use the flag `--skip-install` to skip the install.
 With `npx`:
 
 ```sh
-$ npx @backstage/create-app
+npx @backstage/create-app
 ```
 
 With a local clone of this repo, from the main `create-app/` folder, run:
 
 ```sh
-$ yarn
-$ yarn backstage-create-app
+yarn install
+yarn backstage-create-app
 ```
 
 ## Documentation

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -15,6 +15,7 @@ $ npx @backstage/create-app
 With a local clone of this repo, from the main `create-app/` folder, run:
 
 ```sh
+$ yarn
 $ yarn backstage-create-app
 ```
 

--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -148,6 +148,7 @@ export default async (cmd: Command): Promise<void> => {
     );
     Task.log();
     Task.section('All set! Now you might want to');
+    Task.log(`  Run the app: ${chalk.cyan(`cd ${answers.name} && yarn dev`)}`);
     Task.log(
       '  Set up the software catalog: https://backstage.io/docs/features/software-catalog/configuration',
     );

--- a/packages/create-app/templates/default-app/README.md
+++ b/packages/create-app/templates/default-app/README.md
@@ -5,6 +5,6 @@ This is your newly scaffolded Backstage App, Good Luck!
 To start the app, run:
 
 ```sh
-$ yarn
-$ yarn dev
+yarn install
+yarn dev
 ```

--- a/packages/create-app/templates/default-app/README.md
+++ b/packages/create-app/templates/default-app/README.md
@@ -1,3 +1,10 @@
 # [Backstage](https://backstage.io)
 
 This is your newly scaffolded Backstage App, Good Luck!
+
+To start the app, run:
+
+```sh
+$ yarn
+$ yarn dev
+```


### PR DESCRIPTION
While getting started with Backstage, I noticed one break in the chain where a user would likely switch from the terminal to the documentation again. Outputting the immediate next step in the CLI output and adding the same in the template README decreases the time to get someone started 👍 

New CLI output below (notice the `Run the app:`):

<img width="693" alt="Screenshot 2021-06-01 at 23 50 06" src="https://user-images.githubusercontent.com/1255508/120395523-6b8cba80-c335-11eb-8b3d-1fae4b5ce821.png">

