### PR TITLE
Support relative `url` targets for the `backstage.io/techdocs-ref` annotations

### DIFF
--- a/.changeset/techdocs-sour-ladybugs-whisper.md
+++ b/.changeset/techdocs-sour-ladybugs-whisper.md
@@ -1,0 +1,9 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Support relative `url` targets for the `backstage.io/techdocs-ref` annotations.
+
+This allows a content author to use annotations such as `backstage.io/techdocs-ref: url:.` or `backstage.io/techdocs-ref: url:./my-subfolder`.
+Note that this only works if the entity was loaded from a `url` location.
+The base folder is determined by the `backstage.io/source-location` or `backstage.io/managed-by-location` annotations.

--- a/packages/techdocs-common/api-report.md
+++ b/packages/techdocs-common/api-report.md
@@ -14,6 +14,7 @@ import { GitHubIntegrationConfig } from '@backstage/integration';
 import { GitLabIntegrationConfig } from '@backstage/integration';
 import { Logger } from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import { ScmIntegrations } from '@backstage/integration';
 import { UrlReader } from '@backstage/backend-common';
 import { Writable } from 'stream';
 
@@ -67,7 +68,7 @@ export const getAzureIntegrationConfig: (config: Config, host: string) => AzureI
 export const getDefaultBranch: (repositoryUrl: string, config: Config) => Promise<string>;
 
 // @public (undocumented)
