### PR TITLE
Codeowners processor should specify kind for user entities.

### DIFF
--- a/.changeset/lemon-dancers-taste.md
+++ b/.changeset/lemon-dancers-taste.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+The codeowners processor extracts the username of the primary owner and uses this as the owner field.
+Given the kind isn't specified this is assumed to be a group and so the link to the owner in the about card
+doesn't work. This change specifies the kind where the entity is a user. e.g:
+
+`@iain-b` -> `user:iain-b`

--- a/plugins/catalog-backend/src/ingestion/processors/codeowners/resolve.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/codeowners/resolve.test.ts
@@ -29,7 +29,7 @@ describe('resolveCodeOwner', () => {
 
 describe('normalizeCodeOwner', () => {
   it('should remove the @ symbol', () => {
-    expect(normalizeCodeOwner('@yoda')).toBe('user:yoda');
+    expect(normalizeCodeOwner('@yoda')).toBe('User:yoda');
   });
 
   it('should remove org from org/team format', () => {

--- a/plugins/catalog-backend/src/ingestion/processors/codeowners/resolve.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/codeowners/resolve.test.ts
@@ -29,7 +29,7 @@ describe('resolveCodeOwner', () => {
 
 describe('normalizeCodeOwner', () => {
   it('should remove the @ symbol', () => {
-    expect(normalizeCodeOwner('@yoda')).toBe('yoda');
+    expect(normalizeCodeOwner('@yoda')).toBe('user:yoda');
   });
 
   it('should remove org from org/team format', () => {

--- a/plugins/catalog-backend/src/ingestion/processors/codeowners/resolve.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/codeowners/resolve.ts
@@ -18,6 +18,10 @@ import * as codeowners from 'codeowners-utils';
 import { CodeOwnersEntry } from 'codeowners-utils';
 import { filter, get, head, pipe, reverse } from 'lodash/fp';
 
+const USER_PATTERN = /^@.*/;
+const GROUP_PATTERN = /^@.*\/.*/;
+const EMAIL_PATTERN = /^.*@.*\..*$/;
+
 export function resolveCodeOwner(
   contents: string,
   pattern = '*',
@@ -35,11 +39,11 @@ export function resolveCodeOwner(
 }
 
 export function normalizeCodeOwner(owner: string) {
-  if (owner.match(/^@.*\/.*/)) {
+  if (owner.match(GROUP_PATTERN)) {
     return owner.split('/')[1];
-  } else if (owner.match(/^@.*/)) {
-    return owner.substring(1);
-  } else if (owner.match(/^.*@.*\..*$/)) {
+  } else if (owner.match(USER_PATTERN)) {
+    return `user:${owner.substring(1)}`;
+  } else if (owner.match(EMAIL_PATTERN)) {
     return owner.split('@')[0];
   }
 

--- a/plugins/catalog-backend/src/ingestion/processors/codeowners/resolve.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/codeowners/resolve.ts
@@ -42,7 +42,7 @@ export function normalizeCodeOwner(owner: string) {
   if (owner.match(GROUP_PATTERN)) {
     return owner.split('/')[1];
   } else if (owner.match(USER_PATTERN)) {
-    return `user:${owner.substring(1)}`;
+    return `User:${owner.substring(1)}`;
   } else if (owner.match(EMAIL_PATTERN)) {
     return owner.split('@')[0];
   }


### PR DESCRIPTION
The codeowners processor extracts the username of the primary
owner and uses this as the owner field. Given the kind isn't
specified this is assumed to be a group and so the link to
owner in the about card doesn't work. This change specifies
the a kind where the entity is a user. e.g:
`@iain-b` -> `user:iain-b`

I've assumed that the user pattern is unambiguous (i.e `@user` is always a user) based on [samples](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#codeowners-syntax) and the [original PR](https://github.com/backstage/backstage/pull/3026/files) to support users.

Signed-off-by: Iain Billett <iain@roadie.io>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
