### PR TITLE
Allow adopters to issue auth tokens to enable search

### DIFF
--- a/.changeset/serious-dodos-hunt.md
+++ b/.changeset/serious-dodos-hunt.md
@@ -1,0 +1,24 @@
+---
+'@backstage/plugin-auth-backend': minor
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow adopters to issue auth tokens to enable search
+
+This change breaks how IdentityClient is instantiated. Adopters already using IdentityClient needs to modify their code from
+
+```
+  const discovery = SingleHostDiscovery.fromConfig(config);
+  const identity = new IdentityClient({
+    discovery,
+    issuer: await discovery.getExternalBaseUrl('auth'),
+  });
+```
+
+to
+
+```
+  const identity = await IdentityClient.create(authEnv);
+```
+
+See https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md for full instructions.

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -8,6 +8,7 @@ import { Config } from '@backstage/config';
 import { Entity } from '@backstage/catalog-model';
 import express from 'express';
 import { JSONWebKey } from 'jose';
+import { JWKS } from 'jose';
 import { Logger as Logger_2 } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
@@ -159,7 +160,7 @@ export class IdentityClient {
 // Warning: (ae-missing-release-tag) "microsoftEmailSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const microsoftEmailSignInResolver: SignInResolver<OAuthResult>;
+export const microsoftEmailSignInResolver: SignInResolver<OAuthResult>
 
 // Warning: (ae-missing-release-tag) "MicrosoftProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -147,11 +147,25 @@ export type GoogleProviderOptions = {
 //
 // @public
 export class IdentityClient {
-  constructor(options: { discovery: PluginEndpointDiscovery; issuer: string });
+  // Warning: (ae-forgotten-export) The symbol "TokenFactory" needs to be exported by the entry point index.d.ts
+  constructor(
+    issuer: string,
+    tokenFactory: TokenFactory,
+    publicKeyStore: JWKS.KeyStore,
+    publicKeyStoreUpdated: number,
+  );
   authenticate(token: string | undefined): Promise<BackstageIdentity>;
+  // (undocumented)
+  static create(options: {
+    database: PluginDatabaseManager;
+    discovery: PluginEndpointDiscovery;
+    logger: Logger_2;
+  }): Promise<IdentityClient>;
   static getBearerToken(
     authorizationHeader: string | undefined,
   ): string | undefined;
+  // Warning: (ae-forgotten-export) The symbol "TokenParams" needs to be exported by the entry point index.d.ts
+  issueToken(params: TokenParams): Promise<string>;
   listPublicKeys(): Promise<{
     keys: JSONWebKey[];
   }>;
@@ -160,7 +174,7 @@ export class IdentityClient {
 // Warning: (ae-missing-release-tag) "microsoftEmailSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const microsoftEmailSignInResolver: SignInResolver<OAuthResult>
+export const microsoftEmailSignInResolver: SignInResolver<OAuthResult>;
 
 // Warning: (ae-missing-release-tag) "MicrosoftProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -176,7 +190,7 @@ export type MicrosoftProviderOptions = {
 //
 // @public (undocumented)
 export class OAuthAdapter implements AuthProviderRouteHandlers {
-  constructor(handlers: OAuthHandlers, options: Options);
+  constructor(handlers: OAuthHandlers, options: Options_2);
   // (undocumented)
   frameHandler(req: express.Request, res: express.Response): Promise<void>;
   // Warning: (ae-forgotten-export) The symbol "Options" needs to be exported by the entry point index.d.ts
@@ -186,7 +200,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
     config: AuthProviderConfig,
     handlers: OAuthHandlers,
     options: Pick<
-      Options,
+      Options_2,
       'providerId' | 'persistScopes' | 'disableRefresh' | 'tokenIssuer'
     >,
   ): OAuthAdapter;
@@ -377,7 +391,6 @@ export type WebMessageResponse =
 
 // Warnings were encountered during analysis:
 //
-// src/identity/types.d.ts:25:5 - (ae-forgotten-export) The symbol "TokenParams" needs to be exported by the entry point index.d.ts
 // src/identity/types.d.ts:31:9 - (ae-forgotten-export) The symbol "AnyJWK" needs to be exported by the entry point index.d.ts
 // src/providers/google/provider.d.ts:36:5 - (ae-forgotten-export) The symbol "AuthHandler" needs to be exported by the entry point index.d.ts
 // src/providers/types.d.ts:105:5 - (ae-forgotten-export) The symbol "AuthProviderConfig" needs to be exported by the entry point index.d.ts


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Workaround PR to fix https://github.com/backstage/backstage/issues/5207 while waiting for a more permanent solution to https://github.com/backstage/backstage/issues/5210.

The new search functionality indexes the catalog in a background process which fails for adopters applying auth to their APIs using the outline in https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md. To make this work, this PR allows the search indexer to issue auth tokens.

* Extend the experimental `IdentityClient` in the `auth-backend` plugin to issue tokens. Since plugins may be deployed separately, the dependency between IdentityClient and the `auth-backend` plugin is changed from an API request to retrieve public keys to a database dependency to allow other plugins to generate keys for token issuing and store the public counterpart in the shared database. This is a breaking change for those using api auth as the IdentityClient needs to be instantiated slightly differently.
* ~~Extend DefaultCatalogCollator to optionally use a provided IdentityClient to authorize requests with self-issued tokens~~
* Update relevant contrib doc

Some notable parts:
* ~~Might be cleaner to have adopters make a copy of the DefaultCatalogCollator instead of polluting the default one (changed)~~
* Allowing search plugin to access the auth plugin database breaks the plugin pattern
* Some token parameters (issuer and key duration) are duplicated. Might benefit from moving to config instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
