### PR TITLE
Make GraphiQLIcon compatible with latest core-api version

### DIFF
--- a/.changeset/metal-schools-dream.md
+++ b/.changeset/metal-schools-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-graphiql': patch
+---
+
+Migrated GraphiQLIcon to use `@backstage/core-api` rather than `@backstage/core-plugin-api`

--- a/plugins/graphiql/src/index.ts
+++ b/plugins/graphiql/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import GraphiQLIconComponent from './assets/graphiql.icon.svg';
-import { IconComponent } from '@backstage/core-plugin-api';
+import { IconComponent } from '@backstage/core-api';
 
 export {
   graphiqlPlugin,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When trying to use GraphiQLIcon in the sidebar with the latest backstage core components version, an error is thrown:

```
packages/app/src/components/Root/Root.tsx:89:20 - error TS2322: Type 'import("/Users/renatotodorov/Projects/backstage/node_modules/@backstage/core-plugin-api/dist/index").IconComponent' is not assignable to type 'import("/Users/renatotodorov/Projects/backstage/node_modules/@backstage/core-api/dist/index").IconComponent'.
  Type 'ComponentClass<{ fontSize?: "small" | "default" | "large" | undefined; }, any>' is not assignable to type 'IconComponent'.
    Type 'ComponentClass<{ fontSize?: "small" | "default" | "large" | undefined; }, any>' is not assignable to type 'ComponentClass<SvgIconProps<"svg", {}>, any>'.
      Types of property 'getDerivedStateFromProps' are incompatible.
        Type 'GetDerivedStateFromProps<{ fontSize?: "small" | "default" | "large" | undefined; }, any> | undefined' is not assignable to type 'GetDerivedStateFromProps<SvgIconProps<"svg", {}>, any> | undefined'.
          Type 'GetDerivedStateFromProps<{ fontSize?: "small" | "default" | "large" | undefined; }, any>' is not assignable to type 'GetDerivedStateFromProps<SvgIconProps<"svg", {}>, any>'.
            Types of parameters 'nextProps' and 'nextProps' are incompatible.
              Type 'Readonly<SvgIconProps<"svg", {}>>' is not assignable to type 'Readonly<{ fontSize?: "small" | "default" | "large" | undefined; }>'.
                Types of property 'fontSize' are incompatible.
                  Type '"small" | "inherit" | "default" | "large" | undefined' is not assignable to type '"small" | "default" | "large" | undefined'.

89       <SidebarItem icon={GraphiQLIcon} to="graphiql" text="GraphQL Explorer" />
                      ~~~~

  node_modules/@backstage/core/dist/index.d.ts:776:5
    776     icon: IconComponent;
            ~~~~
    The expected type comes from property 'icon' which is declared here on type 'IntrinsicAttributes & (SidebarItemProps & RefAttributes<any>)'
```

This PR fixes the issue by importing `IconComponent` from the expected library.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
