### PR TITLE
techdocs: add a direct docs link with the warning about techdocs.generate

### DIFF
--- a/.changeset/techdocs-proud-apples-wonder.md
+++ b/.changeset/techdocs-proud-apples-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Add link to https://backstage.io/docs/features/techdocs/configuration in the log warning message about updating techdocs.generate key.

--- a/packages/techdocs-common/src/stages/generate/techdocs.test.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.test.ts
@@ -132,7 +132,8 @@ describe('readGeneratorConfig', () => {
         runIn: 'local',
       });
       expect(logger.warn).toHaveBeenCalledWith(
-        `The 'techdocs.generators.techdocs' configuration key is deprecated and will be removed in the future. Please use 'techdocs.generator' instead.`,
+        `The 'techdocs.generators.techdocs' configuration key is deprecated and will be removed in the future. Please use 'techdocs.generator' instead. ` +
+          `See here https://backstage.io/docs/features/techdocs/configuration`,
       );
     });
   });

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -168,7 +168,8 @@ export function readGeneratorConfig(
 
   if (legacyGeneratorType) {
     logger.warn(
-      `The 'techdocs.generators.techdocs' configuration key is deprecated and will be removed in the future. Please use 'techdocs.generator' instead.`,
+      `The 'techdocs.generators.techdocs' configuration key is deprecated and will be removed in the future. Please use 'techdocs.generator' instead. ` +
+        `See here https://backstage.io/docs/features/techdocs/configuration`,
     );
   }
 


### PR DESCRIPTION
Users should be able to read more about how to address the warning, from the console itself.