### PR TITLE
Fix dependency graph with new nodes

### DIFF
--- a/.changeset/thirty-seas-bathe.md
+++ b/.changeset/thirty-seas-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Handle changes to nodes passed into `<DependencyGraph>` correctly.

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraph.test.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraph.test.tsx
@@ -49,6 +49,28 @@ describe('<DependencyGraph />', () => {
     expect(queryAllByTestId(LABEL_TEST_ID)).toHaveLength(0);
   });
 
+  it('update render if already referenced nodes are added later', async () => {
+    const { getByText, queryAllByTestId, findAllByTestId, rerender } = render(
+      <DependencyGraph nodes={nodes.slice(0, 2)} edges={edges} />,
+    );
+
+    let renderedNodes = await findAllByTestId(NODE_TEST_ID);
+    expect(renderedNodes).toHaveLength(2);
+    expect(getByText(nodes[0].id)).toBeInTheDocument();
+    expect(getByText(nodes[1].id)).toBeInTheDocument();
+    expect(queryAllByTestId(EDGE_TEST_ID)).toHaveLength(2);
+    expect(queryAllByTestId(LABEL_TEST_ID)).toHaveLength(0);
+
+    rerender(<DependencyGraph nodes={nodes} edges={edges} />);
+
+    renderedNodes = await findAllByTestId(NODE_TEST_ID);
+    expect(renderedNodes).toHaveLength(3);
+    expect(getByText(nodes[0].id)).toBeInTheDocument();
+    expect(getByText(nodes[1].id)).toBeInTheDocument();
+    expect(queryAllByTestId(EDGE_TEST_ID)).toHaveLength(2);
+    expect(queryAllByTestId(LABEL_TEST_ID)).toHaveLength(0);
+  });
+
   it('renders edge labels if present', async () => {
     const labeledEdges = [
       { ...edges[0], label: 'first' },

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraph.tsx
@@ -171,7 +171,7 @@ export function DependencyGraph({
         .nodes()
         .find(nodeId => node.id === nodeId);
 
-      if (existingNode) {
+      if (existingNode && graph.current.node(existingNode)) {
         const { width, height, x, y } = graph.current.node(existingNode);
         graph.current.setNode(existingNode, { ...node, width, height, x, y });
       } else {


### PR DESCRIPTION
I run into this issue if I have a graph that has edges pointing to missing nodes, which is fine. If in a later render the missing nodes are added, the viewer crashes. Looks like the graph is internally generating internal nodes for the missing destination nodes of edges. However, these internal nodes are not fully initialized (`undefined`) and have to be initialized to get updated.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
