### PR TITLE
Get rid of flex console warning for IconLink

### DIFF
--- a/.changeset/two-pots-joke.md
+++ b/.changeset/two-pots-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Get rid of flex console warning for IconLink

--- a/plugins/catalog/src/components/EntityLinksCard/IconLink.tsx
+++ b/plugins/catalog/src/components/EntityLinksCard/IconLink.tsx
@@ -50,7 +50,7 @@ export const IconLink = ({
           {Icon ? <Icon /> : <LanguageIcon />}
         </Typography>
       </Box>
-      <Box flex>
+      <Box flexGrow="1">
         <Link to={href} target="_blank" rel="noopener">
           {text || href}
         </Link>


### PR DESCRIPTION
It wasn't allowed to leave an empty value for `flex`, and `flexGrow` what was I was technically after anyway.