### PR TITLE
add ability to specify an external id for assumed role for k8

### DIFF
--- a/.changeset/four-buttons-design.md
+++ b/.changeset/four-buttons-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Adds ability to send an ExternalId with the assume role request to AWS

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -16,6 +16,8 @@ import { Logger as Logger_2 } from 'winston';
 export interface AWSClusterDetails extends ClusterDetails {
   // (undocumented)
   assumeRole?: string;
+  // (undocumented)
+  externalId?: string;
 }
 
 // Warning: (ae-missing-release-tag) "ClusterDetails" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -86,4 +86,5 @@ export interface GKEClusterDetails extends ClusterDetails {}
 export interface ServiceAccountClusterDetails extends ClusterDetails {}
 export interface AWSClusterDetails extends ClusterDetails {
   assumeRole?: string;
+  externalId?: string;
 }


### PR DESCRIPTION
From the AWS documentation.

A cross-account role is usually set up to trust everyone in an account.
Therefore, the administrator of the trusting account might send an external
ID to the administrator of the trusted account. That way, only someone with
the ID can assume the role, rather than everyone in the account.