### PR TITLE
Feature/bitbucket default catalog value

### DIFF
--- a/.changeset/fifty-walls-grin.md
+++ b/.changeset/fifty-walls-grin.md
@@ -1,0 +1,17 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Add a default catalog value for BitBucketDiscoveryProcessor. This allows to have a target like so: https://bitbucket.mycompany.com/projects/backstage/repos/service-*
+which will be expanded to https://bitbucket.mycompany.com/projects/backstage/repos/service-a/catalog-info.yaml given that repository 'service-a' exists.
+
+## Migration
+
+If you are using a custom [Bitbucket parser](https://backstage.io/docs/integrations/bitbucket/discovery#custom-repository-processing) and your `bitbucket-discovery` target (e.g. in your app-config.yaml) omits the catalog path in any of the following ways:
+
+- https://bitbucket.mycompany.com/projects/backstage/repos/service-*
+- https://bitbucket.mycompany.com/projects/backstage/repos/*
+- https://bitbucket.mycompany.com/projects/backstage/repos/*/
+
+then you will be affected by this change.
+The 'target' input to your parser before this commit would be '/', and after this commit it will be '/catalog-info.yaml', and as such needs to be handled to maintain the same functionality.

--- a/docs/integrations/bitbucket/discovery.md
+++ b/docs/integrations/bitbucket/discovery.md
@@ -38,7 +38,11 @@ The target is composed of four parts:
   repositories prefixed with `service-`.
 - The path within each repository to find the catalog YAML file. This will
   usually be `/catalog-info.yaml` or a similar variation for catalog files
-  stored in the root directory of each repository.
+  stored in the root directory of each repository. If omitted, the default value
+  `catalog-info.yaml` will be used. E.g. given that `my-project`and `service-a`
+  exists, `https://bitbucket.mycompany.com/projects/my-project/repos/service-*/`
+  will result in:
+  `https://bitbucket.mycompany.com/projects/my-project/repos/service-a/catalog-info.yaml`.
 
 ## Custom repository processing
 

--- a/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.test.ts
@@ -225,6 +225,34 @@ describe('BitbucketDiscoveryProcessor', () => {
         optional: true,
       });
     });
+
+    it.each`
+      target
+      ${'https://bitbucket.mycompany.com/projects/backstage/repos/*'}
+      ${'https://bitbucket.mycompany.com/projects/backstage/repos/*/'}
+      ${'https://bitbucket.mycompany.com/projects/backstage/repos/techdocs-*/'}
+    `("target '$target' adds default path to catalog", async ({ target }) => {
+      setupStubs([{ key: 'backstage', repos: ['techdocs-cli'] }]);
+
+      const location: LocationSpec = {
+        type: 'bitbucket-discovery',
+        target: target,
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/projects/backstage/repos/techdocs-cli/browse/catalog-info.yaml',
+        },
+        optional: true,
+      });
+    });
   });
 
   describe('Custom repository parser', () => {

--- a/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
@@ -84,13 +84,15 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
     this.logger.info(`Reading Bitbucket repositories from ${location.target}`);
 
     const { catalogPath } = parseUrl(location.target);
+    const expandedCatalogPath =
+      catalogPath === '/' ? '/catalog-info.yaml' : catalogPath;
 
     const result = await readBitbucketOrg(client, location.target);
 
     for (const repository of result.matches) {
       for await (const entity of this.parser({
         integration: integration,
-        target: `${repository.links.self[0].href}${catalogPath}`,
+        target: `${repository.links.self[0].href}${expandedCatalogPath}`,
         logger: this.logger,
       })) {
         emit(entity);


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR adds a default value of "catalog-info.yaml" to BitbucketDiscoveryProcessor that's used when no catalog path is given.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
