### PR TITLE
Use the correct parameter to create a public repository in Bitbucket Server

### DIFF
--- a/.changeset/tough-ravens-change.md
+++ b/.changeset/tough-ravens-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Use the correct parameter to create a public repository in Bitbucket Server.

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/bitbucket.ts
@@ -174,7 +174,7 @@ export class BitbucketPublisher implements PublisherBase {
       body: JSON.stringify({
         name: name,
         description: description,
-        is_private: this.config.repoVisibility === 'private',
+        public: this.config.repoVisibility === 'public',
       }),
       headers: {
         Authorization: this.getAuthorizationHeader(),


### PR DESCRIPTION
The API description is not very descriptive, but the [example response](https://docs.atlassian.com/bitbucket-server/rest/7.13.0/bitbucket-rest.html#idp174) implies that it is called `public: <boolean>`. I tried it manually and it had the correct outcome.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
