### PR TITLE
Expose GRM internals for custom feature development

### DIFF
--- a/.changeset/forty-peaches-cry.md
+++ b/.changeset/forty-peaches-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-git-release-manager': patch
+---
+
+Expose internal constants, helpers and components to make it easier for users to build custom features for GRM.

--- a/plugins/git-release-manager/api-report.md
+++ b/plugins/git-release-manager/api-report.md
@@ -7,8 +7,130 @@
 
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
+import { ReactNode } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
+
+// Warning: (ae-missing-release-tag) "calverRegexp" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const calverRegexp: RegExp;
+
+// Warning: (ae-forgotten-export) The symbol "DifferProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "Differ" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const Differ: ({ current, next, icon }: DifferProps) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "DISABLE_CACHE" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const DISABLE_CACHE: {
+  readonly headers: {
+    readonly 'If-None-Match': '';
+  };
+};
+
+// Warning: (ae-missing-release-tag) "Divider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const Divider: () => JSX.Element;
+
+// Warning: (ae-forgotten-export) The symbol "SemverTagParts" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "getBumpedSemverTagParts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function getBumpedSemverTagParts(
+  tagParts: SemverTagParts,
+  semverBumpLevel: keyof typeof SEMVER_PARTS,
+): {
+  bumpedTagParts: {
+    prefix: string;
+    major: number;
+    minor: number;
+    patch: number;
+  };
+};
+
+// Warning: (ae-missing-release-tag) "getBumpedTag" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function getBumpedTag({
+  project,
+  tag,
+  bumpLevel,
+}: {
+  project: Project;
+  tag: string;
+  bumpLevel: keyof typeof SEMVER_PARTS;
+}):
+  | {
+      bumpedTag: string;
+      tagParts: CalverTagParts;
+      error: undefined;
+    }
+  | {
+      bumpedTag: string;
+      tagParts: {
+        prefix: string;
+        major: number;
+        minor: number;
+        patch: number;
+      };
+      error: undefined;
+    }
+  | {
+      error: AlertError;
+    };
+
+// Warning: (ae-missing-release-tag) "getCalverTagParts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function getCalverTagParts(tag: string):
+  | {
+      error: AlertError;
+      tagParts?: undefined;
+    }
+  | {
+      tagParts: CalverTagParts;
+      error?: undefined;
+    };
+
+// Warning: (ae-missing-release-tag) "getSemverTagParts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function getSemverTagParts(tag: string):
+  | {
+      error: AlertError;
+      tagParts?: undefined;
+    }
+  | {
+      tagParts: SemverTagParts;
+      error?: undefined;
+    };
+
+// Warning: (ae-missing-release-tag) "getShortCommitHash" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function getShortCommitHash(hash: string): string;
+
+// Warning: (ae-missing-release-tag) "getTagParts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+function getTagParts({ project, tag }: { project: Project; tag: string }):
+  | {
+      error: AlertError;
+      tagParts?: undefined;
+    }
+  | {
+      tagParts: CalverTagParts;
+      error?: undefined;
+    }
+  | {
+      tagParts: SemverTagParts;
+      error?: undefined;
+    };
 
 // Warning: (ae-forgotten-export) The symbol "GitReleaseApi" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "gitReleaseManagerApiRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -31,6 +153,136 @@ export const gitReleaseManagerPlugin: BackstagePlugin<
   },
   {}
 >;
