### PR TITLE
Link group ownership boxes through filtered catalog page

### DIFF
--- a/.changeset/cool-dolphins-join.md
+++ b/.changeset/cool-dolphins-join.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': minor
+---
+
+Link group ownership boxes through filtered catalog page

--- a/.changeset/cool-dolphins-join.md
+++ b/.changeset/cool-dolphins-join.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-org': minor
+'@backstage/plugin-org': patch
 ---
 
 Link group ownership boxes through filtered catalog page

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -32,7 +32,8 @@
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",
-    "react-use": "^17.2.4"
+    "react-use": "^17.2.4",
+    "qs": "^6.10.1"
   },
   "devDependencies": {
     "@backstage/cli": "^0.7.8",

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -24,12 +24,7 @@ import { renderInTestApp } from '@backstage/test-utils';
 import { queryByText } from '@testing-library/react';
 import React from 'react';
 import { OwnershipCard } from './OwnershipCard';
-import {
-  ApiProvider,
-  ApiRegistry,
-  ConfigReader,
-} from '@backstage/core-app-api';
-import { ConfigApi, configApiRef } from '@backstage/core-plugin-api';
+import { ApiProvider, ApiRegistry } from '@backstage/core-app-api';
 
 describe('OwnershipCard', () => {
   const userEntity: GroupEntity = {
@@ -122,19 +117,8 @@ describe('OwnershipCard', () => {
       ] as any,
     });
 
-    const configApi: ConfigApi = new ConfigReader({
-      app: {
-        baseUrl: 'http://localhost:3000',
-      },
-    });
-
     const { getByText } = await renderInTestApp(
-      <ApiProvider
-        apis={ApiRegistry.from([
-          [configApiRef, configApi],
-          [catalogApiRef, catalogApi],
-        ])}
-      >
+      <ApiProvider apis={ApiRegistry.with(catalogApiRef, catalogApi)}>
         <EntityProvider entity={userEntity}>
           <OwnershipCard />
         </EntityProvider>

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -125,29 +125,17 @@ describe('OwnershipCard', () => {
       </ApiProvider>,
     );
 
-    expect(getByText('Services')).toBeInTheDocument();
+    expect(getByText('OPENAPI')).toBeInTheDocument();
     expect(
-      queryByText(getByText('Services').parentElement!, '1'),
+      queryByText(getByText('OPENAPI').parentElement!, '1'),
     ).toBeInTheDocument();
-    expect(getByText('Documentation')).toBeInTheDocument();
+    expect(getByText('SERVICE')).toBeInTheDocument();
     expect(
-      queryByText(getByText('Documentation').parentElement!, '0'),
+      queryByText(getByText('SERVICE').parentElement!, '1'),
     ).toBeInTheDocument();
-    expect(getByText('APIs')).toBeInTheDocument();
+    expect(getByText('LIBRARY')).toBeInTheDocument();
     expect(
-      queryByText(getByText('APIs').parentElement!, '1'),
-    ).toBeInTheDocument();
-    expect(getByText('Libraries')).toBeInTheDocument();
-    expect(
-      queryByText(getByText('Libraries').parentElement!, '1'),
-    ).toBeInTheDocument();
-    expect(getByText('Websites')).toBeInTheDocument();
-    expect(
-      queryByText(getByText('Websites').parentElement!, '0'),
-    ).toBeInTheDocument();
-    expect(getByText('Tools')).toBeInTheDocument();
-    expect(
-      queryByText(getByText('Tools').parentElement!, '0'),
+      queryByText(getByText('LIBRARY').parentElement!, '1'),
     ).toBeInTheDocument();
   });
 });

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -19,6 +19,7 @@ import {
   CatalogApi,
   catalogApiRef,
   EntityProvider,
+  catalogRouteRef,
 } from '@backstage/plugin-catalog-react';
 import { renderInTestApp } from '@backstage/test-utils';
 import { queryByText } from '@testing-library/react';
@@ -123,6 +124,11 @@ describe('OwnershipCard', () => {
           <OwnershipCard />
         </EntityProvider>
       </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/create': catalogRouteRef,
+        },
+      },
     );
 
     expect(getByText('OPENAPI')).toBeInTheDocument();

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -24,7 +24,12 @@ import { renderInTestApp } from '@backstage/test-utils';
 import { queryByText } from '@testing-library/react';
 import React from 'react';
 import { OwnershipCard } from './OwnershipCard';
