### PR TITLE
Techdocs: Include cookies when requesting SVGs

### DIFF
--- a/.changeset/bright-pans-rhyme.md
+++ b/.changeset/bright-pans-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Include cookies when making fetch requests for SVG from techdocs plugin

--- a/plugins/techdocs/src/reader/transformers/addBaseUrl.test.ts
+++ b/plugins/techdocs/src/reader/transformers/addBaseUrl.test.ts
@@ -154,6 +154,9 @@ describe('addBaseUrl', () => {
     await waitFor(() => {
       const actualSrc = root.getElementById('x')?.getAttribute('src');
       expect(expectedSrc).toEqual(actualSrc);
+      expect(global.fetch).toHaveBeenCalledWith(`${API_ORIGIN_URL}/test.svg`, {
+        credentials: 'include',
+      });
     });
   });
 

--- a/plugins/techdocs/src/reader/transformers/addBaseUrl.ts
+++ b/plugins/techdocs/src/reader/transformers/addBaseUrl.ts
@@ -64,7 +64,7 @@ export const addBaseUrl = ({
           const apiOrigin = await techdocsStorageApi.getApiOrigin();
           if (isSvgNeedingInlining(attributeName, elemAttribute, apiOrigin)) {
             try {
-              const svg = await fetch(newValue);
+              const svg = await fetch(newValue, { credentials: 'include' });
               const svgContent = await svg.text();
               elem.setAttribute(
                 attributeName,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Refs https://github.com/backstage/backstage/issues/6222

Include credentials in fetch request for SVG from Techdocs plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
