### PR TITLE
scaffolder-backend: use more efficient approach to staging files during publish

### DIFF
--- a/.changeset/large-bears-wash.md
+++ b/.changeset/large-bears-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Use more efficient approach to staging files in git during scaffolder actions

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Git, getVoidLogger } from '@backstage/backend-common';
+import { initRepoAndPush } from './helpers';
+
+jest.mock('@backstage/backend-common', () => ({
+  Git: {
+    fromAuth: jest.fn().mockReturnValue({
+      init: jest.fn(),
+      add: jest.fn(),
+      commit: jest.fn(),
+      addRemote: jest.fn(),
+      push: jest.fn(),
+    }),
+  },
+  getVoidLogger: jest.requireActual('@backstage/backend-common').getVoidLogger,
+}));
+
+const mockedGit = Git.fromAuth({
+  username: 'test-user',
+  password: 'test-password',
+  logger: getVoidLogger(),
+});
+
+describe('initRepoAndPush', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with minimal parameters', () => {
+    beforeEach(async () => {
+      await initRepoAndPush({
+        dir: '/test/repo/dir/',
+        remoteUrl: 'git@github.com:test/repo.git',
+        auth: {
+          username: 'test-user',
+          password: 'test-password',
+        },
+        logger: getVoidLogger(),
+      });
+    });
+
+    it('initializes the repo', () => {
+      expect(mockedGit.init).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        defaultBranch: 'master',
+      });
+    });
+
+    it('stages all files in the repo', () => {
+      expect(mockedGit.add).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        filepath: '.',
+      });
+    });
+
+    it('creates an initial commit', () => {
+      expect(mockedGit.commit).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        message: 'Initial commit',
+        author: {
+          name: 'Scaffolder',
+          email: 'scaffolder@backstage.io',
+        },
+        committer: {
+          name: 'Scaffolder',
+          email: 'scaffolder@backstage.io',
+        },
+      });
+    });
+
+    it('adds the appropriate remote', () => {
+      expect(mockedGit.addRemote).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        url: 'git@github.com:test/repo.git',
+        remote: 'origin',
+      });
+    });
+
+    it('pushes to the remote', () => {
+      expect(mockedGit.push).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        remote: 'origin',
+      });
+    });
+  });
+
+  it('allows overriding the default branch', async () => {
+    await initRepoAndPush({
+      dir: '/test/repo/dir/',
+      defaultBranch: 'trunk',
+      remoteUrl: 'git@github.com:test/repo.git',
+      auth: {
+        username: 'test-user',
+        password: 'test-password',
+      },
+      logger: getVoidLogger(),
+    });
+
+    expect(mockedGit.init).toHaveBeenCalledWith({
+      dir: '/test/repo/dir/',
+      defaultBranch: 'trunk',
+    });
+  });
+
+  it('allows overriding the author', async () => {
+    await initRepoAndPush({
+      dir: '/test/repo/dir/',
+      gitAuthorInfo: {
+        name: 'Custom Scaffolder Author',
+        email: 'scaffolder@example.org',
+      },
+      remoteUrl: 'git@github.com:test/repo.git',
+      auth: {
+        username: 'test-user',
+        password: 'test-password',
+      },
+      logger: getVoidLogger(),
+    });
+
+    expect(mockedGit.commit).toHaveBeenCalledWith({
+      dir: '/test/repo/dir/',
+      message: 'Initial commit',
+      author: {
+        name: 'Custom Scaffolder Author',
+        email: 'scaffolder@example.org',
+      },
+      committer: {
+        name: 'Custom Scaffolder Author',
+        email: 'scaffolder@example.org',
+      },
+    });
+  });
+});

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -16,7 +16,6 @@
 
 import { spawn } from 'child_process';
 import { PassThrough, Writable } from 'stream';
-import globby from 'globby';
 import { Logger } from 'winston';
 import { Git } from '@backstage/backend-common';
 import { Octokit } from '@octokit/rest';
@@ -84,15 +83,7 @@ export async function initRepoAndPush({
     defaultBranch,
   });
 
-  const paths = await globby(['./**', './**/.*', '!.git'], {
-    cwd: dir,
-    gitignore: true,
-    dot: true,
-  });
-
-  for (const filepath of paths) {
-    await git.add({ dir, filepath });
-  }
+  await git.add({ dir, filepath: '.' });
 
   // use provided info if possible, otherwise use fallbacks
   const authorInfo = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #5682.

The investigation in #5682 led to the conclusion that staging all files in one go using `git.add({ dir, filepath: '.' })` is much faster than the current approach which iterates over the files and stages them one by one. This PR switches to that approach, and adds a quick test suite for the `initRepoAndPush` helper method.

I recommend that we wait to merge this until we get some feedback from the maintainers of isomorphic-git on https://github.com/isomorphic-git/isomorphic-git/pull/1405 - it's still possible there are situations where this new approach to staging files won't work correctly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
