### PR TITLE
Add a method to look up additional claims from the catalog in a `signInResolver`

### DIFF
--- a/.changeset/beige-colts-pump.md
+++ b/.changeset/beige-colts-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added `resolveCatalogMemberClaims` utility to query the catalog for additional authentication claims within sign-in resolvers.

--- a/.changeset/beige-colts-pump.md
+++ b/.changeset/beige-colts-pump.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-Added `resolveCatalogMemberClaims` utility to query the catalog for additional authentication claims within sign-in resolvers.
+Added `resolveCatalogMembership` utility to query the catalog for additional authentication claims within sign-in resolvers.

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -135,8 +135,7 @@ export default async function createPlugin({
 
             // Resolve group membership from the Backstage catalog
             const fullEnt = await ctx.catalogIdentityClient.resolveCatalogMembership({
-              sub,
-              ent,
+              entityRefs: [sub].concat(ent),
               logger: ctx.logger,
             });
             const token = await ctx.tokenIssuer.issueToken({
@@ -149,8 +148,8 @@ export default async function createPlugin({
       ...
 ```
 
-The `resolveCatalogMembership` method will retrieve the `sub` and `ent` entities
-from the catalog, if possible, and check for
+The `resolveCatalogMembership` method will retrieve the referenced entities from
+the catalog, if possible, and check for
 [memberOf](../features/software-catalog/well-known-relations.md#memberof-and-hasmember)
 relations to add additional entity claims.
 

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -130,16 +130,18 @@ export default async function createPlugin({
           resolver: async ({ profile: { email } }, ctx) => {
             const [sub] = email?.split('@') ?? '';
             // Fetch from an external system that returns entity claims like:
-            // 'user:default/breanna.davison'
+            // ['user:default/breanna.davison', ...]
             const ent = await externalSystemClient.getUsernames(email);
 
             // Resolve group membership from the Backstage catalog
-            const claims = await ctx.catalogIdentityClient.resolveCatalogMemberClaims(
+            const fullEnt = await ctx.catalogIdentityClient.resolveCatalogMemberClaims({
               sub,
               ent,
-              ctx.logger,
-            );
-            const token = await ctx.tokenIssuer.issueToken(claims);
+              logger: ctx.logger,
+            });
+            const token = await ctx.tokenIssuer.issueToken({
+              claims: { sub: id, fullEnt },
+            });
             return { sub, token };
           },
         },

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -134,7 +134,7 @@ export default async function createPlugin({
             const ent = await externalSystemClient.getUsernames(email);
 
             // Resolve group membership from the Backstage catalog
-            const fullEnt = await ctx.catalogIdentityClient.resolveCatalogMemberClaims({
+            const fullEnt = await ctx.catalogIdentityClient.resolveCatalogMembership({
               sub,
               ent,
               logger: ctx.logger,
@@ -149,8 +149,8 @@ export default async function createPlugin({
       ...
 ```
 
-The `resolveCatalogMemberClaims` method will retrieve the `sub` and `ent`
-entities from the catalog, if possible, and check for
+The `resolveCatalogMembership` method will retrieve the `sub` and `ent` entities
+from the catalog, if possible, and check for
 [memberOf](../features/software-catalog/well-known-relations.md#memberof-and-hasmember)
 relations to add additional entity claims.
 

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -139,7 +139,7 @@ export default async function createPlugin({
               logger: ctx.logger,
             });
             const token = await ctx.tokenIssuer.issueToken({
-              claims: { sub: id, fullEnt },
+              claims: { sub, ent: fullEnt },
             });
             return { sub, token };
           },

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -67,7 +67,7 @@ describe('CatalogIdentityClient', () => {
     });
   });
 
-  it('resolveCatalogMemberClaims resolves membership', async () => {
+  it('resolveCatalogMembership resolves membership', async () => {
     const mockUsers: Array<UserEntityV1alpha1> = [
       {
         apiVersion: 'backstage.io/v1beta1',
@@ -118,7 +118,7 @@ describe('CatalogIdentityClient', () => {
       tokenIssuer,
     });
 
-    const claims = await client.resolveCatalogMemberClaims({
+    const claims = await client.resolveCatalogMembership({
       sub: 'inigom',
       ent: ['User:default/imontoya', 'User:reality/mpatinkin'],
     });

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -119,8 +119,7 @@ describe('CatalogIdentityClient', () => {
     });
 
     const claims = await client.resolveCatalogMembership({
-      sub: 'inigom',
-      ent: ['User:default/imontoya', 'User:reality/mpatinkin'],
+      entityRefs: ['inigom', 'User:default/imontoya', 'User:reality/mpatinkin'],
     });
 
     expect(catalogApi.getEntities).toHaveBeenCalledWith({
@@ -144,6 +143,7 @@ describe('CatalogIdentityClient', () => {
     });
 
     expect(claims).toMatchObject([
+      'user:default/inigom',
       'user:default/imontoya',
       'user:reality/mpatinkin',
       'group:default/team-a',

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { CatalogApi } from '@backstage/catalog-client';
-import { UserEntity } from '@backstage/catalog-model';
+import {
+  RELATION_MEMBER_OF,
+  UserEntity,
+  UserEntityV1alpha1,
+} from '@backstage/catalog-model';
 import { TokenIssuer } from '../../identity';
 import { CatalogIdentityClient } from './CatalogIdentityClient';
 
@@ -37,12 +41,12 @@ describe('CatalogIdentityClient', () => {
 
   afterEach(() => jest.resetAllMocks());
 
-  it('passes through the correct search params', async () => {
+  it('findUser passes through the correct search params', async () => {
     catalogApi.getEntities.mockResolvedValueOnce({ items: [{} as UserEntity] });
     tokenIssuer.issueToken.mockResolvedValue('my-token');
     const client = new CatalogIdentityClient({
-      catalogApi: catalogApi,
-      tokenIssuer: tokenIssuer,
+      catalogApi,
+      tokenIssuer,
     });
 
     await client.findUser({ annotations: { key: 'value' } });
@@ -59,6 +63,95 @@ describe('CatalogIdentityClient', () => {
     expect(tokenIssuer.issueToken).toHaveBeenCalledWith({
       claims: {
         sub: 'backstage.io/auth-backend',
+      },
+    });
+  });
+
+  it('resolveCatalogMemberClaims resolves membership', async () => {
+    const mockUsers: Array<UserEntityV1alpha1> = [
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'User',
+        metadata: {
+          name: 'inigom',
+        },
+        spec: {
+          memberOf: ['team-a'],
+        },
+        relations: [
+          {
+            type: RELATION_MEMBER_OF,
+            target: {
+              kind: 'Group',
+              namespace: 'default',
+              name: 'team-a',
+            },
+          },
+        ],
+      },
+      {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'User',
+        metadata: {
+          name: 'mpatinkin',
+          namespace: 'reality',
+        },
+        spec: {
+          memberOf: ['screen-actors-guild'],
+        },
+        relations: [
+          {
+            type: RELATION_MEMBER_OF,
+            target: {
+              kind: 'Group',
+              namespace: 'reality',
+              name: 'screen-actors-guild',
+            },
+          },
+        ],
+      },
+    ];
+    catalogApi.getEntities.mockResolvedValueOnce({ items: mockUsers });
+
+    const client = new CatalogIdentityClient({
+      catalogApi,
+      tokenIssuer,
+    });
+
+    const claims = await client.resolveCatalogMemberClaims('inigom', [
+      'User:default/imontoya',
+      'User:reality/mpatinkin',
+    ]);
+
+    expect(catalogApi.getEntities).toHaveBeenCalledWith({
+      filter: [
+        {
+          kind: 'user',
+          'metadata.namespace': 'default',
+          'metadata.name': 'inigom',
+        },
+        {
+          kind: 'user',
+          'metadata.namespace': 'default',
+          'metadata.name': 'imontoya',
+        },
+        {
+          kind: 'user',
+          'metadata.namespace': 'reality',
+          'metadata.name': 'mpatinkin',
+        },
+      ],
+    });
+
+    expect(claims).toMatchObject({
+      claims: {
+        sub: 'inigom',
+        ent: [
+          'user:default/imontoya',
+          'user:reality/mpatinkin',
+          'group:default/team-a',
+          'group:reality/screen-actors-guild',
+        ],
       },
     });
   });

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -118,10 +118,10 @@ describe('CatalogIdentityClient', () => {
       tokenIssuer,
     });
 
-    const claims = await client.resolveCatalogMemberClaims('inigom', [
-      'User:default/imontoya',
-      'User:reality/mpatinkin',
-    ]);
+    const claims = await client.resolveCatalogMemberClaims({
+      sub: 'inigom',
+      ent: ['User:default/imontoya', 'User:reality/mpatinkin'],
+    });
 
     expect(catalogApi.getEntities).toHaveBeenCalledWith({
       filter: [
@@ -143,16 +143,11 @@ describe('CatalogIdentityClient', () => {
       ],
     });
 
-    expect(claims).toMatchObject({
-      claims: {
-        sub: 'inigom',
-        ent: [
-          'user:default/imontoya',
-          'user:reality/mpatinkin',
-          'group:default/team-a',
-          'group:reality/screen-actors-guild',
-        ],
-      },
-    });
+    expect(claims).toMatchObject([
+      'user:default/imontoya',
+      'user:reality/mpatinkin',
+      'group:default/team-a',
+      'group:reality/screen-actors-guild',
+    ]);
   });
 });

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
@@ -86,7 +86,7 @@ export class CatalogIdentityClient {
    *
    * Returns a superset of the `ent` argument that can be passed directly to `issueToken` as `ent`.
    */
-  async resolveCatalogMemberClaims({
+  async resolveCatalogMembership({
     sub,
     ent,
     logger,

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
@@ -88,8 +88,7 @@ export class CatalogIdentityClient {
     entityRefs,
     logger,
   }: MemberClaimQuery): Promise<string[]> {
-    let resolvedEntityRefs: Array<EntityName> = [];
-    resolvedEntityRefs = entityRefs
+    const resolvedEntityRefs = entityRefs
       .map((ref: string) => {
         try {
           const parsedRef = parseEntityRef(ref.toLocaleLowerCase('en-US'), {
@@ -98,7 +97,7 @@ export class CatalogIdentityClient {
           });
           return parsedRef;
         } catch {
-          logger?.debug(`Failed to parse entityRef from ${ref}, ignoring`);
+          logger?.warn(`Failed to parse entityRef from ${ref}, ignoring`);
           return null;
         }
       })
@@ -128,9 +127,9 @@ export class CatalogIdentityClient {
           .map(r => r.target) ?? [],
     );
 
-    const newEntityRefs = [...new Set(resolvedEntityRefs.concat(memberOf))].map(
-      stringifyEntityRef,
-    );
+    const newEntityRefs = [
+      ...new Set(resolvedEntityRefs.concat(memberOf).map(stringifyEntityRef)),
+    ];
 
     logger?.debug(`Found catalog membership: ${newEntityRefs.join()}`);
     return newEntityRefs;

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
@@ -24,10 +24,16 @@ import {
   stringifyEntityRef,
   UserEntity,
 } from '@backstage/catalog-model';
-import { TokenIssuer, TokenParams } from '../../identity';
+import { TokenIssuer } from '../../identity';
 
 type UserQuery = {
   annotations: Record<string, string>;
+};
+
+type MemberClaimQuery = {
+  sub: string;
+  ent: string[];
+  logger?: Logger;
 };
 
 /**
@@ -78,14 +84,13 @@ export class CatalogIdentityClient {
    * provided, but group membership and transient group membership lean on imported catalog
    * relations.
    *
-   * Returns a claim structure that can be passed directly to `issueToken`, with the same sub and a
-   * superset of `ent` claims.
+   * Returns a superset of the `ent` argument that can be passed directly to `issueToken` as `ent`.
    */
-  async resolveCatalogMemberClaims(
-    sub: string,
-    ent: string[],
-    logger?: Logger,
-  ): Promise<TokenParams> {
+  async resolveCatalogMemberClaims({
+    sub,
+    ent,
+    logger,
+  }: MemberClaimQuery): Promise<string[]> {
     const subRef: EntityName = parseEntityRef(sub, {
       defaultKind: 'user',
       defaultNamespace: 'default',
@@ -139,11 +144,6 @@ export class CatalogIdentityClient {
     );
 
     logger?.debug(`Found claims for ${sub} in the catalog: ${newEnt.join()}`);
-    return {
-      claims: {
-        sub,
-        ent: newEnt,
-      },
-    };
+    return newEnt;
   }
 }


### PR DESCRIPTION
The `useEntityOwnership` hook added in #6572 looks up catalog membership for the primary auth subject for backwards-compatibility, but _intentionally_ doesn't do this for `ent` claims.

The reason for this is that long-term, all authentication claims should be handled at auth time via [sign-in resolvers](https://github.com/backstage/backstage/issues/6245). This allows ownership to work in a more flexible way, _without_ needing to seed the catalog with Users and Groups.

However, a Backstage installation that _does have_ Users and Groups populated in the catalog may desire to only register lightweight `ent` claims in a sign-in resolver and still rely on the catalog for group membership.

This PR adds a utility method to `CatalogIdentityClient` that's provided in  sign-in resolver `context` to look up all catalog membership claims from a sparse set of `sub` and `ent` claims. This also needs #6675 to properly see the effect in the frontend.

Example usage in a `signInResolver` (using example app data):

```ts
resolver: async ({ profile: { email } }, ctx) => {
  const [sub] = email?.split('@') ?? '';

  const ent = [
    'User:default/breanna.davison',
    'Group:default/team-b',
    'User:default/calum.leavy',
  ];

  const fullEnt = await ctx.catalogIdentityClient.resolveCatalogMemberClaims({
    entityRefs: [sub].concat(ent),
    logger: ctx.logger,
  });
  const token = await ctx.tokenIssuer.issueToken({
    claims: { sub, ent: fullEnt }
  });
  return { sub, token };
},
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
