### PR TITLE
Add EntityNamePicker component to validate entity names in templates

### DIFF
--- a/.changeset/happy-lies-wink.md
+++ b/.changeset/happy-lies-wink.md
@@ -1,0 +1,22 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+- Adds a new field `EntityNamePicker` that can be used in scaffolder templates to accept and validate an entity name. This field is registered by default, and can be used in templates by setting the `ui:field` property to `EntityNamePicker`. If you've customized your scaffolder field extensions, you can include this one by adding it when registering the scaffolder route:
+
+```diff
+import {
+  ScaffolderFieldExtensions,
++   EntityNamePickerFieldExtension,
+} from '@backstage/plugin-scaffolder';
+
+  <Route path="/create" element={<ScaffolderPage />}>
+    <ScaffolderFieldExtensions>
+      {/* ...custom field extensions... */}
+
++       <EntityNamePickerFieldExtension />
+    </ScaffolderFieldExtensions>
+  </Route>;
+```
+
+- Adds a new generic field `TextValuePicker` to be used when writing custom field extensions that use a standard UI with custom validation. An example of doing this can be found in `packages/app/src/components/scaffolder/customScaffolderExtensions.tsx`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@backstage/test-utils": "^0.1.16",
+    "@rjsf/core": "^3.0.0",
     "@testing-library/cypress": "^7.0.1",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^11.2.5",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -50,7 +50,6 @@ import {
   EntityPickerFieldExtension,
   EntityNamePickerFieldExtension,
 } from '@backstage/plugin-scaffolder';
-import { ScaffolderPage, scaffolderPlugin } from '@backstage/plugin-scaffolder';
 import { SearchPage } from '@backstage/plugin-search';
 import { TechRadarPage } from '@backstage/plugin-tech-radar';
 import { TechdocsPage } from '@backstage/plugin-techdocs';
@@ -63,6 +62,7 @@ import { apis } from './apis';
 import { Root } from './components/Root';
 import { entityPage } from './components/catalog/EntityPage';
 import { searchPage } from './components/search/SearchPage';
+import { LowerCaseValuePickerFieldExtension } from './components/scaffolder/customScaffolderExtensions';
 import { providers } from './identityProviders';
 import * as plugins from './plugins';
 
@@ -133,7 +133,6 @@ const routes = (
     />
     <Route path="/graphiql" element={<GraphiQLPage />} />
     <Route path="/lighthouse" element={<LighthousePage />} />
-
     <Route path="/api-docs" element={<ApiExplorerPage />} />
     <Route path="/gcp-projects" element={<GcpProjectsPage />} />
     <Route path="/newrelic" element={<NewRelicPage />} />

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -41,6 +41,15 @@ import { GcpProjectsPage } from '@backstage/plugin-gcp-projects';
 import { GraphiQLPage } from '@backstage/plugin-graphiql';
 import { LighthousePage } from '@backstage/plugin-lighthouse';
 import { NewRelicPage } from '@backstage/plugin-newrelic';
+import {
+  ScaffolderPage,
+  scaffolderPlugin,
+  ScaffolderFieldExtensions,
+  RepoUrlPickerFieldExtension,
+  OwnerPickerFieldExtension,
+  EntityPickerFieldExtension,
+  EntityNamePickerFieldExtension,
+} from '@backstage/plugin-scaffolder';
 import { ScaffolderPage, scaffolderPlugin } from '@backstage/plugin-scaffolder';
 import { SearchPage } from '@backstage/plugin-search';
 import { TechRadarPage } from '@backstage/plugin-tech-radar';
@@ -108,7 +117,15 @@ const routes = (
     </Route>
     <Route path="/catalog-import" element={<CatalogImportPage />} />
     <Route path="/docs" element={<TechdocsPage />} />
-    <Route path="/create" element={<ScaffolderPage />} />
+    <Route path="/create" element={<ScaffolderPage />}>
+      <ScaffolderFieldExtensions>
+        <EntityPickerFieldExtension />
+        <EntityNamePickerFieldExtension />
+        <RepoUrlPickerFieldExtension />
+        <OwnerPickerFieldExtension />
+        <LowerCaseValuePickerFieldExtension />
+      </ScaffolderFieldExtensions>
+    </Route>
     <Route path="/explore" element={<ExplorePage />} />
     <Route
       path="/tech-radar"

--- a/packages/app/src/components/scaffolder/customScaffolderExtensions.tsx
+++ b/packages/app/src/components/scaffolder/customScaffolderExtensions.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { FieldValidation } from '@rjsf/core';
+import {
+  createScaffolderFieldExtension,
+  TextValuePicker,
+  scaffolderPlugin,
+} from '@backstage/plugin-scaffolder';
+
+export const LowerCaseValuePickerFieldExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    name: 'LowerCaseValuePicker',
+    component: TextValuePicker,
+    validation: (value: string, validation: FieldValidation) => {
+      if (value.toLowerCase() !== value) {
+        validation.addError('Only lowercase values are allowed.');
+      }
+    },
+  }),
+);

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -43,6 +43,31 @@ export type CustomFieldValidator<T> =
       },
     ) => void);
 
