### PR TITLE
Adds configuration for request logging handler when creating the backend express app

### DIFF
--- a/.changeset/fuzzy-pots-whisper.md
+++ b/.changeset/fuzzy-pots-whisper.md
@@ -1,0 +1,15 @@
+---
+'@backstage/backend-common': patch
+---
+
+It's possible to customize the request logging handler when building the service. For example in your `backend`
+
+```
+  const service = createServiceBuilder(module)
+    .loadConfig(config)
+    .setRequestLoggingHandler((logger?: Logger): RequestHandler => {
+      const actualLogger = (logger || getRootLogger()).child({
+        type: 'incomingRequest',
+      });
+      return expressWinston.logger({ ...
+```

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -439,6 +439,13 @@ export type ReadTreeResponseFile = {
 // @public
 export function requestLoggingHandler(logger?: Logger_2): RequestHandler;
 
+// Warning: (ae-missing-release-tag) "RequestLoggingHandlerFactory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type RequestLoggingHandlerFactory = (
+  logger?: Logger_2,
+) => RequestHandler;
+
 // Warning: (ae-missing-release-tag) "resolvePackagePath" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -492,6 +499,9 @@ export type ServiceBuilder = {
   enableCors(options: cors.CorsOptions): ServiceBuilder;
   setHttpsSettings(settings: HttpsSettings): ServiceBuilder;
   addRouter(root: string, router: Router | RequestHandler): ServiceBuilder;
+  setRequestLoggingHandler(
+    requestLoggingHandler: RequestLoggingHandlerFactory,
+  ): ServiceBuilder;
   start(): Promise<Server>;
 };
 
@@ -593,6 +603,7 @@ export function useHotMemoize<T>(_module: NodeModule, valueFactory: () => T): T;
 // src/service/types.d.ts:57:5 - (ae-forgotten-export) The symbol "HttpsSettings" needs to be exported by the entry point index.d.ts
 // src/service/types.d.ts:61:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/service/types.d.ts:62:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+// src/service/types.d.ts:70:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/packages/backend-common/src/service/index.ts
+++ b/packages/backend-common/src/service/index.ts
@@ -16,4 +16,4 @@
 
 export { createServiceBuilder } from './createServiceBuilder';
 export { createStatusCheckRouter } from './createStatusCheckRouter';
-export type { ServiceBuilder } from './types';
+export type { ServiceBuilder, RequestLoggingHandlerFactory } from './types';

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -27,9 +27,9 @@ import { getRootLogger } from '../../logging';
 import {
   errorHandler,
   notFoundHandler,
-  requestLoggingHandler,
+  requestLoggingHandler as defaultRequestLoggingHandler,
 } from '../../middleware';
-import { ServiceBuilder } from '../types';
+import { RequestLoggingHandlerFactory, ServiceBuilder } from '../types';
 import {
   CspOptions,
   HttpsSettings,
@@ -65,6 +65,7 @@ export class ServiceBuilderImpl implements ServiceBuilder {
   private cspOptions: Record<string, string[] | false> | undefined;
   private httpsSettings: HttpsSettings | undefined;
   private routers: [string, Router][];
+  private requestLoggingHandler: RequestLoggingHandlerFactory | undefined;
   // Reference to the module where builder is created - needed for hot module
   // reloading
   private module: NodeModule;
@@ -144,6 +145,13 @@ export class ServiceBuilderImpl implements ServiceBuilder {
     return this;
   }
 
+  setRequestLoggingHandler(
+    requestLoggingHandler: RequestLoggingHandlerFactory,
+  ) {
+    this.requestLoggingHandler = requestLoggingHandler;
+    return this;
+  }
+
   async start(): Promise<http.Server> {
     const app = express();
     const {
@@ -160,7 +168,9 @@ export class ServiceBuilderImpl implements ServiceBuilder {
       app.use(cors(corsOptions));
     }
     app.use(compression());
-    app.use(requestLoggingHandler(logger));
+    app.use(
+      (this.requestLoggingHandler ?? defaultRequestLoggingHandler)(logger),
+    );
     for (const [root, route] of this.routers) {
       app.use(root, route);
     }

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -86,7 +86,20 @@ export type ServiceBuilder = {
   addRouter(root: string, router: Router | RequestHandler): ServiceBuilder;
 
   /**
+   * Set the request logging handler
+   *
+   * If no handler is given the default one is used
+   *
+   * @param requestLoggingHandler a factory function that given a logger returns an handler
+   */
+  setRequestLoggingHandler(
+    requestLoggingHandler: RequestLoggingHandlerFactory,
+  ): ServiceBuilder;
+
+  /**
    * Starts the server using the given settings.
    */
   start(): Promise<Server>;
 };
+
+export type RequestLoggingHandlerFactory = (logger?: Logger) => RequestHandler;


### PR DESCRIPTION
Our company policy require us to logs the value of an header that we use to correlate requests. This change allow us to use a custom request logging handler that extracts the header value and add it to the logs (in the meta, so it would be easily parsable in json).

I evaluated adding an option to customize the morgan format but I think that it would not be flexible enough for our case (adding metadata to the logs instead of just changing the message).

Signed-off-by: Carlo Colombo <carlo.colombo@klarna.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
