### PR TITLE
Migrate from the `command-exists-promise` dependency to `command-exists`

### DIFF
--- a/.changeset/thick-donkeys-carry.md
+++ b/.changeset/thick-donkeys-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Migrate from the `command-exists-promise` dependency to `command-exists`.

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.7.0",
     "@backstage/test-utils": "^0.1.13",
+    "@types/command-exists": "^1.2.0",
     "@types/fs-extra": "^9.0.1",
     "@types/mock-fs": "^4.13.0",
     "@types/supertest": "^2.0.8",

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -41,7 +41,7 @@
     "@types/express": "^4.17.6",
     "@types/git-url-parse": "^9.0.0",
     "azure-devops-node-api": "^10.1.1",
-    "command-exists-promise": "^2.0.2",
+    "command-exists": "^1.2.9",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "cross-fetch": "^3.0.6",

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.test.ts
@@ -18,7 +18,7 @@ const runCommand = jest.fn();
 const commandExists = jest.fn();
 
 jest.mock('./helpers', () => ({ runCommand }));
-jest.mock('command-exists-promise', () => commandExists);
+jest.mock('command-exists', () => commandExists);
 jest.mock('fs-extra');
 
 import { ContainerRunner } from '@backstage/backend-common';

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
@@ -21,7 +21,7 @@ import path from 'path';
 import { runCommand } from './helpers';
 import { TemplaterBase, TemplaterRunOptions } from './types';
 
-const commandExists = require('command-exists-promise');
+const commandExists = require('command-exists');
 
 export class CookieCutter implements TemplaterBase {
   private readonly containerRunner: ContainerRunner;

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
@@ -16,12 +16,11 @@
 
 import { ContainerRunner } from '@backstage/backend-common';
 import { JsonValue } from '@backstage/config';
+import commandExists from 'command-exists';
 import fs from 'fs-extra';
 import path from 'path';
 import { runCommand } from './helpers';
 import { TemplaterBase, TemplaterRunOptions } from './types';
-
-const commandExists = require('command-exists');
 
 export class CookieCutter implements TemplaterBase {
   private readonly containerRunner: ContainerRunner;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9802,11 +9802,6 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-command-exists-promise@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/command-exists-promise/-/command-exists-promise-2.0.2.tgz#7beecc4b218299f3c61fa69a4047aa0b36a64a99"
-  integrity sha512-T6PB6vdFrwnHXg/I0kivM3DqaCGZLjjYSOe0a5WgFKcz1sOnmOeIjnhQPXVXX3QjVbLyTJ85lJkX6lUpukTzaA==
-
 command-exists@^1.2.9:
   version "1.2.9"
   resolved "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,6 +5508,11 @@
   dependencies:
     "@types/color-convert" "*"
 
+"@types/command-exists@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@types/command-exists/-/command-exists-1.2.0.tgz#d97e0ed10097090e4ab0367ed425b0312fad86f3"
+  integrity sha512-ugsxEJfsCuqMLSuCD4PIJkp5Uk2z6TCMRCgYVuhRo5cYQY3+1xXTQkSlPtkpGHuvWMjS2KTeVQXxkXRACMbM6A==
+
 "@types/compression@^1.7.0":
   version "1.7.0"
   resolved "https://registry.npmjs.org/@types/compression/-/compression-1.7.0.tgz#8dc2a56604873cf0dd4e746d9ae4d31ae77b2390"


### PR DESCRIPTION
The scaffolder uses the [`command-exists-promise`](https://www.npmjs.com/package/command-exists-promise) dependency which is a fork of [`command-exists`](https://www.npmjs.com/package/command-exists). While the latter one has >100 Stars and >1.4 million downloads, the former has only 7 stars and 14000 downloads.

I don't see a real reason why one would use the fork since the original one also has native support for the promise api. It is also already used in the `check-docs-quality.js` file. Thus, I would propose to switch to the more common package `command-exists` as I find it a good practice to prefer popular packages.

We would like to change it because FOSSA complains with a lot of strange issues and we hope that we can get rid of them by switching to the other package. However, this might also be an error on FOSSA side. There also seem to be issues in the FOSSA integration in this project, though we can't see any details without being part of the (what seems to be the) CNCF FOSSA account: https://app.fossa.com/projects/custom%2B162%2Fbackstage/refs/branch/master/838f4c779a982b1c1b47231b0903cb81b30e23d7/browse/dependencies/?search=command-exists



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
