### PR TITLE
plugins,dev-utils: remove usage of deprecated route registrations

### DIFF
--- a/.changeset/five-baboons-explain.md
+++ b/.changeset/five-baboons-explain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/dev-utils': minor
+---
+
+Removed support for deprecated registered plugin routes. All routes now need to be added using `addPage` instead.

--- a/.changeset/heavy-numbers-refuse.md
+++ b/.changeset/heavy-numbers-refuse.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-api-docs': minor
+'@backstage/plugin-cost-insights': minor
+'@backstage/plugin-gcp-projects': minor
+'@backstage/plugin-gitops-profiles': minor
+'@backstage/plugin-newrelic': minor
+'@backstage/plugin-welcome': minor
+---
+
+**BREAKING CHANGE** Remove deprecated route registrations, meaning that it is no longer enough to only import the plugin in the app and the exported page extension must be used instead.

--- a/packages/dev-utils/src/devApp/render.tsx
+++ b/packages/dev-utils/src/devApp/render.tsx
@@ -39,7 +39,6 @@ import {
 } from '@backstage/integration-react';
 import { Box } from '@material-ui/core';
 import BookmarkIcon from '@material-ui/icons/Bookmark';
-import SentimentDissatisfiedIcon from '@material-ui/icons/SentimentDissatisfied';
 import React, { ComponentType, ReactNode } from 'react';
 import ReactDOM from 'react-dom';
 import { hot } from 'react-hot-loader';
