### PR TITLE
fixed bug on when compared in organzation name on github

### DIFF
--- a/.changeset/purple-rocks-explode.md
+++ b/.changeset/purple-rocks-explode.md
@@ -2,4 +2,4 @@
 '@backstage/integration': patch
 ---
 
-Fixed bug on when compared in organzation name on github
+Fixed bug for comparing Organization name in `GithubCredentialsProvider`

--- a/.changeset/purple-rocks-explode.md
+++ b/.changeset/purple-rocks-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fixed bug on when compared in organzation name on github

--- a/packages/integration/src/github/GithubCredentialsProvider.ts
+++ b/packages/integration/src/github/GithubCredentialsProvider.ts
@@ -129,7 +129,7 @@ class GithubAppManager {
   private async getInstallationData(owner: string): Promise<InstallationData> {
     const allInstallations = await this.getInstallations();
     const installation = allInstallations.find(
-      inst => inst.account?.login.toLowerCase() === owner.toLowerCase(),
+      inst => inst.account?.login?.toLowerCase() === owner.toLowerCase(),
     );
     if (installation) {
       return {

--- a/packages/integration/src/github/GithubCredentialsProvider.ts
+++ b/packages/integration/src/github/GithubCredentialsProvider.ts
@@ -129,7 +129,7 @@ class GithubAppManager {
   private async getInstallationData(owner: string): Promise<InstallationData> {
     const allInstallations = await this.getInstallations();
     const installation = allInstallations.find(
-      inst => inst.account?.login === owner,
+      inst => inst.account?.login.toLowerCase() === owner.toLowerCase(),
     );
     if (installation) {
       return {


### PR DESCRIPTION
Signed-off-by: Aurelio Saraiva <aureliosaraiva@gmail.com>

## Hey, I just made a Pull Request!

This PR fixes an issue when comparing the organization name defined in the config file with the return from the Github API.

This problem only occur using Github App, because before getting a token it gets the existing installation list.

Basically, backstage returns that there is no instance for the organization, as Github returns the organization name as case sensitive.

the fix is relatively simple. It basically makes the organization name lowercase before comparing.

In the use tests I did, only this was necessary to 100% solve the problem.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
