### PR TITLE
[TechDocs] Add support for mkdocs.yaml

### DIFF
--- a/.changeset/techdocs-you-say-yaml.md
+++ b/.changeset/techdocs-you-say-yaml.md
@@ -1,0 +1,7 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+TechDocs generator stage now supports `mkdocs.yaml` file, in addition to `.yml`
+depending on whichever is present at the time of generation. (Assumes the
+latest `spotify/techdocs` container, running mkdocs `v1.2.2` or greater).

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -16,10 +16,10 @@
 
 import { ContainerRunner } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
-import path from 'path';
 import { Logger } from 'winston';
 import {
   addBuildTimestampMetadata,
+  getMkdocsYml,
   patchMkdocsYmlPreBuild,
   runCommand,
   storeEtagMetadata,
@@ -71,19 +71,13 @@ export class TechdocsGenerator implements GeneratorBase {
     logger: childLogger,
     logStream,
   }: GeneratorRunOptions): Promise<void> {
-    // TODO: In future mkdocs.yml can be mkdocs.yaml. So, use a config variable here to find out
-    // the correct file name.
     // Do some updates to mkdocs.yml before generating docs e.g. adding repo_url
-    const mkdocsYmlPath = path.join(inputDir, 'mkdocs.yml');
+    const { path, content } = await getMkdocsYml(inputDir);
     if (parsedLocationAnnotation) {
-      await patchMkdocsYmlPreBuild(
-        mkdocsYmlPath,
-        childLogger,
-        parsedLocationAnnotation,
-      );
+      await patchMkdocsYmlPreBuild(path, childLogger, parsedLocationAnnotation);
     }
 
-    await validateMkdocsYaml(inputDir, mkdocsYmlPath);
+    await validateMkdocsYaml(inputDir, content);
 
     // Directories to bind on container
     const mountDirs = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Checks for `mkdocs.yaml` as well as `mkdocs.yml` and reads the contents of the file that is present.  Culmination of the work done in...

- backstage/mkdocs-techdocs-core#27
- backstage/techdocs-container#14

Closes #3660

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
