### PR TITLE
[TechdocsCommon] Fix Azure  Blob Storage Tests

### DIFF
--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
@@ -175,12 +175,15 @@ describe('publishing with valid credentials', () => {
         directory: wrongPathToGeneratedDirectory,
       });
 
-      await expect(fails).rejects.toThrow(
-        /Unable to upload file\(s\) to Azure. Error: Failed to read template directory: ENOENT, no such file or directory/,
-      );
-      await expect(fails).rejects.toThrow(
-        new RegExp(wrongPathToGeneratedDirectory),
-      );
+      await expect(fails).rejects.toMatchObject({
+        message: expect.stringContaining(
+          'Unable to upload file(s) to Azure. Error: Failed to read template directory: ENOENT, no such file or directory',
+        ),
+      });
+
+      await expect(fails).rejects.toMatchObject({
+        message: expect.stringContaining(wrongPathToGeneratedDirectory),
+      });
     });
 
     it('reports an error when bad account credentials', async () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix the Azure Storage Blob test which is failing when running on Windows machines.
Error example: https://github.com/backstage/backstage/runs/3309320450?check_suite_focus=true

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
