### PR TITLE
fix example template

### DIFF
--- a/plugins/scaffolder-backend/sample-templates/v1beta2-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/v1beta2-demo/template.yaml
@@ -35,7 +35,7 @@ spec:
           description: System of the component
           ui:field: EntityPicker
           ui:options:
-            allowedKinds: 
+            allowedKinds:
               - System
             defaultKind: System
             
@@ -60,6 +60,7 @@ spec:
         values:
           name: '{{ parameters.name }}'
           owner: '{{ parameters.owner }}'
+          system: '{{#if parameters.system }}{{ parameters.system }}{{/if}}'
           destination: '{{ parseRepoUrl parameters.repoUrl }}'
 
     - id: fetch-docs

--- a/plugins/scaffolder-backend/sample-templates/v1beta2-demo/template/catalog-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/v1beta2-demo/template/catalog-info.yaml
@@ -7,6 +7,6 @@ spec:
   type: website
   lifecycle: experimental
   owner: {{cookiecutter.owner | jsonify}}
-{%- if cookiecutter.backstage_system != "" %}
+{%- if cookiecutter.system != "" %}
   system: {{ cookiecutter.system | jsonify }}
 {%- endif %}


### PR DESCRIPTION
In #5730 I broke the example template because I used to wrong field name in the cookiecutter template.
But I also have to pass in the system, which is optional. Not guarding it in an if block lets the handlebar template crash because it is running in strict mode. Further discussion on that is here: https://github.com/backstage/backstage/pull/5849#discussion_r644895406.

No changeset, as the example is not part of the released package.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
