### PR TITLE
Permit, and prefer, "The Backstage Authors" in the copyright header

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,12 @@ module.exports = {
       {
         // eslint-disable-next-line no-restricted-syntax
         templateFile: path.resolve(__dirname, './scripts/copyright-header.txt'),
+        templateVars: {
+          NAME: 'The Backstage Authors',
+        },
+        varRegexps: {
+          NAME: /(The Backstage Authors)|(Spotify AB)/,
+        },
         onNonMatchingHeader: 'replace',
       },
     ],

--- a/scripts/copyright-header.txt
+++ b/scripts/copyright-header.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright <%= YEAR %> Spotify AB
+ * Copyright <%= YEAR %> <%= NAME %>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the first step towards changing the copyright target from "Spotify AB" to "The Backstage Authors".

We will follow up with a larger PR that updates the license across the entire code base, and then let incoming pull requests settle over time, before removing the "Spotify AB" option entirely.