### PR TITLE
Correct version requirements on postgres from 11 to 12

### DIFF
--- a/.changeset/quiet-hornets-yawn.md
+++ b/.changeset/quiet-hornets-yawn.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-backend-module-pg': patch
+---
+
+Correct version requirements on postgres from 11 to 12. Postgres 12 is required
+due the use of generated columns.

--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -43,7 +43,7 @@ provides decent results and performs well with ten thousands of indexed
 documents. The connection to postgres is established via the database manager
 also used by other plugins.
 
-> **Important**: The search plugin requires at least Postgres 11!
+> **Important**: The search plugin requires at least Postgres 12!
 
 To use the `PgSearchEngine`, make sure that you have a Postgres database
 configured and make the following changes to your backend:

--- a/plugins/search-backend-module-pg/README.md
+++ b/plugins/search-backend-module-pg/README.md
@@ -8,7 +8,7 @@ well with ten thousands of indexed documents.
 The connection to postgres is established via the database manager also used by
 other plugins.
 
-> **Important**: The search plugin requires at least Postgres 11!
+> **Important**: The search plugin requires at least Postgres 12!
 
 ## Getting started
 

--- a/plugins/search-backend-module-pg/src/database/DatabaseDocumentStore.ts
+++ b/plugins/search-backend-module-pg/src/database/DatabaseDocumentStore.ts
@@ -34,18 +34,18 @@ export class DatabaseDocumentStore implements DatabaseStore {
     try {
       const majorVersion = await queryPostgresMajorVersion(knex);
 
-      if (majorVersion < 11) {
+      if (majorVersion < 12) {
         // We are using some features (like generated columns) that aren't
         // available in older postgres versions.
         throw new Error(
-          `The PgSearchEngine requires at least postgres version 11 (but is running on ${majorVersion})`,
+          `The PgSearchEngine requires at least postgres version 12 (but is running on ${majorVersion})`,
         );
       }
     } catch {
       // Actually both mysql and sqlite have a full text search, too. We could
       // implement them separately or add them here.
       throw new Error(
-        'The PgSearchEngine is only supported when using a postgres database (>=11.x)',
+        'The PgSearchEngine is only supported when using a postgres database (>=12.x)',
       );
     }
 
@@ -59,7 +59,7 @@ export class DatabaseDocumentStore implements DatabaseStore {
     try {
       const majorVersion = await queryPostgresMajorVersion(knex);
 
-      return majorVersion >= 11;
+      return majorVersion >= 12;
     } catch {
       return false;
     }


### PR DESCRIPTION
Requiring version 11 was wrong, the features we use where introduced in **12**. The was noticed in #6861. Closes #6861 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
