### PR TITLE
Add configurable gradient property to backstage theme

### DIFF
--- a/.changeset/witty-wombats-provide.md
+++ b/.changeset/witty-wombats-provide.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/theme': patch
+---
+
+Add a configurable `palette.bursts.gradient` property to the Backstage theme, to support customizing the gradients in the `ItemCard` header.

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -28,6 +28,7 @@ import { LinkProps as LinkProps_2 } from '@material-ui/core';
 import { LinkProps as LinkProps_3 } from 'react-router-dom';
 import { MaterialTableProps } from '@material-table/core';
 import { NavLinkProps } from 'react-router-dom';
+import { Palette } from '@material-ui/core/styles/createPalette';
 import { ProfileInfoApi } from '@backstage/core-plugin-api';
 import { PropsWithChildren } from 'react';
 import PropTypes from 'prop-types';

--- a/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
+++ b/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
@@ -17,18 +17,18 @@
 import {
   createStyles,
   makeStyles,
-  Theme,
   Typography,
   WithStyles,
 } from '@material-ui/core';
 import React from 'react';
+import { BackstageTheme } from '../../../../theme/src';
 
-const styles = (theme: Theme) =>
+const styles = (theme: BackstageTheme) =>
   createStyles({
     root: {
       color: theme.palette.common.white,
       padding: theme.spacing(2, 2, 3),
-      backgroundImage: 'linear-gradient(-137deg,  #4BB8A5 0%,  #187656 100%)',
+      backgroundImage: theme.palette.bursts.gradient.linear,
       backgroundPosition: 0,
       backgroundSize: 'inherit',
     },

--- a/packages/theme/src/themes.ts
+++ b/packages/theme/src/themes.ts
@@ -38,6 +38,9 @@ export const lightTheme = createTheme({
       backgroundColor: {
         default: '#7C3699',
       },
+      gradient: {
+        linear: 'linear-gradient(-137deg, #4BB8A5 0%, #187656 100%)',
+      },
     },
     primary: {
       main: '#2E77D0',
@@ -99,6 +102,9 @@ export const darkTheme = createTheme({
       slackChannelText: '#ddd',
       backgroundColor: {
         default: '#7C3699',
+      },
+      gradient: {
+        linear: 'linear-gradient(-137deg, #4BB8A5 0%, #187656 100%)',
       },
     },
     primary: {

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -58,6 +58,9 @@ type PaletteAdditions = {
     backgroundColor: {
       default: string;
     };
+    gradient: {
+      linear: string;
+    };
   };
   pinSidebarButton: {
     icon: string;


### PR DESCRIPTION
Signed-off-by: Benjamin <benjamin.mccain@onepeloton.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Added gradient property to burst property inside of themes. Allows for configurable gradient to override default theme colors if needed. Currently only used in the ItemCardHeader, which is used in the /docs page for reference.

<img width="1408" alt="gradient" src="https://user-images.githubusercontent.com/25201407/128902879-2e6cf84f-99f5-45f3-9789-35299659d2e6.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
