### PR TITLE
Scaffolder: Add handlebar 'ne' helper

### DIFF
--- a/.changeset/small-seas-kick.md
+++ b/.changeset/small-seas-kick.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Scaffolder: Added an 'notEq' handlebars helper for use in software template YAML files. This can be used to execute a step depending on the value of an input, e.g.:
+
+```yaml
+steps:
+  id: 'conditional-step'
+  action: 'custom-action'
+  if: '{{ notEq parameters.myvalue "custom" }}',
+```

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.test.ts
@@ -203,7 +203,7 @@ describe('TaskWorker', () => {
     expect((event?.body?.output as JsonObject).result).toBe('winning');
   });
 
-  it('should execute steps conditionally with eq helper', async () => {
+  it('should execute steps conditionally using eq helper', async () => {
     const broker = new StorageTaskBroker(storage, logger);
     const taskWorker = new TaskWorker({
       logger,
@@ -234,6 +234,39 @@ describe('TaskWorker', () => {
     const { events } = await storage.listEvents({ taskId });
     const event = events.find(e => e.type === 'completion');
     expect((event?.body?.output as JsonObject).result).toBe('winning');
+  });
+
+  it('should skip steps conditionally using notEq helper', async () => {
+    const broker = new StorageTaskBroker(storage, logger);
+    const taskWorker = new TaskWorker({
+      logger,
+      workingDirectory: os.tmpdir(),
+      actionRegistry,
+      taskBroker: broker,
+    });
+
+    const { taskId } = await broker.dispatch({
+      steps: [
+        { id: 'test', name: 'test', action: 'test-action' },
+        {
+          id: 'conditional',
+          name: 'conditional',
+          action: 'test-action',
+          if: '{{ notEq steps.test.output.testOutput "winning" }}',
+        },
+      ],
+      output: {
+        result: '{{ steps.conditional.output.testOutput }}',
+      },
+      values: {},
+    });
+
+    const task = await broker.claim();
+    await taskWorker.runOneTask(task);
+
+    const { events } = await storage.listEvents({ taskId });
+    const event = events.find(e => e.type === 'completion');
+    expect((event?.body?.output as JsonObject).result).toBeUndefined();
   });
 
   it('should skip steps conditionally', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -58,6 +58,8 @@ export class TaskWorker {
     this.handlebars.registerHelper('not', value => !isTruthy(value));
 
     this.handlebars.registerHelper('eq', (a, b) => a === b);
+
+    this.handlebars.registerHelper('notEq', (a, b) => a !== b);
   }
 
   start() {


### PR DESCRIPTION
Signed-off-by: OscarDHdz <v-ohernandez@expediagroup.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I've added a `eq` helper to Scaffolder:handlebars. 

```yaml
steps:
    - id: coo-id
      name: Cool Action
      if: "{{ ne parameters.name 'Hello' }}"
```

This is just a complementary `handlebars helper` as part of the `eq` introduced a few days ago with this PR: https://github.com/backstage/backstage/pull/6424 





#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
