### PR TITLE
Handle big names in explore plugin

### DIFF
--- a/.changeset/large-bears-wash.md
+++ b/.changeset/large-bears-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Use more efficient approach to staging files in git during scaffolder actions

--- a/.changeset/lemon-fishes-build.md
+++ b/.changeset/lemon-fishes-build.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-model': patch
+'@backstage/plugin-explore': patch
+---
+
+Handle Group Big Names in explore plugin

--- a/packages/catalog-model/examples/acme/org.yaml
+++ b/packages/catalog-model/examples/acme/org.yaml
@@ -30,3 +30,4 @@ spec:
     - ./team-b-group.yaml
     - ./team-c-group.yaml
     - ./team-d-group.yaml
+    - ./team-e-big-name-group.yaml

--- a/packages/catalog-model/examples/acme/team-e-big-name-group.yaml
+++ b/packages/catalog-model/examples/acme/team-e-big-name-group.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: team-e
+  description: Team E With A Very Very Very Very Big Name Size
+spec:
+  type: team
+  profile:
+    displayName: Team E With A Very Very Very Very Big Name Size
+    email: team-e@example.com
+    picture: https://avatars.dicebear.com/api/identicon/team-e@example.com.svg?background=%23fff&margin=25
+  parent: boxoffice
+  children: []

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.test.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.test.tsx
@@ -33,7 +33,7 @@ describe('<GroupsDiagram />', () => {
     });
   });
 
