### PR TITLE
WIP: Catalog Refresh Endpoint

### DIFF
--- a/.changeset/honest-humans-explode.md
+++ b/.changeset/honest-humans-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Add single location refresh endpoint to catalog-backend.

--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
@@ -156,10 +156,10 @@ export class HigherOrderOperations implements HigherOrderOperation {
   }
 
   // Performs a full refresh of a single location
-  private async refreshSingleLocation(
+  async refreshSingleLocation(
     location: Location,
     optionalLogger?: Logger,
-  ) {
+  ): Promise<void> {
     let startTimestamp = process.hrtime();
     const logger = optionalLogger || this.logger;
 

--- a/plugins/catalog-backend/src/ingestion/types.ts
+++ b/plugins/catalog-backend/src/ingestion/types.ts
@@ -20,6 +20,7 @@ import {
   Location,
   LocationSpec,
 } from '@backstage/catalog-model';
+import { Logger } from 'winston';
 import { RecursivePartial } from '../util/RecursivePartial';
 
 //
@@ -32,6 +33,7 @@ export type HigherOrderOperation = {
     options?: { dryRun?: boolean },
   ): Promise<AddLocationResult>;
   refreshAllLocations(): Promise<void>;
+  refreshSingleLocation(location: Location, optionalLogger?: Logger): Promise<void>;
 };
 
 export type AddLocationResult = {

--- a/plugins/catalog-backend/src/service/router.test.ts
+++ b/plugins/catalog-backend/src/service/router.test.ts
@@ -50,13 +50,23 @@ describe('createRouter readonly disabled', () => {
     higherOrderOperation = {
       addLocation: jest.fn(),
       refreshAllLocations: jest.fn(),
+      refreshSingleLocation: jest.fn(),
     };
     const router = await createRouter({
       entitiesCatalog,
       locationsCatalog,
       higherOrderOperation,
       logger: getVoidLogger(),
-      config: new ConfigReader(undefined),
+      config: new ConfigReader({
+        catalog: {
+          locations: [
+            {
+              type: 'somelocation',
+              target: 'sometarget',
+            },
+          ]
+        },
+      }),
     });
     app = express().use(router);
   });
@@ -289,6 +299,18 @@ describe('createRouter readonly disabled', () => {
     });
   });
 
+  describe('GET /locations/:location/refresh', () => {
+    it('happy path: calls refresh function, returns 200', async () => {
+      const response = await request(app)
+        .get('/locations/somelocation/refresh');
+
+      expect(higherOrderOperation.refreshSingleLocation).toHaveBeenCalledTimes(1);
+      expect(higherOrderOperation.refreshSingleLocation).toHaveBeenCalledWith({type: 'somelocation', target: 'sometarget'});
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual('somelocation refresh started');
+    });
+  });
+
   describe('POST /locations', () => {
     it('rejects malformed locations', async () => {
       const spec = ({
@@ -380,6 +402,7 @@ describe('createRouter readonly enabled', () => {
     higherOrderOperation = {
       addLocation: jest.fn(),
       refreshAllLocations: jest.fn(),
+      refreshSingleLocation: jest.fn(),
     };
     const router = await createRouter({
       entitiesCatalog,

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -183,19 +183,41 @@ export async function createRouter(
   }
 
   if (higherOrderOperation) {
-    router.post('/locations', async (req, res) => {
-      const input = await validateRequestBody(req, locationSpecSchema);
-      const dryRun = yn(req.query.dryRun, { default: false });
+    router
+      .post('/locations', async (req, res) => {
+        const input = await validateRequestBody(req, locationSpecSchema);
+        const dryRun = yn(req.query.dryRun, { default: false });
 
-      // when in dryRun addLocation is effectively a read operation so we don't
-      // need to disallow readonly
-      if (!dryRun) {
-        disallowReadonlyMode(readonlyEnabled);
-      }
+        // when in dryRun addLocation is effectively a read operation so we don't
+        // need to disallow readonly
+        if (!dryRun) {
+          disallowReadonlyMode(readonlyEnabled);
+        }
 
-      const output = await higherOrderOperation.addLocation(input, { dryRun });
-      res.status(201).json(output);
-    });
+        const output = await higherOrderOperation.addLocation(input, {
+          dryRun,
+        });
+        res.status(201).json(output);
+      })
+      .get('/locations/:type/refresh', async (req, res) => {
+        const { type } = req.params;
+        const couldNotRefreshText = `Could not refresh location ${type}:`;
+        let locationData;
+        try {
+          locationData = config
+            .getConfigArray('catalog.locations')
+            // @ts-ignore
+            .map(({data}) => data)
+            .find(location => location.type === type);
+        } catch {
+          res
+            .status(500)
+            .json(`${couldNotRefreshText} location not found or malformed`)
+            .end();
+        }
+        await higherOrderOperation.refreshSingleLocation(locationData, logger);
+        res.status(200).json(`${type} refresh started`).end();
+      });
   }
 
   if (locationsCatalog) {


### PR DESCRIPTION

Signed-off-by: Christina Marie Rahaim <crahaim@wayfair.com>

## Hey, I just made a Pull Request!

Add an endpoint to catalog-backend that refreshes a single specified location in the catalog.

Our particular use case: we created a barebones editor in Backstage to allow users to edit entity configuration for certain in-house entity sources in Backstage itself. Hitting this refresh endpoint syncs up changes made to the source of truth for these entities with Backstage, allowing users to see their changes right away.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ Y ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [N] Added or updated documentation (found none related to add to)
- [ Y ] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [Y] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