+
+// Warning: (ae-missing-release-tag) "InfoCardPlus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const InfoCardPlus: ({
+  children,
+}: {
+  children?: React_2.ReactNode;
+}) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "internals" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const internals: {
+  components: typeof components;
+  constants: typeof constants;
+  helpers: typeof helpers;
+};
+
+// Warning: (ae-missing-release-tag) "isCalverTagParts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function isCalverTagParts(
+  project: Project,
+  _tagParts: unknown,
+): _tagParts is CalverTagParts;
+
+// Warning: (ae-missing-release-tag) "isProjectValid" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function isProjectValid(project: any): project is Project;
+
+// Warning: (ae-missing-release-tag) "LinearProgressWithLabel" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+function LinearProgressWithLabel(props: {
+  progress: number;
+  responseSteps: ResponseStep[];
+}): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "NoLatestRelease" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const NoLatestRelease: () => JSX.Element;
+
+// Warning: (ae-forgotten-export) The symbol "DialogProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "ResponseStepDialog" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const ResponseStepDialog: ({
+  progress,
+  responseSteps,
+  title,
+}: DialogProps) => JSX.Element;
+
+// Warning: (ae-forgotten-export) The symbol "ResponseStepListProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "ResponseStepList" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const ResponseStepList: ({
+  responseSteps,
+  animationDelay,
+  loading,
+  denseList,
+  children,
+}: PropsWithChildren<ResponseStepListProps>) => JSX.Element;
+
+// Warning: (ae-forgotten-export) The symbol "ResponseStepListItemProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "ResponseStepListItem" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const ResponseStepListItem: ({
+  responseStep,
+  animationDelay,
+}: ResponseStepListItemProps) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "SEMVER_PARTS" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const SEMVER_PARTS: {
+  major: 'major';
+  minor: 'minor';
+  patch: 'patch';
+};
+
+// Warning: (ae-missing-release-tag) "semverRegexp" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const semverRegexp: RegExp;
+
+// Warning: (ae-missing-release-tag) "TAG_OBJECT_MESSAGE" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const TAG_OBJECT_MESSAGE =
+  'Tag generated by your friendly neighborhood Backstage Release Manager';
+
+// Warning: (ae-missing-release-tag) "validateTagName" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const validateTagName: ({
+  project,
+  tagName,
+}: {
+  project: Project;
+  tagName?: string | undefined;
+}) =>
+  | {
+      tagNameError: null;
+    }
+  | {
+      tagNameError: AlertError | undefined;
+    };
+
+// Warning: (ae-missing-release-tag) "VERSIONING_STRATEGIES" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const VERSIONING_STRATEGIES: {
+  semver: 'semver';
+  calver: 'calver';
+};
+
+// Warnings were encountered during analysis:
+//
+// src/components/ResponseStepDialog/LinearProgressWithLabel.d.ts:5:5 - (ae-forgotten-export) The symbol "ResponseStep" needs to be exported by the entry point index.d.ts
+// src/helpers/getBumpedTag.d.ts:14:5 - (ae-forgotten-export) The symbol "Project" needs to be exported by the entry point index.d.ts
+// src/helpers/getBumpedTag.d.ts:19:5 - (ae-forgotten-export) The symbol "CalverTagParts" needs to be exported by the entry point index.d.ts
+// src/helpers/getBumpedTag.d.ts:31:5 - (ae-forgotten-export) The symbol "AlertError" needs to be exported by the entry point index.d.ts
+// src/index.d.ts:4:5 - (ae-forgotten-export) The symbol "components" needs to be exported by the entry point index.d.ts
+// src/index.d.ts:5:5 - (ae-forgotten-export) The symbol "constants" needs to be exported by the entry point index.d.ts
+// src/index.d.ts:6:5 - (ae-forgotten-export) The symbol "helpers" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/git-release-manager/api-report.md
+++ b/plugins/git-release-manager/api-report.md
@@ -17,6 +17,20 @@ import { RouteRef } from '@backstage/core-plugin-api';
 // @public (undocumented)
 const calverRegexp: RegExp;
 
+// Warning: (ae-forgotten-export) The symbol "GetCommitResult" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "createMockCommit" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const createMockCommit: (
+  overrides: Partial<GetCommitResult['commit']>,
+) => GetCommitResult;
+
+// Warning: (ae-forgotten-export) The symbol "GetTagResult" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "createMockTag" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const createMockTag: (overrides: Partial<GetTagResult['tag']>) => GetTagResult;
+
 // Warning: (ae-forgotten-export) The symbol "DifferProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Differ" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -170,6 +184,7 @@ export const internals: {
   components: typeof components;
   constants: typeof constants;
   helpers: typeof helpers;
