### PR TITLE
Rename Components and `export` them from `plugin-user-settings`

### DIFF
--- a/.changeset/nice-bugs-beg.md
+++ b/.changeset/nice-bugs-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Exported `General` component from the plugin, to be able to use it in the consumer side and customize the `SettingPage`

--- a/.changeset/nice-bugs-beg.md
+++ b/.changeset/nice-bugs-beg.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-user-settings': patch
 ---
 
-Exported `General` component from the plugin, to be able to use it in the consumer side and customize the `SettingPage`
+Exported and renamed components from the `@backstage/plugin-user-settings` plugin , to be able to use it in the consumer side and customize the `SettingPage`

--- a/.changeset/nice-bugs-beg.md
+++ b/.changeset/nice-bugs-beg.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-user-settings': patch
+'@backstage/plugin-user-settings': minor
 ---
 
 Exported and renamed components from the `@backstage/plugin-user-settings` plugin , to be able to use it in the consumer side and customize the `SettingPage`

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -17,6 +17,9 @@ export const AuthProviders: ({ providerSettings }: Props_2) => JSX.Element;
 export const DefaultProviderSettings: ({ configuredProviders }: Props_3) => JSX.Element;
 
 // @public (undocumented)
+export const General: () => JSX.Element;
+
+// @public (undocumented)
 export const ProviderSettingsItem: ({ title, description, icon: Icon, apiRef, }: Props_4) => JSX.Element;
 
 // @public (undocumented)

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -12,9 +12,6 @@ import { RouteRef } from '@backstage/core-plugin-api';
 import { SessionApi } from '@backstage/core-plugin-api';
 
 // @public (undocumented)
-export const AuthProviders: ({ providerSettings }: Props_2) => JSX.Element;
-
-// @public (undocumented)
 export const DefaultProviderSettings: ({ configuredProviders }: Props_3) => JSX.Element;
 
 // @public (undocumented)
@@ -28,6 +25,12 @@ export const Settings: () => JSX.Element;
 
 // @public (undocumented)
 export const UserSettingsAppearanceCard: () => JSX.Element;
+
+// @public (undocumented)
+export const UserSettingsAuthProviders: ({ providerSettings }: Props_2) => JSX.Element;
+
+// @public (undocumented)
+export const UserSettingsFeatureFlags: () => JSX.Element;
 
 // @public (undocumented)
 export const UserSettingsGeneral: () => JSX.Element;

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -7,6 +7,7 @@
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
+import { ProfileInfo } from '@backstage/core-plugin-api';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { SessionApi } from '@backstage/core-plugin-api';
 
@@ -15,9 +16,6 @@ export const AuthProviders: ({ providerSettings }: Props_2) => JSX.Element;
 
 // @public (undocumented)
 export const DefaultProviderSettings: ({ configuredProviders }: Props_3) => JSX.Element;
-
-// @public (undocumented)
-export const General: () => JSX.Element;
 
 // @public (undocumented)
 export const ProviderSettingsItem: ({ title, description, icon: Icon, apiRef, }: Props_4) => JSX.Element;
@@ -29,9 +27,21 @@ export const Router: ({ providerSettings }: Props) => JSX.Element;
 export const Settings: () => JSX.Element;
 
 // @public (undocumented)
+export const UserSettingsAppearanceCard: () => JSX.Element;
+
+// @public (undocumented)
+export const UserSettingsGeneral: () => JSX.Element;
+
+// @public (undocumented)
+export const UserSettingsMenu: () => JSX.Element;
+
+// @public (undocumented)
 export const UserSettingsPage: ({ providerSettings }: {
     providerSettings?: JSX.Element | undefined;
 }) => JSX.Element;
