### PR TITLE
[TechDocs] Handle error responses in getTechDocsMetadata and `getEntityMetadata` such that `<TechDocsPageHeader>` doesn't throw errors.

### DIFF
--- a/.changeset/techdocs-young-gorillas-share.md
+++ b/.changeset/techdocs-young-gorillas-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Handle error responses in `getTechDocsMetadata` and `getEntityMetadata` such that `<TechDocsPageHeader>` doesn't throw errors.

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -13,7 +13,7 @@ import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { EntityName } from '@backstage/catalog-model';
 import { IdentityApi } from '@backstage/core-plugin-api';
-import { Location as Location_2 } from '@backstage/catalog-model';
+import { LocationSpec } from '@backstage/catalog-model';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // Warning: (ae-missing-release-tag) "DocsCardGrid" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/techdocs/src/client.ts
+++ b/plugins/techdocs/src/client.ts
@@ -17,7 +17,7 @@
 import { EntityName } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
-import { NotFoundError } from '@backstage/errors';
+import { NotFoundError, ResponseError } from '@backstage/errors';
 import EventSource from 'eventsource';
 import { SyncResult, TechDocsApi, TechDocsStorageApi } from './api';
 import { TechDocsEntityMetadata, TechDocsMetadata } from './types';
@@ -72,9 +72,12 @@ export class TechDocsClient implements TechDocsApi {
     const request = await fetch(`${requestUrl}`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
-    const res = await request.json();
 
-    return res;
+    if (!request.ok) {
+      throw await ResponseError.fromResponse(request);
+    }
+
+    return await request.json();
   }
 
   /**
@@ -97,9 +100,12 @@ export class TechDocsClient implements TechDocsApi {
     const request = await fetch(`${requestUrl}`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
-    const res = await request.json();
 
-    return res;
+    if (!request.ok) {
+      throw await ResponseError.fromResponse(request);
+    }
+
+    return await request.json();
   }
 }
 

--- a/plugins/techdocs/src/reader/components/TechDocsPage.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPage.tsx
@@ -30,7 +30,7 @@ export const TechDocsPage = () => {
 
   const techdocsApi = useApi(techdocsApiRef);
 
-  const techdocsMetadataRequest = useAsync(() => {
+  const { value: techdocsMetadataValue } = useAsync(() => {
     if (documentReady) {
       return techdocsApi.getTechDocsMetadata({ kind, namespace, name });
     }
@@ -38,7 +38,7 @@ export const TechDocsPage = () => {
     return Promise.resolve(undefined);
   }, [kind, namespace, name, techdocsApi, documentReady]);
 
-  const entityMetadataRequest = useAsync(() => {
+  const { value: entityMetadataValue } = useAsync(() => {
     return techdocsApi.getEntityMetadata({ kind, namespace, name });
   }, [kind, namespace, name, techdocsApi]);
 
@@ -49,10 +49,8 @@ export const TechDocsPage = () => {
   return (
     <Page themeId="documentation">
       <TechDocsPageHeader
-        metadataRequest={{
-          techdocs: techdocsMetadataRequest,
-          entity: entityMetadataRequest,
-        }}
+        techDocsMetadata={techdocsMetadataValue}
+        entityMetadata={entityMetadataValue}
         entityId={{
           kind,
           namespace,

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.test.tsx
@@ -30,26 +30,23 @@ describe('<TechDocsPageHeader />', () => {
             name: 'test-name',
             namespace: 'test-namespace',
           }}
-          metadataRequest={{
-            entity: {
-              loading: false,
-              value: {
-                locationMetadata: {
-                  type: 'github',
-                  target: 'https://example.com/',
-                },
-                spec: {
-                  owner: 'test',
-                },
-              },
+          entityMetadata={{
+            locationMetadata: {
+              type: 'github',
+              target: 'https://example.com/',
             },
-            techdocs: {
-              loading: false,
-              value: {
-                site_name: 'test-site-name',
-                site_description: 'test-site-desc',
-              },
+            apiVersion: 'v1',
+            kind: 'Component',
+            metadata: {
+              name: 'test',
             },
+            spec: {
+              owner: 'test',
+            },
+          }}
+          techDocsMetadata={{
+            site_name: 'test-site-name',
+            site_description: 'test-site-desc',
           }}
         />,
         {
@@ -75,14 +72,6 @@ describe('<TechDocsPageHeader />', () => {
             name: 'test-name',
             namespace: 'test-namespace',
           }}
-          metadataRequest={{
-            entity: {
-              loading: false,
-            },
-            techdocs: {
-              loading: false,
-            },
-          }}
         />,
         {
           mountedRoutes: {
@@ -105,17 +94,9 @@ describe('<TechDocsPageHeader />', () => {
             name: 'test-name',
             namespace: 'test-namespace',
           }}
-          metadataRequest={{
-            entity: {
-              loading: false,
-            },
-            techdocs: {
-              loading: false,
-              value: {
-                site_name: 'test-site-name',
-                site_description: 'test-site-desc',
-              },
-            },
+          techDocsMetadata={{
+            site_name: 'test-site-name',
+            site_description: 'test-site-desc',
           }}
         />,
         {

--- a/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsPageHeader.tsx
@@ -15,6 +15,8 @@
  */
 
 import { EntityName, RELATION_OWNED_BY } from '@backstage/catalog-model';
+import { Header, HeaderLabel } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/core-plugin-api';
 import {
   EntityRefLink,
   EntityRefLinks,
@@ -22,45 +24,30 @@ import {
 } from '@backstage/plugin-catalog-react';
 import CodeIcon from '@material-ui/icons/Code';
 import React from 'react';
-import { AsyncState } from 'react-use/lib/useAsync';
 import { rootRouteRef } from '../../routes';
-import { TechDocsMetadata } from '../../types';
-
-import { Header, HeaderLabel } from '@backstage/core-components';
-import { useRouteRef } from '@backstage/core-plugin-api';
+import { TechDocsEntityMetadata, TechDocsMetadata } from '../../types';
 
 type TechDocsPageHeaderProps = {
   entityId: EntityName;
-  metadataRequest: {
-    entity: AsyncState<any>;
-    techdocs: AsyncState<TechDocsMetadata>;
-  };
+  entityMetadata?: TechDocsEntityMetadata;
+  techDocsMetadata?: TechDocsMetadata;
 };
 
 export const TechDocsPageHeader = ({
   entityId,
-  metadataRequest,
+  entityMetadata,
+  techDocsMetadata,
 }: TechDocsPageHeaderProps) => {
-  const {
-    techdocs: techdocsMetadata,
-    entity: entityMetadata,
-  } = metadataRequest;
-
-  const { value: techdocsMetadataValues } = techdocsMetadata;
-  const { value: entityMetadataValues } = entityMetadata;
-
   const { name } = entityId;
 
   const { site_name: siteName, site_description: siteDescription } =
-    techdocsMetadataValues || {};
+    techDocsMetadata || {};
 
-  const {
-    locationMetadata,
-    spec: { lifecycle },
-  } = entityMetadataValues || { spec: {} };
+  const { locationMetadata, spec } = entityMetadata || {};
+  const lifecycle = spec?.lifecycle;
 
-  const ownedByRelations = entityMetadataValues
-    ? getEntityRelations(entityMetadataValues, RELATION_OWNED_BY)
+  const ownedByRelations = entityMetadata
+    ? getEntityRelations(entityMetadata, RELATION_OWNED_BY)
     : [];
 
   const docsRootLink = useRouteRef(rootRouteRef)();

--- a/plugins/techdocs/src/types.ts
+++ b/plugins/techdocs/src/types.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import { Entity, Location } from '@backstage/catalog-model';
+import { Entity, LocationSpec } from '@backstage/catalog-model';
 
 export type TechDocsMetadata = {
   site_name: string;
   site_description: string;
 };
 
-export type TechDocsEntityMetadata = Entity & { locationMetadata?: Location };
+export type TechDocsEntityMetadata = Entity & {
+  locationMetadata?: LocationSpec;
+};


### PR DESCRIPTION
When you visit `/docs/<a-nonexisting-entity>` you see the following view:

![localhost_3000_docs_default_Component_documented-componentt (1)](https://user-images.githubusercontent.com/720821/125479318-07240d63-cc0c-4a04-a83b-bc0f7ada93eb.png)

This PR changes it to:

![localhost_3000_docs_default_Component_documented-componentt](https://user-images.githubusercontent.com/720821/125479310-f6709a05-a91a-4c6d-9272-e0ee848607cc.png)

Still not perfect, but at least the page is not completely broken.

I also used the time to refactor the `<TechDocsPageHeader/>` component since it uses `AsyncState<...>` properties as input which I found unnecessary. Plus I used a more fitting `LocationSpec` type since the `Location` type also includes a `{id: string}` property which is not part of the response.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
