### PR TITLE
Use the Backstage `Link` component in the `Button`

### DIFF
--- a/.changeset/honest-rabbits-divide.md
+++ b/.changeset/honest-rabbits-divide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix the link to the documentation page when no owned documents are displayed

--- a/.changeset/yellow-schools-matter.md
+++ b/.changeset/yellow-schools-matter.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/core': patch
+'@backstage/core-components': patch
 ---
 
 Use the Backstage `Link` component in the `Button`

--- a/.changeset/yellow-schools-matter.md
+++ b/.changeset/yellow-schools-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core': patch
+---
+
+Use the Backstage `Link` component in the `Button`

--- a/packages/core-components/src/components/Button/Button.tsx
+++ b/packages/core-components/src/components/Button/Button.tsx
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-import React, { ComponentProps } from 'react';
-import { Button as MaterialButton } from '@material-ui/core';
-import { Link as RouterLink } from 'react-router-dom';
+import {
+  Button as MaterialButton,
+  ButtonProps as MaterialButtonProps,
+} from '@material-ui/core';
+import React from 'react';
+import { Link, LinkProps } from '../Link';
 
-type Props = ComponentProps<typeof MaterialButton> &
-  ComponentProps<typeof RouterLink>;
+type Props = MaterialButtonProps & Omit<LinkProps, 'variant' | 'color'>;
 
 /**
  * Thin wrapper on top of material-ui's Button component
  * Makes the Button to utilise react-router
  */
 export const Button = React.forwardRef<any, Props>((props, ref) => (
-  <MaterialButton ref={ref} component={RouterLink} {...props} />
+  <MaterialButton ref={ref} component={Link} {...props} />
 ));

--- a/packages/core/src/components/Button/Button.tsx
+++ b/packages/core/src/components/Button/Button.tsx
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-import React, { ComponentProps } from 'react';
-import { Button as MaterialButton } from '@material-ui/core';
-import { Link as RouterLink } from 'react-router-dom';
+import {
+  Button as MaterialButton,
+  ButtonProps as MaterialButtonProps,
+} from '@material-ui/core';
+import React from 'react';
+import { Link, LinkProps } from '../Link';
 
-type Props = ComponentProps<typeof MaterialButton> &
-  ComponentProps<typeof RouterLink>;
+type Props = MaterialButtonProps & Omit<LinkProps, 'variant' | 'color'>;
 
 /**
  * Thin wrapper on top of material-ui's Button component
  * Makes the Button to utilise react-router
  */
 export const Button = React.forwardRef<any, Props>((props, ref) => (
-  <MaterialButton ref={ref} component={RouterLink} {...props} />
+  <MaterialButton ref={ref} component={Link} {...props} />
 ));

--- a/plugins/techdocs/src/home/components/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/DocsTable.tsx
@@ -111,7 +111,6 @@ export const DocsTable = ({
           action={
             <Button
               color="primary"
-              href="#"
               to="https://backstage.io/docs/features/techdocs/getting-started"
               variant="contained"
             >


### PR DESCRIPTION
I saw this bug because the docs link in the "Owned Documents" page was broken:
![image](https://user-images.githubusercontent.com/720821/121916041-12a92300-cd34-11eb-97b9-baad9fdf0498.png)

Turned out the `Button` used the original `Link` component from `react-router-dom` that didn't support absolute URLs. I switched to use Backstage's `Link` component instead and fixed the usage on the TechDocs page. I hope this change doesn't break any other link but I didn't find any

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
