### PR TITLE
Reworking the Tech Radar plugin to provide easier API to fetch your own data

### DIFF
--- a/.changeset/proud-bottles-dream.md
+++ b/.changeset/proud-bottles-dream.md
@@ -2,4 +2,31 @@
 '@backstage/plugin-tech-radar': minor
 ---
 
-Migrating the Tech Radar to support using `ApiRefs` to go fetch data
+Migrating the Tech Radar to support using `ApiRefs` to load custom data.
+
+If you had a `getData` function, you'll now need to encapsulate that logic in a class that can override the `techRadarApiRef`.
+
+```ts
+// app/src/lib/MyClient.ts
+import {
+  TechRadarApi,
+  TechRadarLoaderResponse,
+} from '@backstage/plugin-tech-radar';
+
+class MyOwnClient implements TechRadarApi {
+  async load(): Promise<TechRadarLoaderResponse> {
+    // here's where you would put you logic to load the response that was previously passed into getData
+  }
+}
+
+// app/src/apis.ts
+import { MyOwnClient } from './lib/MyClient';
+import { techRadarApiRef } from '@backstage/plugin-tech-radar';
+
+export const apis: AnyApiFactory[] = [
+  /*
+  ...
+  */
+  createApiFactory(techRadarApiRef, new MyOwnClient()),
+];
+```

--- a/.changeset/proud-bottles-dream.md
+++ b/.changeset/proud-bottles-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': minor
+---
+
+Migrating the Tech Radar to support using `ApiRefs` to go fetch data

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -34,13 +34,6 @@ import {
   GraphQLEndpoints,
 } from '@backstage/plugin-graphiql';
 
