### PR TITLE
Mask or hide values on scaffolder review step

### DIFF
--- a/.changeset/fifty-frogs-prove.md
+++ b/.changeset/fifty-frogs-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Add options to mask or hide values on review state

--- a/.changeset/fifty-frogs-prove.md
+++ b/.changeset/fifty-frogs-prove.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder': minor
+'@backstage/plugin-scaffolder': patch
 ---
 
 Add options to mask or hide values on review state

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -230,7 +230,7 @@ spec:
 #### Hide or mask sensitive data on Review step
 
 Sometimes, specially in custom fields, you collect some data on Create form that
-must note be shown to the user on Review step. To hide or mask this data, you
+must not be shown to the user on Review step. To hide or mask this data, you
 can use `ui:widget: password` or set some properties of `ui:backstage`:
 
 ```yaml

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -227,6 +227,33 @@ spec:
             inputType: tel
 ```
 
+#### Hide or mask sensitive data on Review step
+
+Sometimes, specially in custom fields, you collect some data on Create form that
+must note be shown to the user on Review step. To hide or mask this data, you
+can set some properties of `ui:options`:
+
+```yaml
+- title: Hide or mask values
+  properties:
+    password:
+      title: Password
+      type: string
+      ui:widget: password # will print '******' as value for property 'password' on Review Step
+    masked:
+      title: Masked
+      type: string
+      ui:options:
+        review:
+          mask: '<some-value-to-show>' # will print '<some-value-to-show>' as value for property 'Masked' on Review Step
+    hidden:
+      title: Hidden
+      type: string
+      ui:options:
+        review:
+          show: false # wont print any info about 'hidden' property on Review Step
+```
+
 #### The Repository Picker
 
 So in order to make working with repository providers easier, we've built a

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -230,8 +230,8 @@ spec:
 #### Hide or mask sensitive data on Review step
 
 Sometimes, specially in custom fields, you collect some data on Create form that
-must not be shown to the user on Review step. To hide or mask this data, you
-can use `ui:widget: password` or set some properties of `ui:backstage`:
+must not be shown to the user on Review step. To hide or mask this data, you can
+use `ui:widget: password` or set some properties of `ui:backstage`:
 
 ```yaml
 - title: Hide or mask values

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -231,7 +231,7 @@ spec:
 
 Sometimes, specially in custom fields, you collect some data on Create form that
 must note be shown to the user on Review step. To hide or mask this data, you
-can set some properties of `ui:options`:
+can use `ui:widget: password` or set some properties of `ui:backstage`:
 
 ```yaml
 - title: Hide or mask values
@@ -243,13 +243,13 @@ can set some properties of `ui:options`:
     masked:
       title: Masked
       type: string
-      ui:options:
+      ui:backstage:
         review:
           mask: '<some-value-to-show>' # will print '<some-value-to-show>' as value for property 'Masked' on Review Step
     hidden:
       title: Hidden
       type: string
