### PR TITLE
Remove stale TechDocs artifacts after publishing new version

### DIFF
--- a/.changeset/techdocs-stale-breakfast-king.md
+++ b/.changeset/techdocs-stale-breakfast-king.md
@@ -1,0 +1,19 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Stale TechDocs content (files that had previously been published but which have
+since been removed) is now removed from storage at publish-time. This is now
+supported by the following publishers:
+
+- Google GCS
+- AWS S3
+- Azure Blob Storage
+
+You may need to apply a greater level of permissions (e.g. the ability to
+delete objects in your storage provider) to any credentials/accounts used by
+the TechDocs CLI or TechDocs backend in order for this change to take effect.
+
+For more details, see [#6132][issue-ref].
+
+[issue-ref]: https://github.com/backstage/backstage/issues/6132

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -61,7 +61,7 @@ If you do not prefer (3a) and optionally like to use a service account, you can
 follow these steps.
 
 Create a new Service Account and a key associated with it. In roles of the
-service account, use "Storage Admin".
+service account, use "Storage Object Admin".
 
 If you want to create a custom role, make sure to include both `get` and
 `create` permissions for both "Objects" and "Buckets". See
@@ -143,6 +143,8 @@ permissions to:
 
 - `s3:ListBucket` to retrieve bucket metadata
 - `s3:PutObject` to upload files to the bucket
+- `s3:DeleteObject` and `s3:DeleteObjectVersion` to delete stale content during
+  re-publishing
 
 To _read_ TechDocs from the S3 bucket the IAM policy needs to have at a minimum
 permissions to:
@@ -344,6 +346,10 @@ techdocs:
         accountName: ${TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_NAME}
         accountKey: ${TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_KEY}
 ```
+
+In either case, the account or credentials used to access your container and all
+TechDocs objects underneath it should have the `Storage Blog Data Owner` role
+applied, in order to read, write, and delete objects as needed.
 
 **4. That's it!**
 

--- a/packages/techdocs-common/__mocks__/@azure/storage-blob.ts
+++ b/packages/techdocs-common/__mocks__/@azure/storage-blob.ts
@@ -125,6 +125,10 @@ export class ContainerClient {
   getBlockBlobClient(blobName: string) {
     return new BlockBlobClient(blobName);
   }
+
+  listBlobsFlat() {
+    return [];
+  }
 }
 
 class ContainerClientFailGetProperties extends ContainerClient {

--- a/packages/techdocs-common/__mocks__/@azure/storage-blob.ts
+++ b/packages/techdocs-common/__mocks__/@azure/storage-blob.ts
@@ -126,8 +126,20 @@ export class ContainerClient {
     return new BlockBlobClient(blobName);
   }
 
-  listBlobsFlat() {
+  listBlobsFlat({ prefix }: { prefix: string }) {
+    if (
+      this.containerName === 'delete_stale_files_success' ||
+      this.containerName === 'delete_stale_files_error'
+    ) {
+      return [{ name: `${prefix}stale_file.png` }];
+    }
     return [];
+  }
+
+  deleteBlob() {
+    if (this.containerName === 'delete_stale_files_error') {
+      throw new Error('Message');
+    }
   }
 }
 

--- a/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
+++ b/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
@@ -77,6 +77,10 @@ class GCSFile {
     });
     return readable;
   }
+
+  delete() {
+    return Promise.resolve();
+  }
 }
 
 class Bucket {
@@ -105,6 +109,9 @@ class Bucket {
   }
 
   file(destinationFilePath: string) {
+    if (this.bucketName === 'delete_stale_files_error') {
+      throw Error('Message');
+    }
     return new GCSFile(destinationFilePath);
   }
 
@@ -113,6 +120,12 @@ class Bucket {
     readable._read = () => {};
 
     process.nextTick(() => {
+      if (
+        this.bucketName === 'delete_stale_files_success' ||
+        this.bucketName === 'delete_stale_files_error'
+      ) {
+        readable.emit('data', { name: 'stale-file.png' });
+      }
       readable.emit('end');
     });
 

--- a/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
+++ b/packages/techdocs-common/__mocks__/@google-cloud/storage.ts
@@ -107,6 +107,17 @@ class Bucket {
   file(destinationFilePath: string) {
     return new GCSFile(destinationFilePath);
   }
+
+  getFilesStream() {
+    const readable = new Readable();
+    readable._read = () => {};
+
+    process.nextTick(() => {
+      readable.emit('end');
+    });
+
+    return readable;
+  }
 }
 
 export class Storage {

--- a/packages/techdocs-common/__mocks__/aws-sdk.ts
+++ b/packages/techdocs-common/__mocks__/aws-sdk.ts
@@ -105,10 +105,29 @@ export class S3 {
     };
   }
 
-  listObjectsV2() {
+  listObjectsV2({ Bucket }) {
     return {
       promise: () => {
-        return Promise.resolve([]);
+        if (
+          Bucket === 'delete_stale_files_success' ||
+          Bucket === 'delete_stale_files_error'
+        ) {
+          return Promise.resolve({
+            Contents: [{ Key: 'stale_file.png' }],
+          });
+        }
+        return Promise.resolve({});
+      },
+    };
+  }
+
+  deleteObject({ Bucket }) {
+    return {
+      promise: () => {
+        if (Bucket === 'delete_stale_files_error') {
+          throw new Error('Message');
+        }
+        return Promise.resolve();
       },
     };
   }

--- a/packages/techdocs-common/__mocks__/aws-sdk.ts
+++ b/packages/techdocs-common/__mocks__/aws-sdk.ts
@@ -104,6 +104,14 @@ export class S3 {
         }),
     };
   }
+
+  listObjectsV2() {
+    return {
+      promise: () => {
+        return Promise.resolve([]);
+      },
+    };
+  }
 }
 
 export default {

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -178,11 +178,18 @@ export class AwsS3Publish implements PublisherBase {
    * Directory structure used in the bucket is - entityNamespace/entityKind/entityName/index.html
    */
   async publish({ entity, directory }: PublishRequest): Promise<void> {
-    // First, retrieve a list of all individual files in currently existing
-    const remoteFolder = getCloudPathForLocalPath(entity);
-    const existingFiles = await this.getAllObjectsFromBucket({
-      prefix: remoteFolder,
-    });
+    // First, try to retrieve a list of all individual files currently existing
+    let existingFiles: string[] = [];
+    try {
+      const remoteFolder = getCloudPathForLocalPath(entity);
+      existingFiles = await this.getAllObjectsFromBucket({
+        prefix: remoteFolder,
+      });
+    } catch (e) {
+      this.logger.error(
+        `Unable to list files for Entity ${entity.metadata.name}: ${e.message}`,
+      );
+    }
 
     // Then, merge new files into the same folder
     let absoluteFilesToUpload;

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -16,7 +16,7 @@
 import { Entity, EntityName } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import aws, { Credentials } from 'aws-sdk';
-import { ListObjectsV2Output, ManagedUpload } from 'aws-sdk/clients/s3';
+import { ListObjectsV2Output } from 'aws-sdk/clients/s3';
 import { CredentialsOptions } from 'aws-sdk/lib/credentials';
 import express from 'express';
 import fs from 'fs-extra';

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
@@ -137,18 +137,18 @@ export class AzureBlobStoragePublish implements PublisherBase {
    * Directory structure used in the container is - entityNamespace/entityKind/entityName/index.html
    */
   async publish({ entity, directory }: PublishRequest): Promise<void> {
-    // First, retrieve a list of all individual files in currently existing
+    // First, try to retrieve a list of all individual files currently existing
     const remoteFolder = getCloudPathForLocalPath(entity);
-    let existingFiles: string[];
+    let existingFiles: string[] = [];
     try {
       existingFiles = await this.getAllBlobsFromContainer({
         prefix: remoteFolder,
         maxPageSize: BATCH_CONCURRENCY,
       });
     } catch (e) {
-      const errorMessage = `Unable to list file(s) to Azure. ${e}`;
-      this.logger.error(errorMessage);
-      throw new Error(errorMessage);
+      this.logger.error(
+        `Unable to list files for Entity ${entity.metadata.name}: ${e.message}`,
+      );
     }
 
     // Then, merge new files into the same folder
@@ -395,7 +395,7 @@ export class AzureBlobStoragePublish implements PublisherBase {
     let response = (await iterator.next()).value;
 
     do {
-      for (const blob of response.segment.blobItems) {
+      for (const blob of response?.segment?.blobItems ?? []) {
         blobs.push(blob.name);
       }
       iterator = container

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -117,9 +117,16 @@ export class GoogleGCSPublish implements PublisherBase {
   async publish({ entity, directory }: PublishRequest): Promise<void> {
     const bucket = this.storageClient.bucket(this.bucketName);
 
-    // First, retrieve a list of all individual files in currently existing
-    const remoteFolder = getCloudPathForLocalPath(entity);
-    const existingFiles = await this.getFilesForFolder(remoteFolder);
+    // First, try to retrieve a list of all individual files currently existing
+    let existingFiles: string[] = [];
+    try {
+      const remoteFolder = getCloudPathForLocalPath(entity);
+      existingFiles = await this.getFilesForFolder(remoteFolder);
+    } catch (e) {
+      this.logger.error(
+        `Unable to list files for Entity ${entity.metadata.name}: ${e.message}`,
+      );
+    }
 
     // Then, merge new files into the same folder
     let absoluteFilesToUpload;

--- a/packages/techdocs-common/src/stages/publish/googleStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.ts
@@ -15,18 +15,19 @@
  */
 import { Entity, EntityName } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import {
-  FileExistsResponse,
-  Storage,
-  UploadResponse,
-} from '@google-cloud/storage';
+import { FileExistsResponse, Storage } from '@google-cloud/storage';
 import express from 'express';
 import JSON5 from 'json5';
-import createLimiter from 'p-limit';
 import path from 'path';
 import { Readable } from 'stream';
 import { Logger } from 'winston';
-import { getFileTreeRecursively, getHeadersForFileExtension } from './helpers';
+import {
+  bulkStorageOperation,
+  getCloudPathForLocalPath,
+  getFileTreeRecursively,
+  getHeadersForFileExtension,
+  getStaleFiles,
+} from './helpers';
 import { MigrateWriteStream } from './migrations';
 import {
   PublisherBase,
@@ -114,48 +115,67 @@ export class GoogleGCSPublish implements PublisherBase {
    * Directory structure used in the bucket is - entityNamespace/entityKind/entityName/index.html
    */
   async publish({ entity, directory }: PublishRequest): Promise<void> {
+    const bucket = this.storageClient.bucket(this.bucketName);
+
+    // First, retrieve a list of all individual files in currently existing
+    const remoteFolder = getCloudPathForLocalPath(entity);
+    const existingFiles = (
+      await bucket.getFiles({ prefix: remoteFolder })
+    )[0].map(file => file.name);
+
+    // Then, merge new files into the same folder
+    let absoluteFilesToUpload;
     try {
-      // Note: GCS manages creation of parent directories if they do not exist.
-      // So collecting path of only the files is good enough.
-      const allFilesToUpload = await getFileTreeRecursively(directory);
+      // Remove the absolute path prefix of the source directory
+      // Path of all files to upload, relative to the root of the source directory
+      // e.g. ['index.html', 'sub-page/index.html', 'assets/images/favicon.png']
+      absoluteFilesToUpload = await getFileTreeRecursively(directory);
 
-      const limiter = createLimiter(10);
-      const uploadPromises: Array<Promise<UploadResponse>> = [];
-      allFilesToUpload.forEach(sourceFilePath => {
-        // Remove the absolute path prefix of the source directory
-        // Path of all files to upload, relative to the root of the source directory
-        // e.g. ['index.html', 'sub-page/index.html', 'assets/images/favicon.png']
-        const relativeFilePath = path.relative(directory, sourceFilePath);
-
-        // Convert destination file path to a POSIX path for uploading.
-        // GCS expects / as path separator and relativeFilePath will contain \\ on Windows.
-        // https://cloud.google.com/storage/docs/gsutil/addlhelp/HowSubdirectoriesWork
-        const relativeFilePathPosix = relativeFilePath
-          .split(path.sep)
-          .join(path.posix.sep);
-
-        // The / delimiter is intentional since it represents the cloud storage and not the local file system.
-        const entityRootDir = `${entity.metadata.namespace}/${entity.kind}/${entity.metadata.name}`;
-        const destination = `${entityRootDir}/${relativeFilePathPosix}`; // GCS Bucket file relative path
-
-        // Rate limit the concurrent execution of file uploads to batches of 10 (per publish)
-        const uploadFile = limiter(() =>
-          this.storageClient.bucket(this.bucketName).upload(sourceFilePath, {
-            destination,
-          }),
-        );
-        uploadPromises.push(uploadFile);
-      });
-
-      await Promise.all(uploadPromises);
+      await bulkStorageOperation(
+        async absoluteFilePath => {
+          const relativeFilePath = path.relative(directory, absoluteFilePath);
+          return await bucket.upload(absoluteFilePath, {
+            destination: getCloudPathForLocalPath(entity, relativeFilePath),
+          });
+        },
+        absoluteFilesToUpload,
+        { concurrencyLimit: 10 },
+      );
 
       this.logger.info(
-        `Successfully uploaded all the generated files for Entity ${entity.metadata.name}. Total number of files: ${allFilesToUpload.length}`,
+        `Successfully uploaded all the generated files for Entity ${entity.metadata.name}. Total number of files: ${absoluteFilesToUpload.length}`,
       );
     } catch (e) {
       const errorMessage = `Unable to upload file(s) to Google Cloud Storage. ${e}`;
       this.logger.error(errorMessage);
       throw new Error(errorMessage);
+    }
+
+    // Last, try to remove the files that were *only* present previously
+    try {
+      const relativeFilesToUpload = absoluteFilesToUpload.map(
+        absoluteFilePath =>
+          getCloudPathForLocalPath(
+            entity,
+            path.relative(directory, absoluteFilePath),
+          ),
+      );
+      const staleFiles = getStaleFiles(relativeFilesToUpload, existingFiles);
+
+      await bulkStorageOperation(
+        async relativeFilePath => {
+          return await bucket.file(relativeFilePath).delete();
+        },
+        staleFiles,
+        { concurrencyLimit: 10 },
+      );
+
+      this.logger.info(
+        `Successfully deleted stale files for Entity ${entity.metadata.name}. Total number of files: ${staleFiles.length}`,
+      );
+    } catch (error) {
+      const errorMessage = `Unable to delete file(s) from Google Cloud Storage. ${error}`;
+      this.logger.error(errorMessage);
     }
   }
 

--- a/packages/techdocs-common/src/stages/publish/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/publish/helpers.test.ts
@@ -17,6 +17,7 @@ import mockFs from 'mock-fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  getStaleFiles,
   getFileTreeRecursively,
   getHeadersForFileExtension,
   lowerCaseEntityTripletInStoragePath,
@@ -97,5 +98,29 @@ describe('lowerCaseEntityTripletInStoragePath', () => {
     expect(() =>
       lowerCaseEntityTripletInStoragePath(originalPath),
     ).toThrowError(error);
+  });
+});
+
+describe('getStaleFiles', () => {
+  const defaultFiles = [
+    'default/Component/backstage/index.html',
+    'default/Component/backstage/techdocs_metadata.json',
+    'default/Component/backstage/assests/javascripts/bundle.7f4f3c92.min.js',
+    'default/Component/backstage/assets/stylesheets/main.fe0cca5b.min.css',
+  ];
+
+  it('should return empty array if there is no stale file', () => {
+    const oldFiles = [...defaultFiles];
+    const newFiles = [...defaultFiles];
+    const staleFiles = getStaleFiles(newFiles, oldFiles);
+    expect(staleFiles).toHaveLength(0);
+  });
+
+  it('should return all stale files when they exists', () => {
+    const oldFiles = [...defaultFiles, 'stale_file.png'];
+    const newFiles = [...defaultFiles];
+    const staleFiles = getStaleFiles(newFiles, oldFiles);
+    expect(staleFiles).toHaveLength(1);
+    expect(staleFiles).toEqual(expect.arrayContaining(['stale_file.png']));
   });
 });

--- a/packages/techdocs-common/src/stages/publish/helpers.ts
+++ b/packages/techdocs-common/src/stages/publish/helpers.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Entity } from '@backstage/catalog-model';
+import { Entity, ENTITY_DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 import mime from 'mime-types';
 import path from 'path';
 import createLimiter from 'p-limit';
@@ -138,7 +138,9 @@ export const getCloudPathForLocalPath = (
   const relativeFilePathPosix = localPath.split(path.sep).join(path.posix.sep);
 
   // The / delimiter is intentional since it represents the cloud storage and not the local file system.
-  const entityRootDir = `${entity.metadata.namespace}/${entity.kind}/${entity.metadata.name}`;
+  const entityRootDir = `${
+    entity.metadata?.namespace ?? ENTITY_DEFAULT_NAMESPACE
+  }/${entity.kind}/${entity.metadata.name}`;
   return `${entityRootDir}/${relativeFilePathPosix}`; // GCS Bucket file relative path
 };
 

--- a/packages/techdocs-common/src/stages/publish/helpers.ts
+++ b/packages/techdocs-common/src/stages/publish/helpers.ts
@@ -113,14 +113,21 @@ export const lowerCaseEntityTripletInStoragePath = (
   const lowerKind = kind.toLowerCase();
   const lowerName = name.toLowerCase();
   return [lowerNamespace, lowerKind, lowerName, ...parts].join('/');
-}
+};
 
 // Only returns the files that existed previously and are not present anymore.
 export const getStaleFiles = (
   newFiles: string[],
   oldFiles: string[],
+  remoteFolder?: string,
 ): string[] => {
-  const staleFiles = new Set(oldFiles);
+  let filteredFiles = [...oldFiles];
+  if (remoteFolder) {
+    filteredFiles = filteredFiles.filter(filePath =>
+      filePath.match(remoteFolder),
+    );
+  }
+  const staleFiles = new Set(filteredFiles);
   newFiles.forEach(newFile => {
     staleFiles.delete(newFile);
   });

--- a/packages/techdocs-common/src/stages/publish/helpers.ts
+++ b/packages/techdocs-common/src/stages/publish/helpers.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Entity } from '@backstage/catalog-model';
 import mime from 'mime-types';
+import path from 'path';
+import createLimiter from 'p-limit';
 import recursiveReadDir from 'recursive-readdir';
 
 /**
@@ -110,4 +113,41 @@ export const lowerCaseEntityTripletInStoragePath = (
   const lowerKind = kind.toLowerCase();
   const lowerName = name.toLowerCase();
   return [lowerNamespace, lowerKind, lowerName, ...parts].join('/');
+}
+
+// Only returns the files that existed previously and are not present anymore.
+export const getStaleFiles = (
+  newFiles: string[],
+  oldFiles: string[],
+): string[] => {
+  const staleFiles = new Set(oldFiles);
+  newFiles.forEach(newFile => {
+    staleFiles.delete(newFile);
+  });
+  return Array.from(staleFiles);
+};
+
+// Compose actual filename on remote bucket including entity information
+export const getCloudPathForLocalPath = (
+  entity: Entity,
+  localPath = '',
+): string => {
+  // Convert destination file path to a POSIX path for uploading.
+  // GCS expects / as path separator and relativeFilePath will contain \\ on Windows.
+  // https://cloud.google.com/storage/docs/gsutil/addlhelp/HowSubdirectoriesWork
+  const relativeFilePathPosix = localPath.split(path.sep).join(path.posix.sep);
+
+  // The / delimiter is intentional since it represents the cloud storage and not the local file system.
+  const entityRootDir = `${entity.metadata.namespace}/${entity.kind}/${entity.metadata.name}`;
+  return `${entityRootDir}/${relativeFilePathPosix}`; // GCS Bucket file relative path
+};
+
+// Perform rate limited generic operations by passing a function and a list of arguments
+export const bulkStorageOperation = async <T>(
+  operation: (arg: T) => Promise<unknown>,
+  args: T[],
+  { concurrencyLimit } = { concurrencyLimit: 25 },
+) => {
+  const limiter = createLimiter(concurrencyLimit);
+  await Promise.all(args.map(arg => limiter(operation, arg)));
 };

--- a/packages/techdocs-common/src/stages/publish/helpers.ts
+++ b/packages/techdocs-common/src/stages/publish/helpers.ts
@@ -119,15 +119,8 @@ export const lowerCaseEntityTripletInStoragePath = (
 export const getStaleFiles = (
   newFiles: string[],
   oldFiles: string[],
-  remoteFolder?: string,
 ): string[] => {
-  let filteredFiles = [...oldFiles];
-  if (remoteFolder) {
-    filteredFiles = filteredFiles.filter(filePath =>
-      filePath.match(remoteFolder),
-    );
-  }
-  const staleFiles = new Set(filteredFiles);
+  const staleFiles = new Set(oldFiles);
   newFiles.forEach(newFile => {
     staleFiles.delete(newFile);
   });


### PR DESCRIPTION
## 🧹  What / Why

This updates three publishers (GCS, AWS, Azure) in TechDocs common so that they delete stale files from storage during publish.  Prior to this, generated files based on deleted markdown would stick around in storage indefinitely. Same with images/assets/etc.

Closes #6132 

## How to Test

1. Generate a TechDocs site at least once that publishes to one of the updated storage providers.
2. Upload a file manually underneath the folder containing the generated docs that wasn't there previously
3. Re-generate the TechDocs site in order to re-trigger the publish.

You should see logs in your backend that indicate 1 stale file was deleted (and the file should be gone from storage).

![image](https://user-images.githubusercontent.com/6290749/128039322-dc7b43c9-1188-432e-98ce-f20d367e42d9.png)

## FYI
- We refactored some of the bulk storage operations into a helper in order to share concurrency/limiting logic.
- Listing files within a bucket under a folder is not a first-class operation in all storage providers, so we abstracted away some of this logic into helper methods on the publisher classes.
- We should consider refactoring the test/mock situation for these publishers sometime later.......

---

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
