### PR TITLE
add displayName option for Groups diagram

### DIFF
--- a/.changeset/pretty-needles-peel.md
+++ b/.changeset/pretty-needles-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': minor
+---
+
+Using displayName as default value when loading Groups Diagram

--- a/.changeset/pretty-needles-peel.md
+++ b/.changeset/pretty-needles-peel.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-explore': minor
+'@backstage/plugin-explore': patch
 ---
 
 Using displayName as default value when loading Groups Diagram

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.test.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.test.tsx
@@ -46,6 +46,9 @@ describe('<GroupsDiagram />', () => {
                 namespace: 'my-namespace',
               },
               spec: {
+                profile: {
+                  displayName: 'Group A',
+                },
                 type: 'organization',
               },
             },
@@ -64,6 +67,6 @@ describe('<GroupsDiagram />', () => {
       },
     );
 
-    expect(getByText('my-namespace/group-a')).toBeInTheDocument();
+    expect(getByText('Group A')).toBeInTheDocument();
   });
 });

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -96,9 +96,7 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
           alignmentBaseline="baseline"
           style={{ fontWeight: 'bold' }}
         >
-          {props.node.profile?.displayName
-            ? props.node.profile?.displayName
-            : props.node.name}
+          {props.node.profile?.displayName ?? props.node.name}
         </text>
       </Link>
     </g>

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -18,6 +18,7 @@ import {
   RELATION_CHILD_OF,
   stringifyEntityRef,
   parseEntityRef,
+  GroupEntity,
 } from '@backstage/catalog-model';
 import {
   catalogApiRef,
@@ -96,7 +97,7 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
           alignmentBaseline="baseline"
           style={{ fontWeight: 'bold' }}
         >
-          {props.node.profile?.displayName ?? props.node.name}
+          {props.node.name}
         </text>
       </Link>
     </g>
@@ -146,8 +147,9 @@ export function GroupsDiagram() {
     nodes.push({
       id: stringifyEntityRef(catalogItem),
       kind: catalogItem.kind,
-      name: formatEntityRefTitle(catalogItem, { defaultKind: 'Group' }),
-      profile: catalogItem.spec?.profile,
+      name:
+        (catalogItem as GroupEntity).spec?.profile?.displayName ||
+        formatEntityRefTitle(catalogItem, { defaultKind: 'Group' }),
     });
 
     // Edge to parent

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -112,7 +112,6 @@ export function GroupsDiagram() {
     id: string;
     kind: string;
     name: string;
-    profile?: any;
   }>();
   const edges = new Array<{ from: string; to: string; label: string }>();
 

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -96,7 +96,9 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
           alignmentBaseline="baseline"
           style={{ fontWeight: 'bold' }}
         >
-          {props.node.name}
+          {props.node.profile?.displayName
+            ? props.node.profile?.displayName
+            : props.node.name}
         </text>
       </Link>
     </g>
@@ -107,7 +109,12 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
  * Dynamically generates a diagram of groups registered in the catalog.
  */
 export function GroupsDiagram() {
-  const nodes = new Array<{ id: string; kind: string; name: string }>();
+  const nodes = new Array<{
+    id: string;
+    kind: string;
+    name: string;
+    profile?: any;
+  }>();
   const edges = new Array<{ from: string; to: string; label: string }>();
 
   const configApi = useApi(configApiRef);
@@ -142,6 +149,7 @@ export function GroupsDiagram() {
       id: stringifyEntityRef(catalogItem),
       kind: catalogItem.kind,
       name: formatEntityRefTitle(catalogItem, { defaultKind: 'Group' }),
+      profile: catalogItem.spec?.profile,
     });
 
     // Edge to parent


### PR DESCRIPTION
Signed-off-by: roylisto.pradana <roylisto.pradana@grabtaxi.com>

## Hey, I just made a Pull Request!

Make the default variable to show on the Groups diagram using displayName on spec.profile
![image](https://user-images.githubusercontent.com/33563774/123785907-43c44e80-d903-11eb-825f-133c26f1b62e.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->
- [x]  A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
