### PR TITLE
Update writing custom actions documentation

### DIFF
--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -132,6 +132,8 @@ want to have those as well as your new one, you'll need to do the following:
 ```ts
 import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
 
+const integrations = ScmIntegrations.fromConfig(config);
+
 const builtInActions = createBuiltinActions({
   containerRunner,
   integrations,


### PR DESCRIPTION
The "integrations" variable was missing from the auto-generated backstage app.

This is not needed from the backstage CLI tool because it's not used in the scaffolder.ts file until users want to add their own custom actions.

I'm adding this snippet of code to the custom actions documentation in order to help others who want to create custom actions without having to figure out why the integrations object is undefined.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
