### PR TITLE
Unbreak `.well-known` OIDC routes

### DIFF
--- a/.changeset/long-olives-cheer.md
+++ b/.changeset/long-olives-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Unbreak `.well-known` OIDC routes

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -272,6 +272,7 @@ transpilation
 transpiled
 truthy
 ui
+unbreak
 unmanaged
 unregister
 unregistration

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -144,17 +144,17 @@ export async function createRouter({
     }
   }
 
-  router.use('/:provider/', req => {
-    const { provider } = req.params;
-    throw new NotFoundError(`Unknown auth provider '${provider}'`);
-  });
-
   router.use(
     createOidcRouter({
       tokenIssuer,
       baseUrl: authUrl,
     }),
   );
+
+  router.use('/:provider/', req => {
+    const { provider } = req.params;
+    throw new NotFoundError(`Unknown auth provider '${provider}'`);
+  });
 
   return router;
 }


### PR DESCRIPTION
Unfortunately the order of these routes was changed around in such a way that the OIDC match happens with lower prio than the catch-all route.