### PR TITLE
Render the statsFor property in sentry issues table

### DIFF
--- a/.changeset/three-brooms-sell.md
+++ b/.changeset/three-brooms-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sentry': patch
+---
+
+Render the statsFor property in sentry issues table

--- a/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.test.tsx
+++ b/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.test.tsx
@@ -86,6 +86,6 @@ describe('SentryIssuesTable', () => {
         <SentryIssuesTable sentryIssues={issues} statsFor="24h" />
       </ThemeProvider>,
     );
-    expect(await table.findByText('For 24h')).toBeInTheDocument();
+    expect(await table.findByText('Last 24h')).toBeInTheDocument();
   });
 });

--- a/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.test.tsx
+++ b/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.test.tsx
@@ -69,4 +69,23 @@ describe('SentryIssuesTable', () => {
     expect(await table.findByText('101')).toBeInTheDocument();
     expect(await table.findByText('202')).toBeInTheDocument();
   });
+  it('should render statsFor in table subtitle', async () => {
+    const issues: SentryIssue[] = [
+      {
+        ...mockIssue,
+        metadata: {
+          type: 'Exception',
+          value: 'exception was thrown',
+        },
+        count: '101',
+        userCount: 202,
+      },
+    ];
+    const table = await render(
+      <ThemeProvider theme={lightTheme}>
+        <SentryIssuesTable sentryIssues={issues} statsFor="24h" />
+      </ThemeProvider>,
+    );
+    expect(await table.findByText('For 24h')).toBeInTheDocument();
+  });
 });

--- a/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
+++ b/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
@@ -59,14 +59,19 @@ const columns: TableColumn[] = [
 
 type SentryIssuesTableProps = {
   sentryIssues: SentryIssue[];
+  statsFor?: '24h' | '12h';
 };
 
-const SentryIssuesTable = ({ sentryIssues }: SentryIssuesTableProps) => {
+const SentryIssuesTable = ({
+  sentryIssues,
+  statsFor,
+}: SentryIssuesTableProps) => {
   return (
     <Table
       columns={columns}
       options={{ padding: 'dense', paging: true, search: false, pageSize: 5 }}
       title="Sentry issues"
+      subtitle={statsFor ? `For ${statsFor}` : undefined}
       data={sentryIssues}
     />
   );

--- a/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
+++ b/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
@@ -71,7 +71,7 @@ const SentryIssuesTable = ({
       columns={columns}
       options={{ padding: 'dense', paging: true, search: false, pageSize: 5 }}
       title="Sentry issues"
-      subtitle={statsFor ? `For ${statsFor}` : undefined}
+      subtitle={statsFor ? `Last ${statsFor}` : undefined}
       data={sentryIssues}
     />
   );

--- a/plugins/sentry/src/components/SentryIssuesWidget/SentryIssuesWidget.tsx
+++ b/plugins/sentry/src/components/SentryIssuesWidget/SentryIssuesWidget.tsx
@@ -81,5 +81,5 @@ export const SentryIssuesWidget = ({
     );
   }
 
-  return <SentryIssuesTable sentryIssues={value || []} />;
+  return <SentryIssuesTable sentryIssues={value || []} statsFor={statsFor} />;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently, users have no way of knowing which issues are being shown in the sentry table.
This change tries to fix that by adding the `statsFor` property as part of the Sentry issues table subtitle.

![image](https://user-images.githubusercontent.com/4512703/129351972-937fa998-ebe2-464c-a8fd-5ce7206b5503.png)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