@@ -74,6 +73,8 @@ class DevAppBuilder {
   private readonly rootChildren = new Array<ReactNode>();
   private readonly routes = new Array<JSX.Element>();
   private readonly sidebarItems = new Array<JSX.Element>();
+
+  private defaultPage?: string;
 
   /**
    * Register one or more plugins to render in the dev app
@@ -113,6 +114,11 @@ class DevAppBuilder {
    */
   addPage(opts: RegisterPageOptions): DevAppBuilder {
     const path = opts.path ?? `/page-${this.routes.length + 1}`;
+
+    if (!this.defaultPage || path === '/') {
+      this.defaultPage = path;
+    }
+
     if (opts.title) {
       this.sidebarItems.push(
         <SidebarItem
@@ -169,9 +175,6 @@ class DevAppBuilder {
 
     const AppProvider = app.getProvider();
     const AppRouter = app.getRouter();
-    const deprecatedAppRoutes = app.getRoutes();
-
-    const sidebar = this.setupSidebar(this.plugins);
 
     const DevApp = () => {
       return (
@@ -181,10 +184,12 @@ class DevAppBuilder {
           {this.rootChildren}
           <AppRouter>
             <SidebarPage>
-              {sidebar}
+              <Sidebar>
+                <SidebarSpacer />
+                {this.sidebarItems}
+              </Sidebar>
               <FlatRoutes>
                 {this.routes}
-                {deprecatedAppRoutes}
                 <Route path="/_external_route" element={<DummyPage />} />
               </FlatRoutes>
             </SidebarPage>
@@ -207,83 +212,11 @@ class DevAppBuilder {
 
     const DevApp = hot(hotModule)(this.build());
 
-    const paths = this.findPluginPaths(this.plugins);
-
-    if (window.location.pathname === '/') {
-      if (!paths.includes('/') && paths.length > 0) {
-        window.location.pathname = paths[0];
-      }
+    if (window.location.pathname === '/' && this.defaultPage) {
+      window.location.pathname = this.defaultPage;
     }
 
     ReactDOM.render(<DevApp />, document.getElementById('root'));
-  }
-
-  // Create a sidebar that exposes the touchpoints of a plugin
-  private setupSidebar(plugins: BackstagePlugin[]): JSX.Element {
-    const sidebarItems = new Array<JSX.Element>();
-    for (const plugin of plugins) {
-      for (const output of plugin.output()) {
-        switch (output.type) {
-          case 'legacy-route': {
-            const { path } = output;
-            sidebarItems.push(
-              <SidebarItem
-                key={path}
-                to={path}
-                text={path}
-                icon={BookmarkIcon}
-              />,
-            );
-            break;
-          }
-          case 'route': {
-            const { target } = output;
-            sidebarItems.push(
-              <SidebarItem
-                key={target.path}
-                to={target.path}
-                text={target.title}
-                icon={target.icon ?? SentimentDissatisfiedIcon}
-              />,
-            );
-            break;
-          }
-          default:
-            break;
-        }
-      }
-    }
-
-    return (
-      <Sidebar>
-        <SidebarSpacer />
-        {this.sidebarItems}
-        {sidebarItems}
-      </Sidebar>
-    );
-  }
-
-  private findPluginPaths(plugins: BackstagePlugin[]) {
-    const paths = new Array<string>();
-
-    for (const plugin of plugins) {
-      for (const output of plugin.output()) {
-        switch (output.type) {
-          case 'legacy-route': {
-            paths.push(output.path);
-            break;
-          }
-          case 'route': {
-            paths.push(output.target.path);
-            break;
-          }
-          default:
-            break;
-        }
-      }
-    }
-
-    return paths;
   }
 }
 

--- a/plugins/api-docs/dev/index.tsx
+++ b/plugins/api-docs/dev/index.tsx
@@ -30,6 +30,13 @@ import graphqlApiEntity from './graphql-example-api.yaml';
 import openapiApiEntity from './openapi-example-api.yaml';
 import otherApiEntity from './other-example-api.yaml';
 
+const mockEntities = ([
+  openapiApiEntity,
+  asyncapiApiEntity,
+  graphqlApiEntity,
+  otherApiEntity,
+] as unknown) as Entity[];
+
 createDevApp()
   .registerApi({
     api: catalogApiRef,
@@ -38,13 +45,11 @@ createDevApp()
       (({
         async getEntities() {
           return {
-            items: [
-              openapiApiEntity,
-              asyncapiApiEntity,
-              graphqlApiEntity,
-              otherApiEntity,
-            ],
+            items: mockEntities.slice(),
           };
+        },
+        async getEntityByName(name: string) {
+          return mockEntities.find(e => e.metadata.name === name);
         },
       } as unknown) as typeof catalogApiRef.T),
   })

--- a/plugins/api-docs/src/plugin.ts
+++ b/plugins/api-docs/src/plugin.ts
@@ -22,7 +22,6 @@ import {
   createRoutableExtension,
 } from '@backstage/core';
 import { defaultDefinitionWidgets } from './components/ApiDefinitionCard';
-import { ApiExplorerPage as Page } from './components/ApiExplorerPage/ApiExplorerPage';
 import { apiDocsConfigRef } from './config';
 import { createComponentRouteRef, rootRoute } from './routes';
 
@@ -47,9 +46,6 @@ export const apiDocsPlugin = createPlugin({
   ],
   externalRoutes: {
     createComponent: createComponentRouteRef,
-  },
-  register({ router }) {
-    router.addRoute(rootRoute, Page);
   },
 });
 

--- a/plugins/cost-insights/dev/index.tsx
+++ b/plugins/cost-insights/dev/index.tsx
@@ -13,10 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
 import { ExampleCostInsightsClient } from '../src/example';
 import { costInsightsApiRef } from '../src/api';
-import { costInsightsPlugin } from '../src/plugin';
+import {
+  costInsightsPlugin,
+  CostInsightsPage,
+  CostInsightsProjectGrowthInstructionsPage,
+  CostInsightsLabelDataflowInstructionsPage,
+} from '../src/plugin';
 
 createDevApp()
   .registerPlugin(costInsightsPlugin)
@@ -24,5 +31,17 @@ createDevApp()
     api: costInsightsApiRef,
     deps: {},
     factory: () => new ExampleCostInsightsClient(),
+  })
+  .addPage({
+    title: 'Cost Insights',
+    element: <CostInsightsPage />,
+  })
+  .addPage({
+    title: 'Growth',
+    element: <CostInsightsProjectGrowthInstructionsPage />,
+  })
+  .addPage({
+    title: 'Labelling',
+    element: <CostInsightsLabelDataflowInstructionsPage />,
   })
   .render();

--- a/plugins/cost-insights/src/plugin.ts
+++ b/plugins/cost-insights/src/plugin.ts
@@ -19,9 +19,6 @@ import {
   createRouteRef,
   createRoutableExtension,
 } from '@backstage/core';
-import { CostInsightsPage as CostInsightsPageComponent } from './components/CostInsightsPage';
-import { ProjectGrowthInstructionsPage as ProjectGrowthInstructionsPageComponent } from './components/ProjectGrowthInstructionsPage';
-import { LabelDataflowInstructionsPage as LabelDataflowInstructionsPageComponent } from './components/LabelDataflowInstructionsPage';
 
 export const rootRouteRef = createRouteRef({
   path: '/cost-insights',
@@ -40,16 +37,7 @@ export const unlabeledDataflowAlertRef = createRouteRef({
 
 export const costInsightsPlugin = createPlugin({
   id: 'cost-insights',
-  register({ router, featureFlags }) {
-    router.addRoute(rootRouteRef, CostInsightsPageComponent);
-    router.addRoute(
-      projectGrowthAlertRef,
-      ProjectGrowthInstructionsPageComponent,
-    );
-    router.addRoute(
-      unlabeledDataflowAlertRef,
-      LabelDataflowInstructionsPageComponent,
-    );
+  register({ featureFlags }) {
     featureFlags.register('cost-insights-currencies');
   },
   routes: {

--- a/plugins/gcp-projects/dev/index.tsx
+++ b/plugins/gcp-projects/dev/index.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
-import { gcpProjectsPlugin } from '../src/plugin';
+import { gcpProjectsPlugin, GcpProjectsPage } from '../src/plugin';
 
-createDevApp().registerPlugin(gcpProjectsPlugin).render();
+createDevApp()
+  .registerPlugin(gcpProjectsPlugin)
+  .addPage({
+    title: 'GCP Projects',
+    element: <GcpProjectsPage />,
+  })
+  .render();

--- a/plugins/gcp-projects/src/plugin.ts
+++ b/plugins/gcp-projects/src/plugin.ts
@@ -21,10 +21,7 @@ import {
   googleAuthApiRef,
 } from '@backstage/core';
 import { gcpApiRef, GcpClient } from './api';
-import { NewProjectPage } from './components/NewProjectPage';
-import { ProjectDetailsPage } from './components/ProjectDetailsPage';
-import { ProjectListPage } from './components/ProjectListPage';
-import { rootRouteRef, projectRouteRef, newProjectRouteRef } from './routes';
+import { rootRouteRef } from './routes';
 
 export const gcpProjectsPlugin = createPlugin({
   id: 'gcp-projects',
@@ -40,11 +37,6 @@ export const gcpProjectsPlugin = createPlugin({
       },
     }),
   ],
-  register({ router }) {
-    router.addRoute(rootRouteRef, ProjectListPage);
-    router.addRoute(projectRouteRef, ProjectDetailsPage);
-    router.addRoute(newProjectRouteRef, NewProjectPage);
-  },
 });
 
 export const GcpProjectsPage = gcpProjectsPlugin.provide(

--- a/plugins/gitops-profiles/src/plugin.ts
+++ b/plugins/gitops-profiles/src/plugin.ts
@@ -19,9 +19,6 @@ import {
   createApiFactory,
   createRoutableExtension,
 } from '@backstage/core';
-import ProfileCatalog from './components/ProfileCatalog';
-import ClusterPage from './components/ClusterPage';
-import ClusterList from './components/ClusterList';
 import {
   gitOpsClusterListRoute,
   gitOpsClusterDetailsRoute,
@@ -34,11 +31,6 @@ export const gitopsProfilesPlugin = createPlugin({
   apis: [
     createApiFactory(gitOpsApiRef, new GitOpsRestApi('http://localhost:3008')),
   ],
-  register({ router }) {
-    router.addRoute(gitOpsClusterListRoute, ClusterList);
-    router.addRoute(gitOpsClusterDetailsRoute, ClusterPage);
-    router.addRoute(gitOpsClusterCreateRoute, ProfileCatalog);
-  },
   routes: {
     listPage: gitOpsClusterListRoute,
     detailsPage: gitOpsClusterDetailsRoute,

--- a/plugins/newrelic/dev/index.tsx
+++ b/plugins/newrelic/dev/index.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
-import { newRelicPlugin } from '../src/plugin';
+import { newRelicPlugin, NewRelicPage } from '../src/plugin';
 
-createDevApp().registerPlugin(newRelicPlugin).render();
+createDevApp()
+  .registerPlugin(newRelicPlugin)
+  .addPage({
+    title: 'New Relic',
+    element: <NewRelicPage />,
+  })
+  .render();

--- a/plugins/newrelic/src/plugin.ts
+++ b/plugins/newrelic/src/plugin.ts
@@ -22,7 +22,6 @@ import {
   createRoutableExtension,
 } from '@backstage/core';
 import { NewRelicClient, newRelicApiRef } from './api';
-import NewRelicComponent from './components/NewRelicComponent';
 
 export const rootRouteRef = createRouteRef({
   path: '/newrelic',
@@ -38,9 +37,6 @@ export const newRelicPlugin = createPlugin({
       factory: ({ discoveryApi }) => new NewRelicClient({ discoveryApi }),
     }),
   ],
-  register({ router }) {
-    router.addRoute(rootRouteRef, NewRelicComponent);
-  },
   routes: {
     root: rootRouteRef,
   },

--- a/plugins/welcome/dev/index.tsx
+++ b/plugins/welcome/dev/index.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import { createDevApp } from '@backstage/dev-utils';
-import { welcomePlugin } from '../src/plugin';
+import { welcomePlugin, WelcomePage } from '../src/plugin';
 
-createDevApp().registerPlugin(welcomePlugin).render();
+createDevApp()
+  .registerPlugin(welcomePlugin)
+  .addPage({
+    title: 'Welcome',
+    element: <WelcomePage />,
+  })
+  .render();

--- a/plugins/welcome/src/plugin.ts
+++ b/plugins/welcome/src/plugin.ts
@@ -19,7 +19,6 @@ import {
   createRoutableExtension,
   createRouteRef,
 } from '@backstage/core';
-import WelcomePageComponent from './components/WelcomePage';
 
 export const rootRouteRef = createRouteRef({
   title: 'Welcome',
@@ -27,8 +26,7 @@ export const rootRouteRef = createRouteRef({
 
 export const welcomePlugin = createPlugin({
   id: 'welcome',
-  register({ router, featureFlags }) {
-    router.addRoute(rootRouteRef, WelcomePageComponent);
+  register({ featureFlags }) {
     featureFlags.register('enable-welcome-box');
   },
 });


### PR DESCRIPTION
These have been deprecated for a very long time now and are no longer supported in the new `@backstage/core-*` APIs.