### PR TITLE
Handle empty strings in code blocks

### DIFF
--- a/.changeset/shaggy-ties-carry.md
+++ b/.changeset/shaggy-ties-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Handle empty code blocks in markdown files so they don't fail rendering

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -65,8 +65,8 @@ type Props = {
 };
 
 const renderers = {
-  code: ({ language, value }: { language: string; value: string }) => {
-    return <CodeSnippet language={language} text={value} />;
+  code: ({ language, value }: { language: string; value?: string }) => {
+    return <CodeSnippet language={language} text={value ?? ''} />;
   },
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Empty code blocks in markdown files were causing following error. This PR tackles that issue.

<img width="688" alt="Screenshot 2021-07-06 at 15 09 16" src="https://user-images.githubusercontent.com/7230518/124605504-44f9fc00-de6c-11eb-869c-46fc31fc5a86.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
