### PR TITLE
Add extension points for the LDAP processor for advanced customizations 

### DIFF
--- a/.changeset/large-mice-sin.md
+++ b/.changeset/large-mice-sin.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': minor
+---
+
+Add extension points to the `LdapOrgReaderProcessor` to make it possible to do more advanced modifications
+of the ingested users and groups.

--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -122,8 +122,8 @@ The DN under which users are stored, e.g.
 #### users.options
 
 The search options to use when sending the query to the server, when reading all
-users. All of the options are shown below, with their default values, but they
-are all optional.
+users. All the options are shown below, with their default values, but they are
+all optional.
 
 ```yaml
 options:
@@ -158,8 +158,8 @@ set:
 
 Mappings from well known entity fields, to LDAP attribute names. This is where
 you are able to define how to interpret the attributes of each LDAP result item,
-and to move them into the corresponding entity fields. All of the options are
-shown below, with their default values, but they are all optional.
+and to move them into the corresponding entity fields. All the options are shown
+below, with their default values, but they are all optional.
 
 If you leave out an optional mapping, it will still be copied using that default
 value. For example, even if you do not put in the field `displayName` in your
@@ -204,8 +204,8 @@ The DN under which groups are stored, e.g.
 #### groups.options
 
 The search options to use when sending the query to the server, when reading all
-groups. All of the options are shown below, with their default values, but they
-are all optional.
+groups. All the options are shown below, with their default values, but they are
+all optional.
 
 ```yaml
 options:
@@ -281,4 +281,36 @@ map:
   # The name of the attribute that shall be used for the values of
   # the spec.children field of the entity.
   members: member
