### PR TITLE
Improved titles for relationship cards

### DIFF
--- a/.changeset/three-tables-smash.md
+++ b/.changeset/three-tables-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Clearer titles for the relationship cards

--- a/plugins/catalog/src/components/DependsOnResourcesCard/DependsOnResourcesCard.test.tsx
+++ b/plugins/catalog/src/components/DependsOnResourcesCard/DependsOnResourcesCard.test.tsx
@@ -66,7 +66,7 @@ describe('<DependsOnResourcesCard />', () => {
       </Wrapper>,
     );
 
-    expect(getByText('Resources')).toBeInTheDocument();
+    expect(getByText('Depends on resources')).toBeInTheDocument();
     expect(
       getByText(/No resource is a dependency of this component/i),
     ).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('<DependsOnResourcesCard />', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Resources')).toBeInTheDocument();
+      expect(getByText('Depends on resources')).toBeInTheDocument();
       expect(getByText(/target-name/i)).toBeInTheDocument();
     });
   });

--- a/plugins/catalog/src/components/DependsOnResourcesCard/DependsOnResourcesCard.tsx
+++ b/plugins/catalog/src/components/DependsOnResourcesCard/DependsOnResourcesCard.tsx
@@ -31,7 +31,7 @@ export const DependsOnResourcesCard = ({ variant = 'gridItem' }: Props) => {
   return (
     <RelatedEntitiesCard
       variant={variant}
-      title="Resources"
+      title="Depends on resources"
       entityKind="Resource"
       relationType={RELATION_DEPENDS_ON}
       columns={resourceEntityColumns}

--- a/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.test.tsx
+++ b/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.test.tsx
@@ -66,7 +66,7 @@ describe('<HasComponentsCard />', () => {
       </Wrapper>,
     );
 
-    expect(getByText('Components')).toBeInTheDocument();
+    expect(getByText('Has components')).toBeInTheDocument();
     expect(
       getByText(/No component is part of this system/i),
     ).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('<HasComponentsCard />', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Components')).toBeInTheDocument();
+      expect(getByText('Has components')).toBeInTheDocument();
       expect(getByText(/target-name/i)).toBeInTheDocument();
     });
   });

--- a/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
+++ b/plugins/catalog/src/components/HasComponentsCard/HasComponentsCard.tsx
@@ -31,7 +31,7 @@ export const HasComponentsCard = ({ variant = 'gridItem' }: Props) => {
   return (
     <RelatedEntitiesCard
       variant={variant}
-      title="Components"
+      title="Has components"
       entityKind="Component"
       relationType={RELATION_HAS_PART}
       columns={componentEntityColumns}

--- a/plugins/catalog/src/components/HasResourcesCard/HasResourcesCard.test.tsx
+++ b/plugins/catalog/src/components/HasResourcesCard/HasResourcesCard.test.tsx
@@ -66,7 +66,7 @@ describe('<HasResourcesCard />', () => {
       </Wrapper>,
     );
 
-    expect(getByText('Resources')).toBeInTheDocument();
+    expect(getByText('Has resources')).toBeInTheDocument();
     expect(
       getByText(/No resource is part of this system/i),
     ).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('<HasResourcesCard />', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Resources')).toBeInTheDocument();
+      expect(getByText('Has resources')).toBeInTheDocument();
       expect(getByText(/target-name/i)).toBeInTheDocument();
     });
   });

--- a/plugins/catalog/src/components/HasResourcesCard/HasResourcesCard.tsx
+++ b/plugins/catalog/src/components/HasResourcesCard/HasResourcesCard.tsx
@@ -31,7 +31,7 @@ export const HasResourcesCard = ({ variant = 'gridItem' }: Props) => {
   return (
     <RelatedEntitiesCard
       variant={variant}
-      title="Resources"
+      title="Has resources"
       entityKind="Resource"
       relationType={RELATION_HAS_PART}
       columns={resourceEntityColumns}

--- a/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.test.tsx
+++ b/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.test.tsx
@@ -66,7 +66,7 @@ describe('<HasSubcomponentsCard />', () => {
       </Wrapper>,
     );
 
-    expect(getByText('Subcomponents')).toBeInTheDocument();
+    expect(getByText('Has subcomponents')).toBeInTheDocument();
     expect(
       getByText(/No subcomponent is part of this component/i),
     ).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('<HasSubcomponentsCard />', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Subcomponents')).toBeInTheDocument();
+      expect(getByText('Has subcomponents')).toBeInTheDocument();
       expect(getByText(/target-name/i)).toBeInTheDocument();
     });
   });

--- a/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
+++ b/plugins/catalog/src/components/HasSubcomponentsCard/HasSubcomponentsCard.tsx
@@ -30,7 +30,7 @@ export const HasSubcomponentsCard = ({ variant = 'gridItem' }: Props) => {
   return (
     <RelatedEntitiesCard
       variant={variant}
-      title="Subcomponents"
+      title="Has subcomponents"
       entityKind="Component"
       relationType={RELATION_HAS_PART}
       columns={componentEntityColumns}

--- a/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.test.tsx
+++ b/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.test.tsx
@@ -66,7 +66,7 @@ describe('<HasSystemsCard />', () => {
       </Wrapper>,
     );
 
-    expect(getByText('Systems')).toBeInTheDocument();
+    expect(getByText('Has systems')).toBeInTheDocument();
     expect(getByText(/No system is part of this domain/i)).toBeInTheDocument();
   });
 
@@ -112,7 +112,7 @@ describe('<HasSystemsCard />', () => {
     );
 
     await waitFor(() => {
-      expect(getByText('Systems')).toBeInTheDocument();
+      expect(getByText('Has systems')).toBeInTheDocument();
       expect(getByText(/target-name/i)).toBeInTheDocument();
     });
   });

--- a/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
+++ b/plugins/catalog/src/components/HasSystemsCard/HasSystemsCard.tsx
@@ -31,7 +31,7 @@ export const HasSystemsCard = ({ variant = 'gridItem' }: Props) => {
   return (
     <RelatedEntitiesCard
       variant={variant}
-      title="Systems"
+      title="Has systems"
       entityKind="System"
       relationType={RELATION_HAS_PART}
       columns={systemEntityColumns}


### PR DESCRIPTION
Some cards had the same titles, making it difficult to differentiate them. Other's weren't clear about the direction of the relationship.

### Before

![before](https://user-images.githubusercontent.com/562403/123000826-f3e80380-d3a7-11eb-8ab1-5945e5ef3bf4.png)

### After

![after](https://user-images.githubusercontent.com/562403/123000841-f8acb780-d3a7-11eb-969c-8c4e69e992cc.png)


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
