### PR TITLE
Show scroll bar on hover only

### DIFF
--- a/.changeset/late-pants-itch.md
+++ b/.changeset/late-pants-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Show scroll bar of the sidebar wrapper only on hover

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -21,8 +21,10 @@ import {
   makeStyles,
   styled,
   TextField,
+  Theme,
   Typography,
 } from '@material-ui/core';
+import { CreateCSSProperties } from '@material-ui/core/styles/withStyles';
 import SearchIcon from '@material-ui/icons/Search';
 import clsx from 'clsx';
 import React, {
@@ -291,26 +293,31 @@ export const SidebarDivider = styled('hr')({
   margin: '12px 0px',
 });
 
-export const SidebarScrollWrapper = styled('div')(({ theme }) => ({
-  flex: '0 1 auto',
-  overflowX: 'hidden',
-  // 5px space to the right of the scrollbar
-  width: 'calc(100% - 5px)',
-  // Display at least one item in the container
-  // Question: Can this be a config/theme variable - if so, which? :/
-  minHeight: '48px',
-  overflowY: 'hidden',
-
-  '&:hover': {
-    overflowY: 'auto',
-  },
-  '&:hover::-webkit-scrollbar': {
+const styledScrollbar = (theme: Theme): CreateCSSProperties => ({
+  overflowY: 'auto',
+  '&::-webkit-scrollbar': {
     backgroundColor: theme.palette.background.default,
     width: '5px',
     borderRadius: '5px',
   },
-  '&:hover::-webkit-scrollbar-thumb': {
+  '&::-webkit-scrollbar-thumb': {
     backgroundColor: theme.palette.text.hint,
     borderRadius: '5px',
   },
-}));
+});
+
+export const SidebarScrollWrapper = styled('div')(({ theme }) => {
+  const scrollbarStyles = styledScrollbar(theme);
+  return {
+    flex: '0 1 auto',
+    overflowX: 'hidden',
+    // 5px space to the right of the scrollbar
+    width: 'calc(100% - 5px)',
+    // Display at least one item in the container
+    // Question: Can this be a config/theme variable - if so, which? :/
+    minHeight: '48px',
+    overflowY: 'hidden',
+    '@media (hover: none)': scrollbarStyles,
+    '&:hover': scrollbarStyles,
+  };
+});

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -299,12 +299,17 @@ export const SidebarScrollWrapper = styled('div')(({ theme }) => ({
   // Display at least one item in the container
   // Question: Can this be a config/theme variable - if so, which? :/
   minHeight: '48px',
-  '&::-webkit-scrollbar': {
+  overflowY: 'hidden',
+
+  '&:hover': {
+    overflowY: 'auto',
+  },
+  '&:hover::-webkit-scrollbar': {
     backgroundColor: theme.palette.background.default,
     width: '5px',
     borderRadius: '5px',
   },
-  '&::-webkit-scrollbar-thumb': {
+  '&:hover::-webkit-scrollbar-thumb': {
     backgroundColor: theme.palette.text.hint,
     borderRadius: '5px',
   },


### PR DESCRIPTION
@benjdlambert 

Follow up PR to #6344 as mentioned here https://github.com/backstage/backstage/pull/6344#issuecomment-874576937 to support similar behaviour across browsers. 

It looks like this in **Chrome** now: 

![sidebar_hover](https://user-images.githubusercontent.com/8904624/124597857-40c9e080-de64-11eb-80fd-7afb546b6815.gif)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
