### PR TITLE
Fix downloads of repositories located at bitbucket.org

### DIFF
--- a/.changeset/serious-falcons-greet.md
+++ b/.changeset/serious-falcons-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fix downloads from repositories located at bitbucket.org

--- a/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
@@ -119,14 +119,14 @@ describe('BitbucketUrlReader', () => {
             ),
         ),
         rest.get(
-          'https://bitbucket.org/backstage/mock/get/master.tgz',
+          'https://bitbucket.org/backstage/mock/get/master.tar.gz',
           (_, res, ctx) =>
             res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/zip'),
               ctx.set(
                 'content-disposition',
-                'attachment; filename=backstage-mock-12ab34cd56ef.tgz',
+                'attachment; filename=backstage-mock-12ab34cd56ef.tar.gz',
               ),
               ctx.body(repoBuffer),
             ),
@@ -304,14 +304,14 @@ describe('BitbucketUrlReader', () => {
             ),
         ),
         rest.get(
-          'https://bitbucket.org/backstage/mock/get/master.tgz',
+          'https://bitbucket.org/backstage/mock/get/master.tar.gz',
           (_, res, ctx) =>
             res(
               ctx.status(200),
               ctx.set('Content-Type', 'application/zip'),
               ctx.set(
                 'content-disposition',
-                'attachment; filename=backstage-mock-12ab34cd56ef.tgz',
+                'attachment; filename=backstage-mock-12ab34cd56ef.tar.gz',
               ),
               ctx.body(repoBuffer),
             ),

--- a/packages/integration/src/bitbucket/core.test.ts
+++ b/packages/integration/src/bitbucket/core.test.ts
@@ -192,7 +192,7 @@ describe('bitbucket core', () => {
         config,
       );
       expect(result).toEqual(
-        'https://bitbucket.org/backstage/mock/get/master.tgz',
+        'https://bitbucket.org/backstage/mock/get/master.tar.gz',
       );
     });
   });

--- a/packages/integration/src/bitbucket/core.ts
+++ b/packages/integration/src/bitbucket/core.ts
@@ -98,7 +98,7 @@ export async function getBitbucketDownloadUrl(
   // /docs/index.md will download the docs folder and everything below it
   const path = filepath ? `&path=${encodeURIComponent(filepath)}` : '';
   const archiveUrl = isHosted
-    ? `${protocol}://${resource}/${project}/${repoName}/get/${branch}.tgz`
+    ? `${protocol}://${resource}/${project}/${repoName}/get/${branch}.tar.gz`
     : `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/archive?format=tgz&at=${branch}&prefix=${project}-${repoName}${path}`;
 
   return archiveUrl;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #6298 

Downloading the repository as .tgz from bitbucket.org will from backstage give you a `403` response. 
Changing to `tar.gz` will correctly download the repository

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
