### PR TITLE
fix(techdocs): generate correct feedback urls for GitHub

### DIFF
--- a/.changeset/rude-avocados-give.md
+++ b/.changeset/rude-avocados-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Export `replaceGitHubUrlType`

--- a/.changeset/short-flies-sneeze.md
+++ b/.changeset/short-flies-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix Techdocs feedback icon link for GitHub URLs

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -434,6 +434,14 @@ export function readGoogleGcsIntegrationConfig(
   config: Config,
 ): GoogleGcsIntegrationConfig;
 
+// Warning: (ae-missing-release-tag) "replaceUrlType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function replaceGitHubUrlType(
+  url: string,
+  type: 'blob' | 'tree' | 'edit',
+): string;
+
 // Warning: (ae-missing-release-tag) "ScmIntegration" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public

--- a/packages/integration/src/github/index.ts
+++ b/packages/integration/src/github/index.ts
@@ -25,4 +25,7 @@ export {
   GithubCredentialsProvider,
 } from './GithubCredentialsProvider';
 export type { GithubCredentialType } from './GithubCredentialsProvider';
-export { GitHubIntegration } from './GitHubIntegration';
+export {
+  GitHubIntegration,
+  replaceUrlType as replaceGitHubUrlType,
+} from './GitHubIntegration';

--- a/plugins/techdocs/src/reader/transformers/addGitFeedbackLink.test.ts
+++ b/plugins/techdocs/src/reader/transformers/addGitFeedbackLink.test.ts
@@ -85,7 +85,7 @@ describe('addGitFeedbackLink', () => {
       <html>
         <article class="md-content__inner">
           <h1>HeaderText</h1>
-          <a title="Edit this page" href="https://github.com/groupname/reponame/blob/master/docs/docname.md"></>
+          <a title="Edit this page" href="https://github.com/groupname/reponame/edit/master/docs/docname.md"></>
         </article>
       </html>
     `,
@@ -99,7 +99,7 @@ describe('addGitFeedbackLink', () => {
     expect(
       (shadowDom.querySelector('#git-feedback-link') as HTMLLinkElement)!.href,
     ).toEqual(
-      'https://github.com/groupname/reponame/issues/new?title=Documentation%20Feedback%3A%20HeaderText&body=Page%20source%3A%0Ahttps%3A%2F%2Fgithub.com%2Fgroupname%2Freponame%2Fblob%2Fmaster%2Fdocs%2Fdocname.md%0A%0AFeedback%3A',
+      'https://github.com/groupname/reponame/issues/new?title=Documentation%20Feedback%3A%20HeaderText&body=Page%20source%3A%0Ahttps%3A%2F%2Fgithub.com%2Fgroupname%2Freponame%2Fedit%2Fmaster%2Fdocs%2Fdocname.md%0A%0AFeedback%3A',
     );
   });
 

--- a/plugins/techdocs/src/reader/transformers/addGitFeedbackLink.ts
+++ b/plugins/techdocs/src/reader/transformers/addGitFeedbackLink.ts
@@ -15,7 +15,10 @@
  */
 
 import type { Transformer } from './index';
-import { ScmIntegrationRegistry } from '@backstage/integration';
+import {
+  replaceGitHubUrlType,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
 import FeedbackOutlinedIcon from '@material-ui/icons/FeedbackOutlined';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -51,7 +54,13 @@ export const addGitFeedbackLink = (
     const issueDesc = encodeURIComponent(
       `Page source:\n${sourceAnchor.href}\n\nFeedback:`,
     );
-    const gitInfo = parseGitUrl(sourceURL.pathname);
+
+    // Convert GitHub edit url to blob type so it can be parsed by git-url-parse correctly
+    const gitUrl =
+      integration?.type === 'github'
+        ? replaceGitHubUrlType(sourceURL.href, 'blob')
+        : sourceURL.href;
+    const gitInfo = parseGitUrl(gitUrl);
     const repoPath = `/${gitInfo.organization}/${gitInfo.name}`;
 
     const feedbackLink = sourceAnchor.cloneNode() as HTMLAnchorElement;


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Changes from https://github.com/backstage/backstage/pull/6698 broke feedback urls for GitHub.
`git-url-parse` does not parse GitHub edit urls correctly of the form `/<org>/<repo>/edit/<branch>/<path>/<file>` and ended up creating feedback urls like `/<org>/<repo>/edit/<branch>/<path>/<file>/issues/...`

Added a explicit check for SCM system to revert to creating feedback urls correctly for GitHub and support handling subgroups for GitLab

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
