### PR TITLE
make scroll bars etc dark on the microsite

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -7,6 +7,11 @@
 
 /* your custom css */
 
+/* makes scroll bars, inputs etc match the dark theme better */
+html {
+  color-scheme: dark;
+}
+
 /* override font color for new dark tech docs styling */
 table {
   color: white;


### PR DESCRIPTION
The occasional scrollbar was super jarring on the black background.

Before / after

![Screenshot 2021-06-18 at 14 58 42](https://user-images.githubusercontent.com/3097461/122569934-88bacc00-d04b-11eb-8f27-db496a973754.png) ![Screenshot 2021-06-18 at 14 58 29](https://user-images.githubusercontent.com/3097461/122569925-87899f00-d04b-11eb-9efd-bb5f8e1f7095.png)

This does not make a difference on all browsers, but most.