### PR TITLE
Fix Sentry widget showing [No Type]

### DIFF
--- a/.changeset/purple-tigers-tell.md
+++ b/.changeset/purple-tigers-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sentry': patch
+---
+
+Do not show [No Type] when issue metadata includes title instead of type

--- a/plugins/sentry/src/components/ErrorCell/ErrorCell.test.tsx
+++ b/plugins/sentry/src/components/ErrorCell/ErrorCell.test.tsx
@@ -44,4 +44,24 @@ describe('Sentry error cell component', () => {
       'http://example.com',
     );
   });
+  it('should render the title if type is not present', async () => {
+    const testIssue = {
+      ...mockIssue,
+      title: 'Exception: Could not load credentials from any providers',
+      count: '1',
+      metadata: {},
+      userCount: 2,
+      permalink: 'http://example.com',
+    };
+    const cell = render(
+      <ThemeProvider theme={lightTheme}>
+        <ErrorCell sentryIssue={testIssue} />
+      </ThemeProvider>,
+    );
+    const errorType = await cell.findByText('Exception: Could not load cr...');
+    expect(errorType.closest('a')).toHaveAttribute(
+      'href',
+      'http://example.com',
+    );
+  });
 });

--- a/plugins/sentry/src/components/ErrorCell/ErrorCell.tsx
+++ b/plugins/sentry/src/components/ErrorCell/ErrorCell.tsx
@@ -44,13 +44,18 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 
 export const ErrorCell = ({ sentryIssue }: { sentryIssue: SentryIssue }) => {
   const classes = useStyles();
+  let issueType = '[No Type]';
+  if (sentryIssue.metadata.type) {
+    issueType = sentryIssue.metadata.type;
+  } else if (sentryIssue.title) {
+    issueType = sentryIssue.title;
+  }
+
   return (
     <div className={classes.root}>
       <Link href={sentryIssue.permalink}>
         <Typography variant="body1" gutterBottom className={classes.text}>
-          {sentryIssue.metadata.type
-            ? stripText(sentryIssue.metadata.type, 28)
-            : '[No type]'}
+          {stripText(issueType, 28)}
         </Typography>
       </Link>
       <Typography


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes an issue with the sentry plugin showing [No Type] in the sentry error when the issue metadata contains a title instead of a type.

### Current Behaviour
![image](https://user-images.githubusercontent.com/4512703/129343003-59d06758-4311-4fc3-a223-52ca70827cf2.png)

### New Behaviour
![image](https://user-images.githubusercontent.com/4512703/129343199-ffd5e5b3-3e27-4272-a3d9-19df8f71fc40.png)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
