### PR TITLE
todo: fix TodoList table column widths

### DIFF
--- a/.changeset/breezy-camels-bake.md
+++ b/.changeset/breezy-camels-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-todo': patch
+---
+
+Fix TodoList table column widths

--- a/plugins/todo/src/components/TodoList/TodoList.tsx
+++ b/plugins/todo/src/components/TodoList/TodoList.tsx
@@ -34,19 +34,20 @@ const columns: TableColumn<TodoItem>[] = [
   {
     title: 'Tag',
     field: 'tag',
+    width: '10%',
     filtering: false,
   },
   {
     title: 'Text',
     field: 'text',
-    width: '100%',
+    width: '55%',
     highlight: true,
     render: ({ text }) => <OverflowTooltip text={text} />,
   },
   {
     title: 'File',
     field: 'repoFilePath',
-    width: '80%',
+    width: '25%',
     render: ({ viewUrl, repoFilePath }) =>
       viewUrl ? (
         <Link to={viewUrl} target="_blank">
@@ -59,7 +60,7 @@ const columns: TableColumn<TodoItem>[] = [
   {
     title: 'Author',
     field: 'author',
-    width: '20%',
+    width: '10%',
     render: ({ author }) => <OverflowTooltip text={author} />,
   },
 ];


### PR DESCRIPTION
Seems like something changed in material-table recently, which got the column widths screwed up a bit :)

From

![image](https://user-images.githubusercontent.com/4984472/131871357-08cf15c3-614b-45b2-bfd7-df863336f76a.png)

to

![image](https://user-images.githubusercontent.com/4984472/131871451-8f4bf256-d88e-47ae-93a4-9981ad78a71f.png)
