### PR TITLE
e2e-test: avoid page reload between text search attempts

### DIFF
--- a/packages/e2e-test/src/lib/helpers.ts
+++ b/packages/e2e-test/src/lib/helpers.ts
@@ -165,7 +165,6 @@ export async function waitForPageWithText(
     } catch (error) {
       findTextAttempts++;
       if (findTextAttempts <= maxFindTextAttempts) {
-        await browser.visit(path);
         await new Promise(resolve => setTimeout(resolve, intervalMs));
         continue;
       } else {


### PR DESCRIPTION
We're having some trouble with E2E test flakiness being introduced in a PR (#6905).

It looks like this particular retry logic is doing a bit too much in that it attempts to reload the page. While trying this out locally the loop would always exit on the line being removed as it would throw an error. By exiting early we never get the followup attempts to find text on the page, and so the entire page needs to load within the initial timeout.

By removing the reload and letting the outer loop take care of retries for failures in loading the page, I'm hoping we can get rid of the flakiness.