### PR TITLE
Change return value of `SearchEngine.index` to `Promise<void>`

### DIFF
--- a/.changeset/search-mighty-mice-collect.md
+++ b/.changeset/search-mighty-mice-collect.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-backend-node': minor
+---
+
+Change return value of `SearchEngine.index` to `Promise<void>` to support
+implementation of external search engines.

--- a/plugins/search-backend-node/api-report.md
+++ b/plugins/search-backend-node/api-report.md
@@ -32,7 +32,7 @@ export class LunrSearchEngine implements SearchEngine {
     // (undocumented)
     protected docStore: Record<string, IndexableDocument>;
     // (undocumented)
-    index(type: string, documents: IndexableDocument[]): void;
+    index(type: string, documents: IndexableDocument[]): Promise<void>;
     // (undocumented)
     protected logger: Logger_2;
     // (undocumented)
@@ -57,7 +57,7 @@ export class Scheduler {
 
 // @public
 export interface SearchEngine {
-    index(type: string, documents: IndexableDocument[]): void;
+    index(type: string, documents: IndexableDocument[]): Promise<void>;
     query(query: SearchQuery): Promise<SearchResultSet>;
     setTranslator(translator: QueryTranslator): void;
 }

--- a/plugins/search-backend-node/src/IndexBuilder.ts
+++ b/plugins/search-backend-node/src/IndexBuilder.ts
@@ -140,7 +140,7 @@ export class IndexBuilder {
         }
 
         // pushing documents to index to a configured search engine.
-        this.searchEngine.index(type, documents);
+        await this.searchEngine.index(type, documents);
       }, this.collators[type].refreshInterval * 1000);
     });
 

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.test.ts
@@ -15,9 +15,9 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import { ConcreteLunrQuery, LunrSearchEngine } from './LunrSearchEngine';
-import { SearchEngine } from '../types';
 import lunr from 'lunr';
+import { SearchEngine } from '../types';
+import { ConcreteLunrQuery, LunrSearchEngine } from './LunrSearchEngine';
 
 /**
  * Just used to test the default translator shipped with LunrSearchEngine.
@@ -45,7 +45,7 @@ describe('LunrSearchEngine', () => {
       testLunrSearchEngine.setTranslator(translatorSpy);
 
       // When: querying the search engine
-      testLunrSearchEngine.query({
+      await testLunrSearchEngine.query({
         term: 'testTerm',
         filters: {},
         pageCursor: '',
@@ -259,7 +259,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock indexing of 1 document
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
 
       // Perform search query
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -282,7 +282,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock indexing of 1 document
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
 
       // Perform search query
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -315,7 +315,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock indexing of 1 document
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
 
       // Perform search query
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -347,7 +347,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock indexing of 1 document
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
 
       // Perform search query
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -379,7 +379,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock indexing of 1 document
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
 
       // Perform search query
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -412,7 +412,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock indexing of 1 document
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
 
       // Perform search query
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -445,7 +445,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock indexing of 1 document
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
 
       // Perform search query
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -483,7 +483,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock indexing of 2 documents
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
 
       // Perform search query
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -527,8 +527,8 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock 2 indices with 1 document each
-      testLunrSearchEngine.index('test-index', mockDocuments);
-      testLunrSearchEngine.index('test-index-2', mockDocuments2);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index-2', mockDocuments2);
       // Perform search query scoped to "test-index-2" with a filter on the field "extraField"
       const mockedSearchResult = await testLunrSearchEngine.query({
         term: 'testTitle',
@@ -565,7 +565,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock indexing of 2 documents
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
 
       // Perform search query
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -618,8 +618,8 @@ describe('LunrSearchEngine', () => {
       ];
 
       // Mock 2 indices with 2 documents each
-      testLunrSearchEngine.index('test-index', mockDocuments);
-      testLunrSearchEngine.index('test-index-2', mockDocuments2);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index-2', mockDocuments2);
 
       // Perform search query scoped to "test-index-2"
       const mockedSearchResult = await testLunrSearchEngine.query({
@@ -661,7 +661,7 @@ describe('LunrSearchEngine', () => {
       ];
 
       // call index func and ensure the index func was invoked.
-      testLunrSearchEngine.index('test-index', mockDocuments);
+      await testLunrSearchEngine.index('test-index', mockDocuments);
       expect(indexSpy).toHaveBeenCalled();
       expect(indexSpy).toHaveBeenCalledWith('test-index', [
         { title: 'testTerm', text: 'testText', location: 'test/location' },

--- a/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngine.ts
@@ -15,13 +15,13 @@
  */
 
 import {
-  SearchQuery,
   IndexableDocument,
+  SearchQuery,
   SearchResultSet,
 } from '@backstage/search-common';
 import lunr from 'lunr';
 import { Logger } from 'winston';
-import { SearchEngine, QueryTranslator } from '../types';
+import { QueryTranslator, SearchEngine } from '../types';
 
 export type ConcreteLunrQuery = {
   lunrQueryBuilder: lunr.Index.QueryBuilder;
@@ -113,7 +113,7 @@ export class LunrSearchEngine implements SearchEngine {
     this.translator = translator;
   }
 
-  index(type: string, documents: IndexableDocument[]): void {
+  async index(type: string, documents: IndexableDocument[]): Promise<void> {
     const lunrBuilder = new lunr.Builder();
 
     lunrBuilder.pipeline.add(lunr.trimmer, lunr.stopWordFilter, lunr.stemmer);
@@ -139,7 +139,7 @@ export class LunrSearchEngine implements SearchEngine {
     this.lunrIndices[type] = lunrBuilder.build();
   }
 
-  query(query: SearchQuery): Promise<SearchResultSet> {
+  async query(query: SearchQuery): Promise<SearchResultSet> {
     const { lunrQueryBuilder, documentTypes } = this.translator(
       query,
     ) as ConcreteLunrQuery;
@@ -183,6 +183,6 @@ export class LunrSearchEngine implements SearchEngine {
       }),
     };
 
-    return Promise.resolve(realResultSet);
+    return realResultSet;
   }
 }

--- a/plugins/search-backend-node/src/types.ts
+++ b/plugins/search-backend-node/src/types.ts
@@ -67,7 +67,7 @@ export interface SearchEngine {
   /**
    * Add the given documents to the SearchEngine index of the given type.
    */
-  index(type: string, documents: IndexableDocument[]): void;
+  index(type: string, documents: IndexableDocument[]): Promise<void>;
 
   /**
    * Perform a search query against the SearchEngine.


### PR DESCRIPTION
Otherwise it's hard to implement external search engines that need communication. While we could still do async code inside the function if the return value isn't match, my fix in the scheduler (#6362) won't work in that case.

Looks like this doesn't have an effect on the docs.

I think it would also be possible to do this change without a breaking change, but not sure if it's worth that in the current state of the search plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