+// Warning: (ae-missing-release-tag) "EntityNamePicker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const EntityNamePicker: ({
+  schema: { title, description },
+  ...props
+}: FieldProps<string>) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "EntityNamePickerFieldExtension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const EntityNamePickerFieldExtension: () => null;
+
+// Warning: (ae-missing-release-tag) "EntityPicker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const EntityPicker: ({
+  onChange,
+  schema: { title, description },
+  required,
+  uiSchema,
+  rawErrors,
+  formData,
+}: FieldProps<string>) => JSX.Element;
+
 // Warning: (ae-missing-release-tag) "EntityPickerFieldExtension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -57,10 +82,29 @@ export type FieldExtensionOptions<T = any> = {
   validation?: CustomFieldValidator<T>;
 };
 
+// Warning: (ae-missing-release-tag) "OwnerPicker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const OwnerPicker: ({
+  schema: { title, description },
+  uiSchema,
+  ...props
+}: FieldProps<string>) => JSX.Element;
+
 // Warning: (ae-missing-release-tag) "OwnerPickerFieldExtension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const OwnerPickerFieldExtension: () => null;
+
+// Warning: (ae-missing-release-tag) "RepoUrlPicker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const RepoUrlPicker: ({
+  onChange,
+  uiSchema,
+  rawErrors,
+  formData,
+}: FieldProps<string>) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "RepoUrlPickerFieldExtension" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -178,6 +222,18 @@ const scaffolderPlugin: BackstagePlugin<
 >;
 export { scaffolderPlugin as plugin };
 export { scaffolderPlugin };
