### PR TITLE
Correctly recognize whether the cookiecutter command exists

### DIFF
--- a/.changeset/weak-needles-peel.md
+++ b/.changeset/weak-needles-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Correctly recognize whether the cookiecutter command exists

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.test.ts
@@ -35,6 +35,7 @@ describe('CookieCutter Templater', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    commandExists.mockRejectedValue(null);
   });
 
   it('should write a cookiecutter.json file with the values from the entity', async () => {
@@ -228,7 +229,7 @@ describe('CookieCutter Templater', () => {
       };
 
       jest.spyOn(fs, 'readdir').mockResolvedValueOnce(['newthing'] as any);
-      commandExists.mockImplementationOnce(() => () => true);
+      commandExists.mockResolvedValueOnce(true);
 
       const templater = new CookieCutter({ containerRunner });
       await templater.run({

--- a/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/templater/cookiecutter.ts
@@ -70,7 +70,10 @@ export class CookieCutter implements TemplaterBase {
       [intermediateDir]: '/output',
     };
 
-    const cookieCutterInstalled = await commandExists('cookiecutter');
+    // the command-exists package returns `true` or throws an error
+    const cookieCutterInstalled = await commandExists('cookiecutter').catch(
+      () => false,
+    );
     if (cookieCutterInstalled) {
       await runCommand({
         command: 'cookiecutter',


### PR DESCRIPTION
I accidentally broke the detection of the `cookiecutter` command in https://github.com/backstage/backstage/pull/6030 since the `command-exists` library has an unexpected API where it resolves to `true` if it exists and throws if not (instead of returning `false`). The `command-exists-promise` solved this issue but I still think the more widely used library is a better choice. Plus it also solved all our FOSSA problems.

Sorry for any inconveniences when running cookiecutter in docker 😳

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
