### PR TITLE
Avoid constraint problems when migrating to the new processing engine

### DIFF
--- a/.changeset/cuddly-trees-give.md
+++ b/.changeset/cuddly-trees-give.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Avoid constraint problems when migrating to the new processing engine.
+
+This is done by emptying the `entities` table, which is unused in the new code. For most users this is safe to do, since in a rollback scenario this table would be re-populated at startup by processing through all of the registered locations again. However, if you have been adding entities by directly posting to the `/entities` endpoint of the catalog, then those entities _will_ be lost as part of this migration.

--- a/plugins/catalog-backend/migrationsv2/20210302150147_refresh_state.js
+++ b/plugins/catalog-backend/migrationsv2/20210302150147_refresh_state.js
@@ -193,6 +193,7 @@ exports.up = async function up(knex) {
   });
 
   // Delete bootstrap location which is no longer required.
+  await knex('entities').del();
   await knex('locations')
     .where({ type: 'bootstrap', target: 'bootstrap' })
     .delete();


### PR DESCRIPTION
Context: https://github.com/backstage/backstage/issues/5869#issuecomment-853245380

Considered dropping the constraint itself, but there's no need really before we do the cleanup migration that also drops the tables etc.