### PR TITLE
Chore/sentry plugin replace timeago for luxon

### DIFF
--- a/.changeset/ninety-horses-rescue.md
+++ b/.changeset/ninety-horses-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sentry': patch
+---
+
+Migrated the package from `timeago.js` to `luxon`. See #4278

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -38,12 +38,12 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
+    "luxon": "^1.27.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",
     "react-sparklines": "^1.7.0",
-    "react-use": "^17.2.4",
-    "timeago.js": "^4.0.2"
+    "react-use": "^17.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "^0.7.0",
@@ -53,6 +53,7 @@
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^13.1.8",
     "@types/jest": "^26.0.7",
+    "@types/luxon": "^1.27.0",
     "@types/node": "^14.14.32",
     "@types/react": "^16.9",
     "cross-fetch": "^3.0.6",

--- a/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
+++ b/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { Table, TableColumn } from '@backstage/core';
 import { SentryIssue } from '../../api';
-import { format } from 'timeago.js';
+import { DateTime } from 'luxon';
 import { ErrorCell } from '../ErrorCell/ErrorCell';
 import { ErrorGraph } from '../ErrorGraph/ErrorGraph';
 
@@ -35,7 +35,8 @@ const columns: TableColumn[] = [
     field: 'firstSeen',
     render: data => {
       const { firstSeen } = data as SentryIssue;
-      return format(firstSeen);
+
+      return DateTime.fromISO(firstSeen).toRelative({ locale: 'en' });
     },
   },
   {
@@ -43,7 +44,7 @@ const columns: TableColumn[] = [
     field: 'lastSeen',
     render: data => {
       const { lastSeen } = data as SentryIssue;
-      return format(lastSeen);
+      return DateTime.fromISO(lastSeen).toRelative({ locale: 'en' });
     },
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6039,6 +6039,11 @@
   resolved "https://registry.npmjs.org/@types/luxon/-/luxon-1.26.5.tgz#843fb705e16e4d2a90847a351b799ea9d879859e"
   integrity sha512-XeQxxRMyJi1znfzHw4CGDLyup/raj84SnjjkI2fDootZPGlB0yqtvlvEIAmzHDa5wiEI5JJevZOWxpcofsaV+A==
 
+"@types/luxon@^1.27.0":
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/@types/luxon/-/luxon-1.27.0.tgz#1e3b5a7f8ca6944349c43498b4442b742c71ab0b"
+  integrity sha512-rr2lNXsErnA/ARtgFn46NtQjUa66cuwZYeo/2K7oqqxhJErhXgHBPyNKCo+pfOC3L7HFwtao8ebViiU9h4iAxA==
+
 "@types/markdown-to-jsx@^6.11.0":
   version "6.11.2"
   resolved "https://registry.npmjs.org/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.2.tgz#05d1aaffbf15be7be12c70535fa4fed65cc7c64f"
@@ -17952,6 +17957,11 @@ luxon@^1.26.0:
   resolved "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz#d3692361fda51473948252061d0f8561df02b578"
   integrity sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==
 
+luxon@^1.27.0:
+  version "1.27.0"
+  resolved "https://registry.npmjs.org/luxon/-/luxon-1.27.0.tgz#ae10c69113d85dab8f15f5e8390d0cbeddf4f00f"
+  integrity sha512-VKsFsPggTA0DvnxtJdiExAucKdAnwbCCNlMM5ENvHlxubqWd0xhZcdb4XgZ7QFNhaRhilXCFxHuoObP5BNA4PA==
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -25185,11 +25195,6 @@ tildify@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz#f205f3674d677ce698b7067a99e949ce03b4754a"
   integrity sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==
-
-timeago.js@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz#724e8c8833e3490676c7bb0a75f5daf20e558028"
-  integrity sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==
 
 timers-browserify@^2.0.4:
   version "2.0.11"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrated the sentry plugin from using `timeago.js` to `luxon` 

See #4278 for more context.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
