### PR TITLE
Use target=_blank on MissingAnnotation Read More link

### DIFF
--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -76,6 +76,8 @@ export const MissingAnnotationEmptyState = ({ annotation }: Props) => {
             variant="contained"
             color="primary"
             href="https://backstage.io/docs/features/software-catalog/well-known-annotations"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Read more
           </Button>

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { Button, makeStyles, Typography } from '@material-ui/core';
 import { BackstageTheme } from '@backstage/theme';
+import { Link } from '../Link';
 import { EmptyState } from './EmptyState';
 import { CodeSnippet } from '../CodeSnippet';
 
@@ -73,11 +74,9 @@ export const MissingAnnotationEmptyState = ({ annotation }: Props) => {
             />
           </div>
           <Button
-            variant="contained"
             color="primary"
-            href="https://backstage.io/docs/features/software-catalog/well-known-annotations"
-            target="_blank"
-            rel="noopener noreferrer"
+            component={Link}
+            to="https://backstage.io/docs/features/software-catalog/well-known-annotations"
           >
             Read more
           </Button>


### PR DESCRIPTION
Adds `target="_blank" rel="noopener noreferrer"` to the "Read more" link in the Missing Annotation component because I would like Backstage to stay open so I can continue to work with it while I read the docs.

Includes a small, unintended, UI change for reasons explained [here](https://github.com/backstage/backstage/pull/6359#issuecomment-874744468)

![Screenshot 2021-07-06 at 14 15 06](https://user-images.githubusercontent.com/562403/124606263-9e5e2d00-de64-11eb-9272-863b46ad1ae7.png)


- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~~Added or updated documentation~~
- [ ] ~~Tests for new functionality and regression tests for bug fixes~~
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
