### PR TITLE
Add auth token to SonarQubeClient via IdentityApi

### DIFF
--- a/.changeset/little-tools-melt.md
+++ b/.changeset/little-tools-melt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sonarqube': minor
+---
+
+Use IdentityApi to provide Auth Token for SonarQubeClient Api calls

--- a/plugins/sonarqube/src/api/SonarQubeClient.test.ts
+++ b/plugins/sonarqube/src/api/SonarQubeClient.test.ts
@@ -322,7 +322,7 @@ describe('SonarQubeClient', () => {
     server.use(
       rest.get(`${mockBaseUrl}/sonarqube/components/show`, (req, res, ctx) => {
         expect(req.url.searchParams.toString()).toBe('component=our%3Aservice');
-        expect(req.headers.get('Authorization')).toBeUndefined();
+        expect(req.headers.has('Authorization')).toBeFalsy();
         return res(
           ctx.json({
             component: {

--- a/plugins/sonarqube/src/api/SonarQubeClient.test.ts
+++ b/plugins/sonarqube/src/api/SonarQubeClient.test.ts
@@ -20,8 +20,38 @@ import { setupServer } from 'msw/node';
 import { FindingSummary, SonarQubeClient } from './index';
 import { ComponentWrapper, MeasuresWrapper } from './types';
 import { UrlPatternDiscovery } from '@backstage/core-app-api';
+import { IdentityApi } from '@backstage/core-plugin-api';
 
 const server = setupServer();
+
+const identityApiAuthenticated: IdentityApi = {
+  getUserId() {
+    return 'jane-fonda';
+  },
+  getProfile() {
+    return { email: 'jane-fonda@spotify.com' };
+  },
+  async getIdToken() {
+    return Promise.resolve('fake-id-token');
+  },
+  async signOut() {
+    return Promise.resolve();
+  },
+};
+const identityApiGuest: IdentityApi = {
+  getUserId() {
+    return 'guest';
+  },
+  getProfile() {
+    return {};
+  },
+  async getIdToken() {
+    return Promise.resolve(undefined);
+  },
+  async signOut() {
+    return Promise.resolve();
+  },
+};
 
 describe('SonarQubeClient', () => {
   msw.setupDefaultHandlers(server);
@@ -161,7 +191,10 @@ describe('SonarQubeClient', () => {
   it('should report finding summary', async () => {
     setupHandlers();
 
-    const client = new SonarQubeClient({ discoveryApi });
+    const client = new SonarQubeClient({
+      discoveryApi,
+      identityApi: identityApiAuthenticated,
+    });
 
     const summary = await client.getFindingSummary('our:service');
     expect(summary).toEqual(
@@ -197,6 +230,7 @@ describe('SonarQubeClient', () => {
     const client = new SonarQubeClient({
       discoveryApi,
       baseUrl: 'http://a.instance.local',
+      identityApi: identityApiAuthenticated,
     });
 
     const summary = await client.getFindingSummary('our:service');
@@ -234,6 +268,7 @@ describe('SonarQubeClient', () => {
     const client = new SonarQubeClient({
       discoveryApi,
       baseUrl: 'http://a.instance.local',
+      identityApi: identityApiAuthenticated,
     });
 
     const summary = await client.getFindingSummary('our:service');
@@ -254,5 +289,57 @@ describe('SonarQubeClient', () => {
     expect(summary?.getComponentMeasuresUrl('COVERAGE')).toEqual(
       'http://a.instance.local/component_measures?id=our%3Aservice&metric=coverage&resolved=false&view=list',
     );
+  });
+
+  it('should add identity token for logged in users', async () => {
+    setupHandlers();
+    server.use(
+      rest.get(`${mockBaseUrl}/sonarqube/components/show`, (req, res, ctx) => {
+        expect(req.url.searchParams.toString()).toBe('component=our%3Aservice');
+        expect(req.headers.get('Authorization')).toBe('Bearer fake-id-token');
+        return res(
+          ctx.json({
+            component: {
+              analysisDate: '2020-01-01T00:00:00Z',
+            },
+          } as ComponentWrapper),
+        );
+      }),
+    );
+
+    const client = new SonarQubeClient({
+      discoveryApi,
+      baseUrl: 'http://a.instance.local',
+      identityApi: identityApiAuthenticated,
+    });
+    const summary = await client.getFindingSummary('our:service');
+
+    expect(summary?.lastAnalysis).toBe('2020-01-01T00:00:00Z');
+  });
+
+  it('should omit identity token for guest users', async () => {
+    setupHandlers();
+    server.use(
+      rest.get(`${mockBaseUrl}/sonarqube/components/show`, (req, res, ctx) => {
+        expect(req.url.searchParams.toString()).toBe('component=our%3Aservice');
+        expect(req.headers.get('Authorization')).toBeUndefined();
+        return res(
+          ctx.json({
+            component: {
+              analysisDate: '2020-01-01T00:00:00Z',
+            },
+          } as ComponentWrapper),
+        );
+      }),
+    );
+
+    const client = new SonarQubeClient({
+      discoveryApi,
+      baseUrl: 'http://a.instance.local',
+      identityApi: identityApiGuest,
+    });
+    const summary = await client.getFindingSummary('our:service');
+
+    expect(summary?.lastAnalysis).toBe('2020-01-01T00:00:00Z');
   });
 });

--- a/plugins/sonarqube/src/plugin.ts
+++ b/plugins/sonarqube/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   createComponentExtension,
   createPlugin,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 
 export const sonarQubePlugin = createPlugin({
@@ -28,11 +29,16 @@ export const sonarQubePlugin = createPlugin({
   apis: [
     createApiFactory({
       api: sonarQubeApiRef,
-      deps: { configApi: configApiRef, discoveryApi: discoveryApiRef },
-      factory: ({ configApi, discoveryApi }) =>
+      deps: {
+        configApi: configApiRef,
+        discoveryApi: discoveryApiRef,
+        identityApi: identityApiRef,
+      },
+      factory: ({ configApi, discoveryApi, identityApi }) =>
         new SonarQubeClient({
           discoveryApi,
           baseUrl: configApi.getOptionalString('sonarQube.baseUrl'),
+          identityApi,
         }),
     }),
   ],


### PR DESCRIPTION
# Add Authentication for SonarQube plugin

Use the IdentityApi to get a token and add it to SonarQubeClient requests when the token exists.

address #6718

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [✔️ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ✔️] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [✔️ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
