### PR TITLE
Modify ApiHolder to be updated on Provider children changes as well

### DIFF
--- a/.changeset/great-humans-return.md
+++ b/.changeset/great-humans-return.md
@@ -3,5 +3,5 @@
 ---
 
 Store additional, late registered and lazy loaded APIs in the registry as well.
-Route paths, route objs and others are collected already on late reg, this adds APIs to be collected also.
+Route paths, route objects and others are collected already on late registration, this adds APIs to be collected also.
 Enables late registration of plugins into the application and updates ApiHolder when additional plugins have been added in.

--- a/.changeset/great-humans-return.md
+++ b/.changeset/great-humans-return.md
@@ -2,6 +2,4 @@
 '@backstage/core-app-api': patch
 ---
 
-Store additional, late registered and lazy loaded APIs in the registry as well.
-Route paths, route objects and others are collected already on late registration, this adds APIs to be collected also.
-Enables late registration of plugins into the application and updates ApiHolder when additional plugins have been added in.
+Enables late registration of plugins into the application by updating ApiHolder when additional plugins have been added in.

--- a/.changeset/great-humans-return.md
+++ b/.changeset/great-humans-return.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Store additional, late registered and lazy loaded APIs in the registry as well.
+Route paths, route objs and others are collected already on late reg, this adds APIs to be collected also.
+Enables late registration of plugins into the application and updates ApiHolder when additional plugins have been added in.

--- a/packages/core-app-api/src/app/App.tsx
+++ b/packages/core-app-api/src/app/App.tsx
@@ -391,7 +391,7 @@ export class PrivateAppImpl implements BackstageApp {
   private getApiHolder(): ApiHolder {
     if (this.apiHolder) {
       // Register additional plugins if they have been added.
-      // Routes and other config options are updated above when children change
+      // Routes paths, objects and others are already updated in the provider when children of it change
       for (const plugin of this.plugins) {
         for (const factory of plugin.getApis()) {
           if (!this.apiFactoryRegistry.get(factory.api)) {

--- a/packages/core-app-api/src/app/App.tsx
+++ b/packages/core-app-api/src/app/App.tsx
@@ -198,6 +198,7 @@ export class PrivateAppImpl implements BackstageApp {
   private readonly bindRoutes: AppOptions['bindRoutes'];
 
   private readonly identityApi = new AppIdentity();
+  private readonly apiFactoryRegistry: ApiFactoryRegistry;
 
   constructor(options: FullAppOptions) {
     this.apis = options.apis;
@@ -208,6 +209,7 @@ export class PrivateAppImpl implements BackstageApp {
     this.configLoader = options.configLoader;
     this.defaultApis = options.defaultApis;
     this.bindRoutes = options.bindRoutes;
+    this.apiFactoryRegistry = new ApiFactoryRegistry();
   }
 
   getPlugins(): BackstagePlugin<any, any>[] {
@@ -388,17 +390,27 @@ export class PrivateAppImpl implements BackstageApp {
 
   private getApiHolder(): ApiHolder {
     if (this.apiHolder) {
+      // Register additional plugins if they have been added.
+      // Routes and other config options are updated above when children change
+      for (const plugin of this.plugins) {
+        for (const factory of plugin.getApis()) {
+          if (!this.apiFactoryRegistry.get(factory.api)) {
+            this.apiFactoryRegistry.register('default', factory);
+          }
+        }
+      }
+      ApiResolver.validateFactories(
+        this.apiFactoryRegistry,
+        this.apiFactoryRegistry.getAllApis(),
+      );
       return this.apiHolder;
     }
-
-    const registry = new ApiFactoryRegistry();
-
-    registry.register('static', {
+    this.apiFactoryRegistry.register('static', {
       api: appThemeApiRef,
       deps: {},
       factory: () => AppThemeSelector.createWithStorage(this.themes),
     });
-    registry.register('static', {
+    this.apiFactoryRegistry.register('static', {
       api: configApiRef,
       deps: {},
       factory: () => {
@@ -410,7 +422,7 @@ export class PrivateAppImpl implements BackstageApp {
         return this.configApi;
       },
     });
-    registry.register('static', {
+    this.apiFactoryRegistry.register('static', {
       api: identityApiRef,
       deps: {},
       factory: () => this.identityApi,
@@ -418,18 +430,18 @@ export class PrivateAppImpl implements BackstageApp {
 
     // It's possible to replace the feature flag API, but since we must have at least
     // one implementation we add it here directly instead of through the defaultApis.
-    registry.register('default', {
+    this.apiFactoryRegistry.register('default', {
       api: featureFlagsApiRef,
       deps: {},
       factory: () => new LocalStorageFeatureFlags(),
     });
     for (const factory of this.defaultApis) {
-      registry.register('default', factory);
+      this.apiFactoryRegistry.register('default', factory);
     }
 
     for (const plugin of this.plugins) {
       for (const factory of plugin.getApis()) {
-        if (!registry.register('default', factory)) {
+        if (!this.apiFactoryRegistry.register('default', factory)) {
           throw new Error(
             `Plugin ${plugin.getId()} tried to register duplicate or forbidden API factory for ${
               factory.api
@@ -440,17 +452,19 @@ export class PrivateAppImpl implements BackstageApp {
     }
 
     for (const factory of this.apis) {
-      if (!registry.register('app', factory)) {
+      if (!this.apiFactoryRegistry.register('app', factory)) {
         throw new Error(
           `Duplicate or forbidden API factory for ${factory.api} in app`,
         );
       }
     }
 
-    ApiResolver.validateFactories(registry, registry.getAllApis());
+    ApiResolver.validateFactories(
+      this.apiFactoryRegistry,
+      this.apiFactoryRegistry.getAllApis(),
+    );
 
-    this.apiHolder = new ApiResolver(registry);
-
+    this.apiHolder = new ApiResolver(this.apiFactoryRegistry);
     return this.apiHolder;
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* Modify PrivateAppImpl to update apiHolder contents as well, on top of already existing updates to routes and data related to those
* Enables the possibility for late registration of plugins in the application so that their APIs are still retrievable from the holder.

Why though?

At times there is a need to register plugins after the application has been spun up. One of these cases could be dynamically loaded plugins or something like using plugins from federated modules. Late registration or like I like to call it, lazy-lazy loading of a plugin would change the children array on the created Provider and trigger the memoized route/path/featureflag creation. The ApiHolder isn't updated though with this loop since existence of an instance variable is checked whether to update the holder or not.

This splits initialization and getter to separate methods and keeps the logic on the get side the same as it was, modifying the memo-loop to initialize if new children (and by extension, plugins) have been added in. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