+```
+
+## Customize the Processor
+
+In case you want to customize the ingested entities, the
+`LdapOrgReaderProcessor` allows to pass transformers for users and groups.
+
+1. Create a transformer:
+
+```ts
+export async function myGroupTransformer(
+  vendor: LdapVendor,
+  config: GroupConfig,
+  group: SearchEntry,
+): Promise<GroupEntity | undefined> {
+  // Transformations may change namespace, change entity naming pattern, fill
+  // profile with more or other details...
+
+  // Create the group entity on your own, or wrap the default transformer
+  return await defaultGroupTransformer(vendor, config, group);
+}
+```
+
+2. Configure the processor with the transformer:
+
+```ts
+builder.addProcessor(
+  LdapOrgReaderProcessor.fromConfig(config, {
+    logger,
+    groupTransformer: myGroupTransformer,
+  }),
+);
 ```

--- a/plugins/catalog-backend-module-ldap/api-report.md
+++ b/plugins/catalog-backend-module-ldap/api-report.md
@@ -16,6 +16,15 @@ import { SearchEntry } from 'ldapjs';
 import { SearchOptions } from 'ldapjs';
 import { UserEntity } from '@backstage/catalog-model';
 
+// @public (undocumented)
+export function defaultGroupTransformer(vendor: LdapVendor, config: GroupConfig, entry: SearchEntry): Promise<GroupEntity | undefined>;
+
+// @public (undocumented)
+export function defaultUserTransformer(vendor: LdapVendor, config: UserConfig, entry: SearchEntry): Promise<UserEntity | undefined>;
+
+// @public
+export type GroupTransformer = (vendor: LdapVendor, config: GroupConfig, group: SearchEntry) => Promise<GroupEntity | undefined>;
+
 // @public
 export const LDAP_DN_ANNOTATION = "backstage.io/ldap-dn";
 
@@ -40,14 +49,18 @@ export class LdapOrgReaderProcessor implements CatalogProcessor {
     constructor(options: {
         providers: LdapProviderConfig[];
         logger: Logger;
+        groupTransformer?: GroupTransformer;
+        userTransformer?: UserTransformer;
     });
     // (undocumented)
     static fromConfig(config: Config, options: {
         logger: Logger;
+        groupTransformer?: GroupTransformer;
+        userTransformer?: UserTransformer;
     }): LdapOrgReaderProcessor;
     // (undocumented)
     readLocation(location: LocationSpec, _optional: boolean, emit: CatalogProcessorEmit): Promise<boolean>;
-}
+    }
 
 // @public
 export type LdapProviderConfig = {
@@ -58,13 +71,23 @@ export type LdapProviderConfig = {
 };
 
 // @public
+export function mapStringAttr(entry: SearchEntry, vendor: LdapVendor, attributeName: string | undefined, setter: (value: string) => void): void;
+
+// @public
 export function readLdapConfig(config: Config): LdapProviderConfig[];
 
 // @public
-export function readLdapOrg(client: LdapClient, userConfig: UserConfig, groupConfig: GroupConfig): Promise<{
+export function readLdapOrg(client: LdapClient, userConfig: UserConfig, groupConfig: GroupConfig, options: {
+    groupTransformer?: GroupTransformer;
+    userTransformer?: UserTransformer;
+    logger: Logger;
+}): Promise<{
     users: UserEntity[];
     groups: GroupEntity[];
 }>;
+
+// @public
+export type UserTransformer = (vendor: LdapVendor, config: UserConfig, user: SearchEntry) => Promise<UserEntity | undefined>;
 
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/catalog-backend-module-ldap/src/ldap/index.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/index.ts
@@ -15,6 +15,7 @@
  */
 
 export { LdapClient } from './client';
+export { mapStringAttr } from './util';
 export { readLdapConfig } from './config';
 export type { LdapProviderConfig } from './config';
 export {
@@ -22,4 +23,9 @@ export {
   LDAP_RDN_ANNOTATION,
   LDAP_UUID_ANNOTATION,
 } from './constants';
-export { readLdapOrg } from './read';
+export {
+  defaultGroupTransformer,
+  defaultUserTransformer,
+  readLdapOrg,
+} from './read';
+export type { GroupTransformer, UserTransformer } from './types';

--- a/plugins/catalog-backend-module-ldap/src/ldap/types.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/types.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GroupEntity, UserEntity } from '@backstage/catalog-model';
+import { SearchEntry } from 'ldapjs';
+import { LdapVendor } from './vendors';
+import { GroupConfig, UserConfig } from './config';
+
+/**
+ * Customize the ingested User entity
+ *
+ * @param vendor The LDAP vendor that can be used to find and decode vendor specific attributes
+ * @param config The User specific config used by the default transformer.
+ * @param user The found LDAP entry in its source format. This is the entry that you want to transform
+ * @return A `UserEntity` or `undefined` if you want to ignore the found user for being ingested by the catalog
+ */
+export type UserTransformer = (
+  vendor: LdapVendor,
+  config: UserConfig,
+  user: SearchEntry,
+) => Promise<UserEntity | undefined>;
+
+/**
+ * Customize the ingested Group entity
+ *
+ * @param vendor The LDAP vendor that can be used to find and decode vendor specific attributes
+ * @param config The Group specific config used by the default transformer.
+ * @param group The found LDAP entry in its source format. This is the entry that you want to transform
+ * @return A `GroupEntity` or `undefined` if you want to ignore the found group for being ingested by the catalog
+ */
+export type GroupTransformer = (
+  vendor: LdapVendor,
+  config: GroupConfig,
+  group: SearchEntry,
+) => Promise<GroupEntity | undefined>;

--- a/plugins/catalog-backend-module-ldap/src/ldap/util.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/util.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Error as LDAPError } from 'ldapjs';
+import { Error as LDAPError, SearchEntry } from 'ldapjs';
+import { LdapVendor } from './vendors';
 
 /**
  * Builds a string form of an LDAP Error structure.
@@ -23,4 +24,26 @@ import { Error as LDAPError } from 'ldapjs';
  */
 export function errorString(error: LDAPError) {
   return `${error.code} ${error.name}: ${error.message}`;
+}
+
+/**
+ * Maps a single-valued attribute to a consumer
+ *
+ * @param entry The LDAP source entry
+ * @param vendor The LDAP vendor
+ * @param attributeName The source attribute to map. If the attribute is undefined the mapping will be silently ignored.
+ * @param setter The function to be called with the decoded attribute from the source entry
+ */
+export function mapStringAttr(
+  entry: SearchEntry,
+  vendor: LdapVendor,
+  attributeName: string | undefined,
+  setter: (value: string) => void,
+) {
+  if (attributeName) {
+    const values = vendor.decodeStringAttribute(entry, attributeName);
+    if (values && values.length === 1) {
+      setter(values[0]);
+    }
+  }
 }


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

## Hey, I just made a Pull Request!

This pull request is a follow up on the #6116 to add user and group transformers for more advanced customizations.

The pull request also exports the `mapStringAttr` to make easier for implementors to reuse the attribute mapping if they want.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
