### PR TITLE
Add system icons for the built-in entity types and use them in the entity list of the `catalog-import` plugin

### DIFF
--- a/.changeset/brave-days-burn.md
+++ b/.changeset/brave-days-burn.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-app-api': patch
+'@backstage/plugin-catalog-import': patch
+---
+
+Add system icons for the built-in entity types and use them in the entity list of the `catalog-import` plugin.

--- a/packages/core-app-api/src/app/icons.tsx
+++ b/packages/core-app-api/src/app/icons.tsx
@@ -33,41 +33,45 @@ import MuiPersonIcon from '@material-ui/icons/Person';
 import MuiWarningIcon from '@material-ui/icons/Warning';
 
 type AppIconsKey =
-  | 'api'
   | 'brokenImage'
   | 'catalog'
   | 'chat'
-  | 'component'
   | 'dashboard'
   | 'docs'
-  | 'domain'
   | 'email'
   | 'github'
   | 'group'
   | 'help'
-  | 'location'
+  | 'kind:api'
+  | 'kind:component'
+  | 'kind:domain'
+  | 'kind:group'
+  | 'kind:location'
+  | 'kind:system'
+  | 'kind:user'
   | 'user'
-  | 'system'
   | 'warning';
 
 export type AppIcons = { [key in AppIconsKey]: IconComponent };
 
 export const defaultAppIcons: AppIcons = {
-  api: MuiExtensionIcon,
   brokenImage: MuiBrokenImageIcon,
   // To be confirmed: see https://github.com/backstage/backstage/issues/4970
   catalog: MuiMenuBookIcon,
   chat: MuiChatIcon,
-  component: MuiMemoryIcon,
   dashboard: MuiDashboardIcon,
   docs: MuiDocsIcon,
-  domain: MuiApartmentIcon,
   email: MuiEmailIcon,
   github: MuiGitHubIcon,
   group: MuiPeopleIcon,
   help: MuiHelpIcon,
-  location: MuiLocationOnIcon,
+  'kind:api': MuiExtensionIcon,
+  'kind:component': MuiMemoryIcon,
+  'kind:domain': MuiApartmentIcon,
+  'kind:group': MuiPeopleIcon,
+  'kind:location': MuiLocationOnIcon,
+  'kind:system': MuiCategoryIcon,
+  'kind:user': MuiPersonIcon,
   user: MuiPersonIcon,
-  system: MuiCategoryIcon,
   warning: MuiWarningIcon,
 };

--- a/packages/core-app-api/src/app/icons.tsx
+++ b/packages/core-app-api/src/app/icons.tsx
@@ -15,44 +15,59 @@
  */
 
 import { IconComponent } from '@backstage/core-plugin-api';
-import MuiMenuBookIcon from '@material-ui/icons/MenuBook';
+import MuiApartmentIcon from '@material-ui/icons/Apartment';
 import MuiBrokenImageIcon from '@material-ui/icons/BrokenImage';
+import MuiCategoryIcon from '@material-ui/icons/Category';
 import MuiChatIcon from '@material-ui/icons/Chat';
 import MuiDashboardIcon from '@material-ui/icons/Dashboard';
+import MuiDocsIcon from '@material-ui/icons/Description';
 import MuiEmailIcon from '@material-ui/icons/Email';
+import MuiExtensionIcon from '@material-ui/icons/Extension';
 import MuiGitHubIcon from '@material-ui/icons/GitHub';
 import MuiHelpIcon from '@material-ui/icons/Help';
+import MuiLocationOnIcon from '@material-ui/icons/LocationOn';
+import MuiMemoryIcon from '@material-ui/icons/Memory';
+import MuiMenuBookIcon from '@material-ui/icons/MenuBook';
 import MuiPeopleIcon from '@material-ui/icons/People';
 import MuiPersonIcon from '@material-ui/icons/Person';
 import MuiWarningIcon from '@material-ui/icons/Warning';
-import MuiDocsIcon from '@material-ui/icons/Description';
 
 type AppIconsKey =
+  | 'api'
   | 'brokenImage'
   | 'catalog'
   | 'chat'
+  | 'component'
   | 'dashboard'
   | 'docs'
