### PR TITLE
Add explicit isomorphic-form-data import

### DIFF
--- a/.changeset/pink-glasses-type.md
+++ b/.changeset/pink-glasses-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Add explicit import for `isomorphic-form-data` needed for `swagger-ui-react`

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -43,6 +43,7 @@
     "@types/react": "^16.9",
     "graphiql": "^1.0.0-alpha.10",
     "graphql": "^15.3.0",
+    "isomorphic-form-data": "^2.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",


### PR DESCRIPTION
The e2e tests [are failing](https://github.com/backstage/backstage/actions/workflows/e2e.yml):

```
Module not found: Can't resolve 'isomorphic-form-data' in '/tmp/backstage-e2e-3c0fu9/test-app/node_modules/swagger-ui-react'
```

This is filed via https://github.com/swagger-api/swagger-ui/issues/7436; fix for now seems to be including `isomorphic-form-data` explicitly in dependencies.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
