### PR TITLE
Make `yarn dev` for backend plugins respect the `PLUGIN_PORT` env var

### DIFF
--- a/.changeset/fast-trees-arrive.md
+++ b/.changeset/fast-trees-arrive.md
@@ -1,0 +1,24 @@
+---
+'@backstage/cli': patch
+---
+
+Make `yarn dev` in newly created backend plugins respect the `PLUGIN_PORT` environment variable.
+
+You can achieve the same in your created backend plugins by making sure to properly call the port and CORS methods on your service builder. Typically in a file named `src/service/standaloneServer.ts` inside your backend plugin package, replace the following:
+
+```ts
+const service = createServiceBuilder(module)
+  .enableCors({ origin: 'http://localhost:3000' })
+  .addRouter('/my-plugin', router);
+```
+
+With something like the following:
+
+```ts
+let service = createServiceBuilder(module)
+  .setPort(options.port)
+  .addRouter('/my-plugin', router);
+if (options.enableCors) {
+  service = service.enableCors({ origin: 'http://localhost:3000' });
+}
+```

--- a/.changeset/pink-llamas-sniff.md
+++ b/.changeset/pink-llamas-sniff.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-app-backend': patch
+'@backstage/plugin-badges-backend': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-code-coverage-backend': patch
+'@backstage/plugin-proxy-backend': patch
+'@backstage/plugin-rollbar-backend': patch
+'@backstage/plugin-search-backend': patch
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Make `yarn dev` respect the `PLUGIN_PORT` environment variable.

--- a/packages/cli/templates/default-backend-plugin/src/service/standaloneServer.ts.hbs
+++ b/packages/cli/templates/default-backend-plugin/src/service/standaloneServer.ts.hbs
@@ -34,9 +34,12 @@ export async function startStandaloneServer(
     logger,
   });
 
-  const service = createServiceBuilder(module)
-    .enableCors({ origin: 'http://localhost:3000' })
+  let service = createServiceBuilder(module)
+    .setPort(options.port)
     .addRouter('/{{id}}', router);
+  if (options.enableCors) {
+    service = service.enableCors({ origin: 'http://localhost:3000' });
+  }
 
   return await service.start().catch(err => {
     logger.error(err);

--- a/plugins/app-backend/src/service/standaloneServer.ts
+++ b/plugins/app-backend/src/service/standaloneServer.ts
@@ -38,7 +38,9 @@ export async function startStandaloneServer(
     appPackageName: 'example-app',
   });
 
-  const service = createServiceBuilder(module).addRouter('', router);
+  const service = createServiceBuilder(module)
+    .setPort(options.port)
+    .addRouter('', router);
 
   return await service.start().catch(err => {
     logger.error(err);

--- a/plugins/badges-backend/src/service/standaloneServer.ts
+++ b/plugins/badges-backend/src/service/standaloneServer.ts
@@ -40,9 +40,12 @@ export async function startStandaloneServer(
 
   const router = await createRouter({ config, discovery });
 
-  const service = createServiceBuilder(module)
-    .enableCors({ origin: 'http://localhost:3000' })
+  let service = createServiceBuilder(module)
+    .setPort(options.port)
     .addRouter('/badges', router);
+  if (options.enableCors) {
+    service = service.enableCors({ origin: 'http://localhost:3000' });
+  }
 
   return await service.start().catch(err => {
     logger.error(err);

--- a/plugins/catalog-backend/src/service/standaloneServer.ts
+++ b/plugins/catalog-backend/src/service/standaloneServer.ts
@@ -63,9 +63,12 @@ export async function startStandaloneServer(
     logger,
     config,
   });
-  const service = createServiceBuilder(module)
-    .enableCors({ origin: 'http://localhost:3000' })
+  let service = createServiceBuilder(module)
+    .setPort(options.port)
     .addRouter('/catalog', router);
+  if (options.enableCors) {
+    service = service.enableCors({ origin: 'http://localhost:3000' });
+  }
   return await service.start().catch(err => {
     logger.error(err);
     process.exit(1);

--- a/plugins/code-coverage-backend/src/service/standaloneServer.ts
+++ b/plugins/code-coverage-backend/src/service/standaloneServer.ts
@@ -61,9 +61,12 @@ export async function startStandaloneServer(
     logger,
   });
 
-  const service = createServiceBuilder(module)
-    .enableCors({ origin: 'http://localhost:3000' })
+  let service = createServiceBuilder(module)
+    .setPort(options.port)
     .addRouter('/code-coverage', router);
+  if (options.enableCors) {
+    service = service.enableCors({ origin: 'http://localhost:3000' });
+  }
 
   return await service.start().catch(err => {
     logger.error(err);

--- a/plugins/proxy-backend/src/service/standaloneServer.ts
+++ b/plugins/proxy-backend/src/service/standaloneServer.ts
@@ -43,9 +43,12 @@ export async function startStandaloneServer(
     logger,
     discovery,
   });
-  const service = createServiceBuilder(module)
-    .enableCors({ origin: 'http://localhost:3000' })
+  let service = createServiceBuilder(module)
+    .setPort(options.port)
     .addRouter('/proxy', router);
+  if (options.enableCors) {
+    service = service.enableCors({ origin: 'http://localhost:3000' });
+  }
 
   logger.debug('Starting application server...');
 

--- a/plugins/rollbar-backend/src/service/standaloneServer.ts
+++ b/plugins/rollbar-backend/src/service/standaloneServer.ts
@@ -38,9 +38,12 @@ export async function startStandaloneServer(
 
   const router = await createRouter({ logger, config });
 
-  const service = createServiceBuilder(module)
-    .enableCors({ origin: 'http://localhost:3000' })
+  let service = createServiceBuilder(module)
+    .setPort(options.port)
     .addRouter('/catalog', router);
+  if (options.enableCors) {
+    service = service.enableCors({ origin: 'http://localhost:3000' });
+  }
 
   return await service.start().catch(err => {
     logger.error(err);

--- a/plugins/search-backend/src/service/standaloneServer.ts
+++ b/plugins/search-backend/src/service/standaloneServer.ts
@@ -44,9 +44,12 @@ export async function startStandaloneServer(
     logger,
   });
 
-  const service = createServiceBuilder(module)
-    .enableCors({ origin: 'http://localhost:3000' })
+  let service = createServiceBuilder(module)
+    .setPort(options.port)
     .addRouter('/search', router);
+  if (options.enableCors) {
+    service = service.enableCors({ origin: 'http://localhost:3000' });
+  }
 
   return await service.start().catch(err => {
     logger.error(err);

--- a/plugins/techdocs-backend/src/service/standaloneServer.ts
+++ b/plugins/techdocs-backend/src/service/standaloneServer.ts
@@ -88,9 +88,12 @@ export async function startStandaloneServer(
     config,
     discovery,
   });
-  const service = createServiceBuilder(module)
-    .enableCors({ origin: 'http://localhost:3000' })
+  let service = createServiceBuilder(module)
+    .setPort(options.port)
     .addRouter('/techdocs', router);
+  if (options.enableCors) {
+    service = service.enableCors({ origin: 'http://localhost:3000' });
+  }
   return await service.start().catch(err => {
     logger.error(err);
     process.exit(1);


### PR DESCRIPTION
These files could do with some restructuring to be better made overall. But this helps to at least unbreak the functionality until we get around to doing that.