### PR TITLE
Remove default upgrade-insecure-requests

### DIFF
--- a/.changeset/hip-trees-heal.md
+++ b/.changeset/hip-trees-heal.md
@@ -2,9 +2,9 @@
 '@backstage/backend-common': patch
 ---
 
-Omit the `upgrade-insecure-requests` Content-Security-Policy directive by default, to prevent automatic HTTPS request upgrading for HTTP-deployed Backstage sites.
+Omits the `upgrade-insecure-requests` Content-Security-Policy directive by default, to prevent automatic HTTPS request upgrading for HTTP-deployed Backstage sites.
 
-If you previously disable this using `false` in your `app-config.yaml`, this line is no longer necessary:
+If you previously disabled this using `false` in your `app-config.yaml`, this line is no longer necessary:
 
 ```diff
 backend:
@@ -12,10 +12,12 @@ backend:
 -    upgrade-insecure-requests: false
 ```
 
-But if you want to keep the existing behavior of `upgrade-insecure-requests` Content-Security-Policy being enabled, make the following change in your `app-config.yaml`. You can read more the CSP here https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests
+To keep the existing behavior of `upgrade-insecure-requests` Content-Security-Policy being _enabled_, add the key with an empty array as the value in your `app-config.yaml`:
 
 ```diff
 backend:
 +  csp:
 +    upgrade-insecure-requests: []
 ```
+
+Read more on [upgrade-insecure-requests here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests).

--- a/.changeset/hip-trees-heal.md
+++ b/.changeset/hip-trees-heal.md
@@ -1,0 +1,13 @@
+---
+'@backstage/backend-common': patch
+---
+
+Omit the `upgrade-insecure-requests` Content-Security-Policy directive by default, to prevent automatic HTTPS request upgrading for HTTP-deployed Backstage sites.
+
+If you previously disable this using `false` in your `app-config.yaml`, this line is no longer necessary:
+
+```diff
+backend:
+  csp:
+-    upgrade-insecure-requests: false
+```

--- a/.changeset/hip-trees-heal.md
+++ b/.changeset/hip-trees-heal.md
@@ -11,3 +11,11 @@ backend:
   csp:
 -    upgrade-insecure-requests: false
 ```
+
+But if you want to keep the existing behavior of `upgrade-insecure-requests` Content-Security-Policy being enabled, make the following change in your `app-config.yaml`. You can read more the CSP here https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests
+
+```diff
+backend:
++  csp:
++    upgrade-insecure-requests: []
+```

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -37,6 +37,8 @@ backend:
     credentials: true
   csp:
     connect-src: ["'self'", 'http:', 'https:']
+    # Other Content-Security-Policy directives can be added according to the Helmet format:
+    # https://helmetjs.github.io/#reference
   reading:
     allow:
       - host: example.com

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -37,8 +37,8 @@ backend:
     credentials: true
   csp:
     connect-src: ["'self'", 'http:', 'https:']
-    # Other Content-Security-Policy directives can be added according to the Helmet format:
-    # https://helmetjs.github.io/#reference
+    # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
+    # Default Helmet Content-Security-Policy values can be removed by setting the key to false
   reading:
     allow:
       - host: example.com

--- a/contrib/docs/tutorials/help-im-behind-a-corporate-proxy.md
+++ b/contrib/docs/tutorials/help-im-behind-a-corporate-proxy.md
@@ -80,6 +80,4 @@ backend:
     origin: https://your-public-url.com:3000
 ```
 
-If the protocol is `http`, you will need to set `backend.csp.upgrade-insecure-requests` to `false` as well.
-
 The app port must proxy web socket connections in order to make hot reloading work.

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -55,7 +55,6 @@ const DEFAULT_CSP = {
   'script-src': ["'self'", "'unsafe-eval'"],
   'script-src-attr': ["'none'"],
   'style-src': ["'self'", 'https:', "'unsafe-inline'"],
-  'upgrade-insecure-requests': [] as string[],
 };
 
 export class ServiceBuilderImpl implements ServiceBuilder {

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -11,6 +11,8 @@ backend:
     port: 7000
   csp:
     connect-src: ["'self'", 'http:', 'https:']
+    # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
+    # Default Helmet Content-Security-Policy values can be removed by setting the key to false
   cors:
     origin: http://localhost:3000
     methods: [GET, POST, PUT, DELETE]


### PR DESCRIPTION
Removes `upgrade-insecure-requests` from the default Content-Security-Policy. This pops up frequently in Discord, and issues such as #3279 and #3817.

This can be re-enabled if desired in the normal Helmet way:

```ts
upgrade-insecure-requests: []
```

We elected not to include this an example, since it's a known-troublesome example, and instead just linked to the Helmet docs in a comment.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
