### PR TITLE
api-extractor: check whether folder has a package.json

### DIFF
--- a/scripts/api-extractor.ts
+++ b/scripts/api-extractor.ts
@@ -21,6 +21,7 @@ import {
   resolve as resolvePath,
   relative as relativePath,
   dirname,
+  join,
 } from 'path';
 import fs from 'fs-extra';
 import {
@@ -93,6 +94,13 @@ async function findPackageDirs() {
 
       const stat = await fs.stat(fullPackageDir);
       if (!stat.isDirectory()) {
+        continue;
+      }
+
+      try {
+        const packageJsonPath = join(fullPackageDir, 'package.json');
+        await fs.access(packageJsonPath);
+      } catch (_) {
         continue;
       }
 


### PR DESCRIPTION
Often when switching between branches, I have empty folders in my working copy and Git doesn't track folders. Another case is the now deleted `core` package which remains as an empty folder locally (due to the node_modules folder still being there).
Sadly, api-extractor crashes on empty folder, so this introduces a check that the folder is a package by checking for the package.json file.

No changeset required.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
