### PR TITLE
catalog/next: Keep bootstrap location

### DIFF
--- a/.changeset/tender-months-count.md
+++ b/.changeset/tender-months-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Skip deletion of bootstrap location when running the new catalog.

--- a/plugins/catalog-backend/migrationsv2/20210302150147_refresh_state.js
+++ b/plugins/catalog-backend/migrationsv2/20210302150147_refresh_state.js
@@ -191,11 +191,6 @@ exports.up = async function up(knex) {
     table.index(['key'], 'search_key_idx');
     table.index(['value'], 'search_value_idx');
   });
-
-  // Delete bootstrap location which is no longer required.
-  await knex('locations')
-    .where({ type: 'bootstrap', target: 'bootstrap' })
-    .delete();
 };
 
 /**


### PR DESCRIPTION

## Hey, I just made a Pull Request!

Keep the bootstrap location in the locations table in order to flip back and forth between the new and old catalog. 

There's no problem keeping the bootstrap location in the locations table and later do a migration that clean up all old tables when everything is functioning as expected.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
