### PR TITLE
refactor(catalogClient): return fetched entities sorted by ref

### DIFF
--- a/.changeset/forty-dodos-own.md
+++ b/.changeset/forty-dodos-own.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Return entities sorted alphabetically by ref

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -47,7 +47,7 @@ describe('CatalogClient', () => {
         apiVersion: '1',
         kind: 'Component',
         metadata: {
-          name: 'Test1',
+          name: 'Test2',
           namespace: 'test1',
         },
       },
@@ -55,13 +55,13 @@ describe('CatalogClient', () => {
         apiVersion: '1',
         kind: 'Component',
         metadata: {
-          name: 'Test2',
+          name: 'Test1',
           namespace: 'test1',
         },
       },
     ];
     const defaultResponse: CatalogListResponse<Entity> = {
-      items: defaultServiceResponse,
+      items: defaultServiceResponse.reverse(),
     };
 
     beforeEach(() => {
@@ -72,7 +72,7 @@ describe('CatalogClient', () => {
       );
     });
 
-    it('should entities from correct endpoint', async () => {
+    it('should fetch entities from correct endpoint', async () => {
       const response = await client.getEntities({}, { token });
       expect(response).toEqual(defaultResponse);
     });

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -20,6 +20,7 @@ import {
   Location,
   LOCATION_ANNOTATION,
   ORIGIN_LOCATION_ANNOTATION,
+  stringifyEntityRef,
   stringifyLocationReference,
 } from '@backstage/catalog-model';
 import { ResponseError } from '@backstage/errors';
@@ -89,7 +90,20 @@ export class CatalogClient implements CatalogApi {
       `/entities${query}`,
       options,
     );
-    return { items: entities };
+
+    const refCompare = (a: Entity, b: Entity) => {
+      const aRef = stringifyEntityRef(a);
+      const bRef = stringifyEntityRef(b);
+      if (aRef < bRef) {
+        return -1;
+      }
+      if (aRef > bRef) {
+        return 1;
+      }
+      return 0;
+    };
+
+    return { items: entities.sort(refCompare) };
   }
 
   async getEntityByName(


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

Implementing [suggestion](https://discord.com/channels/687207715902193673/687235481154617364/855089230132281364) by @freben to sort entities fetched from the catalog to preserve alphabetical order behavior from the old catalog processing engine.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
