### PR TITLE
feat: add default branch property for publish GitLab, Bitbucket and Azure actions

### DIFF
--- a/.changeset/brown-olives-hang.md
+++ b/.changeset/brown-olives-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+add default branch property for publish GitLab, Bitbucket and Azure actions

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.test.ts
@@ -162,6 +162,29 @@ describe('publish:azure', () => {
     expect(initRepoAndPush).toHaveBeenCalledWith({
       dir: mockContext.workspacePath,
       remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+      defaultBranch: 'master',
+      auth: { username: 'notempty', password: 'tokenlols' },
+      logger: mockContext.logger,
+    });
+  });
+
+  it('should call initRepoAndPush with the correct default branch', async () => {
+    mockGitClient.createRepository.mockImplementation(() => ({
+      remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+    }));
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        defaultBranch: 'main',
+      },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'https://dev.azure.com/organization/project/_git/repo',
+      defaultBranch: 'master',
       auth: { username: 'notempty', password: 'tokenlols' },
       logger: mockContext.logger,
     });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
@@ -30,6 +30,7 @@ export function createPublishAzureAction(options: {
   return createTemplateAction<{
     repoUrl: string;
     description?: string;
+    defaultBranch?: string;
     sourcePath?: string;
   }>({
     id: 'publish:azure',
@@ -47,6 +48,11 @@ export function createPublishAzureAction(options: {
           description: {
             title: 'Repository Description',
             type: 'string',
+          },
+          defaultBranch: {
+            title: 'Default Branch',
+            type: 'string',
+            description: `Sets the default branch on the repository. The default value is 'master'`,
           },
           sourcePath: {
             title:
@@ -70,9 +76,9 @@ export function createPublishAzureAction(options: {
       },
     },
     async handler(ctx) {
-      const { owner, repo, host, organization } = parseRepoUrl(
-        ctx.input.repoUrl,
-      );
+      const { repoUrl, defaultBranch = 'master' } = ctx.input;
+
+      const { owner, repo, host, organization } = parseRepoUrl(repoUrl);
 
       if (!organization) {
         throw new InputError(
@@ -120,6 +126,7 @@ export function createPublishAzureAction(options: {
       await initRepoAndPush({
         dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
         remoteUrl,
+        defaultBranch,
         auth: {
           username: 'notempty',
           password: integrationConfig.config.token,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
@@ -286,6 +286,49 @@ describe('publish:bitbucket', () => {
     expect(initRepoAndPush).toHaveBeenCalledWith({
       dir: mockContext.workspacePath,
       remoteUrl: 'https://bitbucket.org/owner/cloneurl',
+      defaultBranch: 'master',
+      auth: { username: 'x-token-auth', password: 'tokenlols' },
+      logger: mockContext.logger,
+    });
+  });
+
+  it('should call initAndPush with the correct default branch', async () => {
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/owner/repo',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/owner/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/owner/cloneurl',
+                  },
+                ],
+              },
+            }),
+          ),
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        defaultBranch: 'main',
+      },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'https://bitbucket.org/owner/cloneurl',
+      defaultBranch: 'main',
       auth: { username: 'x-token-auth', password: 'tokenlols' },
       logger: mockContext.logger,
     });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
@@ -190,6 +190,7 @@ export function createPublishBitbucketAction(options: {
   return createTemplateAction<{
     repoUrl: string;
     description: string;
+    defaultBranch?: string;
     repoVisibility: 'private' | 'public';
     sourcePath?: string;
     enableLFS: boolean;
@@ -214,6 +215,11 @@ export function createPublishBitbucketAction(options: {
             title: 'Repository Visibility',
             type: 'string',
             enum: ['private', 'public'],
+          },
+          defaultBranch: {
+            title: 'Default Branch',
+            type: 'string',
+            description: `Sets the default branch on the repository. The default value is 'master'`,
           },
           sourcePath: {
             title:
@@ -245,6 +251,7 @@ export function createPublishBitbucketAction(options: {
       const {
         repoUrl,
         description,
+        defaultBranch = 'master',
         repoVisibility = 'private',
         enableLFS = false,
       } = ctx.input;
@@ -288,6 +295,7 @@ export function createPublishBitbucketAction(options: {
             ? integrationConfig.config.appPassword
             : integrationConfig.config.token ?? '',
         },
+        defaultBranch,
         logger: ctx.logger,
       });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
@@ -139,6 +139,30 @@ describe('publish:gitlab', () => {
 
     expect(initRepoAndPush).toHaveBeenCalledWith({
       dir: mockContext.workspacePath,
+      defaultBranch: 'master',
+      remoteUrl: 'http://mockurl.git',
+      auth: { username: 'oauth2', password: 'tokenlols' },
+      logger: mockContext.logger,
+    });
+  });
+
+  it('should call initRepoAndPush with the correct default branch', async () => {
+    mockGitlabClient.Namespaces.show.mockResolvedValue({ id: 1234 });
+    mockGitlabClient.Projects.create.mockResolvedValue({
+      http_url_to_repo: 'http://mockurl.git',
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        defaultBranch: 'main',
+      },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      defaultBranch: 'main',
       remoteUrl: 'http://mockurl.git',
       auth: { username: 'oauth2', password: 'tokenlols' },
       logger: mockContext.logger,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -28,6 +28,7 @@ export function createPublishGitlabAction(options: {
 
   return createTemplateAction<{
     repoUrl: string;
+    defaultBranch?: string;
     repoVisibility: 'private' | 'internal' | 'public';
     sourcePath?: string;
   }>({
@@ -47,6 +48,11 @@ export function createPublishGitlabAction(options: {
             title: 'Repository Visibility',
             type: 'string',
             enum: ['private', 'public', 'internal'],
+          },
+          defaultBranch: {
+            title: 'Default Branch',
+            type: 'string',
+            description: `Sets the default branch on the repository. The default value is 'master'`,
           },
           sourcePath: {
             title:
@@ -70,7 +76,11 @@ export function createPublishGitlabAction(options: {
       },
     },
     async handler(ctx) {
-      const { repoUrl, repoVisibility = 'private' } = ctx.input;
+      const {
+        repoUrl,
+        repoVisibility = 'private',
+        defaultBranch = 'master',
+      } = ctx.input;
 
       const { owner, repo, host } = parseRepoUrl(repoUrl);
 
@@ -114,6 +124,7 @@ export function createPublishGitlabAction(options: {
       await initRepoAndPush({
         dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
         remoteUrl: http_url_to_repo as string,
+        defaultBranch,
         auth: {
           username: 'oauth2',
           password: integrationConfig.config.token,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
It has become common practice to use main as the default branch when initializing a Git repository. This updates the Publish:GiLab/Azure/Bitbucket actions to have the defaultBranch config property. If not provided, master will still be used.

The user will be able to change the default branch in the template like below.
```
- id: publish
   name: Publish
   action: publish:gitlab
   input:
     repoUrl: '{{ parameters.repoUrl }}'
     defaultBranch: 'main' << Add this to change your default branch.
```

Screenshots:
![image](https://user-images.githubusercontent.com/34999291/124368749-7ecdd580-dca7-11eb-9034-410110289eab.png)
![image](https://user-images.githubusercontent.com/34999291/124368751-88efd400-dca7-11eb-8ac6-261b66b6c9e8.png)
![image](https://user-images.githubusercontent.com/34999291/124368756-960cc300-dca7-11eb-9916-37285ff49725.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