+  testHelpers: typeof testHelpers;
 };
 
 // Warning: (ae-missing-release-tag) "isCalverTagParts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -192,6 +207,153 @@ function LinearProgressWithLabel(props: {
   progress: number;
   responseSteps: ResponseStep[];
 }): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "mockApiClient" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+const mockApiClient: GitReleaseApi;
+
+// Warning: (ae-missing-release-tag) "mockBumpedTag" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockBumpedTag = 'rc-2020.01.01_1337';
+
+// Warning: (ae-missing-release-tag) "mockCalverProject" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockCalverProject: Project;
+
+// Warning: (ae-missing-release-tag) "mockDefaultBranch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockDefaultBranch = 'mock_defaultBranch';
+
+// Warning: (ae-forgotten-export) The symbol "getReleaseCandidateGitInfo" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "mockNextGitInfoCalver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockNextGitInfoCalver: ReturnType<typeof getReleaseCandidateGitInfo>;
+
+// Warning: (ae-missing-release-tag) "mockNextGitInfoSemver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockNextGitInfoSemver: ReturnType<typeof getReleaseCandidateGitInfo>;
+
+// Warning: (ae-missing-release-tag) "mockReleaseBranch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockReleaseBranch: {
+  name: string;
+  links: {
+    html: string;
+  };
+  commit: {
+    sha: string;
+    commit: {
+      tree: {
+        sha: string;
+      };
+    };
+  };
+};
+
+// Warning: (ae-missing-release-tag) "mockReleaseCandidateCalver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockReleaseCandidateCalver: {
+  targetCommitish: string;
+  tagName: string;
+  prerelease: boolean;
+  id: number;
+  htmlUrl: string;
+  body?: string | null | undefined;
+};
+
+// Warning: (ae-missing-release-tag) "mockReleaseCandidateSemver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockReleaseCandidateSemver: {
+  targetCommitish: string;
+  tagName: string;
+  prerelease: boolean;
+  id: number;
+  htmlUrl: string;
+  body?: string | null | undefined;
+};
+
+// Warning: (ae-forgotten-export) The symbol "ReleaseStats" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "mockReleaseStats" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockReleaseStats: ReleaseStats;
+
+// Warning: (ae-missing-release-tag) "mockReleaseVersionCalver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockReleaseVersionCalver: {
+  targetCommitish: string;
+  tagName: string;
+  prerelease: boolean;
+  id: number;
+  htmlUrl: string;
+  body?: string | null | undefined;
+};
+
+// Warning: (ae-missing-release-tag) "mockReleaseVersionSemver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockReleaseVersionSemver: {
+  targetCommitish: string;
+  tagName: string;
+  prerelease: boolean;
+  id: number;
+  htmlUrl: string;
+  body?: string | null | undefined;
+};
+
+// Warning: (ae-missing-release-tag) "mockSearchCalver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockSearchCalver: string;
+
+// Warning: (ae-missing-release-tag) "mockSearchSemver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockSearchSemver: string;
+
+// Warning: (ae-missing-release-tag) "mockSelectedPatchCommit" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockSelectedPatchCommit: {
+  htmlUrl: string;
+  sha: string;
+  author: {
+    htmlUrl?: string | undefined;
+    login?: string | undefined;
+  };
+  commit: {
+    message: string;
+  };
+  firstParentSha?: string | undefined;
+};
+
+// Warning: (ae-missing-release-tag) "mockSemverProject" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockSemverProject: Project;
+
+// Warning: (ae-missing-release-tag) "mockTagParts" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockTagParts: CalverTagParts;
+
+// Warning: (ae-missing-release-tag) "mockUser" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockUser: {
+  username: string;
+  email: string;
+};
 
 // Warning: (ae-missing-release-tag) "NoLatestRelease" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -243,11 +405,109 @@ const SEMVER_PARTS: {
 // @public (undocumented)
 const semverRegexp: RegExp;
 
