### PR TITLE
fix(useEntityTypeFilter): fetch unique set of types ignoring case sensitivity 

### DIFF
--- a/.changeset/green-vans-peel.md
+++ b/.changeset/green-vans-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix `EntityTypeFilter` so it produces unique case-insensitive set of available types

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -86,10 +86,11 @@ export function useEntityTypeFilter(): EntityTypeReturn {
     const countByType = entities.reduce((acc, entity) => {
       if (typeof entity.spec?.type !== 'string') return acc;
 
-      if (!acc[entity.spec.type]) {
-        acc[entity.spec.type] = 0;
+      const entityType = entity.spec.type.toLocaleLowerCase('en-US');
+      if (!acc[entityType]) {
+        acc[entityType] = 0;
       }
-      acc[entity.spec.type] += 1;
+      acc[entityType] += 1;
       return acc;
     }, {} as Record<string, number>);
 


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Duplicate types were appearing as options due to consumers using different casing in entity files eg. `spec.type: Library` & `spec.type: library`

Not sure if this would be better addressed on ingestion?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
