### PR TITLE
adds defaultBranch parameter to git init function

### DIFF
--- a/.changeset/brown-bees-call.md
+++ b/.changeset/brown-bees-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+add defaultBranch parameter to git init function

--- a/packages/backend-common/src/scm/git.test.ts
+++ b/packages/backend-common/src/scm/git.test.ts
@@ -213,6 +213,23 @@ describe('Git', () => {
     });
   });
 
+  describe('init-custom-branch', () => {
+    it('should call isomorphic-git with the correct arguments', async () => {
+      const dir = '/some/mock/dir';
+      const defaultBranch = 'main';
+
+      const git = Git.fromAuth({});
+
+      await git.init({ dir, defaultBranch });
+
+      expect(isomorphic.init).toHaveBeenCalledWith({
+        fs,
+        dir,
+        defaultBranch,
+      });
+    });
+  });
+
   describe('merge', () => {
     it('should call isomorphic-git with the correct arguments', async () => {
       const dir = '/some/mock/dir';

--- a/packages/backend-common/src/scm/git.ts
+++ b/packages/backend-common/src/scm/git.ts
@@ -150,12 +150,19 @@ export class Git {
     });
   }
 
-  async init({ dir }: { dir: string }): Promise<void> {
+  async init({
+    dir,
+    defaultBranch,
+  }: {
+    dir: string;
+    defaultBranch?: string;
+  }): Promise<void> {
     this.config.logger?.info(`Init git repository {dir=${dir}}`);
 
     return git.init({
       fs,
       dir,
+      defaultBranch,
     });
   }
 


### PR DESCRIPTION
Signed-off-by: Christopher Diaz <cdiaz@redventures.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
This adds the `defaultBranch` parameter to the isomorphic git init call. This will allow for actions (mainly the scaffolder) to init repos with custom branch names. For example, `main` or `trunk` are becoming more common than `master` for trunk branches. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
