### PR TITLE
Autofix Markdown files using Prettier on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: node scripts/verify-links.js
 
       - name: prettier
-        run: yarn prettier:check
+        run: yarn prettier:check '!ADOPTERS.md'
 
       - name: lock
         run: yarn lock:check

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   autofix-markdown:
     name: Autofix Markdown files using Prettier
-    runs-ons: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -43,22 +43,12 @@ jobs:
         run: yarn install --frozen-lockfile
       # End of yarn setup
 
-      - name: Run Prettier on docs
+      - name: Run Prettier on ADOPTERS.md
         uses: creyD/prettier_action@v3.1
         with:
           # Modifies commit only if prettier autofixed the ADOPTERS.md
           prettier_options: --config docs/prettier.config.js --write ADOPTERS.md
           only_changed: true
-          commit_message: 'Autofix documentation Markdown files using Prettier'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Prettier on root
-        uses: creyD/prettier_action@v3.1
-        with:
-          # Modifies commit only if prettier autofixed a Markdown file
-          prettier_options: --write *.md
-          only_changed: true
-          commit_message: 'Autofix Markdown files using Prettier'
+          commit_message: 'Autofix ADOPTERS.md using Prettier'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Run Prettier on docs
         uses: creyD/prettier_action@v3.1
         with:
-          # Modifies commit only if prettier autofixed a Markdown file
-          prettier_options: --config docs/prettier.config.js --write docs/**/*.md
+          # Modifies commit only if prettier autofixed the ADOPTERS.md
+          prettier_options: --config docs/prettier.config.js --write ADOPTERS.md
           only_changed: true
           commit_message: 'Autofix documentation Markdown files using Prettier'
         env:

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -1,0 +1,55 @@
+name: Prettier
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  autofix-markdown:
+    name: Autofix Markdown files using Prettier
+    runs-ons: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Fetch changes to previous commit - required for 'only_changed' in Prettier action
+          fetch-depth: 0
+
+      # Beginning of yarn setup, keep in sync between all workflows, see ci.yml
+      - name: use node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+      - name: cache all node_modules
+        id: cache-modules
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-v${{ matrix.node-version }}-node_modules-${{ hashFiles('yarn.lock', '**/package.json') }}
+      - name: find location of global yarn cache
+        id: yarn-cache
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: cache global yarn cache
+        uses: actions/cache@v2
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: yarn install
+        run: yarn install --frozen-lockfile
+      # End of yarn setup
+
+      - name: Run Prettier
+        uses: creyD/prettier_action@v3.1
+        with:
+          # Modifies commit only if prettier autofixed a Markdown file
+          prettier_options: --config docs/prettier.config.js --write docs/**/*.md
+          only_changed: true
+          commit_message: "Autofix Markdown files using Prettier"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -49,7 +49,7 @@ jobs:
           # Modifies commit only if prettier autofixed a Markdown file
           prettier_options: --config docs/prettier.config.js --write docs/**/*.md
           only_changed: true
-          commit_message: "Autofix documentation Markdown files using Prettier"
+          commit_message: 'Autofix documentation Markdown files using Prettier'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -59,7 +59,6 @@ jobs:
           # Modifies commit only if prettier autofixed a Markdown file
           prettier_options: --write *.md
           only_changed: true
-          commit_message: "Autofix Markdown files using Prettier"
+          commit_message: 'Autofix Markdown files using Prettier'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -43,11 +43,21 @@ jobs:
         run: yarn install --frozen-lockfile
       # End of yarn setup
 
-      - name: Run Prettier
+      - name: Run Prettier on docs
         uses: creyD/prettier_action@v3.1
         with:
           # Modifies commit only if prettier autofixed a Markdown file
           prettier_options: --config docs/prettier.config.js --write docs/**/*.md
+          only_changed: true
+          commit_message: "Autofix documentation Markdown files using Prettier"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Prettier on root
+        uses: creyD/prettier_action@v3.1
+        with:
+          # Modifies commit only if prettier autofixed a Markdown file
+          prettier_options: --write *.md
           only_changed: true
           commit_message: "Autofix Markdown files using Prettier"
         env:


### PR DESCRIPTION
Add seperate workflow for autofixing MD files using Prettier when PRs get merged into master. Use case: Edit docs from browser, but they don't align Prettier config. For more info checkout out the linked issue

Closes #3256

#### :heavy_check_mark: Checklist


- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))