### PR TITLE
Feature/add disable refresh config for oauth2

### DIFF
--- a/.changeset/witty-donuts-learn.md
+++ b/.changeset/witty-donuts-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Added the disableRefresh option to the OAuth2 config

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -177,6 +177,8 @@ export const createOAuth2Provider = (
       const authorizationUrl = envConfig.getString('authorizationUrl');
       const tokenUrl = envConfig.getString('tokenUrl');
       const scope = envConfig.getOptionalString('scope');
+      const disableRefresh =
+        envConfig.getOptionalBoolean('disableRefresh') ?? false;
 
       const provider = new OAuth2AuthProvider({
         clientId,
@@ -188,7 +190,7 @@ export const createOAuth2Provider = (
       });
 
       return OAuthAdapter.fromConfig(globalConfig, provider, {
-        disableRefresh: false,
+        disableRefresh: disableRefresh,
         providerId,
         tokenIssuer,
       });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have added an optional config to disableRefresh for the OAuth2 provider. This option will allow OAuth providers that do not support refresh tokens to still be used. The default of false is still provided.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
```yaml
oauth2:
      development:
        clientId: ${AUTH_OAUTH2_CLIENT_ID}
        clientSecret: ${AUTH_OAUTH2_CLIENT_SECRET}
        authorizationUrl: ${AUTH_OAUTH2_AUTH_URL}
        tokenUrl: ${AUTH_OAUTH2_TOKEN_URL}
        disableRefresh: true
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
