### PR TITLE
Scaffolder: Fix repository inputs for publish:github:pull-request action

### DIFF
--- a/.changeset/shy-rules-design.md
+++ b/.changeset/shy-rules-design.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Updated inputs for the `publish:github:pull-request` action.
+
+Now requires a `repoUrl` instead of separate `owner` and `repo` inputs. This aligns with the output of the `RepoUrlPicker` ui field used by the pull-request sample template.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
@@ -67,8 +67,7 @@ describe('createPublishGithubPullRequestAction', () => {
 
     beforeEach(() => {
       input = {
-        owner: 'myorg',
-        repo: 'myrepo',
+        repoUrl: 'github.com?owner=myorg&repo=myrepo',
         title: 'Create my new app',
         branchName: 'new-app',
         description: 'This PR is really good',
@@ -127,8 +126,7 @@ describe('createPublishGithubPullRequestAction', () => {
 
     beforeEach(() => {
       input = {
-        owner: 'myorg',
-        repo: 'myrepo',
+        repoUrl: 'github.com?owner=myorg&repo=myrepo',
         title: 'Create my new app',
         branchName: 'new-app',
         description: 'This PR is really good',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -49,10 +49,7 @@ export type GithubPullRequestActionInput = {
   title: string;
   branchName: string;
   description: string;
-  owner?: string;
-  repo?: string;
-  repoUrl?: string;
-  host?: string;
+  repoUrl: string;
   targetPath?: string;
   sourcePath?: string;
 };
@@ -119,18 +116,13 @@ export const createPublishGithubPullRequestAction = ({
     id: 'publish:github:pull-request',
     schema: {
       input: {
-        required: ['owner', 'repo', 'title', 'description', 'branchName'],
+        required: ['repoUrl', 'title', 'description', 'branchName'],
         type: 'object',
         properties: {
-          owner: {
+          repoUrl: {
+            title: 'Repository Location',
+            description: `Accepts the format 'github.com?repo=reponame&owner=owner' where 'reponame' is the repository name and 'owner' is an organization or username`,
             type: 'string',
-            title: 'Repository owner',
-            description: 'The owner of the target repository',
-          },
-          repo: {
-            type: 'string',
-            title: 'Repository',
-            description: 'The github repository to create the file in',
           },
           branchName: {
             type: 'string',
@@ -173,8 +165,6 @@ export const createPublishGithubPullRequestAction = ({
       },
     },
     async handler(ctx) {
-      let { owner, repo } = ctx.input;
-      let host = 'github.com';
       const {
         repoUrl,
         branchName,
@@ -184,18 +174,7 @@ export const createPublishGithubPullRequestAction = ({
         sourcePath,
       } = ctx.input;
 
-      if (repoUrl) {
-        const parsed = parseRepoUrl(repoUrl);
-        host = parsed.host;
-        owner = parsed.owner;
-        repo = parsed.repo;
-      }
-
-      if (!host || !owner || !repo) {
-        throw new InputError(
-          'must provide either valid repo URL or owner and repo as parameters',
-        );
-      }
+      const { owner, repo, host } = parseRepoUrl(repoUrl);
 
       const client = await clientFactory({ integrations, host, owner, repo });
       const fileRoot = sourcePath


### PR DESCRIPTION
Signed-off-by: Joe Porpeglia <josephp@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The [pull-request sample template](https://github.com/backstage/backstage/blob/df12cc25aa4934a98bc42ed03c07f64a1a0a9d72/plugins/scaffolder-backend/sample-templates/pull-request/template.yaml) uses the `RepoUrlPicker` ui field and passes the output `repoUrl` to the `publish:github:pull-request` action. However, the action requires separate `repo` and `owner` inputs and checks for an optional `repoUrl`. These changes remove the required `repo` and `owner` inputs and make `repoUrl` required instead. This aligns with the `github:publish` action and allows for easier integration with the `RepoUrlPicker`.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
