### PR TITLE
Fix empty state not being displayed on missing results

### DIFF
--- a/.changeset/breezy-books-matter.md
+++ b/.changeset/breezy-books-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Fix empty state not being displayed on missing results.

--- a/plugins/search/src/components/SearchResult/SearchResult.test.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.test.tsx
@@ -55,9 +55,23 @@ describe('SearchResult', () => {
     });
   });
 
-  it('On empty result value state', async () => {
+  it('On no result value state', async () => {
     (useSearch as jest.Mock).mockReturnValueOnce({
       result: { loading: false, error: '', value: undefined },
+    });
+
+    const { getByRole } = render(<SearchResult>{() => <></>}</SearchResult>);
+
+    await waitFor(() => {
+      expect(
+        getByRole('heading', { name: 'Sorry, no results were found' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('On empty result value state', async () => {
+    (useSearch as jest.Mock).mockReturnValueOnce({
+      result: { loading: false, error: '', value: { results: [] } },
     });
 
     const { getByRole } = render(<SearchResult>{() => <></>}</SearchResult>);

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -41,7 +41,7 @@ const SearchResultComponent = ({ children }: Props) => {
     );
   }
 
-  if (!value) {
+  if (!value?.results.length) {
     return <EmptyState missing="data" title="Sorry, no results were found" />;
   }
 


### PR DESCRIPTION
Closes #6031.

Actually, this is just a small and trivial issue. `useAsync` can return undefined, but if the results are empty it returns an empty array instead.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
