### PR TITLE
Add an endpoint to catalog-backend that refreshes a single specified location in the catalog.

### DIFF
--- a/plugins/catalog-backend/src/next/DefaultLocationService.test.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationService.test.ts
@@ -27,6 +27,7 @@ describe('DefaultLocationServiceTest', () => {
     createLocation: jest.fn(),
     listLocations: jest.fn(),
     getLocation: jest.fn(),
+    refreshLocation: jest.fn(),
   };
   const locationService = new DefaultLocationService(store, orchestrator);
 

--- a/plugins/catalog-backend/src/next/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationService.ts
@@ -53,6 +53,9 @@ export class DefaultLocationService implements LocationService {
   deleteLocation(id: string): Promise<void> {
     return this.store.deleteLocation(id);
   }
+  refreshLocation(type: string): Promise<string> {
+    return this.store.refreshLocation(type);
+  }
 
   private async dryRunCreateLocation(
     spec: LocationSpec,

--- a/plugins/catalog-backend/src/next/DefaultLocationStore.test.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationStore.test.ts
@@ -178,4 +178,36 @@ describe('DefaultLocationStore', () => {
       60_000,
     );
   });
+
+  describe('refreshLocation', () => {
+    it.each(databases.eachSupportedId())(
+      'type not found',
+      async databaseId => {
+        const type = 'url';
+        const { store } = await createLocationStore(databaseId);
+        await expect(() => store.refreshLocation(type)).rejects.toThrow(
+          new RegExp(`Found no location with type ${type}`),
+        );
+      },
+      60_000,
+    );
+
+    it.each(databases.eachSupportedId())(
+      'happy enough path: type found, refresh row not found',
+      async databaseId => {
+        const type = 'url';
+        const { store } = await createLocationStore(databaseId);
+        await store.createLocation({
+          target:
+            'https://github.com/backstage/demo/blob/master/catalog-info.yml',
+          type,
+        });
+        const result = await store.refreshLocation(type);
+        expect(result).toEqual(
+          `Location found, refresh row not found for type ${type}, please wait a while and try again`,
+        );
+      },
+      60_000,
+    );
+  });
 });

--- a/plugins/catalog-backend/src/next/NextRouter.ts
+++ b/plugins/catalog-backend/src/next/NextRouter.ts
@@ -142,6 +142,11 @@ export async function createNextRouter(
         const output = await locationService.getLocation(id);
         res.status(200).json(output);
       })
+      .get('/locations/:type/refresh', async (req, res) => {
+        const { type } = req.params;
+        const output = await locationService.refreshLocation(type);
+        res.status(200).json(output);
+      })
       .delete('/locations/:id', async (req, res) => {
         disallowReadonlyMode(readonlyEnabled);
 

--- a/plugins/catalog-backend/src/next/types.ts
+++ b/plugins/catalog-backend/src/next/types.ts
@@ -25,6 +25,7 @@ export interface LocationService {
   listLocations(): Promise<Location[]>;
   getLocation(id: string): Promise<Location>;
   deleteLocation(id: string): Promise<void>;
+  refreshLocation(type: string): Promise<string>;
 }
 
 export interface LocationStore {
@@ -32,6 +33,7 @@ export interface LocationStore {
   listLocations(): Promise<Location[]>;
   getLocation(id: string): Promise<Location>;
   deleteLocation(id: string): Promise<void>;
+  refreshLocation(type: string): Promise<string>;
 }
 
 export interface CatalogProcessingEngine {

--- a/plugins/catalog-backend/src/service/router.ts
+++ b/plugins/catalog-backend/src/service/router.ts
@@ -173,6 +173,11 @@ export async function createRouter(
         const output = await locationService.getLocation(id);
         res.status(200).json(output);
       })
+      .get('/locations/:type/refresh', async (req, res) => {
+        const { type } = req.params;
+        const output = await locationService.refreshLocation(type);
+        res.status(200).json(output).end();
+      })
       .delete('/locations/:id', async (req, res) => {
         disallowReadonlyMode(readonlyEnabled);
 
@@ -193,7 +198,9 @@ export async function createRouter(
         disallowReadonlyMode(readonlyEnabled);
       }
 
-      const output = await higherOrderOperation.addLocation(input, { dryRun });
+      const output = await higherOrderOperation.addLocation(input, {
+        dryRun,
+      });
       res.status(201).json(output);
     });
   }


### PR DESCRIPTION
See title.

Signed-off-by: Christina Marie Rahaim <crahaim@wayfair.com>

## Hey, I just made a Pull Request!

Our particular use case: we created a barebones editor in Backstage to allow users to edit entity configuration for certain in-house entity sources in Backstage itself. Hitting this refresh endpoint syncs up changes made to the source of truth for these entities with Backstage, allowing users to see their changes right away.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [Should I?] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [Found none relevant to add to] Added or updated documentation
- [Y] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [Y] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
