### PR TITLE
Implement the etag functionality in the `readUrl` method of `FetchUrlReader`

### DIFF
--- a/.changeset/friendly-tips-jam.md
+++ b/.changeset/friendly-tips-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Implement the etag functionality in the `readUrl` method of `FetchUrlReader`.

--- a/packages/backend-common/src/reading/FetchUrlReader.test.ts
+++ b/packages/backend-common/src/reading/FetchUrlReader.test.ts
@@ -15,11 +15,15 @@
  */
 
 import { ConfigReader } from '@backstage/config';
+import { NotFoundError, NotModifiedError } from '@backstage/errors';
 import { msw } from '@backstage/test-utils';
+import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { getVoidLogger } from '../logging';
 import { FetchUrlReader } from './FetchUrlReader';
 import { DefaultReadTreeResponseFactory } from './tree';
+
+const fetchUrlReader = new FetchUrlReader();
 
 describe('FetchUrlReader', () => {
   const worker = setupServer();
@@ -28,6 +32,39 @@ describe('FetchUrlReader', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    worker.use(
+      rest.get('https://backstage.io/some-resource', (req, res, ctx) => {
+        if (req.headers.get('if-none-match') === 'foo') {
+          return res(
+            ctx.status(304),
+            ctx.set('Content-Type', 'text/plain'),
+            ctx.set('etag', 'foo'),
+          );
+        }
+
+        return res(
+          ctx.status(200),
+          ctx.set('Content-Type', 'text/plain'),
+          ctx.set('etag', 'foo'),
+          ctx.body('content foo'),
+        );
+      }),
+    );
+
+    worker.use(
+      rest.get('https://backstage.io/not-exists', (_req, res, ctx) => {
+        return res(ctx.status(404));
+      }),
+    );
+
+    worker.use(
+      rest.get('https://backstage.io/error', (_req, res, ctx) => {
+        return res(ctx.status(500), ctx.body('An internal error occured'));
+      }),
+    );
   });
 
   it('factory should create a single entry with a predicate that matches config', async () => {
@@ -69,5 +106,56 @@ describe('FetchUrlReader', () => {
     expect(predicate(new URL('https://examples.org:700/test'))).toBe(false);
     expect(predicate(new URL('https://a.examples.org:700/test'))).toBe(true);
     expect(predicate(new URL('https://a.b.examples.org:700/test'))).toBe(true);
+  });
+
+  describe('read', () => {
+    it('should return etag from the response', async () => {
+      const buffer = await fetchUrlReader.read(
+        'https://backstage.io/some-resource',
+      );
+      expect(buffer.toString()).toBe('content foo');
+    });
+
+    it('should throw NotFound if server responds with 404', async () => {
+      await expect(
+        fetchUrlReader.read('https://backstage.io/not-exists'),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('should throw Error if server responds with 500', async () => {
+      await expect(
+        fetchUrlReader.read('https://backstage.io/error'),
+      ).rejects.toThrow(Error);
+    });
+  });
+
+  describe('readUrl', () => {
+    it('should throw NotModified if server responds with 304', async () => {
+      await expect(
+        fetchUrlReader.readUrl('https://backstage.io/some-resource', {
+          etag: 'foo',
+        }),
+      ).rejects.toThrow(NotModifiedError);
+    });
+
+    it('should return etag from the response', async () => {
+      const response = await fetchUrlReader.readUrl(
+        'https://backstage.io/some-resource',
+      );
+      expect(response.etag).toBe('foo');
+      expect((await response.buffer()).toString()).toEqual('content foo');
+    });
+
+    it('should throw NotFound if server responds with 404', async () => {
+      await expect(
+        fetchUrlReader.readUrl('https://backstage.io/not-exists'),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('should throw Error if server responds with 500', async () => {
+      await expect(
+        fetchUrlReader.readUrl('https://backstage.io/error'),
+      ).rejects.toThrow(Error);
+    });
   });
 });

--- a/packages/backend-common/src/reading/FetchUrlReader.ts
+++ b/packages/backend-common/src/reading/FetchUrlReader.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import { NotFoundError, NotModifiedError } from '@backstage/errors';
 import fetch from 'cross-fetch';
-import { NotFoundError } from '@backstage/errors';
 import {
   ReaderFactory,
   ReadTreeResponse,
@@ -57,15 +57,34 @@ export class FetchUrlReader implements UrlReader {
   };
 
   async read(url: string): Promise<Buffer> {
+    const response = await this.readUrl(url);
+    return response.buffer();
+  }
+
+  async readUrl(
+    url: string,
+    options?: ReadUrlOptions,
+  ): Promise<ReadUrlResponse> {
     let response: Response;
     try {
-      response = await fetch(url);
+      response = await fetch(url, {
+        headers: {
+          ...(options?.etag && { 'If-None-Match': options.etag }),
+        },
+      });
     } catch (e) {
       throw new Error(`Unable to read ${url}, ${e}`);
     }
 
+    if (response.status === 304) {
+      throw new NotModifiedError();
+    }
+
     if (response.ok) {
-      return Buffer.from(await response.text());
+      return {
+        buffer: async () => Buffer.from(await response.text()),
+        etag: response.headers.get('ETag') ?? undefined,
+      };
     }
 
     const message = `could not read ${url}, ${response.status} ${response.statusText}`;
@@ -73,15 +92,6 @@ export class FetchUrlReader implements UrlReader {
       throw new NotFoundError(message);
     }
     throw new Error(message);
-  }
-
-  async readUrl(
-    url: string,
-    _options?: ReadUrlOptions,
-  ): Promise<ReadUrlResponse> {
-    // TODO etag is not implemented yet.
-    const buffer = await this.read(url);
-    return { buffer: async () => buffer };
   }
 
   async readTree(): Promise<ReadTreeResponse> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow up of https://github.com/backstage/backstage/pull/6305 to add the caching logic to the `FetchUrlReader`. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
