### PR TITLE
Remove Python requirement from docs

### DIFF
--- a/docs/features/software-templates/configuration.md
+++ b/docs/features/software-templates/configuration.md
@@ -33,9 +33,12 @@ scaffolder:
 
 ### Disabling Docker in Docker situation (Optional)
 
-Software Templates use
-[Cookiecutter](https://github.com/cookiecutter/cookiecutter) as a templating
-library. By default it will use the
+Software templates use the `fetch:template` action by default, which requires no
+external dependencies and offers a
+[Cookiecutter-compatible mode](https://backstage.io/docs/features/software-templates/builtin-actions#using-cookiecuttercompat-mode).
+There is also a `fetch:cookiecutter` action, which uses
+[Cookiecutter](https://github.com/cookiecutter/cookiecutter) directly for
+templating. By default, the `fetch:cookiecutter` action will use the
 [scaffolder-backend/Cookiecutter](https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/scripts/Cookiecutter.dockerfile)
 docker image.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -24,11 +24,9 @@ an easier path to make Pull Requests.
 Backstage provides the `@backstage/create-app` package to scaffold standalone
 instances of Backstage. You will need to have
 [Node.js](https://nodejs.org/en/download/) Active LTS Release installed
-(currently v14), [Yarn](https://classic.yarnpkg.com/en/docs/install) and
-[Python](https://www.python.org/downloads/) (although you likely have it
-already). You will also need to have
-[Docker](https://docs.docker.com/engine/install/) installed to use some features
-like Software Templates and TechDocs.
+(currently v14) and [Yarn](https://classic.yarnpkg.com/en/docs/install). You
+will also need to have [Docker](https://docs.docker.com/engine/install/)
+installed to use some features like Software Templates and TechDocs.
 
 Using `npx` you can then run the following to create an app in a chosen
 subdirectory of your current working directory:


### PR DESCRIPTION
Updating docs now that the `fetch:template` action is the default; Python should no longer be required?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
