### PR TITLE
Don't make `inputs` `undefined` when they are `""`

### DIFF
--- a/.changeset/unlucky-peas-nail.md
+++ b/.changeset/unlucky-peas-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Keep the empty string as empty string in `input` rather than replacing with `undefined` to make empty values ok for `cookiecutter`

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -170,11 +170,6 @@ export class TaskWorker {
                   preventIndent: true,
                 })(templateCtx);
 
-                // If it's just an empty string, treat it as undefined
-                if (templated === '') {
-                  return undefined;
-                }
-
                 // If it smells like a JSON object then give it a parse as an object and if it fails return the string
                 if (
                   (templated.startsWith('"') && templated.endsWith('"')) ||
@@ -212,6 +207,10 @@ export class TaskWorker {
 
           // Keep track of all tmp dirs that are created by the action so we can remove them after
           const tmpDirs = new Array<string>();
+
+          this.options.logger.debug(`Running ${action.id} with input`, {
+            input: JSON.stringify(input, null, 2),
+          });
 
           await action.handler({
             baseUrl: task.spec.baseUrl,


### PR DESCRIPTION
This rolls back the behaviour for parsing as `""` as `undefined` inputs in https://github.com/backstage/backstage/pull/5849.

Reason is, is that previous behaviour `cookiecutter` would receive `""` which meant that things that were not required in template before suddenly became required and produced some weird errors when piping things into `jsonify`. https://discord.com/channels/687207715902193673/687235481154617364/854716629299757096

In some of our templates `description` is not required from the forms point of view but we use `{{ cookiecutter.description | jsonify }}` in the template, which passes `undefined` to `jsonify` which results in the `TypeError: Undefined is not JSON serializable` error. Previously it was `""` to `jsonify` which is fine.

Whilst I think this is good behaviour actually, that we don't pass things into the template that are not set to required in the form that are required for `cookiecutter` maybe we shouldn't have shipped this as a `patch` change, so want to restore the behaviour before thinking a little more if we can do this in a nice way. 

@Fox32 is there something that would block us rolling back this behaviour for now until we can release a potentially template breaking change further down the line? I think overall we probably should have the expected behaviour, and it forces you to check in the `cookiecutter` level to make sure something is defined first, but just not yet :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
