### PR TITLE
Merge default scaffolder field extensions

### DIFF
--- a/.changeset/afraid-pots-protect.md
+++ b/.changeset/afraid-pots-protect.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Previously when supplying custom scaffolder field extensions, it was necessary to also include the default ones if they were needed. Since the field extensions are keyed by name, there's no harm in leaving the default ones in place when adding custom ones - if templates don't refer to them they will be ignored, and if custom ones are introduced with the same name, the custom ones will take priority over the default ones.
+
+Users configuring custom field extensions can remove the default ones from the scaffolder route after this change, and they'll still be available:
+
+```diff
+    <Route path="/create" element={<ScaffolderPage />}>
+      <ScaffolderFieldExtensions>
+-        <EntityPickerFieldExtension />
+-        <EntityNamePickerFieldExtension />
+-        <RepoUrlPickerFieldExtension />
+-        <OwnerPickerFieldExtension />
+        <LowerCaseValuePickerFieldExtension />
+      </ScaffolderFieldExtensions>
+    </Route>
+```

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -45,10 +45,6 @@ import {
   ScaffolderPage,
   scaffolderPlugin,
   ScaffolderFieldExtensions,
-  RepoUrlPickerFieldExtension,
-  OwnerPickerFieldExtension,
-  EntityPickerFieldExtension,
-  EntityNamePickerFieldExtension,
 } from '@backstage/plugin-scaffolder';
 import { SearchPage } from '@backstage/plugin-search';
 import { TechRadarPage } from '@backstage/plugin-tech-radar';
@@ -129,10 +125,6 @@ const routes = (
     />
     <Route path="/create" element={<ScaffolderPage />}>
       <ScaffolderFieldExtensions>
-        <EntityPickerFieldExtension />
-        <EntityNamePickerFieldExtension />
-        <RepoUrlPickerFieldExtension />
-        <OwnerPickerFieldExtension />
         <LowerCaseValuePickerFieldExtension />
       </ScaffolderFieldExtensions>
     </Route>

--- a/plugins/scaffolder/src/components/Router.tsx
+++ b/plugins/scaffolder/src/components/Router.tsx
@@ -32,7 +32,7 @@ import { useElementFilter } from '@backstage/core-plugin-api';
 export const Router = () => {
   const outlet = useOutlet();
 
-  const foundExtensions = useElementFilter(outlet, elements =>
+  const customFieldExtensions = useElementFilter(outlet, elements =>
     elements
       .selectByComponentData({
         key: FIELD_EXTENSION_WRAPPER_KEY,
@@ -42,9 +42,15 @@ export const Router = () => {
       }),
   );
 
-  const fieldExtensions = foundExtensions.length
-    ? foundExtensions
-    : DEFAULT_SCAFFOLDER_FIELD_EXTENSIONS;
+  const fieldExtensions = [
+    ...customFieldExtensions,
+    ...DEFAULT_SCAFFOLDER_FIELD_EXTENSIONS.filter(
+      ({ name }) =>
+        !customFieldExtensions.some(
+          customFieldExtension => customFieldExtension.name === name,
+        ),
+    ),
+  ];
 
   return (
     <Routes>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Note that this PR targets the branch from #6723 for now.

Opening this without a changeset etc. to gather feedback. @OrkoHunter and I noticed that integrators who want to add additional custom scaffolder field extensions must also include all the default ones. This means that these integrators will have to update their App.tsx every time the default set of scaffolder field extensions changes. This PR introduces code in the scaffolder router which merges the default scaffolder field extensions with any custom ones supplied.

An alternative to this might be exporing a `DefaultScaffolderFieldExtensions` component that integrators can use to indicate that they want the default field extensions along with their custom ones.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
