### PR TITLE
Hide pagination when there's just one page

### DIFF
--- a/.changeset/shiny-guests-explain.md
+++ b/.changeset/shiny-guests-explain.md
@@ -1,5 +1,4 @@
 ---
-'example-app': patch
 '@backstage/plugin-catalog': patch
 '@backstage/plugin-org': patch
 ---

--- a/.changeset/shiny-guests-explain.md
+++ b/.changeset/shiny-guests-explain.md
@@ -1,0 +1,7 @@
+---
+'example-app': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-org': patch
+---
+
+This change hides pagination counter of search tables and group memberslist when results/items fit in one page

--- a/.changeset/shiny-guests-explain.md
+++ b/.changeset/shiny-guests-explain.md
@@ -4,4 +4,4 @@
 '@backstage/plugin-org': patch
 ---
 
-This change hides pagination counter of search tables and group memberslist when results/items fit in one page
+This change hides pagination counter of search tables and group members list when results fit in one page

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -83,13 +83,15 @@ const SearchResultList = ({ results }: SearchResultSet) => {
             }
           })}
       </List>
-      <Pagination
-        count={pageAmount}
-        page={page}
-        onChange={changePage}
-        showFirstButton
-        showLastButton
-      />
+      {pageAmount > 1 && (
+        <Pagination
+          count={pageAmount}
+          page={page}
+          onChange={changePage}
+          showFirstButton
+          showLastButton
+        />
+      )}
     </>
   );
 };

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -145,13 +145,14 @@ export const CatalogTable = ({ columns, actions }: CatalogTableProps) => {
   if (typeColumn) {
     typeColumn.hidden = !showTypeColumn;
   }
+  const showPagination = rows.length > 20;
 
   return (
     <Table<EntityRow>
       isLoading={loading}
       columns={columns || defaultColumns}
       options={{
-        paging: true,
+        paging: showPagination,
         pageSize: 20,
         actionsColumnIndex: -1,
         loadingType: 'linear',

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -174,7 +174,7 @@ export const MembersListCard = (_props: {
       <InfoCard
         title={`Members (${members?.length || 0}${paginationLabel})`}
         subheader={`of ${displayName}`}
-        actions={pagination}
+        {...(nbPages <= 1 ? {} : { actions: pagination })}
       >
         <Grid container spacing={3}>
           {members && members.length > 0 ? (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It hides pagination counter of search tables and the group members list only when results fit in one page like in this case.

<img width="1348" alt="Screenshot 2021-08-31 at 09 52 05" src="https://user-images.githubusercontent.com/74989179/131464745-5a498d21-12f0-42ac-b746-190b1cf30576.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
