### PR TITLE
[TechDocs] Use verbose log-level when migrating TechDocs files

### DIFF
--- a/.changeset/techdocs-blink-of-an-eye.md
+++ b/.changeset/techdocs-blink-of-an-eye.md
@@ -1,0 +1,6 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Migrated files are now printed when `techdocs-cli migrate` is run with the
+`--verbose` flag set.

--- a/packages/techdocs-common/src/stages/publish/awsS3.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.ts
@@ -337,7 +337,7 @@ export class AwsS3Publish implements PublisherBase {
           }
 
           try {
-            this.logger.debug(`Migrating ${file}`);
+            this.logger.verbose(`Migrating ${file}`);
             await this.storageClient
               .copyObject({
                 Bucket: this.bucketName,

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.ts
@@ -323,7 +323,7 @@ export class AzureBlobStoragePublish implements PublisherBase {
 
     if (originalPath === newPath) return;
     try {
-      this.logger.debug(`Migrating ${originalPath}`);
+      this.logger.verbose(`Migrating ${originalPath}`);
       await this.renameBlob(originalPath, newPath, removeOriginal);
     } catch (e) {
       this.logger.warn(`Unable to migrate ${originalPath}: ${e.message}`);

--- a/packages/techdocs-common/src/stages/publish/local.ts
+++ b/packages/techdocs-common/src/stages/publish/local.ts
@@ -196,7 +196,7 @@ export class LocalPublish implements PublisherBase {
           // Otherwise, copy or move the file.
           await new Promise<void>(resolve => {
             const migrate = removeOriginal ? fs.move : fs.copyFile;
-            this.logger.debug(`Migrating ${relativeFile}`);
+            this.logger.verbose(`Migrating ${relativeFile}`);
             migrate(file, newFile, err => {
               if (err) {
                 this.logger.warn(

--- a/packages/techdocs-common/src/stages/publish/migrations/GoogleMigration.ts
+++ b/packages/techdocs-common/src/stages/publish/migrations/GoogleMigration.ts
@@ -64,7 +64,7 @@ export class MigrateWriteStream extends Writable {
     const migrate = this.removeOriginal
       ? file.move.bind(file)
       : file.copy.bind(file);
-    this.logger.debug(`Migrating ${file.name}`);
+    this.logger.verbose(`Migrating ${file.name}`);
     migrate(newFile)
       .catch(e =>
         this.logger.warn(`Unable to migrate ${file.name}: ${e.message}`),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up to backstage/techdocs-cli#85.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