-export const getDocFilesFromRepository: (reader: UrlReader, entity: Entity, opts?: {
+export const getDocFilesFromRepository: (reader: UrlReader, scmIntegrations: ScmIntegrations, entity: Entity, opts?: {
     etag?: string | undefined;
     logger?: Logger | undefined;
 } | undefined) => Promise<PreparerResponse>;
@@ -92,6 +93,9 @@ export const getLastCommitTimestamp: (repositoryLocation: string, logger: Logger
 
 // @public (undocumented)
 export const getLocationForEntity: (entity: Entity) => ParsedLocationAnnotation;
+
+// @public
+export const getSourceLocation: (entity: Entity) => string | undefined;
 
 // @public (undocumented)
 export const getTokenForGitRepo: (repositoryUrl: string, config: Config) => Promise<string | undefined>;
@@ -170,7 +174,7 @@ export type TechDocsMetadata = {
 
 // @public (undocumented)
 export class UrlPreparer implements PreparerBase {
-    constructor(reader: UrlReader, logger: Logger);
+    constructor(reader: UrlReader, scmIntegrations: ScmIntegrations, logger: Logger);
     // (undocumented)
     prepare(entity: Entity, options?: {
         etag?: string;

--- a/packages/techdocs-common/src/helpers.test.ts
+++ b/packages/techdocs-common/src/helpers.test.ts
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-import {
-  ReadTreeResponse,
-  SearchResponse,
-  UrlReader,
-} from '@backstage/backend-common';
+import { ReadTreeResponse, UrlReader } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
-import { Readable } from 'stream';
+import { ConfigReader } from '@backstage/config';
+import { ScmIntegrations } from '@backstage/integration';
 import {
   getDocFilesFromRepository,
   getLocationForEntity,
+  getSourceLocation,
   parseReferenceAnnotation,
 } from './helpers';
 
@@ -121,42 +119,140 @@ describe('getLocationForEntity', () => {
   });
 });
 
+describe('getSourceLocation', () => {
+  it('should ignore missing annotations', () => {
+    const entity = {
+      apiVersion: '1',
+      kind: 'Component',
+      metadata: {
+        name: 'test',
+      },
+    };
+
+    expect(getSourceLocation(entity)).toBeUndefined();
+  });
+
+  it('should ignore non-url managed-by-location annotation', () => {
+    const entity = {
+      apiVersion: '1',
+      kind: 'Component',
+      metadata: {
+        name: 'test',
+        annotations: {
+          'backstage.io/managed-by-location':
+            'file:/some/folder/catalog-info.yaml',
+        },
+      },
+    };
+
+    expect(getSourceLocation(entity)).toBeUndefined();
+  });
+
+  it('should use source-location annotation', () => {
+    const entity = {
+      apiVersion: '1',
+      kind: 'Component',
+      metadata: {
+        name: 'test',
+        annotations: {
+          'backstage.io/source-location':
+            'url:https://github.com/backstage/backstage/blob/master/',
+          'backstage.io/managed-by-location':
+            'url:https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+        },
+      },
+    };
+
+    expect(getSourceLocation(entity)).toBe(
+      'https://github.com/backstage/backstage/blob/master/',
+    );
+  });
+
+  it('should use managed-by-location annotation', () => {
+    const entity = {
+      apiVersion: '1',
+      kind: 'Component',
+      metadata: {
+        name: 'test',
+        annotations: {
+          'backstage.io/managed-by-location':
+            'url:https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+        },
+      },
+    };
+
+    expect(getSourceLocation(entity)).toBe(
+      'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+    );
+  });
+});
+
 describe('getDocFilesFromRepository', () => {
+  const mockResponse: jest.Mocked<ReadTreeResponse> = {
+    archive: jest.fn(),
+    dir: jest.fn(),
+    files: jest.fn(),
+    etag: 'etag',
+  };
+
+  let mockUrlReader: jest.Mocked<UrlReader>;
+  beforeEach(() => {
+    mockUrlReader = {
+      read: jest.fn(),
+      readTree: jest.fn(async _ => mockResponse),
+      search: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('should read a remote directory using UrlReader.readTree', async () => {
-    class MockUrlReader implements UrlReader {
-      async read() {
-        return Buffer.from('mock');
-      }
-
-      async readTree(): Promise<ReadTreeResponse> {
-        return {
-          dir: async () => {
-            return '/tmp/testfolder';
-          },
-          files: async () => {
-            return [];
-          },
-          archive: async () => {
-            return Readable.from('');
-          },
-          etag: 'etag123abc',
-        };
-      }
-
-      async search(): Promise<SearchResponse> {
-        return {
-          etag: '',
-          files: [],
-        };
-      }
-    }
+    mockResponse.dir.mockResolvedValue('/tmp/testfolder');
+    mockResponse.etag = 'etag123abc';
 
     const output = await getDocFilesFromRepository(
-      new MockUrlReader(),
+      mockUrlReader,
+      ScmIntegrations.fromConfig(new ConfigReader({})),
       mockEntityWithAnnotation,
+      { etag: 'asdf' },
+    );
+
+    expect(
+      mockUrlReader.readTree,
+    ).toBeCalledWith(
+      'https://github.com/backstage/backstage/blob/master/subfolder/',
+      { etag: 'asdf' },
     );
 
     expect(output.preparedDir).toBe('/tmp/testfolder');
     expect(output.etag).toBe('etag123abc');
+  });
+
+  it('should load relative to the source location', async () => {
+    const entity = {
+      apiVersion: '1',
+      kind: 'a',
+      metadata: {
+        name: 'test',
+        annotations: {
+          'backstage.io/techdocs-ref': 'url:subfolder',
+          'backstage.io/source-location':
+            'url:https://github.com/backstage/backstage/blob/master/subfolder/',
+        },
+      },
+    };
+
+    await getDocFilesFromRepository(
+      mockUrlReader,
+      ScmIntegrations.fromConfig(new ConfigReader({})),
+      entity,
+    );
+
+    expect(mockUrlReader.readTree).toBeCalledWith(
+      'https://github.com/backstage/backstage/tree/master/subfolder/subfolder',
+      {},
+    );
   });
 });

--- a/packages/techdocs-common/src/stages/prepare/preparers.ts
+++ b/packages/techdocs-common/src/stages/prepare/preparers.ts
@@ -13,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { UrlReader } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
+import { ScmIntegrations } from '@backstage/integration';
 import { Logger } from 'winston';
 import { parseReferenceAnnotation } from '../../helpers';
-import { DirectoryPreparer } from './dir';
 import { CommonGitPreparer } from './commonGit';
-import { UrlPreparer } from './url';
+import { DirectoryPreparer } from './dir';
 import { PreparerBase, PreparerBuilder, RemoteProtocol } from './types';
+import { UrlPreparer } from './url';
 
 type factoryOptions = {
   logger: Logger;
@@ -37,7 +39,9 @@ export class Preparers implements PreparerBuilder {
   ): Promise<PreparerBuilder> {
     const preparers = new Preparers();
 
-    const urlPreparer = new UrlPreparer(reader, logger);
+    const scmIntegrations = ScmIntegrations.fromConfig(config);
+
+    const urlPreparer = new UrlPreparer(reader, scmIntegrations, logger);
     preparers.register('url', urlPreparer);
 
     /**


### PR DESCRIPTION
This PR implements the suggestion by @freben as part of the discussions in https://github.com/backstage/backstage/issues/4409.

This change allows an entity author to provide the following file:
```yaml
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  name: documented-component
  description: A Service with TechDocs documentation
  annotations:
    backstage.io/techdocs-ref: 'url:.'
spec:
  type: service
  lifecycle: experimental
  owner: user:guest
```

The `url:.` will be resolved based on the location this entity was registered. Note that this only works if the entity was registered by a `url`-type location.

### Discussion
What I find a bit sad is that this doesn't work for entities that are added from a `file:…` location. We use this feature to register local catalog files in our development environment (-> `yarn dev`) and will not be able to use this feature in our own repo to develop locally. This is not about previewing techdocs, but about having techdocs working in `yarn dev`. This is also done by the [app-config.yaml in this backstage/backstage repository](https://github.com/backstage/backstage/blob/0e059967da6a511785da67525b30dac5e6f01767/app-config.yaml#L232) and example template won't be able to use a relative reference.

This is different in the existing, but deprecated, `dir:…` reference type that both handles `url` and `file` sources. I understand that having relative access to the filesystem in production might be problematic, but I don't see this as a key problem of techdocs but is part of the catalog-backend that added entities from `file:…` locations in the first place.

I think we should decide:

a) Do we want to add this relative `url:my-relative-sub-folder` option?
b) Do we want to keep the `dir:…` option and refactor it to work properly? I.e. remove the old `github`/`gitlab`/`...` way and use the `ScmIntegration` based resolver of this PR for `url` types?
c) Don't support it at all. A backstage integrator could then decide to add a catalog transformer that takes over the task to resolve the URLs.

In case we go with a), I should probably also add this to the docs in this PR (or in a follow-up).

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
