### PR TITLE
catalog-backend: introduce location key as a conflict resolution mechanism

### DIFF
--- a/.changeset/rude-windows-live.md
+++ b/.changeset/rude-windows-live.md
@@ -1,0 +1,17 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Handle entity name conflicts in a deterministic way and avoid crashes due to naming conflicts at startup.
+
+This is a breaking change for the database and entity provider interfaces of the new catalog. The interfaces with breaking changes are `EntityProvider` and `ProcessingDatabase`, and while it's unlikely that these interfaces have much usage yet, a migration guide is provided below.
+
+The breaking change to the `EntityProvider` interface lies within the items passed in the `EntityProviderMutation` type. Rather than passing along entities directly, they are now wrapped up in a `DeferredEntity` type, which is a tuple of an `entity` and a `locationKey`. The `entity` houses the entity as it was passed on before, while the `locationKey` is a new concept that is used for conflict resolution within the catalog.
+
+The `locationKey` is an opaque string that should be unique for each location that an entity could be located at, and undefined if the entity does not have a fixed location. In practice it should be set to the serialized location reference if the entity is stored in Git, for example `https://github.com/backstage/backstage/blob/master/catalog-info.yaml`. A conflict between two entity definitions happen when they have the same entity reference, i.e. kind, namespace, and name. In the event of a conflict the location key will be used according to the following rules to resolve the conflict:
+
+- If the entity is already present in the database but does not have a location key set, the new entity wins and will override the existing one.
+- If the entity is already present in the database the new entity will only win if the location keys of the existing and new entity are the same.
+- If the entity is not already present, insert the entity into the database along with the provided location key.
+
+The breaking change to the `ProcessingDatabase` is similar to the one for the entity provider, as it reflects the switch from `Entity` to `DeferredEntity` in the `ReplaceUnprocessedEntitiesOptions`. In addition, the `addUnprocessedEntities` method has been removed from the `ProcessingDatabase` interface, and the `RefreshStateItem` and `UpdateProcessedEntityOptions` types have received a new optional `locationKey` property.

--- a/plugins/catalog-backend/migrations/20210302150147_refresh_state.js
+++ b/plugins/catalog-backend/migrations/20210302150147_refresh_state.js
@@ -65,8 +65,6 @@ exports.up = async function up(knex) {
       .dateTime('last_discovery_at') // TODO: timezone or change to epoch-millis or similar
       .notNullable()
       .comment('The last timestamp of which this entity was discovered');
-    // TODO: get migrations to work for this field instead. should be removed before merge.
-    table.text('location_key').nullable().comment('Location key');
     table.unique(['entity_ref'], 'refresh_state_entity_ref_uniq');
     table.index('entity_id', 'refresh_state_entity_id_idx');
     table.index('entity_ref', 'refresh_state_entity_ref_idx');

--- a/plugins/catalog-backend/migrations/20210302150147_refresh_state.js
+++ b/plugins/catalog-backend/migrations/20210302150147_refresh_state.js
@@ -65,6 +65,8 @@ exports.up = async function up(knex) {
       .dateTime('last_discovery_at') // TODO: timezone or change to epoch-millis or similar
       .notNullable()
       .comment('The last timestamp of which this entity was discovered');
+    // TODO: get migrations to work for this field instead. should be removed before merge.
+    table.text('location_key').nullable().comment('Location key');
     table.unique(['entity_ref'], 'refresh_state_entity_ref_uniq');
     table.index('entity_id', 'refresh_state_entity_id_idx');
     table.index('entity_ref', 'refresh_state_entity_ref_idx');

--- a/plugins/catalog-backend/migrations/20210622104022_refresh_state_location_key.js
+++ b/plugins/catalog-backend/migrations/20210622104022_refresh_state_location_key.js
@@ -27,7 +27,6 @@ exports.up = async function up(knex) {
       .comment(
         'An opaque key that uniquely identifies the location of an entity in order to support conflict resolution',
       );
-    // table.index(['location_key'], 'refresh_state_location_key_idx');
   });
 };
 
