### PR TITLE
cli: added support for importing font files

### DIFF
--- a/.changeset/big-eyes-dance.md
+++ b/.changeset/big-eyes-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added support for importing font files. Imports in CSS via `url()` are supported for the final frontend bundle, but not for packages that are built for publishing. Module imports of fonts files from TypeScript are supported everywhere.

--- a/packages/cli/asset-types/asset-types.d.ts
+++ b/packages/cli/asset-types/asset-types.d.ts
@@ -68,6 +68,26 @@ declare module '*.svg' {
   export default src;
 }
 
+declare module '*.eot' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.woff' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.woff2' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.ttf' {
+  const src: string;
+  export default src;
+}
+
 declare module '*.css' {
   const classes: { readonly [key: string]: string };
   export default classes;

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -80,7 +80,17 @@ export const makeConfigs = async (
         postcss(),
         forwardFileImports({
           exclude: /\.icon\.svg$/,
-          include: [/\.svg$/, /\.png$/, /\.gif$/, /\.jpg$/, /\.jpeg$/],
+          include: [
+            /\.svg$/,
+            /\.png$/,
+            /\.gif$/,
+            /\.jpg$/,
+            /\.jpeg$/,
+            /\.eot$/,
+            /\.woff$/,
+            /\.woff2$/,
+            /\.ttf$/,
+          ],
         }),
         json(),
         yaml(),

--- a/packages/cli/src/lib/bundler/transforms.ts
+++ b/packages/cli/src/lib/bundler/transforms.ts
@@ -90,6 +90,17 @@ export const transforms = (options: TransformOptions): Transforms => {
       },
     },
     {
+      test: /\.(eot|woff|woff2|ttf)$/,
+      use: [
+        {
+          loader: require.resolve('file-loader'),
+          options: {
+            name: 'static/[name].[hash:8].[ext]',
+          },
+        },
+      ],
+    },
+    {
       test: /\.ya?ml$/,
       use: require.resolve('yml-loader'),
     },


### PR DESCRIPTION
Closing this gap in the tooling. The way to use fonts has been to add imports to the `index.html` template, but let's make it possible to import them in code as well.