### PR TITLE
Fix a react warning in `<EntityListComponent>`

### DIFF
--- a/.changeset/nice-spoons-try.md
+++ b/.changeset/nice-spoons-try.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Fix a react warning in `<EntityListComponent>`.

--- a/plugins/catalog-import/src/components/EntityListComponent/EntityListComponent.tsx
+++ b/plugins/catalog-import/src/components/EntityListComponent/EntityListComponent.tsx
@@ -146,11 +146,15 @@ export const EntityListComponent = ({
             <List component="div" disablePadding dense>
               {sortEntities(r.entities).map(entity => (
                 <ListItem
-                  component={withLinks ? EntityRefLink : 'div'}
-                  entityRef={withLinks ? entity : undefined}
-                  button={withLinks as any}
                   key={formatEntityRefTitle(entity)}
                   className={classes.nested}
+                  {...(withLinks
+                    ? {
+                        component: EntityRefLink,
+                        entityRef: entity,
+                        button: withLinks as any,
+                      }
+                    : {})}
                 >
                   <ListItemIcon>{getEntityIcon(entity)}</ListItemIcon>
                   <ListItemText primary={formatEntityRefTitle(entity)} />


### PR DESCRIPTION
`entityRef` should only be passed conditionally if component is present, otherwise React logs a warning/error to console.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
