### PR TITLE
Fix url reference in documentation

### DIFF
--- a/contrib/docs/tutorials/aws-deployment.md
+++ b/contrib/docs/tutorials/aws-deployment.md
@@ -5,7 +5,7 @@ image](https://backstage.io/docs/getting-started/deployment-docker); this
 tutorial shows how to deploy that Docker image to AWS using Elastic Container
 Registry (ECR) and Elastic Kubernetes Service (EKS). Amazon also supports
 deployments with Helm, covered in the [Helm
-Kubernetes](../kubernetes/basic_kubernetes_example_with_helm) example.
+Kubernetes](../../kubernetes/basic_kubernetes_example_with_helm) example.
 
 The basic workflow for this method is to build a Backstage Docker image, upload
 the new version to a container registry, and update a Kubernetes deployment with


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Reference to the `Helm Kubernetes` documentation needs to go one level deeper. This is a simple change to fix the broken link.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
