### PR TITLE
chore(catalog): export CatalogClientWrapper class

### DIFF
--- a/.changeset/clever-pigs-drum.md
+++ b/.changeset/clever-pigs-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Export `CatalogRequestOptions` type

--- a/.changeset/nasty-worms-approve.md
+++ b/.changeset/nasty-worms-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Export `CatalogClientWrapper` class

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -34,8 +34,6 @@ export interface CatalogApi {
     location: AddLocationRequest,
     options?: CatalogRequestOptions,
   ): Promise<AddLocationResponse>;
-  // Warning: (ae-forgotten-export) The symbol "CatalogRequestOptions" needs to be exported by the entry point index.d.ts
-  //
   // (undocumented)
   getEntities(
     request?: CatalogEntitiesRequest,
@@ -136,6 +134,13 @@ export type CatalogEntitiesRequest = {
 // @public (undocumented)
 export type CatalogListResponse<T> = {
   items: T[];
+};
+
+// Warning: (ae-missing-release-tag) "CatalogRequestOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CatalogRequestOptions = {
+  token?: string;
 };
 
 // Warning: (ae-missing-release-tag) "ENTITY_STATUS_CATALOG_PROCESSING_TYPE" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/catalog-client/src/types/index.ts
+++ b/packages/catalog-client/src/types/index.ts
@@ -20,5 +20,6 @@ export type {
   CatalogApi,
   CatalogEntitiesRequest,
   CatalogListResponse,
+  CatalogRequestOptions,
 } from './api';
 export { ENTITY_STATUS_CATALOG_PROCESSING_TYPE } from './status';

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -5,12 +5,21 @@
 ```ts
 /// <reference types="react" />
 
+import { AddLocationRequest } from '@backstage/catalog-client';
+import { AddLocationResponse } from '@backstage/catalog-client';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { CatalogApi } from '@backstage/catalog-client';
+import { CatalogClient } from '@backstage/catalog-client';
+import { CatalogEntitiesRequest } from '@backstage/catalog-client';
+import { CatalogListResponse } from '@backstage/catalog-client';
+import { CatalogRequestOptions } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import { EntityName } from '@backstage/catalog-model';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
+import { IdentityApi } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
+import { Location as Location_2 } from '@backstage/catalog-model';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
@@ -42,6 +51,53 @@ export const AboutField: ({
   gridSizes,
   children,
 }: Props_3) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "CatalogClientWrapper" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export class CatalogClientWrapper implements CatalogApi {
+  constructor(options: { client: CatalogClient; identityApi: IdentityApi });
+  // (undocumented)
+  addLocation(
+    request: AddLocationRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<AddLocationResponse>;
+  // (undocumented)
+  getEntities(
+    request?: CatalogEntitiesRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<CatalogListResponse<Entity>>;
+  // (undocumented)
+  getEntityByName(
+    compoundName: EntityName,
+    options?: CatalogRequestOptions,
+  ): Promise<Entity | undefined>;
+  // (undocumented)
+  getLocationByEntity(
+    entity: Entity,
+    options?: CatalogRequestOptions,
+  ): Promise<Location_2 | undefined>;
+  // (undocumented)
+  getLocationById(
+    id: string,
+    options?: CatalogRequestOptions,
+  ): Promise<Location_2 | undefined>;
+  // (undocumented)
+  getOriginLocationByEntity(
+    entity: Entity,
+    options?: CatalogRequestOptions,
+  ): Promise<Location_2 | undefined>;
+  // (undocumented)
+  removeEntityByUid(
+    uid: string,
+    options?: CatalogRequestOptions,
+  ): Promise<void>;
+  // (undocumented)
+  removeLocationById(
+    id: string,
+    options?: CatalogRequestOptions,
+  ): Promise<void>;
+}
 
 // Warning: (ae-missing-release-tag) "CatalogEntityPage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/catalog/src/CatalogClientWrapper.ts
+++ b/plugins/catalog/src/CatalogClientWrapper.ts
@@ -19,15 +19,12 @@ import {
   AddLocationRequest,
   AddLocationResponse,
   CatalogApi,
+  CatalogClient,
   CatalogEntitiesRequest,
   CatalogListResponse,
-  CatalogClient,
+  CatalogRequestOptions,
 } from '@backstage/catalog-client';
 import { IdentityApi } from '@backstage/core-plugin-api';
-
-type CatalogRequestOptions = {
-  token?: string;
-};
 
 /**
  * CatalogClient wrapper that injects identity token for all requests

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from './components/AboutCard';
+export { CatalogClientWrapper } from './CatalogClientWrapper';
 export { CatalogLayout } from './components/CatalogPage';
 export { CatalogResultListItem } from './components/CatalogResultListItem';
 export { CatalogTable } from './components/CatalogTable';


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Export `CatalogClientWrapper` class to allow for overriding/extending default `catalogApiRef`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
