### PR TITLE
Custom scrollbar for SidebarScrollWrapper

### DIFF
--- a/.changeset/young-pigs-beg.md
+++ b/.changeset/young-pigs-beg.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Add custom styles to Scrollbar of the Sidebar Wrapper to fix flaky behaviour
+Add custom styles to scroll bar of the sidebar wrapper to fix flaky behaviour

--- a/.changeset/young-pigs-beg.md
+++ b/.changeset/young-pigs-beg.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Add custom styles for scrollbar of sidebar items wrapper to fix flaky behavior
+Add custom styles to Scrollbar of the Sidebar Wrapper to fix flaky behaviour

--- a/.changeset/young-pigs-beg.md
+++ b/.changeset/young-pigs-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add custom styles for scrollbar of sidebar items wrapper to fix flaky behavior

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -291,10 +291,21 @@ export const SidebarDivider = styled('hr')({
   margin: '12px 0px',
 });
 
-export const SidebarScrollWrapper = styled('div')({
+export const SidebarScrollWrapper = styled('div')(({ theme }) => ({
   flex: '0 1 auto',
-  overflowY: 'auto',
+  overflowX: 'hidden',
+  // 5px space to the right of the scrollbar
+  width: 'calc(100% - 5px)',
   // Display at least one item in the container
   // Question: Can this be a config/theme variable - if so, which? :/
   minHeight: '48px',
-});
+  '&::-webkit-scrollbar': {
+    backgroundColor: theme.palette.background.default,
+    width: '5px',
+    borderRadius: '5px',
+  },
+  '&::-webkit-scrollbar-thumb': {
+    backgroundColor: theme.palette.text.hint,
+    borderRadius: '5px',
+  },
+}));


### PR DESCRIPTION
@freben As discussed here the PR for a better scroll behaviour - always happy about feedback! :) Unfortunately it looks different for Chrome & Firefox as Firefox has pretty neat native scrollbar, which I wanted to keep while it looks weird in Chrome so I overwrote the styles using the theme. When merging this it should look similar, but I'm not sure what is better - any opinion on this? 😕  

|Chrome|Firefox|
|----|:---:|
| ![sidebar](https://user-images.githubusercontent.com/8904624/124494827-94322500-ddb7-11eb-9872-112d2c0ebbc6.gif) | ![firefox](https://user-images.githubusercontent.com/8904624/124496172-5df5a500-ddb9-11eb-9928-f4ffb42f4913.gif) |



Relates to changes introduced in #6257 & #6320 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
