### PR TITLE
chore(search-backend): Improve search query log message

### DIFF
--- a/.changeset/nasty-queens-juggle.md
+++ b/.changeset/nasty-queens-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': patch
+---
+
+Improve search query logging message

--- a/plugins/search-backend/src/service/router.ts
+++ b/plugins/search-backend/src/service/router.ts
@@ -38,7 +38,7 @@ export async function createRouter({
     ) => {
       const { term, filters = {}, pageCursor = '' } = req.query;
       logger.info(
-        `Search request received: ${term}, ${JSON.stringify(
+        `Search request received: term="${term}", filters=${JSON.stringify(
           filters,
         )}, ${pageCursor}`,
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When visiting the search homepage by clicking on the spy glass (with no search term), I noticed this in the log:

```
2021-08-06T01:22:29.212Z search info Search request received: , {},  type=plugin
```

It wasn't exactly clear what it was logging. So a few minor tweaks just to elevate the clarity a bit more:

```
2021-08-06T01:18:41.166Z search info Search request received: term="", filters=,  type=plugin
2021-08-06T01:18:41.166Z search info Search request received: term="foo", filters={"kind":"Component"},  type=plugin
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
