### PR TITLE
feat: update plugin path to match same behavior in the main app

### DIFF
--- a/.changeset/friendly-bikes-double.md
+++ b/.changeset/friendly-bikes-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+updated plugin template to generate path equals plugin id for the root page

--- a/docs/plugins/create-a-plugin.md
+++ b/docs/plugins/create-a-plugin.md
@@ -22,9 +22,9 @@ yarn create-plugin
 This will create a new Backstage Plugin based on the ID that was provided. It
 will be built and added to the Backstage App automatically.
 
-> If `yarn start` is already running you should be able to see the default page
-> for your new plugin directly by navigating to
-> `http://localhost:3000/my-plugin`.
+> If the Backstage App is already running (with `yarn start` or `yarn dev`) you
+> should be able to see the default page for your new plugin directly by
+> navigating to `http://localhost:3000/my-plugin`.
 
 ![](../assets/my-plugin_screenshot.png)
 
@@ -32,7 +32,7 @@ You can also serve the plugin in isolation by running `yarn start` in the plugin
 directory. Or by using the yarn workspace command, for example:
 
 ```bash
-yarn workspace @backstage/plugin-welcome start # Also supports --check
+yarn workspace @backstage/my-plugin start # Also supports --check
 ```
 
 This method of serving the plugin provides quicker iteration speed and a faster

--- a/packages/cli/templates/default-plugin/dev/index.tsx.hbs
+++ b/packages/cli/templates/default-plugin/dev/index.tsx.hbs
@@ -7,5 +7,6 @@ createDevApp()
   .addPage({
     element: <{{ extensionName }} />,
     title: 'Root Page',
+    path: '/{{ id }}'
   })
   .render();


### PR DESCRIPTION
## Hey, I just made a Pull Request!
I update the plugin creation workflow:
- Update the doc to be more explicit about the URL location (and what is running)
- Update the template to match the path when running in dev mode

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
