### PR TITLE
fix(EntityListProvider): don't update url if unmounted

### DIFF
--- a/.changeset/small-emus-sin.md
+++ b/.changeset/small-emus-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix `EntityListProvider` to not update url if unmounted

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -25,7 +25,7 @@ import React, {
   useState,
 } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useAsyncFn, useDebounce } from 'react-use';
+import { useAsyncFn, useDebounce, useMountedState } from 'react-use';
 import { catalogApiRef } from '../api';
 import {
   EntityKindFilter,
@@ -102,6 +102,7 @@ type OutputState<EntityFilters extends DefaultEntityFilters> = {
 export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>({
   children,
 }: PropsWithChildren<{}>) => {
+  const isMounted = useMountedState();
   const catalogApi = useApi(catalogApiRef);
   const [searchParams, setSearchParams] = useSearchParams();
   const allQueryParams = qs.parse(searchParams.toString());
@@ -164,12 +165,14 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>({
         });
       }
 
-      setSearchParams(
-        qs.stringify({ ...allQueryParams, filters: queryParams }),
-        {
-          replace: true,
-        },
-      );
+      if (isMounted()) {
+        setSearchParams(
+          qs.stringify({ ...allQueryParams, filters: queryParams }),
+          {
+            replace: true,
+          },
+        );
+      }
     },
     [catalogApi, requestedFilters, outputState],
     { loading: true },


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Fixes a bug where if you leave the current page before the entity list finishes loading, you are redirected back to the previous page once the catalog request completes and the async callback updates the query params with the previous url.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
