### PR TITLE
Shorten changeset-generated CHANGELOGs

### DIFF
--- a/.changeset/backstage-changelog.js
+++ b/.changeset/backstage-changelog.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {
+  default: defaultChangelogFunctions,
+} = require('@changesets/cli/changelog');
+
+// Custom CHANGELOG generation for changesets, stolen from here with one minor change:
+// https://github.com/atlassian/changesets/blob/main/packages/cli/src/changelog/index.ts
+async function getDependencyReleaseLine(changesets, dependenciesUpdated) {
+  if (dependenciesUpdated.length === 0) return '';
+
+  const updatedDepenenciesList = dependenciesUpdated.map(
+    dependency => `  - ${dependency.name}@${dependency.newVersion}`,
+  );
+
+  // Return one `Updated dependencies` bullet instead of repeating for each changeset; this
+  // sacrifices the commit shas for brevity.
+  return ['- Updated dependencies', ...updatedDepenenciesList].join('\n');
+}
+
+module.exports = {
+  getReleaseLine: defaultChangelogFunctions.getReleaseLine,
+  getDependencyReleaseLine,
+};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.3.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "./backstage-changelog.js",
   "commit": false,
   "linked": [["*"]],
   "access": "public",


### PR DESCRIPTION
If a package is affected by a changeset, any package that depends on that original package gets a `Updated dependencies` changeset when `changeset version` is run. This creates some [rather noisy](https://github.com/backstage/backstage/pull/6004) CHANGELOGs and releases.

The changeset config allows custom CHANGELOG generation functions; this implements those to reduce the `Updated dependencies` noise by only printing out `Updated dependencies` once instead of once-per-commit-sha.

plugin-api-docs CHANGELOG before:

![changelog-before](https://user-images.githubusercontent.com/556258/122152084-f2559300-ce1d-11eb-9739-4388d7c45b85.png)

plugin-api-docs CHANGELOG after:

![changelog-after](https://user-images.githubusercontent.com/556258/122247619-b6a1e400-ce84-11eb-89af-5c0f0e717eb9.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
