### PR TITLE
Use EntityNamePicker in sample templates

### DIFF
--- a/.changeset/silver-squids-lay.md
+++ b/.changeset/silver-squids-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Updates the sample templates to use the new `EntityNamePicker` field, and cleans up some unused field configuration.

--- a/plugins/scaffolder-backend/sample-templates/create-react-app/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/create-react-app/template.yaml
@@ -20,6 +20,7 @@ spec:
           title: Name
           type: string
           description: Unique name of the component
+          ui:field: EntityNamePicker
         description:
           title: Description
           type: string

--- a/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml
@@ -24,14 +24,10 @@ spec:
           description: Unique name of the component
           ui:field: EntityNamePicker
           ui:autofocus: true
-          ui:options:
-            rows: 5
         description:
           title: Description
           type: string
           description: A description for the component
-          ui:options:
-            rows: 5
         owner:
           title: Owner
           type: string

--- a/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/docs-template/template.yaml
@@ -22,6 +22,7 @@ spec:
           title: Name
           type: string
           description: Unique name of the component
+          ui:field: EntityNamePicker
           ui:autofocus: true
           ui:options:
             rows: 5

--- a/plugins/scaffolder-backend/sample-templates/pull-request/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/pull-request/template.yaml
@@ -17,6 +17,7 @@ spec:
           title: Name
           type: string
           description: Unique name of the component
+          ui:field: EntityNamePicker
           ui:autofocus: true
           ui:options:
             rows: 5

--- a/plugins/scaffolder-backend/sample-templates/pull-request/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/pull-request/template.yaml
@@ -19,8 +19,6 @@ spec:
           description: Unique name of the component
           ui:field: EntityNamePicker
           ui:autofocus: true
-          ui:options:
-            rows: 5
         description:
           title: Description
           type: string

--- a/plugins/scaffolder-backend/sample-templates/rails-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/rails-demo/template.yaml
@@ -20,8 +20,6 @@ spec:
           description: Unique name of the component
           ui:field: EntityNamePicker
           ui:autofocus: true
-          ui:options:
-            rows: 5
         owner:
           title: Owner
           type: string

--- a/plugins/scaffolder-backend/sample-templates/rails-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/rails-demo/template.yaml
@@ -18,6 +18,7 @@ spec:
           title: Name
           type: string
           description: Unique name of the component
+          ui:field: EntityNamePicker
           ui:autofocus: true
           ui:options:
             rows: 5

--- a/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/react-ssr-template/template.yaml
@@ -20,6 +20,7 @@ spec:
           title: Name
           type: string
           description: Unique name of the component
+          ui:field: EntityNamePicker
         description:
           title: Description
           type: string

--- a/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/springboot-grpc-template/template.yaml
@@ -23,6 +23,7 @@ spec:
           title: Name
           type: string
           description: Unique name of the component
+          ui:field: EntityNamePicker
         java_package_name:
           title: Java Package Name
           type: string

--- a/plugins/scaffolder-backend/sample-templates/v1beta2-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/v1beta2-demo/template.yaml
@@ -20,8 +20,6 @@ spec:
           description: Unique name of the component
           ui:field: EntityNamePicker
           ui:autofocus: true
-          ui:options:
-            rows: 5
         owner:
           title: Owner
           type: string

--- a/plugins/scaffolder-backend/sample-templates/v1beta2-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/v1beta2-demo/template.yaml
@@ -18,6 +18,7 @@ spec:
           title: Name
           type: string
           description: Unique name of the component
+          ui:field: EntityNamePicker
           ui:autofocus: true
           ui:options:
             rows: 5


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Updates the sample templates to use the EntityNamePicker for entity names
- Cleans up some unused config from the sample templates in babcfed.

This PR should not be merged until after the changes in #6723 have been released.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