+
+// Warning: (ae-missing-release-tag) "TextValuePicker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const TextValuePicker: ({
+  onChange,
+  required,
+  schema: { title, description },
+  rawErrors,
+  formData,
+  uiSchema: { 'ui:autofocus': autoFocus },
+}: FieldProps<string>) => JSX.Element;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
@@ -20,6 +20,7 @@ import Input from '@material-ui/core/Input';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 
+// TODO(Mike/Himanshu): Create a simple TextValuePicker so that it could be reused for creating custom field extensions with its own validators.
 export const EntityNamePicker = ({
   onChange,
   required,

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
@@ -15,30 +15,11 @@
  */
 import React from 'react';
 import { FieldProps } from '@rjsf/core';
-import InputLabel from '@material-ui/core/InputLabel';
-import Input from '@material-ui/core/Input';
-import FormControl from '@material-ui/core/FormControl';
-import FormHelperText from '@material-ui/core/FormHelperText';
+import { TextValuePicker } from '../TextValuePicker';
 
-// TODO(Mike/Himanshu): Create a simple TextValuePicker so that it could be reused for creating custom field extensions with its own validators.
 export const EntityNamePicker = ({
-  onChange,
-  required,
   schema: { title = 'Name', description = 'Unique name of the component' },
-  rawErrors,
-  formData,
+  ...props
 }: FieldProps<string>) => (
-  <FormControl
-    margin="normal"
-    required={required}
-    error={rawErrors?.length > 0 && !formData}
-  >
-    <InputLabel htmlFor="nameInput">{title}</InputLabel>
-    <Input
-      id="nameInput"
-      onChange={({ target: { value } }) => onChange(value)}
-      value={formData ?? ''}
-    />
-    <FormHelperText>{description}</FormHelperText>
-  </FormControl>
+  <TextValuePicker schema={{ title, description }} {...props} />
 );

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/EntityNamePicker.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { FieldProps } from '@rjsf/core';
+import InputLabel from '@material-ui/core/InputLabel';
+import Input from '@material-ui/core/Input';
+import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
+
+export const EntityNamePicker = ({
+  onChange,
+  required,
+  schema: { title = 'Name', description = 'Unique name of the component' },
+  rawErrors,
+  formData,
+}: FieldProps<string>) => (
+  <FormControl
+    margin="normal"
+    required={required}
+    error={rawErrors?.length > 0 && !formData}
+  >
+    <InputLabel htmlFor="nameInput">{title}</InputLabel>
+    <Input
+      id="nameInput"
+      onChange={({ target: { value } }) => onChange(value)}
+      value={formData ?? ''}
+    />
+    <FormHelperText>{description}</FormHelperText>
+  </FormControl>
+);

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/index.ts
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/index.ts
@@ -13,7 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './EntityNamePicker';
-export * from './EntityPicker';
-export * from './OwnerPicker';
-export * from './RepoUrlPicker';
+export { EntityNamePicker } from './EntityNamePicker';
+export { entityNamePickerValidation } from './validation';

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/validation.test.ts
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/validation.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FieldValidation } from '@rjsf/core';
+import { KubernetesValidatorFunctions } from '@backstage/catalog-model';
+import { entityNamePickerValidation } from './validation';
+
+jest.mock('@backstage/catalog-model', () => ({
+  KubernetesValidatorFunctions: {
+    isValidObjectName: jest.fn(),
+  },
+}));
+
+const mockIsValidObjectName = KubernetesValidatorFunctions.isValidObjectName as jest.MockedFunction<
+  typeof KubernetesValidatorFunctions.isValidObjectName
+>;
+
+describe('EntityNamePicker Validation', () => {
+  let mockFieldValidation: FieldValidation;
+
+  beforeEach(() => {
+    mockFieldValidation = ({
+      addError: jest.fn(),
+    } as unknown) as FieldValidation;
+  });
+
+  it('calls isValidObjectName to validate value', () => {
+    entityNamePickerValidation('test value', mockFieldValidation);
+
+    expect(mockIsValidObjectName).toHaveBeenCalled();
+  });
+
+  it('does not add an error when isValidObjectName returns true', () => {
+    mockIsValidObjectName.mockReturnValue(true);
+
+    entityNamePickerValidation('test value', mockFieldValidation);
+
+    expect(mockFieldValidation.addError).not.toHaveBeenCalled();
+  });
+
+  it('adds an error when isValidObjectName returns false', () => {
+    mockIsValidObjectName.mockReturnValue(false);
+
+    entityNamePickerValidation('test value', mockFieldValidation);
+
+    expect(mockFieldValidation.addError).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /contain only alphanumeric characters, hyphens, underscores, and periods/,
+      ),
+    );
+  });
+});

--- a/plugins/scaffolder/src/components/fields/EntityNamePicker/validation.ts
+++ b/plugins/scaffolder/src/components/fields/EntityNamePicker/validation.ts
@@ -13,7 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './EntityNamePicker';
-export * from './EntityPicker';
-export * from './OwnerPicker';
-export * from './RepoUrlPicker';
+
+import { FieldValidation } from '@rjsf/core';
+import { KubernetesValidatorFunctions } from '@backstage/catalog-model';
+
+export const entityNamePickerValidation = (
+  value: string,
+  validation: FieldValidation,
+) => {
+  if (!KubernetesValidatorFunctions.isValidObjectName(value)) {
+    validation.addError(
+      'must start and end with an alphanumeric character, and contain only alphanumeric characters, hyphens, underscores, and periods. Maximum length is 63 characters.',
+    );
+  }
+};

