### PR TITLE
Fix incorrect links key

### DIFF
--- a/docs/features/software-templates/migrating-from-v1alpha1-to-v1beta2.md
+++ b/docs/features/software-templates/migrating-from-v1alpha1-to-v1beta2.md
@@ -325,7 +325,7 @@ spec:
   output:
     links:
       - url: '{{steps.publish.output.remoteUrl}}'
-        text: 'Go to Repo'
+        title: 'Go to Repo'
 ```
 
 ## Questions?


### PR DESCRIPTION
Pointed out in Discord; the `links` output should have `title`, not `text`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
