### PR TITLE
Added a `context` parameter to validator functions, letting them have access to the API holder

### DIFF
--- a/.changeset/great-bears-work.md
+++ b/.changeset/great-bears-work.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Added a `context` parameter to validator functions, letting them have access to
+the API holder.
+
+If you have implemented custom validators and use `createScaffolderFieldExtension`,
+your `validation` function can now optionally accept a third parameter,
+`context: { apiHolder: ApiHolder }`.

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ApiHolder } from '@backstage/core-plugin-api';
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
@@ -25,7 +26,19 @@ import { ScmIntegrationRegistry } from '@backstage/integration';
 export function createScaffolderFieldExtension<T = any>(options: FieldExtensionOptions<T>): Extension<() => null>;
 
 // @public (undocumented)
+export type CustomFieldValidator<T> = ((data: T, field: FieldValidation) => void) | ((data: T, field: FieldValidation, context: {
+    apiHolder: ApiHolder;
+}) => void);
+
+// @public (undocumented)
 export const EntityPickerFieldExtension: () => null;
+
+// @public (undocumented)
+export type FieldExtensionOptions<T = any> = {
+    name: string;
+    component: (props: FieldProps<T>) => JSX.Element | null;
+    validation?: CustomFieldValidator<T>;
+};
 
 // @public (undocumented)
 export const OwnerPickerFieldExtension: () => null;

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/validation.test.ts
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/validation.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { repoPickerValidation } from './validation';
 import { FieldValidation } from '@rjsf/core';
 
@@ -22,7 +23,7 @@ describe('RepoPicker Validation', () => {
       addError: jest.fn(),
     } as unknown) as FieldValidation);
 
-  it('validaties when no repo', () => {
+  it('validates when no repo', () => {
     const mockFieldValidation = fieldValidator();
 
     repoPickerValidation('github.com?owner=a', mockFieldValidation);

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/validation.ts
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/validation.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { FieldValidation } from '@rjsf/core';
 
 export const repoPickerValidation = (

--- a/plugins/scaffolder/src/extensions/index.tsx
+++ b/plugins/scaffolder/src/extensions/index.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { FieldExtensionOptions } from './types';
+import { CustomFieldValidator, FieldExtensionOptions } from './types';
 import { Extension, attachComponentData } from '@backstage/core-plugin-api';
 
 export const FIELD_EXTENSION_WRAPPER_KEY = 'scaffolder.extensions.wrapper.v1';
@@ -46,6 +46,6 @@ attachComponentData(
   true,
 );
 
-export type { FieldExtensionOptions };
+export type { CustomFieldValidator, FieldExtensionOptions };
 
 export { DEFAULT_SCAFFOLDER_FIELD_EXTENSIONS } from './default';

--- a/plugins/scaffolder/src/extensions/types.ts
+++ b/plugins/scaffolder/src/extensions/types.ts
@@ -13,10 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ApiHolder } from '@backstage/core-plugin-api';
 import { FieldValidation, FieldProps } from '@rjsf/core';
+
+export type CustomFieldValidator<T> =
+  | ((data: T, field: FieldValidation) => void)
+  | ((
+      data: T,
+      field: FieldValidation,
+      context: { apiHolder: ApiHolder },
+    ) => void);
 
 export type FieldExtensionOptions<T = any> = {
   name: string;
   component: (props: FieldProps<T>) => JSX.Element | null;
-  validation?: (data: T, field: FieldValidation) => void;
+  validation?: CustomFieldValidator<T>;
 };

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -16,9 +16,11 @@
 
 export { scaffolderApiRef, ScaffolderClient } from './api';
 export type { ScaffolderApi } from './api';
-export {
-  createScaffolderFieldExtension,
+export { createScaffolderFieldExtension } from './extensions';
+export type {
   ScaffolderFieldExtensions,
+  CustomFieldValidator,
+  FieldExtensionOptions,
 } from './extensions';
 export {
   EntityPickerFieldExtension,


### PR DESCRIPTION
Context: provides assistance for #5381