+  | 'domain'
   | 'email'
   | 'github'
   | 'group'
   | 'help'
+  | 'location'
   | 'user'
+  | 'system'
   | 'warning';
 
 export type AppIcons = { [key in AppIconsKey]: IconComponent };
 
 export const defaultAppIcons: AppIcons = {
+  api: MuiExtensionIcon,
   brokenImage: MuiBrokenImageIcon,
   // To be confirmed: see https://github.com/backstage/backstage/issues/4970
   catalog: MuiMenuBookIcon,
   chat: MuiChatIcon,
+  component: MuiMemoryIcon,
   dashboard: MuiDashboardIcon,
   docs: MuiDocsIcon,
+  domain: MuiApartmentIcon,
   email: MuiEmailIcon,
   github: MuiGitHubIcon,
   group: MuiPeopleIcon,
   help: MuiHelpIcon,
+  location: MuiLocationOnIcon,
   user: MuiPersonIcon,
+  system: MuiCategoryIcon,
   warning: MuiWarningIcon,
 };

--- a/plugins/catalog-import/src/components/EntityListComponent/EntityListComponent.tsx
+++ b/plugins/catalog-import/src/components/EntityListComponent/EntityListComponent.tsx
@@ -113,8 +113,9 @@ export const EntityListComponent = ({
             <List component="div" disablePadding dense>
               {sortEntities(r.entities).map(entity => {
                 const Icon =
-                  app.getSystemIcon(entity.kind.toLocaleLowerCase('en-US')) ??
-                  WorkIcon;
+                  app.getSystemIcon(
+                    `kind:${entity.kind.toLocaleLowerCase('en-US')}`,
+                  ) ?? WorkIcon;
                 return (
                   <ListItem
                     key={formatEntityRefTitle(entity)}

--- a/plugins/catalog-import/src/components/EntityListComponent/EntityListComponent.tsx
+++ b/plugins/catalog-import/src/components/EntityListComponent/EntityListComponent.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Entity, EntityName } from '@backstage/catalog-model';
+import { useApp } from '@backstage/core-plugin-api';
 import {
   EntityRefLink,
   formatEntityRefTitle,
@@ -29,15 +30,8 @@ import {
   ListItemText,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import ApartmentIcon from '@material-ui/icons/Apartment';
-import CategoryIcon from '@material-ui/icons/Category';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import ExtensionIcon from '@material-ui/icons/Extension';
-import GroupIcon from '@material-ui/icons/Group';
-import LocationOnIcon from '@material-ui/icons/LocationOn';
-import MemoryIcon from '@material-ui/icons/Memory';
-import PersonIcon from '@material-ui/icons/Person';
 import WorkIcon from '@material-ui/icons/Work';
 import React, { useState } from 'react';
 
@@ -51,34 +45,6 @@ function sortEntities(entities: Array<EntityName | Entity>) {
   return entities.sort((a, b) =>
     formatEntityRefTitle(a).localeCompare(formatEntityRefTitle(b)),
   );
-}
-
-function getEntityIcon(entity: { kind: string }): React.ReactElement {
-  switch (entity.kind.toLocaleLowerCase('en-US')) {
-    case 'api':
-      return <ExtensionIcon />;
-
-    case 'component':
-      return <MemoryIcon />;
-
-    case 'domain':
-      return <ApartmentIcon />;
-
-    case 'group':
-      return <GroupIcon />;
-
-    case 'location':
-      return <LocationOnIcon />;
-
-    case 'system':
-      return <CategoryIcon />;
-
-    case 'user':
-      return <PersonIcon />;
-
-    default:
-      return <WorkIcon />;
-  }
 }
 
 type Props = {
@@ -98,6 +64,7 @@ export const EntityListComponent = ({
   firstListItem,
   withLinks = false,
 }: Props) => {
+  const app = useApp();
   const classes = useStyles();
 
   const [expandedUrls, setExpandedUrls] = useState<string[]>([]);
@@ -144,22 +111,29 @@ export const EntityListComponent = ({
             unmountOnExit
           >
             <List component="div" disablePadding dense>
-              {sortEntities(r.entities).map(entity => (
-                <ListItem
-                  key={formatEntityRefTitle(entity)}
-                  className={classes.nested}
-                  {...(withLinks
-                    ? {
-                        component: EntityRefLink,
-                        entityRef: entity,
-                        button: withLinks as any,
-                      }
-                    : {})}
-                >
-                  <ListItemIcon>{getEntityIcon(entity)}</ListItemIcon>
-                  <ListItemText primary={formatEntityRefTitle(entity)} />
-                </ListItem>
-              ))}
+              {sortEntities(r.entities).map(entity => {
+                const Icon =
+                  app.getSystemIcon(entity.kind.toLocaleLowerCase('en-US')) ??
+                  WorkIcon;
+                return (
+                  <ListItem
+                    key={formatEntityRefTitle(entity)}
+                    className={classes.nested}
+                    {...(withLinks
+                      ? {
+                          component: EntityRefLink,
+                          entityRef: entity,
+                          button: withLinks as any,
+                        }
+                      : {})}
+                  >
+                    <ListItemIcon>
+                      <Icon />
+                    </ListItemIcon>
+                    <ListItemText primary={formatEntityRefTitle(entity)} />
+                  </ListItem>
+                );
+              })}
             </List>
           </Collapse>
         </React.Fragment>

--- a/plugins/catalog-import/src/components/StepPrepareSelectLocations/StepPrepareSelectLocations.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareSelectLocations/StepPrepareSelectLocations.test.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { act, render } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { AnalyzeResult } from '../../api';
@@ -57,7 +58,7 @@ describe('<StepPrepareSelectLocations />', () => {
   });
 
   it('renders without exploding', async () => {
-    const { getByRole } = render(
+    const { getByRole } = await renderInTestApp(
       <StepPrepareSelectLocations
         analyzeResult={analyzeResult}
         onPrepare={() => undefined}
@@ -69,7 +70,7 @@ describe('<StepPrepareSelectLocations />', () => {
   });
 
   it('should select and deselect all', async () => {
-    const { getByRole, getAllByRole } = render(
+    const { getByRole, getAllByRole } = await renderInTestApp(
       <StepPrepareSelectLocations
         analyzeResult={analyzeResult}
         onPrepare={() => undefined}
@@ -97,7 +98,7 @@ describe('<StepPrepareSelectLocations />', () => {
   });
 
   it('should preselect prepared locations', async () => {
-    const { getAllByRole } = render(
+    const { getAllByRole } = await renderInTestApp(
       <StepPrepareSelectLocations
         analyzeResult={analyzeResult}
         prepareResult={{
@@ -117,7 +118,7 @@ describe('<StepPrepareSelectLocations />', () => {
   });
 
   it('should select items', async () => {
-    const { getAllByRole } = render(
+    const { getAllByRole } = await renderInTestApp(
       <StepPrepareSelectLocations
         analyzeResult={analyzeResult}
         onPrepare={() => undefined}
@@ -146,7 +147,7 @@ describe('<StepPrepareSelectLocations />', () => {
   it('should go back', async () => {
     const onGoBack = jest.fn();
 
-    const { getByRole } = render(
+    const { getByRole } = await renderInTestApp(
       <StepPrepareSelectLocations
         analyzeResult={analyzeResult}
         onPrepare={() => undefined}
@@ -164,7 +165,7 @@ describe('<StepPrepareSelectLocations />', () => {
   it('should submit', async () => {
     const onPrepare = jest.fn();
 
-    const { getAllByRole, getByRole } = render(
+    const { getAllByRole, getByRole } = await renderInTestApp(
       <StepPrepareSelectLocations
         analyzeResult={analyzeResult}
         onPrepare={onPrepare}


### PR DESCRIPTION
Add default system icons for the most common entity types. The `catalog-import` plugin already introduced common icons for the kinds, however they were not replaceable nor extendable with a custom kind. It now uses the system icons feature of the app.

![image](https://user-images.githubusercontent.com/720821/130588316-107ae25d-d63c-4a7a-8bd5-d87e7dd08b1c.png)

Is this a good idea and do you agree with my chosen naming schema (i.e. the plain entity name as icon name)?

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
