### PR TITLE
fix: make bitbucket publish action use apiBaseUrl if it is provided

### DIFF
--- a/.changeset/modern-ladybugs-perform.md
+++ b/.changeset/modern-ladybugs-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Scaffolding a repository in Bitbucket will now use the apiBaseUrl if it is provided instead of only the host parameter

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
@@ -37,6 +37,7 @@ describe('publish:bitbucket', () => {
           {
             host: 'hosted.bitbucket.com',
             token: 'thing',
+            apiBaseUrl: 'https://hosted.bitbucket.com/rest/api/1.0',
           },
           {
             host: 'notoken.bitbucket.com',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
@@ -84,6 +84,7 @@ const createBitbucketServerRepository = async (opts: {
   description: string;
   repoVisibility: 'private' | 'public';
   authorization: string;
+  apiBaseUrl?: string;
 }) => {
   const {
     host,
@@ -92,6 +93,7 @@ const createBitbucketServerRepository = async (opts: {
     description,
     authorization,
     repoVisibility,
+    apiBaseUrl,
   } = opts;
 
   let response: Response;
@@ -109,10 +111,8 @@ const createBitbucketServerRepository = async (opts: {
   };
 
   try {
-    response = await fetch(
-      `https://${host}/rest/api/1.0/projects/${owner}/repos`,
-      options,
-    );
+    const baseUrl = apiBaseUrl ? apiBaseUrl : `https://${host}/rest/api/1.0`;
+    response = await fetch(`${baseUrl}/projects/${owner}/repos`, options);
   } catch (e) {
     throw new Error(`Unable to create repository, ${e}`);
   }
@@ -223,6 +223,7 @@ export function createPublishBitbucketAction(options: {
       }
 
       const authorization = getAuthorizationHeader(integrationConfig.config);
+      const apiBaseUrl = integrationConfig.config.apiBaseUrl;
 
       const createMethod =
         host === 'bitbucket.org'
@@ -236,6 +237,7 @@ export function createPublishBitbucketAction(options: {
         repo,
         repoVisibility,
         description,
+        apiBaseUrl,
       });
 
       await initRepoAndPush({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes #5851 by making sure that the apiBaseUrl is used when it is provided.  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
