### PR TITLE
backend-common: introduce new createPluginRouter helper

### DIFF
--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -26,3 +26,4 @@ export * from './reading';
 export * from './scm';
 export * from './service';
 export * from './util';
+export type { PluginEnvironment } from './types';

--- a/packages/backend-common/src/service/createPluginRouter.ts
+++ b/packages/backend-common/src/service/createPluginRouter.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Router from 'express-promise-router';
+import { Router as ExpressRouter } from 'express';
+import { notFoundHandler } from '../middleware';
+import { PluginEnvironment } from '../types';
+import { useHotMemoize } from '../hot';
+
+export type CreatePluginRouterOptions = {
+  module: NodeModule;
+  createEnv: (pluginId: string) => PluginEnvironment;
+};
+
+export type CreatePluginRouterPlugins = {
+  [pluginId: string]: () => Promise<{
+    default: (env: PluginEnvironment) => Promise<ExpressRouter>;
+  }>;
+};
+
+export async function createPluginRouter(
+  options: CreatePluginRouterOptions,
+  plugins: CreatePluginRouterPlugins,
+) {
+  const router = Router();
+
+  const pluginEnvs = useHotMemoize(
+    options.module,
+    () =>
+      new Map(
+        Object.keys(plugins).map(pluginId => {
+          return [pluginId, options.createEnv(pluginId)];
+        }),
+      ),
+  );
+
+  await Promise.all(
+    Object.entries(plugins).map(async ([pluginId, pluginLoader]) => {
+      const pluginEnv = pluginEnvs.get(pluginId);
+      if (!pluginEnv) {
+        throw new Error(
+          `An environment for the ${pluginId} plugin was not initialized at startup, a restart is needed`,
+        );
+      }
+      const { default: pluginCreator } = await pluginLoader();
+      const pluginRouter = await pluginCreator(pluginEnv);
+      router.use(`/${pluginId}`, pluginRouter);
+    }),
+  );
+
+  router.use(notFoundHandler);
+
+  return router;
+}

--- a/packages/backend-common/src/types.ts
+++ b/packages/backend-common/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,18 @@
  * limitations under the License.
  */
 
-export { createPluginRouter } from './createPluginRouter';
-export { createServiceBuilder } from './createServiceBuilder';
-export { createStatusCheckRouter } from './createStatusCheckRouter';
-export type { CreatePluginRouterOptions } from './createPluginRouter';
-export type { ServiceBuilder, RequestLoggingHandlerFactory } from './types';
+import { Logger } from 'winston';
+import { Config } from '@backstage/config';
+import { PluginCacheManager } from './cache';
+import { PluginDatabaseManager } from './database';
+import { UrlReader } from './reading';
+import { PluginEndpointDiscovery } from './discovery';
+
+export type PluginEnvironment = {
+  logger: Logger;
+  cache: PluginCacheManager;
+  database: PluginDatabaseManager;
+  config: Config;
+  reader: UrlReader;
+  discovery: PluginEndpointDiscovery;
+};

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -22,13 +22,12 @@
  * Happy hacking!
  */
 
