### PR TITLE
docs: added example dockerfiles for techdocs and templating

### DIFF
--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -270,3 +270,10 @@ docker image.
 If you are running Backstage from a Docker container and you want to avoid
 calling a container inside a container, you can set up Cookiecutter in your own
 image, this will use the local installation instead.
+
+You can do so by including the following lines in the last step of your `Dockerfile`:
+
+```Dockerfile
+RUN apt-get update && apt-get install -y python3 python3-pip
+RUN pip3 install cookiecutter
+```

--- a/docs/features/software-templates/installation.md
+++ b/docs/features/software-templates/installation.md
@@ -271,7 +271,8 @@ If you are running Backstage from a Docker container and you want to avoid
 calling a container inside a container, you can set up Cookiecutter in your own
 image, this will use the local installation instead.
 
-You can do so by including the following lines in the last step of your `Dockerfile`:
+You can do so by including the following lines in the last step of your
+`Dockerfile`:
 
 ```Dockerfile
 RUN apt-get update && apt-get install -y python3 python3-pip

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -213,10 +213,19 @@ environment is compatible with techdocs.
 
 You will have to install the `mkdocs` and `mkdocs-techdocs-core` package from
 pip, as well as `graphviz` and `plantuml` from your OS package manager (e.g.
-apt). See our
+apt). 
+
+
+You can do so by including the following lines in the last step of your `Dockerfile`:
+
+```Dockerfile
+RUN apt-get update && apt-get install -y python3 python3-pip
+RUN pip3 install mkdocs-techdocs-core==0.0.16
+```
+
+Please be aware that the version requirement could change, you need to check our
 [`Dockerfile`](https://github.com/backstage/techdocs-container/blob/main/Dockerfile)
-for the latest requirements. You should be trying to match your `Dockerfile`
-with this one.
+and make sure to match with it.
 
 Note: We recommend Python version 3.7 or higher.
 

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -213,10 +213,10 @@ environment is compatible with techdocs.
 
 You will have to install the `mkdocs` and `mkdocs-techdocs-core` package from
 pip, as well as `graphviz` and `plantuml` from your OS package manager (e.g.
-apt). 
+apt).
 
-
-You can do so by including the following lines in the last step of your `Dockerfile`:
+You can do so by including the following lines in the last step of your
+`Dockerfile`:
 
 ```Dockerfile
 RUN apt-get update && apt-get install -y python3 python3-pip


### PR DESCRIPTION
Heyo - as agreed on Discord (I believe it was with @benjdlambert), I have included code snippets for both the Tech Docs and Software Template's Dockerfile, in order to make it easier for people like myself to get their way around wordings :).

I'm a bit unsure about the wording on the TechDoc part, but I'm open to suggestions for that :).

TechDoc:
![image](https://user-images.githubusercontent.com/9394141/120836449-dfada500-c565-11eb-8673-ff9fcf7c402d.png)

Software Template:
![image](https://user-images.githubusercontent.com/9394141/120836637-1388ca80-c566-11eb-9196-e3e0b30af578.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

