### PR TITLE
backend-common: more informative error message when no url reader is matches

### DIFF
--- a/.changeset/eighty-glasses-mate.md
+++ b/.changeset/eighty-glasses-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Use a more informative error message when URL reading isn't allowed due to no reader matching the target URL.

--- a/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
+++ b/packages/backend-common/src/reading/UrlReaderPredicateMux.ts
@@ -52,7 +52,11 @@ export class UrlReaderPredicateMux implements UrlReader {
       }
     }
 
-    throw new NotAllowedError(`Reading from '${url}' is not allowed`);
+    throw new NotAllowedError(
+      `Reading from '${url}' is not allowed. ` +
+        `You may need to configure an integration for the target host, or add it ` +
+        `to the configured list of allowed hosts at 'backend.reading.allow'`,
+    );
   }
 
   async readUrl(


### PR DESCRIPTION
This is a common source of confusion, so hoping this clears things up.