### PR TITLE
cli/webpack: replace depreacted hash with fullhash

### DIFF
--- a/.changeset/thirty-gorillas-pull.md
+++ b/.changeset/thirty-gorillas-pull.md
@@ -2,4 +2,4 @@
 '@backstage/cli': patch
 ---
 
-Remove webpack deprecation message when running build.
+Remove Webpack deprecation message when running build.

--- a/.changeset/thirty-gorillas-pull.md
+++ b/.changeset/thirty-gorillas-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Remove webpack deprecation message when running build.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -209,7 +209,7 @@ export async function createConfig(
     output: {
       path: paths.targetDist,
       publicPath: validBaseUrl.pathname,
-      filename: isDev ? '[name].js' : 'static/[name].[hash:8].js',
+      filename: isDev ? '[name].js' : 'static/[name].[fullhash:8].js',
       chunkFilename: isDev
         ? '[name].chunk.js'
         : 'static/[name].[chunkhash:8].chunk.js',


### PR DESCRIPTION
Removes this message when building

```
$ backstage-cli app:build
Loaded config from app-config.yaml
(node:94870) [DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_HASH] DeprecationWarning: [hash] is now [fullhash] (also consider using [chunkhash] or [contenthash], see documentation for details)
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Let me know if chunkhash or contenthash should be considered instead, I went with fullhash since it's advertised as the replacement.


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
