### PR TITLE
Update code block in quickstart-app-plugin tutorial to use named import.

### DIFF
--- a/contrib/docs/tutorials/quickstart-app-plugin/ExampleFetchComponent.md
+++ b/contrib/docs/tutorials/quickstart-app-plugin/ExampleFetchComponent.md
@@ -76,7 +76,7 @@ export const DenseTable = ({ viewer }: DenseTableProps) => {
   );
 };
 
-const ExampleFetchComponent = () => {
+export const ExampleFetchComponent = () => {
   const auth = useApi(githubAuthApiRef);
 
   const { value, loading, error } = useAsync(async (): Promise<any> => {
@@ -106,6 +106,4 @@ const ExampleFetchComponent = () => {
     />
   );
 };
-
-export default ExampleFetchComponent;
 ```

--- a/docs/tutorials/quickstart-app-plugin.md
+++ b/docs/tutorials/quickstart-app-plugin.md
@@ -146,11 +146,9 @@ import {
 } from '@backstage/core';
 import { graphql } from '@octokit/graphql';
 
-const ExampleFetchComponent = () => {
+export const ExampleFetchComponent = () => {
   return <div>Nothing to see yet</div>;
 };
-
-export default ExampleFetchComponent;
 ```
 
 3. Save that and ensure you see no errors. Comment out the unused imports if


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When following [this](https://backstage.io/docs/tutorials/quickstart-app-plugin#the-wipe) section of the "Adding Custom Plugin to Existing Monorepo App" tutorial, the app returned an error:

![backstage-error-1](https://user-images.githubusercontent.com/2466523/122462506-483f4d80-cf7a-11eb-9e66-ba16bb10d4e8.png)

The issue appears to be `ExampleComponent.tsx` uses a named import for `ExampleFetchComponent` which only provides a default export if you copy/paste from the code block.  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
