### PR TITLE
catalog-model: deprecated usage of yup-based validators

### DIFF
--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -10,7 +10,7 @@ import { JsonValue } from '@backstage/config';
 import { SerializedError } from '@backstage/errors';
 import * as yup from 'yup';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const analyzeLocationSchema: yup.ObjectSchema<{
     location: LocationSpec;
 }, object>;
@@ -316,7 +316,7 @@ export { LocationEntityV1alpha1 }
 // @public (undocumented)
 export const locationEntityV1alpha1Validator: KindValidator;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const locationSchema: yup.ObjectSchema<Location_2, object>;
 
 // @public (undocumented)
@@ -326,7 +326,7 @@ export type LocationSpec = {
     presence?: 'optional' | 'required';
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const locationSpecSchema: yup.ObjectSchema<LocationSpec, object>;
 
 // @public (undocumented)

--- a/packages/catalog-model/src/location/validation.ts
+++ b/packages/catalog-model/src/location/validation.ts
@@ -17,6 +17,7 @@
 import * as yup from 'yup';
 import { LocationSpec, Location } from './types';
 
+/** @deprecated */
 export const locationSpecSchema = yup
   .object<LocationSpec>({
     type: yup.string().required(),
@@ -26,6 +27,7 @@ export const locationSpecSchema = yup
   .noUnknown()
   .required();
 
+/** @deprecated */
 export const locationSchema = yup
   .object<Location>({
     id: yup.string().required(),
@@ -35,6 +37,7 @@ export const locationSchema = yup
   .noUnknown()
   .required();
 
+/** @deprecated */
 export const analyzeLocationSchema = yup
   .object<{ location: LocationSpec }>({
     location: locationSpecSchema,


### PR DESCRIPTION
Deprecating these as we're looking to remove usage of yup. For now it doesn't include a replacement as there's almost no usage of these within the project. Just looking to get the deprecation message out there in case anyone has any concerns.