### PR TITLE
Use the correct parameter to create a public repository in Bitbucket Server for the v2 templates

### DIFF
--- a/.changeset/healthy-windows-dance.md
+++ b/.changeset/healthy-windows-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Use the correct parameter to create a public repository in Bitbucket Server for the v2 templates

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
@@ -140,7 +140,7 @@ describe('publish:bitbucket', () => {
         'https://hosted.bitbucket.com/rest/api/1.0/projects/owner/repos',
         (req, res, ctx) => {
           expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({ is_private: true, name: 'repo' });
+          expect(req.body).toEqual({ public: false, name: 'repo' });
           return res(
             ctx.status(201),
             ctx.set('Content-Type', 'application/json'),

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
@@ -19,10 +19,10 @@ import {
   BitbucketIntegrationConfig,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
-import { initRepoAndPush } from '../../../stages/publish/helpers';
-import { getRepoSourceDirectory, parseRepoUrl } from './util';
 import fetch from 'cross-fetch';
+import { initRepoAndPush } from '../../../stages/publish/helpers';
 import { createTemplateAction } from '../../createTemplateAction';
+import { getRepoSourceDirectory, parseRepoUrl } from './util';
 
 const createBitbucketCloudRepository = async (opts: {
   owner: string;
@@ -102,7 +102,7 @@ const createBitbucketServerRepository = async (opts: {
     body: JSON.stringify({
       name: repo,
       description: description,
-      is_private: repoVisibility === 'private',
+      public: repoVisibility === 'public',
     }),
     headers: {
       Authorization: authorization,


### PR DESCRIPTION
Same as https://github.com/backstage/backstage/pull/6037, but for the `backstage.io/v1beta2` templates. I didn't recognize that the other code was only used in the old scaffolder templates and not in the new ones. I've only tested it via Postman, but after testing it in Backstage, we noticed that I fixed it in the wrong file...

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
