### PR TITLE
feat(plugin-scaffolder-backend): Default GitHub Webhook Action secret

### DIFF
--- a/.changeset/four-bobcats-confess.md
+++ b/.changeset/four-bobcats-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+GitHubWebhook Action can be created with a default webhook secret. This allows getting secret from environment variable as an alternative to get it from context.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -120,6 +120,7 @@ export function createGithubActionsDispatchAction(options: {
 // @public (undocumented)
 export function createGithubWebhookAction(options: {
   integrations: ScmIntegrationRegistry;
+  webhookSecretDefault?: string;
 }): TemplateAction<any>;
 
 // Warning: (ae-missing-release-tag) "createPublishAzureAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -120,7 +120,7 @@ export function createGithubActionsDispatchAction(options: {
 // @public (undocumented)
 export function createGithubWebhookAction(options: {
   integrations: ScmIntegrationRegistry;
-  webhookSecretDefault?: string;
+  defaultWebhookSecret?: string;
 }): TemplateAction<any>;
 
 // Warning: (ae-missing-release-tag) "createPublishAzureAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
@@ -33,13 +33,16 @@ describe('github:repository:webhook:create', () => {
   });
 
   const integrations = ScmIntegrations.fromConfig(config);
-  const action = createGithubWebhookAction({ integrations });
+  const webhookSecretDefault = 'aafdfdivierernfdk23f';
+  const action = createGithubWebhookAction({
+    integrations,
+    webhookSecretDefault,
+  });
 
   const mockContext = {
     input: {
       repoUrl: 'github.com?repo=repo&owner=owner',
       webhookUrl: 'https://example.com/payload',
-      webhookSecret: 'aafdfdivierernfdk23f',
     },
     workspacePath: 'lol',
     logger: getVoidLogger(),
@@ -57,11 +60,32 @@ describe('github:repository:webhook:create', () => {
   it('should call the githubApi for creating repository Webhook', async () => {
     const repoUrl = 'github.com?repo=repo&owner=owner';
     const webhookUrl = 'https://example.com/payload';
-    const webhookSecret = 'aafdfdivierernfdk23f';
     const ctx = Object.assign({}, mockContext, {
-      input: { repoUrl, webhookUrl, webhookSecret },
+      input: { repoUrl, webhookUrl },
     });
     await action.handler(ctx);
+
+    expect(mockGithubClient.repos.createWebhook).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      events: ['push'],
+      active: true,
+      config: {
+        url: webhookUrl,
+        content_type: 'form',
+        secret: webhookSecretDefault,
+        insecure_ssl: '0',
+      },
+    });
+
+    const webhookSecret = 'yet_another_secret';
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        webhookSecret,
+      },
+    });
 
     expect(mockGithubClient.repos.createWebhook).toHaveBeenCalledWith({
       owner: 'owner',
@@ -92,7 +116,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'form',
-        secret: webhookSecret,
+        secret: webhookSecretDefault,
         insecure_ssl: '0',
       },
     });
@@ -113,7 +137,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'json',
-        secret: webhookSecret,
+        secret: webhookSecretDefault,
         insecure_ssl: '0',
       },
     });
@@ -134,7 +158,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'form',
-        secret: webhookSecret,
+        secret: webhookSecretDefault,
         insecure_ssl: '1',
       },
     });
@@ -155,7 +179,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'form',
-        secret: webhookSecret,
+        secret: webhookSecretDefault,
         insecure_ssl: '1',
       },
     });
@@ -176,7 +200,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'form',
-        secret: webhookSecret,
+        secret: webhookSecretDefault,
         insecure_ssl: '0',
       },
     });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
@@ -33,10 +33,10 @@ describe('github:repository:webhook:create', () => {
   });
 
   const integrations = ScmIntegrations.fromConfig(config);
-  const webhookSecretDefault = 'aafdfdivierernfdk23f';
+  const defaultWebhookSecret = 'aafdfdivierernfdk23f';
   const action = createGithubWebhookAction({
     integrations,
-    webhookSecretDefault,
+    defaultWebhookSecret,
   });
 
   const mockContext = {
@@ -73,7 +73,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'form',
-        secret: webhookSecretDefault,
+        secret: defaultWebhookSecret,
         insecure_ssl: '0',
       },
     });
@@ -116,7 +116,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'form',
-        secret: webhookSecretDefault,
+        secret: defaultWebhookSecret,
         insecure_ssl: '0',
       },
     });
@@ -137,7 +137,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'json',
-        secret: webhookSecretDefault,
+        secret: defaultWebhookSecret,
         insecure_ssl: '0',
       },
     });
@@ -158,7 +158,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'form',
-        secret: webhookSecretDefault,
+        secret: defaultWebhookSecret,
         insecure_ssl: '1',
       },
     });
@@ -179,7 +179,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'form',
-        secret: webhookSecretDefault,
+        secret: defaultWebhookSecret,
         insecure_ssl: '1',
       },
     });
@@ -200,7 +200,7 @@ describe('github:repository:webhook:create', () => {
       config: {
         url: webhookUrl,
         content_type: 'form',
-        secret: webhookSecretDefault,
+        secret: defaultWebhookSecret,
         insecure_ssl: '0',
       },
     });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
@@ -21,9 +21,9 @@ type ContentType = 'form' | 'json';
 
 export function createGithubWebhookAction(options: {
   integrations: ScmIntegrationRegistry;
-  webhookSecretDefault?: string;
+  defaultWebhookSecret?: string;
 }) {
-  const { integrations, webhookSecretDefault } = options;
+  const { integrations, defaultWebhookSecret } = options;
   const octokitProvider = new OctokitProvider(integrations);
 
   return createTemplateAction<{
@@ -90,7 +90,7 @@ export function createGithubWebhookAction(options: {
       const {
         repoUrl,
         webhookUrl,
-        webhookSecret = webhookSecretDefault,
+        webhookSecret = defaultWebhookSecret,
         events = ['push'],
         active = true,
         contentType = 'form',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
@@ -21,8 +21,9 @@ type ContentType = 'form' | 'json';
 
 export function createGithubWebhookAction(options: {
   integrations: ScmIntegrationRegistry;
+  webhookSecretDefault?: string;
 }) {
-  const { integrations } = options;
+  const { integrations, webhookSecretDefault } = options;
   const octokitProvider = new OctokitProvider(integrations);
 
   return createTemplateAction<{
@@ -53,7 +54,8 @@ export function createGithubWebhookAction(options: {
           },
           webhookSecret: {
             title: 'Webhook Secret',
-            description: 'Webhook secret value',
+            description:
+              'Webhook secret value. The default can be provided internally in action creation',
             type: 'string',
           },
           events: {
@@ -88,7 +90,7 @@ export function createGithubWebhookAction(options: {
       const {
         repoUrl,
         webhookUrl,
-        webhookSecret,
+        webhookSecret = webhookSecretDefault,
         events = ['push'],
         active = true,
         contentType = 'form',


### PR DESCRIPTION
## Hey, I just made a Pull Request!
GitHub Webhook Action can be constructed with default Webhook secret

This allows using this action with secrets stored in environment variables.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
