### PR TITLE
Collect the routes of the `ExploreLayout` with `useElementFilter`

### DIFF
--- a/.changeset/afraid-pugs-confess.md
+++ b/.changeset/afraid-pugs-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Collect the routes of a `ExploreLayout` with `useElementFilter`


### PR DESCRIPTION
We want to use `FeatureFlagged` for the tabs in the explore plugin.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
