### PR TITLE
catalog-backend: avoid duplication of work due to race conditions in task pickup

### DIFF
--- a/.changeset/gorgeous-pumas-tickle.md
+++ b/.changeset/gorgeous-pumas-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Rely on `SELECT ... FOR UPDATE SKIP LOCKED` where available in order to speed up processing item acquisition and reduce work duplication.


### PR DESCRIPTION
Did a bit of rough benchmarking of this with a minimal mock setup of just a single backend instance and multiple workers polling for tasks.

Using our existing transaction technique across 5 workers polling the DB in a tight loop, only 2 of the workers ended up getting any work to do at all with the rest not able to pick anything up. I'm not quite sure why that is, but either way they got through 2000 rows per second, but with pretty much complete duplication based on a bit of manual inspection of logs, meaning both workers picked up the same task over and over. That is worker 1 and 2 both picking up task A, then both pick up task B, etc.

With `.forUpdate().skipLocked()` introduced, all 5 workers got work distributed to them, at about 2800 rows per second, and without any duplication of work from what I could see.