### PR TITLE
Add Refresh Location Endpoint

### DIFF
--- a/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
+++ b/plugins/catalog-backend/src/ingestion/HigherOrderOperations.ts
@@ -156,10 +156,10 @@ export class HigherOrderOperations implements HigherOrderOperation {
   }
 
   // Performs a full refresh of a single location
-  private async refreshSingleLocation(
+  async refreshSingleLocation(
     location: Location,
     optionalLogger?: Logger,
-  ) {
+  ): Promise<void> {
     let startTimestamp = process.hrtime();
     const logger = optionalLogger || this.logger;
 

--- a/plugins/catalog-backend/src/ingestion/types.ts
+++ b/plugins/catalog-backend/src/ingestion/types.ts
@@ -20,6 +20,7 @@ import {
   Location,
   LocationSpec,
 } from '@backstage/catalog-model';
+import { Logger } from 'winston';
 import { RecursivePartial } from '../util/RecursivePartial';
 
 //
@@ -32,6 +33,10 @@ export type HigherOrderOperation = {
     options?: { dryRun?: boolean },
   ): Promise<AddLocationResult>;
   refreshAllLocations(): Promise<void>;
+  refreshSingleLocation(
+    location: Location,
+    optionalLogger?: Logger,
+  ): Promise<void>;
 };
 
 export type AddLocationResult = {

--- a/plugins/catalog-backend/src/service/router.test.ts
+++ b/plugins/catalog-backend/src/service/router.test.ts
@@ -50,13 +50,23 @@ describe('createRouter readonly disabled', () => {
     higherOrderOperation = {
       addLocation: jest.fn(),
       refreshAllLocations: jest.fn(),
+      refreshSingleLocation: jest.fn(),
     };
     const router = await createRouter({
       entitiesCatalog,
       locationsCatalog,
       higherOrderOperation,
       logger: getVoidLogger(),
-      config: new ConfigReader(undefined),
+      config: new ConfigReader({
+        catalog: {
+          locations: [
+            {
+              type: 'somelocation',
+              target: 'sometarget',
+            },
+          ],
+        },
+      }),
     });
     app = express().use(router);
   });
@@ -289,6 +299,24 @@ describe('createRouter readonly disabled', () => {
     });
   });
 
+  describe('GET /locations/:location/refresh', () => {
+    it('happy path: calls refresh function, returns 200', async () => {
+      const response = await request(app).get(
+        '/locations/somelocation/refresh',
+      );
+
+      expect(higherOrderOperation.refreshSingleLocation).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(higherOrderOperation.refreshSingleLocation).toHaveBeenCalledWith({
+        type: 'somelocation',
+        target: 'sometarget',
+      });
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual('somelocation refresh started');
+    });
+  });
+
   describe('POST /locations', () => {
     it('rejects malformed locations', async () => {
       const spec = ({
@@ -380,6 +408,7 @@ describe('createRouter readonly enabled', () => {
     higherOrderOperation = {
       addLocation: jest.fn(),
       refreshAllLocations: jest.fn(),
+      refreshSingleLocation: jest.fn(),
     };
     const router = await createRouter({
       entitiesCatalog,


### PR DESCRIPTION
Add an endpoint to catalog-backend that refreshes a single specified location in the catalog.

Signed-off-by: Christina Marie Rahaim <crahaim@wayfair.com>

## Hey, I just made a Pull Request!

Our particular use case: we created a barebones editor in Backstage to allow users to edit entity configuration for certain in-house entity sources in Backstage itself. Hitting this refresh endpoint syncs up changes made to the source of truth for these entities with Backstage, allowing users to see their changes right away.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [Should I?] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [Found none relevant to add to] Added or updated documentation
- [Y] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [Y] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
