### PR TITLE
Escape colons in Lunr search query filters

### DIFF
--- a/.changeset/short-numbers-carry.md
+++ b/.changeset/short-numbers-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-node': patch
+---
+
+Escape : characters in the query

--- a/.changeset/short-numbers-carry.md
+++ b/.changeset/short-numbers-carry.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search-backend-node': patch
 ---
 
-Escape : characters in the query
+Fixed bug preventing searches with filter values containing `:` from returning results.

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
@@ -339,6 +339,46 @@ describe('LunrSearchEngine', () => {
       });
     });
 
+    it('should perform search query and return search results on match with filters that include a : character', async () => {
+      const mockDocuments = [
+        {
+          title: 'testTitle',
+          text: 'testText',
+          location: 'test:location',
+        },
+        {
+          title: 'testTitle',
+          text: 'testText',
+          location: 'test:location2',
+        },
+      ];
+
+      // Mock indexing of 2 documents
+      testLunrSearchEngine.index('test-index', mockDocuments);
+
+      // Perform search query
+      const mockedSearchResult = await testLunrSearchEngine.query({
+        term: 'testTitle',
+        filters: { location: 'test:location2' },
+        pageCursor: '',
+      });
+
+      // Should return 1 of 2 results as we are
+      // 1. Mocking the indexing of 2 documents
+      // 2. Matching on the location field with the filter { location: 'test:location2' }
+      expect(mockedSearchResult).toMatchObject({
+        results: [
+          {
+            document: {
+              title: 'testTitle',
+              text: 'testText',
+              location: 'test:location2',
+            },
+          },
+        ],
+      });
+    });
+
     it('should perform search query and return search results on match, scoped to specific index', async () => {
       const mockDocuments = [
         {

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -57,6 +57,9 @@ export class LunrSearchEngine implements SearchEngine {
         .map(([field, value]) => {
           // Require that the given field has the given value (with +).
           if (['string', 'number', 'boolean'].includes(typeof value)) {
+            if (typeof value === 'string') {
+              return ` +${field}:${value.replace(':', '\\:')}`;
+            }
             return ` +${field}:${value}`;
           }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Escape `:` characters in query filters to allow for things like an owner named `group:default/infrastructure` (common with GitHub). Without escaping, no results are returned; with escaping, the `:` is passed through correctly and results are returned.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
