### PR TITLE
fix: add missing token on job list call to Github API

### DIFF
--- a/.changeset/heavy-terms-vanish.md
+++ b/.changeset/heavy-terms-vanish.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-github-actions': patch
 ---
 
-Add missing token on job list call to Github API
+`Add missing token on job list call to GitHub API

--- a/.changeset/heavy-terms-vanish.md
+++ b/.changeset/heavy-terms-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-actions': patch
+---
+
+Add missing token on job list call to Github API

--- a/.changeset/heavy-terms-vanish.md
+++ b/.changeset/heavy-terms-vanish.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-github-actions': patch
 ---
 
-`Add missing token on job list call to GitHub API
+Add missing token on job list call to GitHub API

--- a/packages/app/src/components/catalog/EntityPage.test.tsx
+++ b/packages/app/src/components/catalog/EntityPage.test.tsx
@@ -44,6 +44,7 @@ describe('EntityPage Test', () => {
     getWorkflow: jest.fn(),
     getWorkflowRun: jest.fn(),
     reRunWorkflow: jest.fn(),
+    listJobsForWorkflowRun: jest.fn(),
     downloadJobLogsForWorkflowRun: jest.fn(),
   } as jest.Mocked<typeof githubActionsApiRef.T>;
 

--- a/plugins/github-actions/src/api/GithubActionsApi.ts
+++ b/plugins/github-actions/src/api/GithubActionsApi.ts
@@ -77,6 +77,23 @@ export type GithubActionsApi = {
     repo: string;
     runId: number;
   }) => Promise<any>;
+  listJobsForWorkflowRun: ({
+    hostname,
+    owner,
+    repo,
+    id,
+    pageSize,
+    page,
+  }: {
+    hostname?: string;
+    owner: string;
+    repo: string;
+    id: number;
+    pageSize?: number;
+    page?: number;
+  }) => Promise<
+    RestEndpointMethodTypes['actions']['listJobsForWorkflowRun']['response']['data']
+  >;
   downloadJobLogsForWorkflowRun: ({
     hostname,
     owner,

--- a/plugins/github-actions/src/api/GithubActionsClient.ts
+++ b/plugins/github-actions/src/api/GithubActionsClient.ts
@@ -128,6 +128,33 @@ export class GithubActionsClient implements GithubActionsApi {
     });
     return run.data;
   }
+  async listJobsForWorkflowRun({
+    hostname,
+    owner,
+    repo,
+    id,
+    pageSize = 100,
+    page = 0,
+  }: {
+    hostname?: string;
+    owner: string;
+    repo: string;
+    id: number;
+    pageSize?: number;
+    page?: number;
+  }): Promise<
+    RestEndpointMethodTypes['actions']['listJobsForWorkflowRun']['response']['data']
+  > {
+    const octokit = await this.getOctokit(hostname);
+    const jobs = await octokit.actions.listJobsForWorkflowRun({
+      owner,
+      repo,
+      run_id: id,
+      per_page: pageSize,
+      page,
+    });
+    return jobs.data;
+  }
   async downloadJobLogsForWorkflowRun({
     hostname,
     owner,

--- a/plugins/github-actions/src/api/types.ts
+++ b/plugins/github-actions/src/api/types.ts
@@ -29,7 +29,7 @@ export type Job = {
   conclusion: string;
   started_at: string;
   completed_at: string;
-  id: string;
+  id: number;
   name: string;
   steps: Step[];
 };

--- a/plugins/github-actions/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunDetails/WorkflowRunDetails.tsx
@@ -168,7 +168,7 @@ export const WorkflowRunDetails = ({ entity }: { entity: Entity }) => {
   )[0].host;
   const [owner, repo] = projectName.value ? projectName.value.split('/') : [];
   const details = useWorkflowRunsDetails({ hostname, owner, repo });
-  const jobs = useWorkflowRunJobs(details.value?.jobs_url);
+  const jobs = useWorkflowRunJobs({ hostname, owner, repo });
 
   const error = projectName.error || (projectName.value && details.error);
   const classes = useStyles();

--- a/plugins/github-actions/src/components/WorkflowRunDetails/useWorkflowRunJobs.ts
+++ b/plugins/github-actions/src/components/WorkflowRunDetails/useWorkflowRunJobs.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useAsync } from 'react-use';
-import { useApi, useRouteRefParams } from '@backstage/core-api';
+import { useApi, useRouteRefParams } from '@backstage/core';
 import { githubActionsApiRef } from '../../api';
 import { buildRouteRef } from '../../routes';
 

--- a/plugins/github-actions/src/components/WorkflowRunDetails/useWorkflowRunJobs.ts
+++ b/plugins/github-actions/src/components/WorkflowRunDetails/useWorkflowRunJobs.ts
@@ -14,19 +14,30 @@
  * limitations under the License.
  */
 import { useAsync } from 'react-use';
-import { Jobs } from '../../api/types';
+import { useApi, useRouteRefParams } from '@backstage/core-api';
+import { githubActionsApiRef } from '../../api';
+import { buildRouteRef } from '../../routes';
 
-export const useWorkflowRunJobs = (jobsUrl?: string) => {
-  const jobs = useAsync(async (): Promise<Jobs> => {
-    if (jobsUrl === undefined) {
-      return {
-        total_count: 0,
-        jobs: [],
-      };
-    }
-
-    const data = await fetch(jobsUrl).then(d => d.json());
-    return data;
-  }, [jobsUrl]);
+export const useWorkflowRunJobs = ({
+  hostname,
+  owner,
+  repo,
+}: {
+  hostname?: string;
+  owner: string;
+  repo: string;
+}) => {
+  const api = useApi(githubActionsApiRef);
+  const { id } = useRouteRefParams(buildRouteRef);
+  const jobs = useAsync(async () => {
+    return repo && owner
+      ? api.listJobsForWorkflowRun({
+          hostname,
+          owner,
+          repo,
+          id: parseInt(id, 10),
+        })
+      : Promise.reject('No repo/owner provided');
+  }, [repo, owner, id]);
   return jobs;
 };

--- a/plugins/github-actions/src/components/WorkflowRunLogs/WorkflowRunLogs.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunLogs/WorkflowRunLogs.tsx
@@ -106,7 +106,7 @@ export const WorkflowRunLogs = ({
   inProgress,
 }: {
   entity: Entity;
-  runId: string;
+  runId: number;
   inProgress: boolean;
 }) => {
   const config = useApi(configApiRef);

--- a/plugins/github-actions/src/components/WorkflowRunLogs/useDownloadWorkflowRunLogs.ts
+++ b/plugins/github-actions/src/components/WorkflowRunLogs/useDownloadWorkflowRunLogs.ts
@@ -27,7 +27,7 @@ export const useDownloadWorkflowRunLogs = ({
   hostname?: string;
   owner: string;
   repo: string;
-  id: string;
+  id: number;
 }) => {
   const api = useApi(githubActionsApiRef);
   const details = useAsync(async () => {
@@ -36,7 +36,7 @@ export const useDownloadWorkflowRunLogs = ({
           hostname,
           owner,
           repo,
-          runId: parseInt(id, 10),
+          runId: id,
         })
       : Promise.reject('No repo/owner provided');
   }, [repo, owner, id]);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes https://github.com/backstage/backstage/issues/5819 by adding a proper method to get a Github Actions workflow run jobs to github client in `github-actions` plugin instead of previously used unauthorized `fetch`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
