### PR TITLE
Add example of visibility of config values

### DIFF
--- a/docs/conf/defining.md
+++ b/docs/conf/defining.md
@@ -93,6 +93,21 @@ declare the visibility of a leaf node of `type: "string"`.
 | `backend`    | (Default) Only in backend                                          |
 | `secret`     | Only in backend and may be excluded from logs for security reasons |
 
+You can set visibility with an `@visibility` comment in the `Config` Typescript
+interface.
+
+```ts
+export interface Config {
+  app: {
+    /**
+     * Frontend root URL
+     * @visibility frontend
+     */
+    baseUrl: string;
+  };
+}
+```
+
 ## Validation
 
 Schemas can be validated using the `backstage-cli config:check` command. If you


### PR DESCRIPTION
Emphasize how to set config visibility in the docs with an example.

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
