### PR TITLE
Allow the entities indexed by DefaultCatalogCollator to be filtered by kind

### DIFF
--- a/.changeset/fast-wasps-matter.md
+++ b/.changeset/fast-wasps-matter.md
@@ -1,0 +1,23 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated the search configuration class to use the static `fromConfig`-based constructor for the `DefaultCatalogCollator`.
+
+To apply this change to an existing app, replace the following line in `search.ts`:
+
+```diff
+-collator: new DefaultCatalogCollator({ discovery })
++collator: DefaultCatalogCollator.fromConfig(config, { discovery })
+```
+
+The `config` parameter was not needed before, so make sure you also add that in the signature of `createPlugin`
+in `search.ts`:
+
+```diff
+export default async function createPlugin({
+  logger,
+  discovery,
++  config,
+}: PluginEnvironment) {
+```

--- a/.changeset/happy-cups-tap.md
+++ b/.changeset/happy-cups-tap.md
@@ -1,5 +1,4 @@
 ---
-'example-backend': patch
 '@backstage/plugin-catalog-backend': patch
 ---
 

--- a/.changeset/happy-cups-tap.md
+++ b/.changeset/happy-cups-tap.md
@@ -1,0 +1,6 @@
+---
+'example-backend': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow the catalog search collator to filter the entities that it indexes

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -68,7 +68,7 @@ export default async function createPlugin({
   // particular collator gathers entities from the software catalog.
   indexBuilder.addCollator({
     defaultRefreshIntervalSeconds: 600,
-    collator: new DefaultCatalogCollator({ discovery }),
+    collator: DefaultCatalogCollator.fromConfig(config, { discovery }),
   });
 
   indexBuilder.addCollator({

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/search.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/search.ts
@@ -10,6 +10,7 @@ import { DefaultCatalogCollator } from '@backstage/plugin-catalog-backend';
 export default async function createPlugin({
   logger,
   discovery,
+  config,
 }: PluginEnvironment) {
   // Initialize a connection to a search engine.
   const searchEngine = new LunrSearchEngine({ logger });
@@ -19,7 +20,7 @@ export default async function createPlugin({
   // particular collator gathers entities from the software catalog.
   indexBuilder.addCollator({
     defaultRefreshIntervalSeconds: 600,
-    collator: new DefaultCatalogCollator({ discovery }),
+    collator: DefaultCatalogCollator.fromConfig(config, { discovery }),
   });
 
   // The scheduler controls when documents are gathered from collators and sent

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -581,9 +581,11 @@ export class DefaultCatalogCollator implements DocumentCollator {
   constructor({
     discovery,
     locationTemplate,
+    allow,
   }: {
     discovery: PluginEndpointDiscovery;
     locationTemplate?: string;
+    allow?: string[];
   });
   // (undocumented)
   protected applyArgsToFormat(
@@ -594,6 +596,15 @@ export class DefaultCatalogCollator implements DocumentCollator {
   protected discovery: PluginEndpointDiscovery;
   // (undocumented)
   execute(): Promise<CatalogEntityDocument[]>;
+  // (undocumented)
+  protected filterUrl: string;
+  // (undocumented)
+  static fromConfig(
+    config: Config,
+    options: {
+      discovery: PluginEndpointDiscovery;
+    },
+  ): DefaultCatalogCollator;
   // (undocumented)
   protected locationTemplate: string;
   // (undocumented)

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -7,6 +7,7 @@
 
 import { Account } from 'aws-sdk/clients/organizations';
 import { BitbucketIntegration } from '@backstage/integration';
+import { CatalogApi } from '@backstage/catalog-client';
 import { CatalogEntitiesRequest } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { DocumentCollator } from '@backstage/search-common';
@@ -567,10 +568,12 @@ export class DefaultCatalogCollator implements DocumentCollator {
     discovery,
     locationTemplate,
     filter,
+    catalogClient,
   }: {
     discovery: PluginEndpointDiscovery;
     locationTemplate?: string;
     filter?: CatalogEntitiesRequest['filter'];
+    catalogClient?: CatalogApi;
   });
   // (undocumented)
   protected applyArgsToFormat(
@@ -578,13 +581,15 @@ export class DefaultCatalogCollator implements DocumentCollator {
     args: Record<string, string>,
   ): string;
   // (undocumented)
+  protected readonly catalogClient: CatalogApi;
+  // (undocumented)
   protected discovery: PluginEndpointDiscovery;
   // Warning: (ae-forgotten-export) The symbol "CatalogEntityDocument" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
   execute(): Promise<CatalogEntityDocument[]>;
   // (undocumented)
-  protected filterUrl?: string;
+  protected filter?: CatalogEntitiesRequest['filter'];
   // (undocumented)
   static fromConfig(
     _config: Config,

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -7,6 +7,7 @@
 
 import { Account } from 'aws-sdk/clients/organizations';
 import { BitbucketIntegration } from '@backstage/integration';
+import { CatalogEntitiesRequest } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { DocumentCollator } from '@backstage/search-common';
 import { Entity } from '@backstage/catalog-model';
@@ -202,22 +203,6 @@ export class CatalogBuilder {
     key: string,
     resolver: PlaceholderResolver,
   ): CatalogBuilder;
-}
-
-// Warning: (ae-missing-release-tag) "CatalogEntityDocument" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export interface CatalogEntityDocument extends IndexableDocument {
-  // (undocumented)
-  componentType: string;
-  // (undocumented)
-  kind: string;
-  // (undocumented)
-  lifecycle: string;
-  // (undocumented)
-  namespace: string;
-  // (undocumented)
-  owner: string;
 }
 
 // Warning: (ae-missing-release-tag) "CatalogProcessingOrchestrator" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -581,11 +566,11 @@ export class DefaultCatalogCollator implements DocumentCollator {
   constructor({
     discovery,
     locationTemplate,
-    allow,
+    filter,
   }: {
     discovery: PluginEndpointDiscovery;
     locationTemplate?: string;
-    allow?: string[];
+    filter?: CatalogEntitiesRequest['filter'];
   });
   // (undocumented)
   protected applyArgsToFormat(
@@ -594,15 +579,18 @@ export class DefaultCatalogCollator implements DocumentCollator {
   ): string;
   // (undocumented)
   protected discovery: PluginEndpointDiscovery;
+  // Warning: (ae-forgotten-export) The symbol "CatalogEntityDocument" needs to be exported by the entry point index.d.ts
+  //
   // (undocumented)
   execute(): Promise<CatalogEntityDocument[]>;
   // (undocumented)
-  protected filterUrl: string;
+  protected filterUrl?: string;
   // (undocumented)
   static fromConfig(
-    config: Config,
+    _config: Config,
     options: {
       discovery: PluginEndpointDiscovery;
+      filter?: CatalogEntitiesRequest['filter'];
     },
   ): DefaultCatalogCollator;
   // (undocumented)

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -179,17 +179,5 @@ export interface Config {
         };
       };
     };
-
-    /**
-     * Configuration for search collation
-     */
-    search?: {
-      /**
-       * Request search to only index these particular kinds.
-       *
-       * E.g. ["Component", "API", "Template", "Location"]
-       */
-      allow: Array<string>;
-    };
   };
 }

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -179,5 +179,17 @@ export interface Config {
         };
       };
     };
+
+    /**
+     * Configuration for search collation
+     */
+    search?: {
+      /**
+       * Request search to only index these particular kinds.
+       *
+       * E.g. ["Component", "API", "Template", "Location"]
+       */
+      allow: Array<string>;
+    };
   };
 }

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.test.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.test.ts
@@ -16,10 +16,7 @@
 
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
-import {
-  DefaultCatalogCollator,
-  mapFilterToQueryString,
-} from './DefaultCatalogCollator';
+import { DefaultCatalogCollator } from './DefaultCatalogCollator';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import { ConfigReader } from '@backstage/config';
@@ -59,7 +56,7 @@ describe('DefaultCatalogCollator', () => {
       rest.get('http://localhost:7000/entities', (req, res, ctx) => {
         if (req.url.searchParams.has('filter')) {
           const filter = req.url.searchParams.get('filter');
-          if (filter === 'kind=Foo,Bar') {
+          if (filter === 'kind=Foo,kind=Bar') {
             // When filtering on the 'Foo,Bar' kinds we simply return no items, to simulate a filter
             return res(ctx.json([]));
           }
@@ -119,24 +116,5 @@ describe('DefaultCatalogCollator', () => {
     const documents = await collator.execute();
     // The simulated 'Foo,Bar' filter should return in an empty list
     expect(documents).toHaveLength(0);
-  });
-
-  it('can map filters to query strings', () => {
-    expect(
-      mapFilterToQueryString({
-        a: 'Foo',
-      }),
-    ).toEqual('?filter=a=Foo');
-    expect(
-      mapFilterToQueryString({
-        a: ['Foo', 'Bar'],
-      }),
-    ).toEqual('?filter=a=Foo,Bar');
-    expect(
-      mapFilterToQueryString({
-        a: ['Foo', 'Bar'],
-        b: ['Quu', 'Qux'],
-      }),
-    ).toEqual('?filter=a=Foo,Bar,b=Quu,Qux');
   });
 });

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.test.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.test.ts
@@ -17,6 +17,11 @@
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { Entity } from '@backstage/catalog-model';
 import { DefaultCatalogCollator } from './DefaultCatalogCollator';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+import { ConfigReader } from '@backstage/config';
+
+const server = setupServer();
 
 const expectedEntities: Entity[] = [
   {
@@ -34,27 +39,37 @@ const expectedEntities: Entity[] = [
   },
 ];
 
-jest.mock('cross-fetch', () => ({
-  __esModule: true,
-  default: async () => {
-    return {
-      json: async () => {
-        return expectedEntities;
-      },
-    };
-  },
-}));
-
 describe('DefaultCatalogCollator', () => {
   let mockDiscoveryApi: jest.Mocked<PluginEndpointDiscovery>;
   let collator: DefaultCatalogCollator;
 
-  beforeEach(() => {
+  beforeAll(() => {
     mockDiscoveryApi = {
-      getBaseUrl: jest.fn().mockResolvedValueOnce('http://localhost:7000'),
+      getBaseUrl: jest.fn().mockResolvedValue('http://localhost:7000'),
       getExternalBaseUrl: jest.fn(),
     };
     collator = new DefaultCatalogCollator({ discovery: mockDiscoveryApi });
+    server.listen();
+  });
+  beforeEach(() => {
+    server.use(
+      rest.get('http://localhost:7000/entities', (req, res, ctx) => {
+        if (req.url.searchParams.has('filter')) {
+          const filter = req.url.searchParams.get('filter');
+          if (filter === 'kind=Foo,Bar') {
+            // When filtering on the 'Foo,Bar' kinds we simply return no items, to simulate a filter
+            return res(ctx.json([]));
+          }
+          throw new Error('Unexpected filter parameter');
+        }
+        return res(ctx.json(expectedEntities));
+      }),
+    );
+  });
+  afterEach(() => server.resetHandlers());
+  afterAll(() => {
+    server.close();
+    jest.useRealTimers();
   });
 
   it('fetches from the configured catalog service', async () => {
@@ -87,5 +102,24 @@ describe('DefaultCatalogCollator', () => {
     expect(documents[0]).toMatchObject({
       location: '/software/test-entity',
     });
+  });
+
+  it('allows filtering of the retrieved catalog entities', async () => {
+    const config = new ConfigReader({
+      catalog: {
+        search: {
+          allow: ['Foo', 'Bar'],
+        },
+      },
+    });
+
+    // Provide an alternate location template.
+    collator = DefaultCatalogCollator.fromConfig(config, {
+      discovery: mockDiscoveryApi,
+    });
+
+    const documents = await collator.execute();
+    // The simulated 'Foo,Bar' filter should return in an empty list
+    expect(documents).toHaveLength(0);
   });
 });

--- a/plugins/catalog-backend/src/search/index.ts
+++ b/plugins/catalog-backend/src/search/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './DefaultCatalogCollator';
+export { DefaultCatalogCollator } from './DefaultCatalogCollator';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have added some configuration for the `DefaultCatalogCollector` that allows the indexed entities to be filtered by kind. Our use case is that we don't really want to include users in the search index.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