@@ -37,6 +36,5 @@ exports.up = async function up(knex) {
 exports.down = async function down(knex) {
   await knex.schema.alterTable('refresh_state', table => {
     table.dropColumn('location_key');
-    // table.dropIndex([], 'refresh_state_location_key_idx');
   });
 };

--- a/plugins/catalog-backend/migrations/20210622104022_refresh_state_location_key.js
+++ b/plugins/catalog-backend/migrations/20210622104022_refresh_state_location_key.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('refresh_state', table => {
+    table.text('location_key').nullable().comment('').alter();
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('refresh_state', table => {
+    table.dropColumn('location_key');
+  });
+};

--- a/plugins/catalog-backend/migrations/20210622104022_refresh_state_location_key.js
+++ b/plugins/catalog-backend/migrations/20210622104022_refresh_state_location_key.js
@@ -21,7 +21,13 @@
  */
 exports.up = async function up(knex) {
   await knex.schema.alterTable('refresh_state', table => {
-    table.text('location_key').nullable().comment('').alter();
+    table
+      .text('location_key')
+      .nullable()
+      .comment(
+        'An opaque key that uniquely identifies the location of an entity in order to support conflict resolution',
+      );
+    // table.index(['location_key'], 'refresh_state_location_key_idx');
   });
 };
 
@@ -31,5 +37,6 @@ exports.up = async function up(knex) {
 exports.down = async function down(knex) {
   await knex.schema.alterTable('refresh_state', table => {
     table.dropColumn('location_key');
+    // table.dropIndex([], 'refresh_state_location_key_idx');
   });
 };

--- a/plugins/catalog-backend/src/next/ConfigLocationEntityProvider.ts
+++ b/plugins/catalog-backend/src/next/ConfigLocationEntityProvider.ts
@@ -42,8 +42,8 @@ export class ConfigLocationEntityProvider implements EntityProvider {
         type,
         target: type === 'file' ? path.resolve(target) : target,
       });
-      const emitKey = getEntityLocationRef(entity);
-      return { entity, emitKey };
+      const locationKey = getEntityLocationRef(entity);
+      return { entity, locationKey };
     });
 
     await this.connection.applyMutation({

--- a/plugins/catalog-backend/src/next/ConfigLocationEntityProvider.ts
+++ b/plugins/catalog-backend/src/next/ConfigLocationEntityProvider.ts
@@ -16,6 +16,7 @@
 
 import { Config } from '@backstage/config';
 import path from 'path';
+import { getEntityLocationRef } from './processing/util';
 import { EntityProvider, EntityProviderConnection } from './types';
 import { locationSpecToLocationEntity } from './util';
 
@@ -37,10 +38,12 @@ export class ConfigLocationEntityProvider implements EntityProvider {
     const entities = locationConfigs.map(location => {
       const type = location.getString('type');
       const target = location.getString('target');
-      return locationSpecToLocationEntity({
+      const entity = locationSpecToLocationEntity({
         type,
         target: type === 'file' ? path.resolve(target) : target,
       });
+      const emitKey = getEntityLocationRef(entity);
+      return { entity, emitKey };
     });
 
     await this.connection.applyMutation({

--- a/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
@@ -125,7 +125,7 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
       },
       processTask: async item => {
         try {
-          const { id, state, unprocessedEntity, entityRef, emitKey } = item;
+          const { id, state, unprocessedEntity, entityRef, locationKey } = item;
           const result = await this.orchestrator.process({
             entity: unprocessedEntity,
             state,
@@ -171,7 +171,7 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
               errors: errorsString,
               relations: result.relations,
               deferredEntities: result.deferredEntities,
-              emitKey,
+              locationKey,
             });
           });
 

--- a/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
@@ -46,7 +46,7 @@ class Connection implements EntityProviderConnection {
     const db = this.config.processingDatabase;
 
     if (mutation.type === 'full') {
-      this.check(mutation.entities);
+      this.check(mutation.entities.map(e => e.entity));
       await db.transaction(async tx => {
         await db.replaceUnprocessedEntities(tx, {
           sourceKey: this.config.id,
@@ -57,8 +57,8 @@ class Connection implements EntityProviderConnection {
       return;
     }
 
-    this.check(mutation.added);
-    this.check(mutation.removed);
+    this.check(mutation.added.map(e => e.entity));
+    this.check(mutation.removed.map(e => e.entity));
     await db.transaction(async tx => {
       await db.replaceUnprocessedEntities(tx, {
         sourceKey: this.config.id,
@@ -125,7 +125,7 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
       },
       processTask: async item => {
         try {
-          const { id, state, unprocessedEntity, entityRef } = item;
+          const { id, state, unprocessedEntity, entityRef, emitKey } = item;
           const result = await this.orchestrator.process({
             entity: unprocessedEntity,
             state,
@@ -171,6 +171,7 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
               errors: errorsString,
               relations: result.relations,
               deferredEntities: result.deferredEntities,
+              emitKey,
             });
           });
 

--- a/plugins/catalog-backend/src/next/DefaultLocationService.test.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationService.test.ts
@@ -48,11 +48,14 @@ describe('DefaultLocationServiceTest', () => {
         },
         deferredEntities: [
           {
-            apiVersion: 'backstage.io/v1alpha1',
-            kind: 'Component',
-            metadata: {
-              name: 'bar',
+            entity: {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'bar',
+              },
             },
+            locationKey: 'file:///tmp/mock.yaml',
           },
         ],
         relations: [],

--- a/plugins/catalog-backend/src/next/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationService.ts
@@ -92,7 +92,6 @@ export class DefaultLocationService implements LocationService {
       });
 
       if (processed.ok) {
-        // todo
         unprocessedEntities.push(...processed.deferredEntities);
         entities.push(processed.completedEntity);
       } else {

--- a/plugins/catalog-backend/src/next/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationService.ts
@@ -20,7 +20,10 @@ import {
   LOCATION_ANNOTATION,
   ORIGIN_LOCATION_ANNOTATION,
 } from '@backstage/catalog-model';
-import { CatalogProcessingOrchestrator } from './processing/types';
+import {
+  CatalogProcessingOrchestrator,
+  DeferredEntity,
+} from './processing/types';
 import { LocationService, LocationStore } from './types';
 import { locationSpecToMetadataName } from './util';
 
@@ -73,7 +76,9 @@ export class DefaultLocationService implements LocationService {
         target: spec.target,
       },
     };
-    const unprocessedEntities: Entity[] = [entity];
+    const unprocessedEntities: DeferredEntity[] = [
+      { entity, locationKey: `${spec.type}:${spec.target}` },
+    ];
     const entities: Entity[] = [];
     const state = new Map(); // ignored
     while (unprocessedEntities.length) {
@@ -82,11 +87,12 @@ export class DefaultLocationService implements LocationService {
         continue;
       }
       const processed = await this.orchestrator.process({
-        entity: currentEntity,
+        entity: currentEntity.entity,
         state,
       });
 
       if (processed.ok) {
+        // todo
         unprocessedEntities.push(...processed.deferredEntities);
         entities.push(processed.completedEntity);
       } else {

--- a/plugins/catalog-backend/src/next/DefaultLocationStore.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationStore.ts
@@ -64,7 +64,7 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
     const entity = locationSpecToLocationEntity(location);
     await this.connection.applyMutation({
       type: 'delta',
-      added: [{ entity, emitKey: getEntityLocationRef(entity) }],
+      added: [{ entity, locationKey: getEntityLocationRef(entity) }],
       removed: [],
     });
 
@@ -107,7 +107,7 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
     await this.connection.applyMutation({
       type: 'delta',
       added: [],
-      removed: [{ entity, emitKey: getEntityLocationRef(entity) }],
+      removed: [{ entity, locationKey: getEntityLocationRef(entity) }],
     });
   }
 
@@ -126,7 +126,7 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
 
     const entities = locations.map(location => {
       const entity = locationSpecToLocationEntity(location);
-      return { entity, emitKey: getEntityLocationRef(entity) };
+      return { entity, locationKey: getEntityLocationRef(entity) };
     });
 
     await this.connection.applyMutation({

--- a/plugins/catalog-backend/src/next/DefaultLocationStore.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationStore.ts
@@ -19,6 +19,7 @@ import { ConflictError, NotFoundError } from '@backstage/errors';
 import { Knex } from 'knex';
 import { v4 as uuid } from 'uuid';
 import { DbLocationsRow } from './database/tables';
+import { getEntityLocationRef } from './processing/util';
 import {
   EntityProvider,
   EntityProviderConnection,
@@ -60,10 +61,10 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
 
       return inner;
     });
-
+    const entity = locationSpecToLocationEntity(location);
     await this.connection.applyMutation({
       type: 'delta',
-      added: [locationSpecToLocationEntity(location)],
+      added: [{ entity, emitKey: getEntityLocationRef(entity) }],
       removed: [],
     });
 
@@ -102,11 +103,11 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
       await tx<DbLocationsRow>('locations').where({ id }).del();
       return location;
     });
-
+    const entity = locationSpecToLocationEntity(deleted);
     await this.connection.applyMutation({
       type: 'delta',
       added: [],
-      removed: [locationSpecToLocationEntity(deleted)],
+      removed: [{ entity, emitKey: getEntityLocationRef(entity) }],
     });
   }
 
@@ -124,7 +125,8 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
     const locations = await this.locations();
 
     const entities = locations.map(location => {
-      return locationSpecToLocationEntity(location);
+      const entity = locationSpecToLocationEntity(location);
+      return { entity, emitKey: getEntityLocationRef(entity) };
     });
 
     await this.connection.applyMutation({

--- a/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
@@ -64,18 +64,18 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       errors,
       relations,
       deferredEntities,
-      emitKey,
+      locationKey,
     } = options;
     const refreshResult = await tx<DbRefreshStateRow>('refresh_state')
       .update({
         processed_entity: JSON.stringify(processedEntity),
         cache: JSON.stringify(state),
         errors,
-        emit_key: emitKey,
+        location_key: locationKey,
       })
       .where('entity_id', id)
-      .andWhere('emit_key', emitKey)
-      .orWhere('emit_key', '');
+      .andWhere('location_key', locationKey)
+      .orWhere('location_key', '');
     if (refreshResult === 0) {
       throw new NotFoundError(`Processing state not found for ${id}`);
     }
@@ -286,11 +286,11 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
 
     if (toAdd.length) {
       const state: Knex.DbRecord<DbRefreshStateRow>[] = toAdd.map(
-        ({ entity, emitKey }) => ({
+        ({ entity, locationKey }) => ({
           entity_id: uuid(),
           entity_ref: stringifyEntityRef(entity),
           unprocessed_entity: JSON.stringify(entity),
-          emit_key: emitKey,
+          location_key: locationKey,
           errors: '',
           next_update_at: tx.fn.now(),
           last_discovery_at: tx.fn.now(),
@@ -320,13 +320,13 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
     const tx = txOpaque as Knex.Transaction;
 
     const stateRows = options.entities.map(
-      ({ entity, emitKey }) =>
+      ({ entity, locationKey }) =>
         ({
           entity_id: uuid(),
           entity_ref: stringifyEntityRef(entity),
           unprocessed_entity: JSON.stringify(entity),
           errors: '',
-          emit_key: emitKey,
+          location_key: locationKey,
           next_update_at: tx.fn.now(),
           last_discovery_at: tx.fn.now(),
         } as Knex.DbRecord<DbRefreshStateRow>),
@@ -414,7 +414,7 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
               ? JSON.parse(i.cache)
               : new Map<string, JsonObject>(),
             errors: i.errors,
-            emitKey: i.emit_key,
+            locationKey: i.location_key,
           } as RefreshStateItem),
       ),
     };

--- a/plugins/catalog-backend/src/next/database/tables.ts
+++ b/plugins/catalog-backend/src/next/database/tables.ts
@@ -29,6 +29,7 @@ export type DbRefreshStateRow = {
   next_update_at: string;
   last_discovery_at: string; // remove?
   errors?: string;
+  emit_key: string;
 };
 
 export type DbRefreshStateReferencesRow = {

--- a/plugins/catalog-backend/src/next/database/tables.ts
+++ b/plugins/catalog-backend/src/next/database/tables.ts
@@ -29,7 +29,7 @@ export type DbRefreshStateRow = {
   next_update_at: string;
   last_discovery_at: string; // remove?
   errors?: string;
-  emit_key: string;
+  location_key?: string;
 };
 
 export type DbRefreshStateReferencesRow = {

--- a/plugins/catalog-backend/src/next/database/types.ts
+++ b/plugins/catalog-backend/src/next/database/types.ts
@@ -17,10 +17,11 @@
 import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
 import { JsonObject } from '@backstage/config';
 import { Transaction } from '../../database/types';
+import { DeferredEntity } from '../processing/types';
 
 export type AddUnprocessedEntitiesOptions = {
   entityRef: string;
-  entities: Entity[];
+  entities: DeferredEntity[];
 };
 
 export type AddUnprocessedEntitiesResult = {};
@@ -31,7 +32,8 @@ export type UpdateProcessedEntityOptions = {
   state?: Map<string, JsonObject>;
   errors?: string;
   relations: EntityRelationSpec[];
-  deferredEntities: Entity[];
+  deferredEntities: DeferredEntity[];
+  emitKey: string;
 };
 
 export type UpdateProcessedEntityErrorsOptions = {
@@ -48,6 +50,7 @@ export type RefreshStateItem = {
   lastDiscoveryAt: string; // remove?
   state: Map<string, JsonObject>;
   errors?: string;
+  emitKey: string;
 };
 
 export type GetProcessableEntitiesResult = {
@@ -57,13 +60,13 @@ export type GetProcessableEntitiesResult = {
 export type ReplaceUnprocessedEntitiesOptions =
   | {
       sourceKey: string;
-      items: Entity[];
+      items: DeferredEntity[];
       type: 'full';
     }
   | {
       sourceKey: string;
-      added: Entity[];
-      removed: Entity[];
+      added: DeferredEntity[];
+      removed: DeferredEntity[];
       type: 'delta';
     };
 

--- a/plugins/catalog-backend/src/next/database/types.ts
+++ b/plugins/catalog-backend/src/next/database/types.ts
@@ -33,7 +33,7 @@ export type UpdateProcessedEntityOptions = {
   errors?: string;
   relations: EntityRelationSpec[];
   deferredEntities: DeferredEntity[];
-  emitKey: string;
+  locationKey?: string;
 };
 
 export type UpdateProcessedEntityErrorsOptions = {
@@ -50,7 +50,7 @@ export type RefreshStateItem = {
   lastDiscoveryAt: string; // remove?
   state: Map<string, JsonObject>;
   errors?: string;
-  emitKey: string;
+  locationKey?: string;
 };
 
 export type GetProcessableEntitiesResult = {

--- a/plugins/catalog-backend/src/next/database/types.ts
+++ b/plugins/catalog-backend/src/next/database/types.ts
@@ -19,10 +19,15 @@ import { JsonObject } from '@backstage/config';
 import { Transaction } from '../../database/types';
 import { DeferredEntity } from '../processing/types';
 
-export type AddUnprocessedEntitiesOptions = {
-  entityRef: string;
-  entities: DeferredEntity[];
-};
+export type AddUnprocessedEntitiesOptions =
+  | {
+      sourceEntityRef: string;
+      entities: DeferredEntity[];
+    }
+  | {
+      sourceKey: string;
+      entities: DeferredEntity[];
+    };
 
 export type AddUnprocessedEntitiesResult = {};
 

--- a/plugins/catalog-backend/src/next/database/types.ts
+++ b/plugins/catalog-backend/src/next/database/types.ts
@@ -78,11 +78,6 @@ export type ReplaceUnprocessedEntitiesOptions =
 export interface ProcessingDatabase {
   transaction<T>(fn: (tx: Transaction) => Promise<T>): Promise<T>;
 
-  addUnprocessedEntities(
-    tx: Transaction,
-    options: AddUnprocessedEntitiesOptions,
-  ): Promise<void>;
-
   replaceUnprocessedEntities(
     txOpaque: Transaction,
     options: ReplaceUnprocessedEntitiesOptions,

--- a/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -68,7 +68,6 @@ export class DefaultCatalogProcessingOrchestrator
   async process(
     request: EntityProcessingRequest,
   ): Promise<EntityProcessingResult> {
-    // TODO: implement dryRun/eager
     return this.processSingleEntity(request.entity);
   }
 

--- a/plugins/catalog-backend/src/next/processing/ProcessorOutputCollector.ts
+++ b/plugins/catalog-backend/src/next/processing/ProcessorOutputCollector.ts
@@ -101,14 +101,14 @@ export class ProcessorOutputCollector {
         };
       }
 
-      this.deferredEntities.push({ entity, emitKey: location });
+      this.deferredEntities.push({ entity, locationKey: location });
     } else if (i.type === 'location') {
       const entity = locationSpecToLocationEntity(
         i.location,
         this.parentEntity,
       );
-      const emitKey = getEntityLocationRef(entity);
-      this.deferredEntities.push({ entity, emitKey });
+      const locationKey = getEntityLocationRef(entity);
+      this.deferredEntities.push({ entity, locationKey });
     } else if (i.type === 'relation') {
       this.relations.push(i.relation);
     } else if (i.type === 'error') {

--- a/plugins/catalog-backend/src/next/processing/ProcessorOutputCollector.ts
+++ b/plugins/catalog-backend/src/next/processing/ProcessorOutputCollector.ts
@@ -24,7 +24,12 @@ import {
 import { Logger } from 'winston';
 import { CatalogProcessorResult } from '../../ingestion';
 import { locationSpecToLocationEntity } from '../util';
-import { getEntityOriginLocationRef, validateEntityEnvelope } from './util';
+import { DeferredEntity } from './types';
+import {
+  getEntityLocationRef,
+  getEntityOriginLocationRef,
+  validateEntityEnvelope,
+} from './util';
 
 /**
  * Helper class for aggregating all of the emitted data from processors.
@@ -32,7 +37,7 @@ import { getEntityOriginLocationRef, validateEntityEnvelope } from './util';
 export class ProcessorOutputCollector {
   private readonly errors = new Array<Error>();
   private readonly relations = new Array<EntityRelationSpec>();
-  private readonly deferredEntities = new Array<Entity>();
+  private readonly deferredEntities = new Array<DeferredEntity>();
   private done = false;
 
   constructor(
@@ -73,6 +78,8 @@ export class ProcessorOutputCollector {
         return;
       }
 
+      const location = stringifyLocationReference(i.location);
+
       // Note that at this point, we have only validated the envelope part of
       // the entity data. Annotations are not part of that, so we have to be
       // defensive. If the annotations were malformed (e.g. were not a valid
@@ -81,7 +88,6 @@ export class ProcessorOutputCollector {
       const annotations = entity.metadata.annotations || {};
       if (typeof annotations === 'object' && !Array.isArray(annotations)) {
         const originLocation = getEntityOriginLocationRef(this.parentEntity);
-        const location = stringifyLocationReference(i.location);
         entity = {
           ...entity,
           metadata: {
@@ -95,11 +101,14 @@ export class ProcessorOutputCollector {
         };
       }
 
-      this.deferredEntities.push(entity);
+      this.deferredEntities.push({ entity, emitKey: location });
     } else if (i.type === 'location') {
-      this.deferredEntities.push(
-        locationSpecToLocationEntity(i.location, this.parentEntity),
+      const entity = locationSpecToLocationEntity(
+        i.location,
+        this.parentEntity,
       );
+      const emitKey = getEntityLocationRef(entity);
+      this.deferredEntities.push({ entity, emitKey });
     } else if (i.type === 'relation') {
       this.relations.push(i.relation);
     } else if (i.type === 'error') {

--- a/plugins/catalog-backend/src/next/processing/types.ts
+++ b/plugins/catalog-backend/src/next/processing/types.ts
@@ -42,5 +42,5 @@ export interface CatalogProcessingOrchestrator {
 
 export type DeferredEntity = {
   entity: Entity;
-  emitKey: string;
+  locationKey?: string;
 };

--- a/plugins/catalog-backend/src/next/processing/types.ts
+++ b/plugins/catalog-backend/src/next/processing/types.ts
@@ -27,7 +27,7 @@ export type EntityProcessingResult =
       ok: true;
       state: Map<string, JsonObject>;
       completedEntity: Entity;
-      deferredEntities: Entity[];
+      deferredEntities: DeferredEntity[];
       relations: EntityRelationSpec[];
       errors: Error[];
     }
@@ -39,3 +39,8 @@ export type EntityProcessingResult =
 export interface CatalogProcessingOrchestrator {
   process(request: EntityProcessingRequest): Promise<EntityProcessingResult>;
 }
+
+export type DeferredEntity = {
+  entity: Entity;
+  emitKey: string;
+};

--- a/plugins/catalog-backend/src/next/types.ts
+++ b/plugins/catalog-backend/src/next/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { Entity, Location, LocationSpec } from '@backstage/catalog-model';
+import { DeferredEntity } from './processing/types';
 
 export interface LocationService {
   createLocation(
@@ -39,8 +40,8 @@ export interface CatalogProcessingEngine {
 }
 
 export type EntityProviderMutation =
-  | { type: 'full'; entities: Entity[] }
-  | { type: 'delta'; added: Entity[]; removed: Entity[] };
+  | { type: 'full'; entities: DeferredEntity[] }
+  | { type: 'delta'; added: DeferredEntity[]; removed: DeferredEntity[] };
 
 export interface EntityProviderConnection {
   applyMutation(mutation: EntityProviderMutation): Promise<void>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #4760

Bunch of info in the changeset, so won't repeat it here :grin:

In short this introduces a new key that we use to determine if two entities are "the same". With the provided set of rules we also hope that this particular way to handle conflicts will help make it much easier to migrate from automatically discovered or imported entities to ones that are defined in YAML. Essentially, it is possible to import entities without assigning one of these new keys for them, and when registering an entity that is defined in YAML it will always have the key set, and therefore always override the discovered entity.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
