### PR TITLE
Docs: Update Docker host build documentation with new default Dockerfile

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -59,7 +59,7 @@ Once the host build is complete, we are ready to build our image. The following
 FROM node:14-buster-slim
 
 WORKDIR /app
-
+# Copy repo skeleton first, to avoid unnecessary docker cache invalidation.
 # The skeleton contains the package.json of each package in the monorepo,
 # and along with yarn.lock and the root package.json, that's enough to run yarn install.
 COPY yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -60,15 +60,16 @@ FROM node:14-buster-slim
 
 WORKDIR /app
 
-# Copy repo skeleton first, to avoid unnecessary docker cache invalidation.
 # The skeleton contains the package.json of each package in the monorepo,
 # and along with yarn.lock and the root package.json, that's enough to run yarn install.
-ADD yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
+COPY yarn.lock package.json packages/backend/dist/skeleton.tar.gz ./
+RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 
 RUN yarn install --frozen-lockfile --production --network-timeout 300000 && rm -rf "$(yarn cache dir)"
 
 # Then copy the rest of the backend bundle, along with any other files we might want.
-ADD packages/backend/dist/bundle.tar.gz app-config.yaml ./
+COPY packages/backend/dist/bundle.tar.gz app-config.yaml ./
+RUN tar xzf bundle.tar.gz && rm bundle.tar.gz
 
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]
 ```


### PR DESCRIPTION
Signed-off-by: michael.rode <michael.rode@rigup.com>

## Hey, I just made a Pull Request!

The `Dockerfile` referenced in the [Host Build Docker](https://backstage.io/docs/deployment/docker#host-build) section is either out of date or incorrect. I have updated it with the correct `Dockerfile` that is generated when creating a new app with `@backstage/create-app`

## Screenshots
![Screen Shot 2021-07-01 at 12 19 46 AM](https://user-images.githubusercontent.com/57153992/124069637-1c07e000-da02-11eb-8930-a2fc82a851a0.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
