### PR TITLE
Update pagerduty Authorization to Token token

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -72,7 +72,7 @@ proxy:
   '/pagerduty':
     target: https://api.pagerduty.com
     headers:
-      Authorization: ${PAGERDUTY_TOKEN}
+      Authorization: Token token=${PAGERDUTY_TOKEN}
 
   '/buildkite/api':
     target: https://api.buildkite.com/v2/


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes https://github.com/backstage/backstage/issues/6142

Updated the Authorization of Pagerduty from "${PAGERDUTY_TOKEN}" to "Token token=${PAGERDUTY_TOKEN}"

Docs: https://developer.pagerduty.com/docs/rest-api-v2/authentication/#api-token-authentication

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
