### PR TITLE
[TechDocs] Local Publisher Case Sensitivity Compatibility

### DIFF
--- a/.changeset/techdocs-search-log-fatigue.md
+++ b/.changeset/techdocs-search-log-fatigue.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Errors encountered while attempting to load TechDocs search indices at
+collation-time are now logged at `DEBUG` instead of `WARN` level.

--- a/.changeset/techdocs-the-beta-local.md
+++ b/.changeset/techdocs-the-beta-local.md
@@ -1,0 +1,6 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+"Local" (out-of-the-box) publisher explicitly follows lower-case entity triplet
+logic.

--- a/packages/techdocs-common/src/stages/publish/local.test.ts
+++ b/packages/techdocs-common/src/stages/publish/local.test.ts
@@ -147,10 +147,10 @@ describe('local publisher', () => {
     });
 
     it('should redirect case-sensitive triplet path to lower-case', async () => {
-      await request(app)
+      const response = await request(app)
         .get('/default/TestKind/TestName/index.html')
-        .expect(301)
         .expect('Location', '/default/testkind/testname/index.html');
+      expect(response.status).toBe(301);
     });
 
     it('should resolve lower-case triplet path content eventually', async () => {
@@ -173,9 +173,10 @@ describe('local publisher', () => {
       );
       app = express().use(legacyPublisher.docsRouter());
 
-      await request(app)
-        .get('/default/TestKind/TestName/index.html')
-        .expect(404);
+      const response = await request(app).get(
+        '/default/TestKind/TestName/index.html',
+      );
+      expect(response.status).toBe(404);
     });
   });
 });

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
@@ -110,7 +110,7 @@ export class DefaultTechDocsCollator implements DocumentCollator {
                   ?.target?.name || '',
             }));
           } catch (e) {
-            this.logger.warn(
+            this.logger.debug(
               `Failed to retrieve tech docs search index for entity ${entityInfo.namespace}/${entityInfo.kind}/${entityInfo.name}`,
               e,
             );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In #6709, we made the assumption that "no changes are necessary to the local publisher because if the docs aren't found, they'll just be regenerated with the correct case."  We also ran into no issues testing this assumption because MacOS' file system is case-insensitive by default and so nothing seemed awry when we were testing locally.

This corrects things by bringing the `Local` publisher up-to-snuff with the GCS/AWS/Azure publishers by...

- [x] Lower-casing entity triplets on write/publish.
- [x] Lower-casing entity triplets on simple reads (`hasDocsBeenGenerated` and `fetchTechDocsMetadata`)
- [x] Redirects requests for non-lowercase entity triplet objects to their lowercase equivalents (there is otherwise no easy way to continue to take advantage of the `express.static()` middleware)
- [x] Respecting the `techdocs.legacyUseCaseSensitiveTripletPaths` (by undoing all of the above when set to `true`)

Closes #6979 #6980 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
