### PR TITLE
Fix/cli error formatting

### DIFF
--- a/.changeset/sour-brooms-dream.md
+++ b/.changeset/sour-brooms-dream.md
@@ -1,0 +1,9 @@
+---
+'@backstage/cli': patch
+---
+
+Fix error message formatting in the packaging process.
+
+error.errors can be undefined which will lead to a TypeError, swallowing the actual error message in the process.
+
+For instance, if you break your tsconfig.json with invalid syntax, backstage-cli will not be able to build anything and it will be very hard to find out why because the underlying error message is hidden behind a TypeError.

--- a/packages/cli/src/lib/builder/packager.test.ts
+++ b/packages/cli/src/lib/builder/packager.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatErrorMessage } from './packager';
+
+describe('formatErrorMessage with esbuild plugin error', () => {
+  it('given error with missing errors array then error message should be shown', () => {
+    const msg = formatErrorMessage({
+      code: 'PLUGIN_ERROR',
+      plugin: 'esbuild',
+      message: 'test',
+    });
+    expect(msg).toBe('test\n\n');
+  });
+});

--- a/packages/cli/src/lib/builder/packager.test.ts
+++ b/packages/cli/src/lib/builder/packager.test.ts
@@ -23,6 +23,16 @@ describe('formatErrorMessage with esbuild plugin error', () => {
       plugin: 'esbuild',
       message: 'test',
     });
-    expect(msg).toBe('test\n\n');
+    expect(msg).toBe('test');
+  });
+  it('given error with errors array then error message should have new lines', () => {
+    const msg = formatErrorMessage({
+      code: 'PLUGIN_ERROR',
+      plugin: 'esbuild',
+      message: 'test',
+      id: 'index.js',
+      errors: [{ text: 'Dummy', location: { line: 1, column: 1 } }],
+    });
+    expect(msg).toContain('test\n\n');
   });
 });

--- a/packages/cli/src/lib/builder/packager.ts
+++ b/packages/cli/src/lib/builder/packager.ts
@@ -27,8 +27,9 @@ export function formatErrorMessage(error: any) {
 
   if (error.code === 'PLUGIN_ERROR') {
     if (error.plugin === 'esbuild') {
-      msg += `${error.message}\n\n`;
-      if (error.errors) {
+      msg += `${error.message}`;
+      if (error.errors?.length) {
+        msg += `\n\n`;
         for (const { text, location } of error.errors) {
           const { line, column } = location;
           const path = relativePath(paths.targetDir, error.id);

--- a/packages/cli/src/lib/builder/packager.ts
+++ b/packages/cli/src/lib/builder/packager.ts
@@ -22,7 +22,7 @@ import { paths } from '../paths';
 import { makeConfigs } from './config';
 import { BuildOptions } from './types';
 
-function formatErrorMessage(error: any) {
+export function formatErrorMessage(error: any) {
   let msg = '';
 
   if (error.code === 'PLUGIN_ERROR') {

--- a/packages/cli/src/lib/builder/packager.ts
+++ b/packages/cli/src/lib/builder/packager.ts
@@ -28,15 +28,17 @@ function formatErrorMessage(error: any) {
   if (error.code === 'PLUGIN_ERROR') {
     if (error.plugin === 'esbuild') {
       msg += `${error.message}\n\n`;
-      for (const { text, location } of error.errors) {
-        const { line, column } = location;
-        const path = relativePath(paths.targetDir, error.id);
-        const loc = chalk.cyan(`${path}:${line}:${column}`);
+      if (error.errors) {
+        for (const { text, location } of error.errors) {
+          const { line, column } = location;
+          const path = relativePath(paths.targetDir, error.id);
+          const loc = chalk.cyan(`${path}:${line}:${column}`);
 
-        if (text === 'Unexpected "<"' && error.id.endsWith('.js')) {
-          msg += `${loc}: ${text}, JavaScript files with JSX should use a .jsx extension`;
-        } else {
-          msg += `${loc}: ${text}`;
+          if (text === 'Unexpected "<"' && error.id.endsWith('.js')) {
+            msg += `${loc}: ${text}, JavaScript files with JSX should use a .jsx extension`;
+          } else {
+            msg += `${loc}: ${text}`;
+          }
         }
       }
     } else {


### PR DESCRIPTION
error.errors can be undefined which will lead to a TypeError, swallowing the actual error message in the process

Signed-off-by: Max Falk <gmdfalk@gmail.com>

## Hey, I just made a Pull Request!

Before, actual error message does not get displayed:
<img width="686" alt="before" src="https://user-images.githubusercontent.com/279131/120937233-ae230e00-c70c-11eb-812b-7e60a87ca57a.png">

After, error message is shown:
<img width="674" alt="after" src="https://user-images.githubusercontent.com/279131/120937226-a9f6f080-c70c-11eb-9a0a-af50cf9763a2.png">

You can reproduce/verify this issue by modifying the tsconfig.json in the backstage root directory with invalid syntax. `yarn build` will then always spit out a useless error message about error.errors. Spent too many hours tracking this down ...

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
