### PR TITLE
Scaffolder: Add handlebar 'eq' helper

### DIFF
--- a/.changeset/pretty-drinks-serve.md
+++ b/.changeset/pretty-drinks-serve.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Scaffolder: Added an 'eq' handlebars helper for use in software template YAML files. This can be used to execute a step depending on the value of an input, e.g.:
+
+```yaml
+steps:
+  id: 'conditional-step'
+  action: 'custom-action'
+  if: '{{ eq parameters.myvalue "custom" }}',
+```

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -56,6 +56,8 @@ export class TaskWorker {
     this.handlebars.registerHelper('json', obj => JSON.stringify(obj));
 
     this.handlebars.registerHelper('not', value => !isTruthy(value));
+
+    this.handlebars.registerHelper('eq', (a, b) => a === b);
   }
 
   start() {


### PR DESCRIPTION
Signed-off-by: OscarDHdz <v-ohernandez@expediagroup.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
I've added a `eq` helper to Scaffolder:handlebars. 

```yaml
steps:
    - id: coo-id
      name: Cool Action
      if: "{{ eq parameters.name 'Hello' }}"
```

At Expedia we have few templates that use conditional steps depending on user input. The thing is, we currently rely in adding a bunch of checkboxes so that we can capture a "Yes/No" from the user. Which works, but does not offer the best user experience. For instance, here's a simple scenario:

1. User selects `X` `value` from a `dropdown`
2. Then we render a `checkbox` to confirm `value` `X` was selected. (with `schema dependencies`)

With this helper, we should be able to reduce the use of `checkbox` inputs, by being able to directly compare which `value` was selected from a dropdown (`enum` value)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
