### PR TITLE
Add a warning log message that `passport-saml` will require a `cert` config parameter imminently

### DIFF
--- a/.changeset/friendly-tables-heal.md
+++ b/.changeset/friendly-tables-heal.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Add a warning log message that `passport-saml` will require a `cert` config parameter imminently.
+
+We intend to upgrade this package soon, past the point where we will start to strictly require the `auth.saml.cert` configuration parameter to be present. To avoid issues starting your auth backend, please

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -119,7 +119,7 @@ export type SamlProviderOptions = {};
 export const createSamlProvider = (
   _options?: SamlProviderOptions,
 ): AuthProviderFactory => {
-  return ({ providerId, globalConfig, config, tokenIssuer }) => {
+  return ({ providerId, globalConfig, config, tokenIssuer, logger }) => {
     const opts = {
       callbackUrl: `${globalConfig.baseUrl}/${providerId}/handler/frame`,
       entryPoint: config.getString('entryPoint'),
@@ -141,8 +141,14 @@ export const createSamlProvider = (
     // passport-saml will return an error if the `cert` key is set, and the value is empty.
     // Since we read from config (such as environment variables) an empty string should be equal to being unset.
     if (!opts.cert) {
+      logger.warn(
+        'SamlAuthProvider was initialized without a cert configuration parameter. ' +
+          'This will soon be required by the underlying passport-saml library, which may soon lead to failures to start the auth backend. ' +
+          'Please add an "auth.saml.cert" config parameter.',
+      );
       delete opts.cert;
     }
+
     return new SamlAuthProvider(opts);
   };
 };


### PR DESCRIPTION
@lowjoel You added this check initially - I thought you might be interested to know about this.