### PR TITLE
chore(UnregisterEntityDialog): migrate to catalog-react

### DIFF
--- a/.changeset/seven-glasses-sit.md
+++ b/.changeset/seven-glasses-sit.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-react': patch
+---
+
+Migrate and export `UnregisterEntityDialog` component from `catalog-react` package

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -715,6 +715,17 @@ export function reduceEntityFilters(
 // @public (undocumented)
 export const rootRoute: RouteRef<undefined>;
 
+// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "UnregisterEntityDialog" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const UnregisterEntityDialog: ({
+  open,
+  onConfirm,
+  onClose,
+  entity,
+}: Props_3) => JSX.Element;
+
 // Warning: (ae-missing-release-tag) "useEntity" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.test.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.test.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { UnregisterEntityDialog } from './UnregisterEntityDialog';
 import { ORIGIN_LOCATION_ANNOTATION } from '@backstage/catalog-model';
 import { CatalogClient } from '@backstage/catalog-client';
-import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { catalogApiRef } from '../../api';
 import { screen, waitFor } from '@testing-library/react';
 import { renderInTestApp } from '@backstage/test-utils';
 import * as state from './useUnregisterEntityDialogState';

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { EntityRefLink } from '@backstage/plugin-catalog-react';
+import { EntityRefLink } from '../EntityRefLink';
 import {
   Box,
   Button,

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/index.ts
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './EntityKindPicker';
-export * from './EntityLifecyclePicker';
-export * from './EntityOwnerPicker';
-export * from './EntityProvider';
-export * from './EntityRefLink';
-export * from './EntitySearchBar';
-export * from './EntityTable';
-export * from './EntityTagPicker';
-export * from './EntityTypePicker';
-export * from './FavoriteEntity';
-export * from './UnregisterEntityDialog';
-export * from './UserListPicker';
+
+export { UnregisterEntityDialog } from './UnregisterEntityDialog';

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.test.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.test.tsx
@@ -19,7 +19,8 @@ import {
   Location,
   ORIGIN_LOCATION_ANNOTATION,
 } from '@backstage/catalog-model';
-import { CatalogApi, catalogApiRef } from '@backstage/plugin-catalog-react';
+import { CatalogApi } from '@backstage/catalog-client';
+import { catalogApiRef } from '../../api';
 import {
   act,
   renderHook,

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.ts
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.ts
@@ -20,7 +20,7 @@ import {
   getEntityName,
   ORIGIN_LOCATION_ANNOTATION,
 } from '@backstage/catalog-model';
-import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { catalogApiRef } from '../../api';
 import { useCallback } from 'react';
 import { useAsync } from 'react-use';
 import { useApi } from '@backstage/core-plugin-api';

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -39,6 +39,7 @@ import {
   EntityRefLinks,
   FavoriteEntity,
   getEntityRelations,
+  UnregisterEntityDialog,
   useEntityCompoundName,
 } from '@backstage/plugin-catalog-react';
 import { Box, TabProps } from '@material-ui/core';
@@ -46,7 +47,6 @@ import { Alert } from '@material-ui/lab';
 import React, { useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { EntityContextMenu } from '../EntityContextMenu/EntityContextMenu';
-import { UnregisterEntityDialog } from '../UnregisterEntityDialog/UnregisterEntityDialog';
 
 type SubRoute = {
   path: string;

--- a/plugins/catalog/src/components/EntityPageLayout/EntityPageLayout.tsx
+++ b/plugins/catalog/src/components/EntityPageLayout/EntityPageLayout.tsx
@@ -23,13 +23,13 @@ import {
   EntityRefLinks,
   FavoriteEntity,
   getEntityRelations,
+  UnregisterEntityDialog,
   useEntityCompoundName,
 } from '@backstage/plugin-catalog-react';
 import { Box } from '@material-ui/core';
 import React, { useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { EntityContextMenu } from '../EntityContextMenu/EntityContextMenu';
-import { UnregisterEntityDialog } from '../UnregisterEntityDialog/UnregisterEntityDialog';
 import { Tabbed } from './Tabbed';
 
 import {


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!
Exporting `UnregisterEntityDialog` so it can be reused by apps
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
