### PR TITLE
Add 404 handling for catalog and techdocs

### DIFF
--- a/.changeset/pretty-pumas-jog.md
+++ b/.changeset/pretty-pumas-jog.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-sentry': patch
+'@backstage/plugin-sonarqube': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Add 404 handling for catalog entity page and TechDocs reader page

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -44,6 +44,7 @@ import {
   Page,
   Progress,
   RoutedTabs,
+  ErrorPage,
 } from '@backstage/core-components';
 
 type SubRoute = {
@@ -228,11 +229,20 @@ export const EntityLayout = ({
 
       {entity && <RoutedTabs routes={routes} />}
 
+      {!loading && !error && !entity && (
+        <ErrorPage
+          status="404"
+          statusMessage="Not Found"
+          additionalInfo="There is no catalog entity with that kind, namespace, and name"
+        />
+      )}
+
       {error && (
         <Content>
           <Alert severity="error">{error.toString()}</Alert>
         </Content>
       )}
+
       <UnregisterEntityDialog
         open={confirmationDialogOpen}
         entity={entity!}

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -79,7 +79,9 @@ export interface TechDocsApi {
   // Warning: (ae-forgotten-export) The symbol "TechDocsEntityMetadata" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
-  getEntityMetadata(entityId: EntityName): Promise<TechDocsEntityMetadata>;
+  getEntityMetadata(
+    entityId: EntityName,
+  ): Promise<TechDocsEntityMetadata | undefined>;
   // Warning: (ae-forgotten-export) The symbol "TechDocsMetadata" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
@@ -115,7 +117,9 @@ export class TechDocsClient implements TechDocsApi {
   getApiOrigin(): Promise<string>;
   // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-  getEntityMetadata(entityId: EntityName): Promise<TechDocsEntityMetadata>;
+  getEntityMetadata(
+    entityId: EntityName,
+  ): Promise<TechDocsEntityMetadata | undefined>;
   // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
   getTechDocsMetadata(entityId: EntityName): Promise<TechDocsMetadata>;

--- a/plugins/techdocs/src/api.ts
+++ b/plugins/techdocs/src/api.ts
@@ -49,5 +49,7 @@ export interface TechDocsStorageApi {
 export interface TechDocsApi {
   getApiOrigin(): Promise<string>;
   getTechDocsMetadata(entityId: EntityName): Promise<TechDocsMetadata>;
-  getEntityMetadata(entityId: EntityName): Promise<TechDocsEntityMetadata>;
+  getEntityMetadata(
+    entityId: EntityName,
+  ): Promise<TechDocsEntityMetadata | undefined>;
 }

--- a/plugins/techdocs/src/client.ts
+++ b/plugins/techdocs/src/client.ts
@@ -87,7 +87,7 @@ export class TechDocsClient implements TechDocsApi {
    */
   async getEntityMetadata(
     entityId: EntityName,
-  ): Promise<TechDocsEntityMetadata> {
+  ): Promise<TechDocsEntityMetadata | undefined> {
     const { kind, namespace, name } = entityId;
 
     const apiOrigin = await this.getApiOrigin();
@@ -97,8 +97,10 @@ export class TechDocsClient implements TechDocsApi {
     const request = await fetch(`${requestUrl}`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
+    if (request.status === 404) {
+      return undefined;
+    }
     const res = await request.json();
-
     return res;
   }
 }

--- a/plugins/techdocs/src/reader/components/TechDocsPage.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPage.tsx
@@ -20,6 +20,7 @@ import { useAsync } from 'react-use';
 import { techdocsApiRef } from '../../api';
 import { Reader } from './Reader';
 import { TechDocsPageHeader } from './TechDocsPageHeader';
+import { TechDocsNotFound } from './TechDocsNotFound';
 
 import { Content, Page } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
@@ -45,6 +46,13 @@ export const TechDocsPage = () => {
   const onReady = useCallback(() => {
     setDocumentReady(true);
   }, [setDocumentReady]);
+
+  if (
+    !entityMetadataRequest.loading &&
+    entityMetadataRequest.value === undefined
+  ) {
+    return <TechDocsNotFound />;
+  }
 
   return (
     <Page themeId="documentation">


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add display of appropriate error for catalog entity not found and TechDocs entity not found.

Entity name in /catalog url is not found
Old behavior:  Header with blank page
Fixed behavior: 
![image](https://user-images.githubusercontent.com/14866712/123911717-b76f6580-d9ae-11eb-9435-557a1ae022fa.png)

Entity name in /docs url is not found
Old behavior: Completely blank page
Fixed behavior:
![image](https://user-images.githubusercontent.com/14866712/123912070-264cbe80-d9af-11eb-85d4-c56ecfc30165.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [:heavy_check_mark: ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [NA] Added or updated documentation
- [NA] Tests for new functionality and regression tests for bug fixes
- [:heavy_check_mark:] Screenshots attached (for UI changes)
- [:heavy_check_mark:] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
