### PR TITLE
feat(plugin-scaffolder-backend): add defaultCommitMessage config option

### DIFF
--- a/.changeset/soft-news-float.md
+++ b/.changeset/soft-news-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Add the `scaffolder.defaultCommitMessage`, which defaults to `Initial commit`, so it can be customized.

--- a/.changeset/soft-news-float.md
+++ b/.changeset/soft-news-float.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': minor
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
 Add the `scaffolder.defaultCommitMessage`, which defaults to `Initial commit`, so it can be customized.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -256,6 +256,8 @@ scaffolder:
   # defaultAuthor:
   #   name: Scaffolder
   #   email: scaffolder@backstage.io
+  # Use to customize the default commit message when new components are created
+  # defaultCommitMessage: 'Initial commit'
   github:
     token: ${GITHUB_TOKEN}
     visibility: public # or 'internal' or 'private'

--- a/plugins/scaffolder-backend/config.d.ts
+++ b/plugins/scaffolder-backend/config.d.ts
@@ -24,6 +24,10 @@ export interface Config {
       name?: string;
       email?: string;
     };
+    /**
+     * The commit message used when new components are created.
+     */
+    defaultCommitMessage?: string;
     github?: {
       [key: string]: string;
       /**

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -62,6 +62,7 @@ export async function initRepoAndPush({
   auth,
   logger,
   defaultBranch = 'master',
+  commitMessage = 'Initial commit',
   gitAuthorInfo,
 }: {
   dir: string;
@@ -69,6 +70,7 @@ export async function initRepoAndPush({
   auth: { username: string; password: string };
   logger: Logger;
   defaultBranch?: string;
+  commitMessage?: string;
   gitAuthorInfo?: { name?: string; email?: string };
 }): Promise<void> {
   const git = Git.fromAuth({
@@ -100,7 +102,7 @@ export async function initRepoAndPush({
 
   await git.commit({
     dir,
-    message: 'Initial commit',
+    message: commitMessage,
     author: authorInfo,
     committer: authorInfo,
   });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
@@ -139,6 +139,9 @@ export function createPublishAzureAction(options: {
           password: integrationConfig.config.token,
         },
         logger: ctx.logger,
+        commitMessage: config.getOptionalString(
+          'scaffolder.defaultCommitMessage',
+        ),
         gitAuthorInfo,
       });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
@@ -407,6 +407,74 @@ describe('publish:bitbucket', () => {
     });
   });
 
+  it('should call initAndPush with the configured defaultCommitMessage', async () => {
+    const customAuthorConfig = new ConfigReader({
+      integrations: {
+        bitbucket: [
+          {
+            host: 'bitbucket.org',
+            token: 'tokenlols',
+          },
+          {
+            host: 'hosted.bitbucket.com',
+            token: 'thing',
+            apiBaseUrl: 'https://hosted.bitbucket.com/rest/api/1.0',
+          },
+          {
+            host: 'notoken.bitbucket.com',
+          },
+        ],
+      },
+      scaffolder: {
+        defaultCommitMessage: 'Test commit message',
+      },
+    });
+
+    const customAuthorIntegrations = ScmIntegrations.fromConfig(
+      customAuthorConfig,
+    );
+    const customAuthorAction = createPublishBitbucketAction({
+      integrations: customAuthorIntegrations,
+      config: customAuthorConfig,
+    });
+
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/owner/repo',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/owner/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/owner/cloneurl',
+                  },
+                ],
+              },
+            }),
+          ),
+      ),
+    );
+
+    await customAuthorAction.handler(mockContext);
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'https://bitbucket.org/owner/cloneurl',
+      auth: { username: 'x-token-auth', password: 'tokenlols' },
+      logger: mockContext.logger,
+      defaultBranch: 'master',
+      commitMessage: 'Test commit message',
+      gitAuthorInfo: { email: undefined, name: undefined },
+    });
+  });
+
   it('should call outputs with the correct urls', async () => {
     server.use(
       rest.post(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
@@ -304,6 +304,9 @@ export function createPublishBitbucketAction(options: {
         },
         defaultBranch,
         logger: ctx.logger,
+        commitMessage: config.getOptionalString(
+          'scaffolder.defaultCommitMessage',
+        ),
         gitAuthorInfo,
       });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -260,6 +260,51 @@ describe('publish:github', () => {
     });
   });
 
+  it('should call initRepoAndPush with the configured defaultCommitMessage', async () => {
+    const customAuthorConfig = new ConfigReader({
+      integrations: {
+        github: [
+          { host: 'github.com', token: 'tokenlols' },
+          { host: 'ghe.github.com' },
+        ],
+      },
+      scaffolder: {
+        defaultCommitMessage: 'Test commit message',
+      },
+    });
+
+    const customAuthorIntegrations = ScmIntegrations.fromConfig(
+      customAuthorConfig,
+    );
+    const customAuthorAction = createPublishGithubAction({
+      integrations: customAuthorIntegrations,
+      config: customAuthorConfig,
+    });
+
+    mockGithubClient.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+
+    mockGithubClient.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    await customAuthorAction.handler(mockContext);
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'https://github.com/clone/url.git',
+      defaultBranch: 'master',
+      auth: { username: 'x-access-token', password: 'tokenlols' },
+      logger: mockContext.logger,
+      commitMessage: 'Test commit message',
+      gitAuthorInfo: { email: undefined, name: undefined },
+    });
+  });
+
   it('should add access for the team when it starts with the owner', async () => {
     mockGithubClient.users.getByUsername.mockResolvedValue({
       data: { type: 'User' },

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -264,6 +264,9 @@ export function createPublishGithubAction(options: {
           password: token,
         },
         logger: ctx.logger,
+        commitMessage: config.getOptionalString(
+          'scaffolder.defaultCommitMessage',
+        ),
         gitAuthorInfo,
       });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
@@ -219,6 +219,52 @@ describe('publish:gitlab', () => {
     });
   });
 
+  it('should call initRepoAndPush with the configured defaultCommitMessage', async () => {
+    const customAuthorConfig = new ConfigReader({
+      integrations: {
+        gitlab: [
+          {
+            host: 'gitlab.com',
+            token: 'tokenlols',
+            apiBaseUrl: 'https://api.gitlab.com',
+          },
+          {
+            host: 'hosted.gitlab.com',
+            apiBaseUrl: 'https://api.hosted.gitlab.com',
+          },
+        ],
+      },
+      scaffolder: {
+        defaultCommitMessage: 'Test commit message',
+      },
+    });
+
+    const customAuthorIntegrations = ScmIntegrations.fromConfig(
+      customAuthorConfig,
+    );
+    const customAuthorAction = createPublishGitlabAction({
+      integrations: customAuthorIntegrations,
+      config: customAuthorConfig,
+    });
+
+    mockGitlabClient.Namespaces.show.mockResolvedValue({ id: 1234 });
+    mockGitlabClient.Projects.create.mockResolvedValue({
+      http_url_to_repo: 'http://mockurl.git',
+    });
+
+    await customAuthorAction.handler(mockContext);
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: mockContext.workspacePath,
+      remoteUrl: 'http://mockurl.git',
+      auth: { username: 'oauth2', password: 'tokenlols' },
+      logger: mockContext.logger,
+      defaultBranch: 'master',
+      commitMessage: 'Test commit message',
+      gitAuthorInfo: { email: undefined, name: undefined },
+    });
+  });
+
   it('should call output with the remoteUrl and repoContentsUrl', async () => {
     mockGitlabClient.Namespaces.show.mockResolvedValue({ id: 1234 });
     mockGitlabClient.Projects.create.mockResolvedValue({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -137,6 +137,9 @@ export function createPublishGitlabAction(options: {
           password: integrationConfig.config.token,
         },
         logger: ctx.logger,
+        commitMessage: config.getOptionalString(
+          'scaffolder.defaultCommitMessage',
+        ),
         gitAuthorInfo,
       });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For teams that use services such as Release Please, or any other conventional commit driven release process, it would be nice to be able to customize the initial commit to a repository.

For example, our team's desired initial commit is:

```
chore: initial commit :tada:
```

Being able to set this with the following would now be possible:

```
scaffolder:
  defaultCommitMessage: 'chore: initial commit :tada:'
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
