### PR TITLE
refactor(api-docs): move type filter and remove api: prefix from names

### DIFF
--- a/.changeset/great-ads-yawn.md
+++ b/.changeset/great-ads-yawn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Allow `defaultKind` from `CatalogTable.column.creatNameColumn` to be configurable

--- a/.changeset/tender-trees-notice.md
+++ b/.changeset/tender-trees-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Move `EntityTypePicker` to be consistent with `CatalogPage` and remove `api:` prefix from entity names

--- a/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/ApiExplorerPage.tsx
@@ -47,6 +47,16 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const defaultColumns: TableColumn<CatalogTableRow>[] = [
+  CatalogTable.columns.createNameColumn({ defaultKind: 'API' }),
+  CatalogTable.columns.createSystemColumn(),
+  CatalogTable.columns.createOwnerColumn(),
+  CatalogTable.columns.createSpecTypeColumn(),
+  CatalogTable.columns.createSpecLifecycleColumn(),
+  CatalogTable.columns.createMetadataDescriptionColumn(),
+  CatalogTable.columns.createTagsColumn(),
+];
+
 export type ApiExplorerPageProps = {
   initiallySelectedFilter?: UserListFilterKind;
   columns?: TableColumn<CatalogTableRow>[];
@@ -79,13 +89,13 @@ export const ApiExplorerPage = ({
           <EntityListProvider>
             <div>
               <EntityKindPicker initialFilter="api" hidden />
-              <UserListPicker initialFilter={initiallySelectedFilter} />
               <EntityTypePicker />
+              <UserListPicker initialFilter={initiallySelectedFilter} />
               <EntityOwnerPicker />
               <EntityLifecyclePicker />
               <EntityTagPicker />
             </div>
-            <CatalogTable columns={columns} />
+            <CatalogTable columns={columns || defaultColumns} />
           </EntityListProvider>
         </div>
       </Content>

--- a/plugins/catalog/src/components/CatalogTable/columns.tsx
+++ b/plugins/catalog/src/components/CatalogTable/columns.tsx
@@ -19,13 +19,22 @@ import { OverflowTooltip, TableColumn } from '@backstage/core';
 import { Chip } from '@material-ui/core';
 import { EntityRow } from './types';
 
-export function createNameColumn(): TableColumn<EntityRow> {
+type NameColumnProps = {
+  defaultKind?: string;
+};
+
+export function createNameColumn(
+  props?: NameColumnProps,
+): TableColumn<EntityRow> {
   return {
     title: 'Name',
     field: 'resolved.name',
     highlight: true,
     render: ({ entity }) => (
-      <EntityRefLink entityRef={entity} defaultKind="Component" />
+      <EntityRefLink
+        entityRef={entity}
+        defaultKind={props?.defaultKind || 'Component'}
+      />
     ),
   };
 }


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

Minor UI tweaks overlooked from #5984
## Hey, I just made a Pull Request!
![Screen Shot 2021-06-17 at 1 04 50 PM](https://user-images.githubusercontent.com/6998196/122443575-baf5fc00-cf6d-11eb-85cc-c81370b482bc.png)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
