### PR TITLE
Export missing types used by the LDAP transformers

### DIFF
--- a/.changeset/short-eggs-confess.md
+++ b/.changeset/short-eggs-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+---
+
+Expose missing types used by the custom transformers

--- a/plugins/catalog-backend-module-ldap/api-report.md
+++ b/plugins/catalog-backend-module-ldap/api-report.md
@@ -23,6 +23,26 @@ export function defaultGroupTransformer(vendor: LdapVendor, config: GroupConfig,
 export function defaultUserTransformer(vendor: LdapVendor, config: UserConfig, entry: SearchEntry): Promise<UserEntity | undefined>;
 
 // @public
+export type GroupConfig = {
+    dn: string;
+    options: SearchOptions;
+    set?: {
+        [path: string]: JsonValue;
+    };
+    map: {
+        rdn: string;
+        name: string;
+        description: string;
+        type: string;
+        displayName: string;
+        email?: string;
+        picture?: string;
+        memberOf: string;
+        members: string;
+    };
+};
+
+// @public
 export type GroupTransformer = (vendor: LdapVendor, config: GroupConfig, group: SearchEntry) => Promise<GroupEntity | undefined>;
 
 // @public
@@ -71,6 +91,13 @@ export type LdapProviderConfig = {
 };
 
 // @public
+export type LdapVendor = {
+    dnAttributeName: string;
+    uuidAttributeName: string;
+    decodeStringAttribute: (entry: SearchEntry, name: string) => string[];
+};
+
+// @public
 export function mapStringAttr(entry: SearchEntry, vendor: LdapVendor, attributeName: string | undefined, setter: (value: string) => void): void;
 
 // @public
@@ -85,6 +112,24 @@ export function readLdapOrg(client: LdapClient, userConfig: UserConfig, groupCon
     users: UserEntity[];
     groups: GroupEntity[];
 }>;
+
+// @public
+export type UserConfig = {
+    dn: string;
+    options: SearchOptions;
+    set?: {
+        [path: string]: JsonValue;
+    };
+    map: {
+        rdn: string;
+        name: string;
+        description?: string;
+        displayName: string;
+        email: string;
+        picture?: string;
+        memberOf: string;
+    };
+};
 
 // @public
 export type UserTransformer = (vendor: LdapVendor, config: UserConfig, user: SearchEntry) => Promise<UserEntity | undefined>;

--- a/plugins/catalog-backend-module-ldap/src/ldap/index.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/index.ts
@@ -17,7 +17,8 @@
 export { LdapClient } from './client';
 export { mapStringAttr } from './util';
 export { readLdapConfig } from './config';
-export type { LdapProviderConfig } from './config';
+export type { LdapProviderConfig, GroupConfig, UserConfig } from './config';
+export type { LdapVendor } from './vendors';
 export {
   LDAP_DN_ANNOTATION,
   LDAP_RDN_ANNOTATION,


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

## Hey, I just made a Pull Request!

This pull request will export the missing types to be able to utilize the [custom LDAP transformers](https://backstage.io/docs/integrations/ldap/org#customize-the-processor)

This is not the first time that I miss to export the necessary types. Any suggestions on how to make sure that it is not missed the next time?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
