### PR TITLE
webpack5: Add Buffer polyfill

### DIFF
--- a/.changeset/ninety-ducks-relate.md
+++ b/.changeset/ninety-ducks-relate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add Buffer to `ProvidePlugin` since this is no longer provided in `webpack@5`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "@yarnpkg/lockfile": "^1.1.0",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "bfj": "^7.0.2",
+    "buffer": "^6.0.3",
     "chalk": "^4.0.0",
     "chokidar": "^3.3.1",
     "commander": "^6.1.0",

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -119,6 +119,7 @@ export async function createConfig(
   plugins.push(
     new ProvidePlugin({
       process: 'process/browser',
+      Buffer: ['buffer', 'Buffer'],
     }),
   );
 


### PR DESCRIPTION
This seems to no longer be provided in webpack@5; see https://github.com/swagger-api/swagger-ui/issues/6869. This breaks at least swagger-ui:

![buffer](https://user-images.githubusercontent.com/556258/129259057-3af95bac-7072-41b9-9227-d76ed58b7919.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
