### PR TITLE
catalog-backend: add margin for test execution

### DIFF
--- a/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.test.ts
@@ -1011,9 +1011,8 @@ describe('Default Processing Database', () => {
           .where('entity_ref', 'location:default/new-root')
           .select();
         const nextUpdate = parseDate(result[0].next_update_at);
-        expect(nextUpdate.diff(now, 'seconds').seconds).toBeGreaterThanOrEqual(
-          100,
-        );
+        const nextUpdateDiff = nextUpdate.diff(now, 'seconds');
+        expect(nextUpdateDiff.seconds).toBeGreaterThanOrEqual(90);
       },
       60_000,
     );


### PR DESCRIPTION
This was probably around 3% flaky or so :grin:

I was picking a random time between 0 and 50, and then expecting that time not to have passed, so picking a low value with a slight delay in the test caused it to fail