### PR TITLE
core-components: fall back to using `idToken` for backwards compatibility

### DIFF
--- a/packages/core-components/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core-components/src/layout/SignInPage/SignInPage.tsx
@@ -130,7 +130,9 @@ export const SingleSignInPage = ({
           userId: identity!.id,
           profile: profile!,
           getIdToken: () => {
-            return authApi.getBackstageIdentity().then(i => i!.token);
+            return authApi
+              .getBackstageIdentity()
+              .then(i => i!.token ?? i!.idToken);
           },
           signOut: async () => {
             await authApi.signOut();

--- a/packages/core-components/src/layout/SignInPage/auth0Provider.tsx
+++ b/packages/core-components/src/layout/SignInPage/auth0Provider.tsx
@@ -40,7 +40,7 @@ const Component: ProviderComponent = ({ onResult }) => {
         userId: identity!.id,
         profile: profile!,
         getIdToken: () =>
-          auth0AuthApi.getBackstageIdentity().then(i => i!.token),
+          auth0AuthApi.getBackstageIdentity().then(i => i!.token ?? i!.idToken),
         signOut: async () => {
           await auth0AuthApi.signOut();
         },
@@ -82,7 +82,8 @@ const loader: ProviderLoader = async apis => {
   return {
     userId: identity.id,
     profile: profile!,
-    getIdToken: () => auth0AuthApi.getBackstageIdentity().then(i => i!.token),
+    getIdToken: () =>
+      auth0AuthApi.getBackstageIdentity().then(i => i!.token ?? i!.idToken),
     signOut: async () => {
       await auth0AuthApi.signOut();
     },

--- a/packages/core-components/src/layout/SignInPage/commonProvider.tsx
+++ b/packages/core-components/src/layout/SignInPage/commonProvider.tsx
@@ -86,7 +86,8 @@ const loader: ProviderLoader = async (apis, apiRef) => {
   return {
     userId: identity.id,
     profile: profile!,
-    getIdToken: () => authApi.getBackstageIdentity().then(i => i!.token),
+    getIdToken: () =>
+      authApi.getBackstageIdentity().then(i => i!.token ?? i!.idToken),
     signOut: async () => {
       await authApi.signOut();
     },


### PR DESCRIPTION
Small followup to #6675 to make it backwards compatible