### PR TITLE
feat: add default branch prop for publish:github action

### DIFF
--- a/.changeset/violet-maps-smell.md
+++ b/.changeset/violet-maps-smell.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-common': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+add defaultBranch property for publish GitHub action

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -183,8 +183,9 @@ export class Git {
         logger?: Logger | undefined;
     }) => Git;
     // (undocumented)
-    init({ dir }: {
+    init({ dir, defaultBranch, }: {
         dir: string;
+        defaultBranch?: string;
     }): Promise<void>;
     // (undocumented)
     merge({ dir, theirs, ours, author, committer, }: {

--- a/packages/backend-common/src/scm/git.test.ts
+++ b/packages/backend-common/src/scm/git.test.ts
@@ -201,14 +201,16 @@ describe('Git', () => {
   describe('init', () => {
     it('should call isomorphic-git with the correct arguments', async () => {
       const dir = '/some/mock/dir';
+      const defaultBranch = 'master';
 
       const git = Git.fromAuth({});
 
-      await git.init({ dir });
+      await git.init({ dir, defaultBranch });
 
       expect(isomorphic.init).toHaveBeenCalledWith({
         fs,
         dir,
+        defaultBranch,
       });
     });
   });

--- a/packages/backend-common/src/scm/git.ts
+++ b/packages/backend-common/src/scm/git.ts
@@ -150,12 +150,19 @@ export class Git {
     });
   }
 
-  async init({ dir }: { dir: string }): Promise<void> {
+  async init({
+    dir,
+    defaultBranch = 'master',
+  }: {
+    dir: string;
+    defaultBranch?: string;
+  }): Promise<void> {
     this.config.logger?.info(`Init git repository {dir=${dir}}`);
 
     return git.init({
       fs,
       dir,
+      defaultBranch,
     });
   }
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -175,6 +175,36 @@ describe('publish:github', () => {
     expect(initRepoAndPush).toHaveBeenCalledWith({
       dir: mockContext.workspacePath,
       remoteUrl: 'https://github.com/clone/url.git',
+      defaultBranch: 'master',
+      auth: { username: 'x-access-token', password: 'tokenlols' },
+      logger: mockContext.logger,
+    });
+  });
+
+  it('should call initRepoAndPush with the correct defaultBranch main', async () => {
+    mockGithubClient.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+
+    mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        defaultBranch: 'main',
+      },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'https://github.com/clone/url.git',
+      defaultBranch: 'main',
       auth: { username: 'x-access-token', password: 'tokenlols' },
       logger: mockContext.logger,
     });
@@ -428,6 +458,36 @@ describe('publish:github', () => {
     expect(mockContext.output).toHaveBeenCalledWith(
       'repoContentsUrl',
       'https://github.com/html/url/blob/master',
+    );
+  });
+
+  it('should use main as default branch', async () => {
+    mockGithubClient.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+
+    mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        defaultBranch: 'main',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://github.com/clone/url.git',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'repoContentsUrl',
+      'https://github.com/html/url/blob/main',
     );
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -45,6 +45,7 @@ export function createPublishGithubAction(options: {
     repoUrl: string;
     description?: string;
     access?: string;
+    defaultBranch?: string;
     sourcePath?: string;
     repoVisibility: 'private' | 'internal' | 'public';
     collaborators: Collaborator[];
@@ -76,6 +77,11 @@ export function createPublishGithubAction(options: {
             title: 'Repository Visibility',
             type: 'string',
             enum: ['private', 'public', 'internal'],
+          },
+          defaultBranch: {
+            title: 'Default Branch',
+            type: 'string',
+            description: `Sets the default branch on the repository. The default value is 'master'`,
           },
           sourcePath: {
             title:
@@ -131,6 +137,7 @@ export function createPublishGithubAction(options: {
         description,
         access,
         repoVisibility = 'private',
+        defaultBranch = 'master',
         collaborators,
         topics,
       } = ctx.input;
@@ -239,11 +246,12 @@ export function createPublishGithubAction(options: {
       }
 
       const remoteUrl = newRepo.clone_url;
-      const repoContentsUrl = `${newRepo.html_url}/blob/master`;
+      const repoContentsUrl = `${newRepo.html_url}/blob/${defaultBranch}`;
 
       await initRepoAndPush({
         dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
         remoteUrl,
+        defaultBranch,
         auth: {
           username: 'x-access-token',
           password: token,
@@ -257,6 +265,7 @@ export function createPublishGithubAction(options: {
           client,
           repoName: newRepo.name,
           logger: ctx.logger,
+          defaultBranch,
         });
       } catch (e) {
         throw new Error(

--- a/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/stages/publish/helpers.ts
@@ -24,11 +24,13 @@ export async function initRepoAndPush({
   remoteUrl,
   auth,
   logger,
+  defaultBranch = 'master',
 }: {
   dir: string;
   remoteUrl: string;
   auth: { username: string; password: string };
   logger: Logger;
+  defaultBranch?: string;
 }): Promise<void> {
   const git = Git.fromAuth({
     username: auth.username,
@@ -38,6 +40,7 @@ export async function initRepoAndPush({
 
   await git.init({
     dir,
+    defaultBranch,
   });
 
   const paths = await globby(['./**', './**/.*', '!.git'], {
@@ -74,6 +77,7 @@ type BranchProtectionOptions = {
   owner: string;
   repoName: string;
   logger: Logger;
+  defaultBranch?: string;
 };
 
 export const enableBranchProtectionOnDefaultRepoBranch = async ({
@@ -81,6 +85,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
   client,
   owner,
   logger,
+  defaultBranch = 'master',
 }: BranchProtectionOptions): Promise<void> => {
   const tryOnce = async () => {
     try {
@@ -97,7 +102,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
         },
         owner,
         repo: repoName,
-        branch: 'master',
+        branch: defaultBranch,
         required_status_checks: { strict: true, contexts: [] },
         restrictions: null,
         enforce_admins: true,


### PR DESCRIPTION
Closes https://github.com/backstage/backstage/issues/6310

## Hey, I just made a Pull Request!
It has become common practice to use main as the default branch when initializing a Git repository. This updates the Publish:GitHub action to have the defaultBranch config property. If not provided, master will still be used.

The user will be able to change the default branch in your template like below.
```
- id: publish
   name: Publish
   action: publish:github
   input:
     allowedHosts: ['github.com']
     description: 'This is {{ parameters.name }}'
     repoUrl: '{{ parameters.repoUrl }}'
     defaultBranch: 'main' << Add this to change your default branch.
```

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


