### PR TITLE
Jenkins backend fix "no last build"

### DIFF
--- a/.changeset/wise-rings-hammer.md
+++ b/.changeset/wise-rings-hammer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins-backend': patch
+---
+
+Fix the case where lastBuild is null.

--- a/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
@@ -284,6 +284,15 @@ describe('JenkinsApi', () => {
         },
       };
 
+      const projectWithoutBuild: JenkinsProject = {
+        actions: [],
+        displayName: 'Example Build',
+        fullDisplayName: 'Example jobName » Example Build',
+        fullName: 'example-jobName/exampleBuild',
+        inQueue: false,
+        lastBuild: null,
+      };
+
       it('augments project', async () => {
         mockedJenkinsClient.job.get.mockResolvedValueOnce({
           jobs: [projectWithScmActions],
@@ -293,6 +302,16 @@ describe('JenkinsApi', () => {
 
         expect(result).toHaveLength(1);
         expect(result[0].status).toEqual('success');
+      });
+      it('augments project without build', async () => {
+        mockedJenkinsClient.job.get.mockResolvedValueOnce({
+          jobs: [projectWithoutBuild],
+        });
+
+        const result = await jenkinsApi.getProjects(jenkinsInfo);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].status).toEqual('build not found');
       });
       it('augments  build', async () => {
         mockedJenkinsClient.job.get.mockResolvedValueOnce({
@@ -304,7 +323,7 @@ describe('JenkinsApi', () => {
         expect(result).toHaveLength(1);
         // TODO: I am really just asserting the previous behaviour wth no understanding here.
         // In my 2 Jenkins instances, 1 returns a lot of different and confusing BuildData sections and 1 returns none ☹️
-        expect(result[0].lastBuild.source).toEqual({
+        expect(result[0].lastBuild!.source).toEqual({
           branchName: 'master',
           commit: {
             hash: '14d31bde',
@@ -322,7 +341,7 @@ describe('JenkinsApi', () => {
         const result = await jenkinsApi.getProjects(jenkinsInfo);
 
         expect(result).toHaveLength(1);
-        expect(result[0].lastBuild.tests).toEqual({
+        expect(result[0].lastBuild!.tests).toEqual({
           total: 635,
           passed: 632,
           skipped: 1,

--- a/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -154,7 +154,7 @@ export class JenkinsApiImpl {
 
     if (project.inQueue) {
       status = 'queued';
-    } else if (project.lastBuild === null) {
+    } else if (!project.lastBuild) {
       status = 'build not found';
     } else if (project.lastBuild.building) {
       status = 'running';

--- a/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -151,8 +151,11 @@ export class JenkinsApiImpl {
 
   private augmentProject(project: JenkinsProject): BackstageProject {
     let status: string;
+
     if (project.inQueue) {
       status = 'queued';
+    } else if (project.lastBuild === null) {
+      status = 'build not found';
     } else if (project.lastBuild.building) {
       status = 'running';
     } else if (!project.lastBuild.result) {
@@ -165,7 +168,10 @@ export class JenkinsApiImpl {
 
     return {
       ...project,
-      lastBuild: this.augmentBuild(project.lastBuild, jobScmInfo),
+      lastBuild:
+        project.lastBuild === null
+          ? null
+          : this.augmentBuild(project.lastBuild, jobScmInfo),
       status,
       // actions: undefined,
     };

--- a/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -168,10 +168,9 @@ export class JenkinsApiImpl {
 
     return {
       ...project,
-      lastBuild:
-        project.lastBuild === null
-          ? null
-          : this.augmentBuild(project.lastBuild, jobScmInfo),
+      lastBuild: project.lastBuild
+        ? this.augmentBuild(project.lastBuild, jobScmInfo)
+        : null,
       status,
       // actions: undefined,
     };

--- a/plugins/jenkins-backend/src/types.ts
+++ b/plugins/jenkins-backend/src/types.ts
@@ -63,7 +63,7 @@ export interface BackstageBuild extends CommonBuild {
 
 export interface CommonProject {
   // standard Jenkins
-  lastBuild: CommonBuild;
+  lastBuild: CommonBuild | null;
   displayName: string;
   fullDisplayName: string;
   fullName: string;
@@ -72,7 +72,7 @@ export interface CommonProject {
 
 export interface JenkinsProject extends CommonProject {
   // standard Jenkins
-  lastBuild: JenkinsBuild;
+  lastBuild: JenkinsBuild | null;
 
   // read by us from jenkins but not passed to frontend
   actions: object[];
@@ -80,7 +80,7 @@ export interface JenkinsProject extends CommonProject {
 
 export interface BackstageProject extends CommonProject {
   // standard Jenkins
-  lastBuild: BackstageBuild;
+  lastBuild: BackstageBuild | null;
 
   // added by us
   status: string; // == inQueue ? 'queued' : lastBuild.building ? 'running' : lastBuild.result,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fix #6725.  Jenkins may have jobs without lastBuild, so backstage need to manage correctly that.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
