### PR TITLE
Fix overlapping sidebar with tabs in techdocs

### DIFF
--- a/.changeset/metal-cycles-run.md
+++ b/.changeset/metal-cycles-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix the overlapping between the sidebar and the tabs navigation when enabled in mkdocs (features: navigation.tabs)

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -64,9 +64,10 @@ export const Reader = ({ entityId, onReady }: Props) => {
 
   const updateSidebarPosition = useCallback(() => {
     if (!!shadowDomRef.current && !!sidebars) {
-      const mdTabs = shadowDomRef.current!.querySelector(
-        '.md-container > .md-tabs',
-      );
+      const shadowDiv: HTMLElement = shadowDomRef.current!;
+      const shadowRoot =
+        shadowDiv.shadowRoot || shadowDiv.attachShadow({ mode: 'open' });
+      const mdTabs = shadowRoot.querySelector('.md-container > .md-tabs');
       sidebars!.forEach(sidebar => {
         const newTop = Math.max(
           shadowDomRef.current!.getBoundingClientRect().top,


### PR DESCRIPTION
## Prerequisite
This is a follow-up on #6011 and #5640. Emre (The person who created the PR) is my ex-colleague, he is in a long vacation now. I've created a replicate PR so I can address your comments and resolve your requests so we can get this patch merged.

Once this PR is merged, #6011 should be closed manually

closes #6011

## Description
There is a feature in MKDocs that shows a navigation in top-aligned tabs. When that is enabled, the sidebar will overlap with the tabs at the top. This PR fixes this issue.
<details>
<summary>Steps to reproduce</summary>

1. Create a documentation using MKDocs
2. Enable tabs navigation
    ```yaml
    features:
        - navigation.tabs
    ```
3. Try to view this documentation in Backstage
4. See the overlapping sidebar

</details>

### Before
https://user-images.githubusercontent.com/10633734/122617149-04d50400-d08c-11eb-82ae-aac51a60d7fc.mov

### After
https://user-images.githubusercontent.com/10633734/122617133-fdadf600-d08b-11eb-9864-11deb6cc0905.mov

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))