### PR TITLE
feat: open external tools in new tab

### DIFF
--- a/.changeset/fair-falcons-scream.md
+++ b/.changeset/fair-falcons-scream.md
@@ -1,5 +1,7 @@
 ---
+'@backstage/core-components': patch
 '@backstage/plugin-explore': patch
 ---
 
-Enhanced tools card to open external tools in new tab
+- Enhanced core `Button` component to open external links in new tab.
+- Replaced the use of `Button` component from material by `core-components` in tools card.

--- a/.changeset/fair-falcons-scream.md
+++ b/.changeset/fair-falcons-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Enhanced tools card to open external tools in new tab

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -29,7 +29,6 @@ export const isExternalUri = (uri: string) => /^([a-z+.-]+):/.test(uri);
 export type LinkProps = MaterialLinkProps &
   RouterLinkProps & {
     component?: ElementType<any>;
-    externalLinkTarget?: undefined | '_blank';
   };
 
 /**
@@ -43,9 +42,7 @@ export const Link = React.forwardRef<any, LinkProps>((props, ref) => {
     <MaterialLink
       ref={ref}
       href={to}
-      {...(props.externalLinkTarget
-        ? { target: props.externalLinkTarget, rel: 'noopener' }
-        : {})}
+      {...{ target: '_blank', rel: 'noopener' }}
       {...props}
     />
   ) : (

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -29,6 +29,7 @@ export const isExternalUri = (uri: string) => /^([a-z+.-]+):/.test(uri);
 export type LinkProps = MaterialLinkProps &
   RouterLinkProps & {
     component?: ElementType<any>;
+    externalLinkTarget?: undefined | '_blank';
   };
 
 /**
@@ -39,7 +40,14 @@ export const Link = React.forwardRef<any, LinkProps>((props, ref) => {
   const to = String(props.to);
   return isExternalUri(to) ? (
     // External links
-    <MaterialLink ref={ref} href={to} {...props} />
+    <MaterialLink
+      ref={ref}
+      href={to}
+      {...(props.externalLinkTarget
+        ? { target: props.externalLinkTarget }
+        : {})}
+      {...props}
+    />
   ) : (
     // Interact with React Router for internal links
     <MaterialLink ref={ref} component={RouterLink} {...props} />

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -37,12 +37,14 @@ export type LinkProps = MaterialLinkProps &
  */
 export const Link = React.forwardRef<any, LinkProps>((props, ref) => {
   const to = String(props.to);
-  return isExternalUri(to) ? (
+  const external = isExternalUri(to);
+  const newWindow = external && !!/^https?:/.exec(to);
+  return external ? (
     // External links
     <MaterialLink
       ref={ref}
       href={to}
-      {...{ target: '_blank', rel: 'noopener' }}
+      {...(newWindow ? { target: '_blank', rel: 'noopener' } : {})}
       {...props}
     />
   ) : (

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -44,7 +44,7 @@ export const Link = React.forwardRef<any, LinkProps>((props, ref) => {
       ref={ref}
       href={to}
       {...(props.externalLinkTarget
-        ? { target: props.externalLinkTarget }
+        ? { target: props.externalLinkTarget, rel: 'noopener' }
         : {})}
       {...props}
     />

--- a/plugins/explore/src/components/ToolCard/ToolCard.tsx
+++ b/plugins/explore/src/components/ToolCard/ToolCard.tsx
@@ -63,6 +63,7 @@ export const ToolCard = ({ card, objectFit }: Props) => {
   const classes = useStyles();
 
   const { title, description, url, image, lifecycle, tags } = card;
+  const isExternalUrl = url.startsWith('https://') || url.startsWith('http://');
 
   return (
     <Card key={title}>
@@ -97,7 +98,12 @@ export const ToolCard = ({ card, objectFit }: Props) => {
         )}
       </CardContent>
       <CardActions>
-        <Button color="primary" href={url} disabled={!url}>
+        <Button
+          {...(isExternalUrl ? { target: '_blank' } : {})}
+          color="primary"
+          href={url}
+          disabled={!url}
+        >
           Explore
         </Button>
       </CardActions>

--- a/plugins/explore/src/components/ToolCard/ToolCard.tsx
+++ b/plugins/explore/src/components/ToolCard/ToolCard.tsx
@@ -97,12 +97,7 @@ export const ToolCard = ({ card, objectFit }: Props) => {
         )}
       </CardContent>
       <CardActions>
-        <Button
-          externalLinkTarget="_blank"
-          color="primary"
-          to={url}
-          disabled={!url}
-        >
+        <Button color="primary" to={url} disabled={!url}>
           Explore
         </Button>
       </CardActions>

--- a/plugins/explore/src/components/ToolCard/ToolCard.tsx
+++ b/plugins/explore/src/components/ToolCard/ToolCard.tsx
@@ -18,7 +18,6 @@ import { ExploreTool } from '@backstage/plugin-explore-react';
 import { BackstageTheme } from '@backstage/theme';
 import {
   Box,
-  Button,
   Card,
   CardActions,
   CardContent,
@@ -27,6 +26,7 @@ import {
   makeStyles,
   Typography,
 } from '@material-ui/core';
+import { Button } from '@backstage/core-components';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -63,7 +63,6 @@ export const ToolCard = ({ card, objectFit }: Props) => {
   const classes = useStyles();
 
   const { title, description, url, image, lifecycle, tags } = card;
-  const isExternalUrl = url.startsWith('https://') || url.startsWith('http://');
 
   return (
     <Card key={title}>
@@ -99,9 +98,9 @@ export const ToolCard = ({ card, objectFit }: Props) => {
       </CardContent>
       <CardActions>
         <Button
-          {...(isExternalUrl ? { target: '_blank' } : {})}
+          externalLinkTarget="_blank"
           color="primary"
-          href={url}
+          to={url}
           disabled={!url}
         >
           Explore

--- a/plugins/git-release-manager/src/features/Features.test.tsx
+++ b/plugins/git-release-manager/src/features/Features.test.tsx
@@ -69,6 +69,7 @@ describe('Features', () => {
           <a
             class="MuiTypography-root MuiLink-root MuiLink-underlineHover MuiTypography-colorPrimary"
             href="https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository"
+            rel="noopener"
             target="_blank"
             to="https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository"
           >


### PR DESCRIPTION
Signed-off-by: Deepak Bhardwaj <deepak.bhardwaj@outlook.com>

## Hey, I just made a Pull Request!

Small enhancement in the explorer plugin - open external tools (i.e., url starting with http(s)://) in new tab.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
