### PR TITLE
Use `EntityListProvider` in `ScaffolderPage`

### DIFF
--- a/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.test.tsx
@@ -17,7 +17,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
-import { EntityKindFilter } from '../../types';
+import { EntityKindFilter } from '../../filters';
 import { EntityKindPicker } from './EntityKindPicker';
 
 describe('<EntityKindPicker/>', () => {

--- a/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityKindPicker/EntityKindPicker.tsx
@@ -17,7 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import { Alert } from '@material-ui/lab';
 import { useEntityListProvider } from '../../hooks';
-import { EntityKindFilter } from '../../types';
+import { EntityKindFilter } from '../../filters';
 
 type EntityKindFilterProps = {
   initialFilter?: string;

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
@@ -18,7 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
-import { EntityLifecycleFilter } from '../../types';
+import { EntityLifecycleFilter } from '../../filters';
 import { EntityLifecyclePicker } from './EntityLifecyclePicker';
 
 const sampleEntities: Entity[] = [

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -28,7 +28,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { Autocomplete } from '@material-ui/lab';
 import React, { useMemo } from 'react';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
-import { EntityLifecycleFilter } from '../../types';
+import { EntityLifecycleFilter } from '../../filters';
 
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -18,7 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
-import { EntityOwnerFilter } from '../../types';
+import { EntityOwnerFilter } from '../../filters';
 import { EntityOwnerPicker } from './EntityOwnerPicker';
 
 const sampleEntities: Entity[] = [

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -28,7 +28,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { Autocomplete } from '@material-ui/lab';
 import React, { useMemo } from 'react';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
-import { EntityOwnerFilter } from '../../types';
+import { EntityOwnerFilter } from '../../filters';
 import { getEntityRelations } from '../../utils';
 import { formatEntityRefTitle } from '../EntityRefLink';
 

--- a/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.test.tsx
+++ b/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.test.tsx
@@ -17,29 +17,9 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { EntitySearchBar } from './EntitySearchBar';
-import { Entity } from '@backstage/catalog-model';
 import { DefaultEntityFilters } from '../../hooks/useEntityListProvider';
-import { EntityTextFilter } from '../../types';
+import { EntityTextFilter } from '../../filters';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
-
-const entities: Entity[] = [
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      name: 'react-app',
-      tags: ['react', 'experimental'],
-    },
-  },
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      name: 'gRPC service',
-      tags: ['gRPC', 'java'],
-    },
-  },
-];
 
 describe('EntitySearchBar', () => {
   it('should display search value and execute set callback', async () => {
@@ -50,9 +30,7 @@ describe('EntitySearchBar', () => {
     };
 
     const { getByDisplayValue } = render(
-      <MockEntityListContextProvider
-        value={{ entities, updateFilters, filters }}
-      >
+      <MockEntityListContextProvider value={{ updateFilters, filters }}>
         <EntitySearchBar />
       </MockEntityListContextProvider>,
     );

--- a/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.test.tsx
+++ b/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.test.tsx
@@ -15,14 +15,12 @@
  */
 
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
-import SearchToolbar from './SearchToolbar';
-import {
-  DefaultEntityFilters,
-  EntityTextFilter,
-  MockEntityListContextProvider,
-} from '@backstage/plugin-catalog-react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { EntitySearchBar } from './EntitySearchBar';
 import { Entity } from '@backstage/catalog-model';
+import { DefaultEntityFilters } from '../../hooks/useEntityListProvider';
+import { EntityTextFilter } from '../../types';
+import { MockEntityListContextProvider } from '../../testUtils/providers';
 
 const entities: Entity[] = [
   {
@@ -43,7 +41,7 @@ const entities: Entity[] = [
   },
 ];
 
-describe('SearchToolbar', () => {
+describe('EntitySearchBar', () => {
   it('should display search value and execute set callback', async () => {
     const updateFilters = jest.fn();
 
@@ -55,7 +53,7 @@ describe('SearchToolbar', () => {
       <MockEntityListContextProvider
         value={{ entities, updateFilters, filters }}
       >
-        <SearchToolbar />
+        <EntitySearchBar />
       </MockEntityListContextProvider>,
     );
 
@@ -63,11 +61,13 @@ describe('SearchToolbar', () => {
     expect(searchInput).toBeInTheDocument();
 
     fireEvent.change(searchInput, { target: { value: 'world' } });
+    await waitFor(() => expect(updateFilters.mock.calls.length).toBe(1));
     expect(updateFilters).toHaveBeenCalledWith({
       text: new EntityTextFilter('world'),
     });
 
     fireEvent.change(searchInput, { target: { value: '' } });
+    await waitFor(() => expect(updateFilters.mock.calls.length).toBe(2));
     expect(updateFilters).toHaveBeenCalledWith({
       text: undefined,
     });

--- a/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
+++ b/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
@@ -27,7 +27,7 @@ import Search from '@material-ui/icons/Search';
 import React, { useState } from 'react';
 import { useDebounce } from 'react-use';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
-import { EntityTextFilter } from '../../types';
+import { EntityTextFilter } from '../../filters';
 
 const useStyles = makeStyles(_theme => ({
   searchToolbar: {

--- a/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
+++ b/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  EntityTextFilter,
-  useEntityListProvider,
-} from '@backstage/plugin-catalog-react';
+
 import {
   FormControl,
   IconButton,
@@ -27,7 +24,10 @@ import {
 } from '@material-ui/core';
 import Clear from '@material-ui/icons/Clear';
 import Search from '@material-ui/icons/Search';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
+import { useDebounce } from 'react-use';
+import { useEntityListProvider } from '../../hooks/useEntityListProvider';
+import { EntityTextFilter } from '../../types';
 
 const useStyles = makeStyles(_theme => ({
   searchToolbar: {
@@ -36,18 +36,21 @@ const useStyles = makeStyles(_theme => ({
   },
 }));
 
-// TODO(chaseajen): move component to /plugins/catalog-react
-const SearchToolbar = () => {
+export const EntitySearchBar = () => {
   const styles = useStyles();
 
   const { filters, updateFilters } = useEntityListProvider();
   const [search, setSearch] = useState(filters.text?.value ?? '');
 
-  useEffect(() => {
-    updateFilters({
-      text: search.length ? new EntityTextFilter(search) : undefined,
-    });
-  }, [search, updateFilters]);
+  useDebounce(
+    () => {
+      updateFilters({
+        text: search.length ? new EntityTextFilter(search) : undefined,
+      });
+    },
+    250,
+    [search, updateFilters],
+  );
 
   return (
     <Toolbar className={styles.searchToolbar}>
@@ -80,5 +83,3 @@ const SearchToolbar = () => {
     </Toolbar>
   );
 };
-
-export default SearchToolbar;

--- a/plugins/catalog-react/src/components/EntitySearchBar/index.ts
+++ b/plugins/catalog-react/src/components/EntitySearchBar/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './EntityKindPicker';
-export * from './EntityLifecyclePicker';
-export * from './EntityOwnerPicker';
-export * from './EntityProvider';
-export * from './EntityRefLink';
-export * from './EntitySearchBar';
-export * from './EntityTable';
-export * from './EntityTagPicker';
-export * from './EntityTypePicker';
-export * from './UserListPicker';
+
+export { EntitySearchBar } from './EntitySearchBar';

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
@@ -18,7 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
-import { EntityTagFilter } from '../../types';
+import { EntityTagFilter } from '../../filters';
 import { EntityTagPicker } from './EntityTagPicker';
 
 const taggedEntities: Entity[] = [

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -28,7 +28,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { Autocomplete } from '@material-ui/lab';
 import React, { useMemo } from 'react';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
-import { EntityTagFilter } from '../../types';
+import { EntityTagFilter } from '../../filters';
 
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;

--- a/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
@@ -28,7 +28,7 @@ import { Entity } from '@backstage/catalog-model';
 import { EntityTypePicker } from './EntityTypePicker';
 import { MockEntityListContextProvider } from '../../testUtils/providers';
 import { catalogApiRef } from '../../api';
-import { EntityKindFilter, EntityTypeFilter } from '../../types';
+import { EntityKindFilter, EntityTypeFilter } from '../../filters';
 
 const entities: Entity[] = [
   {

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -32,7 +32,7 @@ import {
   identityApiRef,
   storageApiRef,
 } from '@backstage/core';
-import { EntityTagFilter, UserListFilter } from '../../types';
+import { EntityTagFilter, UserListFilter } from '../../filters';
 import { CatalogApi } from '@backstage/catalog-client';
 import { catalogApiRef } from '../../api';
 import { MockStorageApi } from '@backstage/test-utils';

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -102,13 +102,27 @@ function getFilterGroups(orgName: string | undefined): ButtonGroup[] {
 
 type UserListPickerProps = {
   initialFilter?: UserListFilterKind;
+  availableFilters?: UserListFilterKind[];
 };
 
-export const UserListPicker = ({ initialFilter }: UserListPickerProps) => {
+export const UserListPicker = ({
+  initialFilter,
+  availableFilters,
+}: UserListPickerProps) => {
   const classes = useStyles();
   const configApi = useApi(configApiRef);
   const orgName = configApi.getOptionalString('organization.name') ?? 'Company';
-  const filterGroups = getFilterGroups(orgName);
+
+  // Remove group items that aren't in availableFilters and exclude
+  // any now-empty groups.
+  const filterGroups = getFilterGroups(orgName)
+    .map(filterGroup => ({
+      ...filterGroup,
+      items: filterGroup.items.filter(
+        ({ id }) => !availableFilters || availableFilters.includes(id),
+      ),
+    }))
+    .filter(({ items }) => !!items.length);
 
   const { value: user } = useOwnUser();
   const { isStarredEntity } = useStarredEntities();

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -17,7 +17,8 @@
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { compact } from 'lodash';
 import { configApiRef, IconComponent, useApi } from '@backstage/core';
-import { UserListFilter, UserListFilterKind } from '../../types';
+import { UserListFilterKind } from '../../types';
+import { UserListFilter } from '../../filters';
 import {
   useEntityListProvider,
   useOwnUser,

--- a/plugins/catalog-react/src/filters.test.ts
+++ b/plugins/catalog-react/src/filters.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity, TemplateEntityV1beta2 } from '@backstage/catalog-model';
+import { EntityTextFilter } from './filters';
+
+const entities: Entity[] = [
+  {
+    apiVersion: '1',
+    kind: 'Component',
+    metadata: {
+      name: 'react-app',
+      tags: ['react', 'experimental'],
+    },
+  },
+  {
+    apiVersion: '1',
+    kind: 'Component',
+    metadata: {
+      name: 'gRPC service',
+      tags: ['gRPC', 'java'],
+    },
+  },
+];
+
+const templates: TemplateEntityV1beta2[] = [
+  {
+    apiVersion: 'backstage.io/v1beta2',
+    kind: 'Template',
+    metadata: {
+      name: 'react-app',
+      title: 'Create React App Template',
+      tags: ['react', 'experimental'],
+    },
+    spec: {
+      type: '',
+      steps: [],
+    },
+  },
+  {
+    apiVersion: 'backstage.io/v1beta2',
+    kind: 'Template',
+    metadata: {
+      name: 'gRPC service',
+      title: 'Spring Boot gRPC Service',
+      tags: ['gRPC', 'java'],
+    },
+    spec: {
+      type: '',
+      steps: [],
+    },
+  },
+];
+
+describe('EntityTextFilter', () => {
+  it('should search name', () => {
+    const filter = new EntityTextFilter('app');
+    expect(filter.filterEntity(entities[0])).toBeTruthy();
+    expect(filter.filterEntity(entities[1])).toBeFalsy();
+  });
+
+  it('should search template title', () => {
+    const filter = new EntityTextFilter('spring');
+    expect(filter.filterEntity(templates[0])).toBeFalsy();
+    expect(filter.filterEntity(templates[1])).toBeTruthy();
+  });
+
+  it('should search tags', () => {
+    const filter = new EntityTextFilter('java');
+    expect(filter.filterEntity(entities[0])).toBeFalsy();
+    expect(filter.filterEntity(entities[1])).toBeTruthy();
+  });
+
+  it('should be case insensitive', () => {
+    const filter = new EntityTextFilter('JaVa');
+    expect(filter.filterEntity(entities[0])).toBeFalsy();
+    expect(filter.filterEntity(entities[1])).toBeTruthy();
+  });
+});

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  UserEntity,
+  RELATION_OWNED_BY,
+} from '@backstage/catalog-model';
+import { EntityFilter, UserListFilterKind } from './types';
+import { getEntityRelations, isOwnerOf } from './utils';
+import { formatEntityRefTitle } from './components/EntityRefLink';
+
+export class EntityKindFilter implements EntityFilter {
+  constructor(readonly value: string) {}
+
+  getCatalogFilters(): Record<string, string | string[]> {
+    return { kind: this.value };
+  }
+}
+
+export class EntityTypeFilter implements EntityFilter {
+  constructor(readonly value: string) {}
+
+  getCatalogFilters(): Record<string, string | string[]> {
+    return { 'spec.type': this.value };
+  }
+}
+
+export class EntityTagFilter implements EntityFilter {
+  constructor(readonly values: string[]) {}
+
+  filterEntity(entity: Entity): boolean {
+    return this.values.every(v => (entity.metadata.tags ?? []).includes(v));
+  }
+}
+
+export class EntityTextFilter implements EntityFilter {
+  constructor(readonly value: string) {}
+
+  filterEntity(entity: Entity): boolean {
+    const upperCaseValue = this.value.toLocaleUpperCase('en-US');
+
+    return (
+      entity.metadata.name
+        .toLocaleUpperCase('en-US')
+        .includes(upperCaseValue) ||
+      `${entity.metadata.title}`
+        .toLocaleUpperCase('en-US')
+        .includes(upperCaseValue) ||
+      entity.metadata.tags
+        ?.join('')
+        .toLocaleUpperCase('en-US')
+        .indexOf(upperCaseValue) !== -1
+    );
+  }
+}
+
+export class EntityOwnerFilter implements EntityFilter {
+  constructor(readonly values: string[]) {}
+
+  filterEntity(entity: Entity): boolean {
+    return this.values.some(v =>
+      getEntityRelations(entity, RELATION_OWNED_BY).some(
+        o => formatEntityRefTitle(o, { defaultKind: 'group' }) === v,
+      ),
+    );
+  }
+}
+
+export class EntityLifecycleFilter implements EntityFilter {
+  constructor(readonly values: string[]) {}
+
+  filterEntity(entity: Entity): boolean {
+    return this.values.some(v => entity.spec?.lifecycle === v);
+  }
+}
+
+export class UserListFilter implements EntityFilter {
+  constructor(
+    readonly value: UserListFilterKind,
+    readonly user: UserEntity | undefined,
+    readonly isStarredEntity: (entity: Entity) => boolean,
+  ) {}
+
+  filterEntity(entity: Entity): boolean {
+    switch (this.value) {
+      case 'owned':
+        return this.user !== undefined && isOwnerOf(this.user, entity);
+      case 'starred':
+        return this.isStarredEntity(entity);
+      default:
+        return true;
+    }
+  }
+}

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -33,12 +33,8 @@ import {
   useEntityListProvider,
 } from './useEntityListProvider';
 import { catalogApiRef } from '../api';
-import {
-  EntityKindFilter,
-  EntityTypeFilter,
-  UserListFilter,
-  UserListFilterKind,
-} from '../types';
+import { UserListFilterKind } from '../types';
+import { EntityKindFilter, EntityTypeFilter, UserListFilter } from '../filters';
 import { EntityKindPicker, UserListPicker } from '../components';
 
 const mockUser: UserEntity = {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -113,6 +113,9 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>({
       compact(Object.values(outputState.appliedFilters)),
     );
 
+    // TODO(mtlewis): currently entities will never be requested unless
+    // there's at least one filter, we should allow an initial request
+    // to happen with no filters.
     if (!isEqual(previousBackendFilter, backendFilter)) {
       // TODO(timbonicus): should limit fields here, but would need filter
       // fields + table columns

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -27,7 +27,6 @@ import React, {
 import { useAsyncFn, useDebounce } from 'react-use';
 import { catalogApiRef } from '../api';
 import {
-  EntityFilter,
   EntityKindFilter,
   EntityLifecycleFilter,
   EntityOwnerFilter,
@@ -35,7 +34,8 @@ import {
   EntityTextFilter,
   EntityTypeFilter,
   UserListFilter,
-} from '../types';
+} from '../filters';
+import { EntityFilter } from '../types';
 import { reduceCatalogFilters, reduceEntityFilters } from '../utils';
 
 export type DefaultEntityFilters = {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -32,6 +32,7 @@ import {
   EntityLifecycleFilter,
   EntityOwnerFilter,
   EntityTagFilter,
+  EntityTextFilter,
   EntityTypeFilter,
   UserListFilter,
 } from '../types';
@@ -44,6 +45,7 @@ export type DefaultEntityFilters = {
   owners?: EntityOwnerFilter;
   lifecycles?: EntityLifecycleFilter;
   tags?: EntityTagFilter;
+  text?: EntityTextFilter;
 };
 
 export type EntityListContextProps<

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -22,7 +22,7 @@ import {
   DefaultEntityFilters,
   useEntityListProvider,
 } from './useEntityListProvider';
-import { EntityTypeFilter } from '../types';
+import { EntityTypeFilter } from '../filters';
 
 type EntityTypeReturn = {
   loading: boolean;

--- a/plugins/catalog-react/src/index.ts
+++ b/plugins/catalog-react/src/index.ts
@@ -17,6 +17,7 @@ export type { CatalogApi } from '@backstage/catalog-client';
 export { catalogApiRef } from './api';
 export * from './components';
 export * from './hooks';
+export * from './filters';
 export {
   catalogRouteRef,
   entityRoute,

--- a/plugins/catalog-react/src/types.ts
+++ b/plugins/catalog-react/src/types.ts
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Entity,
-  RELATION_OWNED_BY,
-  UserEntity,
-} from '@backstage/catalog-model';
-import { getEntityRelations, isOwnerOf } from './utils';
-import { formatEntityRefTitle } from './components/EntityRefLink';
+import { Entity } from '@backstage/catalog-model';
 
 export type EntityFilter = {
   /**
@@ -42,85 +36,4 @@ export type EntityFilter = {
   filterEntity?: (entity: Entity) => boolean;
 };
 
-export class EntityKindFilter implements EntityFilter {
-  constructor(readonly value: string) {}
-
-  getCatalogFilters(): Record<string, string | string[]> {
-    return { kind: this.value };
-  }
-}
-
-export class EntityTypeFilter implements EntityFilter {
-  constructor(readonly value: string) {}
-
-  getCatalogFilters(): Record<string, string | string[]> {
-    return { 'spec.type': this.value };
-  }
-}
-
-export class EntityTagFilter implements EntityFilter {
-  constructor(readonly values: string[]) {}
-
-  filterEntity(entity: Entity): boolean {
-    return this.values.every(v => (entity.metadata.tags ?? []).includes(v));
-  }
-}
-
-// TODO(chaseajen): add unit test for logic
-export class EntityTextFilter implements EntityFilter {
-  constructor(readonly value: string) {}
-
-  filterEntity(entity: Entity): boolean {
-    const upperCaseValue = this.value.toLocaleUpperCase('en-US');
-
-    return (
-      `${entity.metadata.title}`
-        .toLocaleUpperCase('en-US')
-        .includes(upperCaseValue) ||
-      entity.metadata.tags
-        ?.join('')
-        .toLocaleUpperCase('en-US')
-        .indexOf(upperCaseValue) !== -1
-    );
-  }
-}
-
-export class EntityOwnerFilter implements EntityFilter {
-  constructor(readonly values: string[]) {}
-
-  filterEntity(entity: Entity): boolean {
-    return this.values.some(v =>
-      getEntityRelations(entity, RELATION_OWNED_BY).some(
-        o => formatEntityRefTitle(o, { defaultKind: 'group' }) === v,
-      ),
-    );
-  }
-}
-
-export class EntityLifecycleFilter implements EntityFilter {
-  constructor(readonly values: string[]) {}
-
-  filterEntity(entity: Entity): boolean {
-    return this.values.some(v => entity.spec?.lifecycle === v);
-  }
-}
-
 export type UserListFilterKind = 'owned' | 'starred' | 'all';
-export class UserListFilter implements EntityFilter {
-  constructor(
-    readonly value: UserListFilterKind,
-    readonly user: UserEntity | undefined,
-    readonly isStarredEntity: (entity: Entity) => boolean,
-  ) {}
-
-  filterEntity(entity: Entity): boolean {
-    switch (this.value) {
-      case 'owned':
-        return this.user !== undefined && isOwnerOf(this.user, entity);
-      case 'starred':
-        return this.isStarredEntity(entity);
-      default:
-        return true;
-    }
-  }
-}

--- a/plugins/catalog-react/src/types.ts
+++ b/plugins/catalog-react/src/types.ts
@@ -66,6 +66,25 @@ export class EntityTagFilter implements EntityFilter {
   }
 }
 
+// TODO(chaseajen): add unit test for logic
+export class EntityTextFilter implements EntityFilter {
+  constructor(readonly value: string) {}
+
+  filterEntity(entity: Entity): boolean {
+    const upperCaseValue = this.value.toLocaleUpperCase('en-US');
+
+    return (
+      `${entity.metadata.title}`
+        .toLocaleUpperCase('en-US')
+        .includes(upperCaseValue) ||
+      entity.metadata.tags
+        ?.join('')
+        .toLocaleUpperCase('en-US')
+        .indexOf(upperCaseValue) !== -1
+    );
+  }
+}
+
 export class EntityOwnerFilter implements EntityFilter {
   constructor(readonly values: string[]) {}
 

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Entity,
-  EntityMeta,
-  TemplateEntityV1alpha1,
-} from '@backstage/catalog-model';
+import { TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 import {
   Content,
   ContentHeader,
@@ -39,7 +35,7 @@ import {
   UserListPicker,
 } from '@backstage/plugin-catalog-react';
 import { Button, Link, makeStyles, Typography } from '@material-ui/core';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { registerComponentRouteRef } from '../../routes';
 import SearchToolbar from '../SearchToolbar/SearchToolbar';
@@ -58,25 +54,7 @@ export const ScaffolderPageContents = () => {
   const styles = useStyles();
   const { loading, error, entities } = useEntityListProvider();
 
-  const [search, setSearch] = useState('');
-  const [matchingEntities, setMatchingEntities] = useState([] as Entity[]);
-
-  const matchesQuery = (metadata: EntityMeta, query: string) =>
-    `${metadata.title}`.toLocaleUpperCase('en-US').includes(query) ||
-    metadata.tags?.join('').toLocaleUpperCase('en-US').indexOf(query) !== -1;
-
   const registerComponentLink = useRouteRef(registerComponentRouteRef);
-
-  useEffect(() => {
-    if (search.length === 0) {
-      return setMatchingEntities(entities);
-    }
-    return setMatchingEntities(
-      entities.filter(template =>
-        matchesQuery(template.metadata, search.toLocaleUpperCase('en-US')),
-      ),
-    );
-  }, [search, entities]);
 
   return (
     <Page themeId="home">
@@ -110,8 +88,7 @@ export const ScaffolderPageContents = () => {
 
         <div className={styles.contentWrapper}>
           <div>
-            {/* TODO(mtlewis) extract SearchToolbar as a frontend filter */}
-            <SearchToolbar search={search} setSearch={setSearch} />
+            <SearchToolbar />
             <EntityKindPicker initialFilter="template" hidden />
             <UserListPicker
               initialFilter="all"
@@ -133,23 +110,20 @@ export const ScaffolderPageContents = () => {
               </WarningPanel>
             )}
 
-            {!error &&
-              !loading &&
-              matchingEntities &&
-              !matchingEntities.length && (
-                <Typography variant="body2">
-                  No templates found that match your filter. Learn more about{' '}
-                  <Link href="https://backstage.io/docs/features/software-templates/adding-templates">
-                    adding templates
-                  </Link>
-                  .
-                </Typography>
-              )}
+            {!error && !loading && entities && !entities.length && (
+              <Typography variant="body2">
+                No templates found that match your filter. Learn more about{' '}
+                <Link href="https://backstage.io/docs/features/software-templates/adding-templates">
+                  adding templates
+                </Link>
+                .
+              </Typography>
+            )}
 
             <ItemCardGrid>
-              {matchingEntities &&
-                matchingEntities?.length > 0 &&
-                matchingEntities.map((template, i) => (
+              {entities &&
+                entities?.length > 0 &&
+                entities.map((template, i) => (
                   <TemplateCard
                     key={i}
                     template={template as TemplateEntityV1alpha1}

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -30,6 +30,7 @@ import {
 import {
   EntityKindPicker,
   EntityListProvider,
+  EntitySearchBar,
   EntityTypePicker,
   useEntityListProvider,
   UserListPicker,
@@ -38,7 +39,6 @@ import { Button, Link, makeStyles, Typography } from '@material-ui/core';
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { registerComponentRouteRef } from '../../routes';
-import SearchToolbar from '../SearchToolbar/SearchToolbar';
 import { TemplateCard } from '../TemplateCard';
 
 const useStyles = makeStyles(theme => ({
@@ -88,7 +88,7 @@ export const ScaffolderPageContents = () => {
 
         <div className={styles.contentWrapper}>
           <div>
-            <SearchToolbar />
+            <EntitySearchBar />
             <EntityKindPicker initialFilter="template" hidden />
             <UserListPicker
               initialFilter="all"

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import { EntityMeta, TemplateEntityV1alpha1 } from '@backstage/catalog-model';
 import {
-  configApiRef,
+  Entity,
+  EntityMeta,
+  TemplateEntityV1alpha1,
+} from '@backstage/catalog-model';
+import {
   Content,
   ContentHeader,
   Header,
@@ -25,20 +28,20 @@ import {
   Page,
   Progress,
   SupportButton,
-  useApi,
   useRouteRef,
   WarningPanel,
 } from '@backstage/core';
-import { useStarredEntities } from '@backstage/plugin-catalog-react';
+import {
+  EntityKindPicker,
+  EntityListProvider,
+  EntityTypePicker,
+  useEntityListProvider,
+  UserListPicker,
+} from '@backstage/plugin-catalog-react';
 import { Button, Link, makeStyles, Typography } from '@material-ui/core';
-import StarIcon from '@material-ui/icons/Star';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { EntityFilterGroupsProvider, useFilteredEntities } from '../../filter';
 import { registerComponentRouteRef } from '../../routes';
-import { ResultsFilter } from '../ResultsFilter/ResultsFilter';
-import { ScaffolderFilter } from '../ScaffolderFilter';
-import { ButtonGroup } from '../ScaffolderFilter/ScaffolderFilter';
 import SearchToolbar from '../SearchToolbar/SearchToolbar';
 import { TemplateCard } from '../TemplateCard';
 
@@ -53,45 +56,10 @@ const useStyles = makeStyles(theme => ({
 
 export const ScaffolderPageContents = () => {
   const styles = useStyles();
-  const {
-    loading,
-    error,
-    filteredEntities,
-    availableCategories,
-  } = useFilteredEntities();
-  const configApi = useApi(configApiRef);
-  const orgName = configApi.getOptionalString('organization.name') ?? 'Company';
-  const { isStarredEntity } = useStarredEntities();
-  const filterGroups = useMemo<ButtonGroup[]>(
-    () => [
-      {
-        name: orgName,
-        items: [
-          {
-            id: 'all',
-            label: 'All',
-            filterFn: () => true,
-          },
-        ],
-      },
-      {
-        name: 'Personal',
-        items: [
-          {
-            id: 'starred',
-            label: 'Starred',
-            icon: StarIcon,
-            filterFn: isStarredEntity,
-          },
-        ],
-      },
-    ],
-    [isStarredEntity, orgName],
-  );
+  const { loading, error, entities } = useEntityListProvider();
+
   const [search, setSearch] = useState('');
-  const [matchingEntities, setMatchingEntities] = useState(
-    [] as TemplateEntityV1alpha1[],
-  );
+  const [matchingEntities, setMatchingEntities] = useState([] as Entity[]);
 
   const matchesQuery = (metadata: EntityMeta, query: string) =>
     `${metadata.title}`.toLocaleUpperCase('en-US').includes(query) ||
@@ -101,14 +69,14 @@ export const ScaffolderPageContents = () => {
 
   useEffect(() => {
     if (search.length === 0) {
-      return setMatchingEntities(filteredEntities);
+      return setMatchingEntities(entities);
     }
     return setMatchingEntities(
-      filteredEntities.filter(template =>
+      entities.filter(template =>
         matchesQuery(template.metadata, search.toLocaleUpperCase('en-US')),
       ),
     );
-  }, [search, filteredEntities]);
+  }, [search, entities]);
 
   return (
     <Page themeId="home">
@@ -142,14 +110,21 @@ export const ScaffolderPageContents = () => {
 
         <div className={styles.contentWrapper}>
           <div>
+            {/* TODO(mtlewis) extract SearchToolbar as a frontend filter */}
             <SearchToolbar search={search} setSearch={setSearch} />
-            <ScaffolderFilter
-              buttonGroups={filterGroups}
-              initiallySelected="all"
+            <EntityKindPicker initialFilter="template" hidden />
+            <UserListPicker
+              initialFilter="all"
+              availableFilters={['all', 'starred']}
             />
-            <ResultsFilter availableCategories={availableCategories} />
+            {/* TODO(mtlewis) replace with custom checkbox list? maybe multiselect */}
+            {/* TODO(mtlewis) delete removed components since they're no longer used  */}
+            <EntityTypePicker />
+            {/* TODO(mtlewis) consider adding tag picker?  */}
           </div>
           <div>
+            {/* TODO(mtlewis) figure out flash of error state when entities are loading */}
+            {/* TODO(mtlewis) move loading, error handling etc. inside card list */}
             {loading && <Progress />}
 
             {error && (
@@ -177,7 +152,7 @@ export const ScaffolderPageContents = () => {
                 matchingEntities.map((template, i) => (
                   <TemplateCard
                     key={i}
-                    template={template}
+                    template={template as TemplateEntityV1alpha1}
                     deprecated={template.apiVersion === 'backstage.io/v1alpha1'}
                   />
                 ))}
@@ -190,7 +165,7 @@ export const ScaffolderPageContents = () => {
 };
 
 export const ScaffolderPage = () => (
-  <EntityFilterGroupsProvider>
+  <EntityListProvider>
     <ScaffolderPageContents />
-  </EntityFilterGroupsProvider>
+  </EntityListProvider>
 );

--- a/plugins/scaffolder/src/components/SearchToolbar/SearchToolbar.test.tsx
+++ b/plugins/scaffolder/src/components/SearchToolbar/SearchToolbar.test.tsx
@@ -17,17 +17,59 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import SearchToolbar from './SearchToolbar';
+import {
+  DefaultEntityFilters,
+  EntityTextFilter,
+  MockEntityListContextProvider,
+} from '@backstage/plugin-catalog-react';
+import { Entity } from '@backstage/catalog-model';
+
+const entities: Entity[] = [
+  {
+    apiVersion: '1',
+    kind: 'Component',
+    metadata: {
+      name: 'react-app',
+      tags: ['react', 'experimental'],
+    },
+  },
+  {
+    apiVersion: '1',
+    kind: 'Component',
+    metadata: {
+      name: 'gRPC service',
+      tags: ['gRPC', 'java'],
+    },
+  },
+];
 
 describe('SearchToolbar', () => {
   it('should display search value and execute set callback', async () => {
-    const setSearchSpy = jest.fn();
+    const updateFilters = jest.fn();
+
+    const filters: DefaultEntityFilters = {
+      text: new EntityTextFilter('hello'),
+    };
+
     const { getByDisplayValue } = render(
-      <SearchToolbar search="hello" setSearch={setSearchSpy} />,
+      <MockEntityListContextProvider
+        value={{ entities, updateFilters, filters }}
+      >
+        <SearchToolbar />
+      </MockEntityListContextProvider>,
     );
 
     const searchInput = getByDisplayValue('hello');
     expect(searchInput).toBeInTheDocument();
+
     fireEvent.change(searchInput, { target: { value: 'world' } });
-    expect(setSearchSpy).toHaveBeenCalled();
+    expect(updateFilters).toHaveBeenCalledWith({
+      text: new EntityTextFilter('world'),
+    });
+
+    fireEvent.change(searchInput, { target: { value: '' } });
+    expect(updateFilters).toHaveBeenCalledWith({
+      text: undefined,
+    });
   });
 });

--- a/plugins/scaffolder/src/components/SearchToolbar/SearchToolbar.tsx
+++ b/plugins/scaffolder/src/components/SearchToolbar/SearchToolbar.tsx
@@ -13,22 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import {
+  EntityTextFilter,
+  useEntityListProvider,
+} from '@backstage/plugin-catalog-react';
 import {
   FormControl,
+  IconButton,
+  Input,
   InputAdornment,
   makeStyles,
   Toolbar,
-  Input,
-  IconButton,
 } from '@material-ui/core';
-import Search from '@material-ui/icons/Search';
 import Clear from '@material-ui/icons/Clear';
-
-interface Props {
-  search: string;
-  setSearch: Function;
-}
+import Search from '@material-ui/icons/Search';
+import React, { useEffect, useState } from 'react';
 
 const useStyles = makeStyles(_theme => ({
   searchToolbar: {
@@ -37,8 +36,19 @@ const useStyles = makeStyles(_theme => ({
   },
 }));
 
-const SearchToolbar = ({ search, setSearch }: Props) => {
+// TODO(chaseajen): move component to /plugins/catalog-react
+const SearchToolbar = () => {
   const styles = useStyles();
+
+  const { filters, updateFilters } = useEntityListProvider();
+  const [search, setSearch] = useState(filters.text?.value ?? '');
+
+  useEffect(() => {
+    updateFilters({
+      text: search.length ? new EntityTextFilter(search) : undefined,
+    });
+  }, [search, updateFilters]);
+
   return (
     <Toolbar className={styles.searchToolbar}>
       <FormControl>


### PR DESCRIPTION
## Use entity list provider in scaffolder page

Refactoring the `ScaffolderPage` to use the `EntityListProvider` previously added in #5643.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
