### PR TITLE
Feat: Pull the app.title from config and replace " | Backstage"

### DIFF
--- a/.changeset/famous-rockets-share.md
+++ b/.changeset/famous-rockets-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+use app.title for helmet in header

--- a/packages/core/src/layout/Header/Header.test.tsx
+++ b/packages/core/src/layout/Header/Header.test.tsx
@@ -33,7 +33,7 @@ describe('<Header/>', () => {
   it('should set document title', async () => {
     const rendered = await renderInTestApp(<Header title="Title1" />);
     rendered.getByText('Title1');
-    rendered.getByText('defaultTitle: Title1 | Backstage');
+    rendered.getByText('defaultTitle: Title1 | Backstage Example App');
   });
 
   it('should override document title', async () => {
@@ -41,7 +41,7 @@ describe('<Header/>', () => {
       <Header title="Title1" pageTitleOverride="Title2" />,
     );
     rendered.getByText('Title1');
-    rendered.getByText('defaultTitle: Title2 | Backstage');
+    rendered.getByText('defaultTitle: Title2 | Backstage Example App');
   });
 
   it('should have subtitle', async () => {

--- a/packages/core/src/layout/Header/Header.tsx
+++ b/packages/core/src/layout/Header/Header.tsx
@@ -18,6 +18,7 @@ import { BackstageTheme } from '@backstage/theme';
 import { makeStyles, Tooltip, Typography } from '@material-ui/core';
 import React, { CSSProperties, PropsWithChildren, ReactNode } from 'react';
 import { Helmet } from 'react-helmet';
+import { useApi, configApiRef } from '@backstage/core-api';
 import { Link } from '../../components/Link';
 import { Breadcrumbs } from '../Breadcrumbs';
 
@@ -189,8 +190,12 @@ export const Header = ({
   const classes = useStyles();
   const documentTitle = pageTitleOverride || title;
   const pageTitle = title || pageTitleOverride;
-  const titleTemplate = `${documentTitle} | %s | Backstage`;
-  const defaultTitle = `${documentTitle} | Backstage`;
+  const configApi = useApi(configApiRef);
+  const appTitle = configApi.has('app.title')
+    ? configApi.getString('app.title')
+    : 'Backstage';
+  const titleTemplate = `${documentTitle} | %s | ${appTitle}`;
+  const defaultTitle = `${documentTitle} | ${appTitle}`;
 
   return (
     <>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- pulls the app.title from config and replaces " | Backstage"
- this was the suggested edit https://discord.com/channels/687207715902193673/687207715902193679/748494668697698334

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<img width="272" alt="backstage-tab-title" src="https://user-images.githubusercontent.com/3435674/120751110-1388bc00-c4cd-11eb-8f2f-8bcd07b3f599.png">

