### PR TITLE
Allow configurable number of taskworkers

### DIFF
--- a/.changeset/seven-badgers-marry.md
+++ b/.changeset/seven-badgers-marry.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': minor
 ---
 
-This adds a configuration option to the scaffolder plugin router, so we can allow for multiple taskworkers. Currently with only one taskworker you are limited to scaffolding one thing at a time. Set the `taskWorkers?: number` option in your scaffolder router to get more than 1 taskworker
+This adds a configuration option to the scaffolder plugin router, so we can allow for multiple TaskWorkers. Currently with only one TaskWorker you are limited to scaffolding one thing at a time. Set the `taskWorkers?: number` option in your scaffolder router to get more than 1 TaskWorker

--- a/.changeset/seven-badgers-marry.md
+++ b/.changeset/seven-badgers-marry.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
-This adds a configuration option to the scaffolder plugin router, so we can allow for multiple TaskWorkers. Currently with only one TaskWorker you are limited to scaffolding one thing at a time. Set the `taskWorkers?: number` option in your scaffolder router to get more than 1 TaskWorker
+This adds a configuration option to the scaffolder plugin router, so we can allow for multiple `TaskWorkers`. Currently with only one `TaskWorker` you are limited to scaffolding one thing at a time. Set the `taskWorkers?: number` option in your scaffolder router to get more than 1 `TaskWorker`

--- a/.changeset/seven-badgers-marry.md
+++ b/.changeset/seven-badgers-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+This adds a configuration option to the scaffolder plugin router, so we can allow for multiple taskworkers. Currently with only one taskworker you are limited to scaffolding one thing at a time. Set the `taskWorkers?: number` option in your scaffolder router to get more than 1 taskworker

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -241,10 +241,6 @@ supertype
 talkdesk
 Talkdesk
 tasklist
-taskworker
-Taskworker
-taskworkers
-Taskworkers
 techdocs
 Telenor
 templated

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -241,6 +241,10 @@ supertype
 talkdesk
 Talkdesk
 tasklist
+taskworker
+Taskworker
+taskworkers
+Taskworkers
 techdocs
 Telenor
 templated

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -105,16 +105,16 @@ export async function createRouter(
   );
   const taskBroker = new StorageTaskBroker(databaseTaskStore, logger);
   const actionRegistry = new TemplateActionRegistry();
-  const workers = new Array(taskWorkers || 1);
-  workers.map(_ => {
+  const workers = [];
+  for (let i = 0; i < (taskWorkers || 1); i++) {
     const worker = new TaskWorker({
       logger,
       taskBroker,
       actionRegistry,
       workingDirectory,
     });
-    return worker;
-  });
+    workers.push(worker);
+  }
 
   const actionsToRegister = Array.isArray(actions)
     ? actions


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Right now we are limited to one taskworker in the scaffolder backend
which means you can only scaffold one thing at a time. This is a poor
user experience for larger organizations where multiple users maybe
scaffolding at the same time.

This adds an optional configuration option to increase the number
of taskworkers via the router options if you like, but defaults to
1 if not set.

Fixes #5889 
Signed-off-by: jrusso1020 <jrusso@brex.com>

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
