### PR TITLE
Allow Kubernetes plugin to filter the list of configured clusters on a per entity filter

### DIFF
--- a/.changeset/little-llamas-roll.md
+++ b/.changeset/little-llamas-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': minor
+---
+
+Allow Kubernetes plugin to filter the list of configured clusters on a per entity filter

--- a/plugins/kubernetes-backend/src/service/KubernetesClusterFilter.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClusterFilter.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@backstage/backend-common';
+import { KubernetestClusterFilter } from './KubernetesClusterFilter';
+
+describe('KubernetestClusterFilter', () => {
+  it('empty filter is not valid', () => {
+    expect(() => new KubernetestClusterFilter('')).toThrow(
+      "Invalid filter: ''",
+    );
+  });
+
+  it('filter with forbidden chars is not valid', () => {
+    expect(() => new KubernetestClusterFilter('a?b')).toThrow(
+      "Invalid filter: 'a?b'",
+    );
+  });
+
+  it('simple text filter should match whole name', () => {
+    const filter = new KubernetestClusterFilter('foo');
+    expect(filter.isMatch('foo')).toBeTruthy();
+    expect(filter.isMatch('foo2')).toBeFalsy();
+    expect(filter.isMatch('2foo')).toBeFalsy();
+    expect(filter.isMatch('2foo2')).toBeFalsy();
+  });
+
+  it('filter with special chars should match whole name', () => {
+    const filter = new KubernetestClusterFilter('foo - Bar_v3');
+    expect(filter.isMatch('foo - Bar_v3')).toBeTruthy();
+    expect(filter.isMatch('foo - Bar_v32')).toBeFalsy();
+    expect(filter.isMatch('2foo - Bar_v3')).toBeFalsy();
+    expect(filter.isMatch('2foo - Bar_v32')).toBeFalsy();
+  });
+
+  it('filter should match partial expressions - one star - suffix', async () => {
+    const filter = new KubernetestClusterFilter('corpo-*');
+    expect(filter.isMatch('corpo-dev')).toBeTruthy();
+    expect(filter.isMatch('corpo-Prod')).toBeTruthy();
+    expect(filter.isMatch('bi-dev')).toBeFalsy();
+    expect(filter.isMatch('bi-Prod')).toBeFalsy();
+  });
+
+  it('filter should match partial expressions - one star - prefix', async () => {
+    const filter = new KubernetestClusterFilter('*-dev');
+    expect(filter.isMatch('corpo-dev')).toBeTruthy();
+    expect(filter.isMatch('bi-dev')).toBeTruthy();
+    expect(filter.isMatch('corpo-prod')).toBeFalsy();
+    expect(filter.isMatch('bi-prod')).toBeFalsy();
+  });
+
+  it('filter should match partial expressions - two stars', async () => {
+    const filter = new KubernetestClusterFilter('*-dept1-*');
+    expect(filter.isMatch('prefix-dept1-suffix')).toBeTruthy();
+    expect(filter.isMatch('Prefix-dept1-Suffix')).toBeTruthy();
+    expect(filter.isMatch('dept1')).toBeFalsy();
+    expect(filter.isMatch('dept1-suffix')).toBeFalsy();
+    expect(filter.isMatch('-dept1-suffix')).toBeFalsy();
+    expect(filter.isMatch('prefix-dept1')).toBeFalsy();
+    expect(filter.isMatch('prefix-dept1-')).toBeFalsy();
+  });
+});

--- a/plugins/kubernetes-backend/src/service/KubernetesClusterFilter.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClusterFilter.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ALLOWED_FILTER_CHARS = /^[0-9a-zA-Z-_*\s]+$/;
+
+function buildRegexFromFilter(filter: string): RegExp {
+  if (!ALLOWED_FILTER_CHARS.test(filter)) {
+    throw new Error(`Invalid filter: '${filter}'`);
+  }
+  const pattern = filter.replace(/\*/g, '.+');
+  return RegExp(`^${pattern}$`);
+}
+
+export class KubernetestClusterFilter {
+  private _filterRegex: RegExp;
+
+  constructor(filter: string) {
+    this._filterRegex = buildRegexFromFilter(filter);
+  }
+
+  isMatch(name: string): boolean {
+    return this._filterRegex.test(name);
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We have multiple departments and each department has 3 clusters (for dev, staging and production), so we end up with quite a big list of clusters.

So, in order to avoid fetching clusters that are not used by a specific service, I ended up adding a new kubernetes annotation which allows one to configure a simple filter on the valid cluster names.

If we have the following app-config:
```
kubernetes:
  serviceLocatorMethod:
    type: 'multiTenant'
  clusterLocatorMethods:
    - type: 'config'
      clusters:
        - url: '...'
          name: corpo-dev
        - url: '...'
          name: corpo-staging
        - url: '...'
          name: corpo-prod  
        - url: '...'
          name: bi-dev
        - url: '...'
          name: bi-staging
        - url: '...'
          name: bi-prod
```

Then we can add the following '**backstage.io/kubernetes-cluster-filter**' annotation to a service description:

```
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  name: petstore
  # This is an extra long description
  description: The Petstore is an example API used to show features of the OpenAPI spec.
  links:
    - url: https://github.com/swagger-api/swagger-petstore
      title: GitHub Repo
      icon: github
  annotations:
    backstage.io/kubernetes-id: petstore
    backstage.io/kubernetes-cluster-filter: 'corpo-*'
spec:
  type: service
  lifecycle: experimental
  owner: team-c
  providesApis:
    - petstore
    - streetlights
    - hello-world
```
Note that in order to make the filter simple and easy to read, I'm just offering something similar to a SQL like expression, using a star instead of a percentage. So, 'corpo-*' is the same as the '^corpo-.+$' regex.

I didn't provide additional documentation since I don't know if you will like this addition (and I haven't done any documentation in backstage yet!).


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
