### PR TITLE
Support  custom template card on ScaffolderPage

### DIFF
--- a/plugins/scaffolder/src/components/FavouriteTemplate/index.ts
+++ b/plugins/scaffolder/src/components/FavouriteTemplate/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './FavouriteTemplate';

--- a/plugins/scaffolder/src/components/Router.tsx
+++ b/plugins/scaffolder/src/components/Router.tsx
@@ -29,7 +29,11 @@ import {
 } from '../extensions';
 import { useElementFilter } from '@backstage/core-plugin-api';
 
-export const Router = () => {
+type RouterProps = {
+  renderTemplateCard?: Function | undefined;
+};
+
+export const Router = ({ renderTemplateCard }: RouterProps) => {
   const outlet = useOutlet();
 
   const customFieldExtensions = useElementFilter(outlet, elements =>
@@ -54,7 +58,10 @@ export const Router = () => {
 
   return (
     <Routes>
-      <Route path="/" element={<ScaffolderPage />} />
+      <Route
+        path="/"
+        element={<ScaffolderPage renderTemplateCard={renderTemplateCard} />}
+      />
       <Route
         path="/templates/:templateName"
         element={<TemplatePage customFieldExtensions={fieldExtensions} />}

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -46,7 +46,13 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export const ScaffolderPageContents = () => {
+export type ScaffolderPageProps = {
+  renderTemplateCard: Function | undefined;
+};
+
+export const ScaffolderPageContents = ({
+  renderTemplateCard,
+}: ScaffolderPageProps) => {
   const styles = useStyles();
 
   const registerComponentLink = useRouteRef(registerComponentRouteRef);
@@ -87,7 +93,7 @@ export const ScaffolderPageContents = () => {
             <EntityTagPicker />
           </div>
           <div>
-            <TemplateList />
+            <TemplateList renderTemplateCard={renderTemplateCard} />
           </div>
         </div>
       </Content>
@@ -95,8 +101,8 @@ export const ScaffolderPageContents = () => {
   );
 };
 
-export const ScaffolderPage = () => (
+export const ScaffolderPage = ({ renderTemplateCard }: ScaffolderPageProps) => (
   <EntityListProvider>
-    <ScaffolderPageContents />
+    <ScaffolderPageContents renderTemplateCard={renderTemplateCard} />
   </EntityListProvider>
 );

--- a/plugins/scaffolder/src/components/TemplateList/TemplateList.tsx
+++ b/plugins/scaffolder/src/components/TemplateList/TemplateList.tsx
@@ -25,7 +25,11 @@ import { useEntityListProvider } from '@backstage/plugin-catalog-react';
 import { Link, Typography } from '@material-ui/core';
 import { TemplateCard } from '../TemplateCard';
 
-export const TemplateList = () => {
+export type TemplateListProps = {
+  renderTemplateCard?: Function | undefined;
+};
+
+export const TemplateList = ({ renderTemplateCard }: TemplateListProps) => {
   const { loading, error, entities } = useEntityListProvider();
   return (
     <>
@@ -50,12 +54,16 @@ export const TemplateList = () => {
       <ItemCardGrid>
         {entities &&
           entities?.length > 0 &&
-          entities.map((template, i) => (
-            <TemplateCard
-              key={i}
-              template={template as TemplateEntityV1beta2}
-            />
-          ))}
+          entities.map((template, i) =>
+            renderTemplateCard ? (
+              renderTemplateCard(i, template)
+            ) : (
+              <TemplateCard
+                key={i}
+                template={template as TemplateEntityV1beta2}
+              />
+            ),
+          )}
       </ItemCardGrid>
     </>
   );

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -37,3 +37,5 @@ export {
   RepoUrlPicker,
   TextValuePicker,
 } from './components/fields';
+export { FavouriteTemplate } from './components/FavouriteTemplate';
+export { rootRouteRef as scaffolderRootRouteRef } from './routes';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR is to add the ability to ScaffolderPage to render a custom templateCard, passing a prop to handle this as we discuss on [#6759](https://github.com/backstage/backstage/issues/6759).
**Current Behaviour**
![Screen Shot 2021-08-13 at 16 36 08](https://user-images.githubusercontent.com/40499017/129420712-758bc4c0-4b99-4b61-9dc2-78bbc3d8d55e.png)

**New Behaviour**
![Screen Shot 2021-08-13 at 16 33 37](https://user-images.githubusercontent.com/40499017/129420829-1464eb9f-c852-42c1-93f0-2d3d50864663.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
