### PR TITLE
catalog-import: Display prepareResult in final step

### DIFF
--- a/.changeset/real-bulldogs-greet.md
+++ b/.changeset/real-bulldogs-greet.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-client': patch
+'@backstage/plugin-catalog-import': patch
+---
+
+Display preview result final step.

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -134,12 +134,6 @@ export class CatalogClient implements CatalogApi {
       throw new Error(`Location wasn't added: ${target}`);
     }
 
-    // TODO(jhaals): This will throw using the experimental catalog since all discovered entities are deferred.
-    if (entities.length === 0) {
-      throw new Error(
-        `Location was added but has no entities specified yet: ${target}`,
-      );
-    }
     return {
       location,
       entities,

--- a/plugins/catalog-import/src/components/ImportStepper/defaults.tsx
+++ b/plugins/catalog-import/src/components/ImportStepper/defaults.tsx
@@ -328,7 +328,7 @@ export const defaultStepper: StepperProvider = {
     stepLabel: <StepLabel>Finish</StepLabel>,
     content: (
       <StepFinishImportLocation
-        reviewResult={state.reviewResult}
+        prepareResult={state.prepareResult}
         onReset={state.onReset}
       />
     ),

--- a/plugins/catalog-import/src/components/StepFinishImportLocation/StepFinishImportLocation.tsx
+++ b/plugins/catalog-import/src/components/StepFinishImportLocation/StepFinishImportLocation.tsx
@@ -20,25 +20,25 @@ import LocationOnIcon from '@material-ui/icons/LocationOn';
 import React from 'react';
 import { BackButton } from '../Buttons';
 import { EntityListComponent } from '../EntityListComponent';
-import { ReviewResult } from '../useImportState';
+import { PrepareResult } from '../useImportState';
 
 type Props = {
-  reviewResult: ReviewResult;
+  prepareResult: PrepareResult;
   onReset: () => void;
 };
 
-export const StepFinishImportLocation = ({ reviewResult, onReset }: Props) => (
+export const StepFinishImportLocation = ({ prepareResult, onReset }: Props) => (
   <>
-    {reviewResult.type === 'repository' && (
+    {prepareResult.type === 'repository' && (
       <>
         <Typography paragraph>
           The following Pull Request has been opened:{' '}
           <Link
-            to={reviewResult.pullRequest.url}
+            to={prepareResult.pullRequest.url}
             target="_blank"
             rel="noreferrer"
           >
-            {reviewResult.pullRequest.url}
+            {prepareResult.pullRequest.url}
           </Link>
         </Typography>
 
@@ -53,7 +53,7 @@ export const StepFinishImportLocation = ({ reviewResult, onReset }: Props) => (
     </Typography>
 
     <EntityListComponent
-      locations={reviewResult.locations}
+      locations={prepareResult.locations}
       locationListItemIcon={() => <LocationOnIcon />}
       withLinks
     />

--- a/plugins/catalog-import/src/components/useImportState.test.tsx
+++ b/plugins/catalog-import/src/components/useImportState.test.tsx
@@ -127,7 +127,7 @@ describe('useImportState', () => {
         activeState: 'finish',
         analyzeResult: locationAP,
         prepareResult: locationAP,
-        reviewResult: locationR,
+        reviewResult: locationAP,
       });
 
       act(() => result.current.onReset());
@@ -138,8 +138,8 @@ describe('useImportState', () => {
         analysisUrl: undefined,
         activeState: 'analyze',
         analyzeResult: undefined,
-        prepareResult: undefined,
-        reviewResult: locationR,
+        prepareResult: locationR,
+        reviewResult: undefined,
       });
     });
 

--- a/plugins/catalog-import/src/components/useImportState.ts
+++ b/plugins/catalog-import/src/components/useImportState.ts
@@ -227,9 +227,9 @@ function reducer(state: ReducerState, action: ReducerActions): ReducerState {
       return {
         ...init(action.initialUrl),
 
-        // we keep the old reviewResult since the form is animated and an
+        // we keep the old prepareResult since the form is animated and an
         // undefined value might crash the last step.
-        reviewResult: state.reviewResult,
+        prepareResult: state.prepareResult,
       };
 
     default:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR updates the catalog-import plugin to display the result from dry run in the final stage.
This is to accommodate for the new catalog which lazily discovers entities from locations when posting locations without the dry-run flag.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
