### PR TITLE
Improve user settings design

### DIFF
--- a/.changeset/late-taxis-smile.md
+++ b/.changeset/late-taxis-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Aligns switch left and allows clicking on rows

--- a/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
@@ -17,8 +17,10 @@
 import React from 'react';
 import {
   ListItem,
+  Divider,
   ListItemSecondaryAction,
   ListItemText,
+  ListItemIcon,
   Switch,
   Tooltip,
 } from '@material-ui/core';
@@ -31,20 +33,22 @@ type Props = {
 };
 
 export const FlagItem = ({ flag, enabled, toggleHandler }: Props) => (
-  <ListItem>
-    <ListItemText
-      primary={flag.name}
-      secondary={`Registered in ${flag.pluginId} plugin`}
-    />
-    <ListItemSecondaryAction>
-      <Tooltip placement="top" arrow title={enabled ? 'Disable' : 'Enable'}>
-        <Switch
-          color="primary"
-          checked={enabled}
-          onChange={() => toggleHandler(flag.name)}
-          name={flag.name}
-        />
-      </Tooltip>
-    </ListItemSecondaryAction>
-  </ListItem>
+  <>
+    <ListItem divider button onClick={() => toggleHandler(flag.name)}>
+      <ListItemIcon>
+        <Tooltip placement="top" arrow title={enabled ? 'Disable' : 'Enable'}>
+          <Switch
+            color="primary"
+            checked={enabled}
+            onChange={() => toggleHandler(flag.name)}
+            name={flag.name}
+          />
+        </Tooltip>
+      </ListItemIcon>
+      <ListItemText
+        primary={flag.name}
+        secondary={`Registered in ${flag.pluginId} plugin`}
+      />
+    </ListItem>
+  </>
 );

--- a/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
@@ -31,17 +31,15 @@ type Props = {
 };
 
 export const FlagItem = ({ flag, enabled, toggleHandler }: Props) => (
-  <>
-    <ListItem divider button onClick={() => toggleHandler(flag.name)}>
-      <ListItemIcon>
-        <Tooltip placement="top" arrow title={enabled ? 'Disable' : 'Enable'}>
-          <Switch color="primary" checked={enabled} name={flag.name} />
-        </Tooltip>
-      </ListItemIcon>
-      <ListItemText
-        primary={flag.name}
-        secondary={`Registered in ${flag.pluginId} plugin`}
-      />
-    </ListItem>
-  </>
+  <ListItem divider button onClick={() => toggleHandler(flag.name)}>
+    <ListItemIcon>
+      <Tooltip placement="top" arrow title={enabled ? 'Disable' : 'Enable'}>
+        <Switch color="primary" checked={enabled} name={flag.name} />
+      </Tooltip>
+    </ListItemIcon>
+    <ListItemText
+      primary={flag.name}
+      secondary={`Registered in ${flag.pluginId} plugin`}
+    />
+  </ListItem>
 );

--- a/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
@@ -17,8 +17,6 @@
 import React from 'react';
 import {
   ListItem,
-  Divider,
-  ListItemSecondaryAction,
   ListItemText,
   ListItemIcon,
   Switch,

--- a/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/FeatureFlagsItem.tsx
@@ -37,12 +37,7 @@ export const FlagItem = ({ flag, enabled, toggleHandler }: Props) => (
     <ListItem divider button onClick={() => toggleHandler(flag.name)}>
       <ListItemIcon>
         <Tooltip placement="top" arrow title={enabled ? 'Disable' : 'Enable'}>
-          <Switch
-            color="primary"
-            checked={enabled}
-            onChange={() => toggleHandler(flag.name)}
-            name={flag.name}
-          />
+          <Switch color="primary" checked={enabled} name={flag.name} />
         </Tooltip>
       </ListItemIcon>
       <ListItemText


### PR DESCRIPTION
I was annoyed by how hard it was to find which switch related to which item in the feature flags list. Maybe I have bad spacial coordination, or bad vision. But maybe the UX was just bad. Anyways, my suggestion here is 1) align the sliders left, since we're mainly working on desktops 2) make the rows buttonish (hover changes color) 3) adds a little divider per line 4) allows clicking on row.

Before:
<img width="1699" alt="Screenshot 2021-07-21 at 16 32 49" src="https://user-images.githubusercontent.com/308196/126509401-adc120e6-ffd2-47ea-b7f5-669fb7dd292e.png">

After:
<img width="1704" alt="Screenshot 2021-07-21 at 16 43 14" src="https://user-images.githubusercontent.com/308196/126509413-8fe9d603-00b3-4cd2-8d65-c1c79b098966.png">
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
