### PR TITLE
Edit Button for Group Profile Card

### DIFF
--- a/.changeset/six-birds-approve.md
+++ b/.changeset/six-birds-approve.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-org': patch
+---
+
+Add edit button to Group Profile Card

--- a/packages/core-components/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core-components/src/layout/InfoCard/InfoCard.tsx
@@ -37,7 +37,6 @@ const useStyles = makeStyles(theme => ({
     },
   },
   header: {
-    display: 'inline-block',
     padding: theme.spacing(2, 2, 2, 2.5),
   },
   headerTitle: {
@@ -121,6 +120,7 @@ type Props = {
   children?: ReactNode;
   headerStyle?: object;
   headerProps?: CardHeaderProps;
+  action?: ReactNode;
   actionsClassName?: string;
   actions?: ReactNode;
   cardClassName?: string;
@@ -141,6 +141,7 @@ export const InfoCard = ({
   children,
   headerStyle,
   headerProps,
+  action,
   actionsClassName,
   actions,
   cardClassName,
@@ -190,6 +191,7 @@ export const InfoCard = ({
             }}
             title={title}
             subheader={subheader}
+            action={action}
             style={{ ...headerStyle }}
             titleTypographyProps={titleTypographyProps}
             {...headerProps}

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -79,28 +79,31 @@ export const GroupProfileCard = ({
     kind: 'group',
   });
 
-  const entityMetadataEditUrl = getEntityMetadataEditUrl(group) ?? '#';
+  const entityMetadataEditUrl = getEntityMetadataEditUrl(group);
 
   const displayName = profile?.displayName ?? name;
   const emailHref = profile?.email ? `mailto:${profile.email}` : '#';
+  const infoCardAction = entityMetadataEditUrl ? (
+    <IconButton
+      aria-label="Edit"
+      title="Edit Metadata"
+      component={Link}
+      to={entityMetadataEditUrl}
+    >
+      <EditIcon />
+    </IconButton>
+  ) : (
+    <IconButton aria-label="Edit" disabled title="Edit Metadata">
+      <EditIcon />
+    </IconButton>
+  );
 
   return (
     <InfoCard
       title={<CardTitle title={displayName} />}
       subheader={description}
       variant={variant}
-      action={
-        <IconButton
-          aria-label="Edit"
-          disabled={!entityMetadataEditUrl}
-          title="Edit Metadata"
-          component={Link}
-          target="_blank"
-          to={entityMetadataEditUrl}
-        >
-          <EditIcon />
-        </IconButton>
-      }
+      action={infoCardAction}
     >
       <Grid container spacing={3}>
         <Grid item xs={12} sm={2} xl={1}>

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -28,7 +28,6 @@ import {
 import {
   Box,
   Grid,
-  Link,
   List,
   ListItem,
   ListItemIcon,
@@ -42,7 +41,12 @@ import GroupIcon from '@material-ui/icons/Group';
 import EditIcon from '@material-ui/icons/Edit';
 import Alert from '@material-ui/lab/Alert';
 import React from 'react';
-import { Avatar, InfoCard, InfoCardVariants } from '@backstage/core-components';
+import {
+  Avatar,
+  InfoCard,
+  InfoCardVariants,
+  Link,
+} from '@backstage/core-components';
 
 const CardTitle = ({ title }: { title: string }) => (
   <Box display="flex" alignItems="center">
@@ -75,10 +79,10 @@ export const GroupProfileCard = ({
     kind: 'group',
   });
 
-  const entityMetadataEditUrl = getEntityMetadataEditUrl(group);
+  const entityMetadataEditUrl = getEntityMetadataEditUrl(group) ?? '#';
 
   const displayName = profile?.displayName ?? name;
-  const emailHref = profile?.email ? `mailto:${profile.email}` : undefined;
+  const emailHref = profile?.email ? `mailto:${profile.email}` : '#';
 
   return (
     <InfoCard
@@ -90,9 +94,9 @@ export const GroupProfileCard = ({
           aria-label="Edit"
           disabled={!entityMetadataEditUrl}
           title="Edit Metadata"
-          onClick={() => {
-            window.open(entityMetadataEditUrl ?? '#', '_blank');
-          }}
+          component={Link}
+          target="_blank"
+          to={entityMetadataEditUrl}
         >
           <EditIcon />
         </IconButton>
@@ -112,7 +116,7 @@ export const GroupProfileCard = ({
                   </Tooltip>
                 </ListItemIcon>
                 <ListItemText>
-                  <Link href={emailHref}>{profile.email}</Link>
+                  <Link to={emailHref}>{profile.email}</Link>
                 </ListItemText>
               </ListItem>
             )}

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -33,10 +33,12 @@ import {
   ListItemIcon,
   ListItemText,
   Tooltip,
+  IconButton,
 } from '@material-ui/core';
 import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';
+import EditIcon from '@material-ui/icons/Edit';
 import Alert from '@material-ui/lab/Alert';
 import React from 'react';
 import { Avatar, InfoCard, InfoCardVariants } from '@backstage/core-components';
@@ -80,6 +82,18 @@ export const GroupProfileCard = ({
       title={<CardTitle title={displayName} />}
       subheader={description}
       variant={variant}
+      action={
+        <IconButton
+          aria-label="Edit"
+          // disabled={!entityMetadataEditUrl}
+          title="Edit Metadata"
+          onClick={() => {
+            // window.open(entityMetadataEditUrl ?? '#', '_blank');
+          }}
+        >
+          <EditIcon />
+        </IconButton>
+      }
     >
       <Grid container spacing={3}>
         <Grid item xs={12} sm={2} xl={1}>

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -23,6 +23,7 @@ import {
   EntityRefLinks,
   getEntityRelations,
   useEntity,
+  getEntityMetadataEditUrl,
 } from '@backstage/plugin-catalog-react';
 import {
   Box,
@@ -74,6 +75,8 @@ export const GroupProfileCard = ({
     kind: 'group',
   });
 
+  const entityMetadataEditUrl = getEntityMetadataEditUrl(group);
+
   const displayName = profile?.displayName ?? name;
   const emailHref = profile?.email ? `mailto:${profile.email}` : undefined;
 
@@ -85,10 +88,10 @@ export const GroupProfileCard = ({
       action={
         <IconButton
           aria-label="Edit"
-          // disabled={!entityMetadataEditUrl}
+          disabled={!entityMetadataEditUrl}
           title="Edit Metadata"
           onClick={() => {
-            // window.open(entityMetadataEditUrl ?? '#', '_blank');
+            window.open(entityMetadataEditUrl ?? '#', '_blank');
           }}
         >
           <EditIcon />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
I want to add an Edit Button to the Group Profile card, for example when we see this page https://demo.backstage.io/catalog/default/group/acme-corp it doesn't have any edit button like other entities

So this PR is to add that functionality and for making it easy to open and edit the metadata file so it would be consistent across entities
![image](https://user-images.githubusercontent.com/33563774/123920580-4f218380-d9b0-11eb-840b-ba50f5f16c01.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
