### PR TITLE
Add @types/react to dependencies generated by the backstage CLI 'create-plugin' command

### DIFF
--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -32,8 +32,7 @@
     "@material-ui/lab": "4.0.0-alpha.45",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-use": "^17.2.4",
-    "@types/react": "^16.9"
+    "react-use": "^17.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "^{{version '@backstage/cli'}}",
@@ -45,6 +44,7 @@
     "@testing-library/user-event": "^13.1.8",
     "@types/jest": "^26.0.7",
     "@types/node": "^14.14.32",
+    "@types/react": "^16.9",
     "msw": "^0.29.0",
     "cross-fetch": "^3.0.6"
   },

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -32,7 +32,8 @@
     "@material-ui/lab": "4.0.0-alpha.45",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-use": "^17.2.4"
+    "react-use": "^17.2.4",
+    "@types/react": "^16.9"
   },
   "devDependencies": {
     "@backstage/cli": "^{{version '@backstage/cli'}}",


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR updates the `create-plugin` command in the backstage CLI such that @types/react v. 16.9 is included as a dependency in the generated `package.json`.

Fixes #6508

#### :heavy_check_mark: Checklist
- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
