### PR TITLE
catalog-plugin-react: clarified messaging around deleting entities from configured locations

### DIFF
--- a/.changeset/grumpy-scissors-refuse.md
+++ b/.changeset/grumpy-scissors-refuse.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Clarified messaging around configured locations in the `UnregisterEntityDialog`.

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/UnregisterEntityDialog.tsx
@@ -155,8 +155,8 @@ const Contents = ({
     return (
       <>
         <DialogContentText>
-          This entity does not seem to originate from a location. You therefore
-          only have the option to delete it outright from the catalog.
+          This entity does not seem to originate from a registered location. You
+          therefore only have the option to delete it outright from the catalog.
         </DialogContentText>
         <Button
           variant="contained"


### PR DESCRIPTION
There was a small confusion here so figured we could clarify the messaging a bit