### PR TITLE
[plugin] GRM: Don't expose API mock files

### DIFF
--- a/plugins/git-release-manager/api-report.md
+++ b/plugins/git-release-manager/api-report.md
@@ -12,10 +12,28 @@ import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 
+// Warning: (ae-missing-release-tag) "A_CALVER_VERSION" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const A_CALVER_VERSION = '2020.01.01_1';
+
+// Warning: (ae-missing-release-tag) "A_SEMVER_VERSION" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const A_SEMVER_VERSION = '1.2.3';
+
 // Warning: (ae-missing-release-tag) "calverRegexp" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 const calverRegexp: RegExp;
+
+// Warning: (ae-forgotten-export) The symbol "GetBranchResult" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "createMockBranch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+const createMockBranch: ({
+  ...rest
+}?: Partial<GetBranchResult>) => GetBranchResult['branch'];
 
 // Warning: (ae-forgotten-export) The symbol "GetCommitResult" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "createMockCommit" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -24,6 +42,26 @@ const calverRegexp: RegExp;
 const createMockCommit: (
   overrides: Partial<GetCommitResult['commit']>,
 ) => GetCommitResult;
+
+// Warning: (ae-forgotten-export) The symbol "GetRecentCommitsResultSingle" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "createMockRecentCommit" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+const createMockRecentCommit: ({
+  ...rest
+}: Partial<GetRecentCommitsResultSingle>) => GetRecentCommitsResultSingle;
+
+// Warning: (ae-forgotten-export) The symbol "GetLatestReleaseResult" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "createMockRelease" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+const createMockRelease: ({
+  id,
+  prerelease,
+  ...rest
+}?: Partial<
+  NonNullable<GetLatestReleaseResult['latestRelease']>
+>) => NonNullable<GetLatestReleaseResult['latestRelease']>;
 
 // Warning: (ae-forgotten-export) The symbol "GetTagResult" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "createMockTag" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -208,10 +246,45 @@ function LinearProgressWithLabel(props: {
   responseSteps: ResponseStep[];
 }): JSX.Element;
 
-// Warning: (ae-missing-release-tag) "mockApiClient" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "MOCK_RELEASE_BRANCH_NAME_CALVER" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public
-const mockApiClient: GitReleaseApi;
+// @public (undocumented)
+const MOCK_RELEASE_BRANCH_NAME_CALVER: string;
+
+// Warning: (ae-missing-release-tag) "MOCK_RELEASE_BRANCH_NAME_SEMVER" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const MOCK_RELEASE_BRANCH_NAME_SEMVER: string;
+
+// Warning: (ae-missing-release-tag) "MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER: string;
+
+// Warning: (ae-missing-release-tag) "MOCK_RELEASE_CANDIDATE_TAG_NAME_SEMVER" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const MOCK_RELEASE_CANDIDATE_TAG_NAME_SEMVER: string;
+
+// Warning: (ae-missing-release-tag) "MOCK_RELEASE_NAME_CALVER" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const MOCK_RELEASE_NAME_CALVER: string;
+
+// Warning: (ae-missing-release-tag) "MOCK_RELEASE_NAME_SEMVER" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const MOCK_RELEASE_NAME_SEMVER: string;
+
+// Warning: (ae-missing-release-tag) "MOCK_RELEASE_VERSION_TAG_NAME_CALVER" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const MOCK_RELEASE_VERSION_TAG_NAME_CALVER: string;
+
+// Warning: (ae-missing-release-tag) "MOCK_RELEASE_VERSION_TAG_NAME_SEMVER" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const MOCK_RELEASE_VERSION_TAG_NAME_SEMVER: string;
 
 // Warning: (ae-missing-release-tag) "mockBumpedTag" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -228,6 +301,11 @@ const mockCalverProject: Project;
 // @public (undocumented)
 const mockDefaultBranch = 'mock_defaultBranch';
 
+// Warning: (ae-missing-release-tag) "mockEmail" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockEmail = 'mock_email';
+
 // Warning: (ae-forgotten-export) The symbol "getReleaseCandidateGitInfo" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "mockNextGitInfoCalver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -238,6 +316,11 @@ const mockNextGitInfoCalver: ReturnType<typeof getReleaseCandidateGitInfo>;
 //
 // @public (undocumented)
 const mockNextGitInfoSemver: ReturnType<typeof getReleaseCandidateGitInfo>;
