### PR TITLE
Fix docs and types for InfoCard styling props

### DIFF
--- a/.changeset/hot-bees-sleep.md
+++ b/.changeset/hot-bees-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Remove unused props from InfoCard prop type

--- a/.changeset/hot-bees-sleep.md
+++ b/.changeset/hot-bees-sleep.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/core-components': patch
+'@backstage/core-components': minor
 ---
 
 Remove unused props from InfoCard prop type

--- a/packages/core-components/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core-components/src/layout/InfoCard/InfoCard.tsx
@@ -91,8 +91,8 @@ export type InfoCardVariants = 'flex' | 'fullHeight' | 'gridItem';
 /**
  * InfoCard is used to display a paper-styled block on the screen, similar to a panel.
  *
- * You can custom style an InfoCard with the 'style' (outer container) and 'cardStyle' (inner container)
- * styles.
+ * You can custom style an InfoCard with the 'className' (outer container) and 'cardClassName' (inner container)
+ * props. This is typically used with the material-ui makeStyles mechanism.
  *
  * The InfoCard serves as an error boundary. As a result, if you provide an 'errorBoundaryProps' property this
  * specifies the extra information to display in the error component that is displayed if an error occurs
@@ -115,8 +115,6 @@ type Props = {
   slackChannel?: string;
   errorBoundaryProps?: ErrorBoundaryProps;
   variant?: InfoCardVariants;
-  style?: object;
-  cardStyle?: object;
   children?: ReactNode;
   headerStyle?: object;
   headerProps?: CardHeaderProps;


### PR DESCRIPTION
Fix docs and types for InfoCard styling props

Note that there is no change in the api-report due to `Warning:
(ae-forgotten-export) The symbol "Props" needs to be exported by the entry
point index.d.ts` and as these props are currently ignored, I think this is
fine as a patch release but please confirm.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
