### PR TITLE
[TechDocs] Add styles for scrollbars in long code blocks

### DIFF
--- a/.changeset/techdocs-lamp-lit-prose.md
+++ b/.changeset/techdocs-lamp-lit-prose.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed bug preventing scroll bar from showing up on code blocks in a TechDocs site.

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -185,6 +185,17 @@ export const Reader = ({ entityId, onReady }: Props) => {
         `,
       }),
       injectCss({
+        // Properly style code blocks.
+        css: `
+        .md-typeset pre > code::-webkit-scrollbar-thumb {
+          background-color: hsla(0, 0%, 0%, 0.32);
+        }
+        .md-typeset pre > code::-webkit-scrollbar-thumb:hover {
+          background-color: hsla(0, 0%, 0%, 0.87);
+        }
+        `,
+      }),
+      injectCss({
         // Admonitions and others are using SVG masks to define icons. These
         // masks are defined as CSS variables.
         // As the MkDocs output is rendered in shadow DOM, the CSS variable


### PR DESCRIPTION
Co-authored-by: Camila Belo <camilaibs@gmail.com>
Co-authored-by: Raghunandan Balachandran <raghunandan@spotify.com>
Signed-off-by: Eric Peterson <ericpeterson@spotify.com>

## Hey, I just made a Pull Request!

Adds (back) the little scroll-bar to code blocks:

<img width="590" alt="Screenshot 2021-07-08 at 12 21 35" src="https://user-images.githubusercontent.com/3496491/124906187-148a9d00-dfe7-11eb-9655-7789b22602d3.png">

Closes #5467.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