+
+// Warning: (ae-missing-release-tag) "mockOwner" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockOwner = 'mock_owner';
 
 // Warning: (ae-missing-release-tag) "mockReleaseBranch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -311,6 +394,11 @@ const mockReleaseVersionSemver: {
   body?: string | null | undefined;
 };
 
+// Warning: (ae-missing-release-tag) "mockRepo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockRepo = 'mock_repo';
+
 // Warning: (ae-missing-release-tag) "mockSearchCalver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -354,6 +442,11 @@ const mockUser: {
   username: string;
   email: string;
 };
+
+// Warning: (ae-missing-release-tag) "mockUsername" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+const mockUsername = 'mock_username';
 
 // Warning: (ae-missing-release-tag) "NoLatestRelease" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -483,6 +576,20 @@ const TEST_IDS: {
 
 declare namespace testHelpers_2 {
   export {
+    mockUsername,
+    mockEmail,
+    mockOwner,
+    mockRepo,
+    A_CALVER_VERSION,
+    MOCK_RELEASE_NAME_CALVER,
+    MOCK_RELEASE_BRANCH_NAME_CALVER,
+    MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER,
+    MOCK_RELEASE_VERSION_TAG_NAME_CALVER,
+    A_SEMVER_VERSION,
+    MOCK_RELEASE_NAME_SEMVER,
+    MOCK_RELEASE_BRANCH_NAME_SEMVER,
+    MOCK_RELEASE_CANDIDATE_TAG_NAME_SEMVER,
+    MOCK_RELEASE_VERSION_TAG_NAME_SEMVER,
     createMockTag,
     createMockCommit,
     mockUser,
@@ -495,13 +602,15 @@ declare namespace testHelpers_2 {
     mockNextGitInfoCalver,
     mockTagParts,
     mockBumpedTag,
+    createMockRelease,
     mockReleaseCandidateCalver,
     mockReleaseVersionCalver,
     mockReleaseCandidateSemver,
     mockReleaseVersionSemver,
+    createMockBranch,
     mockReleaseBranch,
+    createMockRecentCommit,
     mockSelectedPatchCommit,
-    mockApiClient,
   };
 }
 

--- a/plugins/git-release-manager/src/features/CreateReleaseCandidate/hooks/useCreateReleaseCandidate.test.tsx
+++ b/plugins/git-release-manager/src/features/CreateReleaseCandidate/hooks/useCreateReleaseCandidate.test.tsx
@@ -17,7 +17,6 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 
 import {
-  mockApiClient,
   mockCalverProject,
   mockDefaultBranch,
   mockNextGitInfoCalver,
@@ -25,6 +24,7 @@ import {
   mockUser,
 } from '../../../test-helpers/test-helpers';
 import { useCreateReleaseCandidate } from './useCreateReleaseCandidate';
+import { mockApiClient } from '../../../test-helpers/mock-api-client';
 
 jest.mock('@backstage/core-plugin-api', () => ({
   ...jest.requireActual('@backstage/core-plugin-api'),

--- a/plugins/git-release-manager/src/features/Features.test.tsx
+++ b/plugins/git-release-manager/src/features/Features.test.tsx
@@ -18,8 +18,9 @@ import React from 'react';
 import { render, act, waitFor } from '@testing-library/react';
 
 import { Features } from './Features';
-import { mockApiClient, mockCalverProject } from '../test-helpers/test-helpers';
+import { mockCalverProject } from '../test-helpers/test-helpers';
 import { TEST_IDS } from '../test-helpers/test-ids';
+import { mockApiClient } from '../test-helpers/mock-api-client';
 
 jest.mock('@backstage/core-plugin-api', () => ({
   ...jest.requireActual('@backstage/core-plugin-api'),

--- a/plugins/git-release-manager/src/features/Patch/PatchBody.test.tsx
+++ b/plugins/git-release-manager/src/features/Patch/PatchBody.test.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import { render, waitFor, screen } from '@testing-library/react';
 
 import {
-  mockApiClient,
   mockBumpedTag,
   mockCalverProject,
   mockReleaseBranch,
@@ -26,6 +25,7 @@ import {
   mockReleaseVersionCalver,
   mockTagParts,
 } from '../../test-helpers/test-helpers';
+import { mockApiClient } from '../../test-helpers/mock-api-client';
 import { PatchBody } from './PatchBody';
 import { TEST_IDS } from '../../test-helpers/test-ids';
 

--- a/plugins/git-release-manager/src/features/Patch/hooks/usePatch.test.ts
+++ b/plugins/git-release-manager/src/features/Patch/hooks/usePatch.test.ts
@@ -18,7 +18,6 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 
 import {
-  mockApiClient,
   mockBumpedTag,
   mockCalverProject,
   mockReleaseVersionCalver,
@@ -27,6 +26,7 @@ import {
   mockUser,
 } from '../../../test-helpers/test-helpers';
 import { usePatch } from './usePatch';
+import { mockApiClient } from '../../../test-helpers/mock-api-client';
 
 jest.mock('@backstage/core-plugin-api', () => ({
   ...jest.requireActual('@backstage/core-plugin-api'),

--- a/plugins/git-release-manager/src/features/PromoteRc/hooks/usePromoteRc.test.ts
+++ b/plugins/git-release-manager/src/features/PromoteRc/hooks/usePromoteRc.test.ts
@@ -18,12 +18,12 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 
 import {
-  mockApiClient,
   mockCalverProject,
   mockReleaseCandidateCalver,
   mockUser,
 } from '../../../test-helpers/test-helpers';
 import { usePromoteRc } from './usePromoteRc';
+import { mockApiClient } from '../../../test-helpers/mock-api-client';
 
 jest.mock('@backstage/core-plugin-api', () => ({
   ...jest.requireActual('@backstage/core-plugin-api'),

--- a/plugins/git-release-manager/src/features/RepoDetailsForm/Owner.test.tsx
+++ b/plugins/git-release-manager/src/features/RepoDetailsForm/Owner.test.tsx
@@ -18,7 +18,6 @@ import React from 'react';
 import { render, waitFor, screen } from '@testing-library/react';
 
 import {
-  mockApiClient,
   mockCalverProject,
   mockSearchCalver,
   mockUser,
@@ -26,6 +25,7 @@ import {
 import { TEST_IDS } from '../../test-helpers/test-ids';
 import { useProjectContext } from '../../contexts/ProjectContext';
 import { Owner } from './Owner';
+import { mockApiClient } from '../../test-helpers/mock-api-client';
 
 jest.mock('react-router', () => ({
   useNavigate: jest.fn(),

--- a/plugins/git-release-manager/src/features/RepoDetailsForm/Repo.test.tsx
+++ b/plugins/git-release-manager/src/features/RepoDetailsForm/Repo.test.tsx
@@ -18,13 +18,13 @@ import React from 'react';
 import { render, waitFor, screen } from '@testing-library/react';
 
 import {
-  mockApiClient,
   mockCalverProject,
   mockSearchCalver,
 } from '../../test-helpers/test-helpers';
+import { mockApiClient } from '../../test-helpers/mock-api-client';
+import { Repo } from './Repo';
 import { TEST_IDS } from '../../test-helpers/test-ids';
 import { useProjectContext } from '../../contexts/ProjectContext';
-import { Repo } from './Repo';
 
 jest.mock('react-router', () => ({
   useNavigate: jest.fn(),

--- a/plugins/git-release-manager/src/features/Stats/helpers/getTagDates.test.ts
+++ b/plugins/git-release-manager/src/features/Stats/helpers/getTagDates.test.ts
@@ -17,10 +17,10 @@
 import {
   createMockCommit,
   createMockTag,
-  mockApiClient,
   mockSemverProject,
 } from '../../../test-helpers/test-helpers';
 import { getTagDates } from './getTagDates';
+import { mockApiClient } from '../../../test-helpers/mock-api-client';
 
 describe('getTagDates', () => {
   beforeEach(() => {

--- a/plugins/git-release-manager/src/hooks/useGetGitBatchInfo.test.ts
+++ b/plugins/git-release-manager/src/hooks/useGetGitBatchInfo.test.ts
@@ -17,7 +17,8 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 
-import { mockApiClient, mockSemverProject } from '../test-helpers/test-helpers';
+import { mockApiClient } from '../test-helpers/mock-api-client';
+import { mockSemverProject } from '../test-helpers/test-helpers';
 import { useGetGitBatchInfo } from './useGetGitBatchInfo';
 
 describe('useGetHubBatchInfo', () => {

--- a/plugins/git-release-manager/src/test-helpers/mock-api-client.ts
+++ b/plugins/git-release-manager/src/test-helpers/mock-api-client.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GitReleaseApi } from '../api/GitReleaseClient';
+import {
+  createMockBranch,
+  createMockRecentCommit,
+  createMockRelease,
+  mockDefaultBranch,
+  mockEmail,
+  mockOwner,
+  mockRepo,
+  MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER,
+} from './test-helpers';
+
+export const mockApiClient: GitReleaseApi = {
+  getHost: jest.fn(() => 'github.com'),
+
+  getRepoPath: jest.fn(() => `${mockOwner}/${mockRepo}`),
+
+  getOwners: jest.fn(async () => ({
+    owners: [mockOwner, `${mockOwner}2`],
+  })),
+
+  getRepositories: jest.fn(async () => ({
+    repositories: [mockRepo, `${mockRepo}2`],
+  })),
+
+  getUser: jest.fn(async () => ({
+    user: {
+      username: mockOwner,
+      email: mockEmail,
+    },
+  })),
+
+  getRecentCommits: jest.fn(async () => ({
+    recentCommits: [
+      createMockRecentCommit({ sha: 'mock_sha_recent_commits_1' }),
+      createMockRecentCommit({ sha: 'mock_sha_recent_commits_2' }),
+    ],
+  })),
+
+  getLatestRelease: jest.fn(async () => ({
+    latestRelease: createMockRelease(),
+  })),
+
+  getRepository: jest.fn(async () => ({
+    repository: {
+      pushPermissions: true,
+      defaultBranch: mockDefaultBranch,
+      name: mockRepo,
+    },
+  })),
+
+  getCommit: jest.fn(async () => ({
+    commit: {
+      sha: 'latestCommit.sha',
+      htmlUrl: 'https://latestCommit.html_url',
+      commit: {
+        message: 'latestCommit.commit.message',
+      },
+      createdAt: '2021-01-01T10:11:12Z',
+    },
+  })),
+
+  getBranch: jest.fn(async () => ({
+    branch: createMockBranch(),
+  })),
+
+  createRef: jest.fn(async () => ({
+    reference: {
+      ref: 'mock_createRef_ref',
+      objectSha: 'mock_createRef_objectSha',
+    },
+  })),
+
+  createRelease: jest.fn(async () => ({
+    release: {
+      name: 'mock_createRelease_name',
+      htmlUrl: 'https://mock_createRelease_html_url',
+      tagName: 'mock_createRelease_tag_name',
+    },
+  })),
+
+  getComparison: jest.fn(async () => ({
+    comparison: {
+      htmlUrl: 'https://mock_compareCommits_html_url',
+      aheadBy: 1,
+    },
+  })),
+
+  createTagObject: jest.fn(async () => ({
+    tagObject: {
+      tagName: 'mock_tag_object_tag',
+      tagSha: 'mock_tag_object_sha',
+    },
+  })),
+
+  createCommit: jest.fn(async () => ({
+    commit: {
+      message: 'mock_commit_message',
+      sha: 'mock_commit_sha',
+    },
+  })),
+
+  updateRef: jest.fn(async () => ({
+    reference: {
+      ref: 'mock_update_ref_ref',
+      object: {
+        sha: 'mock_update_ref_object_sha',
+      },
+    },
+  })),
+
+  merge: jest.fn(async () => ({
+    merge: {
+      htmlUrl: 'https://mock_merge_html_url',
+      commit: {
+        message: 'mock_merge_commit_message',
+        tree: {
+          sha: 'mock_merge_commit_tree_sha',
+        },
+      },
+    },
+  })),
+
+  updateRelease: jest.fn(async () => ({
+    release: {
+      name: 'mock_update_release_name',
+      tagName: 'mock_update_release_tag_name',
+      htmlUrl: 'https://mock_update_release_html_url',
+    },
+  })),
+
+  getAllTags: jest.fn(async () => ({
+    tags: [
+      {
+        tagName: MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER,
+        tagSha: 'mock_sha',
+        tagType: 'tag' as const,
+      },
+    ],
+  })),
+
+  getAllReleases: jest.fn(async () => ({
+    releases: [
+      {
+        id: 1,
+        name: 'mock_release_name',
+        tagName: 'mock_release_tag_name',
+        createdAt: 'mock_release_published_at',
+        htmlUrl: 'https://mock_release_html_url',
+      },
+    ],
+  })),
+
+  getTag: jest.fn(async () => ({
+    tag: {
+      date: '2021-04-29T12:48:30.120Z',
+      username: 'mock_user_single_tag_name',
+      userEmail: 'mock_user_single_tag_email',
+      objectSha: 'mock_single_tag_object_sha',
+    },
+  })),
+};

--- a/plugins/git-release-manager/src/test-helpers/test-helpers.ts
+++ b/plugins/git-release-manager/src/test-helpers/test-helpers.ts
@@ -19,29 +19,28 @@ import {
   GetLatestReleaseResult,
   GetRecentCommitsResultSingle,
   GetTagResult,
-  GitReleaseApi,
   GetCommitResult,
 } from '../api/GitReleaseClient';
 import { CalverTagParts } from '../helpers/tagParts/getCalverTagParts';
 import { Project } from '../contexts/ProjectContext';
 import { getReleaseCandidateGitInfo } from '../helpers/getReleaseCandidateGitInfo';
 
-const mockUsername = 'mock_username';
-const mockEmail = 'mock_email';
-const mockOwner = 'mock_owner';
-const mockRepo = 'mock_repo';
+export const mockUsername = 'mock_username';
+export const mockEmail = 'mock_email';
+export const mockOwner = 'mock_owner';
+export const mockRepo = 'mock_repo';
 
-const A_CALVER_VERSION = '2020.01.01_1';
-const MOCK_RELEASE_NAME_CALVER = `Version ${A_CALVER_VERSION}`;
-const MOCK_RELEASE_BRANCH_NAME_CALVER = `rc/${A_CALVER_VERSION}`;
-const MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER = `rc-${A_CALVER_VERSION}`;
-const MOCK_RELEASE_VERSION_TAG_NAME_CALVER = `version-${A_CALVER_VERSION}`;
+export const A_CALVER_VERSION = '2020.01.01_1';
+export const MOCK_RELEASE_NAME_CALVER = `Version ${A_CALVER_VERSION}`;
+export const MOCK_RELEASE_BRANCH_NAME_CALVER = `rc/${A_CALVER_VERSION}`;
+export const MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER = `rc-${A_CALVER_VERSION}`;
+export const MOCK_RELEASE_VERSION_TAG_NAME_CALVER = `version-${A_CALVER_VERSION}`;
 
-const A_SEMVER_VERSION = '1.2.3';
-const MOCK_RELEASE_NAME_SEMVER = `Version ${A_SEMVER_VERSION}`;
-const MOCK_RELEASE_BRANCH_NAME_SEMVER = `rc/${A_SEMVER_VERSION}`;
-const MOCK_RELEASE_CANDIDATE_TAG_NAME_SEMVER = `rc-${A_SEMVER_VERSION}`;
-const MOCK_RELEASE_VERSION_TAG_NAME_SEMVER = `version-${A_SEMVER_VERSION}`;
+export const A_SEMVER_VERSION = '1.2.3';
+export const MOCK_RELEASE_NAME_SEMVER = `Version ${A_SEMVER_VERSION}`;
+export const MOCK_RELEASE_BRANCH_NAME_SEMVER = `rc/${A_SEMVER_VERSION}`;
+export const MOCK_RELEASE_CANDIDATE_TAG_NAME_SEMVER = `rc-${A_SEMVER_VERSION}`;
+export const MOCK_RELEASE_VERSION_TAG_NAME_SEMVER = `version-${A_SEMVER_VERSION}`;
 
 export const createMockTag = (
   overrides: Partial<GetTagResult['tag']>,
@@ -121,7 +120,7 @@ export const mockBumpedTag = 'rc-2020.01.01_1337';
 /**
  * MOCK RELEASE
  */
-const createMockRelease = ({
+export const createMockRelease = ({
   id = 1,
   prerelease = false,
   ...rest
@@ -162,7 +161,7 @@ export const mockReleaseVersionSemver = createMockRelease({
 /**
  * MOCK BRANCH
  */
-const createMockBranch = ({
+export const createMockBranch = ({
   ...rest
 }: Partial<GetBranchResult> = {}): GetBranchResult['branch'] => ({
   name: MOCK_RELEASE_BRANCH_NAME_SEMVER,
@@ -184,7 +183,7 @@ export const mockReleaseBranch = createMockBranch();
 /**
  * MOCK COMMIT
  */
-const createMockRecentCommit = ({
+export const createMockRecentCommit = ({
   ...rest
 }: Partial<GetRecentCommitsResultSingle>): GetRecentCommitsResultSingle => ({
   author: {
@@ -203,157 +202,3 @@ const createMockRecentCommit = ({
 export const mockSelectedPatchCommit = createMockRecentCommit({
   sha: 'mock_sha_selected_patch_commit',
 });
-
-/**
- * MOCK API CLIENT
- */
-export const mockApiClient: GitReleaseApi = {
-  getHost: jest.fn(() => 'github.com'),
-
-  getRepoPath: jest.fn(() => `${mockOwner}/${mockRepo}`),
-
-  getOwners: jest.fn(async () => ({
-    owners: [mockOwner, `${mockOwner}2`],
-  })),
-
-  getRepositories: jest.fn(async () => ({
-    repositories: [mockRepo, `${mockRepo}2`],
-  })),
-
-  getUser: jest.fn(async () => ({
-    user: {
-      username: mockOwner,
-      email: mockEmail,
-    },
-  })),
-
-  getRecentCommits: jest.fn(async () => ({
-    recentCommits: [
-      createMockRecentCommit({ sha: 'mock_sha_recent_commits_1' }),
-      createMockRecentCommit({ sha: 'mock_sha_recent_commits_2' }),
-    ],
-  })),
-
-  getLatestRelease: jest.fn(async () => ({
-    latestRelease: createMockRelease(),
-  })),
-
-  getRepository: jest.fn(async () => ({
-    repository: {
-      pushPermissions: true,
-      defaultBranch: mockDefaultBranch,
-      name: mockRepo,
-    },
-  })),
-
-  getCommit: jest.fn(async () => ({
-    commit: {
-      sha: 'latestCommit.sha',
-      htmlUrl: 'https://latestCommit.html_url',
-      commit: {
-        message: 'latestCommit.commit.message',
-      },
-      createdAt: '2021-01-01T10:11:12Z',
-    },
-  })),
-
-  getBranch: jest.fn(async () => ({
-    branch: createMockBranch(),
-  })),
-
-  createRef: jest.fn(async () => ({
-    reference: {
-      ref: 'mock_createRef_ref',
-      objectSha: 'mock_createRef_objectSha',
-    },
-  })),
-
-  createRelease: jest.fn(async () => ({
-    release: {
-      name: 'mock_createRelease_name',
-      htmlUrl: 'https://mock_createRelease_html_url',
-      tagName: 'mock_createRelease_tag_name',
-    },
-  })),
-
-  getComparison: jest.fn(async () => ({
-    comparison: {
-      htmlUrl: 'https://mock_compareCommits_html_url',
-      aheadBy: 1,
-    },
-  })),
-
-  createTagObject: jest.fn(async () => ({
-    tagObject: {
-      tagName: 'mock_tag_object_tag',
-      tagSha: 'mock_tag_object_sha',
-    },
-  })),
-
-  createCommit: jest.fn(async () => ({
-    commit: {
-      message: 'mock_commit_message',
-      sha: 'mock_commit_sha',
-    },
-  })),
-
-  updateRef: jest.fn(async () => ({
-    reference: {
-      ref: 'mock_update_ref_ref',
-      object: {
-        sha: 'mock_update_ref_object_sha',
-      },
-    },
-  })),
-
-  merge: jest.fn(async () => ({
-    merge: {
-      htmlUrl: 'https://mock_merge_html_url',
-      commit: {
-        message: 'mock_merge_commit_message',
-        tree: {
-          sha: 'mock_merge_commit_tree_sha',
-        },
-      },
-    },
-  })),
-
-  updateRelease: jest.fn(async () => ({
-    release: {
-      name: 'mock_update_release_name',
-      tagName: 'mock_update_release_tag_name',
-      htmlUrl: 'https://mock_update_release_html_url',
-    },
-  })),
-
-  getAllTags: jest.fn(async () => ({
-    tags: [
-      {
-        tagName: MOCK_RELEASE_CANDIDATE_TAG_NAME_CALVER,
-        tagSha: 'mock_sha',
-        tagType: 'tag' as const,
-      },
-    ],
-  })),
-
-  getAllReleases: jest.fn(async () => ({
-    releases: [
-      {
-        id: 1,
-        name: 'mock_release_name',
-        tagName: 'mock_release_tag_name',
-        createdAt: 'mock_release_published_at',
-        htmlUrl: 'https://mock_release_html_url',
-      },
-    ],
-  })),
-
-  getTag: jest.fn(async () => ({
-    tag: {
-      date: '2021-04-29T12:48:30.120Z',
-      username: 'mock_user_single_tag_name',
-      userEmail: 'mock_user_single_tag_email',
-      objectSha: 'mock_single_tag_object_sha',
-    },
-  })),
-};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Tested the nightly build and exposing the API mock files caused some issues as they invoke `jest` functions.

Since I'm not interested in these mocks outside of the plugin source code itself, I can simply move it to a separate file and remove it from the plugin's API.

@Rugvip does this require another patch update or is it fine as it (afaik) hasn't been published yet (other than in a nightly build)?

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
