### PR TITLE
move to node 14 & 16

### DIFF
--- a/.changeset/neat-pigs-lay.md
+++ b/.changeset/neat-pigs-lay.md
@@ -1,0 +1,22 @@
+---
+'@backstage/create-app': patch
+---
+
+Switched required engine from Node.js 12 or 14, to 14 or 16.
+
+To apply these changes to an existing app, switch out the following in the root `package.json`:
+
+```diff
+   "engines": {
+-    "node": "12 || 14"
++    "node": "14 || 16"
+   },
+```
+
+Also get rid of the entire `engines` object in `packages/backend/package.json`, as it is redundant:
+
+```diff
+-  "engines": {
+-    "node": "12 || 14"
+-  },
+```

--- a/.changeset/tidy-windows-compare.md
+++ b/.changeset/tidy-windows-compare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switched the Jest YAML transform from `yaml-jest` to `jest-transform-yaml`, which works with newer versions of Node.js.

--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -38,6 +38,6 @@ labels: bug
 
 <!--- Include as many relevant details about the environment you experienced the bug in -->
 
-- NodeJS Version (v12):
+- NodeJS Version (v14):
 - Operating System and Version (e.g. Ubuntu 14.04):
 - Browser Information:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     services:
       postgres13:

--- a/.github/workflows/e2e-win.yml
+++ b/.github/workflows/e2e-win.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     env:
       CI: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     env:
       CI: true

--- a/.github/workflows/master-win.yml
+++ b/.github/workflows/master-win.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     env:
       CI: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     services:
       postgres13:

--- a/contrib/docker/kubernetes-example-backend/Dockerfile
+++ b/contrib/docker/kubernetes-example-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-buster
+FROM node:14-buster
 
 WORKDIR /usr/src/app
 

--- a/docs/tutorials/quickstart-app-plugin.md
+++ b/docs/tutorials/quickstart-app-plugin.md
@@ -20,7 +20,7 @@ title: Adding Custom Plugin to Existing Monorepo App
 > functionality, extend the Sidebar to make our life easy. Finally, we add
 > custom code to display GitHub repository information.
 >
