### PR TITLE
cli: reintroduce node polyfills that were removed in webpack 5 migration

### DIFF
--- a/.changeset/neat-jars-rule.md
+++ b/.changeset/neat-jars-rule.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Reintroduce Node.js shims that were removed in the Webpack 5 migration.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -85,6 +85,7 @@
     "json-schema": "^0.3.0",
     "lodash": "^4.17.19",
     "mini-css-extract-plugin": "^1.4.1",
+    "node-libs-browser": "^2.2.1",
     "ora": "^5.3.0",
     "postcss": "^8.1.0",
     "process": "^0.11.10",

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -32,6 +32,7 @@ import { BundlingOptions, BackendBundlingOptions, LernaPackage } from './types';
 import { version } from '../../lib/version';
 import { paths as cliPaths } from '../../lib/paths';
 import { runPlain } from '../run';
+import pickBy from 'lodash/pickBy';
 
 export function resolveBaseUrl(config: Config): URL {
   const baseUrl = config.getString('app.baseUrl');
@@ -177,6 +178,7 @@ export async function createConfig(
       extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx'],
       mainFields: ['browser', 'module', 'main'],
       fallback: {
+        ...pickBy(require('node-libs-browser')),
         module: false,
         dgram: false,
         dns: false,


### PR DESCRIPTION
The Webpack 5 migration in #5292 is supposed to be a non-breaking change. Since webpack 5 removed the default Node.js polyfills and we only reintroduced some of them, it lead to issues like #6824. This reintroduces all of the polyfills that we didn't already explicitly disable, and we'll leave the deprecation of those to a future breaking update.

Fixes #6824