### PR TITLE
fix(techdocs-commons): remove utf8 encoding on openstack publisher

### DIFF
--- a/.changeset/gorgeous-timers-cover.md
+++ b/.changeset/gorgeous-timers-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Fix openStack swift publisher encoding issue. Remove utf8 forced encoding on binary files

--- a/packages/techdocs-common/src/stages/publish/openStackSwift.ts
+++ b/packages/techdocs-common/src/stages/publish/openStackSwift.ts
@@ -156,7 +156,7 @@ export class OpenStackSwiftPublish implements PublisherBase {
         const uploadFile = limiter(
           () =>
             new Promise((res, rej) => {
-              const readStream = fs.createReadStream(filePath, 'utf8');
+              const readStream = fs.createReadStream(filePath);
 
               const writeStream = this.storageClient.upload(params);
 


### PR DESCRIPTION
The utf8 encoding, which was not setted for other cloud storage providers, broke all images and other binary files.
The files uploaded were unreadable except plain text files. So in a standard documentation, all images were broken"

Signed-off-by: Flavien Chantelot <flavien.chantelot@ovhcloud.com>

## Hey, I just made a Pull Request!

In the openstack swift publisher, in the `createReadStream` function, the encoding parameter was setted to `utf8`.
It doesn't make any issues on plain text files like css / js / html. 
But when you deal with bin files as images for example, the published files are unreadable. For example, an png file before the publish: `Content Length: 140521` and after the publish: `Content Length: 253489`

So img can't be displayed correctly when you try to browse your doc through backstage.
If you display it locally with `npx @techdocs/cli serve` everything is alright.

If you look what is existing on other publisher like [awsS3](https://github.com/backstage/backstage/blob/master/packages/techdocs-common/src/stages/publish/awsS3.ts#L200), this parameter is not setted.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
