### PR TITLE
Make `isJenkinsAvailable` recognise both the old and the new Jenkins annotation

### DIFF
--- a/.changeset/quick-trains-flow.md
+++ b/.changeset/quick-trains-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins': patch
+---
+
+Make `isJenkinsAvailable` recognise both the old and the new Jenkins annotation.

--- a/plugins/jenkins/api-report.md
+++ b/plugins/jenkins/api-report.md
@@ -43,7 +43,7 @@ export { isJenkinsAvailable as isPluginApplicableToEntity };
 // Warning: (ae-missing-release-tag) "JENKINS_ANNOTATION" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const JENKINS_ANNOTATION = 'jenkins.io/github-folder';
+export const JENKINS_ANNOTATION = 'jenkins.io/job-full-name';
 
 // Warning: (ae-missing-release-tag) "JenkinsApi" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -142,6 +142,11 @@ export const LatestRunCard: ({
   branch: string;
   variant?: InfoCardVariants | undefined;
 }) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "LEGACY_JENKINS_ANNOTATION" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const LEGACY_JENKINS_ANNOTATION = 'jenkins.io/github-folder';
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Router" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/jenkins/src/components/Router.tsx
+++ b/plugins/jenkins/src/components/Router.tsx
@@ -13,18 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Entity } from '@backstage/catalog-model';
+import { MissingAnnotationEmptyState } from '@backstage/core-components';
+import { useEntity } from '@backstage/plugin-catalog-react';
 import React from 'react';
 import { Route, Routes } from 'react-router';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import { JENKINS_ANNOTATION, LEGACY_JENKINS_ANNOTATION } from '../constants';
 import { buildRouteRef, rootRouteRef } from '../plugin';
-import { DetailedViewPage } from './BuildWithStepsPage/';
-import { JENKINS_ANNOTATION } from '../constants';
-import { Entity } from '@backstage/catalog-model';
 import { CITable } from './BuildsPage/lib/CITable';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
+import { DetailedViewPage } from './BuildWithStepsPage/';
 
 export const isJenkinsAvailable = (entity: Entity) =>
-  Boolean(entity.metadata.annotations?.[JENKINS_ANNOTATION]);
+  Boolean(entity.metadata.annotations?.[JENKINS_ANNOTATION]) ||
+  Boolean(entity.metadata.annotations?.[LEGACY_JENKINS_ANNOTATION]);
 
 type Props = {
   /** @deprecated The entity is now grabbed from context instead */

--- a/plugins/jenkins/src/constants.ts
+++ b/plugins/jenkins/src/constants.ts
@@ -13,6 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 export const LEGACY_JENKINS_ANNOTATION = 'jenkins.io/github-folder';
 export const JENKINS_ANNOTATION = 'jenkins.io/job-full-name';

--- a/plugins/jenkins/src/constants.ts
+++ b/plugins/jenkins/src/constants.ts
@@ -13,5 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const LEGACY_JENKINS_ANNOTATION = 'jenkins.io/github-folder';
 export const JENKINS_ANNOTATION = 'jenkins.io/job-full-name';
+// @deprecated The legacy annotation used for identifing Jenkins jobs, use
+// JENKINS_ANNOTATION instead.
+export const LEGACY_JENKINS_ANNOTATION = 'jenkins.io/github-folder';

--- a/plugins/jenkins/src/constants.ts
+++ b/plugins/jenkins/src/constants.ts
@@ -13,4 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const JENKINS_ANNOTATION = 'jenkins.io/github-folder';
+
+export const LEGACY_JENKINS_ANNOTATION = 'jenkins.io/github-folder';
+export const JENKINS_ANNOTATION = 'jenkins.io/job-full-name';

--- a/plugins/jenkins/src/index.ts
+++ b/plugins/jenkins/src/index.ts
@@ -26,5 +26,5 @@ export {
   isJenkinsAvailable,
   isJenkinsAvailable as isPluginApplicableToEntity,
 } from './components/Router';
-export { JENKINS_ANNOTATION } from './constants';
+export { JENKINS_ANNOTATION, LEGACY_JENKINS_ANNOTATION } from './constants';
 export * from './api';


### PR DESCRIPTION
The annotation was renamed, but the backend still supports the old and the new annotation. This makes sure that the frontend correctly handles the new annotation.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
