### PR TITLE
Fix passing arguments from `backstage-cli backend:dev` to package

### DIFF
--- a/.changeset/two-suits-act.md
+++ b/.changeset/two-suits-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix `backstage-cli backend:dev` argument passing

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -318,6 +318,7 @@ export async function createBackendConfig(
       new RunScriptWebpackPlugin({
         name: 'main.js',
         nodeArgs: options.inspectEnabled ? ['--inspect'] : undefined,
+        args: process.argv.slice(3), // drop `node backstage-cli backend:dev`
       }),
       new webpack.HotModuleReplacementPlugin(),
       ...(checksEnabled


### PR DESCRIPTION
The old Webpack version would invoke the backend package in the same
process, hence `process.argv` would contain the arguments passed to
`backstage-cli`. This no longer seems to be true in Webpack 5, so
arguments must be explicitly passed.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
