### PR TITLE
Fix TechDocs URL Reader: disable by default stripping of first directory from ZIP archive

### DIFF
--- a/.changeset/angry-planes-visit.md
+++ b/.changeset/angry-planes-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Disable stripping of ZIP archive

--- a/packages/backend-common/src/reading/tree/ZipArchiveResponse.ts
+++ b/packages/backend-common/src/reading/tree/ZipArchiveResponse.ts
@@ -38,6 +38,7 @@ export class ZipArchiveResponse implements ReadTreeResponse {
     private readonly workDir: string,
     public readonly etag: string,
     private readonly filter?: (path: string, info: { size: number }) => boolean,
+    private readonly stripFirstDirectoryFromPath?: boolean,
   ) {
     if (subPath) {
       if (!subPath.endsWith('/')) {
@@ -67,7 +68,7 @@ export class ZipArchiveResponse implements ReadTreeResponse {
   }
 
   private shouldBeIncluded(entry: Entry): boolean {
-    const strippedPath = stripFirstDirectoryFromPath(entry.path);
+    const strippedPath = this.stripFirstDirectoryFromPath ? stripFirstDirectoryFromPath(entry.path) : entry.path;
 
     if (this.subPath) {
       if (!strippedPath.startsWith(this.subPath)) {
@@ -99,7 +100,7 @@ export class ZipArchiveResponse implements ReadTreeResponse {
 
         if (this.shouldBeIncluded(entry)) {
           files.push({
-            path: this.getInnerPath(stripFirstDirectoryFromPath(entry.path)),
+            path: this.getInnerPath(this.stripFirstDirectoryFromPath ? stripFirstDirectoryFromPath(entry.path) : entry.path),
             content: () => entry.buffer(),
           });
         } else {
@@ -148,7 +149,7 @@ export class ZipArchiveResponse implements ReadTreeResponse {
         // as a zip can have files with directories without directory entries
         if (entry.type === 'File' && this.shouldBeIncluded(entry)) {
           const entryPath = this.getInnerPath(
-            stripFirstDirectoryFromPath(entry.path),
+            this.stripFirstDirectoryFromPath ? stripFirstDirectoryFromPath(entry.path) : entry.path,
           );
           const dirname = platformPath.dirname(entryPath);
           if (dirname) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes problem described in the following issue: https://github.com/backstage/backstage/issues/4359

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
