### PR TITLE
Avoid vulnerable versions of `ws` in dependency tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     ]
   },
   "resolutions": {
+    "**/@graphql-tools/url-loader/**/ws": "^7.4.6",
     "**/@roadiehq/**/@backstage/core": "*",
     "**/@roadiehq/**/@backstage/plugin-catalog": "*",
     "**/@roadiehq/**/@backstage/catalog-model": "*",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "resolutions": {
-    "**/@graphql-tools/url-loader/**/ws": "^7.4.6",
+    "**/@graphql-codegen/cli/**/ws": "^7.4.6",
     "**/@roadiehq/**/@backstage/core": "*",
     "**/@roadiehq/**/@backstage/plugin-catalog": "*",
     "**/@roadiehq/**/@backstage/catalog-model": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26566,10 +26566,10 @@ write-pkg@^4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@7.4.5:
-  version "7.4.5"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
-  integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
+ws@7.4.5, ws@^7.4.6:
+  version "7.5.3"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
+  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
 
 ws@^5.2.0:
   version "5.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -26572,9 +26572,9 @@ ws@7.4.5:
   integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
 
 ws@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
-  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  version "5.2.3"
+  resolved "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz#05541053414921bc29c63bee14b8b0dd50b07b3d"
+  integrity sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==
   dependencies:
     async-limiter "~1.0.0"
 
@@ -26584,9 +26584,9 @@ ws@^5.2.0:
   integrity sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==
 
 ws@^6.1.2, ws@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  version "6.2.2"
+  resolved "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
+  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR aims to mitigate [SNYK-JS-WS-1296835](https://snyk.io/vuln/SNYK-JS-WS-1296835) by avoiding vulnerable versions of ws in our yarn.lock file. I took two different actions here, both of which have the potential to be controversial, so keen to get feedback from maintainers:

1. Removed the `ws` entries from yarn.lock and re-ran `yarn install`, committed as 1401985. This has the effect of updating the version of `ws` used to a non-vulnerable one everywhere in the tree except for one place (see 2.)
2. Used a resolution to force the version of `ws` used inside `@graphql-tools/url-loader` to 7.4.6. The version of `ws` is currently pinned in this package, which means there's no way to avoid the vulnerable version with yarn.lock changes alone.

I don't personally know whether fixes in yarn.lock alone will be enough to make Snyk happy. Since projects that depend on Backstage packages will have their own entirely separate yarn.lock file, it's still entirely possible for integrators to be running versions of `ws` that have been marked by Snyk regardless of the contents of our lockfile.

Once we have Snyk monitoring this repository directly, it will be much easier to verify fixes. Note that integrating directly with Snyk is currently blocked - I just opened https://github.com/snyk/snyk/issues/2126 which describes the blocking issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
