### PR TITLE
techdocs/create-app: update app config to use the latest techdocs.generator option

### DIFF
--- a/.changeset/techdocs-spicy-icons-explode.md
+++ b/.changeset/techdocs-spicy-icons-explode.md
@@ -1,0 +1,7 @@
+---
+'@backstage/create-app': patch
+---
+
+Update `techdocs.generators` with the latest `techdocs.generator` config in `app-config.yaml`. See
+https://backstage.io/docs/features/techdocs/configuration for reference and relevant PR
+https://github.com/backstage/backstage/pull/6071/files for the changes.

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -24,13 +24,13 @@ techdocs:
 
     runIn: 'docker'
 
-    # techdocs.generator.dockerImage can be used to control the docker image used during documentation generation. This can be useful
+    # (Optional) techdocs.generator.dockerImage can be used to control the docker image used during documentation generation. This can be useful
     # if you want to use MkDocs plugins or other packages that are not included in the default techdocs-container (spotify/techdocs).
     # NOTE: This setting is only used when techdocs.generator.runIn is set to 'docker'.
 
     dockerImage: 'spotify/techdocs'
 
-    # techdocs.generator.pullImage can be used to disable pulling the latest docker image by default. This can be useful when you are
+    # (Optional) techdocs.generator.pullImage can be used to disable pulling the latest docker image by default. This can be useful when you are
     # using a custom techdocs.generator.dockerImage and you have a custom docker login requirement. For example, you need to login to
     # AWS ECR to pull the docker image.
     # NOTE: Disabling this requires the docker image was pulled by other means before running the techdocs generator.

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -60,8 +60,8 @@ proxy:
 # https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
 techdocs:
   builder: 'local' # Alternatives - 'external'
-  generators:
-    techdocs: 'docker' # Alternatives - 'local'
+  generator:
+    runIn: 'docker' # Alternatives - 'local'
   publisher:
     type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
 


### PR DESCRIPTION
I saw a warning about the old `techdocs.generators` config in the logs, when I created a fresh Backstage app. I feel, we can update the create-app template to use the recommended `techdocs.generator` config instead.

See https://backstage.io/docs/features/techdocs/configuration
PR https://github.com/backstage/backstage/pull/6071

Signed-off-by: Himanshu Mishra <himanshu@orkohunter.net>## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
