### PR TITLE
Fix/scaffolder support UI schema for dependent forms

### DIFF
--- a/.changeset/red-ladybugs-promise.md
+++ b/.changeset/red-ladybugs-promise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+add support for uiSchema on dependent form fields

--- a/plugins/scaffolder/src/components/MultistepJsonForm/schema.test.ts
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/schema.test.ts
@@ -286,4 +286,64 @@ describe('transformSchemaToProps', () => {
       uiSchema: expectedUiSchema,
     });
   });
+
+  it('transforms schema with dependencies', () => {
+    const inputSchema = {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        credit_card: {
+          type: 'number',
+        },
+      },
+      required: ['name'],
+      dependencies: {
+        credit_card: {
+          properties: {
+            billing_address: {
+              type: 'string',
+              'ui:widget': 'textarea',
+            },
+          },
+          required: ['billing_address'],
+        },
+      },
+    };
+    const expectedSchema = {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        credit_card: {
+          type: 'number',
+        },
+      },
+      required: ['name'],
+      dependencies: {
+        credit_card: {
+          properties: {
+            billing_address: {
+              type: 'string',
+            },
+          },
+          required: ['billing_address'],
+        },
+      },
+    };
+    const expectedUiSchema = {
+      billing_address: {
+        'ui:widget': 'textarea',
+      },
+      credit_card: {},
+      name: {},
+    };
+
+    expect(transformSchemaToProps(inputSchema)).toEqual({
+      schema: expectedSchema,
+      uiSchema: expectedUiSchema,
+    });
+  });
 });

--- a/plugins/scaffolder/src/components/MultistepJsonForm/schema.ts
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/schema.ts
@@ -26,7 +26,7 @@ function extractUiSchema(schema: JsonObject, uiSchema: JsonObject) {
     return;
   }
 
-  const { properties, anyOf, oneOf, allOf } = schema;
+  const { properties, anyOf, oneOf, allOf, dependencies } = schema;
 
   for (const propName in schema) {
     if (!schema.hasOwnProperty(propName)) {
@@ -75,6 +75,16 @@ function extractUiSchema(schema: JsonObject, uiSchema: JsonObject) {
 
   if (Array.isArray(allOf)) {
     for (const schemaNode of allOf) {
+      if (!isObject(schemaNode)) {
+        continue;
+      }
+      extractUiSchema(schemaNode, uiSchema);
+    }
+  }
+
+  if (isObject(dependencies)) {
+    for (const depName of Object.keys(dependencies)) {
+      const schemaNode = dependencies[depName];
       if (!isObject(schemaNode)) {
         continue;
       }


### PR DESCRIPTION
Signed-off-by: Jos Craw <jos@joscraw.net>

## Hey, I just made a Pull Request!

I have added support for dependent forms to use uiSchema in scaffolder. Before these `ui:*` objects were ignored when within the `dependencies` of a form.

### Form YAML
```yaml
parameters:
  - title: Dep Test
    required:
      - name
      - credit_card
    properties:
      name:
        type: string
      credit_card:
        type: number
      required:
        - name
    dependencies:
      credit_card:
        properties:
          billing_address:
            type: string
            ui:widget: textarea
        required:
          - billing_address
```

### Before
<img width="775" alt="Screen Shot 2021-07-07 at 10 02 13 PM" src="https://user-images.githubusercontent.com/38315540/124740544-026d1800-df6f-11eb-9d0f-106754e7ac80.png">

### After
<img width="775" alt="Screen Shot 2021-07-07 at 9 59 31 PM" src="https://user-images.githubusercontent.com/38315540/124740157-a3a79e80-df6e-11eb-8e36-3c2c42e122a7.png">

The dependent `billing_address` is now a `textarea`! 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