--- a/plugins/scaffolder/src/components/fields/TextValuePicker/TextValuePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/TextValuePicker/TextValuePicker.tsx
@@ -23,6 +23,7 @@ export const TextValuePicker = ({
   schema: { title, description },
   rawErrors,
   formData,
+  uiSchema: { 'ui:autofocus': autoFocus },
 }: FieldProps<string>) => (
   <TextField
     label={title}
@@ -32,5 +33,6 @@ export const TextValuePicker = ({
     onChange={({ target: { value } }) => onChange(value)}
     margin="normal"
     error={rawErrors?.length > 0 && !formData}
+    inputProps={{ autoFocus }}
   />
 );

--- a/plugins/scaffolder/src/components/fields/TextValuePicker/TextValuePicker.tsx
+++ b/plugins/scaffolder/src/components/fields/TextValuePicker/TextValuePicker.tsx
@@ -13,8 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './EntityNamePicker';
-export * from './EntityPicker';
-export * from './OwnerPicker';
-export * from './RepoUrlPicker';
-export * from './TextValuePicker';
+import React from 'react';
+import { FieldProps } from '@rjsf/core';
+import { TextField } from '@material-ui/core';
+
+export const TextValuePicker = ({
+  onChange,
+  required,
+  schema: { title, description },
+  rawErrors,
+  formData,
+}: FieldProps<string>) => (
+  <TextField
+    label={title}
+    helperText={description}
+    required={required}
+    value={formData ?? ''}
+    onChange={({ target: { value } }) => onChange(value)}
+    margin="normal"
+    error={rawErrors?.length > 0 && !formData}
+  />
+);

--- a/plugins/scaffolder/src/components/fields/TextValuePicker/index.ts
+++ b/plugins/scaffolder/src/components/fields/TextValuePicker/index.ts
@@ -13,8 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './EntityNamePicker';
-export * from './EntityPicker';
-export * from './OwnerPicker';
-export * from './RepoUrlPicker';
-export * from './TextValuePicker';
+export { TextValuePicker } from './TextValuePicker';

--- a/plugins/scaffolder/src/extensions/default.ts
+++ b/plugins/scaffolder/src/extensions/default.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 import { EntityPicker } from '../components/fields/EntityPicker';
+import {
+  EntityNamePicker,
+  entityNamePickerValidation,
+} from '../components/fields/EntityNamePicker';
 import { OwnerPicker } from '../components/fields/OwnerPicker';
 import {
   repoPickerValidation,
@@ -25,6 +29,11 @@ export const DEFAULT_SCAFFOLDER_FIELD_EXTENSIONS: FieldExtensionOptions[] = [
   {
     component: EntityPicker,
     name: 'EntityPicker',
+  },
+  {
+    component: EntityNamePicker,
+    name: 'EntityNamePicker',
+    validation: entityNamePickerValidation,
   },
   {
     component: RepoUrlPicker,

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -23,6 +23,7 @@ export {
 export type { CustomFieldValidator, FieldExtensionOptions } from './extensions';
 export {
   EntityPickerFieldExtension,
+  EntityNamePickerFieldExtension,
   OwnerPickerFieldExtension,
   RepoUrlPickerFieldExtension,
   ScaffolderPage,

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -30,3 +30,9 @@ export {
   scaffolderPlugin as plugin,
   scaffolderPlugin,
 } from './plugin';
+export {
+  EntityNamePicker,
+  EntityPicker,
+  OwnerPicker,
+  RepoUrlPicker,
+} from './components/fields';

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -35,4 +35,5 @@ export {
   EntityPicker,
   OwnerPicker,
   RepoUrlPicker,
+  TextValuePicker,
 } from './components/fields';

--- a/plugins/scaffolder/src/plugin.ts
+++ b/plugins/scaffolder/src/plugin.ts
@@ -17,6 +17,10 @@
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 import { scaffolderApiRef, ScaffolderClient } from './api';
 import { EntityPicker } from './components/fields/EntityPicker';
+import {
+  entityNamePickerValidation,
+  EntityNamePicker,
+} from './components/fields/EntityNamePicker';
 import { OwnerPicker } from './components/fields/OwnerPicker';
 import {
   repoPickerValidation,
@@ -58,6 +62,14 @@ export const EntityPickerFieldExtension = scaffolderPlugin.provide(
   createScaffolderFieldExtension({
     component: EntityPicker,
     name: 'EntityPicker',
+  }),
+);
+
+export const EntityNamePickerFieldExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    component: EntityNamePicker,
+    name: 'EntityNamePicker',
+    validation: entityNamePickerValidation,
   }),
 );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #6687.

- Adds an `EntityNamePicker` component that reuses the entity name validation from the catalog
- Adds this field to the default scaffolder field extensions

### To do 

- [x] Open PR to update [software-templates](https://github.com/backstage/software-templates) examples to use EntityNamePicker - https://github.com/backstage/software-templates/pull/5
- [x] Changeset

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
