### PR TITLE
Feat: Pull the app.title from config and replace " | Backstage"

### DIFF
--- a/.changeset/famous-rockets-share.md
+++ b/.changeset/famous-rockets-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Use app.title for helmet in header

--- a/packages/core-components/src/layout/Header/Header.test.tsx
+++ b/packages/core-components/src/layout/Header/Header.test.tsx
@@ -17,6 +17,12 @@
 import React from 'react';
 import { renderInTestApp } from '@backstage/test-utils';
 import { Header } from './Header';
+import {
+  ApiRegistry,
+  ConfigReader,
+  ApiProvider,
+} from '@backstage/core-app-api';
+import { configApiRef } from '@backstage/core-plugin-api';
 
 jest.mock('react-helmet', () => {
   return {
@@ -63,5 +69,18 @@ describe('<Header/>', () => {
       <Header title="Title" type="tool" typeLink="/tool" />,
     );
     rendered.getAllByText('Title');
+  });
+
+  it('should use app.title', async () => {
+    const apiRegistry = ApiRegistry.with(
+      configApiRef,
+      new ConfigReader({ app: { title: 'Blah' } }),
+    );
+    const rendered = await renderInTestApp(
+      <ApiProvider apis={apiRegistry}>
+        <Header title="Title" type="tool" typeLink="/tool" />,
+      </ApiProvider>,
+    );
+    rendered.getAllByText(/Title | Blah/);
   });
 });

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import { BackstageTheme } from '@backstage/theme';
 import { makeStyles, Tooltip, Typography } from '@material-ui/core';
 import React, { CSSProperties, PropsWithChildren, ReactNode } from 'react';
@@ -187,10 +188,12 @@ export const Header = ({
   typeLink,
 }: PropsWithChildren<Props>) => {
   const classes = useStyles();
+  const configApi = useApi(configApiRef);
+  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
   const documentTitle = pageTitleOverride || title;
   const pageTitle = title || pageTitleOverride;
-  const titleTemplate = `${documentTitle} | %s | Backstage`;
-  const defaultTitle = `${documentTitle} | Backstage`;
+  const titleTemplate = `${documentTitle} | %s | ${appTitle}`;
+  const defaultTitle = `${documentTitle} | ${appTitle}`;
 
   return (
     <>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- pulls the app.title from config and replaces " | Backstage"
- this was the suggested edit https://discord.com/channels/687207715902193673/687207715902193679/748494668697698334

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<img width="272" alt="backstage-tab-title" src="https://user-images.githubusercontent.com/3435674/120751110-1388bc00-c4cd-11eb-8f2f-8bcd07b3f599.png">

