### PR TITLE
Fixed bug on when compared in organzation name

### DIFF
--- a/packages/integration/src/github/GithubCredentialsProvider.test.ts
+++ b/packages/integration/src/github/GithubCredentialsProvider.test.ts
@@ -255,29 +255,6 @@ describe('GithubCredentialsProvider tests', () => {
     ).resolves.toEqual({ headers: undefined, token: undefined, type: 'token' });
   });
 
-  // it('should return installation', async () => {
-  //   const githubProvider = GithubCredentialsProvider.create({
-  //     host: 'github.com',
-  //     apps: [
-  //       {
-  //         appId: 1,
-  //         privateKey: 'privateKey',
-  //         webhookSecret: '123',
-  //         clientId: 'CLIENT_ID',
-  //         clientSecret: 'CLIENT_SECRET',
-  //       },
-  //     ],
-  //   });
-  //
-  //   octokit.apps.listInstallations.mockResolvedValue(({
-  //     data: [],
-  //   } as unknown) as RestEndpointMethodTypes['apps']['listInstallations']['response']);
-  //
-  //   await expect(
-  //     githubProvider.getInstallationCredentials('Backstage'),
-  //   ).resolves.toEqual({ headers: undefined, token: undefined, type: 'token' });
-  // });
-
   it('should to create and ignore case sensitive when creating a token', async () => {
     octokit.apps.listInstallations.mockResolvedValue({
       headers: {

--- a/packages/integration/src/github/GithubCredentialsProvider.ts
+++ b/packages/integration/src/github/GithubCredentialsProvider.ts
@@ -129,7 +129,7 @@ class GithubAppManager {
   private async getInstallationData(owner: string): Promise<InstallationData> {
     const allInstallations = await this.getInstallations();
     const installation = allInstallations.find(
-      inst => inst.account?.login === owner,
+      inst => inst.account?.login.toLowerCase() === owner.toLowerCase(),
     );
     if (installation) {
       return {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes an issue when comparing the organization name defined in the config file with the return from the Github API.

This problem only occur using Github App, because before getting a token it gets the existing installation list.

Basically, backstage returns that there is no instance for the organization, as Github returns the organization name as case sensitive.

the fix is relatively simple. It basically makes the organization name lowercase before comparing.

In the use tests I did, only this was necessary to 100% solve the problem.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
