### PR TITLE
fix(techdocs): fetch entity relations field to determine owned docs

### DIFF
--- a/.changeset/fifty-hornets-punch.md
+++ b/.changeset/fifty-hornets-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix displaying owned documents list by fetching associated entity relations

--- a/plugins/techdocs/src/home/components/TechDocsCustomHome.tsx
+++ b/plugins/techdocs/src/home/components/TechDocsCustomHome.tsx
@@ -125,7 +125,14 @@ export const TechDocsCustomHome = ({
 
   const { value: entities, loading, error } = useAsync(async () => {
     const response = await catalogApi.getEntities({
-      fields: ['apiVersion', 'kind', 'metadata', 'spec.owner', 'spec.type'],
+      fields: [
+        'apiVersion',
+        'kind',
+        'metadata',
+        'relations',
+        'spec.owner',
+        'spec.type',
+      ],
     });
     return response.items.filter((entity: Entity) => {
       return !!entity.metadata.annotations?.['backstage.io/techdocs-ref'];


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Fix displaying owned documents issue due to mistakenly leaving out the `relations` field from https://github.com/backstage/backstage/pull/6267 (sorry!)
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
