### PR TITLE
Fix hitbox of sidebar search input

### DIFF
--- a/.changeset/chilled-cars-cough.md
+++ b/.changeset/chilled-cars-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Increase the vertical padding of the sidebar search input field to match the height of the parent anchor tag. This prevents users from accidentally navigating to the search page when they actually wanted to use the search input directly.

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -44,7 +44,6 @@ const useStyles = makeStyles<BackstageTheme>(theme => {
     drawerWidthOpen,
     iconContainerWidth,
   } = sidebarConfig;
-
   return {
     root: {
       color: theme.palette.navigation.color,
@@ -98,7 +97,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => {
       fontSize: theme.typography.fontSize,
     },
     searchFieldHTMLInput: {
-      padding: '15px 0 17px',
+      padding: `${theme.spacing(2)} 0 ${theme.spacing(2)}`,
     },
     searchContainer: {
       width: drawerWidthOpen - iconContainerWidth,

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -97,6 +97,9 @@ const useStyles = makeStyles<BackstageTheme>(theme => {
       fontWeight: 'bold',
       fontSize: theme.typography.fontSize,
     },
+    searchFieldHTMLInput: {
+      padding: '15px 0 17px',
+    },
     searchContainer: {
       width: drawerWidthOpen - iconContainerWidth,
     },
@@ -270,6 +273,9 @@ export const SidebarSearchField = (props: SidebarSearchFieldProps) => {
           InputProps={{
             disableUnderline: true,
             className: classes.searchField,
+          }}
+          inputProps={{
+            className: classes.searchFieldHTMLInput,
           }}
         />
       </SidebarItem>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
     
Increase the vertical padding of the sidebar search input field to match the height of the parent anchor tag. This prevents users from accidentally navigating to the search page when they actually wanted to use the search input directly.

Fixes #6529

Before:

https://user-images.githubusercontent.com/24435169/126139192-23bea8a5-f33d-46d3-8cbc-dbc771bcbca8.mp4

After:

https://user-images.githubusercontent.com/24435169/126139223-24ba8fba-2f09-4e04-92b9-1536bdeb4af6.mp4

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
