### PR TITLE
Make branch protection attempt less restrictive

### DIFF
--- a/.changeset/wet-queens-deny.md
+++ b/.changeset/wet-queens-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+removing mandatory of protection for the default branch, that could be handled by the GitHub automation in async manner, thus throwing floating errors

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -268,8 +268,8 @@ export function createPublishGithubAction(options: {
           defaultBranch,
         });
       } catch (e) {
-        throw new Error(
-          `Failed to add branch protection to '${newRepo.name}', ${e}`,
+        ctx.logger.warn(
+          `Skipping: default branch protection on '${newRepo.name}', ${e.message}`,
         );
       }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In case if something wrong happens along the way when trying to apply protection of a newly created branch - it will now log an error, instead of throwing it, thus making scaffolder exit with non-zero exit code.

( This one addresses issue #6330 )

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
