### PR TITLE
Searching for things like "World" in "Hello World." returns no results.

### DIFF
--- a/.changeset/cyan-drinks-dream.md
+++ b/.changeset/cyan-drinks-dream.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search-backend-node': patch
 ---
 
-Searching for things like "World" in "Hello World." returns no results.
+Improved the quality of free text searches in LunrSearchEngine.

--- a/.changeset/cyan-drinks-dream.md
+++ b/.changeset/cyan-drinks-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-node': minor
+---
+
+Searching for things like "World" in "Hello World." returns no results.

--- a/.changeset/cyan-drinks-dream.md
+++ b/.changeset/cyan-drinks-dream.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-search-backend-node': minor
+'@backstage/plugin-search-backend-node': patch
 ---
 
 Searching for things like "World" in "Hello World." returns no results.

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
@@ -191,6 +191,72 @@ describe('LunrSearchEngine', () => {
       });
     });
 
+    it('should perform search query with trailing punctuation and return search results on match (trimming)', async () => {
+      const mockDocuments = [
+        {
+          title: 'testTitle',
+          text: 'Hello World.',
+          location: 'test/location',
+        },
+      ];
+
+      // Mock indexing of 1 document
+      testLunrSearchEngine.index('test-index', mockDocuments);
+
+      // Perform search query
+      const mockedSearchResult = await testLunrSearchEngine.query({
+        term: 'World',
+        filters: {},
+        pageCursor: '',
+      });
+
+      // Should return 1 result as we are mocking the indexing of 1 document with match on the title field
+      expect(mockedSearchResult).toMatchObject({
+        results: [
+          {
+            document: {
+              title: 'testTitle',
+              text: 'Hello World.',
+              location: 'test/location',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should perform search query by similar words and return search results on match (stemming)', async () => {
+      const mockDocuments = [
+        {
+          title: 'testTitle',
+          text: 'Searching',
+          location: 'test/location',
+        },
+      ];
+
+      // Mock indexing of 1 document
+      testLunrSearchEngine.index('test-index', mockDocuments);
+
+      // Perform search query
+      const mockedSearchResult = await testLunrSearchEngine.query({
+        term: 'Search',
+        filters: {},
+        pageCursor: '',
+      });
+
+      // Should return 1 result as we are mocking the indexing of 1 document with match on the title field
+      expect(mockedSearchResult).toMatchObject({
+        results: [
+          {
+            document: {
+              title: 'testTitle',
+              text: 'Searching',
+              location: 'test/location',
+            },
+          },
+        ],
+      });
+    });
+
     it('should perform search query and return search results on match with filters', async () => {
       const mockDocuments = [
         {

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -90,6 +90,10 @@ export class LunrSearchEngine implements SearchEngine {
 
   index(type: string, documents: IndexableDocument[]): void {
     const lunrBuilder = new lunr.Builder();
+
+    lunrBuilder.pipeline.add(lunr.trimmer, lunr.stopWordFilter, lunr.stemmer);
+    lunrBuilder.searchPipeline.add(lunr.stemmer);
+
     // Make this lunr index aware of all relevant fields.
     Object.keys(documents[0]).forEach(field => {
       lunrBuilder.field(field);


### PR DESCRIPTION
Signed-off-by: Kevin <dl_xq@sina.com>

## Hey, I just made a Pull Request!

In [release-2021-06-10.1](https://github.com/backstage/backstage/releases/tag/release-2021-06-10.1), search results are not accurate.

### Current Behavior

- Searching for things like `World` in `Hello World.`: returns empty.
- Searching for things like `World.` in `Hello World.`: returns match for `World`.

### Expected Behavior

- Searching for things like `World` in `Hello World.`: returns match for `World`.

### @backstage Versions

- app
  - @backstage/plugin-search@0.4.0
- backend
  - @backstage/plugin-search-backend@0.2.0
  - @backstage/plugin-search-backend-node@0.2.0

### Reference

Reference resources: https://github.com/olivernn/lunr.js/blob/master/lib/lunr.js#L35.

```js
var lunr = function (config) {
  var builder = new lunr.Builder

  builder.pipeline.add(
    lunr.trimmer,
    lunr.stopWordFilter,
    lunr.stemmer
  )

  builder.searchPipeline.add(
    lunr.stemmer
  )

  config.call(builder, builder)
  return builder.build()
}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
