### PR TITLE
add troubleshot instructions when plugins.ts is missing

### DIFF
--- a/plugins/shortcuts/README.md
+++ b/plugins/shortcuts/README.md
@@ -19,7 +19,7 @@ This plugin requires explicit registration, so you will need to add it to your A
 export { shortcutsPlugin } from '@backstage/plugin-shortcuts';
 ```
 
-If you don't have a `plugins.ts` see: [troubleshoot](#troubleshoot)
+If you don't have a `plugins.ts` file see: [troubleshooting](#troubleshooting)
 
 ### Add the `<Shortcuts />` component within your `<Sidebar>`:
 
@@ -55,9 +55,9 @@ export const apis = [
 ];
 ```
 
-# Troubleshoot
+# Troubleshooting
 
-If you don't have a `plugins.ts` you can create a new one on `packages/app/src/plugins.ts` and then add this lines to your `App.tsx` if there is other plugins that requires explicit registration:
+If you don't have a `plugins.ts` file, you can create it with the path `packages/app/src/plugins.ts` and then import it into your `App.tsx`:
 
 ```diff
 + import * as plugins from './plugins';

--- a/plugins/shortcuts/README.md
+++ b/plugins/shortcuts/README.md
@@ -4,20 +4,24 @@ The shortcuts plugin allows a user to have easy access to pages within a Backsta
 
 ## Usage
 
-Install the package:
+### Install the package:
 
 ```bash
 yarn add @backstage/plugin-shortcuts
 ```
 
-Add it to your App's `plugins.ts` file:
+### Register plugin:
+
+This plugin requires explicit registration, so you will need to add it to your App's `plugins.ts` file:
 
 ```ts
 // ...
 export { shortcutsPlugin } from '@backstage/plugin-shortcuts';
 ```
 
-Add the `<Shortcuts />` component within your `<Sidebar>`:
+If you don't have a `plugins.ts` see: [troubleshoot](#troubleshoot)
+
+### Add the `<Shortcuts />` component within your `<Sidebar>`:
 
 ```tsx
 import { Sidebar, SidebarDivider, SidebarSpace } from '@backstage/core';
@@ -49,4 +53,34 @@ export const apis = [
     factory: () => new CustomShortcutsImpl(),
   }),
 ];
+```
+
+# Troubleshoot
+
+If you don't have a `plugins.ts` you can create a new one on `packages/app/src/plugins.ts` and then add this lines to your `App.tsx` if there is other plugins that requires explicit registration:
+
+```diff
++ import * as plugins from './plugins';
+
+const app = createApp({
+  apis,
++   plugins: Object.values(plugins),
+  bindRoutes({ bind }) {
+    /* ... */
+  },
+});
+```
+
+Or simply edit `App.tsx` with:
+
+```diff
++ import { shortcutsPlugin } from '@backstage/plugin-shortcuts
+
+const app = createApp({
+  apis,
++   plugins: [shortcutsPlugin],
+  bindRoutes({ bind }) {
+    /* ... */
+  },
+});
 ```


### PR DESCRIPTION
Signed-off-by: Juan Pablo Garcia Ripa <sarabadu@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Starting from zero and trying to add the shortcuts plugin was no clear because the create-app does not include a `plugins.ts` file as default now and is necessary for this plugin

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
