### PR TITLE
Making sure to use proper luxon parser

### DIFF
--- a/.changeset/dirty-moose-cheer.md
+++ b/.changeset/dirty-moose-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+fixes `DateTime` parsing used in prometheus metrics collection

--- a/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
@@ -44,7 +44,7 @@ class Connection implements EntityProviderConnection {
       processingDatabase: ProcessingDatabase;
       id: string;
     },
-  ) {}
+  ) { }
 
   async applyMutation(mutation: EntityProviderMutation): Promise<void> {
     const db = this.config.processingDatabase;
@@ -108,7 +108,7 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
     private readonly orchestrator: CatalogProcessingOrchestrator,
     private readonly stitcher: Stitcher,
     private readonly createHash: () => Hash,
-  ) {}
+  ) { }
 
   async start() {
     if (this.stopFunc) {
@@ -145,9 +145,13 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
       processTask: async item => {
         let endTimer;
         try {
+          const nextUpdateAt = typeof item.nextUpdateAt === 'string'
+            ? DateTime.fromSQL(item.nextUpdateAt, { zone: 'UTC' })
+            : DateTime.fromJSDate(item.nextUpdateAt);
+
           this.metrics.processedEntities.inc(1);
           this.metrics.processingQueueDelay.observe(
-            -DateTime.fromSQL(item.nextUpdateAt, { zone: 'UTC' })
+            -nextUpdateAt
               .diffNow()
               .as('seconds'),
           );


### PR DESCRIPTION
If the backstage is using postgres the [newly added prometheus metrics functionality]
(https://github.com/backstage/backstage/pull/6848/files#) generate warnings 

> [2766b2a](https://github.com/backstage/backstage/commit/2766b2aa51865174a114614d0a757d15e485f08a): Add experimental Prometheus metrics instrumentation to the catalog


```
catalog warn Processing failed with: Value is not a valid number: {} type=plugin stack=TypeError: Value is not a valid number: {}
    at /Users/Valerii.Udodov/src/catalogue/node_modules/prom-client/lib/summary.js:160:10
    at Summary.observe (/Users/Valerii.Udodov/src/catalogue/node_modules/prom-client/lib/summary.js:47:54)
    at processTask (/Users/Valerii.Udodov/src/catalogue/node_modules/@backstage/plugin-catalog-backend/dist/index.cjs.js:3149:45)
    at /Users/Valerii.Udodov/src/catalogue/node_modules/@backstage/plugin-catalog-backend/dist/index.cjs.js:3036:7
    at Array.forEach (<anonymous>)
    at maybeLoadMore (/Users/Valerii.Udodov/src/catalogue/node_modules/@backstage/plugin-catalog-backend/dist/index.cjs.js:3035:17)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

Appears that `nextUpdateAt` is not guaranteed to be a `string` 🤷 . 

In case of postgres it is a JS object
```js
typeof item.nextUpdateAt
'object'
```

Adding a simple check to use corresponding luxon parser.

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
