### PR TITLE
fix: Sys Diagram clipped if wider than container

### DIFF
--- a/.changeset/grumpy-sloths-check.md
+++ b/.changeset/grumpy-sloths-check.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-System Diagram was getting clipped when it was wider than the container.
+Fixed sizing of the System diagram when the rendered graph was wider than the container.

--- a/.changeset/grumpy-sloths-check.md
+++ b/.changeset/grumpy-sloths-check.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-catalog': patch
+---
+
+System Diagram was getting clipped when it was wider than the container.

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
@@ -262,7 +262,7 @@ export function DependencyGraph({
     <svg
       ref={containerRef}
       {...svgProps}
-      width={maxWidth}
+      width="100%"
       height={maxHeight}
       viewBox={`0 0 ${maxWidth} ${maxHeight}`}
     >

--- a/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
+++ b/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
@@ -29,7 +29,7 @@ import {
   getEntityRelations,
   useEntity,
 } from '@backstage/plugin-catalog-react';
-import { Box, makeStyles, Typography } from '@material-ui/core';
+import { Box, makeStyles, Typography, useTheme } from '@material-ui/core';
 import ZoomOutMap from '@material-ui/icons/ZoomOutMap';
 import React from 'react';
 import { useAsync } from 'react-use';
@@ -151,6 +151,7 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
  */
 export function SystemDiagramCard() {
   const { entity } = useEntity();
+  const theme = useTheme();
   const currentSystemName = entity.metadata.name;
   const currentSystemNode = stringifyEntityRef(entity);
   const systemNodes = new Array<{ id: string; kind: string; name: string }>();
@@ -262,8 +263,8 @@ export function SystemDiagramCard() {
         nodeMargin={10}
         direction={DependencyGraphTypes.Direction.BOTTOM_TOP}
         renderNode={RenderNode}
-        paddingX={50}
-        paddingY={50}
+        paddingX={theme.spacing(4)}
+        paddingY={theme.spacing(4)}
       />
       <Box m={1} />
       <Typography

--- a/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
+++ b/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.tsx
@@ -262,6 +262,8 @@ export function SystemDiagramCard() {
         nodeMargin={10}
         direction={DependencyGraphTypes.Direction.BOTTOM_TOP}
         renderNode={RenderNode}
+        paddingX={50}
+        paddingY={50}
       />
       <Box m={1} />
       <Typography


### PR DESCRIPTION
Signed-off-by: Deepak Bhardwaj <Deepak.Bhardwaj@outlook.com>

## Hey, I just made a Pull Request!

Fixed the issue where system diagram was getting clipped when its width was larger than its container.

![Screenshot 2021-06-25 at 9 14 01 PM](https://user-images.githubusercontent.com/62239457/123452328-efb42400-d5fb-11eb-9482-aef4cc9914e7.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
