### PR TITLE
core-api,core-plugin-api: make RouteRef* types forwards and backwards compatible

### DIFF
--- a/.changeset/little-eggs-change.md
+++ b/.changeset/little-eggs-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Made the deprecated `icon` fields compatible with the `IconComponent` type from `@backstage/core` in order to smooth out the migration.

--- a/.changeset/unlucky-lemons-sip.md
+++ b/.changeset/unlucky-lemons-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-api': patch
+---
+
+Made the `RouteRef*` types compatible with the ones exported from `@backstage/core-plugin-api`.

--- a/packages/core-api/package.json
+++ b/packages/core-api/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@backstage/config": "^0.1.4",
+    "@backstage/core-plugin-api": "^0.1.0",
     "@backstage/theme": "^0.2.6",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/packages/core-api/src/routing/types.ts
+++ b/packages/core-api/src/routing/types.ts
@@ -16,6 +16,7 @@
 
 import { IconComponent } from '../icons/types';
 import { getOrCreateGlobalSingleton } from '../lib/globalObject';
+import { RouteRef as NewRouteRef } from '@backstage/core-plugin-api';
 
 export type AnyParams = { [param in string]: string } | undefined;
 export type ParamKeys<Params extends AnyParams> = keyof Params extends never
@@ -34,7 +35,11 @@ export type RouteFunc<Params extends AnyParams> = (
   ...[params]: Params extends undefined ? readonly [] : readonly [Params]
 ) => string;
 
-export const routeRefType: unique symbol = getOrCreateGlobalSingleton<any>(
+type RouteRefType = Exclude<
+  keyof NewRouteRef,
+  'params' | 'path' | 'title' | 'icon'
+>;
+export const routeRefType: RouteRefType = getOrCreateGlobalSingleton<any>(
   'route-ref-type',
   () => Symbol('route-ref-type'),
 );

--- a/packages/core-plugin-api/package.json
+++ b/packages/core-plugin-api/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@backstage/config": "^0.1.3",
     "@backstage/theme": "^0.2.3",
+    "@material-ui/core": "^4.11.0",
     "@types/react": "^16.9",
     "history": "^5.0.0",
     "prop-types": "^15.7.2",

--- a/packages/core-plugin-api/src/icons/types.ts
+++ b/packages/core-plugin-api/src/icons/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { ComponentType } from 'react';
+import { SvgIconProps } from '@material-ui/core';
 
 /**
  * IconComponent is the common icon type used throughout Backstage when
@@ -31,3 +32,10 @@ import { ComponentType } from 'react';
 export type IconComponent = ComponentType<{
   fontSize?: 'default' | 'small' | 'large';
 }>;
+
+/**
+ * This exists for backwards compatibility with the old core package.
+ * It's used in some parts of this package in order to smooth out the
+ * migration, but it is not exported.
+ */
+export type OldIconComponent = ComponentType<SvgIconProps>;

--- a/packages/core-plugin-api/src/routing/RouteRef.ts
+++ b/packages/core-plugin-api/src/routing/RouteRef.ts
@@ -21,13 +21,13 @@ import {
   ParamKeys,
   OptionalParams,
 } from './types';
-import { IconComponent } from '../icons/types';
+import { OldIconComponent } from '../icons/types';
 
 // TODO(Rugvip): Remove this in the next breaking release, it's exported but unused
 export type RouteRefConfig<Params extends AnyParams> = {
   params?: ParamKeys<Params>;
   path?: string;
-  icon?: IconComponent;
+  icon?: OldIconComponent;
   title: string;
 };
 
@@ -40,7 +40,7 @@ export class RouteRefImpl<Params extends AnyParams>
     readonly params: ParamKeys<Params>,
     private readonly config: {
       path?: string;
-      icon?: IconComponent;
+      icon?: OldIconComponent;
       title?: string;
     },
   ) {}
@@ -79,7 +79,7 @@ export function createRouteRef<
   /** @deprecated Route refs no longer decide their own path */
   path?: string;
   /** @deprecated Route refs no longer decide their own icon */
-  icon?: IconComponent;
+  icon?: OldIconComponent;
   /** @deprecated Route refs no longer decide their own title */
   title?: string;
 }): RouteRef<OptionalParams<Params>> {

--- a/packages/core-plugin-api/src/routing/types.ts
+++ b/packages/core-plugin-api/src/routing/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IconComponent } from '../icons/types';
+import { OldIconComponent } from '../icons/types';
 import { getOrCreateGlobalSingleton } from '../lib/globalObject';
 
 export type AnyParams = { [param in string]: string } | undefined;
@@ -48,7 +48,7 @@ export type RouteRef<Params extends AnyParams = any> = {
   /** @deprecated paths are no longer accessed directly from RouteRefs, use useRouteRef instead */
   path: string;
   /** @deprecated icons are no longer accessed via RouteRefs */
-  icon?: IconComponent;
+  icon?: OldIconComponent;
   /** @deprecated titles are no longer accessed via RouteRefs */
   title?: string;
 };


### PR DESCRIPTION
Some code migration required quite a lot of things to be migrated in lockstep because of incompatible `RouteRef*` types between the new and old core libraries. This fixes that by making the types compatible.