### PR TITLE
Load cluster information from a user’s kubeconfig

### DIFF
--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -25,8 +25,20 @@ import {
 import { ClusterDetails } from '../types/types';
 
 export class KubernetesClientProvider {
-  // visible for testing
-  getKubeConfig(clusterDetails: ClusterDetails) {
+  getKubeConfigFromFile(clusterDetails: ClusterDetails) {
+    const kc = new KubeConfig();
+
+    if (clusterDetails.kubeConfigFile) {
+      kc.loadFromFile(clusterDetails.kubeConfigFile);
+    } else {
+      kc.loadFromDefault();
+    }
+
+    kc.setCurrentContext(clusterDetails.kubeConfigContext);
+    return kc;
+  }
+
+  getKubeConfigFromClusterDetails(clusterDetails: ClusterDetails) {
     const cluster = {
       name: clusterDetails.name,
       server: clusterDetails.url,
@@ -52,6 +64,20 @@ export class KubernetesClientProvider {
       contexts: [context],
       currentContext: context.name,
     });
+
+    return kc;
+  }
+
+  // visible for testing
+  getKubeConfig(clusterDetails: ClusterDetails) {
+    let kc;
+
+    if (clusterDetails.kubeConfigContext) {
+      kc = this.getKubeConfigFromFile(clusterDetails);
+    } else {
+      kc = this.getKubeConfigFromClusterDetails(clusterDetails);
+    }
+   
     return kc;
   }
 

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -72,10 +72,10 @@ export type ServiceLocatorMethod = 'multiTenant' | 'http'; // TODO implement htt
 
 export interface ClusterDetails {
   name: string;
-  url: string;
+  url?: string;
   authProvider: string;
   serviceAccountToken?: string | undefined;
   skipTLSVerify?: boolean;
-  kubeConfigContext: string;
-  kubeConfigFile: string;
+  kubeConfigContext?: string;
+  kubeConfigFile?: string;
 }

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -76,4 +76,6 @@ export interface ClusterDetails {
   authProvider: string;
   serviceAccountToken?: string | undefined;
   skipTLSVerify?: boolean;
+  kubeConfigContext: string;
+  kubeConfigFile: string;
 }


### PR DESCRIPTION
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR enables you to load cluster information from a user's kubeconfig. When `kubeConfigContext` is present in the cluster config the `KubernetesClientProvider` will load the kubernetes config from 
the kubeconfig file in the default location. `kubeConfigFile` can optionally be provided to load config from a different location.

This change enables the full use of all kube config options to access the cluster. The impetus for this change is that I want to be able to use the aws-iam-authenticator to authenticate access with my clusters. 

This PR is a proof of concept so that I can get feedback on whether the approach is correct. Once that has been validated I will work to bring it up to spec.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
