### PR TITLE
cli: exclude core packages from package dependency diff

### DIFF
--- a/.changeset/early-colts-stare.md
+++ b/.changeset/early-colts-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Exclude core packages from package dependency diff.

--- a/packages/cli/src/lib/diff/handlers.ts
+++ b/packages/cli/src/lib/diff/handlers.ts
@@ -172,6 +172,11 @@ class PackageJsonHandler {
       if (this.variant === 'app' && key.startsWith('plugin-')) {
         continue;
       }
+      // Skip checking of the core packages, since we're migrating over
+      if (key.startsWith('@backstage/core')) {
+        continue;
+      }
+
       await this.syncField(key, pkgDeps, targetDeps, fieldName);
     }
   }


### PR DESCRIPTION
Making the `@backstage/core` migration a bit easier by getting rid of this check.