### PR TITLE
Add topics input to publish:github action

### DIFF
--- a/.changeset/proud-jars-look.md
+++ b/.changeset/proud-jars-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Add a `topics` input to `publish:github` action that can be used to set topics on the repository upon creation.

--- a/.changeset/proud-jars-look.md
+++ b/.changeset/proud-jars-look.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
 Add a `topics` input to `publish:github` action that can be used to set topics on the repository upon creation.

--- a/plugins/scaffolder-backend/src/scaffolder/__mocks__/@octokit/rest/index.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/__mocks__/@octokit/rest/index.ts
@@ -19,6 +19,7 @@ export const mockGithubClient = {
     createInOrg: jest.fn(),
     createForAuthenticatedUser: jest.fn(),
     addCollaborator: jest.fn(),
+    replaceAllTopics: jest.fn(),
   },
   users: {
     getByUsername: jest.fn(),

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -341,6 +341,39 @@ describe('publish:github', () => {
     ]);
   });
 
+  it('should add topics when provided', async () => {
+    mockGithubClient.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+
+    mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    mockGithubClient.repos.replaceAllTopics.mockResolvedValue({
+      data: {
+        names: ['node.js'],
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        topics: ['node.js'],
+      },
+    });
+
+    expect(mockGithubClient.repos.replaceAllTopics).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      names: ['node.js'],
+    });
+  });
+
   it('should call output with the remoteUrl and the repoContentsUrl', async () => {
     mockGithubClient.users.getByUsername.mockResolvedValue({
       data: { type: 'User' },

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -374,6 +374,39 @@ describe('publish:github', () => {
     });
   });
 
+  it('should lowercase topics when provided', async () => {
+    mockGithubClient.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+
+    mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    mockGithubClient.repos.replaceAllTopics.mockResolvedValue({
+      data: {
+        names: ['backstage'],
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        topics: ['BACKSTAGE'],
+      },
+    });
+
+    expect(mockGithubClient.repos.replaceAllTopics).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      names: ['backstage'],
+    });
+  });
+
   it('should call output with the remoteUrl and the repoContentsUrl', async () => {
     mockGithubClient.users.getByUsername.mockResolvedValue({
       data: { type: 'User' },

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -48,6 +48,7 @@ export function createPublishGithubAction(options: {
     sourcePath?: string;
     repoVisibility: 'private' | 'internal' | 'public';
     collaborators: Collaborator[];
+    topics?: string[];
   }>({
     id: 'publish:github',
     description:
@@ -99,6 +100,14 @@ export function createPublishGithubAction(options: {
               },
             },
           },
+          topics: {
+            title: 'Topics',
+            description: 'Uppercase letters no allowed',
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
         },
       },
       output: {
@@ -122,6 +131,7 @@ export function createPublishGithubAction(options: {
         access,
         repoVisibility = 'private',
         collaborators,
+        topics,
       } = ctx.input;
 
       const { owner, repo, host } = parseRepoUrl(repoUrl);
@@ -212,6 +222,18 @@ export function createPublishGithubAction(options: {
               `Skipping ${permission} access for ${team_slug}, ${e.message}`,
             );
           }
+        }
+      }
+
+      if (topics) {
+        try {
+          await client.repos.replaceAllTopics({
+            owner,
+            repo,
+            names: topics,
+          });
+        } catch (e) {
+          ctx.logger.warn(`Skipping topics ${topics.join(' ')}, ${e.message}`);
         }
       }
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -102,7 +102,6 @@ export function createPublishGithubAction(options: {
           },
           topics: {
             title: 'Topics',
-            description: 'Uppercase letters no allowed',
             type: 'array',
             items: {
               type: 'string',
@@ -230,7 +229,7 @@ export function createPublishGithubAction(options: {
           await client.repos.replaceAllTopics({
             owner,
             repo,
-            names: topics,
+            names: topics.map(t => t.toLowerCase()),
           });
         } catch (e) {
           ctx.logger.warn(`Skipping topics ${topics.join(' ')}, ${e.message}`);


### PR DESCRIPTION
This change adds an array input of topics to attach on a repository upon
creation.

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
