### PR TITLE
auth: Show better error message if auth provider keys are undefined

### DIFF
--- a/.changeset/thirty-turtles-carry.md
+++ b/.changeset/thirty-turtles-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Show better error message when configs defined under auth.providers.<provider> are undefined.

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -88,15 +88,12 @@ export async function createRouter({
   const providersConfig = config.getConfig('auth.providers');
   const configuredProviders = providersConfig.keys();
 
-  for (const providerId of Object.keys(allProviderFactories)) {
+  for (const [providerId, providerFactory] of Object.entries(
+    allProviderFactories,
+  )) {
     if (configuredProviders.includes(providerId)) {
       logger.info(`Configuring provider, ${providerId}`);
       try {
-        const providerFactory = allProviderFactories[providerId];
-        if (!providerFactory) {
-          throw Error(`No auth provider available for '${providerId}'`);
-        }
-
         const provider = providerFactory({
           providerId,
           globalConfig: { baseUrl: authUrl, appUrl },

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -144,6 +144,11 @@ export async function createRouter({
     }
   }
 
+  router.use('/:provider/', req => {
+    const { provider } = req.params;
+    throw new NotFoundError(`Unknown auth provider '${provider}'`);
+  });
+
   router.use(
     createOidcRouter({
       tokenIssuer,

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -86,47 +86,64 @@ export async function createRouter({
     ...providerFactories,
   };
   const providersConfig = config.getConfig('auth.providers');
-  const providers = providersConfig.keys();
+  const configuredProviders = providersConfig.keys();
 
-  for (const providerId of providers) {
-    logger.info(`Configuring provider, ${providerId}`);
-    try {
-      const providerFactory = allProviderFactories[providerId];
-      if (!providerFactory) {
-        throw Error(`No auth provider available for '${providerId}'`);
+  for (const providerId of Object.keys(allProviderFactories)) {
+    if (configuredProviders.includes(providerId)) {
+      logger.info(`Configuring provider, ${providerId}`);
+      try {
+        const providerFactory = allProviderFactories[providerId];
+        if (!providerFactory) {
+          throw Error(`No auth provider available for '${providerId}'`);
+        }
+
+        const provider = providerFactory({
+          providerId,
+          globalConfig: { baseUrl: authUrl, appUrl },
+          config: providersConfig.getConfig(providerId),
+          logger,
+          tokenIssuer,
+          discovery,
+          catalogApi,
+        });
+
+        const r = Router();
+
+        r.get('/start', provider.start.bind(provider));
+        r.get('/handler/frame', provider.frameHandler.bind(provider));
+        r.post('/handler/frame', provider.frameHandler.bind(provider));
+        if (provider.logout) {
+          r.post('/logout', provider.logout.bind(provider));
+        }
+        if (provider.refresh) {
+          r.get('/refresh', provider.refresh.bind(provider));
+        }
+
+        router.use(`/${providerId}`, r);
+      } catch (e) {
+        if (process.env.NODE_ENV !== 'development') {
+          throw new Error(
+            `Failed to initialize ${providerId} auth provider, ${e.message}`,
+          );
+        }
+
+        logger.warn(`Skipping ${providerId} auth provider, ${e.message}`);
+
+        router.use(`/${providerId}`, () => {
+          // If the user added the provider under auth.providers but the clientId and clientSecret etc. were not found.
+          throw new NotFoundError(
+            `Auth provider registered for '${providerId}' is misconfigured. This could mean the configs under ` +
+              `auth.providers.${providerId} are missing or the environment variables used are not defined. ` +
+              `Check the auth backend plugin logs when the backend starts to see more details.`,
+          );
+        });
       }
-
-      const provider = providerFactory({
-        providerId,
-        globalConfig: { baseUrl: authUrl, appUrl },
-        config: providersConfig.getConfig(providerId),
-        logger,
-        tokenIssuer,
-        discovery,
-        catalogApi,
-      });
-
-      const r = Router();
-
-      r.get('/start', provider.start.bind(provider));
-      r.get('/handler/frame', provider.frameHandler.bind(provider));
-      r.post('/handler/frame', provider.frameHandler.bind(provider));
-      if (provider.logout) {
-        r.post('/logout', provider.logout.bind(provider));
-      }
-      if (provider.refresh) {
-        r.get('/refresh', provider.refresh.bind(provider));
-      }
-
-      router.use(`/${providerId}`, r);
-    } catch (e) {
-      if (process.env.NODE_ENV !== 'development') {
-        throw new Error(
-          `Failed to initialize ${providerId} auth provider, ${e.message}`,
+    } else {
+      router.use(`/${providerId}`, () => {
+        throw new NotFoundError(
+          `No auth provider registered for '${providerId}'`,
         );
-      }
-
-      logger.warn(`Skipping ${providerId} auth provider, ${e.message}`);
+      });
     }
   }
 
@@ -136,20 +153,6 @@ export async function createRouter({
       baseUrl: authUrl,
     }),
   );
-
-  router.use('/:provider/', req => {
-    const { provider } = req.params;
-    if (providers.includes(provider)) {
-      // If the user added the provider under auth.providers but the clientId and clientSecret etc. were not found.
-      throw new NotFoundError(
-        `Auth provider registered for '${provider}' is misconfigured. This could mean the configs under ` +
-          `auth.providers.${provider} are missing or the environment variables used are not defined. ` +
-          `Check the auth backend plugin logs when the backend starts to see more details.`,
-      );
-    } else {
-      throw new NotFoundError(`No auth provider registered for '${provider}'`);
-    }
-  });
 
   return router;
 }

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -139,7 +139,16 @@ export async function createRouter({
 
   router.use('/:provider/', req => {
     const { provider } = req.params;
-    throw new NotFoundError(`No auth provider registered for '${provider}'`);
+    if (providers.includes(provider)) {
+      // If they added the provider under auth.providers but the clientId and clientSecret etc. were not found.
+      throw new NotFoundError(
+        `Auth provider registered for '${provider}' is misconfigured. This could mean the configs under ` +
+          `auth.providers.${provider} are missing or the environment variables used are not defined. ` +
+          `Check the auth backend plugin logs when the backend starts to see more details.`,
+      );
+    } else {
+      throw new NotFoundError(`No auth provider registered for '${provider}'`);
+    }
   });
 
   return router;

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -140,7 +140,7 @@ export async function createRouter({
   router.use('/:provider/', req => {
     const { provider } = req.params;
     if (providers.includes(provider)) {
-      // If they added the provider under auth.providers but the clientId and clientSecret etc. were not found.
+      // If the user added the provider under auth.providers but the clientId and clientSecret etc. were not found.
       throw new NotFoundError(
         `Auth provider registered for '${provider}' is misconfigured. This could mean the configs under ` +
           `auth.providers.${provider} are missing or the environment variables used are not defined. ` +


### PR DESCRIPTION
Closes https://github.com/backstage/backstage/issues/6161

This PR updates how the provider endpoints get registered in the auth backend plugin.

Response code 200 for properly registered auth providers
404 (with proper message) for misconfigured providers (missing keys or such)
404 (plain): for unknown providers

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))