### PR TITLE
Minor identity-resolver doc correction

### DIFF
--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -128,20 +128,20 @@ export default async function createPlugin({
       google: createGoogleProvider({
         signIn: {
           resolver: async ({ profile: { email } }, ctx) => {
-            const [sub] = email?.split('@') ?? '';
+            const [id] = email?.split('@') ?? '';
             // Fetch from an external system that returns entity claims like:
             // ['user:default/breanna.davison', ...]
             const ent = await externalSystemClient.getUsernames(email);
 
             // Resolve group membership from the Backstage catalog
             const fullEnt = await ctx.catalogIdentityClient.resolveCatalogMembership({
-              entityRefs: [sub].concat(ent),
+              entityRefs: [id].concat(ent),
               logger: ctx.logger,
             });
             const token = await ctx.tokenIssuer.issueToken({
-              claims: { sub, ent: fullEnt },
+              claims: { sub: id, ent: fullEnt },
             });
-            return { sub, token };
+            return { id, token };
           },
         },
       }),


### PR DESCRIPTION
Minor documentation correction; the sign-in resolvers return `{ id, token }`, got this confused with `{ sub, ent }` in the claims in the example.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
