### PR TITLE
Kubenetes-backend: Retrieve the externalId from the config

### DIFF
--- a/.changeset/rich-mayflies-do.md
+++ b/.changeset/rich-mayflies-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Fixes bug reading ExternalId from k8s backend config

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
@@ -115,6 +115,14 @@ describe('ConfigClusterLocator', () => {
           authProvider: 'aws',
           skipTLSVerify: true,
         },
+        {
+          assumeRole: 'SomeRole',
+          name: 'cluster2',
+          externalId: 'SomeExternalId',
+          url: 'http://localhost:8081',
+          authProvider: 'aws',
+          skipTLSVerify: true,
+        },
       ],
     });
 
@@ -127,6 +135,7 @@ describe('ConfigClusterLocator', () => {
         assumeRole: undefined,
         name: 'cluster1',
         serviceAccountToken: 'token',
+        externalId: undefined,
         url: 'http://localhost:8080',
         authProvider: 'aws',
         skipTLSVerify: false,
@@ -134,8 +143,18 @@ describe('ConfigClusterLocator', () => {
       {
         assumeRole: 'SomeRole',
         name: 'cluster2',
+        externalId: undefined,
         serviceAccountToken: undefined,
         url: 'http://localhost:8081',
+        authProvider: 'aws',
+        skipTLSVerify: true,
+      },
+      {
+        assumeRole: 'SomeRole',
+        name: 'cluster2',
+        externalId: 'SomeExternalId',
+        url: 'http://localhost:8081',
+        serviceAccountToken: undefined,
         authProvider: 'aws',
         skipTLSVerify: true,
       },

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -44,7 +44,9 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
           }
           case 'aws': {
             const assumeRole = c.getOptionalString('assumeRole');
-            return { assumeRole, ...clusterDetails };
+            const externalId = c.getOptionalString('externalId');
+
+            return { assumeRole, externalId, ...clusterDetails };
           }
           case 'serviceAccount': {
             return clusterDetails;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

My previous change to enable the external id, had missed the part
that actually reads the externalId from the config.

This change is the final piece, all going well.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