+declare namespace stats {
+  export { mockReleaseStats };
+}
+
 // Warning: (ae-missing-release-tag) "TAG_OBJECT_MESSAGE" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 const TAG_OBJECT_MESSAGE =
   'Tag generated by your friendly neighborhood Backstage Release Manager';
+
+// Warning: (ae-missing-release-tag) "TEST_IDS" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const TEST_IDS: {
+  info: {
+    info: string;
+    infoFeaturePlus: string;
+  };
+  createRc: {
+    cta: string;
+    semverSelect: string;
+  };
+  promoteRc: {
+    mockedPromoteRcBody: string;
+    notRcWarning: string;
+    promoteRc: string;
+    cta: string;
+  };
+  patch: {
+    error: string;
+    loading: string;
+    notPrerelease: string;
+    body: string;
+  };
+  form: {
+    owner: {
+      loading: string;
+      select: string;
+      error: string;
+      empty: string;
+    };
+    repo: {
+      loading: string;
+      select: string;
+      error: string;
+      empty: string;
+    };
+    versioningStrategy: {
+      radioGroup: string;
+    };
+  };
+  components: {
+    divider: string;
+    noLatestRelease: string;
+    circularProgress: string;
+    responseStepListDialogContent: string;
+    responseStepListItem: string;
+    responseStepListItemIconSuccess: string;
+    responseStepListItemIconFailure: string;
+    responseStepListItemIconLink: string;
+    responseStepListItemIconDefault: string;
+    differ: {
+      current: string;
+      next: string;
+      icons: {
+        tag: string;
+        branch: string;
+        github: string;
+        slack: string;
+        versioning: string;
+      };
+    };
+    linearProgressWithLabel: string;
+  };
+};
+
+declare namespace testHelpers_2 {
+  export {
+    createMockTag,
+    createMockCommit,
+    mockUser,
+    mockSemverProject,
+    mockCalverProject,
+    mockSearchCalver,
+    mockSearchSemver,
+    mockDefaultBranch,
+    mockNextGitInfoSemver,
+    mockNextGitInfoCalver,
+    mockTagParts,
+    mockBumpedTag,
+    mockReleaseCandidateCalver,
+    mockReleaseVersionCalver,
+    mockReleaseCandidateSemver,
+    mockReleaseVersionSemver,
+    mockReleaseBranch,
+    mockSelectedPatchCommit,
+    mockApiClient,
+  };
+}
+
+declare namespace testIds {
+  export { TEST_IDS };
+}
 
 // Warning: (ae-missing-release-tag) "validateTagName" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -283,6 +543,7 @@ const VERSIONING_STRATEGIES: {
 // src/index.d.ts:4:5 - (ae-forgotten-export) The symbol "components" needs to be exported by the entry point index.d.ts
 // src/index.d.ts:5:5 - (ae-forgotten-export) The symbol "constants" needs to be exported by the entry point index.d.ts
 // src/index.d.ts:6:5 - (ae-forgotten-export) The symbol "helpers" needs to be exported by the entry point index.d.ts
+// src/index.d.ts:7:5 - (ae-forgotten-export) The symbol "testHelpers" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/git-release-manager/src/components/index.tsx
+++ b/plugins/git-release-manager/src/components/index.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-export {
-  gitReleaseManagerPlugin,
-  GitReleaseManagerPage,
-  gitReleaseManagerApiRef,
-  internals,
-} from './plugin';
+export { Differ } from './Differ';
+export { Divider } from './Divider';
+export { InfoCardPlus } from './InfoCardPlus';
+export { LinearProgressWithLabel } from './ResponseStepDialog/LinearProgressWithLabel';
+export { NoLatestRelease } from './NoLatestRelease';
+export { ResponseStepDialog } from './ResponseStepDialog/ResponseStepDialog';
+export { ResponseStepList } from './ResponseStepDialog/ResponseStepList';
+export { ResponseStepListItem } from './ResponseStepDialog/ResponseStepListItem';

