### PR TITLE
regex to validate names following k8s validation rule

### DIFF
--- a/.changeset/flat-donkeys-rhyme.md
+++ b/.changeset/flat-donkeys-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Changed the regex to validate names following the Kubernetes validation rule, this allow to be more permissive validating the name of the object in Backstage.

--- a/packages/catalog-model/src/validation/KubernetesValidatorFunctions.test.ts
+++ b/packages/catalog-model/src/validation/KubernetesValidatorFunctions.test.ts
@@ -76,9 +76,10 @@ describe('KubernetesValidatorFunctions', () => {
     ['a-b', true],
     ['-a-b', false],
     ['a-b-', false],
-    ['a--b', false],
+    ['a--b', true],
     ['a_b', true],
     ['a.b', true],
+    ['a..b', true],
   ])(`isValidObjectName %p ? %p`, (value, matches) => {
     expect(KubernetesValidatorFunctions.isValidObjectName(value)).toBe(matches);
   });
@@ -114,9 +115,10 @@ describe('KubernetesValidatorFunctions', () => {
     ['a-b', true],
     ['-a-b', false],
     ['a-b-', false],
-    ['a--b', false],
+    ['a--b', true],
     ['a_b', true],
     ['a.b', true],
+    ['a..b', true],
     ['a/a', true],
     ['a-b.c/a', true],
     ['a--b.c/a', false],
@@ -150,9 +152,10 @@ describe('KubernetesValidatorFunctions', () => {
     ['a-b', true],
     ['-a-b', false],
     ['a-b-', false],
-    ['a--b', false],
+    ['a--b', true],
     ['a_b', true],
     ['a.b', true],
+    ['a..b', true],
   ])(`isValidLabelValue %p ? %p`, (value, matches) => {
     expect(KubernetesValidatorFunctions.isValidLabelValue(value)).toBe(matches);
   });
@@ -169,9 +172,10 @@ describe('KubernetesValidatorFunctions', () => {
     ['a-b', true],
     ['-a-b', false],
     ['a-b-', false],
-    ['a--b', false],
+    ['a--b', true],
     ['a_b', true],
     ['a.b', true],
+    ['a..b', true],
     ['a/a', true],
     ['a-b.c/a', true],
     ['a--b.c/a', false],

--- a/packages/catalog-model/src/validation/KubernetesValidatorFunctions.ts
+++ b/packages/catalog-model/src/validation/KubernetesValidatorFunctions.ts
@@ -48,7 +48,7 @@ export class KubernetesValidatorFunctions {
       typeof value === 'string' &&
       value.length >= 1 &&
       value.length <= 63 &&
-      /^[a-z0-9A-Z]+([-_.][a-z0-9A-Z]+)*$/.test(value)
+      /^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/.test(value)
     );
   }
 


### PR DESCRIPTION
Signed-off-by: matteobarone <barmat90@gmail.com>

## Hey, I just made a Pull Request!

Changed the regex to validate names following the Kubernetes validation rule, this allow to be more permissive validating the name of the object in Backstage. For example `a--b` currently is discarded, with this implementation will be accepted.
This issue was already discussed in the previous days in Discord, and this PR contain the implementation that should adjust it.
https://discord.com/channels/687207715902193673/687207715902193679/854343624589312020

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