-  it('shows groups', async () => {
+  it('show single group', async () => {
     const catalogApi: Partial<CatalogApi> = {
       getEntities: () =>
         Promise.resolve({
@@ -66,7 +66,184 @@ describe('<GroupsDiagram />', () => {
         },
       },
     );
+    expect(getByText('Group A', { selector: 'tspan' })).toBeInTheDocument();
+  });
 
-    expect(getByText('Group A')).toBeInTheDocument();
+  it('show multiple groups', async () => {
+    const catalogApi: Partial<CatalogApi> = {
+      getEntities: () =>
+        Promise.resolve({
+          items: [
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Group',
+              metadata: {
+                name: 'group-a',
+                namespace: 'my-namespace',
+              },
+              spec: {
+                profile: {
+                  displayName: 'Group A',
+                },
+                type: 'organization',
+              },
+            },
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Group',
+              metadata: {
+                name: 'group-b',
+                namespace: 'my-namespace',
+              },
+              spec: {
+                profile: {
+                  displayName: 'Group B',
+                },
+                type: 'organization',
+              },
+            },
+          ] as Entity[],
+        }),
+    };
+
+    const { getByText } = await renderInTestApp(
+      <ApiProvider apis={ApiRegistry.from([[catalogApiRef, catalogApi]])}>
+        <GroupsDiagram />
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+    expect(getByText('Group A', { selector: 'tspan' })).toBeInTheDocument();
+    expect(getByText('Group B', { selector: 'tspan' })).toBeInTheDocument();
+  });
+
+  it('show single group with big name/displayName', async () => {
+    const catalogApi: Partial<CatalogApi> = {
+      getEntities: () =>
+        Promise.resolve({
+          items: [
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Group',
+              metadata: {
+                name: 'group-a',
+                namespace: 'my-namespace',
+              },
+              spec: {
+                profile: {
+                  displayName:
+                    'Group A Big Name1 Name2 Name3 Name4 Name5 Name6',
+                },
+                type: 'organization',
+              },
+            },
+          ] as Entity[],
+        }),
+    };
+
+    const { getByText } = await renderInTestApp(
+      <ApiProvider apis={ApiRegistry.from([[catalogApiRef, catalogApi]])}>
+        <GroupsDiagram />
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(
+      getByText('Group A Big Name1 Name2 Name3 Name4 Name5 Name6', {
+        selector: 'title',
+      }),
+    ).toBeInTheDocument();
+    expect(getByText('Group A Big', { selector: 'tspan' })).toBeInTheDocument();
+    expect(
+      getByText('Name1 Name2 Name3', { selector: 'tspan' }),
+    ).toBeInTheDocument();
+    expect(
+      getByText('Name4 Name5 Name6...', { selector: 'tspan' }),
+    ).toBeInTheDocument();
+  });
+
+  it('show multiple groups and one with big name', async () => {
+    const catalogApi: Partial<CatalogApi> = {
+      getEntities: () =>
+        Promise.resolve({
+          items: [
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Group',
+              metadata: {
+                name: 'group-a',
+                namespace: 'my-namespace',
+              },
+              spec: {
+                profile: {
+                  displayName: 'Group A',
+                },
+                type: 'organization',
+              },
+            },
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Group',
+              metadata: {
+                name: 'group-b',
+                namespace: 'my-namespace',
+              },
+              spec: {
+                profile: {
+                  displayName: 'Group B',
+                },
+                type: 'organization',
+              },
+            },
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Group',
+              metadata: {
+                name: 'group-c',
+                namespace: 'my-namespace',
+              },
+              spec: {
+                profile: {
+                  displayName:
+                    'Group C Big Name1 Name2 Name3 Name4 Name5 Name6',
+                },
+                type: 'organization',
+              },
+            },
+          ] as Entity[],
+        }),
+    };
+
+    const { getByText } = await renderInTestApp(
+      <ApiProvider apis={ApiRegistry.from([[catalogApiRef, catalogApi]])}>
+        <GroupsDiagram />
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+    expect(getByText('Group A', { selector: 'tspan' })).toBeInTheDocument();
+    expect(getByText('Group B', { selector: 'tspan' })).toBeInTheDocument();
+    expect(
+      getByText('Group C Big Name1 Name2 Name3 Name4 Name5 Name6', {
+        selector: 'title',
+      }),
+    ).toBeInTheDocument();
+    expect(getByText('Group C Big', { selector: 'tspan' })).toBeInTheDocument();
+    expect(
+      getByText('Name1 Name2 Name3', { selector: 'tspan' }),
+    ).toBeInTheDocument();
+    expect(
+      getByText('Name4 Name5 Name6...', { selector: 'tspan' }),
+    ).toBeInTheDocument();
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Git, getVoidLogger } from '@backstage/backend-common';
+import { initRepoAndPush } from './helpers';
+
+jest.mock('@backstage/backend-common', () => ({
+  Git: {
+    fromAuth: jest.fn().mockReturnValue({
+      init: jest.fn(),
+      add: jest.fn(),
+      commit: jest.fn(),
+      addRemote: jest.fn(),
+      push: jest.fn(),
+    }),
+  },
+  getVoidLogger: jest.requireActual('@backstage/backend-common').getVoidLogger,
+}));
+
+const mockedGit = Git.fromAuth({
+  username: 'test-user',
+  password: 'test-password',
+  logger: getVoidLogger(),
+});
+
+describe('initRepoAndPush', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with minimal parameters', () => {
+    beforeEach(async () => {
+      await initRepoAndPush({
+        dir: '/test/repo/dir/',
+        remoteUrl: 'git@github.com:test/repo.git',
+        auth: {
+          username: 'test-user',
+          password: 'test-password',
+        },
+        logger: getVoidLogger(),
+      });
+    });
+
+    it('initializes the repo', () => {
+      expect(mockedGit.init).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        defaultBranch: 'master',
+      });
+    });
+
+    it('stages all files in the repo', () => {
+      expect(mockedGit.add).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        filepath: '.',
+      });
+    });
+
+    it('creates an initial commit', () => {
+      expect(mockedGit.commit).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        message: 'Initial commit',
+        author: {
+          name: 'Scaffolder',
+          email: 'scaffolder@backstage.io',
+        },
+        committer: {
+          name: 'Scaffolder',
+          email: 'scaffolder@backstage.io',
+        },
+      });
+    });
+
+    it('adds the appropriate remote', () => {
+      expect(mockedGit.addRemote).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        url: 'git@github.com:test/repo.git',
+        remote: 'origin',
+      });
+    });
+
+    it('pushes to the remote', () => {
+      expect(mockedGit.push).toHaveBeenCalledWith({
+        dir: '/test/repo/dir/',
+        remote: 'origin',
+      });
+    });
+  });
+
+  it('allows overriding the default branch', async () => {
+    await initRepoAndPush({
+      dir: '/test/repo/dir/',
+      defaultBranch: 'trunk',
+      remoteUrl: 'git@github.com:test/repo.git',
+      auth: {
+        username: 'test-user',
+        password: 'test-password',
+      },
+      logger: getVoidLogger(),
+    });
+
+    expect(mockedGit.init).toHaveBeenCalledWith({
+      dir: '/test/repo/dir/',
+      defaultBranch: 'trunk',
+    });
+  });
+
+  it('allows overriding the author', async () => {
+    await initRepoAndPush({
+      dir: '/test/repo/dir/',
+      gitAuthorInfo: {
+        name: 'Custom Scaffolder Author',
+        email: 'scaffolder@example.org',
+      },
+      remoteUrl: 'git@github.com:test/repo.git',
+      auth: {
+        username: 'test-user',
+        password: 'test-password',
+      },
+      logger: getVoidLogger(),
+    });
+
+    expect(mockedGit.commit).toHaveBeenCalledWith({
+      dir: '/test/repo/dir/',
+      message: 'Initial commit',
+      author: {
+        name: 'Custom Scaffolder Author',
+        email: 'scaffolder@example.org',
+      },
+      committer: {
+        name: 'Custom Scaffolder Author',
+        email: 'scaffolder@example.org',
+      },
+    });
+  });
+});

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -16,7 +16,6 @@
 
 import { spawn } from 'child_process';
 import { PassThrough, Writable } from 'stream';
