### PR TITLE
Fix broken links to 'String References' from 'Descriptor Format'

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -547,8 +547,8 @@ The current set of well-known and common values for this field is:
 
 ### `spec.owner` [required]
 
-An [entity reference](#string-references) to the owner of the component, e.g.
-`artist-relations-team`. This field is required.
+An [entity reference](references.md#string-references) to the owner of the
+component, e.g. `artist-relations-team`. This field is required.
 
 In Backstage, the owner of a component is the singular entity (commonly a team)
 that bears ultimate responsibility for the component, and has the authority and
@@ -566,8 +566,8 @@ component, but there will always be one ultimate owner.
 
 ### `spec.system` [optional]
 
-An [entity reference](#string-references) to the system that the component
-belongs to, e.g. `artist-engagement-portal`. This field is optional.
+An [entity reference](references.md#string-references) to the system that the
+component belongs to, e.g. `artist-engagement-portal`. This field is optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                            |
 | --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
@@ -575,8 +575,8 @@ belongs to, e.g. `artist-engagement-portal`. This field is optional.
 
 ### `spec.subcomponentOf` [optional]
 
-An [entity reference](#string-references) to another component of which the
-component is a part, e.g. `spotify-ios-app`. This field is optional.
+An [entity reference](references.md#string-references) to another component of
+which the component is a part, e.g. `spotify-ios-app`. This field is optional.
 
 | [`kind`](#apiversion-and-kind-required)  | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                            |
 | ---------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
@@ -584,8 +584,8 @@ component is a part, e.g. `spotify-ios-app`. This field is optional.
 
 ### `spec.providesApis` [optional]
 
-An array of [entity references](#string-references) to the APIs that are
-provided by the component, e.g. `artist-api`. This field is optional.
+An array of [entity references](references.md#string-references) to the APIs
+that are provided by the component, e.g. `artist-api`. This field is optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                                  |
 | --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------- |
@@ -593,8 +593,8 @@ provided by the component, e.g. `artist-api`. This field is optional.
 
 ### `spec.consumesApis` [optional]
 
-An array of [entity references](#string-references) to the APIs that are
-consumed by the component, e.g. `artist-api`. This field is optional.
+An array of [entity references](references.md#string-references) to the APIs
+that are consumed by the component, e.g. `artist-api`. This field is optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                                  |
 | --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------- |
@@ -602,9 +602,9 @@ consumed by the component, e.g. `artist-api`. This field is optional.
 
 ### `spec.dependsOn` [optional]
 
-An array of [entity references](#string-references) to the components and
-resources that the component depends on, e.g. `artists-db`. This field is
-optional.
+An array of [entity references](references.md#string-references) to the
+components and resources that the component depends on, e.g. `artists-db`. This
+field is optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                            |
 | --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
@@ -732,8 +732,8 @@ You can find out more about the `steps` key
 
 ### `spec.owner` [optional]
 
-An [entity reference](#string-references) to the owner of the template, e.g.
-`artist-relations-team`. This field is required.
+An [entity reference](references.md#string-references) to the owner of the
+template, e.g. `artist-relations-team`. This field is required.
 
 In Backstage, the owner of a Template is the singular entity (commonly a team)
 that bears ultimate responsibility for the Template, and has the authority and
@@ -842,8 +842,8 @@ The current set of well-known and common values for this field is:
 
 ### `spec.owner` [required]
 
-An [entity reference](#string-references) to the owner of the component, e.g.
-`artist-relations-team`. This field is required.
+An [entity reference](references.md#string-references) to the owner of the
+component, e.g. `artist-relations-team`. This field is required.
 
 In Backstage, the owner of an API is the singular entity (commonly a team) that
 bears ultimate responsibility for the API, and has the authority and capability
@@ -861,8 +861,8 @@ one ultimate owner.
 
 ### `spec.system` [optional]
 
-An [entity reference](#string-references) to the system that the API belongs to,
-e.g. `artist-engagement-portal`. This field is optional.
+An [entity reference](references.md#string-references) to the system that the
+API belongs to, e.g. `artist-engagement-portal`. This field is optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                            |
 | --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
@@ -1069,8 +1069,8 @@ Exactly equal to `backstage.io/v1alpha1` and `Resource`, respectively.
 
 ### `spec.owner` [required]
 
-An [entity reference](#string-references) to the owner of the resource, e.g.
-`artist-relations-team`. This field is required.
+An [entity reference](references.md#string-references) to the owner of the
+resource, e.g. `artist-relations-team`. This field is required.
 
 In Backstage, the owner of a resource is the singular entity (commonly a team)
 that bears ultimate responsibility for the resource, and has the authority and
@@ -1101,8 +1101,8 @@ Some common values for this field could be:
 
 ### `spec.system` [optional]
 
-An [entity reference](#string-references) to the system that the resource
-belongs to, e.g. `artist-engagement-portal`. This field is optional.
+An [entity reference](references.md#string-references) to the system that the
+resource belongs to, e.g. `artist-engagement-portal`. This field is optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                            |
 | --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
@@ -1110,9 +1110,9 @@ belongs to, e.g. `artist-engagement-portal`. This field is optional.
 
 ### `spec.dependsOn` [optional]
 
-An array of [entity references](#string-references) to the components and
-resources that the resource depends on, e.g. `artist-lookup`. This field is
-optional.
+An array of [entity references](references.md#string-references) to the
+components and resources that the resource depends on, e.g. `artist-lookup`.
+This field is optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                            |
 | --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
@@ -1156,8 +1156,8 @@ Exactly equal to `backstage.io/v1alpha1` and `System`, respectively.
 
 ### `spec.owner` [required]
 
-An [entity reference](#string-references) to the owner of the system, e.g.
-`artist-relations-team`. This field is required.
+An [entity reference](references.md#string-references) to the owner of the
+system, e.g. `artist-relations-team`. This field is required.
 
 In Backstage, the owner of a system is the singular entity (commonly a team)
 that bears ultimate responsibility for the system, and has the authority and
@@ -1175,8 +1175,8 @@ but there will always be one ultimate owner.
 
 ### `spec.domain` [optional]
 
-An [entity reference](#string-references) to the domain that the system belongs
-to, e.g. `artists`. This field is optional.
+An [entity reference](references.md#string-references) to the domain that the
+system belongs to, e.g. `artists`. This field is optional.
 
 | [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                            |
 | --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
@@ -1215,8 +1215,8 @@ Exactly equal to `backstage.io/v1alpha1` and `Domain`, respectively.
 
 ### `spec.owner` [required]
 
-An [entity reference](#string-references) to the owner of the domain, e.g.
-`artist-relations-team`. This field is required.
+An [entity reference](references.md#string-references) to the owner of the
+domain, e.g. `artist-relations-team`. This field is required.
 
 In Backstage, the owner of a domain is the singular entity (commonly a team)
 that bears ultimate responsibility for the domain, and has the authority and


### PR DESCRIPTION
Signed-off-by: James Bourne <james.bourne@contentful.com>

## Hey, I just made a Pull Request!

- Link from the 'Descriptor Format of Catalog Entities' page to 'String References' were broken as they exist in a different file (`references.md`) - these should now work.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
