### PR TITLE
lerna.json: set version to 0.1.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*", "plugins/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.1"
+  "version": "0.1.0"
 }


### PR DESCRIPTION
This is the reason all plugins are created with version 0.1.1, figured this makes more sense