### PR TITLE
Disambiguate titles of dependency cards

### DIFF
--- a/.changeset/smart-insects-care.md
+++ b/.changeset/smart-insects-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Disambiguated titles of `EntityDependencyOfComponentsCard` and `EntityDependsOnComponentsCard`.

--- a/plugins/catalog/src/components/DependencyOfComponentsCard/DependencyOfComponentsCard.test.tsx
+++ b/plugins/catalog/src/components/DependencyOfComponentsCard/DependencyOfComponentsCard.test.tsx
@@ -66,7 +66,7 @@ describe('<DependencyOfComponentsCard />', () => {
       </Wrapper>,
     );
 
-    expect(getByText('Components')).toBeInTheDocument();
+    expect(getByText('Dependency of components')).toBeInTheDocument();
     expect(
       getByText(/No component depends on this component/i),
     ).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('<DependencyOfComponentsCard />', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Components')).toBeInTheDocument();
+      expect(getByText('Dependency of components')).toBeInTheDocument();
       expect(getByText(/target-name/i)).toBeInTheDocument();
     });
   });

--- a/plugins/catalog/src/components/DependencyOfComponentsCard/DependencyOfComponentsCard.tsx
+++ b/plugins/catalog/src/components/DependencyOfComponentsCard/DependencyOfComponentsCard.tsx
@@ -30,7 +30,7 @@ type Props = {
 
 export const DependencyOfComponentsCard = ({
   variant = 'gridItem',
-  title = 'Components',
+  title = 'Dependency of components',
 }: Props) => {
   return (
     <RelatedEntitiesCard

--- a/plugins/catalog/src/components/DependsOnComponentsCard/DependsOnComponentsCard.test.tsx
+++ b/plugins/catalog/src/components/DependsOnComponentsCard/DependsOnComponentsCard.test.tsx
@@ -66,7 +66,7 @@ describe('<DependsOnComponentsCard />', () => {
       </Wrapper>,
     );
 
-    expect(getByText('Components')).toBeInTheDocument();
+    expect(getByText('Depends on components')).toBeInTheDocument();
     expect(
       getByText(/No component is a dependency of this component/i),
     ).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('<DependsOnComponentsCard />', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Components')).toBeInTheDocument();
+      expect(getByText('Depends on components')).toBeInTheDocument();
       expect(getByText(/target-name/i)).toBeInTheDocument();
     });
   });

--- a/plugins/catalog/src/components/DependsOnComponentsCard/DependsOnComponentsCard.tsx
+++ b/plugins/catalog/src/components/DependsOnComponentsCard/DependsOnComponentsCard.tsx
@@ -30,7 +30,7 @@ type Props = {
 
 export const DependsOnComponentsCard = ({
   variant = 'gridItem',
-  title = 'Components',
+  title = 'Depends on components',
 }: Props) => {
   return (
     <RelatedEntitiesCard


### PR DESCRIPTION
Without this the `EntityDependsOnComponentsCard` and the `EntityDependencyOfComponentsCard` cards have the same title and you can't tell which is which.

`sample-service-1` depends on `sample-service-2`.

![Screenshot 2021-06-21 at 15 53 28](https://user-images.githubusercontent.com/562403/122783521-8ce42500-d2a9-11eb-9eea-5fc1e9bc1217.png)

![Screenshot 2021-06-21 at 15 35 10](https://user-images.githubusercontent.com/562403/122783537-8fdf1580-d2a9-11eb-97a2-8efc30c36299.png)


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
