### PR TITLE
[Cost Insights] Allow currencies to be extended

### DIFF
--- a/.changeset/metal-olives-relax.md
+++ b/.changeset/metal-olives-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Added optional currencies prop

--- a/plugins/cost-insights/api-report.md
+++ b/plugins/cost-insights/api-report.md
@@ -370,10 +370,13 @@ export const costInsightsApiRef: ApiRef<CostInsightsApi>;
 // @public (undocumented)
 export const CostInsightsLabelDataflowInstructionsPage: () => JSX.Element;
 
+// Warning: (ae-forgotten-export) The symbol "CostInsightsPageProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "CostInsightsPage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const CostInsightsPage: () => JSX.Element;
+export const CostInsightsPage: ({
+  currencies,
+}: CostInsightsPageProps) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "CostInsightsPaletteAdditions" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "CostInsightsPalette" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPageRoot.tsx
+++ b/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPageRoot.tsx
@@ -24,10 +24,15 @@ import { ScrollProvider } from '../../hooks/useScroll';
 import { ConfigProvider } from '../../hooks/useConfig';
 import { BillingDateProvider } from '../../hooks/useLastCompleteBillingDate';
 import { CostInsightsThemeProvider } from './CostInsightsThemeProvider';
+import { Currency } from '../../types';
 
-export const CostInsightsPageRoot = () => (
+export type CostInsightsPageProps = {
+  currencies?: Currency[];
+};
+
+export const CostInsightsPageRoot = ({ currencies }: CostInsightsPageProps) => (
   <CostInsightsThemeProvider>
-    <ConfigProvider>
+    <ConfigProvider currencies={currencies}>
       <LoadingProvider>
         <GroupsProvider>
           <BillingDateProvider>

--- a/plugins/cost-insights/src/hooks/useConfig.tsx
+++ b/plugins/cost-insights/src/hooks/useConfig.tsx
@@ -68,7 +68,14 @@ const defaultState: ConfigContextProps = {
   currencies: defaultCurrencies,
 };
 
-export const ConfigProvider = ({ children }: PropsWithChildren<{}>) => {
+export type ConfigProviderProps = {
+  currencies?: Currency[];
+};
+
+export const ConfigProvider = ({
+  currencies,
+  children,
+}: PropsWithChildren<ConfigProviderProps>) => {
   const c: BackstageConfig = useApi(configApiRef);
   const [config, setConfig] = useState(defaultState);
   const [loading, setLoading] = useState(true);
@@ -124,6 +131,7 @@ export const ConfigProvider = ({ children }: PropsWithChildren<{}>) => {
         products,
         engineerCost,
         icons,
+        currencies: currencies?.length ? currencies : defaultCurrencies,
       }));
 
       setLoading(false);

--- a/plugins/cost-insights/src/hooks/useCurrency.tsx
+++ b/plugins/cost-insights/src/hooks/useCurrency.tsx
@@ -21,8 +21,7 @@ import React, {
   PropsWithChildren,
 } from 'react';
 import { Currency } from '../types';
-import { findAlways } from '../utils/assert';
-import { defaultCurrencies } from '../utils/currency';
+import { useConfig } from './useConfig';
 
 export type CurrencyContextProps = {
   currency: Currency;
@@ -34,8 +33,11 @@ export const CurrencyContext = React.createContext<
 >(undefined);
 
 export const CurrencyProvider = ({ children }: PropsWithChildren<{}>) => {
-  const engineers = findAlways(defaultCurrencies, c => c.kind === null);
-  const [currency, setCurrency] = useState<Currency>(engineers);
+  const config = useConfig();
+  const engineers = config.currencies.find(currency => currency.kind === null);
+  const [currency, setCurrency] = useState<Currency>(
+    engineers || config.currencies[0],
+  );
   return (
     <CurrencyContext.Provider value={{ currency, setCurrency }}>
       {children}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Added an optional prop to pass currencies into CostInsightsPage to replace defaultCurrencies. Closes https://github.com/backstage/backstage/issues/6695

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