--- a/plugins/git-release-manager/src/helpers/getBumpedTag.ts
+++ b/plugins/git-release-manager/src/helpers/getBumpedTag.ts
@@ -21,6 +21,14 @@ import { Project } from '../contexts/ProjectContext';
 import { SEMVER_PARTS } from '../constants/constants';
 import { SemverTagParts } from './tagParts/getSemverTagParts';
 
+/**
+ * Calculates the next version for the project
+ *
+ * For calendar versioning this means a bump in patch
+ *
+ * For semantic versioning this means either a minor or a patch bump
+ * depending on the value of `bumpLevel`
+ */
 export function getBumpedTag({
   project,
   tag,
@@ -74,6 +82,10 @@ function getBumpedSemverTag(
   };
 }
 
+/**
+ * Calculates the next semantic version, taking into account
+ * whether or not it's a minor or patch
+ */
 export function getBumpedSemverTagParts(
   tagParts: SemverTagParts,
   semverBumpLevel: keyof typeof SEMVER_PARTS,

--- a/plugins/git-release-manager/src/helpers/index.tsx
+++ b/plugins/git-release-manager/src/helpers/index.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-export {
-  gitReleaseManagerPlugin,
-  GitReleaseManagerPage,
-  gitReleaseManagerApiRef,
-  internals,
-} from './plugin';
+export { calverRegexp, getCalverTagParts } from './tagParts/getCalverTagParts';
+export { getBumpedSemverTagParts, getBumpedTag } from './getBumpedTag';
+export { getSemverTagParts, semverRegexp } from './tagParts/getSemverTagParts';
+export { getShortCommitHash } from './getShortCommitHash';
+export { getTagParts } from './tagParts/getTagParts';
+export { isCalverTagParts } from './isCalverTagParts';
+export { isProjectValid } from './isProjectValid';
+export { validateTagName } from './tagParts/validateTagName';

--- a/plugins/git-release-manager/src/helpers/tagParts/getTagParts.ts
+++ b/plugins/git-release-manager/src/helpers/tagParts/getTagParts.ts
@@ -18,6 +18,10 @@ import { getCalverTagParts } from './getCalverTagParts';
 import { getSemverTagParts } from './getSemverTagParts';
 import { Project } from '../../contexts/ProjectContext';
 
+/**
+ * Tag parts are the individual parts of a version, e.g. <major>.<minor>.<patch>
+ * are the parts of a semantic version
+ */
 export function getTagParts({
   project,
   tag,

--- a/plugins/git-release-manager/src/index.ts
+++ b/plugins/git-release-manager/src/index.ts
@@ -18,5 +18,12 @@ export {
   gitReleaseManagerPlugin,
   GitReleaseManagerPage,
   gitReleaseManagerApiRef,
-  internals,
 } from './plugin';
+
+import { components, constants, helpers } from './plugin';
+
+export const internals = {
+  components,
+  constants,
+  helpers,
+};

--- a/plugins/git-release-manager/src/plugin.test.ts
+++ b/plugins/git-release-manager/src/plugin.test.ts
@@ -21,6 +21,9 @@ describe('git-release-manager', () => {
     expect(Object.keys(plugin)).toMatchInlineSnapshot(`
       Array [
         "gitReleaseManagerApiRef",
+        "constants",
+        "helpers",
+        "components",
         "gitReleaseManagerPlugin",
         "GitReleaseManagerPage",
       ]

--- a/plugins/git-release-manager/src/plugin.test.ts
+++ b/plugins/git-release-manager/src/plugin.test.ts
@@ -24,6 +24,7 @@ describe('git-release-manager', () => {
         "constants",
         "helpers",
         "components",
+        "testHelpers",
         "gitReleaseManagerPlugin",
         "GitReleaseManagerPage",
       ]

--- a/plugins/git-release-manager/src/plugin.ts
+++ b/plugins/git-release-manager/src/plugin.ts
@@ -25,11 +25,11 @@ import {
 import { GitReleaseClient } from './api/GitReleaseClient';
 import { gitReleaseManagerApiRef } from './api/serviceApiRef';
 import { rootRouteRef } from './routes';
+import * as constants from './constants/constants';
+import * as helpers from './helpers';
+import * as components from './components';
 
-export * as constants from './constants/constants';
-export * as helpers from './helpers';
-export * as components from './components';
-export { gitReleaseManagerApiRef };
+export { gitReleaseManagerApiRef, constants, helpers, components };
 
 export const gitReleaseManagerPlugin = createPlugin({
   id: 'git-release-manager',

--- a/plugins/git-release-manager/src/plugin.ts
+++ b/plugins/git-release-manager/src/plugin.ts
@@ -25,16 +25,11 @@ import {
 import { GitReleaseClient } from './api/GitReleaseClient';
 import { gitReleaseManagerApiRef } from './api/serviceApiRef';
 import { rootRouteRef } from './routes';
-import * as constants from './constants/constants';
-import * as helpers from './helpers';
-import * as components from './components';
 
+export * as constants from './constants/constants';
+export * as helpers from './helpers';
+export * as components from './components';
 export { gitReleaseManagerApiRef };
-export const internals = {
-  constants,
-  helpers,
-  components,
-};
 
 export const gitReleaseManagerPlugin = createPlugin({
   id: 'git-release-manager',

--- a/plugins/git-release-manager/src/plugin.ts
+++ b/plugins/git-release-manager/src/plugin.ts
@@ -28,8 +28,9 @@ import { rootRouteRef } from './routes';
 import * as constants from './constants/constants';
 import * as helpers from './helpers';
 import * as components from './components';
+import * as testHelpers from './test-helpers';
 
-export { gitReleaseManagerApiRef, constants, helpers, components };
+export { gitReleaseManagerApiRef, constants, helpers, components, testHelpers };
 
 export const gitReleaseManagerPlugin = createPlugin({
   id: 'git-release-manager',

--- a/plugins/git-release-manager/src/plugin.ts
+++ b/plugins/git-release-manager/src/plugin.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-import { gitReleaseManagerApiRef } from './api/serviceApiRef';
-
-import { GitReleaseClient } from './api/GitReleaseClient';
-import { rootRouteRef } from './routes';
 import {
   configApiRef,
   createPlugin,
@@ -26,7 +22,19 @@ import {
   createRoutableExtension,
 } from '@backstage/core-plugin-api';
 
+import { GitReleaseClient } from './api/GitReleaseClient';
+import { gitReleaseManagerApiRef } from './api/serviceApiRef';
+import { rootRouteRef } from './routes';
+import * as constants from './constants/constants';
+import * as helpers from './helpers';
+import * as components from './components';
+
 export { gitReleaseManagerApiRef };
+export const internals = {
+  constants,
+  helpers,
+  components,
+};
 
 export const gitReleaseManagerPlugin = createPlugin({
   id: 'git-release-manager',

--- a/plugins/git-release-manager/src/test-helpers/index.ts
+++ b/plugins/git-release-manager/src/test-helpers/index.ts
@@ -14,17 +14,6 @@
  * limitations under the License.
  */
 
-export {
-  gitReleaseManagerPlugin,
-  GitReleaseManagerPage,
-  gitReleaseManagerApiRef,
-} from './plugin';
-
-import { components, constants, helpers, testHelpers } from './plugin';
-
-export const internals = {
-  components,
-  constants,
-  helpers,
-  testHelpers,
-};
+export * as stats from './stats';
+export * as testHelpers from './test-helpers';
+export * as testIds from './test-ids';

--- a/plugins/git-release-manager/src/test-helpers/index.ts
+++ b/plugins/git-release-manager/src/test-helpers/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
-export * as stats from './stats';
-export * as testHelpers from './test-helpers';
-export * as testIds from './test-ids';
+import * as stats from './stats';
+import * as testHelpers from './test-helpers';
+import * as testIds from './test-ids';
+
+export { stats, testHelpers, testIds };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

## Motivation

When building custom features for GRM (git-release-manager) it'd be _very_ helpful to have access to the same helpers as GRM itself uses rather than having to implement e.g. version validators multiple times.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
