### PR TITLE
fix OIDC Auth provider

### DIFF
--- a/.changeset/little-colts-hang.md
+++ b/.changeset/little-colts-hang.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-Fix oidc auth provider
+Configuration updates for the `OpenID Connect` auth provider to allow `prompt` configuration and some sensible defaults.

--- a/.changeset/little-colts-hang.md
+++ b/.changeset/little-colts-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fix oidc auth provider

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -320,8 +320,8 @@ auth:
         authorizationUrl: ${AUTH_OIDC_AUTH_URL}
         tokenUrl: ${AUTH_OIDC_TOKEN_URL}
         tokenSignedResponseAlg: ${AUTH_OIDC_TOKEN_SIGNED_RESPONSE_ALG} # default='RS256'
-        scope: ${AUTH_OIDC_SCOPE}                                      # default='openid profile email'
-        prompt: ${AUTH_OIDC_PROMPT}                                    # default='' (allowed values: '', 'none', 'consent', 'login')
+        scope: ${AUTH_OIDC_SCOPE} # default='openid profile email'
+        prompt: ${AUTH_OIDC_PROMPT} # default='' (allowed values: '', 'none', 'consent', 'login')
     auth0:
       development:
         clientId: ${AUTH_AUTH0_CLIENT_ID}

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -312,7 +312,11 @@ auth:
         #
         # scope: saml-login-selector openid profile email
     oidc:
-      # Note that you must define a session secret (above) since the oidc provider requires session support
+      # Note that you must define a session secret (see above) since the oidc provider requires session support.
+      # Note that by default, this provider will use the 'none' prompt which assumes that your are already logged on in the IDP.
+      # You should set prompt to:
+      # - auto: will let the IDP decide if you need to log on or if you can skip login when you have an active SSO session
+      # - login: will force the IDP to always present a login form to the user
       development:
         metadataUrl: ${AUTH_OIDC_METADATA_URL}
         clientId: ${AUTH_OIDC_CLIENT_ID}
@@ -321,7 +325,7 @@ auth:
         tokenUrl: ${AUTH_OIDC_TOKEN_URL}
         tokenSignedResponseAlg: ${AUTH_OIDC_TOKEN_SIGNED_RESPONSE_ALG} # default='RS256'
         scope: ${AUTH_OIDC_SCOPE} # default='openid profile email'
-        prompt: ${AUTH_OIDC_PROMPT} # default='' (allowed values: '', 'none', 'consent', 'login')
+        prompt: ${AUTH_OIDC_PROMPT} # default=none (allowed values: auto, none, consent, login)
     auth0:
       development:
         clientId: ${AUTH_AUTH0_CLIENT_ID}

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -312,13 +312,16 @@ auth:
         #
         # scope: saml-login-selector openid profile email
     oidc:
+      # Note that you must define a session secret (above) since the oidc provider requires session support
       development:
         metadataUrl: ${AUTH_OIDC_METADATA_URL}
         clientId: ${AUTH_OIDC_CLIENT_ID}
         clientSecret: ${AUTH_OIDC_CLIENT_SECRET}
         authorizationUrl: ${AUTH_OIDC_AUTH_URL}
         tokenUrl: ${AUTH_OIDC_TOKEN_URL}
-        tokenSignedResponseAlg: ${AUTH_OIDC_TOKEN_SIGNED_RESPONSE_ALG}
+        tokenSignedResponseAlg: ${AUTH_OIDC_TOKEN_SIGNED_RESPONSE_ALG} # default='RS256'
+        scope: ${AUTH_OIDC_SCOPE}                                      # default='openid profile email'
+        prompt: ${AUTH_OIDC_PROMPT}                                    # default='' (allowed values: '', 'none', 'consent', 'login')
     auth0:
       development:
         clientId: ${AUTH_AUTH0_CLIENT_ID}

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -73,12 +73,16 @@ export class OidcAuthProvider implements OAuthHandlers {
 
   async start(req: OAuthStartRequest): Promise<RedirectInfo> {
     const { strategy } = await this.implementation;
-    return await executeRedirectStrategy(req, strategy, {
+    const options: Record<string, string> = {
       accessType: 'offline',
-      prompt: this.prompt || '',
       scope: req.scope || this.scope || 'openid profile email',
       state: encodeState(req.state),
-    });
+    };
+    const prompt = this.prompt || 'none';
+    if (prompt !== 'auto') {
+      options.prompt = prompt;
+    }
+    return await executeRedirectStrategy(req, strategy, options);
   }
 
   async handler(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While trying to configure the OIDC auth provider in a newly generated Backstage application, I faced several issues:
1) I had to specify a value for tokenSignedResponseAlg which should have a default (RS256)
2) I had to define scopes since there is no default (so, I changed this to 'openid profile, email')
3) I had to understand that I needed a session secret defined since the OIDC provider requires session support (so, I documented it in the app-config.yaml)
4) I had to fork the code in order to change the hardcoded behaviour for the prompt parameter which was set to 'none', preventing the OIDC server to display a login page. I defaulted to empty string, to let the server decide and benefit from SSO, but I added a new configuration option to provide a custom value such as 'login' to force the login screen every time for instance.

I've tested the provider using an already installed Keycloak server and everything seems to be fine.

All unit tests are green.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
