### PR TITLE
auth-backend,core-app-api: add support for auth via GitHub Apps + handler options

### DIFF
--- a/.changeset/four-vans-sit.md
+++ b/.changeset/four-vans-sit.md
@@ -1,0 +1,10 @@
+---
+'@backstage/core-app-api': patch
+'@backstage/plugin-auth-backend': patch
+---
+
+Added support for using authenticating via GitHub Apps in addition to GitHub OAuth Apps. It used to be possible to use GitHub Apps, but they did not handle session refresh correctly.
+
+Note that GitHub Apps handle OAuth scope at the app installation level, meaning that the `scope` parameter for `getAccessToken` has no effect. When calling `getAccessToken` in open source plugins, one should still include the appropriate scope, but also document in the plugin README what scopes are required in the case of GitHub Apps.
+
+In addition, the `authHandler` and `signInResolver` options have been implemented for the GitHub provider in the auth backend.

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -10,10 +10,15 @@ that can authenticate users using GitHub or GitHub Enterprise OAuth.
 
 ## Create an OAuth App on GitHub
 
-To add GitHub authentication, you must create an OAuth App from the GitHub
+To add GitHub authentication, you must create either a GitHub App, or an OAuth
+App from the GitHub
 [developer settings](https://github.com/settings/developers). The `Homepage URL`
 should point to Backstage's frontend, while the `Authorization callback URL`
 will point to the auth backend.
+
+Note that if you're using a GitHub App, the allowed scopes are configured as
+part of that app. This means you need to verify what scopes the plugins you use
+require, so be sure to check the plugin READMEs for that information.
 
 Settings for local development:
 
@@ -51,3 +56,11 @@ The GitHub provider is a structure with three configuration keys:
 To add the provider to the frontend, add the `githubAuthApi` reference and
 `SignInPage` component as shown in
 [Adding the provider to the sign-in page](../index.md#adding-the-provider-to-the-sign-in-page).
+
+## Difference between GitHub Apps and GitHub OAuth Apps
+
+GitHub Apps handle OAuth scope at the app installation level, meaning that the
+`scope` parameter for the call to `getAccessToken` in the frontend has no
+effect. When calling `getAccessToken` in open source plugins, one should still
+include the appropriate scope, but also document in the plugin README what
+scopes are required for GitHub Apps.

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -394,7 +394,7 @@ export type GithubSession = {
   providerInfo: {
     accessToken: string;
     scopes: Set<string>;
-    expiresAt: Date;
+    expiresAt?: Date;
   };
   profile: ProfileInfo;
   backstageIdentity: BackstageIdentity;

--- a/packages/core-app-api/src/apis/implementations/auth/github/types.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/github/types.ts
@@ -20,7 +20,7 @@ export type GithubSession = {
   providerInfo: {
     accessToken: string;
     scopes: Set<string>;
-    expiresAt: Date;
+    expiresAt?: Date;
   };
   profile: ProfileInfo;
   backstageIdentity: BackstageIdentity;

--- a/packages/core-app-api/src/lib/AuthSessionManager/AuthSessionStore.test.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/AuthSessionStore.test.ts
@@ -128,6 +128,19 @@ describe('GheAuth AuthSessionStore', () => {
     expect(manager.removeSession).toHaveBeenCalled();
   });
 
+  it('should set session', async () => {
+    const manager = new MockManager();
+    const store = new AuthSessionStore({ manager, ...defaultOptions });
+
+    await expect(store.getSession({ optional: true })).resolves.toBe(undefined);
+    expect(localStorage.getItem('my-key')).toBe(null);
+    expect(manager.setSession).not.toHaveBeenCalled();
+    store.setSession('123');
+    expect(manager.setSession).toHaveBeenCalled();
+    expect(localStorage.getItem('my-key')).toBe('"123"');
+    await expect(store.getSession({ optional: true })).resolves.toBe('123');
+  });
+
   it('should forward sessionState calls', () => {
     const manager = new MockManager();
     const store = new AuthSessionStore({ manager, ...defaultOptions });

--- a/packages/core-app-api/src/lib/AuthSessionManager/AuthSessionStore.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/AuthSessionStore.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  SessionManager,
   MutableSessionManager,
   SessionScopesFunc,
   SessionShouldRefreshFunc,
@@ -40,7 +39,7 @@ type Options<T> = {
  *
  * Session is serialized to JSON with special support for following types: Set.
  */
-export class AuthSessionStore<T> implements SessionManager<T> {
+export class AuthSessionStore<T> implements MutableSessionManager<T> {
   private readonly manager: MutableSessionManager<T>;
   private readonly storageKey: string;
   private readonly sessionShouldRefreshFunc: SessionShouldRefreshFunc<T>;
@@ -61,6 +60,11 @@ export class AuthSessionStore<T> implements SessionManager<T> {
       sessionScopes,
       defaultScopes: new Set(),
     });
+  }
+
+  setSession(session: T | undefined): void {
+    this.manager.setSession(session);
+    this.saveSession(session);
   }
 
   async getSession(options: GetSessionOptions): Promise<T | undefined> {

--- a/packages/core-app-api/src/lib/AuthSessionManager/OptionalRefreshSessionManagerMux.test.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/OptionalRefreshSessionManagerMux.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Observable, SessionState } from '@backstage/core-plugin-api';
+import { OptionalRefreshSessionManagerMux } from './OptionalRefreshSessionManagerMux';
+import { MutableSessionManager, SessionManager } from './types';
+
+class MockManager implements MutableSessionManager<string> {
+  constructor(public session?: string) {}
+
+  setSession(session: string | undefined): void {
+    this.session = session;
+  }
+  async getSession(): Promise<string | undefined> {
+    return this.session;
+  }
+  async removeSession(): Promise<void> {
+    delete this.session;
+  }
+  sessionState$(): Observable<SessionState> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+function trackState(manager: SessionManager<any>) {
+  const states = new Array<boolean>();
+  manager
+    .sessionState$()
+    .subscribe(state => states.push(state === SessionState.SignedIn));
+  return states;
+}
+
+describe('OptionalRefreshSessionManagerMux', () => {
+  it('finds no session', async () => {
+    const mux = new OptionalRefreshSessionManagerMux({
+      staticSessionManager: new MockManager(),
+      refreshingSessionManager: new MockManager(),
+      sessionCanRefresh: () => false,
+    });
+
+    const states = trackState(mux);
+    await expect(mux.getSession({})).resolves.toBe(undefined);
+    expect(states).toEqual([false]);
+  });
+
+  it('prioritizes a static session', async () => {
+    const mux = new OptionalRefreshSessionManagerMux({
+      staticSessionManager: new MockManager('static'),
+      refreshingSessionManager: new MockManager('refreshing'),
+      sessionCanRefresh: () => false,
+    });
+
+    const states = trackState(mux);
+    await expect(mux.getSession({})).resolves.toBe('static');
+    expect(states).toEqual([false, true]);
+  });
+
+  it('transfers a refreshing session to the static manager', async () => {
+    const staticSessionManager = new MockManager();
+    const refreshingSessionManager = new MockManager('refreshing');
+    const mux = new OptionalRefreshSessionManagerMux({
+      staticSessionManager,
+      refreshingSessionManager,
+      sessionCanRefresh: () => false,
+    });
+
+    const states = trackState(mux);
+    expect(staticSessionManager.session).toBeUndefined();
+    await expect(mux.getSession({})).resolves.toBe('refreshing');
+    expect(staticSessionManager.session).toBe('refreshing');
+    expect(states).toEqual([false, true]);
+  });
+
+  it('relies on the refreshing manager if refresh is available', async () => {
+    const staticSessionManager = new MockManager();
+    const refreshingSessionManager = new MockManager('refreshing');
+    const mux = new OptionalRefreshSessionManagerMux({
+      staticSessionManager,
+      refreshingSessionManager,
+      sessionCanRefresh: () => true,
+    });
+
+    const states = trackState(mux);
+    await expect(mux.getSession({})).resolves.toBe('refreshing');
+    expect(staticSessionManager.session).toBeUndefined();
+    expect(states).toEqual([false, true]);
+  });
+
+  it('can switch between refreshing and static sessions', async () => {
+    let canRefresh = true;
+    const staticSessionManager = new MockManager();
+    const refreshingSessionManager = new MockManager('refreshing');
+    const mux = new OptionalRefreshSessionManagerMux({
+      staticSessionManager,
+      refreshingSessionManager,
+      sessionCanRefresh: () => canRefresh,
+    });
+
+    const states = trackState(mux);
+    await expect(mux.getSession({})).resolves.toBe('refreshing');
+    expect(staticSessionManager.session).toBeUndefined();
+    canRefresh = false;
+    await expect(mux.getSession({})).resolves.toBe('refreshing');
+    expect(staticSessionManager.session).toBe('refreshing');
+
+    expect(states).toEqual([false, true]);
+  });
+
+  it('removes sessions from both managers', async () => {
+    const staticSessionManager = new MockManager('static');
+    const refreshingSessionManager = new MockManager('refreshing');
+    const mux = new OptionalRefreshSessionManagerMux({
+      staticSessionManager,
+      refreshingSessionManager,
+      sessionCanRefresh: () => true,
+    });
+
+    const states = trackState(mux);
+    await expect(mux.getSession({})).resolves.toBe('static');
+    await mux.removeSession();
+    expect(staticSessionManager.session).toBeUndefined();
+    expect(refreshingSessionManager.session).toBeUndefined();
+    expect(states).toEqual([false, true, false]);
+  });
+});

--- a/packages/core-app-api/src/lib/AuthSessionManager/OptionalRefreshSessionManagerMux.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/OptionalRefreshSessionManagerMux.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Observable, SessionState } from '@backstage/core-plugin-api';
+import {
+  SessionManager,
+  MutableSessionManager,
+  GetSessionOptions,
+} from './types';
+import { SessionStateTracker } from './SessionStateTracker';
+
+type Options<T> = {
+  /**
+   * A callback that is called to determine whether a given session supports refresh
+   */
+  sessionCanRefresh: (session: T) => boolean;
+
+  /**
+   * The session manager that is used if the a session does not support refresh.
+   */
+  staticSessionManager: MutableSessionManager<T>;
+
+  /**
+   * The session manager that is used if the a session supports refresh.
+   */
+  refreshingSessionManager: SessionManager<T>;
+};
+
+/**
+ * OptionalRefreshSessionManagerMux wraps two different session managers, one for
+ * static session storage and another one that supports refresh. For each session
+ * that is retrieved is checked for whether it supports refresh. If it does, the
+ * refreshing session manager is used, otherwise the static session manager is used.
+ */
+export class OptionalRefreshSessionManagerMux<T> implements SessionManager<T> {
+  private readonly stateTracker = new SessionStateTracker();
+
+  private readonly sessionCanRefresh: (session: T) => boolean;
+  private readonly staticSessionManager: MutableSessionManager<T>;
+  private readonly refreshingSessionManager: SessionManager<T>;
+
+  constructor(options: Options<T>) {
+    this.sessionCanRefresh = options.sessionCanRefresh;
+    this.staticSessionManager = options.staticSessionManager;
+    this.refreshingSessionManager = options.refreshingSessionManager;
+  }
+
+  async getSession(options: GetSessionOptions): Promise<T | undefined> {
+    // First we check if there is an existing static session, using an optional request
+    const staticSession = await this.staticSessionManager.getSession({
+      ...options,
+      optional: true,
+    });
+    if (staticSession) {
+      this.stateTracker.setIsSignedIn(true);
+      return staticSession;
+    }
+
+    // If there is no static session available, we ask the refresh manager to get a session
+    const session = await this.refreshingSessionManager.getSession(options);
+
+    // Handling the case where the session request is optional
+    if (!session) {
+      this.stateTracker.setIsSignedIn(false);
+      return undefined;
+    }
+
+    // Next we check if the session we received from the refreshing manager can actually
+    // be refreshed. If it can, we use this session without storing it in the static manager.
+    if (this.sessionCanRefresh(session)) {
+      this.stateTracker.setIsSignedIn(true);
+      return session;
+    }
+
+    // If the session can't be refreshed, we store it in the static manager
+    this.staticSessionManager.setSession(session);
+    this.stateTracker.setIsSignedIn(true);
+    return session;
+  }
+
+  async removeSession(): Promise<void> {
+    await Promise.all([
+      this.refreshingSessionManager.removeSession(),
+      this.staticSessionManager.removeSession(),
+    ]);
+    this.stateTracker.setIsSignedIn(false);
+  }
+
+  sessionState$(): Observable<SessionState> {
+    return this.stateTracker.sessionState$();
+  }
+}

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -140,11 +140,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
         response.providerInfo.scope = grantedScopes;
       }
 
-      if (!this.options.disableRefresh) {
-        if (!refreshToken) {
-          throw new InputError('Missing refresh token');
-        }
-
+      if (refreshToken && !this.options.disableRefresh) {
         // set new refresh token
         this.setRefreshTokenCookie(res, refreshToken);
       }
@@ -174,10 +170,9 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
       return;
     }
 
-    if (!this.options.disableRefresh) {
-      // remove refresh token cookie before logout
-      this.removeRefreshTokenCookie(res);
-    }
+    // remove refresh token cookie if it is set
+    this.removeRefreshTokenCookie(res);
+
     res.status(200).send('logout!');
   }
 

--- a/plugins/auth-backend/src/lib/passport/PassportStrategyHelper.ts
+++ b/plugins/auth-backend/src/lib/passport/PassportStrategyHelper.ts
@@ -30,8 +30,6 @@ export const makeProfileInfo = (
   profile: passport.Profile,
   idToken?: string,
 ): ProfileInfo => {
-  let { displayName } = profile;
-
   let email: string | undefined = undefined;
   if (profile.emails && profile.emails.length > 0) {
     const [firstEmail] = profile.emails;
@@ -43,6 +41,9 @@ export const makeProfileInfo = (
     const [firstPhoto] = profile.photos;
     picture = firstPhoto.value;
   }
+
+  let displayName: string | undefined =
+    profile.displayName ?? profile.username ?? profile.id;
 
   if ((!email || !picture || !displayName) && idToken) {
     try {

--- a/plugins/auth-backend/src/providers/github/index.ts
+++ b/plugins/auth-backend/src/providers/github/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { createGithubProvider } from './provider';
-export type { GithubProviderOptions } from './provider';
+export type { GithubOAuthResult, GithubProviderOptions } from './provider';

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -198,13 +198,10 @@ export type GithubProviderOptions = {
   /**
    * Configure sign-in for this provider, without it the provider can not be used to sign users in.
    */
-  /**
-   * Maps an auth result to a Backstage identity for the user.
-   *
-   * Set to `'email'` to use the default email-based sign in resolver, which will search
-   * the catalog for a single user entity that has a matching `google.com/email` annotation.
-   */
   signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
     resolver?: SignInResolver<GithubOAuthResult>;
   };
 };

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -240,13 +240,10 @@ export type GoogleProviderOptions = {
   /**
    * Configure sign-in for this provider, without it the provider can not be used to sign users in.
    */
-  /**
-   * Maps an auth result to a Backstage identity for the user.
-   *
-   * Set to `'email'` to use the default email-based sign in resolver, which will search
-   * the catalog for a single user entity that has a matching `google.com/email` annotation.
-   */
   signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
     resolver?: SignInResolver<OAuthResult>;
   };
 };

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -247,13 +247,10 @@ export type MicrosoftProviderOptions = {
   /**
    * Configure sign-in for this provider, without it the provider can not be used to sign users in.
    */
-  /**
-   * Maps an auth result to a Backstage identity for the user.
-   *
-   * Set to `'email'` to use the default email-based sign in resolver, which will search
-   * the catalog for a single user entity that has a matching `microsoft.com/email` annotation.
-   */
   signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
     resolver?: SignInResolver<OAuthResult>;
   };
 };

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -250,13 +250,10 @@ export type OktaProviderOptions = {
   /**
    * Configure sign-in for this provider, without it the provider can not be used to sign users in.
    */
-  /**
-   * Maps an auth result to a Backstage identity for the user.
-   *
-   * Set to `'email'` to use the default email-based sign in resolver, which will search
-   * the catalog for a single user entity that has a matching `okta.com/email` annotation.
-   */
   signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
     resolver?: SignInResolver<OAuthResult>;
   };
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This implements #6245 for GitHub. It also fixes #6877, fixes #6792, and fixes #6710.

The GitHub provider in the auth backend now supports auth both via [GitHub Apps](https://docs.github.com/en/developers/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps), and [GitHub OAuth Apps](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps). A distinction between the two is that OAuth apps do not use token refresh, while apps do. In the frontend this adds a bit more complexity if we want to keep it configuration free. The `core-app-api` handles this by introducing a new auth session manager that is able to switch between static session storage and session refresh as needed, based on what the session supports. 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
