### PR TITLE
Switch frontend identity to use `token` instead of `idToken`

### DIFF
--- a/.changeset/lucky-spiders-impress.md
+++ b/.changeset/lucky-spiders-impress.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/core-plugin-api': patch
+---
+
+Switched frontend identity code to use `token` instead of the deprecated `idToken` field

--- a/packages/core-components/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core-components/src/layout/SignInPage/SignInPage.tsx
@@ -130,7 +130,7 @@ export const SingleSignInPage = ({
           userId: identity!.id,
           profile: profile!,
           getIdToken: () => {
-            return authApi.getBackstageIdentity().then(i => i!.idToken);
+            return authApi.getBackstageIdentity().then(i => i!.token);
           },
           signOut: async () => {
             await authApi.signOut();

--- a/packages/core-components/src/layout/SignInPage/auth0Provider.tsx
+++ b/packages/core-components/src/layout/SignInPage/auth0Provider.tsx
@@ -40,7 +40,7 @@ const Component: ProviderComponent = ({ onResult }) => {
         userId: identity!.id,
         profile: profile!,
         getIdToken: () =>
-          auth0AuthApi.getBackstageIdentity().then(i => i!.idToken),
+          auth0AuthApi.getBackstageIdentity().then(i => i!.token),
         signOut: async () => {
           await auth0AuthApi.signOut();
         },
@@ -82,7 +82,7 @@ const loader: ProviderLoader = async apis => {
   return {
     userId: identity.id,
     profile: profile!,
-    getIdToken: () => auth0AuthApi.getBackstageIdentity().then(i => i!.idToken),
+    getIdToken: () => auth0AuthApi.getBackstageIdentity().then(i => i!.token),
     signOut: async () => {
       await auth0AuthApi.signOut();
     },

--- a/packages/core-components/src/layout/SignInPage/commonProvider.tsx
+++ b/packages/core-components/src/layout/SignInPage/commonProvider.tsx
@@ -86,7 +86,7 @@ const loader: ProviderLoader = async (apis, apiRef) => {
   return {
     userId: identity.id,
     profile: profile!,
-    getIdToken: () => authApi.getBackstageIdentity().then(i => i!.idToken),
+    getIdToken: () => authApi.getBackstageIdentity().then(i => i!.token),
     signOut: async () => {
       await authApi.signOut();
     },

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -196,6 +196,7 @@ export type AuthRequestOptions = {
 export type BackstageIdentity = {
   id: string;
   idToken: string;
+  token: string;
 };
 
 // Warning: (tsdoc-undefined-tag) The TSDoc tag "@IdentityApi" is not defined in this configuration

--- a/packages/core-plugin-api/src/apis/definitions/auth.ts
+++ b/packages/core-plugin-api/src/apis/definitions/auth.ts
@@ -151,9 +151,15 @@ export type BackstageIdentity = {
   id: string;
 
   /**
-   * An ID token that can be used to authenticate the user within Backstage.
+   * This is deprecated, use `token` instead.
+   * @deprecated
    */
   idToken: string;
+
+  /**
+   * The token used to authenticate the user within Backstage.
+   */
+  token: string;
 };
 
 /**

--- a/packages/core-plugin-api/src/apis/definitions/auth.ts
+++ b/packages/core-plugin-api/src/apis/definitions/auth.ts
@@ -151,8 +151,7 @@ export type BackstageIdentity = {
   id: string;
 
   /**
-   * This is deprecated, use `token` instead.
-   * @deprecated
+   * @deprecated This is deprecated, use `token` instead.
    */
   idToken: string;
 


### PR DESCRIPTION
#4532 added the `signInResolver` mechanism for auth providers, so additional auth claims can be provided post-authentication. These additional claims are stored on the `ent` key of the BackstageIdentity field `token`. The `idToken` field is [marked as deprecated](https://github.com/backstage/backstage/blob/master/plugins/auth-backend/src/providers/types.ts#L161) in `auth-backend` and does not receive the additional auth claims.

This updates the matching frontend BackstageIdentity to expose the `token` field and switches frontend providers to use it. This is a follow-on to #6572 which added the `useEntityOwnership` hook to pay attention to the `ent` claims on the frontend. This hook doesn't currently work, since the token referenced is the deprecated `idToken` without the additional claims.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
