### PR TITLE
microsite: Updating default OG description for a blog post

### DIFF
--- a/microsite/blog/2021-06-22-spotify-backstage-is-growing.md
+++ b/microsite/blog/2021-06-22-spotify-backstage-is-growing.md
@@ -4,7 +4,7 @@ author: Austin Lamon, Spotify
 authorURL: https://www.linkedin.com/in/austinlamon
 ---
 
-[![Spotify Backstage: Proven at Spotify. Made just for you.](assets/21-06-22/spotify-backstage-header.gif)](https://backstage.spotify.com/)
+[![The Backstage community is growing! In just over a year, Backstage has gone from a few open source building blocks to a thriving platform used by engineering orgs with thousands of developers. But even with 30+ adopting companies and 400+ contributors, we are still in the very early stages of reaching the platform’s potential.](assets/21-06-22/spotify-backstage-header.gif)](https://backstage.spotify.com/)
 _[backstage.spotify.com](https://backstage.spotify.com)_
 
 The Backstage community is growing! In just over [a year](https://engineering.atspotify.com/2021/03/16/happy-birthday-backstage-spotifys-biggest-open-source-project-grows-up-fast/), Backstage has gone from a few open source building blocks to a thriving platform used by engineering orgs with thousands of developers. But even with 30+ [adopting companies](https://github.com/backstage/backstage/blob/master/ADOPTERS.md) and 400+ contributors, we are still in the very early stages of reaching the platform’s potential.


### PR DESCRIPTION
The post's OpenGraph description (the text that appears in the link previews in Twitter, Slack, etc.) is defaulting to displaying the image markup.

As a workaround, adding more alt. text to that image tag in order to a provide a more readable description when sharing a link to the post.

Signed-off-by: Jeff Feng <fengypants@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