-import { ApiProvider, ApiRegistry } from '@backstage/core-app-api';
+import {
+  ApiProvider,
+  ApiRegistry,
+  ConfigReader,
+} from '@backstage/core-app-api';
+import { ConfigApi, configApiRef } from '@backstage/core-plugin-api';
 
 describe('OwnershipCard', () => {
   const userEntity: GroupEntity = {
@@ -117,8 +122,19 @@ describe('OwnershipCard', () => {
       ] as any,
     });
 
+    const configApi: ConfigApi = new ConfigReader({
+      app: {
+        baseUrl: 'http://localhost:3000',
+      },
+    });
+
     const { getByText } = await renderInTestApp(
-      <ApiProvider apis={ApiRegistry.with(catalogApiRef, catalogApi)}>
+      <ApiProvider
+        apis={ApiRegistry.from([
+          [configApiRef, configApi],
+          [catalogApiRef, catalogApi],
+        ])}
+      >
         <EntityProvider entity={userEntity}>
           <OwnershipCard />
         </EntityProvider>

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -19,6 +19,7 @@ import {
   catalogApiRef,
   isOwnerOf,
   useEntity,
+  catalogRouteRef,
 } from '@backstage/plugin-catalog-react';
 import { BackstageTheme, genPageTheme } from '@backstage/theme';
 import {
@@ -39,7 +40,7 @@ import {
   Progress,
   ResponseErrorPanel,
 } from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 
 type EntityTypeProps = {
   name: string;
@@ -93,10 +94,11 @@ const EntityCountTile = ({
   queryParams: string;
 }) => {
   const classes = useStyles({ type });
+  const catalogLink = useRouteRef(catalogRouteRef);
 
   return (
     <Link
-      href={generatePath(`/catalog/?${queryParams}`)}
+      href={generatePath(`${catalogLink()}/?${queryParams}`)}
       target="_blank"
       rel="noreferrer noopenner"
       variant="body2"

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -41,8 +41,6 @@ import {
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
-type BoxTypes = 'box1' | 'box2' | 'box3' | 'box4' | 'box5' | 'box6';
-
 type EntityTypeProps = {
   name: string;
   kind: string;
@@ -76,44 +74,35 @@ const useStyles = makeStyles((theme: BackstageTheme) =>
     bold: {
       fontWeight: theme.typography.fontWeightBold,
     },
-    box1: {
-      background: createPageTheme(theme, 'home', 'service'),
-    },
-    box2: {
-      background: createPageTheme(theme, 'home', 'website'),
-    },
-    box3: {
-      background: createPageTheme(theme, 'home', 'library'),
-    },
-    box4: {
-      background: createPageTheme(theme, 'home', 'documentation'),
-    },
-    box5: {
-      background: createPageTheme(theme, 'home', 'home'),
-    },
-    box6: {
-      background: createPageTheme(theme, 'home', 'tool'),
+    entityTypeBox: {
+      background: (props: { type: string }) =>
+        createPageTheme(theme, props.type, props.type),
     },
   }),
 );
 
 const EntityCountTile = ({
   counter,
-  className,
+  type,
   name,
-  url,
+  queryParams,
 }: {
   counter: number;
-  className: BoxTypes;
+  type: string;
   name: string;
-  url: string;
+  queryParams: string;
 }) => {
-  const classes = useStyles();
+  const classes = useStyles({ type });
 
   return (
-    <Link href={url} target="_blank" rel="noreferrer noopenner" variant="body2">
+    <Link
+      href={generatePath(`/catalog/?${queryParams}`)}
+      target="_blank"
+      rel="noreferrer noopenner"
+      variant="body2"
+    >
       <Box
-        className={`${classes.card} ${classes[className]}`}
+        className={`${classes.card} ${classes.entityTypeBox}`}
         display="flex"
         flexDirection="column"
         alignItems="center"
@@ -129,7 +118,7 @@ const EntityCountTile = ({
   );
 };
 
-const getFilteredUrl = (
+const getQueryParams = (
   owner: Entity,
   selectedEntity: EntityTypeProps,
 ): string => {
@@ -144,9 +133,8 @@ const getFilteredUrl = (
       user: 'all',
     },
   });
-  const filteredUrl = generatePath(`/catalog/?${queryParams}`);
 
-  return filteredUrl;
+  return queryParams;
 };
 
 export const OwnershipCard = ({
@@ -196,7 +184,7 @@ export const OwnershipCard = ({
           acc.push({
             name,
             kind: ownedEntity.kind,
-            type: ownedEntity.spec?.type?.toString(),
+            type: ownedEntity.spec?.type,
             count: 1,
           });
         }
@@ -208,16 +196,16 @@ export const OwnershipCard = ({
     // Return top N (six) entities to be displayed in ownership boxes
     const topN = counts.sort((a, b) => b.count - a.count).slice(0, 6);
 
-    return topN.map((topEntity, index) => ({
+    return topN.map(topEntity => ({
       counter: topEntity.count,
-      className: `box${index + 1}`,
+      type: topEntity.type,
       name: topEntity.type.toLocaleUpperCase('en-US'),
-      url: getFilteredUrl(entity, topEntity),
+      queryParams: getQueryParams(entity, topEntity),
     })) as Array<{
       counter: number;
-      className: BoxTypes;
+      type: string;
       name: string;
-      url: string;
+      queryParams: string;
     }>;
   }, [catalogApi, entity]);
 
@@ -234,9 +222,9 @@ export const OwnershipCard = ({
           <Grid item xs={6} md={6} lg={4} key={c.name}>
             <EntityCountTile
               counter={c.counter}
-              className={c.className}
+              type={c.type}
               name={c.name}
-              url={c.url}
+              queryParams={c.queryParams}
             />
           </Grid>
         ))}

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -224,7 +224,6 @@ export const OwnershipCard = ({
     })) as Array<{
       counter: number;
       className: BoxTypes;
-      entities: Entity[];
       name: string;
       url: string;
     }>;

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -125,8 +125,7 @@ const getQueryParams = (
   selectedEntity: EntityTypeProps,
 ): string => {
   const ownerName = owner.metadata.name;
-  const kind = selectedEntity.kind;
-  const type = selectedEntity.type;
+  const { kind, type } = selectedEntity;
   const queryParams = qs.stringify({
     filters: {
       kind,

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -192,11 +192,11 @@ export const OwnershipCard = ({
     // Return top N (six) entities to be displayed in ownership boxes
     const topN = counts.sort((a, b) => b.count - a.count).slice(0, 6);
 
-    return topN.map(topEntity => ({
-      counter: topEntity.count,
-      type: topEntity.type,
-      name: topEntity.type.toLocaleUpperCase('en-US'),
-      queryParams: getQueryParams(entity, topEntity),
+    return topN.map(topOwnedEntity => ({
+      counter: topOwnedEntity.count,
+      type: topOwnedEntity.type,
+      name: topOwnedEntity.type.toLocaleUpperCase('en-US'),
+      queryParams: getQueryParams(entity, topOwnedEntity),
     })) as Array<{
       counter: number;
       type: string;

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -43,7 +43,6 @@ import {
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 
 type EntityTypeProps = {
-  name: string;
   kind: string;
   type: string;
   count: number;
@@ -173,12 +172,10 @@ export const OwnershipCard = ({
         const match = acc.find(
           x => x.kind === ownedEntity.kind && x.type === ownedEntity.spec?.type,
         );
-        const name = ownedEntity.metadata.name;
         if (match) {
           match.count += 1;
         } else {
           acc.push({
-            name,
             kind: ownedEntity.kind,
             type: ownedEntity.spec?.type,
             count: 1,

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -86,23 +86,17 @@ const EntityCountTile = ({
   counter,
   type,
   name,
-  queryParams,
+  url,
 }: {
   counter: number;
   type: string;
   name: string;
-  queryParams: string;
+  url: string;
 }) => {
   const classes = useStyles({ type });
-  const catalogLink = useRouteRef(catalogRouteRef);
 
   return (
-    <Link
-      href={generatePath(`${catalogLink()}/?${queryParams}`)}
-      target="_blank"
-      rel="noreferrer noopenner"
-      variant="body2"
-    >
+    <Link href={url} target="_blank" rel="noreferrer noopenner" variant="body2">
       <Box
         className={`${classes.card} ${classes.entityTypeBox}`}
         display="flex"
@@ -147,6 +141,7 @@ export const OwnershipCard = ({
 }) => {
   const { entity } = useEntity();
   const catalogApi = useApi(catalogApiRef);
+  const catalogLink = useRouteRef(catalogRouteRef);
 
   const {
     loading,
@@ -225,7 +220,7 @@ export const OwnershipCard = ({
               counter={c.counter}
               type={c.type}
               name={c.name}
-              queryParams={c.queryParams}
+              url={generatePath(`${catalogLink()}/?${c.queryParams}`)}
             />
           </Grid>
         ))}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Pull Request for this issue : https://github.com/backstage/backstage/issues/6681

I want to implement an active link if one of these boxes (eg: Services) is clicked , the page will moved to a filtered entity catalog page that is belong to that particular group.

What does this PR change : 
- Dynamically show top 6 entity types in boxes (does not include 0 count)
- Make these ownership boxes become clickable, it **will open a new tab** to a filtered catalog page
- Remove tooltip logic

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<img width="1680" alt="Screen Shot 2021-08-13 at 22 10 37" src="https://user-images.githubusercontent.com/7909323/129380476-e270a98e-7288-4945-bc37-60ad3a5e79bd.png">
<img width="1675" alt="Screen Shot 2021-08-13 at 22 11 59" src="https://user-images.githubusercontent.com/7909323/129380504-3fd5c904-26c1-4a45-8c06-c53622e4192a.png">
<img width="1675" alt="Screen Shot 2021-08-13 at 22 12 20" src="https://user-images.githubusercontent.com/7909323/129380509-0717001a-f889-4c70-b6d5-96f0356664b9.png">
<img width="1680" alt="Screen Shot 2021-08-13 at 22 12 35" src="https://user-images.githubusercontent.com/7909323/129380515-34ae2cd1-922d-463a-aa47-b05b4a19542b.png">

