### PR TITLE
Reintroduce export of `defaultConfigLoader`

### DIFF
--- a/.changeset/fuzzy-bottles-greet.md
+++ b/.changeset/fuzzy-bottles-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Reintroduce export of `defaultConfigLoader`.

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -201,6 +201,9 @@ export { ConfigReader }
 export function createApp(options?: AppOptions): PrivateAppImpl;
 
 // @public
+export const defaultConfigLoader: AppConfigLoader;
+
+// @public
 export class ErrorAlerter implements ErrorApi {
     constructor(alertApi: AlertApi, errorApi: ErrorApi);
     // (undocumented)

--- a/packages/core-app-api/src/app/index.ts
+++ b/packages/core-app-api/src/app/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export { createApp } from './createApp';
+export { createApp, defaultConfigLoader } from './createApp';
 export * from './types';

--- a/packages/core-app-api/src/index.test.ts
+++ b/packages/core-app-api/src/index.test.ts
@@ -21,6 +21,7 @@ describe('index', () => {
     expect(index).toEqual({
       // Public API
       createApp: expect.any(Function),
+      defaultConfigLoader: expect.any(Function),
       ApiProvider: expect.any(Function),
       // TODO(Rugvip): Figure out if we need these
       ApiFactoryRegistry: expect.any(Function),


### PR DESCRIPTION
Initialy introduced in #3603

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
