### PR TITLE
Remove the trailing space from a the aria-label of the Template "CHOOSE" button

### DIFF
--- a/.changeset/cyan-weeks-lie.md
+++ b/.changeset/cyan-weeks-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Remove the trailing space from a the aria-label of the Template "CHOOSE" button.

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -182,7 +182,7 @@ export const TemplateCard = ({ template, deprecated }: TemplateCardProps) => {
         <Button
           color="primary"
           to={href}
-          aria-label={`Choose ${templateProps.title} `}
+          aria-label={`Choose ${templateProps.title}`}
         >
           Choose
         </Button>


### PR DESCRIPTION
I was happy that I this label exists and we can use it in an e2e test. But the trailing space doesn't seem to belong there.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
