### PR TITLE
Properly handle Azure DevOps Server download URL

### DIFF
--- a/.changeset/fuzzy-pigs-wash.md
+++ b/.changeset/fuzzy-pigs-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Update to properly handle Azure DevOps Server download URL

--- a/packages/integration/src/azure/core.test.ts
+++ b/packages/integration/src/azure/core.test.ts
@@ -97,5 +97,20 @@ describe('azure core', () => {
       );
       expect(new URL(result).searchParams.get('scopePath')).toEqual('docs');
     });
+
+    it.each([
+      {
+        url: 'https://dev.azure.com/org-name/project-name/_git/repo-name',
+        result:
+          'https://dev.azure.com/org-name/project-name/_apis/git/repositories/repo-name/items?recursionLevel=full&download=true&api-version=6.0',
+      },
+      {
+        url: 'https://api.com/org-name/project-name/_git/repo-name',
+        result:
+          'https://api.com/org-name/project-name/_apis/git/repositories/repo-name/items?recursionLevel=full&download=true&api-version=6.0',
+      },
+    ])('should handle happy path %#', async ({ url, result }) => {
+      expect(getAzureDownloadUrl(url)).toBe(result);
+    });
   });
 });

--- a/packages/integration/src/azure/core.ts
+++ b/packages/integration/src/azure/core.ts
@@ -100,7 +100,7 @@ export function getAzureDownloadUrl(url: string): string {
     ? `&scopePath=${encodeURIComponent(filepath)}`
     : '';
 
-  if (url.includes('dev.azure.com')) {
+  if (resource === 'dev.azure.com') {
     return `${protocol}://${resource}/${organization}/${project}/_apis/git/repositories/${repoName}/items?recursionLevel=full&download=true&api-version=6.0${scopePath}`;
   }
 

--- a/packages/integration/src/azure/core.ts
+++ b/packages/integration/src/azure/core.ts
@@ -100,7 +100,17 @@ export function getAzureDownloadUrl(url: string): string {
     ? `&scopePath=${encodeURIComponent(filepath)}`
     : '';
 
-  return `${protocol}://${resource}/${organization}/${project}/_apis/git/repositories/${repoName}/items?recursionLevel=full&download=true&api-version=6.0${scopePath}`;
+  if (url.includes('dev.azure.com')) {
+    return `${protocol}://${resource}/${organization}/${project}/_apis/git/repositories/${repoName}/items?recursionLevel=full&download=true&api-version=6.0${scopePath}`;
+  }
+
+  // For Azure DevOps Server `parseGitUrl` returns the same values
+  // for `organization` and `project` like this: `organization/project/_git`
+  // so we drop `project` and then strip `/_git` from `organization`
+  return `${protocol}://${resource}/${organization.replace(
+    '/_git',
+    '',
+  )}/_apis/git/repositories/${repoName}/items?recursionLevel=full&download=true&api-version=6.0${scopePath}`;
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <awanlin@rapidrtc.com>

## Hey, I just made a Pull Request!

This change properly handles the download URL for Azure DevOps Server which is the on-premise version

For Azure DevOps Server `parseGitUrl` returns the same values for `organization` and `project` like this: `organization/project/_git` so we drop `project` and then strip `/_git` from `organization`. 

I've also added some really simple tests, very open to suggestions here, have not used Jest much, at all really

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
