### PR TITLE
fix: typo in openStackSwift credentials username

### DIFF
--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -370,7 +370,7 @@ techdocs:
     openStackSwift:
       containerName: 'name-of-techdocs-storage-bucket'
       credentials:
-        userName: ${OPENSTACK_SWIFT_STORAGE_USERNAME}
+        username: ${OPENSTACK_SWIFT_STORAGE_USERNAME}
         password: ${OPENSTACK_SWIFT_STORAGE_PASSWORD}
       authUrl: ${OPENSTACK_SWIFT_STORAGE_AUTH_URL}
       keystoneAuthVersion: ${OPENSTACK_SWIFT_STORAGE_AUTH_VERSION}


### PR DESCRIPTION
A typo was made inside the credentials used by openStackSwift publisher.
As you can see here: https://github.com/backstage/backstage/blob/master/packages/techdocs-common/src/stages/publish/openStackSwift.ts#L67
or https://github.com/backstage/backstage/blob/master/plugins/techdocs-backend/config.d.ts#L119


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
