### PR TITLE
microsite: search box and header fixes

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -146,6 +146,11 @@ td {
   content: "No results"
 }
 
+.navSearchWrapper {
+  /* Prevents the search box from detaching from its icon when pushed down */
+  justify-content: flex-start;
+}
+
 /* header */
 .fixedHeaderContainer {
   position: fixed;
@@ -155,6 +160,12 @@ td {
   box-shadow: 3px 3px 8px rgba(38, 38, 38, 0.25);
   color: #fff;
 }
+
+.wrapper.headerWrapper {
+  /* Keep the header stretched across the screen on the mid breakpoint, since we need a bit more space */
+  max-width: 1400px;
+}
+
 @media only screen and (min-width: 1024px) {
   .fixedHeaderContainer {
     height: 66px;

--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -138,12 +138,12 @@ td {
 }
 
 /* search */
-[aria-expanded="true"] ~ .aa-without-1 {
+[aria-expanded='true'] ~ .aa-without-1 {
   display: block !important;
 }
 
-[aria-expanded="true"] ~ .aa-without-1 .aa-dataset-1:after {
-  content: "No results"
+[aria-expanded='true'] ~ .aa-without-1 .aa-dataset-1:after {
+  content: 'No results';
 }
 
 .navSearchWrapper {

--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -137,6 +137,15 @@ td {
   color: $navigatorItemTextColor;
 }
 
+/* search */
+[aria-expanded="true"] ~ .aa-without-1 {
+  display: block !important;
+}
+
+[aria-expanded="true"] ~ .aa-without-1 .aa-dataset-1:after {
+  content: "No results"
+}
+
 /* header */
 .fixedHeaderContainer {
   position: fixed;


### PR DESCRIPTION
Fixes #6303 with by showing "No results":

![image](https://user-images.githubusercontent.com/4984472/124266095-cda82d80-db36-11eb-9bb6-b85c6a12f818.png)

Fixes #6249 by making sure the search input doesn't break when wrapped, and reduce the size range at which it needs to be wrapped:

The size range change changes this:

![image](https://user-images.githubusercontent.com/4984472/124266443-4a3b0c00-db37-11eb-9b46-6ef4f7d8a044.png)

to this:

![image](https://user-images.githubusercontent.com/4984472/124266465-53c47400-db37-11eb-9406-e2072fcc40ec.png)

The box unbreaking makes it look like this when wrapped, which only happens for 50px or so:

![image](https://user-images.githubusercontent.com/4984472/124266549-69d23480-db37-11eb-85e4-34063c964467.png)

Making it wrap earlier requires a lot of media query css overrides because afaik it's not configurable in docusaurus, so skipped that