### PR TITLE
fix: todo-plugin ignores images and files that are bigger than/equal 200k

### DIFF
--- a/.changeset/fair-otters-applaud.md
+++ b/.changeset/fair-otters-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Add an optional `info` parameter to the `readTree` filter option with a `size` property.

--- a/.changeset/mean-spiders-run.md
+++ b/.changeset/mean-spiders-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-todo-backend': minor
+---
+
+images will be ignored and files bigger than 200Kb will also be ignored so that the todo plugin doesn't stay hanging

--- a/.changeset/mean-spiders-run.md
+++ b/.changeset/mean-spiders-run.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-todo-backend': minor
+'@backstage/plugin-todo-backend': patch
 ---
 
-images will be ignored and files bigger than 200Kb will also be ignored so that the todo plugin doesn't stay hanging
+Ignore images and files that are larger than 200KB.

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -593,7 +593,7 @@ export function useHotMemoize<T>(_module: NodeModule, valueFactory: () => T): T;
 // src/cache/types.d.ts:34:5 - (ae-forgotten-export) The symbol "ClientOptions" needs to be exported by the entry point index.d.ts
 // src/middleware/errorHandler.d.ts:17:26 - (tsdoc-malformed-html-name) Invalid HTML element: A space is not allowed here
 // src/reading/AzureUrlReader.d.ts:9:9 - (ae-forgotten-export) The symbol "ReadTreeResponseFactory" needs to be exported by the entry point index.d.ts
-// src/reading/types.d.ts:106:5 - (ae-forgotten-export) The symbol "ReadTreeResponseDirOptions" needs to be exported by the entry point index.d.ts
+// src/reading/types.d.ts:108:5 - (ae-forgotten-export) The symbol "ReadTreeResponseDirOptions" needs to be exported by the entry point index.d.ts
 // src/service/types.d.ts:12:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/service/types.d.ts:22:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/service/types.d.ts:30:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/packages/backend-common/src/reading/tree/TarArchiveResponse.ts
+++ b/packages/backend-common/src/reading/tree/TarArchiveResponse.ts
@@ -98,6 +98,11 @@ export class TarArchiveResponse implements ReadTreeResponse {
         }
       }
 
+      if (entry.size && entry.size >= 20000) {
+        entry.resume();
+        return;
+      }
+
       const content = new Promise<Buffer>(async resolve => {
         await pipeline(entry, concatStream(resolve));
       });

--- a/packages/backend-common/src/reading/tree/TarArchiveResponse.ts
+++ b/packages/backend-common/src/reading/tree/TarArchiveResponse.ts
@@ -43,7 +43,7 @@ export class TarArchiveResponse implements ReadTreeResponse {
     private readonly subPath: string,
     private readonly workDir: string,
     public readonly etag: string,
-    private readonly filter?: (path: string) => boolean,
+    private readonly filter?: (path: string, info: { size: number }) => boolean,
   ) {
     if (subPath) {
       if (!subPath.endsWith('/')) {
@@ -92,15 +92,10 @@ export class TarArchiveResponse implements ReadTreeResponse {
 
       const path = relativePath.slice(this.subPath.length);
       if (this.filter) {
-        if (!this.filter(path)) {
+        if (!this.filter(path, { size: entry.remain })) {
           entry.resume();
           return;
         }
-      }
-
-      if (entry.size && entry.size >= 20000) {
-        entry.resume();
-        return;
       }
 
       const content = new Promise<Buffer>(async resolve => {
@@ -160,7 +155,7 @@ export class TarArchiveResponse implements ReadTreeResponse {
       tar.extract({
         strip,
         cwd: dir,
-        filter: path => {
+        filter: (path, stat) => {
           // File path relative to the root extracted directory. Will remove the
           // top level dir name from the path since its name is hard to predetermine.
           const relativePath = stripFirstDirectoryFromPath(path);
@@ -169,7 +164,7 @@ export class TarArchiveResponse implements ReadTreeResponse {
           }
           if (this.filter) {
             const innerPath = path.split('/').slice(strip).join('/');
-            return this.filter(innerPath);
+            return this.filter(innerPath, { size: stat.size });
           }
           return true;
         },

--- a/packages/backend-common/src/reading/tree/ZipArchiveResponse.ts
+++ b/packages/backend-common/src/reading/tree/ZipArchiveResponse.ts
@@ -68,6 +68,11 @@ export class ZipArchiveResponse implements ReadTreeResponse {
 
   private shouldBeIncluded(entry: Entry): boolean {
     const strippedPath = stripFirstDirectoryFromPath(entry.path);
+    const size = entry.vars.compressedSize;
+
+    if (size >= 20000) {
+      return false;
+    }
 
     if (this.subPath) {
       if (!strippedPath.startsWith(this.subPath)) {

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -104,7 +104,7 @@ export type ReadTreeOptions = {
    *
    * If no filter is provided all files are extracted.
    */
-  filter?(path: string): boolean;
+  filter?(path: string, info?: { size: number }): boolean;
 
   /**
    * An etag can be provided to check whether readTree's response has changed from a previous execution.
@@ -164,7 +164,7 @@ export type FromArchiveOptions = {
   // etag of the blob
   etag: string;
   // Filter passed on from the ReadTreeOptions
-  filter?: (path: string) => boolean;
+  filter?: (path: string, info?: { size: number }) => boolean;
 };
 
 export interface ReadTreeResponseFactory {

--- a/plugins/todo-backend/src/lib/TodoReader/TodoScmReader.test.ts
+++ b/plugins/todo-backend/src/lib/TodoReader/TodoScmReader.test.ts
@@ -74,7 +74,13 @@ describe('TodoScmReader', () => {
       ],
     };
 
-    await expect(todoReader.readTodos({ url })).resolves.toEqual(expected);
+    // These two reads should only result in a single call to readTree
+    await expect(
+      Promise.all([
+        todoReader.readTodos({ url }),
+        todoReader.readTodos({ url }),
+      ]),
+    ).resolves.toEqual([expected, expected]);
 
     expect(reader.readTree).toHaveBeenCalledTimes(1);
     expect(reader.readTree).toHaveBeenCalledWith(

--- a/plugins/todo-backend/src/lib/TodoReader/TodoScmReader.ts
+++ b/plugins/todo-backend/src/lib/TodoReader/TodoScmReader.ts
@@ -27,6 +27,7 @@ import {
 } from './types';
 import { Config } from '@backstage/config';
 import { createTodoParser } from './createTodoParser';
+import path from 'path';
 
 type Options = {
   logger: Logger;
@@ -80,10 +81,25 @@ export class TodoScmReader implements TodoReader {
     { url }: ReadTodosOptions,
     etag?: string,
   ): Promise<CacheItem> {
+    const shouldNotInclude = [
+      '.png',
+      '.svg',
+      '.jpg',
+      '.jpeg',
+      '.gif',
+      '.raw',
+      '.lock',
+      '.ico',
+    ];
     const tree = await this.reader.readTree(url, {
       etag,
-      filter(path) {
-        return !path.startsWith('.') && !path.includes('/.');
+      filter(filePath) {
+        const extname = path.extname(filePath);
+        return (
+          !filePath.startsWith('.') &&
+          !filePath.includes('/.') &&
+          !shouldNotInclude.includes(extname)
+        );
       },
     });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes #5997 by ignoring images and files that are bigger than 200Kb

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
