### PR TITLE
Update msw in @backstage/plugin-catalog-backend-module-ldap

### DIFF
--- a/plugins/catalog-backend-module-ldap/package.json
+++ b/plugins/catalog-backend-module-ldap/package.json
@@ -40,7 +40,7 @@
     "@backstage/cli": "^0.7.1",
     "@backstage/test-utils": "^0.1.13",
     "@types/lodash": "^4.14.151",
-    "msw": "^0.21.2"
+    "msw": "^0.29.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
While https://github.com/backstage/backstage/pull/6116 was open, https://github.com/backstage/backstage/pull/6173 has been merged and now causes not committed lockfile changes on my machine. This aligns the msw version in this new package.

There shouldn't be the need for a changeset since this is only a dev dependency.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
