### PR TITLE
cli: fix frontend serving without a public folder

### DIFF
--- a/packages/cli/src/lib/bundler/server.ts
+++ b/packages/cli/src/lib/bundler/server.ts
@@ -52,7 +52,7 @@ export async function serveBundle(options: ServeOptions) {
       },
       static: {
         publicPath: config.output?.publicPath as string,
-        directory: paths.targetPublic,
+        directory: paths.targetPublic ?? '/',
       },
       historyApiFallback: {
         // Paths with dots should still use the history fallback.


### PR DESCRIPTION
Fixes the following error when trying to serve plugins in isolation:

```
TypeError: Expected a `string`, got `undefined`
```

Skipping changeset since this is part of the webpack 5 upgrade