### PR TITLE
cli: add new --with-cli option to build commands

### DIFF
--- a/packages/cli/src/commands/backend/build.ts
+++ b/packages/cli/src/commands/backend/build.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { Command } from 'commander';
 import { buildPackage, Output } from '../../lib/builder';
 
-export default async () => {
+export default async (cmd: Command) => {
   await buildPackage({
     outputs: new Set([Output.cjs, Output.types]),
+    withCli: cmd.withCli,
   });
 };

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -33,5 +33,5 @@ export default async (cmd: Command) => {
     outputs = new Set([Output.types, Output.esm, Output.cjs]);
   }
 
-  await buildPackage({ outputs });
+  await buildPackage({ outputs, withCli: cmd.withCli });
 };

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -43,6 +43,10 @@ export function registerCommands(program: CommanderStatic) {
   program
     .command('backend:build')
     .description('Build a backend plugin')
+    .option(
+      '--with-cli',
+      'Build an additional bundle from the cli/index.ts entrypoint (EXPERIMENTAL)',
+    )
     .action(lazy(() => import('./backend/build').then(m => m.default)));
 
   program
@@ -97,6 +101,10 @@ export function registerCommands(program: CommanderStatic) {
   program
     .command('plugin:build')
     .description('Build a plugin')
+    .option(
+      '--with-cli',
+      'Build an additional bundle from the cli/index.ts entrypoint (EXPERIMENTAL)',
+    )
     .action(lazy(() => import('./plugin/build').then(m => m.default)));
 
   program
@@ -117,6 +125,10 @@ export function registerCommands(program: CommanderStatic) {
     .command('build')
     .description('Build a package for publishing')
     .option('--outputs <formats>', 'List of formats to output [types,cjs,esm]')
+    .option(
+      '--with-cli',
+      'Build an additional bundle from the cli/index.ts entrypoint (EXPERIMENTAL)',
+    )
     .action(lazy(() => import('./build').then(m => m.default)));
 
   program

--- a/packages/cli/src/commands/plugin/build.ts
+++ b/packages/cli/src/commands/plugin/build.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { Command } from 'commander';
 import { buildPackage, Output } from '../../lib/builder';
 
-export default async () => {
+export default async (cmd: Command) => {
   await buildPackage({
     outputs: new Set([Output.esm, Output.types]),
+    withCli: cmd.withCli,
   });
 };

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -38,6 +38,38 @@ export const makeConfigs = async (
 ): Promise<RollupOptions[]> => {
   const configs = new Array<RollupOptions>();
 
+  if (options.withCli) {
+    configs.push({
+      input: 'cli/index.ts',
+      output: [
+        {
+          dir: 'dist',
+          entryFileNames: 'cli.cjs.js',
+          chunkFileNames: 'cli/[name]-[hash].cjs.js',
+          format: 'commonjs',
+          sourcemap: true,
+        },
+      ],
+      preserveEntrySignatures: 'strict',
+      external: require('module').builtinModules,
+      plugins: [
+        peerDepsExternal({
+          includeDependencies: true,
+        }),
+        resolve({ mainFields: ['module', 'main'] }),
+        commonjs({
+          include: /node_modules/,
+          exclude: [/\/[^/]+\.(?:stories|test)\.[^/]+$/],
+        }),
+        json(),
+        yaml(),
+        esbuild({
+          target: 'es2019',
+        }),
+      ],
+    });
+  }
+
   if (options.outputs.has(Output.cjs) || options.outputs.has(Output.esm)) {
     const output = new Array<OutputOptions>();
     const mainFields = ['module', 'main'];

--- a/packages/cli/src/lib/builder/types.ts
+++ b/packages/cli/src/lib/builder/types.ts
@@ -22,4 +22,5 @@ export enum Output {
 
 export type BuildOptions = {
   outputs: Set<Output>;
+  withCli?: boolean;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "packages/*/src",
     "plugins/*/src",
     "plugins/*/dev",
+    "plugins/*/cli",
     "plugins/*/migrations"
   ],
   "compilerOptions": {


### PR DESCRIPTION
Draft with a possible idea for how to handle the build of additional package CLIs such as the one in #6638

Some open questions here are whether it makes sense to hardcode this for CLIs only, or if we should strive for something more complex that can handle multiple entrypoints. We could also skip the `--with-cli` flag and just automatically build `cli/index.ts` if it exists. There's also the question of whether `cli/index.ts` makes sense, compared to for example `src/cli.ts`, where I'm thinking that it's better to separate the CLI bits from the rest.

The changes to `tsconfig.json` are needed for the type checking similar to the plugin `dev/` one, although that change wouldn't be needed if we put the cli `src/`.

The way this would be used is to add the `--with-cli` flag to the build script, and then point a package.json `bin` entry to `dist/cli.cjs.js`. This does only cover the production build though, so if we want to go with something like this we should add execution via `ts-node` for development as well.

This is a bit of a hack compared to some other solutions, so happy hear ideas or if someone wants to take on the task of building this out. My vision for the implementation of helpers like the one in #6638 is really that there would be something like a `backstage-cli install-plugin <plugin-package-name>` command, and that it would add the dependency to the project but also be able run some form of declarative setup script that is bundled with the plugin. That's much more work though and not somewhere we wanna put focus atm.