### PR TITLE
Add stripFirstDirectoryFromPath parameter on fetch:template action

### DIFF
--- a/.changeset/fifty-hairs-nail.md
+++ b/.changeset/fifty-hairs-nail.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+fetch:template now accept parameter stripFirstDirectoryFromPath (default=false)
+
+usage sample:
+
+```diff
+    - id: fetch-base
+      name: Fetch Base
+      action: fetch:template
+      input:
+        url: ./template
++       stripFirstDirectoryFromPath: true
+        values:
+          name: '{{ parameters.name }}'
+          owner: '{{ parameters.owner }}'
+```

--- a/.changeset/odd-rivers-check.md
+++ b/.changeset/odd-rivers-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+export function stripFirstDirectoryFromPath

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -598,6 +598,11 @@ export interface StatusCheckHandlerOptions {
   statusCheck?: StatusCheck;
 }
 
+// Warning: (ae-missing-release-tag) "stripFirstDirectoryFromPath" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function stripFirstDirectoryFromPath(path: string): string;
+
 // Warning: (ae-missing-release-tag) "UrlReader" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public

--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -26,3 +26,4 @@ export * from './reading';
 export * from './scm';
 export * from './service';
 export * from './util';
+export * from './reading/tree/util';

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -15,7 +15,11 @@
  */
 
 import { resolve as resolvePath, extname } from 'path';
-import { resolveSafeChildPath, UrlReader } from '@backstage/backend-common';
+import {
+  resolveSafeChildPath,
+  UrlReader,
+  stripFirstDirectoryFromPath,
+} from '@backstage/backend-common';
 import { InputError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
 import { fetchContents } from './helpers';
@@ -50,6 +54,7 @@ type ExtensionInput = {
 export type FetchTemplateInput = {
   url: string;
   targetPath?: string;
+  stripFirstDirectoryFromPath?: boolean;
   values: any;
 } & CookieCompatInput &
   ExtensionInput;
@@ -74,6 +79,12 @@ export function createFetchTemplateAction(options: {
             description:
               'Relative path or absolute URL pointing to the directory tree to fetch',
             type: 'string',
+          },
+          stripFirstDirectoryFromPath: {
+            title: 'Strip First Directory From File Path',
+            description:
+              'When writing files to the new directory, strip the first path.',
+            type: 'boolean',
           },
           targetPath: {
             title: 'Target Path',
@@ -227,7 +238,9 @@ export function createFetchTemplateAction(options: {
         let renderFilename: boolean;
         let renderContents: boolean;
 
-        let localOutputPath = location;
+        let localOutputPath = ctx.input.stripFirstDirectoryFromPath
+          ? stripFirstDirectoryFromPath(location)
+          : location;
         if (extension) {
           renderFilename = true;
           renderContents = extname(localOutputPath) === extension;


### PR DESCRIPTION
Signed-off-by: Tarcisio Ambrosio Wensing <tarcisio.wensing@midway.com.br>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Before this merge: https://github.com/backstage/backstage/commit/a365f1faf4dbb262062775e3d000dd93c5851235 , the templater was downloading the zip archieve from azure devops and stripping the first directory by default, but it was stripping the directory for the tech docs too (see issue: https://github.com/backstage/backstage/issues/5708 and https://github.com/backstage/backstage/issues/4359)

After the merge the behavior changed, so the tech docs was correctly not removing the first directory for each folder in the root repository, but now the templater is not stripping the first folder (skeleton or any other name), 


result without this pull request (Azure DevOps cloud instance)

![image](https://user-images.githubusercontent.com/5432351/131772764-c7bcf4ca-4016-485f-9d6e-67a712197cb7.png)


result with this changes and flag intentionally true

![image](https://user-images.githubusercontent.com/5432351/131772850-e8710207-c3fe-44ad-88d2-f05829e1d88a.png)

I've added the flag in the `fetch:template` since it will be useful not only for Azure DevOps Cloud and this will make this pull request not a breaking change

![image](https://user-images.githubusercontent.com/5432351/131773980-704577e2-9789-4f5e-920c-40a81605b7fe.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
