### PR TITLE
Export catalog components to match docs

### DIFF
--- a/.changeset/chilly-owls-punch.md
+++ b/.changeset/chilly-owls-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Exports `CatalogLayout` and `CreateComponentButton` for catalog customization.

--- a/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogLayout.tsx
@@ -21,7 +21,7 @@ type Props = {
   children?: React.ReactNode;
 };
 
-const CatalogLayout = ({ children }: Props) => {
+export const CatalogLayout = ({ children }: Props) => {
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
 

--- a/plugins/catalog/src/components/CatalogPage/index.ts
+++ b/plugins/catalog/src/components/CatalogPage/index.ts
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export { CatalogLayout } from './CatalogLayout';
 export { CatalogPage } from './CatalogPage';

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -15,8 +15,10 @@
  */
 
 export * from './components/AboutCard';
+export { CatalogLayout } from './components/CatalogPage';
 export { CatalogResultListItem } from './components/CatalogResultListItem';
 export { CatalogTable } from './components/CatalogTable';
+export { CreateComponentButton } from './components/CreateComponentButton';
 export { EntityLayout } from './components/EntityLayout';
 export * from './components/EntityOrphanWarning';
 export { EntityPageLayout } from './components/EntityPageLayout';


### PR DESCRIPTION
Fixes #6028.

Two of the components shown in [Catalog Customization](https://backstage.io/docs/features/software-catalog/catalog-customization) were not exported.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
