### PR TITLE
Add additionalKnexConfig section to the config

### DIFF
--- a/.changeset/swift-clocks-cry.md
+++ b/.changeset/swift-clocks-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Add additionalKnexConfig config section

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -69,6 +69,11 @@ export interface Config {
        * Defaults to true if unspecified.
        */
       ensureExists?: boolean;
+      /**
+       * Arbitrary config object to pass to knex when initialising (https://knexjs.org/#Installation-client).
+       * Most notable is the debug and asyncStackTraces booleans
+       */
+      additionalKnexConfig: object;
       /** Plugin specific database configuration and client override */
       plugin?: {
         [pluginId: string]: {
@@ -84,6 +89,13 @@ export interface Config {
            * Defaults to base config if unspecified.
            */
           ensureExists?: boolean;
+          /**
+           * Arbitrary config object to pass to knex when initialising (https://knexjs.org/#Installation-client).
+           * Most notable is the debug and asyncStackTraces booleans.
+           *
+           * This is merged recursively into the base additionalKnexConfig
+           */
+          additionalKnexConfig: object;
         };
       };
     };

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -73,7 +73,7 @@ export interface Config {
        * Arbitrary config object to pass to knex when initialising (https://knexjs.org/#Installation-client).
        * Most notable is the debug and asyncStackTraces booleans
        */
-      additionalKnexConfig: object;
+      additionalKnexConfig?: object;
       /** Plugin specific database configuration and client override */
       plugin?: {
         [pluginId: string]: {
@@ -95,7 +95,7 @@ export interface Config {
            *
            * This is merged recursively into the base additionalKnexConfig
            */
-          additionalKnexConfig: object;
+          additionalKnexConfig?: object;
         };
       };
     };


### PR DESCRIPTION
Add the ability to set arbitrary knex options from the backstage app-config. This will be most useful to set `debug` or `asyncStackTraces` but has been left generic to support the other options.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
