### PR TITLE
[TechDocs] Provide a migration path from case-sensitive to lower-case entity triplets in docs storage

### DIFF
--- a/.changeset/techdocs-migration.md
+++ b/.changeset/techdocs-migration.md
@@ -1,0 +1,13 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Added a `migrateDocsCase()` method to TechDocs publishers, along with
+implementations for AWS, Azure, and GCS.
+
+This change is in support of a future update to TechDocs that will allow for
+case-insensitive entity triplet URL access to documentation pages which will
+require a migration of existing documentation objects in external storage
+solutions.
+
+See [#4367](https://github.com/backstage/backstage/issues/4367) for details.

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -150,6 +150,39 @@ permissions to:
 - `s3:ListBucket` - To retrieve bucket metadata
 - `s3:GetObject` - To retrieve files from the bucket
 
+> Note: If you need to migrate documentation objects from an older-style path
+> format including case-sensitive entity metadata, you will need to add some
+> additional permissions to be able to perform the migration, including:
+>
+> - `s3:PutBucketAcl` (for copying files,
+>   [more info here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html))
+> - `s3:DeleteObject` and `s3:DeleteObjectVersion` (for deleting migrated files,
+>   [more info here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html))
+>
+> ...And you will need to ensure the permissions apply to the bucket itself, as
+> well as all resources under the bucket. See the example policy below.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TechDocsWithMigration",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObjectVersion",
+        "s3:ListBucket",
+        "s3:DeleteObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": ["arn:aws:s3:::your-bucket", "arn:aws:s3:::your-bucket/*"]
+    }
+  ]
+}
+```
+
 **4a. (Recommended) Setup authentication the AWS way, using environment
 variables**
 

--- a/packages/techdocs-common/api-report.md
+++ b/packages/techdocs-common/api-report.md
@@ -194,6 +194,7 @@ export interface PublisherBase {
   fetchTechDocsMetadata(entityName: EntityName): Promise<TechDocsMetadata>;
   getReadiness(): Promise<ReadinessResponse>;
   hasDocsBeenGenerated(entityName: Entity): Promise<boolean>;
+  migrateDocsCase?(migrateRequest: MigrateRequest): Promise<void>;
   publish(request: PublishRequest): Promise<PublishResponse>;
 }
 

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -313,19 +313,6 @@ export class AwsS3Publish implements PublisherBase {
     }
   }
 
-  /**
-   * todo: Put this documentation somewhere the user will actually see and read
-   * it.
-   *
-   * Note: In addition to the usual `PutObject`, `ListBucket` and `GetObject`
-   * actions, will need to add `PutObjectAcl` for copying files as well as
-   * `DeleteObject` if the removeOriginal flag is set to true. You may need to
-   * ensure access to the bucket resource in the following way:
-   * [
-   *   "arn:aws:s3:::your-bucket",
-   *   "arn:aws:s3:::your-bucket/*"
-   * ]
-   */
   async migrateDocsCase({
     removeOriginal = false,
     concurrency = 25,

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -323,7 +323,13 @@ export class AwsS3Publish implements PublisherBase {
     await Promise.all(
       allObjects.map(f =>
         limiter(async file => {
-          const newPath = lowerCaseEntityTripletInStoragePath(file);
+          let newPath;
+          try {
+            newPath = lowerCaseEntityTripletInStoragePath(file);
+          } catch (e) {
+            this.logger.warn(e.message);
+            return;
+          }
 
           // If all parts are already lowercase, ignore.
           if (file === newPath) {

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
@@ -25,7 +25,11 @@ import JSON5 from 'json5';
 import limiterFactory from 'p-limit';
 import { default as path, default as platformPath } from 'path';
 import { Logger } from 'winston';
-import { getFileTreeRecursively, getHeadersForFileExtension } from './helpers';
+import {
+  getFileTreeRecursively,
+  getHeadersForFileExtension,
+  lowerCaseEntityTripletInStoragePath,
+} from './helpers';
 import {
   PublisherBase,
   PublishRequest,
@@ -290,14 +294,6 @@ export class AzureBlobStoragePublish implements PublisherBase {
       .exists();
   }
 
-  protected toLowerCase(originalName: string): string {
-    const [namespace, kind, name, ...parts] = originalName.split('/');
-    const lowerNamespace = namespace.toLowerCase();
-    const lowerKind = kind.toLowerCase();
-    const lowerName = name.toLowerCase();
-    return [lowerNamespace, lowerKind, lowerName, ...parts].join('/');
-  }
-
   protected async renameBlob(
     originalName: string,
     newName: string,
@@ -314,16 +310,16 @@ export class AzureBlobStoragePublish implements PublisherBase {
   }
 
   protected async renameBlobToLowerCase(
-    originalName: string,
+    originalPath: string,
     removeOriginal: boolean,
   ) {
-    const newName = this.toLowerCase(originalName);
-    if (originalName === newName) return;
+    const newPath = lowerCaseEntityTripletInStoragePath(originalPath);
+    if (originalPath === newPath) return;
     try {
-      this.logger.debug(`Migrating ${originalName}`);
-      await this.renameBlob(originalName, newName, removeOriginal);
+      this.logger.debug(`Migrating ${originalPath}`);
+      await this.renameBlob(originalPath, newPath, removeOriginal);
     } catch (e) {
-      this.logger.warn(`Unable to migrate ${originalName}: ${e.message}`);
+      this.logger.warn(`Unable to migrate ${originalPath}: ${e.message}`);
     }
   }
 

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
@@ -323,10 +323,6 @@ export class AzureBlobStoragePublish implements PublisherBase {
     }
   }
 
-  /**
-   * todo: Put this documentation somewhere the user will actually see and read
-   * it.
-   */
   async migrateDocsCase({
     removeOriginal = false,
     concurrency = 25,

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
@@ -313,7 +313,14 @@ export class AzureBlobStoragePublish implements PublisherBase {
     originalPath: string,
     removeOriginal: boolean,
   ) {
-    const newPath = lowerCaseEntityTripletInStoragePath(originalPath);
+    let newPath;
+    try {
+      newPath = lowerCaseEntityTripletInStoragePath(originalPath);
+    } catch (e) {
+      this.logger.warn(e.message);
+      return;
+    }
+
     if (originalPath === newPath) return;
     try {
       this.logger.debug(`Migrating ${originalPath}`);

--- a/packages/techdocs-common/src/stages/publish/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/publish/helpers.test.ts
@@ -90,4 +90,12 @@ describe('lowerCaseEntityTripletInStoragePath', () => {
     const actualPath = lowerCaseEntityTripletInStoragePath(originalPath);
     expect(actualPath).toBe('default/component/backstage/assets/IMAGE.png');
   });
+
+  it('throws error when there is no triplet', () => {
+    const originalPath = '/default/component/IMAGE.png';
+    const error = `Encountered file unmanaged by TechDocs ${originalPath}. Skipping.`;
+    expect(() =>
+      lowerCaseEntityTripletInStoragePath(originalPath),
+    ).toThrowError(error);
+  });
 });

--- a/packages/techdocs-common/src/stages/publish/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/publish/helpers.test.ts
@@ -16,7 +16,11 @@
 import mockFs from 'mock-fs';
 import * as os from 'os';
 import * as path from 'path';
-import { getFileTreeRecursively, getHeadersForFileExtension } from './helpers';
+import {
+  getFileTreeRecursively,
+  getHeadersForFileExtension,
+  lowerCaseEntityTripletInStoragePath,
+} from './helpers';
 
 describe('getHeadersForFileExtension', () => {
   const correctMapOfExtensions = [
@@ -71,5 +75,19 @@ describe('getFileTreeRecursively', () => {
     expect(fileList.length).toBe(2);
     expect(fileList).toContain(path.resolve(root, 'file1'));
     expect(fileList).toContain(path.resolve(root, 'subDirA/file2'));
+  });
+});
+
+describe('lowerCaseEntityTripletInStoragePath', () => {
+  it('returns lower-cased entity triplet path', () => {
+    const originalPath = 'default/Component/backstage/index.html';
+    const actualPath = lowerCaseEntityTripletInStoragePath(originalPath);
+    expect(actualPath).toBe('default/component/backstage/index.html');
+  });
+
+  it('does not lowercase beyond the triplet', () => {
+    const originalPath = 'default/Component/backstage/assets/IMAGE.png';
+    const actualPath = lowerCaseEntityTripletInStoragePath(originalPath);
+    expect(actualPath).toBe('default/component/backstage/assets/IMAGE.png');
   });
 });

--- a/packages/techdocs-common/src/stages/publish/helpers.ts
+++ b/packages/techdocs-common/src/stages/publish/helpers.ts
@@ -97,6 +97,14 @@ export const getFileTreeRecursively = async (
 export const lowerCaseEntityTripletInStoragePath = (
   originalPath: string,
 ): string => {
+  const trimmedPath =
+    originalPath[0] === '/' ? originalPath.substring(1) : originalPath;
+  const matches = trimmedPath.match(/\//g) || [];
+  if (matches.length <= 2) {
+    throw new Error(
+      `Encountered file unmanaged by TechDocs ${originalPath}. Skipping.`,
+    );
+  }
   const [namespace, kind, name, ...parts] = originalPath.split('/');
   const lowerNamespace = namespace.toLowerCase();
   const lowerKind = kind.toLowerCase();

--- a/packages/techdocs-common/src/stages/publish/helpers.ts
+++ b/packages/techdocs-common/src/stages/publish/helpers.ts
@@ -82,3 +82,24 @@ export const getFileTreeRecursively = async (
   });
   return fileList;
 };
+
+/**
+ * Returns the version of an object's storage path where the first three parts
+ * of the path (the entity triplet of namespace, kind, and name) are
+ * lower-cased.
+ *
+ * Path must not include a starting slash.
+ *
+ * @example
+ * lowerCaseEntityTripletInStoragePath('default/Component/backstage')
+ * // return default/component/backstage
+ */
+export const lowerCaseEntityTripletInStoragePath = (
+  originalPath: string,
+): string => {
+  const [namespace, kind, name, ...parts] = originalPath.split('/');
+  const lowerNamespace = namespace.toLowerCase();
+  const lowerKind = kind.toLowerCase();
+  const lowerName = name.toLowerCase();
+  return [lowerNamespace, lowerKind, lowerName, ...parts].join('/');
+};

--- a/packages/techdocs-common/src/stages/publish/local.ts
+++ b/packages/techdocs-common/src/stages/publish/local.ts
@@ -32,7 +32,11 @@ import {
   ReadinessResponse,
   TechDocsMetadata,
 } from './types';
-import { getFileTreeRecursively, getHeadersForFileExtension } from './helpers';
+import {
+  getFileTreeRecursively,
+  getHeadersForFileExtension,
+  lowerCaseEntityTripletInStoragePath,
+} from './helpers';
 
 // TODO: Use a more persistent storage than node_modules or /tmp directory.
 // Make it configurable with techdocs.publisher.local.publishDirectory
@@ -182,30 +186,14 @@ export class LocalPublish implements PublisherBase {
       files.map(f =>
         limit(async file => {
           const relativeFile = file.replace(`${staticDocsDir}${path.sep}`, '');
-          const [namespace, kind, name, ...parts] = relativeFile.split(
-            path.sep,
-          );
-          const lowerNamespace = namespace.toLowerCase();
-          const lowerKind = kind.toLowerCase();
-          const lowerName = name.toLowerCase();
+          const newFile = lowerCaseEntityTripletInStoragePath(relativeFile);
 
           // If all parts are already lowercase, ignore.
-          if (
-            namespace === lowerNamespace &&
-            kind === lowerKind &&
-            name === lowerName
-          ) {
+          if (relativeFile === newFile) {
             return;
           }
 
           // Otherwise, copy or move the file.
-          const newFile = [
-            staticDocsDir,
-            lowerNamespace,
-            lowerKind,
-            lowerName,
-            ...parts,
-          ].join(path.sep);
           await new Promise<void>(resolve => {
             const migrate = removeOriginal ? fs.move : fs.copyFile;
             this.logger.debug(`Migrating ${relativeFile}`);

--- a/packages/techdocs-common/src/stages/publish/migrations/GoogleMigration.ts
+++ b/packages/techdocs-common/src/stages/publish/migrations/GoogleMigration.ts
@@ -38,7 +38,14 @@ export class MigrateWriteStream extends Writable {
 
   _write(file: File, _encoding: BufferEncoding, next: Function) {
     let shouldCallNext = true;
-    const newFile = lowerCaseEntityTripletInStoragePath(file.name);
+    let newFile;
+    try {
+      newFile = lowerCaseEntityTripletInStoragePath(file.name);
+    } catch (e) {
+      this.logger.warn(e.message);
+      next();
+      return;
+    }
 
     // If all parts are already lowercase, ignore.
     if (newFile === file.name) {

--- a/packages/techdocs-common/src/stages/publish/migrations/GoogleMigration.ts
+++ b/packages/techdocs-common/src/stages/publish/migrations/GoogleMigration.ts
@@ -54,9 +54,8 @@ export class MigrateWriteStream extends Writable {
     }
 
     // Otherwise, copy or move the file.
-    // todo: Use file.move instead of file.copy when removeOriginal is true.
     const migrate = this.removeOriginal
-      ? file.copy.bind(file)
+      ? file.move.bind(file)
       : file.copy.bind(file);
     this.logger.debug(`Migrating ${file.name}`);
     migrate(newFile)

--- a/packages/techdocs-common/src/stages/publish/migrations/GoogleMigration.ts
+++ b/packages/techdocs-common/src/stages/publish/migrations/GoogleMigration.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { File } from '@google-cloud/storage';
+import { Writable } from 'stream';
+import { Logger } from 'winston';
+
+/**
+ * Writable stream to handle object copy/move operations. This implementation
+ * ensures we don't read in files from GCS faster than GCS can copy/move them.
+ */
+export class MigrateWriteStream extends Writable {
+  protected logger: Logger;
+  protected removeOriginal: boolean;
+  protected maxConcurrency: number;
+  protected inFlight = 0;
+
+  constructor(logger: Logger, removeOriginal: boolean, concurrency: number) {
+    super({ objectMode: true });
+    this.logger = logger;
+    this.removeOriginal = removeOriginal;
+    this.maxConcurrency = concurrency;
+  }
+
+  _write(file: File, _encoding: BufferEncoding, next: Function) {
+    let shouldCallNext = true;
+    const [namespace, kind, name, ...parts] = file.name.split('/');
+    const lowerNamespace = namespace.toLowerCase();
+    const lowerKind = kind.toLowerCase();
+    const lowerName = name.toLowerCase();
+
+    // If all parts are already lowercase, ignore.
+    if (
+      namespace === lowerNamespace &&
+      kind === lowerKind &&
+      name === lowerName
+    ) {
+      next();
+      return;
+    }
+
+    // Allow up to n-many files to be migrated at a time.
+    this.inFlight++;
+    if (this.inFlight < this.maxConcurrency) {
+      next();
+      shouldCallNext = false;
+    }
+
+    // Otherwise, copy or move the file.
+    const newFile = [lowerNamespace, lowerKind, lowerName, ...parts].join('/');
+    // todo: Use file.move instead of file.copy when removeOriginal is true.
+    const migrate = this.removeOriginal
+      ? file.copy.bind(file)
+      : file.copy.bind(file);
+    this.logger.debug(`Migrating ${file.name}`);
+    migrate(newFile)
+      .catch(e =>
+        this.logger.warn(`Unable to migrate ${file.name}: ${e.message}`),
+      )
+      .finally(() => {
+        this.inFlight--;
+        if (shouldCallNext) {
+          next();
+        }
+      });
+  }
+}

--- a/packages/techdocs-common/src/stages/publish/migrations/index.ts
+++ b/packages/techdocs-common/src/stages/publish/migrations/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { MigrateWriteStream } from './GoogleMigration';

--- a/packages/techdocs-common/src/stages/publish/types.ts
+++ b/packages/techdocs-common/src/stages/publish/types.ts
@@ -55,6 +55,19 @@ export type TechDocsMetadata = {
   etag: string;
 };
 
+export type MigrateRequest = {
+  /**
+   * Whether or not to remove the source file. Defaults to false (acting like a
+   * copy instead of a move).
+   */
+  removeOriginal?: boolean;
+
+  /**
+   * Maximum number of files/objects to migrate at once. Defaults to 25.
+   */
+  concurrency?: number;
+};
+
 /**
  * Base class for a TechDocs publisher (e.g. Local, Google GCS Bucket, AWS S3, etc.)
  * The publisher handles publishing of the generated static files after the prepare and generate steps of TechDocs.
@@ -92,4 +105,14 @@ export interface PublisherBase {
    * Check if the index.html is present for the Entity at the Storage location.
    */
   hasDocsBeenGenerated(entityName: Entity): Promise<boolean>;
+
+  /**
+   * Migrates documentation objects with case sensitive entity triplets to
+   * lowercase entity triplets. This was (will be) a change introduced in
+   * techdocs-cli v{0.x.y} and techdocs-backend v{0.x.y}.
+   *
+   * Implementation of this method is unnecessary in publishers introduced
+   * after v{0.x.y} of techdocs-common.
+   */
+  migrateDocsCase?(migrateRequest: MigrateRequest): Promise<void>;
 }

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -256,7 +256,7 @@ export async function createRouter(
         await publisher.migrateDocsCase({
           // removeOriginal: !!req.query?.removeOriginal,
           concurrency:
-            parseInt((req.query?.concurrency as string) || '', 10) || undefined,
+            parseInt((req.query?.concurrency as string) || '', 25) || undefined,
         });
         res.status(200).send('Good job');
       } catch (e) {

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -246,28 +246,6 @@ export async function createRouter(
     }
   });
 
-  /**
-   * TODO: Remove this endpoint before merging. This is just a convenient way
-   * to test publisher.migrateDocsCase() implementations.
-   */
-  router.get('/do-not-commit/migrate', async (req, res) => {
-    if (publisher.migrateDocsCase) {
-      try {
-        await publisher.migrateDocsCase({
-          // removeOriginal: !!req.query?.removeOriginal,
-          concurrency:
-            parseInt((req.query?.concurrency as string) || '', 25) || undefined,
-        });
-        res.status(200).send('Good job');
-      } catch (e) {
-        logger.error(e);
-        res.status(500).send('Uh-oh');
-      }
-    } else {
-      res.status(400).send('Not valid');
-    }
-  });
-
   // Route middleware which serves files from the storage set in the publisher.
   router.use('/static/docs', publisher.docsRouter());
 

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -246,6 +246,28 @@ export async function createRouter(
     }
   });
 
+  /**
+   * TODO: Remove this endpoint before merging. This is just a convenient way
+   * to test publisher.migrateDocsCase() implementations.
+   */
+  router.get('/do-not-commit/migrate', async (req, res) => {
+    if (publisher.migrateDocsCase) {
+      try {
+        await publisher.migrateDocsCase({
+          // removeOriginal: !!req.query?.removeOriginal,
+          concurrency:
+            parseInt((req.query?.concurrency as string) || '', 10) || undefined,
+        });
+        res.status(200).send('Good job');
+      } catch (e) {
+        logger.error(e);
+        res.status(500).send('Uh-oh');
+      }
+    } else {
+      res.status(400).send('Not valid');
+    }
+  });
+
   // Route middleware which serves files from the storage set in the publisher.
   router.use('/static/docs', publisher.docsRouter());
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is step one of a multi-step process toward resolving #4367.  This adds the necessary logic on a publisher-by-publisher basis to migrate objects in storage from, e.g. `default/Component/foo/index.html` to `default/component/foo/index.html`.

Those steps are:

1. Define and implement migration logic for storage providers. <-- We are here.
2. Expose the implementations in `techdocs-cli`
3. Update publisher implementations to read/write lower-case'd versions of the entity triplet, regardless of how the path arguments come in (expectation being that those running external storage configurations will run the aforementioned migration path prior to deployment)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
