### PR TITLE
backend-common: clarify DB connection error

### DIFF
--- a/.changeset/fair-points-grin.md
+++ b/.changeset/fair-points-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Provide a more clear error message when database connection fails.

--- a/packages/backend-common/src/database/SingleConnection.ts
+++ b/packages/backend-common/src/database/SingleConnection.ts
@@ -77,6 +77,12 @@ export class SingleConnectionDatabaseManager {
 
   private async ensureDatabase(database: string) {
     const config = this.config;
-    await ensureDatabaseExists(config, database);
+    try {
+      await ensureDatabaseExists(config, database);
+    } catch (error) {
+      throw new Error(
+        `Failed to connect to the database to make sure that '${database}' exists, ${error}`,
+      );
+    }
   }
 }


### PR DESCRIPTION
The lack of information when failing to connect to the DB during backend startup is a quite common source of confusion, so wrapping up the error with some more context.