### PR TITLE
Only return the selected fields from the new catalog

### DIFF
--- a/.changeset/small-kings-repair.md
+++ b/.changeset/small-kings-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Only return the selected fields from the new catalog.

--- a/plugins/catalog-backend/src/next/NextEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/next/NextEntitiesCatalog.ts
@@ -133,8 +133,14 @@ export class NextEntitiesCatalog implements EntitiesCatalog {
       };
     }
 
+    const dbResponse = rows.map(e => JSON.parse(e.final_entity!));
+
+    const entities = dbResponse.map(e =>
+      request?.fields ? request.fields(e) : e,
+    );
+
     return {
-      entities: rows.map(e => JSON.parse(e.final_entity!)),
+      entities,
       pageInfo,
     };
   }


### PR DESCRIPTION
This feature was missing in the new catalog backend. There are no tests yet so I also didn't add one 🔥.

I tested it locally but it might be helpful if a reviewer gives it a quick test so we don't accidentally break something.

⚠️ Please note that this PR should only be merged after #6215 is solved.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
