### PR TITLE
TechDocs: Sidebars not adjusting positions

### DIFF
--- a/.changeset/techdocs-stale-lies-greet.md
+++ b/.changeset/techdocs-stale-lies-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Techdocs: fix sidebars not adjusting position automatically

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -82,10 +82,10 @@ export const Reader = ({ entityId, onReady }: Props) => {
 
   useEffect(() => {
     updateSidebarPosition();
-    window.addEventListener('scroll', updateSidebarPosition);
+    window.addEventListener('scroll', updateSidebarPosition, true);
     window.addEventListener('resize', updateSidebarPosition);
     return () => {
-      window.removeEventListener('scroll', updateSidebarPosition);
+      window.removeEventListener('scroll', updateSidebarPosition, true);
       window.removeEventListener('resize', updateSidebarPosition);
     };
     // an update to "state" might lead to an updated UI so we include it as a trigger


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Sidebars in TechDocs were not adjusting position automatically. This appears to be due to scroll events in some part of the document not bubbling to window level. Scroll listeners at window level changed to use capture phase.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [:heavy_check_mark: ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ NA  ] Added or updated documentation
- [ NA ] Tests for new functionality and regression tests for bug fixes
- [ NA ] Screenshots attached (for UI changes)
- [ :heavy_check_mark: ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
