### PR TITLE
ability to discover catalog-infos from default branch

### DIFF
--- a/.changeset/big-jars-repair.md
+++ b/.changeset/big-jars-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+GitHub discovery processor adds support for discovering the default GitHub branch

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
@@ -35,7 +35,8 @@ describe('GithubDiscoveryProcessor', () => {
         org: 'foo',
         host: 'github.com',
         repoSearchPath: /^proj$/,
-        catalogPath: '/blob/master/catalog.yaml',
+        branch: 'master',
+        catalogPath: '/catalog.yaml',
       });
       expect(
         parseUrl('https://github.com/foo/proj*/blob/master/catalog.yaml'),
@@ -43,11 +44,15 @@ describe('GithubDiscoveryProcessor', () => {
         org: 'foo',
         host: 'github.com',
         repoSearchPath: /^proj.*$/,
-        catalogPath: '/blob/master/catalog.yaml',
+        branch: 'master',
+        catalogPath: '/catalog.yaml',
       });
       expect(parseUrl('https://github.com/foo')).toEqual({
         org: 'foo',
         host: 'github.com',
+        repoSearchPath: /^.*$/,
+        branch: '-',
+        catalogPath: '/catalog-info.yaml',
       });
     });
 

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
@@ -45,12 +45,15 @@ describe('GithubDiscoveryProcessor', () => {
         repoSearchPath: /^proj.*$/,
         catalogPath: '/blob/master/catalog.yaml',
       });
+      expect(parseUrl('https://github.com/foo')).toEqual({
+        org: 'foo',
+        host: 'github.com',
+      });
     });
 
     it('throws on incorrectly formed URLs', () => {
       expect(() => parseUrl('https://github.com')).toThrow();
       expect(() => parseUrl('https://github.com//')).toThrow();
-      expect(() => parseUrl('https://github.com/foo')).toThrow();
       expect(() => parseUrl('https://github.com//foo')).toThrow();
       expect(() => parseUrl('https://github.com/org/teams')).toThrow();
       expect(() => parseUrl('https://github.com/org//teams')).toThrow();

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
@@ -128,11 +128,17 @@ describe('GithubDiscoveryProcessor', () => {
             name: 'backstage',
             url: 'https://github.com/backstage/backstage',
             isArchived: false,
+            defaultBranchRef: {
+              name: 'master',
+            },
           },
           {
             name: 'demo',
             url: 'https://github.com/backstage/demo',
             isArchived: false,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
         ],
       });
@@ -171,16 +177,25 @@ describe('GithubDiscoveryProcessor', () => {
             name: 'backstage',
             url: 'https://github.com/backstage/backstage',
             isArchived: false,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
           {
             name: 'techdocs-cli',
             url: 'https://github.com/backstage/techdocs-cli',
             isArchived: false,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
           {
             name: 'techdocs-container',
             url: 'https://github.com/backstage/techdocs-container',
             isArchived: false,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
         ],
       });
@@ -218,21 +233,33 @@ describe('GithubDiscoveryProcessor', () => {
             name: 'abstest',
             url: 'https://github.com/backstage/abctest',
             isArchived: false,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
           {
             name: 'test',
             url: 'https://github.com/backstage/test',
             isArchived: false,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
           {
             name: 'test-archived',
             url: 'https://github.com/backstage/test',
             isArchived: true,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
           {
             name: 'testxyz',
             url: 'https://github.com/backstage/testxyz',
             isArchived: false,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
         ],
       });

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.test.ts
@@ -201,11 +201,17 @@ describe('github', () => {
                 name: 'backstage',
                 url: 'https://github.com/backstage/backstage',
                 isArchived: false,
+                defaultBranchRef: {
+                  name: 'main',
+                },
               },
               {
                 name: 'demo',
                 url: 'https://github.com/backstage/demo',
                 isArchived: true,
+                defaultBranchRef: {
+                  name: 'main',
+                },
               },
             ],
             pageInfo: {
@@ -221,11 +227,17 @@ describe('github', () => {
             name: 'backstage',
             url: 'https://github.com/backstage/backstage',
             isArchived: false,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
           {
             name: 'demo',
             url: 'https://github.com/backstage/demo',
             isArchived: true,
+            defaultBranchRef: {
+              name: 'main',
+            },
           },
         ],
       };

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.ts
@@ -60,6 +60,9 @@ export type Repository = {
   name: string;
   url: string;
   isArchived: boolean;
+  defaultBranchRef: {
+    name: string;
+  };
 };
 
 export type Connection<T> = {
@@ -252,6 +255,9 @@ export async function getOrganizationRepositories(
             name
             url
             isArchived
+            defaultBranchRef {
+              name
+            }
           }
           pageInfo {
             hasNextPage


### PR DESCRIPTION
Previously the github-discovery supported only repos from a specific
branch. This change cause the discovery to work in two modes. It continues
to work as it did with a wildcard for repositories on a specified branch.

The new mode added causes the discovery processor to use the default branch
and looks for a file called catalog-info.yaml.

Signed-off-by: Brian Fletcher <brian@roadie.io>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
