### PR TITLE
[Techdocs] Set the correct edit_uri or repo_url for documentation pages that are hosted on GitHub and GitLab

### DIFF
--- a/.changeset/techdocs-three-icons-collect.md
+++ b/.changeset/techdocs-three-icons-collect.md
@@ -1,0 +1,7 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Only write the updated `mkdocs.yml` file if the content was updated.
+
+This keeps local files unchanged if the `dir` annotation is used in combination with the `file` location.

--- a/.changeset/techdocs-warm-walls-smile.md
+++ b/.changeset/techdocs-warm-walls-smile.md
@@ -1,0 +1,17 @@
+---
+'@backstage/techdocs-common': minor
+---
+
+Set the correct `edit_uri` or `repo_url` for documentation pages that are hosted on GitHub and GitLab.
+
+The constructor of the `TechDocsGenerator` changed.
+Prefer the use of `TechdocsGenerator.fromConfig(…)` instead:
+
+```diff
+- const techdocsGenerator = new TechdocsGenerator({
++ const techdocsGenerator = TechdocsGenerator.fromConfig(config, {
+    logger,
+    containerRunner,
+-   config,
+  });
+```

--- a/packages/techdocs-common/api-report.md
+++ b/packages/techdocs-common/api-report.md
@@ -230,10 +230,12 @@ export class TechdocsGenerator implements GeneratorBase {
     logger,
     containerRunner,
     config,
+    scmIntegrations,
   }: {
     logger: Logger_2;
     containerRunner: ContainerRunner;
     config: Config;
+    scmIntegrations: ScmIntegrationRegistry;
   });
   // (undocumented)
   static fromConfig(
@@ -245,7 +247,7 @@ export class TechdocsGenerator implements GeneratorBase {
       containerRunner: ContainerRunner;
       logger: Logger_2;
     },
-  ): Promise<TechdocsGenerator>;
+  ): TechdocsGenerator;
   // (undocumented)
   run({
     inputDir,

--- a/packages/techdocs-common/package.json
+++ b/packages/techdocs-common/package.json
@@ -49,6 +49,7 @@
     "aws-sdk": "^2.840.0",
     "express": "^4.17.1",
     "fs-extra": "9.1.0",
+    "git-url-parse": "~11.4.4",
     "js-yaml": "^4.0.0",
     "json5": "^2.1.3",
     "mime-types": "^2.1.27",

--- a/packages/techdocs-common/src/stages/generate/__fixtures__/mkdocs_with_comments.yml
+++ b/packages/techdocs-common/src/stages/generate/__fixtures__/mkdocs_with_comments.yml
@@ -1,0 +1,3 @@
+site_name: Test site name
+site_description: Test site description
+# This is a comment that is removed after editing

--- a/packages/techdocs-common/src/stages/generate/__fixtures__/mkdocs_with_edit_uri.yml
+++ b/packages/techdocs-common/src/stages/generate/__fixtures__/mkdocs_with_edit_uri.yml
@@ -1,0 +1,4 @@
+site_name: Test site name
+site_description: Test site description
+
+edit_uri: https://github.com/backstage/backstage/edit/main/docs

--- a/packages/techdocs-common/src/stages/generate/generators.test.ts
+++ b/packages/techdocs-common/src/stages/generate/generators.test.ts
@@ -44,10 +44,9 @@ describe('generators', () => {
 
   it('should return correct registered generator', async () => {
     const generators = new Generators();
-    const techdocs = new TechdocsGenerator({
+    const techdocs = TechdocsGenerator.fromConfig(new ConfigReader({}), {
       logger,
       containerRunner,
-      config: new ConfigReader({}),
     });
 
     generators.register('techdocs', techdocs);

--- a/packages/techdocs-common/src/stages/generate/generators.ts
+++ b/packages/techdocs-common/src/stages/generate/generators.ts
@@ -38,10 +38,9 @@ export class Generators implements GeneratorBuilder {
   ): Promise<GeneratorBuilder> {
     const generators = new Generators();
 
-    const techdocsGenerator = new TechdocsGenerator({
+    const techdocsGenerator = TechdocsGenerator.fromConfig(config, {
       logger,
       containerRunner,
-      config,
     });
     generators.register('techdocs', techdocsGenerator);
 

--- a/packages/techdocs-common/src/stages/generate/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.test.ts
@@ -61,6 +61,9 @@ const mkdocsYmlWithInvalidDocDir = fs.readFileSync(
 const mkdocsYmlWithInvalidDocDir2 = fs.readFileSync(
   resolvePath(__filename, '../__fixtures__/mkdocs_invalid_doc_dir2.yml'),
 );
+const mkdocsYmlWithComments = fs.readFileSync(
+  resolvePath(__filename, '../__fixtures__/mkdocs_with_comments.yml'),
+);
 const mockLogger = getVoidLogger();
 const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
 
@@ -163,6 +166,7 @@ describe('helpers', () => {
         '/mkdocs_with_repo_url.yml': mkdocsYmlWithRepoUrl,
         '/mkdocs_with_edit_uri.yml': mkdocsYmlWithEditUri,
         '/mkdocs_with_extensions.yml': mkdocsYmlWithExtensions,
+        '/mkdocs_with_comments.yml': mkdocsYmlWithComments,
       });
     });
 
@@ -257,6 +261,28 @@ describe('helpers', () => {
       expect(updatedMkdocsYml.toString()).not.toContain(
         'https://github.com/neworg/newrepo',
       );
+    });
+
+    it('should not update mkdocs.yml if nothing should be changed', async () => {
+      const parsedLocationAnnotation: ParsedLocationAnnotation = {
+        type: 'dir',
+        target: '/unsupported/path',
+      };
+
+      await patchMkdocsYmlPreBuild(
+        '/mkdocs_with_comments.yml',
+        mockLogger,
+        parsedLocationAnnotation,
+        scmIntegrations,
+      );
+
+      const updatedMkdocsYml = await fs.readFile('/mkdocs_with_comments.yml');
+
+      expect(updatedMkdocsYml.toString()).toContain(
+        '# This is a comment that is removed after editing',
+      );
+      expect(updatedMkdocsYml.toString()).not.toContain('edit_uri');
+      expect(updatedMkdocsYml.toString()).not.toContain('repo_url');
     });
   });
 

--- a/packages/techdocs-common/src/stages/generate/helpers.test.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.test.ts
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
+import { ScmIntegrations } from '@backstage/integration';
 import fs from 'fs-extra';
 import mockFs from 'mock-fs';
 import os from 'os';
 import path, { resolve as resolvePath } from 'path';
 import { ParsedLocationAnnotation } from '../../helpers';
-import { RemoteProtocol } from '../prepare/types';
 import {
   addBuildTimestampMetadata,
   getGeneratorKey,
   getMkdocsYml,
   getRepoUrlFromLocationAnnotation,
-  isValidRepoUrlForMkdocs,
   patchMkdocsYmlPreBuild,
   storeEtagMetadata,
   validateMkdocsYaml,
@@ -48,6 +49,9 @@ const mkdocsYmlWithExtensions = fs.readFileSync(
 const mkdocsYmlWithRepoUrl = fs.readFileSync(
   resolvePath(__filename, '../__fixtures__/mkdocs_with_repo_url.yml'),
 );
+const mkdocsYmlWithEditUri = fs.readFileSync(
+  resolvePath(__filename, '../__fixtures__/mkdocs_with_edit_uri.yml'),
+);
 const mkdocsYmlWithValidDocDir = fs.readFileSync(
   resolvePath(__filename, '../__fixtures__/mkdocs_valid_doc_dir.yml'),
 );
@@ -60,6 +64,8 @@ const mkdocsYmlWithInvalidDocDir2 = fs.readFileSync(
 const mockLogger = getVoidLogger();
 const rootDir = os.platform() === 'win32' ? 'C:\\rootDir' : '/rootDir';
 
+const scmIntegrations = ScmIntegrations.fromConfig(new ConfigReader({}));
+
 describe('helpers', () => {
   describe('getGeneratorKey', () => {
     it('should return techdocs as the only generator key', () => {
@@ -68,120 +74,85 @@ describe('helpers', () => {
     });
   });
 
-  describe('isValidRepoUrlForMkdocs', () => {
-    it('should return true for valid repo_url values for mkdocs', () => {
-      const validRepoUrls = [
-        'https://github.com/org/repo',
-        'https://github.com/backstage/backstage/',
-        'https://github.com/org123/repo1-2-3/',
-        'http://github.com/insecureOrg/insecureRepo',
-        'https://gitlab.com/org/repo',
-        'https://gitlab.com/backstage/backstage/',
-        'https://gitlab.com/org123/repo1-2-3/',
-        'http://gitlab.com/insecureOrg/insecureRepo',
-      ];
-
-      const validRemoteProtocols = ['github', 'gitlab'];
-
-      validRepoUrls.forEach(url => {
-        validRemoteProtocols.forEach(targetType => {
-          expect(
-            isValidRepoUrlForMkdocs(url, targetType as RemoteProtocol),
-          ).toBe(true);
-        });
-      });
-    });
-
-    it('should return false for invalid repo_urls values for mkdocs', () => {
-      const invalidRepoUrls = [
-        'git@github.com:org/repo',
-        'https://github.com/backstage/backstage/tree/master/plugins/techdocs-backend',
-      ];
-
-      invalidRepoUrls.forEach(url => {
-        expect(isValidRepoUrlForMkdocs(url, 'github')).toBe(false);
-      });
-    });
-
-    it('should return false for unsupported remote protocols', () => {
-      const validRepoUrl = 'https://github.com/backstage/backstage';
-
-      const unsupportedRemoteProtocols = ['dir', 'file', 'url'];
-
-      unsupportedRemoteProtocols.forEach(targetType => {
-        expect(
-          isValidRepoUrlForMkdocs(validRepoUrl, targetType as RemoteProtocol),
-        ).toBe(false);
-      });
-    });
-  });
-
   describe('getRepoUrlFromLocationAnnotation', () => {
-    it('should return undefined for unsupported location type', () => {
-      const parsedLocationAnnotation1: ParsedLocationAnnotation = {
+    it.each`
+      url                                                                        | repo_url                                    | edit_uri
+      ${'https://github.com/backstage/backstage'}                                | ${'https://github.com/backstage/backstage'} | ${undefined}
+      ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${undefined}                                | ${'https://github.com/backstage/backstage/edit/main/examples/techdocs/docs'}
+      ${'https://github.com/backstage/backstage/tree/main/'}                     | ${undefined}                                | ${'https://github.com/backstage/backstage/edit/main/docs'}
+      ${'https://gitlab.com/backstage/backstage'}                                | ${'https://gitlab.com/backstage/backstage'} | ${undefined}
+      ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${undefined}                                | ${'https://gitlab.com/backstage/backstage/-/edit/main/examples/techdocs/docs'}
+      ${'https://gitlab.com/backstage/backstage/-/blob/main/'}                   | ${undefined}                                | ${'https://gitlab.com/backstage/backstage/-/edit/main/docs'}
+    `('should convert $url', ({ url: target, repo_url, edit_uri }) => {
+      const parsedLocationAnnotation: ParsedLocationAnnotation = {
+        type: 'url',
+        target,
+      };
+
+      expect(
+        getRepoUrlFromLocationAnnotation(
+          parsedLocationAnnotation,
+          scmIntegrations,
+        ),
+      ).toEqual({ repo_url, edit_uri });
+    });
+
+    it.each`
+      url                                                                        | edit_uri
+      ${'https://github.com/backstage/backstage/tree/main/examples/techdocs/'}   | ${'https://github.com/backstage/backstage/edit/main/examples/techdocs/custom/folder'}
+      ${'https://github.com/backstage/backstage/tree/main/'}                     | ${'https://github.com/backstage/backstage/edit/main/custom/folder'}
+      ${'https://gitlab.com/backstage/backstage/-/blob/main/examples/techdocs/'} | ${'https://gitlab.com/backstage/backstage/-/edit/main/examples/techdocs/custom/folder'}
+      ${'https://gitlab.com/backstage/backstage/-/blob/main/'}                   | ${'https://gitlab.com/backstage/backstage/-/edit/main/custom/folder'}
+    `(
+      'should convert $url with custom docsFolder',
+      ({ url: target, edit_uri }) => {
+        const parsedLocationAnnotation: ParsedLocationAnnotation = {
+          type: 'url',
+          target,
+        };
+
+        expect(
+          getRepoUrlFromLocationAnnotation(
+            parsedLocationAnnotation,
+            scmIntegrations,
+            './custom/folder',
+          ),
+        ).toEqual({ edit_uri });
+      },
+    );
+
+    it.each`
+      url
+      ${'https://bitbucket.org/backstage/backstage/src/master/examples/techdocs/'}
+      ${'https://bitbucket.org/backstage/backstage/src/master/'}
+      ${'https://dev.azure.com/organization/project/_git/repository?path=%2Fexamples%2Ftechdocs'}
+      ${'https://dev.azure.com/organization/project/_git/repository?path=%2F'}
+    `('should ignore $url', ({ url: target }) => {
+      const parsedLocationAnnotation: ParsedLocationAnnotation = {
+        type: 'url',
+        target,
+      };
+
+      expect(
+        getRepoUrlFromLocationAnnotation(
+          parsedLocationAnnotation,
+          scmIntegrations,
+        ),
+      ).toEqual({});
+    });
+
+    it('should ignore unsupported location type', () => {
+      const parsedLocationAnnotation: ParsedLocationAnnotation = {
         type: 'dir',
         target: '/home/user/workspace/docs-repository',
       };
 
-      const parsedLocationAnnotation2: ParsedLocationAnnotation = {
-        type: 'file' as RemoteProtocol,
-        target: '/home/user/workspace/docs-repository/catalog-info.yaml',
-      };
-
-      const parsedLocationAnnotation3: ParsedLocationAnnotation = {
-        type: 'url',
-        target: 'https://my-website.com/storage/this/docs/repository',
-      };
-
-      expect(getRepoUrlFromLocationAnnotation(parsedLocationAnnotation1)).toBe(
-        undefined,
-      );
-      expect(getRepoUrlFromLocationAnnotation(parsedLocationAnnotation2)).toBe(
-        undefined,
-      );
-
-      expect(getRepoUrlFromLocationAnnotation(parsedLocationAnnotation3)).toBe(
-        undefined,
-      );
-    });
-
-    it('should return correct target url for supported hosts', () => {
-      const parsedLocationAnnotation1: ParsedLocationAnnotation = {
-        type: 'github' as RemoteProtocol,
-        target: 'https://github.com/backstage/backstage.git',
-      };
-
-      expect(getRepoUrlFromLocationAnnotation(parsedLocationAnnotation1)).toBe(
-        'https://github.com/backstage/backstage',
-      );
-
-      const parsedLocationAnnotation2: ParsedLocationAnnotation = {
-        type: 'github' as RemoteProtocol,
-        target: 'https://github.com/org/repo',
-      };
-
-      expect(getRepoUrlFromLocationAnnotation(parsedLocationAnnotation2)).toBe(
-        'https://github.com/org/repo',
-      );
-
-      const parsedLocationAnnotation3: ParsedLocationAnnotation = {
-        type: 'gitlab' as RemoteProtocol,
-        target: 'https://gitlab.com/org/repo',
-      };
-
-      expect(getRepoUrlFromLocationAnnotation(parsedLocationAnnotation3)).toBe(
-        'https://gitlab.com/org/repo',
-      );
-
-      const parsedLocationAnnotation4: ParsedLocationAnnotation = {
-        type: 'github' as RemoteProtocol,
-        target:
-          'github.com/backstage/backstage/blob/master/plugins/techdocs-backend/examples/documented-component',
-      };
-
-      expect(getRepoUrlFromLocationAnnotation(parsedLocationAnnotation4)).toBe(
-        'github.com/backstage/backstage/blob/master/plugins/techdocs-backend/examples/documented-component',
-      );
+      expect(
+        getRepoUrlFromLocationAnnotation(
+          parsedLocationAnnotation,
+          scmIntegrations,
+        ),
+      ).toEqual({});
     });
   });
 
@@ -190,6 +161,7 @@ describe('helpers', () => {
       mockFs({
         '/mkdocs.yml': mkdocsYml,
         '/mkdocs_with_repo_url.yml': mkdocsYmlWithRepoUrl,
+        '/mkdocs_with_edit_uri.yml': mkdocsYmlWithEditUri,
         '/mkdocs_with_extensions.yml': mkdocsYmlWithExtensions,
       });
     });
@@ -198,9 +170,9 @@ describe('helpers', () => {
       mockFs.restore();
     });
 
-    it('should add repo_url to mkdocs.yml', async () => {
+    it('should add edit_uri to mkdocs.yml', async () => {
       const parsedLocationAnnotation: ParsedLocationAnnotation = {
-        type: 'github' as RemoteProtocol,
+        type: 'url',
         target: 'https://github.com/backstage/backstage',
       };
 
@@ -208,6 +180,7 @@ describe('helpers', () => {
         '/mkdocs.yml',
         mockLogger,
         parsedLocationAnnotation,
+        scmIntegrations,
       );
 
       const updatedMkdocsYml = await fs.readFile('/mkdocs.yml');
@@ -219,7 +192,7 @@ describe('helpers', () => {
 
     it('should add repo_url to mkdocs.yml that contains custom yaml tags', async () => {
       const parsedLocationAnnotation: ParsedLocationAnnotation = {
-        type: 'github' as RemoteProtocol,
+        type: 'url',
         target: 'https://github.com/backstage/backstage',
       };
 
@@ -227,6 +200,7 @@ describe('helpers', () => {
         '/mkdocs_with_extensions.yml',
         mockLogger,
         parsedLocationAnnotation,
+        scmIntegrations,
       );
 
       const updatedMkdocsYml = await fs.readFile('/mkdocs_with_extensions.yml');
@@ -241,7 +215,7 @@ describe('helpers', () => {
 
     it('should not override existing repo_url in mkdocs.yml', async () => {
       const parsedLocationAnnotation: ParsedLocationAnnotation = {
-        type: 'github' as RemoteProtocol,
+        type: 'url',
         target: 'https://github.com/neworg/newrepo',
       };
 
@@ -249,6 +223,7 @@ describe('helpers', () => {
         '/mkdocs_with_repo_url.yml',
         mockLogger,
         parsedLocationAnnotation,
+        scmIntegrations,
       );
 
       const updatedMkdocsYml = await fs.readFile('/mkdocs_with_repo_url.yml');
@@ -258,6 +233,29 @@ describe('helpers', () => {
       );
       expect(updatedMkdocsYml.toString()).not.toContain(
         'repo_url: https://github.com/neworg/newrepo',
+      );
+    });
+
+    it('should not override existing edit_uri in mkdocs.yml', async () => {
+      const parsedLocationAnnotation: ParsedLocationAnnotation = {
+        type: 'url',
+        target: 'https://github.com/neworg/newrepo',
+      };
+
+      await patchMkdocsYmlPreBuild(
+        '/mkdocs_with_edit_uri.yml',
+        mockLogger,
+        parsedLocationAnnotation,
+        scmIntegrations,
+      );
+
+      const updatedMkdocsYml = await fs.readFile('/mkdocs_with_edit_uri.yml');
+
+      expect(updatedMkdocsYml.toString()).toContain(
+        'edit_uri: https://github.com/backstage/backstage/edit/main/docs',
+      );
+      expect(updatedMkdocsYml.toString()).not.toContain(
+        'https://github.com/neworg/newrepo',
       );
     });
   });

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -19,6 +19,10 @@ import { Config } from '@backstage/config';
 import path from 'path';
 import { Logger } from 'winston';
 import {
+  ScmIntegrationRegistry,
+  ScmIntegrations,
+} from '@backstage/integration';
+import {
   addBuildTimestampMetadata,
   getMkdocsYml,
   patchMkdocsYmlPreBuild,
@@ -39,29 +43,39 @@ export class TechdocsGenerator implements GeneratorBase {
   private readonly logger: Logger;
   private readonly containerRunner: ContainerRunner;
   private readonly options: GeneratorConfig;
+  private readonly scmIntegrations: ScmIntegrationRegistry;
 
-  static async fromConfig(
+  static fromConfig(
     config: Config,
     {
       containerRunner,
       logger,
     }: { containerRunner: ContainerRunner; logger: Logger },
   ) {
-    return new TechdocsGenerator({ logger, containerRunner, config });
+    const scmIntegrations = ScmIntegrations.fromConfig(config);
+    return new TechdocsGenerator({
+      logger,
+      containerRunner,
+      config,
+      scmIntegrations,
+    });
   }
 
   constructor({
     logger,
     containerRunner,
     config,
+    scmIntegrations,
   }: {
     logger: Logger;
     containerRunner: ContainerRunner;
     config: Config;
+    scmIntegrations: ScmIntegrationRegistry;
   }) {
     this.logger = logger;
     this.options = readGeneratorConfig(config, logger);
     this.containerRunner = containerRunner;
+    this.scmIntegrations = scmIntegrations;
   }
 
   public async run({
@@ -74,15 +88,18 @@ export class TechdocsGenerator implements GeneratorBase {
   }: GeneratorRunOptions): Promise<void> {
     // Do some updates to mkdocs.yml before generating docs e.g. adding repo_url
     const { path: mkdocsYmlPath, content } = await getMkdocsYml(inputDir);
+
+    // validate the docs_dir first
+    await validateMkdocsYaml(inputDir, content);
+
     if (parsedLocationAnnotation) {
       await patchMkdocsYmlPreBuild(
         mkdocsYmlPath,
         childLogger,
         parsedLocationAnnotation,
+        this.scmIntegrations,
       );
     }
-
-    await validateMkdocsYaml(inputDir, content);
 
     // Directories to bind on container
     const mountDirs = {

--- a/plugins/techdocs-backend/src/service/standaloneServer.ts
+++ b/plugins/techdocs-backend/src/service/standaloneServer.ts
@@ -70,10 +70,9 @@ export async function startStandaloneServer(
   const containerRunner = new DockerContainerRunner({ dockerClient });
 
   const generators = new Generators();
-  const techdocsGenerator = new TechdocsGenerator({
+  const techdocsGenerator = TechdocsGenerator.fromConfig(config, {
     logger,
     containerRunner,
-    config,
   });
   generators.register('techdocs', techdocsGenerator);
 


### PR DESCRIPTION
Closes: #6696

Add the `repo_url` or `edit_uri` according to the [MkDocs documentation](https://www.mkdocs.org/user-guide/configuration/#repo_url).
* For the recommended `dir:*` annotation, this will automatically be transformed into a full url (like `url:https://github.com/backstage/backstage/tree/main/`), and will result in `edit_uri: https://github.com/backstage/backstage/edit/main/docs`. MkDocs will follow this pattern to compute the edit urls.
* For the `url:*` annotation, the short form that links only to the repo (like `url:https://github.com/backstage/backstage`) will result in `repo_url: https://github.com/backstage/backstage`. MkDocs has some logic to construct the expected edit url in this case.

Note that this only works for GitHub and GitLab. I don't have much experience with Azure or Bitbucket, and the UrlReaders either don't support the generation of edit urls or the results are incompatible with MkDocs.

I also added a fix that doesn't update the `mkdocs.yml` if neither the `repo_url` nor the `edit_uri` changed. Before, local files were updated when using the `dir:*` annotation on a `file` location.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