-import globby from 'globby';
 import { Logger } from 'winston';
 import { Git } from '@backstage/backend-common';
 import { Octokit } from '@octokit/rest';
@@ -84,15 +83,7 @@ export async function initRepoAndPush({
     defaultBranch,
   });
 
-  const paths = await globby(['./**', './**/.*', '!.git'], {
-    cwd: dir,
-    gitignore: true,
-    dot: true,
-  });
-
-  for (const filepath of paths) {
-    await git.add({ dir, filepath });
-  }
+  await git.add({ dir, filepath: '.' });
 
   // use provided info if possible, otherwise use fallbacks
   const authorInfo = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This pull request is a intention to handle big names at the explore plugin, normally when the name is bigger than the node width, the name overflow the rect obj. (issue: https://github.com/backstage/backstage/issues/6917)

![image](https://user-images.githubusercontent.com/5432351/130649840-42004b66-2783-4303-9da7-6388e101fc47.png)

The update are now handling it by allowing max 3 words (default) per line and max 3 lines (default).

![image](https://user-images.githubusercontent.com/5432351/130650076-2dabac34-0afc-40a2-a20a-81774359b5e9.png)

a three dots are displayed at the end to "show" that something is hidden

![image](https://user-images.githubusercontent.com/5432351/130650614-e74695c0-484a-4676-a720-2129016ce685.png)

A tooltip when the mouse is over the NODE will show the full name 

![image](https://user-images.githubusercontent.com/5432351/130650346-7585b2ec-127e-459b-aa8b-85892f43f399.png)


All Nodes wil have the title:

![image](https://user-images.githubusercontent.com/5432351/130650442-866085ab-f469-40af-84eb-e44f7b6791be.png)


Added more tests:

![image](https://user-images.githubusercontent.com/5432351/130651102-577c0509-9525-4b56-9198-a2a23dccf08e.png)


Please take a look at the logic, I guess it has some space for improvement



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


