### PR TITLE
Export createScaffolderFieldExtension to enable the creation of new field extensions

### DIFF
--- a/.changeset/quick-dancers-approve.md
+++ b/.changeset/quick-dancers-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Export createScaffolderFieldExtension to enable the creation of new field extensions

--- a/.changeset/quick-dancers-approve.md
+++ b/.changeset/quick-dancers-approve.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Export createScaffolderFieldExtension to enable the creation of new field extensions
+Export `createScaffolderFieldExtension` to enable the creation of new field extensions.

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -16,7 +16,10 @@
 
 export { scaffolderApiRef, ScaffolderClient } from './api';
 export type { ScaffolderApi } from './api';
-export { ScaffolderFieldExtensions } from './extensions';
+export {
+  createScaffolderFieldExtension,
+  ScaffolderFieldExtensions,
+} from './extensions';
 export {
   EntityPickerFieldExtension,
   OwnerPickerFieldExtension,


### PR DESCRIPTION
I wanted to try to add a new field extension but the `createScaffolderFieldExtension` could not be called outside of the scaffolder plugin.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
