### PR TITLE
cli: disable GitHub App webhook by default

### DIFF
--- a/.changeset/odd-humans-exercise.md
+++ b/.changeset/odd-humans-exercise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Make the `create-github-app` command disable webhooks by default.

--- a/docs/plugins/github-apps.md
+++ b/docs/plugins/github-apps.md
@@ -43,6 +43,10 @@ root of the project which you can then use as an `include` in your
 `app-config.yaml`. You can go ahead and
 [skip ahead](#including-in-integrations-config) if you've already got an app.
 
+Note that the created app will have a webhook that is disabled by default and
+points to `smee.io`, which is intended for local development. There's also
+currently no part of Backstage that makes use of the webhook.
+
 ### GitHub Enterprise
 
 You have to create the GitHub Application manually using these

--- a/packages/cli/src/commands/create-github-app/GithubCreateAppServer.ts
+++ b/packages/cli/src/commands/create-github-app/GithubCreateAppServer.ts
@@ -120,6 +120,7 @@ export class GithubCreateAppServer {
       redirect_url: `${baseUrl}/callback`,
       hook_attributes: {
         url: this.webhookUrl,
+        active: false,
       },
     };
     const manifestJson = JSON.stringify(manifest).replace(/\"/g, '&quot;');


### PR DESCRIPTION
We don't use the webhooks currently, so I think it's best to have them disabled by default. The templated app creation flow also requires a webhook URL to be set, and it's a bit tricky to have any sane option there that couldn't cause trouble. The `smee.io` URL is very convenient for local development, but for any production deployment you'd want to replace it if the hook is active, even though the url isn't guessable and secret.