### PR TITLE
Don't crash if the entities response doesn't include the entities name and kind

### DIFF
--- a/.changeset/sour-cherries-occur.md
+++ b/.changeset/sour-cherries-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Don't crash if the entities response doesn't include the entities name and kind

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -151,6 +151,26 @@ describe('CatalogClient', () => {
 
       expect(response.items).toEqual([]);
     });
+
+    it('handles field filtered entities', async () => {
+      server.use(
+        rest.get(`${mockBaseUrl}/entities`, (_req, res, ctx) => {
+          return res(ctx.json([{ apiVersion: '1' }, { apiVersion: '2' }]));
+        }),
+      );
+
+      const response = await client.getEntities(
+        {
+          fields: ['apiVersion'],
+        },
+        { token },
+      );
+
+      expect(response.items).toEqual([
+        { apiVersion: '1' },
+        { apiVersion: '2' },
+      ]);
+    });
   });
 
   describe('getLocationById', () => {

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -92,6 +92,16 @@ export class CatalogClient implements CatalogApi {
     );
 
     const refCompare = (a: Entity, b: Entity) => {
+      // in case field filtering is used, these fields might not be part of the response
+      if (
+        a.metadata?.name === undefined ||
+        a.metadata?.kind === undefined ||
+        b.metadata?.name === undefined ||
+        b.metadata?.kind === undefined
+      ) {
+        return 0;
+      }
+
       const aRef = stringifyEntityRef(a);
       const bRef = stringifyEntityRef(b);
       if (aRef < bRef) {

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -95,9 +95,9 @@ export class CatalogClient implements CatalogApi {
       // in case field filtering is used, these fields might not be part of the response
       if (
         a.metadata?.name === undefined ||
-        a.metadata?.kind === undefined ||
+        a.kind === undefined ||
         b.metadata?.name === undefined ||
-        b.metadata?.kind === undefined
+        b.kind === undefined
       ) {
         return 0;
       }


### PR DESCRIPTION
Resolves #6215

A quick fix until the sort is moved into the backend.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
