### PR TITLE
example-backend: log info about creating a standalone app for deployment

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -6,9 +6,7 @@ The main purpose of this package is to provide a test bed for Backstage plugins
 that have a backend part. Feel free to experiment locally or within your fork
 by adding dependencies and routes to this backend, to try things out.
 
-Our goal is to eventually amend the create-app flow of the CLI, such that a
-production ready version of a backend skeleton is made alongside the frontend
-app. Until then, feel free to experiment here!
+By running the `@backstage/create-app` script, you get your own separate Backstage backend.
 
 ## Development
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -71,9 +71,11 @@ function makeCreateEnv(config: Config) {
 }
 
 async function main() {
+  const logger = getRootLogger();
+
   const config = await loadBackendConfig({
     argv: process.argv,
-    logger: getRootLogger(),
+    logger,
   });
   const createEnv = makeCreateEnv(config);
 
@@ -118,7 +120,7 @@ async function main() {
     .addRouter('', await app(appEnv));
 
   await service.start().catch(err => {
-    console.log(err);
+    logger.error(err);
     process.exit(1);
   });
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -73,6 +73,11 @@ function makeCreateEnv(config: Config) {
 async function main() {
   const logger = getRootLogger();
 
+  logger.info(
+    `You are running an example backend, which is supposed to be mainly used for contributing back to Backstage. ` +
+      `Do NOT deploy this to production. Read more here https://backstage.io/docs/getting-started/`,
+  );
+
   const config = await loadBackendConfig({
     argv: process.argv,
     logger,


### PR DESCRIPTION
Noticed on Discord that some people are still deploying this repository. Maybe adding a line in the logs of the example-backend will help a little bit.