### PR TITLE
Fix catalog-import plugin

### DIFF
--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreparePullRequestForm.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreparePullRequestForm.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import {
+  FormProvider,
   SubmitHandler,
   UnpackNestedValue,
   useForm,
@@ -55,12 +56,15 @@ export const PreparePullRequestForm = <
   onSubmit,
   render,
 }: Props<TFieldValues>) => {
+  const methods = useForm<TFieldValues>({ mode: 'onTouched', defaultValues });
   const { handleSubmit, watch, control, register, formState, setValue } =
-    useForm<TFieldValues>({ mode: 'onTouched', defaultValues });
+    methods;
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      {render({ values: watch(), formState, register, control, setValue })}
-    </form>
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        {render({ values: watch(), formState, register, control, setValue })}
+      </form>
+    </FormProvider>
   );
 };


### PR DESCRIPTION
Follow up of https://github.com/backstage/backstage/pull/6694 that adds the missed changes.

Some fields (e.g. Autocomplete) use a controller that reads the form control from the context. But this context must be created by the `FormProvider`.

I didn't add a changeset because it belongs to the react-hook-form update.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