+
+// @public (undocumented)
+export const UserSettingsPinToggle: () => JSX.Element;
 
 // @public (undocumented)
 const userSettingsPlugin: BackstagePlugin<{
@@ -41,6 +51,21 @@ const userSettingsPlugin: BackstagePlugin<{
 export { userSettingsPlugin as plugin }
 
 export { userSettingsPlugin }
+
+// @public (undocumented)
+export const UserSettingsProfileCard: () => JSX.Element;
+
+// @public (undocumented)
+export const UserSettingsSignInAvatar: ({ size }: Props_5) => JSX.Element;
+
+// @public (undocumented)
+export const UserSettingsThemeToggle: () => JSX.Element;
+
+// @public (undocumented)
+export const useUserProfile: () => {
+    profile: ProfileInfo;
+    displayName: string;
+};
 
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/user-settings/src/components/AuthProviders/UserSettingsAuthProviders.test.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/UserSettingsAuthProviders.test.tsx
@@ -17,7 +17,7 @@
 import { renderWithEffects, wrapInTestApp } from '@backstage/test-utils';
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
-import { AuthProviders } from './AuthProviders';
+import { UserSettingsAuthProviders } from './UserSettingsAuthProviders';
 
 import {
   ApiProvider,
@@ -52,12 +52,12 @@ const apiRegistry = ApiRegistry.from([
   [googleAuthApiRef, mockGoogleAuth],
 ]);
 
-describe('<AuthProviders />', () => {
+describe('<UserSettingsAuthProviders />', () => {
   it('displays a provider and calls its sign-in handler on click', async () => {
     const rendered = await renderWithEffects(
       wrapInTestApp(
         <ApiProvider apis={apiRegistry}>
-          <AuthProviders />
+          <UserSettingsAuthProviders />
         </ApiProvider>,
       ),
     );

--- a/plugins/user-settings/src/components/AuthProviders/UserSettingsAuthProviders.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/UserSettingsAuthProviders.tsx
@@ -26,7 +26,7 @@ type Props = {
   providerSettings?: JSX.Element;
 };
 
-export const AuthProviders = ({ providerSettings }: Props) => {
+export const UserSettingsAuthProviders = ({ providerSettings }: Props) => {
   const configApi = useApi(configApiRef);
   const providersConfig = configApi.getOptionalConfig('auth.providers');
   const configuredProviders = providersConfig?.keys() || [];

--- a/plugins/user-settings/src/components/AuthProviders/index.ts
+++ b/plugins/user-settings/src/components/AuthProviders/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { AuthProviders } from './AuthProviders';
+export { UserSettingsAuthProviders } from './UserSettingsAuthProviders';
 export { DefaultProviderSettings } from './DefaultProviderSettings';
 export { ProviderSettingsItem } from './ProviderSettingsItem';

--- a/plugins/user-settings/src/components/FeatureFlags/UserSettingsFeatureFlags.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/UserSettingsFeatureFlags.tsx
@@ -26,7 +26,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { InfoCard } from '@backstage/core-components';
 
-export const FeatureFlags = () => {
+export const UserSettingsFeatureFlags = () => {
   const featureFlagsApi = useApi(featureFlagsApiRef);
   const featureFlags = featureFlagsApi.getRegisteredFlags();
 

--- a/plugins/user-settings/src/components/FeatureFlags/index.ts
+++ b/plugins/user-settings/src/components/FeatureFlags/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { FeatureFlags } from './FeatureFlags';
+export { UserSettingsFeatureFlags } from './UserSettingsFeatureFlags';

--- a/plugins/user-settings/src/components/General/UserSettingsAppearanceCard.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsAppearanceCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,27 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Grid, List } from '@material-ui/core';
 import React from 'react';
-import { PinButton } from './PinButton';
-import { Profile } from './Profile';
-import { ThemeToggle } from './ThemeToggle';
+import { List } from '@material-ui/core';
 import { InfoCard } from '@backstage/core-components';
+import { UserSettingsPinToggle } from './UserSettingsPinToggle';
+import { UserSettingsThemeToggle } from './UserSettingsThemeToggle';
 
-export const General = () => {
-  return (
-    <Grid container direction="row" spacing={3}>
-      <Grid item sm={12} md={6}>
-        <Profile />
-      </Grid>
-      <Grid item sm={12} md={6}>
-        <InfoCard title="Appearance">
-          <List dense>
-            <ThemeToggle />
-            <PinButton />
-          </List>
-        </InfoCard>
-      </Grid>
-    </Grid>
-  );
-};
+export const UserSettingsAppearanceCard = () => (
+  <InfoCard title="Appearance">
+    <List dense>
+      <UserSettingsThemeToggle />
+      <UserSettingsPinToggle />
+    </List>
+  </InfoCard>
+);

--- a/plugins/user-settings/src/components/General/UserSettingsGeneral.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsGeneral.tsx
@@ -13,11 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Grid } from '@material-ui/core';
+import React from 'react';
+import { UserSettingsProfileCard } from './UserSettingsProfileCard';
+import { UserSettingsAppearanceCard } from './UserSettingsAppearanceCard';
 
-export { UserSettingsGeneral } from './UserSettingsGeneral';
-export { UserSettingsProfileCard } from './UserSettingsProfileCard';
-export { UserSettingsMenu } from './UserSettingsMenu';
-export { UserSettingsSignInAvatar } from './UserSettingsSignInAvatar';
-export { UserSettingsAppearanceCard } from './UserSettingsAppearanceCard';
-export { UserSettingsThemeToggle } from './UserSettingsThemeToggle';
-export { UserSettingsPinToggle } from './UserSettingsPinToggle';
+export const UserSettingsGeneral = () => {
+  return (
+    <Grid container direction="row" spacing={3}>
+      <Grid item sm={12} md={6}>
+        <UserSettingsProfileCard />
+      </Grid>
+      <Grid item sm={12} md={6}>
+        <UserSettingsAppearanceCard />
+      </Grid>
+    </Grid>
+  );
+};

--- a/plugins/user-settings/src/components/General/UserSettingsPinToggle.test.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsPinToggle.test.tsx
@@ -17,10 +17,10 @@
 import { renderWithEffects, wrapInTestApp } from '@backstage/test-utils';
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
-import { PinButton } from './PinButton';
+import { UserSettingsPinToggle } from './UserSettingsPinToggle';
 import { SidebarPinStateContext } from '@backstage/core-components';
 
-describe('<PinButton />', () => {
+describe('<UserSettingsPinToggle />', () => {
   it('toggles the pin sidebar button', async () => {
     const mockToggleFn = jest.fn();
     const rendered = await renderWithEffects(
@@ -28,7 +28,7 @@ describe('<PinButton />', () => {
         <SidebarPinStateContext.Provider
           value={{ isPinned: false, toggleSidebarPinState: mockToggleFn }}
         >
-          <PinButton />
+          <UserSettingsPinToggle />
         </SidebarPinStateContext.Provider>,
       ),
     );

--- a/plugins/user-settings/src/components/General/UserSettingsPinToggle.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsPinToggle.tsx
@@ -24,7 +24,7 @@ import {
 } from '@material-ui/core';
 import { SidebarPinStateContext } from '@backstage/core-components';
 
-export const PinButton = () => {
+export const UserSettingsPinToggle = () => {
   const { isPinned, toggleSidebarPinState } = useContext(
     SidebarPinStateContext,
   );

--- a/plugins/user-settings/src/components/General/UserSettingsProfileCard.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsProfileCard.tsx
@@ -15,19 +15,19 @@
  */
 import { Grid, Typography } from '@material-ui/core';
 import React from 'react';
-import { SignInAvatar } from './SignInAvatar';
+import { UserSettingsSignInAvatar } from './UserSettingsSignInAvatar';
 import { UserSettingsMenu } from './UserSettingsMenu';
 import { useUserProfile } from '../useUserProfileInfo';
 import { InfoCard } from '@backstage/core-components';
 
-export const Profile = () => {
+export const UserSettingsProfileCard = () => {
   const { profile, displayName } = useUserProfile();
 
   return (
     <InfoCard title="Profile">
       <Grid container spacing={6}>
         <Grid item>
-          <SignInAvatar size={96} />
+          <UserSettingsSignInAvatar size={96} />
         </Grid>
         <Grid item xs={12} sm container>
           <Grid item xs container direction="column" spacing={2}>

--- a/plugins/user-settings/src/components/General/UserSettingsSignInAvatar.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsSignInAvatar.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles<BackstageTheme, { size: number }>(theme => ({
 
 type Props = { size?: number };
 
-export const SignInAvatar = ({ size }: Props) => {
+export const UserSettingsSignInAvatar = ({ size }: Props) => {
   const { iconSize } = sidebarConfig;
   const classes = useStyles(size ? { size } : { size: iconSize });
   const { profile } = useUserProfile();

--- a/plugins/user-settings/src/components/General/UserSettingsThemeToggle.test.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsThemeToggle.test.tsx
@@ -19,7 +19,7 @@ import { renderWithEffects, wrapInTestApp } from '@backstage/test-utils';
 import { lightTheme } from '@backstage/theme';
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
-import { ThemeToggle } from './ThemeToggle';
+import { UserSettingsThemeToggle } from './UserSettingsThemeToggle';
 import {
   ApiProvider,
   ApiRegistry,
@@ -37,13 +37,13 @@ const apiRegistry = ApiRegistry.from([
   [appThemeApiRef, AppThemeSelector.createWithStorage([mockTheme])],
 ]);
 
-describe('<ThemeToggle />', () => {
+describe('<UserSettingsThemeToggle />', () => {
   it('toggles the theme select button', async () => {
     const themeApi = apiRegistry.get(appThemeApiRef);
     const rendered = await renderWithEffects(
       wrapInTestApp(
         <ApiProvider apis={apiRegistry}>
-          <ThemeToggle />
+          <UserSettingsThemeToggle />
         </ApiProvider>,
       ),
     );

--- a/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
@@ -87,7 +87,7 @@ const TooltipToggleButton = ({
   </Tooltip>
 );
 
-export const ThemeToggle = () => {
+export const UserSettingsThemeToggle = () => {
   const classes = useStyles();
   const appThemeApi = useApi(appThemeApiRef);
   const themeId = useObservable(

--- a/plugins/user-settings/src/components/SettingsPage.tsx
+++ b/plugins/user-settings/src/components/SettingsPage.tsx
@@ -15,8 +15,8 @@
  */
 
 import React from 'react';
-import { AuthProviders } from './AuthProviders';
-import { FeatureFlags } from './FeatureFlags';
+import { UserSettingsAuthProviders } from './AuthProviders';
+import { UserSettingsFeatureFlags } from './FeatureFlags';
 import { UserSettingsGeneral } from './General';
 import { Header, Page, TabbedLayout } from '@backstage/core-components';
 
@@ -37,10 +37,10 @@ export const SettingsPage = ({ providerSettings }: Props) => {
           path="auth-providers"
           title="Authentication Providers"
         >
-          <AuthProviders providerSettings={providerSettings} />
+          <UserSettingsAuthProviders providerSettings={providerSettings} />
         </TabbedLayout.Route>
         <TabbedLayout.Route path="feature-flags" title="Feature Flags">
-          <FeatureFlags />
+          <UserSettingsFeatureFlags />
         </TabbedLayout.Route>
       </TabbedLayout>
     </Page>

--- a/plugins/user-settings/src/components/SettingsPage.tsx
+++ b/plugins/user-settings/src/components/SettingsPage.tsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { AuthProviders } from './AuthProviders';
 import { FeatureFlags } from './FeatureFlags';
-import { General } from './General';
+import { UserSettingsGeneral } from './General';
 import { Header, Page, TabbedLayout } from '@backstage/core-components';
 
 type Props = {
@@ -31,7 +31,7 @@ export const SettingsPage = ({ providerSettings }: Props) => {
 
       <TabbedLayout>
         <TabbedLayout.Route path="general" title="General">
-          <General />
+          <UserSettingsGeneral />
         </TabbedLayout.Route>
         <TabbedLayout.Route
           path="auth-providers"

--- a/plugins/user-settings/src/components/index.ts
+++ b/plugins/user-settings/src/components/index.ts
@@ -17,4 +17,5 @@ export { Settings } from './Settings';
 export { SettingsPage as Router } from './SettingsPage';
 export * from './AuthProviders';
 export * from './General';
+export * from './FeatureFlags';
 export { useUserProfile } from './useUserProfileInfo';

--- a/plugins/user-settings/src/components/index.ts
+++ b/plugins/user-settings/src/components/index.ts
@@ -16,4 +16,5 @@
 export { Settings } from './Settings';
 export { SettingsPage as Router } from './SettingsPage';
 export * from './AuthProviders';
-export { General } from './General';
+export * from './General';
+export { useUserProfile } from './useUserProfileInfo';

--- a/plugins/user-settings/src/components/index.ts
+++ b/plugins/user-settings/src/components/index.ts
@@ -16,3 +16,4 @@
 export { Settings } from './Settings';
 export { SettingsPage as Router } from './SettingsPage';
 export * from './AuthProviders';
+export { General } from './General';


### PR DESCRIPTION
Signed-off-by: Matteo Barone <matteo.barone@klarna.com>

## Hey, I just made a Pull Request!

Exported `General` component from the `@backstage/plugin-user-settings` plugin, to be able to use it in the consumer side and customize the `SettingPage`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
