### PR TITLE
bug: fix invalidation of entity and re-rendering of the EntityRoutes when Entity Changes

### DIFF
--- a/.changeset/four-planes-retire.md
+++ b/.changeset/four-planes-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fix bug with re-rendering the EntityRoutes when the entity changes but the route does not

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -174,28 +174,31 @@ export const EntityLayout = ({
 }: EntityLayoutProps) => {
   const { kind, namespace, name } = useEntityCompoundName();
   const { entity, loading, error } = useContext(EntityContext);
+  const routes = useElementFilter(
+    children,
+    elements =>
+      elements
+        .selectByComponentData({
+          key: dataKey,
+          withStrictError:
+            'Child of EntityLayout must be an EntityLayout.Route',
+        })
+        .getElements<SubRoute>() // all nodes, element data, maintain structure or not?
+        .flatMap(({ props }) => {
+          if (props.if && entity && !props.if(entity)) {
+            return [];
+          }
 
-  const routes = useElementFilter(children, elements =>
-    elements
-      .selectByComponentData({
-        key: dataKey,
-        withStrictError: 'Child of EntityLayout must be an EntityLayout.Route',
-      })
-      .getElements<SubRoute>() // all nodes, element data, maintain structure or not?
-      .flatMap(({ props }) => {
-        if (props.if && entity && !props.if(entity)) {
-          return [];
-        }
-
-        return [
-          {
-            path: props.path,
-            title: props.title,
-            children: props.children,
-            tabProps: props.tabProps,
-          },
-        ];
-      }),
+          return [
+            {
+              path: props.path,
+              title: props.title,
+              children: props.children,
+              tabProps: props.tabProps,
+            },
+          ];
+        }),
+    [entity],
   );
 
   const { headerTitle, headerType } = headerProps(


### PR DESCRIPTION
Fixes #6699 

Need to add the Entity as a dependency to the `elementFilter`
