### PR TITLE
[jenkins-plugin] Support Jenkins build details for branches that contains slashes

### DIFF
--- a/.changeset/honest-pianos-smell.md
+++ b/.changeset/honest-pianos-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins': patch
+---
+
+Support showing build details for branches with slashes in their names

--- a/plugins/jenkins/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
+++ b/plugins/jenkins/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
@@ -50,7 +50,9 @@ const BuildWithStepsView = () => {
   const projectName = useProjectSlugFromEntity();
   const { branch, buildNumber } = useRouteRefParams(buildRouteRef);
   const classes = useStyles();
-  const buildPath = `${projectName}/${branch}/${buildNumber}`;
+  const buildPath = `${projectName}/${encodeURIComponent(
+    branch,
+  )}/${buildNumber}`;
   const [{ value }] = useBuildWithSteps(buildPath);
 
   return (

--- a/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
+++ b/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.tsx
@@ -118,7 +118,7 @@ const generatedColumns: TableColumn[] = [
         <Link
           component={RouterLink}
           to={generatePath(buildRouteRef.path, {
-            branch: row.source.branchName,
+            branch: encodeURIComponent(row.source.branchName),
             buildNumber: row.buildNumber.toString(),
           })}
         >


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This pull request will add support for showing Jenkins build details for branches with slashes in the branchname.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
