### PR TITLE
Only warn once per key when trying to read visibility-filtered values

### DIFF
--- a/.changeset/real-ants-perform.md
+++ b/.changeset/real-ants-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config': patch
+---
+
+Only warn once per key when trying to read visibility-filtered values

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -63,6 +63,7 @@ export class ConfigReader implements Config {
    * the frontend in development mode.
    */
   private filteredKeys?: string[];
+  private notifiedFilteredKeys: Set<string>;
 
   static fromConfigs(configs: AppConfig[]): ConfigReader {
     if (configs.length === 0) {
@@ -86,7 +87,9 @@ export class ConfigReader implements Config {
     private readonly context: string = 'mock-config',
     private readonly fallback?: ConfigReader,
     private readonly prefix: string = '',
-  ) {}
+  ) {
+    this.notifiedFilteredKeys = new Set();
+  }
 
   has(key: string): boolean {
     const value = this.readValue(key);
@@ -118,7 +121,11 @@ export class ConfigReader implements Config {
       if (process.env.NODE_ENV === 'development') {
         if (fallbackValue === undefined && key) {
           const fullKey = this.fullKey(key);
-          if (this.filteredKeys?.includes(fullKey)) {
+          if (
+            this.filteredKeys?.includes(fullKey) &&
+            !this.notifiedFilteredKeys.has(fullKey)
+          ) {
+            this.notifiedFilteredKeys.add(fullKey);
             // eslint-disable-next-line no-console
             console.warn(
               `Failed to read configuration value at '${fullKey}' as it is not visible. ` +
@@ -190,7 +197,11 @@ export class ConfigReader implements Config {
     if (!configs) {
       if (process.env.NODE_ENV === 'development') {
         const fullKey = this.fullKey(key);
-        if (this.filteredKeys?.some(k => k.startsWith(fullKey))) {
+        if (
+          this.filteredKeys?.some(k => k.startsWith(fullKey)) &&
+          !this.notifiedFilteredKeys.has(key)
+        ) {
+          this.notifiedFilteredKeys.add(key);
           // eslint-disable-next-line no-console
           console.warn(
             `Failed to read configuration array at '${key}' as it does not have any visible elements. ` +
@@ -310,7 +321,11 @@ export class ConfigReader implements Config {
     if (value === undefined) {
       if (process.env.NODE_ENV === 'development') {
         const fullKey = this.fullKey(key);
-        if (this.filteredKeys?.includes(fullKey)) {
+        if (
+          this.filteredKeys?.includes(fullKey) &&
+          !this.notifiedFilteredKeys.has(fullKey)
+        ) {
+          this.notifiedFilteredKeys.add(fullKey);
           // eslint-disable-next-line no-console
           console.warn(
             `Failed to read configuration value at '${fullKey}' as it is not visible. ` +


### PR DESCRIPTION
This was being noisy in some views :) Is this worth addressing or not?

I chose to put the set locally in each instance instead of the more complex shared `filteredKeys` strategy - because otherwise I'd have to change the `AppConfig` interface too, and in practice we only ever pass around the topmost config reader. So I deemed it fine to ignore the theoretical possibility of double warnings if somebody tries to read values out of different parts of the chain.