### PR TITLE
Describe publish:github scaffolder action fields

### DIFF
--- a/.changeset/honest-parents-join.md
+++ b/.changeset/honest-parents-join.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Describe `publish:github` scaffolder action fields
+
+This change adds a description to the fields with examples of what to input. The
+`collaborators` description is also expanded a bit to make it more clear that
+these are additional compared to access and owner.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -59,6 +59,7 @@ export function createPublishGithubAction(options: {
         properties: {
           repoUrl: {
             title: 'Repository Location',
+            description: `Accepts the format 'github.com?repo=reponame&owner=owner' where 'reponame' is the new repository name and 'owner' is an organization or username`,
             type: 'string',
           },
           description: {
@@ -67,6 +68,7 @@ export function createPublishGithubAction(options: {
           },
           access: {
             title: 'Repository Access',
+            description: `Sets an admin collaborator on the repository. Can either be a user reference different from 'owner' in 'repoUrl' or team reference, eg. 'org/team-name'`,
             type: 'string',
           },
           repoVisibility: {
@@ -81,7 +83,7 @@ export function createPublishGithubAction(options: {
           },
           collaborators: {
             title: 'Collaborators',
-            description: 'Provide users with permissions',
+            description: 'Provide additional users with permissions',
             type: 'array',
             items: {
               type: 'object',


### PR DESCRIPTION
Currently the fields of the `publish:github` action uses some undocumented
conventions in the `repoUrl` and `access` input fields.

This change adds a description to the fields with examples of what to input. The
`collaborators` description is also expanded a bit to make it more clear that
these are additional compared to `access` and `owner`.

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
