### PR TITLE
Sanitize special characters before building search query for postgres

### DIFF
--- a/.changeset/eleven-snakes-give.md
+++ b/.changeset/eleven-snakes-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-pg': patch
+---
+
+Sanitize special characters before building search query for postgres

--- a/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngine.test.ts
+++ b/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngine.test.ts
@@ -65,6 +65,17 @@ describe('PgSearchEngine', () => {
       });
     });
 
+    it('should sanitize query term', async () => {
+      const actualTranslatedQuery = searchEngine.translator({
+        term: 'H&e|l!l*o W\0o(r)l:d',
+        pageCursor: '',
+      }) as PgSearchQuery;
+
+      expect(actualTranslatedQuery).toMatchObject({
+        pgTerm: '("Hello" | "Hello":*)&("World" | "World":*)',
+      });
+    });
+
     it('should return translated query with filters', async () => {
       const actualTranslatedQuery = searchEngine.translator({
         term: 'testTerm',

--- a/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngine.ts
+++ b/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngine.ts
@@ -50,7 +50,7 @@ export class PgSearchEngine implements SearchEngine {
     return {
       pgTerm: query.term
         .split(/\s/)
-        .map(p => p.trim())
+        .map(p => p.replace(/[\0()|&:*!]/g, '').trim())
         .filter(p => p !== '')
         .map(p => `(${JSON.stringify(p)} | ${JSON.stringify(p)}:*)`)
         .join('&'),


### PR DESCRIPTION
If you type in characters like `:` it collides with the query syntax. The problem is, that there seems to be now way of escaping them in the syntax. Another alternative would be working with `tsquery` objects in SQL and to chain them together there (parse the terms with `to_tsvector`, iterate over the lexems, concat or term with wildcard, and [then aggregate them with a AND expression](https://stackoverflow.com/a/42760445/218902)).  But than I would have to pass a `tx.raw` object over to the store, which is something I would prefer to avoid.
In the end, these characters aren't part of the index anyway, so there is also no need to search for them. So we can just strip them out.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
