### PR TITLE
cost-insights: move canvas package to dev deps

### DIFF
--- a/.changeset/cyan-suns-chew.md
+++ b/.changeset/cyan-suns-chew.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Move `canvas` package to `devDependencies`.

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -39,7 +39,6 @@
     "@material-ui/styles": "^4.9.6",
     "@types/react": "^16.9",
     "@types/recharts": "^1.8.14",
-    "canvas": "^2.6.1",
     "classnames": "^2.2.6",
     "dayjs": "^1.9.4",
     "history": "^5.0.0",
@@ -67,6 +66,7 @@
     "@types/recharts": "^1.8.14",
     "@types/regression": "^2.0.0",
     "@types/yup": "^0.29.8",
+    "canvas": "^2.6.1",
     "cross-fetch": "^3.0.6",
     "msw": "^0.21.2"
   },


### PR DESCRIPTION
It's been there since the initial release as it used to not have any impact in our internal repo, but here it matters a lot :grin:

As far as I can tell this is only used to make the canvas APIs available in the jsdom environment during jest tests.