-> This document assumes you have Node.js 12 active along with Yarn and Python.
+> This document assumes you have Node.js 14 active along with Yarn and Python.
 > Please note, that at the time of this writing, the current version is
 > 0.1.1-alpha.21. This guide can still be used with future versions, just,
 > verify as you go. If you run into issues, you can compare your setup with mine

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "engines": {
-    "node": "12 || 14"
+    "node": "14 || 16"
   },
   "scripts": {
     "dev": "concurrently \"yarn start\" \"yarn start-backend\"",

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -97,7 +97,7 @@
     "get-port": "^5.1.1",
     "http-errors": "^1.7.3",
     "jest": "^26.0.1",
-    "mock-fs": "^4.13.0",
+    "mock-fs": "^5.1.0",
     "msw": "^0.29.0",
     "mysql2": "^2.2.5",
     "recursive-readdir": "^2.2.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -5,9 +5,6 @@
   "types": "src/index.ts",
   "license": "Apache-2.0",
   "private": true,
-  "engines": {
-    "node": "12 || 14"
-  },
   "homepage": "https://backstage.io",
   "repository": {
     "type": "git",

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -80,9 +80,8 @@ async function getConfig() {
     transform: {
       '\\.esm\\.js$': require.resolve('./jestEsmTransform.js'), // See jestEsmTransform.js
       '\\.(js|jsx|ts|tsx)$': require.resolve('@sucrase/jest-plugin'),
-      '\\.(bmp|gif|jpg|jpeg|png|frag|xml|svg|eot|woff|woff2|ttf)$': require.resolve(
-        './jestFileTransform.js',
-      ),
+      '\\.(bmp|gif|jpg|jpeg|png|frag|xml|svg|eot|woff|woff2|ttf)$':
+        require.resolve('./jestFileTransform.js'),
       '\\.(yaml)$': require.resolve('jest-transform-yaml'),
     },
 

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -80,9 +80,10 @@ async function getConfig() {
     transform: {
       '\\.esm\\.js$': require.resolve('./jestEsmTransform.js'), // See jestEsmTransform.js
       '\\.(js|jsx|ts|tsx)$': require.resolve('@sucrase/jest-plugin'),
-      '\\.(bmp|gif|jpg|jpeg|png|frag|xml|svg|eot|woff|woff2|ttf)$':
-        require.resolve('./jestFileTransform.js'),
-      '\\.(yaml)$': require.resolve('yaml-jest'),
+      '\\.(bmp|gif|jpg|jpeg|png|frag|xml|svg|eot|woff|woff2|ttf)$': require.resolve(
+        './jestFileTransform.js',
+      ),
+      '\\.(yaml)$': require.resolve('jest-transform-yaml'),
     },
 
     // A bit more opinionated

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -141,7 +141,7 @@
     "@types/webpack-dev-server": "^3.11.5",
     "@types/yarnpkg__lockfile": "^1.1.4",
     "del": "^6.0.0",
-    "mock-fs": "^4.13.0",
+    "mock-fs": "^5.1.0",
     "nodemon": "^2.0.2",
     "ts-node": "^10.0.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -82,6 +82,7 @@
     "jest": "^26.0.1",
     "jest-css-modules": "^2.1.0",
     "json-schema": "^0.3.0",
+    "jest-transform-yaml": "^0.1.1",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "^1.4.1",
     "node-libs-browser": "^2.2.1",
@@ -112,7 +113,6 @@
     "webpack-dev-server": "4.0.0-rc.0",
     "webpack-node-externals": "^3.0.0",
     "yaml": "^1.10.0",
-    "yaml-jest": "^1.0.5",
     "yml-loader": "^2.1.0",
     "yn": "^4.0.0"
   },

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -48,7 +48,7 @@
     "@types/mock-fs": "^4.10.0",
     "@types/node": "^14.14.32",
     "@types/yup": "^0.29.8",
-    "mock-fs": "^4.13.0"
+    "mock-fs": "^5.1.0"
   },
   "files": [
     "dist"

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "12 || 14"
+    "node": "14 || 16"
   },
   "scripts": {
     "dev": "concurrently \"yarn start\" \"yarn start-backend\"",

--- a/packages/create-app/templates/default-app/packages/backend/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/backend/package.json.hbs
@@ -4,9 +4,6 @@
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,
-  "engines": {
-    "node": "12 || 14"
-  },
   "scripts": {
     "build": "backstage-cli backend:bundle",
     "build-image": "docker build ../.. -f Dockerfile --tag backstage",

--- a/packages/techdocs-common/package.json
+++ b/packages/techdocs-common/package.json
@@ -54,7 +54,7 @@
     "js-yaml": "^4.0.0",
     "json5": "^2.1.3",
     "mime-types": "^2.1.27",
-    "mock-fs": "^4.13.0",
+    "mock-fs": "^5.1.0",
     "p-limit": "^3.1.0",
     "recursive-readdir": "^2.2.2",
     "winston": "^3.2.1"

--- a/plugins/git-release-manager/src/hooks/useGetGitBatchInfo.test.ts
+++ b/plugins/git-release-manager/src/hooks/useGetGitBatchInfo.test.ts
@@ -70,7 +70,9 @@ describe('useGetHubBatchInfo', () => {
   });
 
   it('should handle repositories without any releases', async () => {
-    (mockApiClient.getLatestRelease as jest.Mock).mockResolvedValueOnce(null);
+    (mockApiClient.getLatestRelease as jest.Mock).mockResolvedValueOnce({
+      latestRelease: null,
+    });
 
     const { result } = renderHook(() =>
       useGetGitBatchInfo({
@@ -85,8 +87,16 @@ describe('useGetHubBatchInfo', () => {
 
     expect(result.current.gitBatchInfo).toMatchInlineSnapshot(`
       Object {
-        "error": [TypeError: Cannot read property 'latestRelease' of null],
         "loading": false,
+        "value": Object {
+          "latestRelease": null,
+          "releaseBranch": null,
+          "repository": Object {
+            "defaultBranch": "mock_defaultBranch",
+            "name": "mock_repo",
+            "pushPermissions": true,
+          },
+        },
       }
     `);
   });

--- a/plugins/scaffolder-backend-module-cookiecutter/package.json
+++ b/plugins/scaffolder-backend-module-cookiecutter/package.json
@@ -37,7 +37,7 @@
     "@types/mock-fs": "^4.13.0",
     "@types/jest": "^26.0.7",
     "@types/command-exists": "^1.2.0",
-    "mock-fs": "^4.13.0",
+    "mock-fs": "^5.1.0",
     "msw": "^0.29.0"
   },
   "files": [

--- a/plugins/scaffolder-backend-module-rails/package.json
+++ b/plugins/scaffolder-backend-module-rails/package.json
@@ -37,7 +37,7 @@
     "@types/fs-extra": "^9.0.1",
     "@types/mock-fs": "^4.13.0",
     "jest-when": "^3.1.0",
-    "mock-fs": "^4.13.0"
+    "mock-fs": "^5.1.0"
   },
   "files": [
     "dist"

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -77,7 +77,7 @@
     "@types/nunjucks": "^3.1.4",
     "@types/supertest": "^2.0.8",
     "jest-when": "^3.1.0",
-    "mock-fs": "^4.13.0",
+    "mock-fs": "^5.1.0",
     "msw": "^0.29.0",
     "supertest": "^6.1.3",
     "yaml": "^1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11480,6 +11480,11 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+crypto@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
+
 css-box-model@^1.2.0:
   version "1.2.1"
   resolved "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
@@ -17390,6 +17395,14 @@ jest-snapshot@^26.6.2:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
+jest-transform-yaml@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/jest-transform-yaml/-/jest-transform-yaml-0.1.1.tgz#829bfa58e962d37ad1509e018791b469a8b9e92b"
+  integrity sha512-4UPmA5xs364ifqJTdnfepNMmdYL/OrjUMkWGPZndcZ1s3vUDSu0UuSe5ZrpDd7/7syb8j7JKR8D5vLec2XGNQQ==
+  dependencies:
+    crypto "1.0.1"
+    js-yaml "4.1.0"
+
 jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
@@ -17532,14 +17545,14 @@ js-string-escape@1.0.1, js-string-escape@^1.0.1:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@=4.1.0, js-yaml@^4.0.0, js-yaml@^4.1.0:
+js-yaml@4.1.0, js-yaml@=4.1.0, js-yaml@^4.0.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.8.3:
+js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.6.1, js-yaml@^3.8.3:
   version "3.14.1"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -28271,13 +28284,6 @@ yaml-ast-parser@0.0.43, yaml-ast-parser@^0.0.43:
   version "0.0.43"
   resolved "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
   integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
-
-yaml-jest@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/yaml-jest/-/yaml-jest-1.0.5.tgz#288e541bae1b551d113d4864d6cb8f316e1bd331"
-  integrity sha1-KI5UG64bVR0RPUhk1suPMW4b0zE=
-  dependencies:
-    js-yaml "^3.7.0"
 
 yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2, yaml@^1.9.2:
   version "1.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19786,10 +19786,10 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mock-fs@^4.13.0:
-  version "4.13.0"
-  resolved "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz#31c02263673ec3789f90eb7b6963676aa407a598"
-  integrity sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==
+mock-fs@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.0.tgz#a9aebd4e6d74a626f84b86eae8a372bd061754e8"
+  integrity sha512-wXdQ2nIk81TYIGLphUnbXl8akQpjb9ItfZefMcTxZcoe+djMkd5POU8fQdSEErxVAeT4CgDHWveYquys4H6Cmw==
 
 modify-values@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Time to phase out support for Node.js v12 and start making sure we're running smooth on v16. It is [scheduled](https://nodejs.org/en/about/releases/) for active LTS at the end of October, while v12 is already in maintenance mode.

For now the primary version we use is still v14, but once this is merged we can start using v14+ features and syntax.