### PR TITLE
Fix proxy redirect for base path without slash

### DIFF
--- a/.changeset/wild-wasps-turn.md
+++ b/.changeset/wild-wasps-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-proxy-backend': patch
+---
+
+Fixed proxy requests to the base URL of routes without a trailing slash redirecting to the `target` with the full path appended.

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -74,7 +74,7 @@ describe('buildMiddleware', () => {
     expect(filter('', { method: 'PATCH', headers: {} })).toBe(true);
     expect(filter('', { method: 'DELETE', headers: {} })).toBe(true);
 
-    expect(fullConfig.pathRewrite).toEqual({ '^/proxy/test/': '/' });
+    expect(fullConfig.pathRewrite).toEqual({ '^/proxy/test/?': '/' });
     expect(fullConfig.changeOrigin).toBe(true);
     expect(fullConfig.logProvider!(logger)).toBe(logger);
   });
@@ -94,7 +94,7 @@ describe('buildMiddleware', () => {
     expect(filter('', { method: 'PATCH', headers: {} })).toBe(true);
     expect(filter('', { method: 'DELETE', headers: {} })).toBe(true);
 
-    expect(fullConfig.pathRewrite).toEqual({ '^/proxy/test/': '/' });
+    expect(fullConfig.pathRewrite).toEqual({ '^/proxy/test/?': '/' });
     expect(fullConfig.changeOrigin).toBe(true);
     expect(fullConfig.logProvider!(logger)).toBe(logger);
   });
@@ -114,7 +114,7 @@ describe('buildMiddleware', () => {
     expect(filter('', { method: 'PATCH', headers: {} })).toBe(true);
     expect(filter('', { method: 'DELETE', headers: {} })).toBe(true);
 
-    expect(fullConfig.pathRewrite).toEqual({ '^/proxy/test/': '/' });
+    expect(fullConfig.pathRewrite).toEqual({ '^/proxy/test/?': '/' });
     expect(fullConfig.changeOrigin).toBe(true);
     expect(fullConfig.logProvider!(logger)).toBe(logger);
   });
@@ -137,7 +137,7 @@ describe('buildMiddleware', () => {
     expect(filter('', { method: 'PATCH', headers: {} })).toBe(false);
     expect(filter('', { method: 'DELETE', headers: {} })).toBe(true);
 
-    expect(fullConfig.pathRewrite).toEqual({ '^/proxy/test/': '/' });
+    expect(fullConfig.pathRewrite).toEqual({ '^/proxy/test/?': '/' });
     expect(fullConfig.changeOrigin).toBe(true);
     expect(fullConfig.logProvider!(logger)).toBe(logger);
   });

--- a/plugins/proxy-backend/src/service/router.ts
+++ b/plugins/proxy-backend/src/service/router.ts
@@ -95,8 +95,12 @@ export function buildMiddleware(
       routeWithSlash = routeWithSlash.substring(1);
     }
 
+    // The ? makes the slash optional for the rewrite, so that a base path without an ending slash
+    // will also be matched (e.g. '/sample' and then requesting just '/api/proxy/sample' without an
+    // ending slash). Otherwise the target gets called with the full '/api/proxy/sample' path
+    // appended.
     fullConfig.pathRewrite = {
-      [`^${pathPrefix}${routeWithSlash}`]: '/',
+      [`^${pathPrefix}${routeWithSlash}?`]: '/',
     };
   }
 


### PR DESCRIPTION
Fixes #5932.

The `proxy-backend` router was constructing a `pathRewrite` that always had an ending slash, so requesting the base path without a slash appended the full path to the target.

Given a proxy configuration of:
```yaml
proxy:
  '/sample': http://localhost:7000/api/scaffolder
```

Requests would be resolved as follows:

```
# Base route, incorrect result
http://localhost:7000/api/proxy/sample -> http://localhost:7000/api/scaffolder/api/proxy/sample

# Added slash, correct result
http://localhost:7000/api/proxy/sample/ -> http://localhost:7000/api/scaffolder

# More path, correct result
http://localhost:7000/api/proxy/sample/asdf -> http://localhost:7000/api/scaffolder/asdf
```

I **thought** adding the `?` would introduce a problem with paths that the route is a substring of, such that you might get:

```
http://localhost:7000/api/proxy/samplefoo -> http://localhost:7000/api/scaffolder/foo
```

But this doesn't happen 🤔  I'm not entirely sure why.. the more strict, verbose alternative was to match the path without a trailing slash _only exactly_:

```ts
fullConfig.pathRewrite = {
  [`^(${pathPrefix}${routeWithSlash}|${pathPrefix}${route}^)`]: '/',
};
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
