### PR TITLE
[Microsite] Adjust docs navigation background color for smaller screens

### DIFF
--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -289,12 +289,12 @@ td {
     display: none;
   }
 
-  .docsSliderActive .toc section .navGroups{
+  .docsSliderActive .toc section .navGroups {
     padding-top: 0;
     padding-bottom: 0;
   }
 
-  .docsSliderActive.docsNavContainer{
+  .docsSliderActive.docsNavContainer {
     background-color: #121212;
     padding-bottom: 0;
   }

--- a/microsite/static/css/custom.css
+++ b/microsite/static/css/custom.css
@@ -288,6 +288,16 @@ td {
   .tocToggler {
     display: none;
   }
+
+  .docsSliderActive .toc section .navGroups{
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .docsSliderActive.docsNavContainer{
+    background-color: #121212;
+    padding-bottom: 0;
+  }
 }
 
 /* content */


### PR DESCRIPTION
- Adjust docs navigation background colour for smaller screens
- Reduce padding for navigation on smaller screens

Closes #6326 

| Old | New|
|:--:|:--:|
| ![old_microsite](https://user-images.githubusercontent.com/8904624/127516949-4d5d799a-c275-4a56-b1a0-e254c29ff266.gif) | ![new_microsite](https://user-images.githubusercontent.com/8904624/127516980-cab47072-0179-413e-96b2-86aa7c039f24.gif) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