-import { techRadarApiRef, TechRadarApi } from '@backstage/plugin-tech-radar';
-
-class MyOwnClient implements TechRadarApi {
-  async load() {
-    throw new Error('blah');
-  }
-}
 export const apis: AnyApiFactory[] = [
   createApiFactory({
     api: scmIntegrationsApiRef,
@@ -68,6 +61,4 @@ export const apis: AnyApiFactory[] = [
   }),
 
   createApiFactory(costInsightsApiRef, new ExampleCostInsightsClient()),
-
-  createApiFactory(),
 ];

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -34,6 +34,13 @@ import {
   GraphQLEndpoints,
 } from '@backstage/plugin-graphiql';
 
+import { techRadarApiRef, TechRadarApi } from '@backstage/plugin-tech-radar';
+
+class MyOwnClient implements TechRadarApi {
+  async load() {
+    throw new Error('blah');
+  }
+}
 export const apis: AnyApiFactory[] = [
   createApiFactory({
     api: scmIntegrationsApiRef,
@@ -61,4 +68,6 @@ export const apis: AnyApiFactory[] = [
   }),
 
   createApiFactory(costInsightsApiRef, new ExampleCostInsightsClient()),
+
+  createApiFactory(),
 ];

--- a/plugins/tech-radar/README.md
+++ b/plugins/tech-radar/README.md
@@ -60,7 +60,6 @@ export type TechRadarPageProps = TechRadarComponentProps & {
 export interface TechRadarPageProps {
   width: number;
   height: number;
-  getData?: () => Promise<TechRadarLoaderResponse>;
   svgProps?: object;
 }
 ```

--- a/plugins/tech-radar/README.md
+++ b/plugins/tech-radar/README.md
@@ -72,36 +72,35 @@ export interface TechRadarPageProps {
 
 ### How do I load in my own data?
 
-It's simple, you can pass through a `getData` prop which expects a `Promise<TechRadarLoaderResponse>` signature.
+The `TechRadar` plugin uses the `TechRadarApiRef` to get a client which implements the `TechRadarApi` interface. The default sample one is located here: https://github.com/backstage/backstage/blob/master/plugins/tech-radar/src/sample.ts. To load your own data, you'll need to provide a class that implements the `TechRadarApi` and override the `TechRadarApiRef` in the `app/src/apis.ts`.
 
-Here's an example:
+```ts
+// app/src/lib/MyClient.ts
+import {
+  TechRadarApi,
+  TechRadarLoaderResponse,
+} from '@backstage/plugin-tech-radar';
 
-```tsx
-const getHardCodedData = () =>
-  Promise.resolve({
-    quadrants: [{ id: 'infrastructure', name: 'Infrastructure' }],
-    rings: [{ id: 'use', name: 'USE', color: '#93c47d' }],
-    entries: [
-      {
-        url: '#',
-        key: 'github-actions',
-        id: 'github-actions',
-        title: 'GitHub Actions',
-        quadrant: 'infrastructure',
-        timeline: [
-          {
-            moved: 0,
-            ringId: 'use',
-            date: new Date('2020-08-06'),
-            description:
-              'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat',
-          },
-        ],
-      },
-    ],
-  });
+class MyOwnClient implements TechRadarApi {
+  async load(): Promise<TechRadarLoaderResponse> {
+    const data = await fetch('https://mydata.json').then(res => res.json());
 
-<TechRadarComponent width={1400} height={800} getData={getHardCodedData} />;
+    // maybe you'll need to do some data transformation here to make it look like TechRadarLoaderResponse
+
+    return data;
+  }
+}
+
+// app/src/apis.ts
+import { MyOwnClient } from './lib/MyClient';
+import { techRadarApiRef } from '@backstage/plugin-tech-radar';
+
+export const apis: AnyApiFactory[] = [
+  /*
+  ...
+  */
+  createApiFactory(techRadarApiRef, new MyOwnClient()),
+];
 ```
 
 ### How do I write tests?

--- a/plugins/tech-radar/README.md
+++ b/plugins/tech-radar/README.md
@@ -72,7 +72,7 @@ export interface TechRadarPageProps {
 
 ### How do I load in my own data?
 
-The `TechRadar` plugin uses the `TechRadarApiRef` to get a client which implements the `TechRadarApi` interface. The default sample one is located here: https://github.com/backstage/backstage/blob/master/plugins/tech-radar/src/sample.ts. To load your own data, you'll need to provide a class that implements the `TechRadarApi` and override the `TechRadarApiRef` in the `app/src/apis.ts`.
+The `TechRadar` plugin uses the `techRadarApiRef` to get a client which implements the `TechRadarApi` interface. The default sample one is located [here](https://github.com/backstage/backstage/blob/master/plugins/tech-radar/src/sample.ts). To load your own data, you'll need to provide a class that implements the `TechRadarApi` and override the `techRadarApiRef` in the `app/src/apis.ts`.
 
 ```ts
 // app/src/lib/MyClient.ts

--- a/plugins/tech-radar/src/api.ts
+++ b/plugins/tech-radar/src/api.ts
@@ -15,6 +15,17 @@
  */
 
 import { MovedState } from './utils/types';
+import { createApiRef } from '@backstage/core';
+
+export const techRadarApiRef = createApiRef<TechRadarApi>({
+  id: 'plugin.techradar.service',
+  description: 'Used to populate data in the TechRadar plugin',
+});
+
+export interface TechRadarApi {
+  // Loads the TechRadar response data to pass through to the TechRadar component
+  load: () => Promise<TechRadarLoaderResponse>;
+}
 
 /**
  * Types related to the Radar's visualization.
@@ -65,16 +76,5 @@ export interface TechRadarLoaderResponse {
 export interface TechRadarComponentProps {
   width: number;
   height: number;
-  getData?: () => Promise<TechRadarLoaderResponse>;
   svgProps?: object;
-}
-
-/**
- * Set up the Radar as a Backstage plugin.
- */
-
-export interface TechRadarApi extends TechRadarComponentProps {
-  title?: string;
-  subtitle?: string;
-  pageTitle?: string;
 }

--- a/plugins/tech-radar/src/components/RadarComponent.tsx
+++ b/plugins/tech-radar/src/components/RadarComponent.tsx
@@ -15,38 +15,35 @@
  */
 
 import React, { useEffect } from 'react';
-import { Progress, useApi, errorApiRef, ErrorApi } from '@backstage/core';
+import { Progress, useApi, errorApiRef } from '@backstage/core';
 import { useAsync } from 'react-use';
 import Radar from '../components/Radar';
-import { TechRadarComponentProps, TechRadarLoaderResponse } from '../api';
-import getSampleData from '../sampleData';
+import {
+  techRadarApiRef,
+  TechRadarComponentProps,
+  TechRadarLoaderResponse,
+} from '../api';
 import { Entry } from '../utils/types';
 
-const useTechRadarLoader = (props: TechRadarComponentProps) => {
-  const errorApi = useApi<ErrorApi>(errorApiRef);
+const useTechRadarLoader = () => {
+  const errorApi = useApi(errorApiRef);
+  const techRadarApi = useApi(techRadarApiRef);
 
-  const { getData } = props;
-
-  const state = useAsync(async () => {
-    if (getData) {
-      const response: TechRadarLoaderResponse = await getData();
-      return response;
-    }
-    return undefined;
-  }, [getData, errorApi]);
+  const { error, value, loading } = useAsync(async () => techRadarApi.load(), [
+    techRadarApi,
+  ]);
 
   useEffect(() => {
-    const { error } = state;
     if (error) {
       errorApi.post(error);
     }
-  }, [errorApi, state]);
+  }, [error, errorApi]);
 
-  return state;
+  return { loading, value, error };
 };
 
 const RadarComponent = (props: TechRadarComponentProps): JSX.Element => {
-  const { loading, error, value: data } = useTechRadarLoader(props);
+  const { loading, error, value: data } = useTechRadarLoader();
 
   const mapToEntries = (
     loaderResponse: TechRadarLoaderResponse | undefined,
@@ -87,10 +84,6 @@ const RadarComponent = (props: TechRadarComponentProps): JSX.Element => {
       )}
     </>
   );
-};
-
-RadarComponent.defaultProps = {
-  getData: getSampleData,
 };
 
 export default RadarComponent;

--- a/plugins/tech-radar/src/plugin.ts
+++ b/plugins/tech-radar/src/plugin.ts
@@ -18,7 +18,11 @@ import {
   createPlugin,
   createRouteRef,
   createRoutableExtension,
+  createApiFactory,
 } from '@backstage/core';
+
+import { techRadarApiRef } from './api';
+import { SampleTechRadarApi } from './sample';
 
 const rootRouteRef = createRouteRef({
   title: 'Tech Radar',
@@ -29,6 +33,7 @@ export const techRadarPlugin = createPlugin({
   routes: {
     root: rootRouteRef,
   },
+  apis: [createApiFactory(techRadarApiRef, new SampleTechRadarApi())],
 });
 
 export const TechRadarPage = techRadarPlugin.provide(

--- a/plugins/tech-radar/src/sample.ts
+++ b/plugins/tech-radar/src/sample.ts
@@ -19,6 +19,7 @@ import {
   RadarQuadrant,
   RadarEntry,
   TechRadarLoaderResponse,
+  TechRadarApi,
 } from './api';
 
 const rings = new Array<RadarRing>();
@@ -164,15 +165,19 @@ entries.push({
   ],
   url: '#',
   key: 'github-actions',
-  id: 'github-actions',
-  title: 'GitHub Actions',
+  id: 'github-actiosns',
+  title: 'GitHub Acssstions',
   quadrant: 'infrastructure',
 });
 
-export default function getSampleData(): Promise<TechRadarLoaderResponse> {
-  return Promise.resolve({
-    rings,
-    quadrants,
-    entries,
-  });
+export const mock: TechRadarLoaderResponse = {
+  entries,
+  quadrants,
+  rings,
+};
+
+export class SampleTechRadarApi implements TechRadarApi {
+  async load() {
+    return mock;
+  }
 }

--- a/plugins/tech-radar/src/sample.ts
+++ b/plugins/tech-radar/src/sample.ts
@@ -165,8 +165,8 @@ entries.push({
   ],
   url: '#',
   key: 'github-actions',
-  id: 'github-actiosns',
-  title: 'GitHub Acssstions',
+  id: 'github-actions',
+  title: 'GitHub Actions',
   quadrant: 'infrastructure',
 });
 


### PR DESCRIPTION
Signed-off-by: blam <ben@blam.sh>

## Hey, I just made a Pull Request!

The `TechRadar` plugin needs a little bit of love :heart:, It's was one of the first plugins that was moved into Backstage and the ecosystem has moved on without it.

This enables the ability to implement your own `TechRadarApi` which has a `load` promise on there to go fetch your data from wherever rather than the `prop` injection which was causing all sorts of issues for people.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
