### PR TITLE
Support deep linking in OpenAPI definitions

### DIFF
--- a/.changeset/small-guests-invite.md
+++ b/.changeset/small-guests-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Support deep linking in OpenAPI definitions.

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinitionWidget.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import React, { useEffect, useState } from 'react';
 import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
 
@@ -83,7 +83,7 @@ export const OpenApiDefinitionWidget = ({ definition }: Props) => {
 
   return (
     <div className={classes.root}>
-      <SwaggerUI spec={def} />
+      <SwaggerUI spec={def} deepLinking />
     </div>
   );
 };


### PR DESCRIPTION
Just came along that this is disabled while implementing a search collator for OpenAPI documents.
Not sure if it is worth to test it. This would require to mock some evil stuff 😅 But I'm open for suggestions

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
