### PR TITLE
feat(plugin-scaffolder-backend): GitHub option to require Code Owners

### DIFF
--- a/.changeset/three-eggs-punch.md
+++ b/.changeset/three-eggs-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+GitHub branch protection option 'Require review from Code Owners' can be enabled by adding `requireCodeOwnersReview: true` in context input.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -124,6 +124,7 @@ type BranchProtectionOptions = {
   owner: string;
   repoName: string;
   logger: Logger;
+  requireCodeOwnerReviews: boolean;
   defaultBranch?: string;
 };
 
@@ -132,6 +133,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
   client,
   owner,
   logger,
+  requireCodeOwnerReviews,
   defaultBranch = 'master',
 }: BranchProtectionOptions): Promise<void> => {
   const tryOnce = async () => {
@@ -153,7 +155,10 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
         required_status_checks: { strict: true, contexts: [] },
         restrictions: null,
         enforce_admins: true,
-        required_pull_request_reviews: { required_approving_review_count: 1 },
+        required_pull_request_reviews: {
+          required_approving_review_count: 1,
+          require_code_owner_reviews: requireCodeOwnerReviews,
+        },
       });
     } catch (e) {
       if (

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -49,6 +49,7 @@ export function createPublishGithubAction(options: {
     access?: string;
     defaultBranch?: string;
     sourcePath?: string;
+    requireCodeOwnerReviews?: boolean;
     repoVisibility: 'private' | 'internal' | 'public';
     collaborators: Collaborator[];
     topics?: string[];
@@ -74,6 +75,11 @@ export function createPublishGithubAction(options: {
             title: 'Repository Access',
             description: `Sets an admin collaborator on the repository. Can either be a user reference different from 'owner' in 'repoUrl' or team reference, eg. 'org/team-name'`,
             type: 'string',
+          },
+          requireCodeOwnerReviews: {
+            title:
+              'Require an approved review in PR including files with a designated Code Owner',
+            type: 'boolean',
           },
           repoVisibility: {
             title: 'Repository Visibility',
@@ -138,6 +144,7 @@ export function createPublishGithubAction(options: {
         repoUrl,
         description,
         access,
+        requireCodeOwnerReviews = false,
         repoVisibility = 'private',
         defaultBranch = 'master',
         collaborators,
@@ -283,6 +290,7 @@ export function createPublishGithubAction(options: {
           repoName: newRepo.name,
           logger: ctx.logger,
           defaultBranch,
+          requireCodeOwnerReviews,
         });
       } catch (e) {
         ctx.logger.warn(


### PR DESCRIPTION

## Hey, I just made a Pull Request!

In order to make creation of a new repository in GitHub using scaffolder more powerful option to enable 'Require review from Code Owners' has been added. The default behaviour is that this option is disabled as without the change. However, adding `requireCodeOwnersReview: true` in context input enables it.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
