### PR TITLE
Build search queries using the query build in `LunrSearchEngine`

### DIFF
--- a/.changeset/search-olive-cars-talk.md
+++ b/.changeset/search-olive-cars-talk.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-search-backend-node': patch
+---
+
+Enhance the search results of `LunrSearchEngine` to support a more natural
+search experience. This is done by allowing typos (by using fuzzy search) and
+supporting typeahead search (using wildcard queries to match incomplete words).

--- a/.changeset/search-slimy-taxis-live.md
+++ b/.changeset/search-slimy-taxis-live.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-search-backend-node': minor
+---
+
+Build search queries using the query builder in `LunrSearchEngine`. This removes
+the support for specifying custom queries with the lunr query syntax, but makes
+sure that inputs are properly escaped. Supporting the full lunr syntax is still
+possible by setting a custom query translator.
+The interface of `LunrSearchEngine.setTranslator()` is changed to support
+building lunr queries.

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -274,6 +274,7 @@ touchpoints
 transpilation
 transpiled
 truthy
+typeahead
 ui
 unbreak
 unmanaged

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -23,9 +23,9 @@ import lunr from 'lunr';
 import { Logger } from 'winston';
 import { SearchEngine, QueryTranslator } from '../types';
 
-type ConcreteLunrQuery = {
-  lunrQueryString: string;
-  documentTypes: string[];
+export type ConcreteLunrQuery = {
+  lunrQueryBuilder: lunr.Index.QueryBuilder;
+  documentTypes?: string[];
 };
 
 type LunrResultEnvelope = {
@@ -50,40 +50,62 @@ export class LunrSearchEngine implements SearchEngine {
     filters,
     types,
   }: SearchQuery): ConcreteLunrQuery => {
-    let lunrQueryFilters;
-    const lunrTerm = term ? `+${term}` : '';
-    if (filters) {
-      lunrQueryFilters = Object.entries(filters)
-        .map(([field, value]) => {
-          // Require that the given field has the given value (with +).
-          if (['string', 'number', 'boolean'].includes(typeof value)) {
-            if (typeof value === 'string') {
-              return ` +${field}:${value.replace(':', '\\:')}`;
-            }
-            return ` +${field}:${value}`;
-          }
-
-          // Illustrate how multi-value filters could work.
-          if (Array.isArray(value)) {
-            // But warn that Lurn supports this poorly.
-            this.logger.warn(
-              `Non-scalar filter value used for field ${field}. Consider using a different Search Engine for better results.`,
-            );
-            return ` ${value.map(v => {
-              return `${field}:${v}`;
-            })}`;
-          }
-
-          // Log a warning or something about unknown filter value
-          this.logger.warn(`Unknown filter type used on field ${field}`);
-          return '';
-        })
-        .join('');
-    }
-
     return {
-      lunrQueryString: `${lunrTerm}${lunrQueryFilters || ''}`,
-      documentTypes: types || ['*'],
+      lunrQueryBuilder: q => {
+        const termToken = lunr.tokenizer(term);
+
+        // Support for typeahead seach is based on https://github.com/olivernn/lunr.js/issues/256#issuecomment-295407852
+        // look for an exact match and apply a large positive boost
+        q.term(termToken, {
+          usePipeline: true,
+          boost: 100,
+        });
+        // look for terms that match the beginning of this term and apply a
+        // medium boost
+        q.term(termToken, {
+          usePipeline: false,
+          boost: 10,
+          wildcard: lunr.Query.wildcard.TRAILING,
+        });
+        // look for terms that match with an edit distance of 2 and apply a
+        // small boost
+        q.term(termToken, {
+          usePipeline: false,
+          editDistance: 2,
+          boost: 1,
+        });
+
+        if (filters) {
+          Object.entries(filters).forEach(([field, value]) => {
+            if (!q.allFields.includes(field)) {
+              // Throw for unknown field, as this will be a non match
+              throw new Error(`unrecognised field ${field}`);
+            }
+
+            // Require that the given field has the given value
+            if (['string', 'number', 'boolean'].includes(typeof value)) {
+              q.term(lunr.tokenizer(value?.toString()), {
+                presence: lunr.Query.presence.REQUIRED,
+                fields: [field],
+              });
+            } else if (Array.isArray(value)) {
+              // Illustrate how multi-value filters could work.
+              // But warn that Lurn supports this poorly.
+              this.logger.warn(
+                `Non-scalar filter value used for field ${field}. Consider using a different Search Engine for better results.`,
+              );
+              q.term(lunr.tokenizer(value), {
+                presence: lunr.Query.presence.OPTIONAL,
+                fields: [field],
+              });
+            } else {
+              // Log a warning or something about unknown filter value
+              this.logger.warn(`Unknown filter type used on field ${field}`);
+            }
+          });
+        }
+      },
+      documentTypes: types,
     };
   };
 
@@ -118,18 +140,19 @@ export class LunrSearchEngine implements SearchEngine {
   }
 
   query(query: SearchQuery): Promise<SearchResultSet> {
-    const { lunrQueryString, documentTypes } = this.translator(
+    const { lunrQueryBuilder, documentTypes } = this.translator(
       query,
     ) as ConcreteLunrQuery;
 
     const results: LunrResultEnvelope[] = [];
 
-    if (documentTypes.length === 1 && documentTypes[0] === '*') {
-      // Iterate over all this.lunrIndex values.
-      Object.keys(this.lunrIndices).forEach(type => {
+    // Iterate over the filtered list of this.lunrIndex keys.
+    Object.keys(this.lunrIndices)
+      .filter(type => !documentTypes || documentTypes.includes(type))
+      .forEach(type => {
         try {
           results.push(
-            ...this.lunrIndices[type].search(lunrQueryString).map(result => {
+            ...this.lunrIndices[type].query(lunrQueryBuilder).map(result => {
               return {
                 result: result,
                 type: type,
@@ -139,36 +162,14 @@ export class LunrSearchEngine implements SearchEngine {
         } catch (err) {
           // if a field does not exist on a index, we can see that as a no-match
           if (
-            err instanceof lunr.QueryParseError &&
+            err instanceof Error &&
             err.message.startsWith('unrecognised field')
-          )
+          ) {
             return;
+          }
+          throw err;
         }
       });
-    } else {
-      // Iterate over the filtered list of this.lunrIndex keys.
-      Object.keys(this.lunrIndices)
-        .filter(type => documentTypes.includes(type))
-        .forEach(type => {
-          try {
-            results.push(
-              ...this.lunrIndices[type].search(lunrQueryString).map(result => {
-                return {
-                  result: result,
-                  type: type,
-                };
-              }),
-            );
-          } catch (err) {
-            // if a field does not exist on a index, we can see that as a no-match
-            if (
-              err instanceof lunr.QueryParseError &&
-              err.message.startsWith('unrecognised field')
-            )
-              return;
-          }
-        });
-    }
 
     // Sort results.
     results.sort((doc1, doc2) => {

--- a/plugins/search-backend-node/src/engines/index.ts
+++ b/plugins/search-backend-node/src/engines/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { LunrSearchEngine } from './LunrSearchEngine';
+export type { ConcreteLunrQuery } from './LunrSearchEngine';


### PR DESCRIPTION
This changes the internals from `LunrSearchEngine` from generating a search string that lunr has to parse to directly building a query with the query builder. This resolves some issues with escaping and search for multiple words.

I also took the time to play around with fuzzy and wildcard search and got much better results than before. That way you even get results for incomplete search terms (but ranked lower than the actual matches).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
