### PR TITLE
Document techdocs svg_object limitation

### DIFF
--- a/docs/features/techdocs/troubleshooting.md
+++ b/docs/features/techdocs/troubleshooting.md
@@ -55,3 +55,20 @@ INFO    -  Start watching changes
 [I 210115 19:00:45 handlers:64] Start detecting changes
 INFO    -  Start detecting changes
 ```
+
+## PlantUML with `svg_object` doesn't render
+
+The [plantuml-markdown](https://pypi.org/project/plantuml-markdown/) MkDocs
+plugin available in
+[`mkdocs-techdocs-core`](https://github.com/backstage/mkdocs-techdocs-core)
+supports different formats for rendering diagrams. TechDocs does however not
+support all of them.
+
+The `svg_object` format renders a diagram as an HTML `<object>` tag but this is
+not allowed as it enables bad actors to inject malicious content into
+documentation pages. See
+[CVE-2021-32661](https://github.com/advisories/GHSA-gg96-f8wr-p89f) for more
+details.
+
+Instead use `svg_inline` which renders as an `<svg>` tag and provides the same
+benefits as `svg_object`.


### PR DESCRIPTION
Currently it is not possible to use the PlantUML format 'svg_object' as this
makes it possible for bad actors to inject malicious content into documentation.

This change documents this limitation under the troubleshooting section of the
techdocs feature as discussed in #6232.

PR https://github.com/backstage/mkdocs-techdocs-core/pull/28 also adds some info on this to make it clear when exploring the available plugins.

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