-      ui:options:
+      ui:backstage:
         review:
           show: false # wont print any info about 'hidden' property on Review Step
 ```

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.test.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.test.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getReviewData } from './MultistepJsonForm';
+
+describe('MultistepJsonForm', () => {
+  const formDataMock = {
+    password: 'password',
+    masked: 'Some info to mask',
+    open: 'Some open info',
+    hidden: 'Some info to hide',
+    'other-open': 'Other open info',
+  };
+
+  const stepsMock = [
+    {
+      title: 'The test template',
+      schema: {
+        title: 'The test template',
+        properties: {
+          password: {
+            title: 'Password',
+            type: 'string',
+            'ui:widget': 'password',
+          },
+          masked: {
+            title: 'Masked',
+            type: 'string',
+            'ui:options': {
+              review: {
+                show: true,
+                mask: '******',
+              },
+            },
+          },
+          open: {
+            title: 'Open info',
+            type: 'string',
+          },
+        },
+      },
+    },
+    {
+      title: 'Other fields',
+      schema: {
+        title: 'Other fields',
+        properties: {
+          hidden: {
+            title: 'Hidden',
+            type: 'string',
+            'ui:options': {
+              review: {
+                show: false,
+              },
+            },
+          },
+          'other-open': {
+            title: 'Other Open Info',
+            type: 'string',
+          },
+        },
+      },
+    },
+  ];
+
+  test('Fields are defined to be hidden or masked', () => {
+    const reviewData = getReviewData(formDataMock, stepsMock);
+
+    expect(reviewData.password).toBe('******');
+    expect(reviewData.masked).toBe('******');
+    expect(reviewData.open).toBe('Some open info');
+    expect(reviewData.hidden).toBeUndefined();
+    expect(reviewData['other-open']).toBe('Other open info');
+  });
+});

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.test.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.test.tsx
@@ -39,7 +39,7 @@ describe('MultistepJsonForm', () => {
           masked: {
             title: 'Masked',
             type: 'string',
-            'ui:options': {
+            'ui:backstage': {
               review: {
                 show: true,
                 mask: '******',
@@ -61,7 +61,7 @@ describe('MultistepJsonForm', () => {
           hidden: {
             title: 'Hidden',
             type: 'string',
-            'ui:options': {
+            'ui:backstage': {
               review: {
                 show: false,
               },

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -63,7 +63,6 @@ export function getUiSchemasFromSteps(steps: Step[]): UiSchema[] {
       }
     }
   });
-
   return uiSchemas;
 }
 
@@ -84,12 +83,12 @@ export function getReviewData(formData: Record<string, any>, steps: Step[]) {
         continue;
       }
 
-      if (!uiSchema['ui:options'] || !uiSchema['ui:options'].review) {
+      if (!uiSchema['ui:backstage'] || !uiSchema['ui:backstage'].review) {
         reviewData[key] = formData[key];
         continue;
       }
 
-      const review = uiSchema['ui:options'].review as JsonObject;
+      const review = uiSchema['ui:backstage'].review as JsonObject;
       if (!review.show) {
         continue;
       }

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -52,7 +52,7 @@ type Props = {
 export function getUiSchemasFromSteps(steps: Step[]): UiSchema[] {
   const uiSchemas: Array<UiSchema> = [];
   steps.forEach(step => {
-    if (!step.schema || !step.schema.properties) return;
+    if (!step.schema || !step.schema.properties) return [];
 
     const schemaProps = step.schema.properties as JsonObject;
     for (const key in schemaProps) {

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -52,11 +52,9 @@ type Props = {
 export function getUiSchemasFromSteps(steps: Step[]): UiSchema[] {
   const uiSchemas: Array<UiSchema> = [];
   steps.forEach(step => {
-    if (!step.schema || !step.schema.properties) return [];
-
     const schemaProps = step.schema.properties as JsonObject;
     for (const key in schemaProps) {
-      if (Object.prototype.hasOwnProperty.call(schemaProps, key)) {
+      if (schemaProps.hasOwnProperty.call(schemaProps, key)) {
         const uiSchema = schemaProps[key] as UiSchema;
         uiSchema.name = key;
         uiSchemas.push(uiSchema);
@@ -70,7 +68,7 @@ export function getReviewData(formData: Record<string, any>, steps: Step[]) {
   const uiSchemas = getUiSchemasFromSteps(steps);
   const reviewData: Record<string, any> = {};
   for (const key in formData) {
-    if (Object.prototype.hasOwnProperty.call(formData, key)) {
+    if (formData.hasOwnProperty.call(formData, key)) {
       const uiSchema = uiSchemas.find(us => us.name === key);
 
       if (!uiSchema) {
@@ -114,7 +112,6 @@ export const MultistepJsonForm = ({
   widgets,
 }: Props) => {
   const [activeStep, setActiveStep] = useState(0);
-  const [reviewData, setReviewData] = useState({});
 
   const handleReset = () => {
     setActiveStep(0);
@@ -122,10 +119,6 @@ export const MultistepJsonForm = ({
   };
   const handleNext = () => {
     setActiveStep(Math.min(activeStep + 1, steps.length));
-
-    if (Math.min(activeStep + 1, steps.length) === steps.length) {
-      setReviewData(getReviewData(formData, steps));
-    }
   };
   const handleBack = () => setActiveStep(Math.max(activeStep - 1, 0));
 
@@ -174,7 +167,10 @@ export const MultistepJsonForm = ({
         <Content>
           <Paper square elevation={0}>
             <Typography variant="h6">Review and create</Typography>
-            <StructuredMetadataTable dense metadata={reviewData} />
+            <StructuredMetadataTable
+              dense
+              metadata={getReviewData(formData, steps)}
+            />
             <Box mb={4} />
             <Button onClick={handleBack}>Back</Button>
             <Button onClick={handleReset}>Reset</Button>

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -54,7 +54,7 @@ export function getUiSchemasFromSteps(steps: Step[]): UiSchema[] {
   steps.forEach(step => {
     const schemaProps = step.schema.properties as JsonObject;
     for (const key in schemaProps) {
-      if (schemaProps.hasOwnProperty.call(schemaProps, key)) {
+      if (schemaProps.hasOwnProperty(key)) {
         const uiSchema = schemaProps[key] as UiSchema;
         uiSchema.name = key;
         uiSchemas.push(uiSchema);
@@ -68,7 +68,7 @@ export function getReviewData(formData: Record<string, any>, steps: Step[]) {
   const uiSchemas = getUiSchemasFromSteps(steps);
   const reviewData: Record<string, any> = {};
   for (const key in formData) {
-    if (formData.hasOwnProperty.call(formData, key)) {
+    if (formData.hasOwnProperty(key)) {
       const uiSchema = uiSchemas.find(us => us.name === key);
 
       if (!uiSchema) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `ui:options` to hide or mask field values on Review Step

```yaml
parameters:
    - title: The test template
      properties:
        secret-password:
          title: Secret Password
          type: string
          ui:widget: password # will mask the value on review step
        secret-masked:
          title: Secret Masked
          type: string
          ui:options:
            review: 
              show: true # true / false. Default true
              mask: '******' # string to be showed instead the value
        secret-hidden:
          title: Secret Hidden
          type: string
          ui:options:
            review: 
              show: false # property will not be shown
        owner:
          title: Repository Location
          type: string
        repo:
          title: Repository Location
          type: string
```

![image](https://user-images.githubusercontent.com/5077079/124992967-13269800-e01a-11eb-81a2-dc3f4b48977e.png)

![image](https://user-images.githubusercontent.com/5077079/124993016-220d4a80-e01a-11eb-9fd2-346e6031d3c7.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

closes #6393