### PR TITLE
config-loader: bump typescript-json-schema and remove workaround + catalog-model cleanup

### DIFF
--- a/.changeset/sharp-candles-type.md
+++ b/.changeset/sharp-candles-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Removed workaround for breaking change in typescript 4.3 and bump `typescript-json-schema` instead. This should again allow the usage of `@items.visibility <value>` to set the visibility of array items.

--- a/.changeset/thirty-turkeys-sing.md
+++ b/.changeset/thirty-turkeys-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Removed unused `typescript-json-schema` dependency.

--- a/packages/catalog-model/package.json
+++ b/packages/catalog-model/package.json
@@ -35,7 +35,6 @@
     "@types/yup": "^0.29.8",
     "ajv": "^7.0.3",
     "json-schema": "^0.3.0",
-    "typescript-json-schema": "^0.49.0",
     "lodash": "^4.17.15",
     "uuid": "^8.0.0",
     "yup": "^0.29.3"

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -37,7 +37,7 @@
     "fs-extra": "^9.0.0",
     "json-schema": "^0.3.0",
     "json-schema-merge-allof": "^0.8.1",
-    "typescript-json-schema": "^0.49.0",
+    "typescript-json-schema": "^0.50.1",
     "yaml": "^1.9.2",
     "yup": "^0.29.3"
   },

--- a/packages/config-loader/src/lib/schema/collect.test.ts
+++ b/packages/config-loader/src/lib/schema/collect.test.ts
@@ -28,6 +28,15 @@ const mockSchema = {
   },
 };
 
+// We need to load in actual TS libraries when using mock-fs.
+// This lookup is to allow the `typescript` dependency to exist either
+// at top level or inside node_modules of typescript-json-schema
+const typescriptModuleDir = path.dirname(
+  require.resolve('typescript/package.json', {
+    paths: [require.resolve('typescript-json-schema')],
+  }),
+);
+
 describe('collectConfigSchemas', () => {
   afterEach(() => {
     mockFs.restore();
@@ -157,9 +166,7 @@ describe('collectConfigSchemas', () => {
         },
       },
       // TypeScript compilation needs to load some real files inside the typescript dir
-      '../../node_modules/typescript': (mockFs as any).load(
-        '../../node_modules/typescript',
-      ),
+      [typescriptModuleDir]: (mockFs as any).load(typescriptModuleDir),
     });
 
     await expect(collectConfigSchemas(['a', 'b', 'c'])).resolves.toEqual([
@@ -218,9 +225,7 @@ describe('collectConfigSchemas', () => {
         },
       },
       // TypeScript compilation needs to load some real files inside the typescript dir
-      '../../node_modules/typescript': (mockFs as any).load(
-        '../../node_modules/typescript',
-      ),
+      [typescriptModuleDir]: (mockFs as any).load(typescriptModuleDir),
     });
 
     await expect(collectConfigSchemas(['a'])).rejects.toThrow(

--- a/packages/config-loader/src/lib/schema/collect.ts
+++ b/packages/config-loader/src/lib/schema/collect.ts
@@ -168,23 +168,6 @@ function compileTsSchemas(paths: string[]) {
         },
         [path.split(sep).join('/')], // Unix paths are expected for all OSes here
       ) as JsonObject | null;
-
-      // This is a workaround for an API change in TypeScript 4.3 where doc comments no
-      // longer are represented by a single string, but instead an array of objects.
-      // This isn't handled by typescript-json-schema so we do the conversion here instead.
-      value = JSON.parse(JSON.stringify(value), (key, prop) => {
-        if (key === 'visibility' && Array.isArray(prop)) {
-          const text = prop[0]?.text;
-          if (!text) {
-            const propStr = JSON.stringify(prop);
-            throw new Error(
-              `Failed conversion of visibility schema, got ${propStr}`,
-            );
-          }
-          return text;
-        }
-        return prop;
-      });
     } catch (error) {
       if (error.message !== 'type Config not found') {
         throw error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6161,6 +6161,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-13.13.45.tgz#e6676bcca092bae5751d015f074a234d5a82eb63"
   integrity sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow==
 
+"@types/node@^14.14.33":
+  version "14.17.3"
+  resolved "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz#6d327abaa4be34a74e421ed6409a0ae2f47f4c3d"
+  integrity sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -25679,10 +25684,28 @@ typescript-json-schema@^0.49.0:
     typescript "^4.1.3"
     yargs "^16.2.0"
 
+typescript-json-schema@^0.50.1:
+  version "0.50.1"
+  resolved "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.50.1.tgz#48041eb9f6efbdf4ba88c3e3af9433601f7a2b47"
+  integrity sha512-GCof/SDoiTDl0qzPonNEV4CHyCsZEIIf+mZtlrjoD8vURCcEzEfa2deRuxYid8Znp/e27eDR7Cjg8jgGrimBCA==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@types/node" "^14.14.33"
+    glob "^7.1.6"
+    json-stable-stringify "^1.0.1"
+    ts-node "^9.1.1"
+    typescript "~4.2.3"
+    yargs "^16.2.0"
+
 typescript@^4.0.3, typescript@^4.1.3, typescript@~4.1.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+
+typescript@~4.2.3:
+  version "4.2.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 ua-parser-js@^0.7.18:
   version "0.7.28"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,7 +1356,6 @@
     ajv "^7.0.3"
     json-schema "^0.3.0"
     lodash "^4.17.15"
-    typescript-json-schema "^0.49.0"
     uuid "^8.0.0"
     yup "^0.29.3"
 
@@ -1370,7 +1369,6 @@
     ajv "^7.0.3"
     json-schema "^0.3.0"
     lodash "^4.17.15"
-    typescript-json-schema "^0.49.0"
     uuid "^8.0.0"
     yup "^0.29.3"
 
@@ -25672,18 +25670,6 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-json-schema@^0.49.0:
-  version "0.49.0"
-  resolved "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.49.0.tgz#442f6347ca85fb0d9811f217fb0d6537b68734b3"
-  integrity sha512-PumZkTmEE3T8TVyoJU6ZCp3K6VCmCb3Ei6fUaRIuDsIzYtmdJc6jV1D0RyBe5sd5mJ1iB6Zckm4KAKbqXs9oDw==
-  dependencies:
-    "@types/json-schema" "^7.0.6"
-    glob "^7.1.6"
-    json-stable-stringify "^1.0.1"
-    ts-node "^9.1.1"
-    typescript "^4.1.3"
-    yargs "^16.2.0"
-
 typescript-json-schema@^0.50.1:
   version "0.50.1"
   resolved "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.50.1.tgz#48041eb9f6efbdf4ba88c3e3af9433601f7a2b47"
@@ -25697,7 +25683,7 @@ typescript-json-schema@^0.50.1:
     typescript "~4.2.3"
     yargs "^16.2.0"
 
-typescript@^4.0.3, typescript@^4.1.3, typescript@~4.1.3:
+typescript@^4.0.3, typescript@~4.1.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #5912

A fix (kind of) is out for `typescript-json-schema`, so let's rely on that instead of the awkward workaround. Also happens fo fix the issue with setting visibility of array items.

Saw that `catalog-model` also had a dependency on `typescript-json-schema` while at it, which I assume is unintentional, so got rid of it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
