### PR TITLE
Kubernetes: Make objectTypes configurable from app-config.yaml

### DIFF
--- a/.changeset/purple-comics-fold.md
+++ b/.changeset/purple-comics-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Add configuration option to the kubernetes object types. Config option is under `kubernetes.resources`. Defaults to ['pods', 'services', 'configmaps', 'deployments', 'replicasets', 'horizontalpodautoscalers', 'ingresses']

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -51,6 +51,11 @@ export interface CustomResource {
   plural: string;
 }
 
+// Warning: (ae-missing-release-tag) "DEFAULT_OBJECTS" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const DEFAULT_OBJECTS: KubernetesObjectTypes[];
+
 // Warning: (ae-missing-release-tag) "FetchResponseWrapper" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/plugins/kubernetes-backend/schema.d.ts
+++ b/plugins/kubernetes-backend/schema.d.ts
@@ -16,6 +16,15 @@
 
 export interface Config {
   kubernetes?: {
+    objectTypes?: Array<
+      | 'pods'
+      | 'services'
+      | 'configmaps'
+      | 'deployments'
+      | 'replicasets'
+      | 'horizontalpodautoscalers'
+      | 'ingresses'
+    >;
     serviceLocatorMethod: {
       type: 'multiTenant';
     };

--- a/plugins/kubernetes-backend/src/index.ts
+++ b/plugins/kubernetes-backend/src/index.ts
@@ -16,3 +16,5 @@
 
 export * from './service/router';
 export * from './types/types';
+
+export { DEFAULT_OBJECTS } from './service/KubernetesFanOutHandler';

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -129,16 +129,16 @@ describe('handleGetKubernetesObjectsForService', () => {
 
     mockFetch(fetchObjectsForService);
 
-    const sut = new KubernetesFanOutHandler(
-      getVoidLogger(),
-      {
+    const sut = new KubernetesFanOutHandler({
+      logger: getVoidLogger(),
+      fetcher: {
         fetchObjectsForService,
       },
-      {
+      serviceLocator: {
         getClustersByServiceId,
       },
-      [],
-    );
+      customResources: [],
+    });
 
     const result = await sut.getKubernetesObjectsByEntity({
       entity: {
@@ -221,16 +221,16 @@ describe('handleGetKubernetesObjectsForService', () => {
 
     mockFetch(fetchObjectsForService);
 
-    const sut = new KubernetesFanOutHandler(
-      getVoidLogger(),
-      {
+    const sut = new KubernetesFanOutHandler({
+      logger: getVoidLogger(),
+      fetcher: {
         fetchObjectsForService,
       },
-      {
+      serviceLocator: {
         getClustersByServiceId,
       },
-      [],
-    );
+      customResources: [],
+    });
 
     const result = await sut.getKubernetesObjectsByEntity({
       auth: {
@@ -357,16 +357,16 @@ describe('handleGetKubernetesObjectsForService', () => {
 
     mockFetch(fetchObjectsForService);
 
-    const sut = new KubernetesFanOutHandler(
-      getVoidLogger(),
-      {
+    const sut = new KubernetesFanOutHandler({
+      logger: getVoidLogger(),
+      fetcher: {
         fetchObjectsForService,
       },
-      {
+      serviceLocator: {
         getClustersByServiceId,
       },
-      [],
-    );
+      customResources: [],
+    });
 
     const result = await sut.getKubernetesObjectsByEntity({
       auth: {
@@ -497,16 +497,16 @@ describe('handleGetKubernetesObjectsForService', () => {
 
     mockFetch(fetchObjectsForService);
 
-    const sut = new KubernetesFanOutHandler(
-      getVoidLogger(),
-      {
+    const sut = new KubernetesFanOutHandler({
+      logger: getVoidLogger(),
+      fetcher: {
         fetchObjectsForService,
       },
-      {
+      serviceLocator: {
         getClustersByServiceId,
       },
-      [],
-    );
+      customResources: [],
+    });
 
     const result = await sut.getKubernetesObjectsByEntity({
       auth: {

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -63,15 +63,15 @@ export class KubernetesFanOutHandler {
         'backstage.io/kubernetes-id'
       ] || requestBody.entity?.metadata?.name;
 
-    const clusterDetails: ClusterDetails[] =
-      await this.serviceLocator.getClustersByServiceId(entityName);
+    const clusterDetails: ClusterDetails[] = await this.serviceLocator.getClustersByServiceId(
+      entityName,
+    );
 
     // Execute all of these async actions simultaneously/without blocking sequentially as no common object is modified by them
     const promises: Promise<ClusterDetails>[] = clusterDetails.map(cd => {
-      const kubernetesAuthTranslator: KubernetesAuthTranslator =
-        KubernetesAuthTranslatorGenerator.getKubernetesAuthTranslatorInstance(
-          cd.authProvider,
-        );
+      const kubernetesAuthTranslator: KubernetesAuthTranslator = KubernetesAuthTranslatorGenerator.getKubernetesAuthTranslatorInstance(
+        cd.authProvider,
+      );
       return kubernetesAuthTranslator.decorateClusterDetailsWithAuth(
         cd,
         requestBody,

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -26,7 +26,7 @@ import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { KubernetesAuthTranslator } from '../kubernetes-auth-translator/types';
 import { KubernetesAuthTranslatorGenerator } from '../kubernetes-auth-translator/KubernetesAuthTranslatorGenerator';
 
-const DEFAULT_OBJECTS = new Set<KubernetesObjectTypes>([
+const DEFAULT_OBJECTS: KubernetesObjectTypes[] = [
   'pods',
   'services',
   'configmaps',
@@ -34,44 +34,44 @@ const DEFAULT_OBJECTS = new Set<KubernetesObjectTypes>([
   'replicasets',
   'horizontalpodautoscalers',
   'ingresses',
-]);
+];
 
 export class KubernetesFanOutHandler {
   private readonly logger: Logger;
   private readonly fetcher: KubernetesFetcher;
   private readonly serviceLocator: KubernetesServiceLocator;
   private readonly customResources: CustomResource[];
+  private readonly objectTypesToFetch: KubernetesObjectTypes[];
 
   constructor(
     logger: Logger,
     fetcher: KubernetesFetcher,
     serviceLocator: KubernetesServiceLocator,
     customResources: CustomResource[],
+    objectTypesToFetch: KubernetesObjectTypes[] = DEFAULT_OBJECTS,
   ) {
     this.logger = logger;
     this.fetcher = fetcher;
     this.serviceLocator = serviceLocator;
     this.customResources = customResources;
+    this.objectTypesToFetch = objectTypesToFetch;
   }
 
-  async getKubernetesObjectsByEntity(
-    requestBody: KubernetesRequestBody,
-    objectTypesToFetch: Set<KubernetesObjectTypes> = DEFAULT_OBJECTS,
-  ) {
+  async getKubernetesObjectsByEntity(requestBody: KubernetesRequestBody) {
     const entityName =
       requestBody.entity?.metadata?.annotations?.[
         'backstage.io/kubernetes-id'
       ] || requestBody.entity?.metadata?.name;
 
-    const clusterDetails: ClusterDetails[] = await this.serviceLocator.getClustersByServiceId(
-      entityName,
-    );
+    const clusterDetails: ClusterDetails[] =
+      await this.serviceLocator.getClustersByServiceId(entityName);
 
     // Execute all of these async actions simultaneously/without blocking sequentially as no common object is modified by them
     const promises: Promise<ClusterDetails>[] = clusterDetails.map(cd => {
-      const kubernetesAuthTranslator: KubernetesAuthTranslator = KubernetesAuthTranslatorGenerator.getKubernetesAuthTranslatorInstance(
-        cd.authProvider,
-      );
+      const kubernetesAuthTranslator: KubernetesAuthTranslator =
+        KubernetesAuthTranslatorGenerator.getKubernetesAuthTranslatorInstance(
+          cd.authProvider,
+        );
       return kubernetesAuthTranslator.decorateClusterDetailsWithAuth(
         cd,
         requestBody,
@@ -98,7 +98,7 @@ export class KubernetesFanOutHandler {
           .fetchObjectsForService({
             serviceId: entityName,
             clusterDetails: clusterDetailsItem,
-            objectTypesToFetch,
+            objectTypesToFetch: new Set(this.objectTypesToFetch),
             labelSelector,
             customResources: this.customResources,
           })

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -26,7 +26,7 @@ import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { KubernetesAuthTranslator } from '../kubernetes-auth-translator/types';
 import { KubernetesAuthTranslatorGenerator } from '../kubernetes-auth-translator/KubernetesAuthTranslatorGenerator';
 
-const DEFAULT_OBJECTS: KubernetesObjectTypes[] = [
+export const DEFAULT_OBJECTS: KubernetesObjectTypes[] = [
   'pods',
   'services',
   'configmaps',
@@ -36,6 +36,14 @@ const DEFAULT_OBJECTS: KubernetesObjectTypes[] = [
   'ingresses',
 ];
 
+export interface KubernetesFanOutHandlerOptions {
+  logger: Logger;
+  fetcher: KubernetesFetcher;
+  serviceLocator: KubernetesServiceLocator;
+  customResources: CustomResource[];
+  objectTypesToFetch: KubernetesObjectTypes[];
+}
+
 export class KubernetesFanOutHandler {
   private readonly logger: Logger;
   private readonly fetcher: KubernetesFetcher;
@@ -43,13 +51,13 @@ export class KubernetesFanOutHandler {
   private readonly customResources: CustomResource[];
   private readonly objectTypesToFetch: KubernetesObjectTypes[];
 
-  constructor(
-    logger: Logger,
-    fetcher: KubernetesFetcher,
-    serviceLocator: KubernetesServiceLocator,
-    customResources: CustomResource[],
-    objectTypesToFetch: KubernetesObjectTypes[] = DEFAULT_OBJECTS,
-  ) {
+  constructor({
+    logger,
+    fetcher,
+    serviceLocator,
+    customResources,
+    objectTypesToFetch = DEFAULT_OBJECTS,
+  }: KubernetesFanOutHandlerOptions) {
     this.logger = logger;
     this.fetcher = fetcher;
     this.serviceLocator = serviceLocator;

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -41,7 +41,7 @@ export interface KubernetesFanOutHandlerOptions {
   fetcher: KubernetesFetcher;
   serviceLocator: KubernetesServiceLocator;
   customResources: CustomResource[];
-  objectTypesToFetch: KubernetesObjectTypes[];
+  objectTypesToFetch?: KubernetesObjectTypes[];
 }
 
 export class KubernetesFanOutHandler {

--- a/plugins/kubernetes-backend/src/service/router.ts
+++ b/plugins/kubernetes-backend/src/service/router.ts
@@ -71,8 +71,9 @@ export const makeRouter = (
     const serviceId = req.params.serviceId;
     const requestBody: KubernetesRequestBody = req.body;
     try {
-      const response =
-        await kubernetesFanOutHandler.getKubernetesObjectsByEntity(requestBody);
+      const response = await kubernetesFanOutHandler.getKubernetesObjectsByEntity(
+        requestBody,
+      );
       res.json(response);
     } catch (e) {
       logger.error(

--- a/plugins/kubernetes-backend/src/service/router.ts
+++ b/plugins/kubernetes-backend/src/service/router.ts
@@ -134,17 +134,17 @@ export async function createRouter(
   );
 
   const serviceLocator = getServiceLocator(options.config, clusterDetails);
-  const objectTypes = options.config.getOptionalStringArray(
+  const objectTypesToFetch = options.config.getOptionalStringArray(
     'kubernetes.objectTypes',
   ) as KubernetesObjectTypes[];
 
-  const kubernetesFanOutHandler = new KubernetesFanOutHandler(
+  const kubernetesFanOutHandler = new KubernetesFanOutHandler({
     logger,
     fetcher,
     serviceLocator,
     customResources,
-    objectTypes,
-  );
+    objectTypesToFetch,
+  });
 
   return makeRouter(logger, kubernetesFanOutHandler, clusterDetails);
 }

--- a/plugins/kubernetes-backend/src/service/router.ts
+++ b/plugins/kubernetes-backend/src/service/router.ts
@@ -23,6 +23,7 @@ import { MultiTenantServiceLocator } from '../service-locator/MultiTenantService
 import {
   ClusterDetails,
   KubernetesClustersSupplier,
+  KubernetesObjectTypes,
   KubernetesServiceLocator,
   ServiceLocatorMethod,
   CustomResource,
@@ -70,9 +71,8 @@ export const makeRouter = (
     const serviceId = req.params.serviceId;
     const requestBody: KubernetesRequestBody = req.body;
     try {
-      const response = await kubernetesFanOutHandler.getKubernetesObjectsByEntity(
-        requestBody,
-      );
+      const response =
+        await kubernetesFanOutHandler.getKubernetesObjectsByEntity(requestBody);
       res.json(response);
     } catch (e) {
       logger.error(
@@ -133,12 +133,16 @@ export async function createRouter(
   );
 
   const serviceLocator = getServiceLocator(options.config, clusterDetails);
+  const objectTypes = options.config.getOptionalStringArray(
+    'kubernetes.objectTypes',
+  ) as KubernetesObjectTypes[];
 
   const kubernetesFanOutHandler = new KubernetesFanOutHandler(
     logger,
     fetcher,
     serviceLocator,
     customResources,
+    objectTypes,
   );
 
   return makeRouter(logger, kubernetesFanOutHandler, clusterDetails);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Make the kubernetes resources configurable. For our use case we don't want to use some of the functionality that the plugin currently provides. Unfortunately if we don't give access to call all the resources there will be a warning/error displayed on the UI. So I think it would be nice if we could configure what resources do we want (if we want to there would be a default one if you don't provide) So there would be no error if we intentionally decide to not use a specific resource.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