-import Router from 'express-promise-router';
 import {
   CacheManager,
+  createPluginRouter,
   createServiceBuilder,
   getRootLogger,
   loadBackendConfig,
-  notFoundHandler,
   DatabaseManager,
   SingleHostDiscovery,
   UrlReaders,
@@ -36,21 +35,7 @@ import {
 } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
 import healthcheck from './plugins/healthcheck';
-import auth from './plugins/auth';
-import catalog from './plugins/catalog';
-import codeCoverage from './plugins/codecoverage';
-import kubernetes from './plugins/kubernetes';
-import kafka from './plugins/kafka';
-import rollbar from './plugins/rollbar';
-import scaffolder from './plugins/scaffolder';
-import proxy from './plugins/proxy';
-import search from './plugins/search';
-import techdocs from './plugins/techdocs';
-import todo from './plugins/todo';
-import graphql from './plugins/graphql';
 import app from './plugins/app';
-import badges from './plugins/badges';
-import jenkins from './plugins/jenkins';
 import { PluginEnvironment } from './types';
 
 function makeCreateEnv(config: Config) {
@@ -86,45 +71,32 @@ async function main() {
   const createEnv = makeCreateEnv(config);
 
   const healthcheckEnv = useHotMemoize(module, () => createEnv('healthcheck'));
-  const catalogEnv = useHotMemoize(module, () => createEnv('catalog'));
-  const codeCoverageEnv = useHotMemoize(module, () =>
-    createEnv('code-coverage'),
-  );
-  const scaffolderEnv = useHotMemoize(module, () => createEnv('scaffolder'));
-  const authEnv = useHotMemoize(module, () => createEnv('auth'));
-  const proxyEnv = useHotMemoize(module, () => createEnv('proxy'));
-  const rollbarEnv = useHotMemoize(module, () => createEnv('rollbar'));
-  const searchEnv = useHotMemoize(module, () => createEnv('search'));
-  const techdocsEnv = useHotMemoize(module, () => createEnv('techdocs'));
-  const todoEnv = useHotMemoize(module, () => createEnv('todo'));
-  const kubernetesEnv = useHotMemoize(module, () => createEnv('kubernetes'));
-  const kafkaEnv = useHotMemoize(module, () => createEnv('kafka'));
-  const graphqlEnv = useHotMemoize(module, () => createEnv('graphql'));
   const appEnv = useHotMemoize(module, () => createEnv('app'));
-  const badgesEnv = useHotMemoize(module, () => createEnv('badges'));
-  const jenkinsEnv = useHotMemoize(module, () => createEnv('jenkins'));
 
-  const apiRouter = Router();
-  apiRouter.use('/catalog', await catalog(catalogEnv));
-  apiRouter.use('/code-coverage', await codeCoverage(codeCoverageEnv));
-  apiRouter.use('/rollbar', await rollbar(rollbarEnv));
-  apiRouter.use('/scaffolder', await scaffolder(scaffolderEnv));
-  apiRouter.use('/auth', await auth(authEnv));
-  apiRouter.use('/search', await search(searchEnv));
-  apiRouter.use('/techdocs', await techdocs(techdocsEnv));
-  apiRouter.use('/todo', await todo(todoEnv));
-  apiRouter.use('/kubernetes', await kubernetes(kubernetesEnv));
-  apiRouter.use('/kafka', await kafka(kafkaEnv));
-  apiRouter.use('/proxy', await proxy(proxyEnv));
-  apiRouter.use('/graphql', await graphql(graphqlEnv));
-  apiRouter.use('/badges', await badges(badgesEnv));
-  apiRouter.use('/jenkins', await jenkins(jenkinsEnv));
-  apiRouter.use(notFoundHandler());
+  const pluginRouter = await createPluginRouter(
+    { module, createEnv },
+    {
+      auth: () => import('./plugins/auth'),
+      badges: () => import('./plugins/badges'),
+      catalog: () => import('./plugins/catalog'),
+      'code-coverage': () => import('./plugins/codecoverage'),
+      graphql: () => import('./plugins/graphql'),
+      jenkins: () => import('./plugins/jenkins'),
+      kafka: () => import('./plugins/kafka'),
+      kubernetes: () => import('./plugins/kubernetes'),
+      proxy: () => import('./plugins/proxy'),
+      rollbar: () => import('./plugins/rollbar'),
+      scaffolder: () => import('./plugins/scaffolder'),
+      search: () => import('./plugins/search'),
+      techdocs: () => import('./plugins/techdocs'),
+      todo: () => import('./plugins/todo'),
+    },
+  );
 
   const service = createServiceBuilder(module)
     .loadConfig(config)
     .addRouter('', await healthcheck(healthcheckEnv))
-    .addRouter('/api', apiRouter)
+    .addRouter('/api', pluginRouter)
     .addRouter('', await app(appEnv));
 
   await service.start().catch(err => {


### PR DESCRIPTION
Draft to see what people think :grin:

There are a couple of reasons I wanna do this:

- Installing a backend plugin is a lot of copy pasting and duplicating of lines. It is tedious and error prone, leading to confusing errors when installing new backend plugins.
- It's sometimes desirable to disable some backend plugins to focus development. The current setup requires multiple lines to be commented out per plugin, with this change just requiring a singe line to be commented.
- It introduces the common `PluginEnvironment` type in `@backstage/backend-common`, which so far has just been more of a de-facto standard.