### PR TITLE
fix: scaffolder backend fetch:template preserves file permissions when templating

### DIFF
--- a/.changeset/breezy-gifts-wave.md
+++ b/.changeset/breezy-gifts-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix issue #7021 scaffolder action fetch:template preserves templates file permissions

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
@@ -146,6 +146,10 @@ describe('fetch:template', () => {
         mockFetchContents.mockImplementation(({ outputPath }) => {
           mockFs({
             [outputPath]: {
+              'an-executable.sh': mockFs.file({
+                content: '#!/usr/bin/env bash',
+                mode: parseInt('100755', 8),
+              }),
               'empty-dir-${{ values.count }}': {},
               'static.txt': 'static content',
               '${{ values.name }}.txt': 'static content',
@@ -210,6 +214,13 @@ describe('fetch:template', () => {
         await expect(
           fs.readFile(`${workspacePath}/target/a-binary-file.png`),
         ).resolves.toEqual(aBinaryFile);
+      });
+      it('copies files and maintains the original file permissions', async () => {
+        await expect(
+          fs
+            .stat(`${workspacePath}/target/an-executable.sh`)
+            .then(fObj => fObj.mode),
+        ).resolves.toEqual(parseInt('100755', 8));
       });
     });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -262,8 +262,9 @@ export function createFetchTemplateAction(options: {
             );
             await fs.copy(inputFilePath, outputPath);
           } else {
+            const statsObj = await fs.stat(inputFilePath);
             ctx.logger.info(
-              `Writing file ${location} to template output path.`,
+              `Writing file ${location} to template output path. mode: ${statsObj.mode}`,
             );
             const inputFileContents = await fs.readFile(inputFilePath, 'utf-8');
             await fs.outputFile(
@@ -272,6 +273,7 @@ export function createFetchTemplateAction(options: {
                 ? templater.renderString(inputFileContents, context)
                 : inputFileContents,
             );
+            await fs.chmod(outputPath, statsObj.mode);
           }
         }
       }

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -272,8 +272,8 @@ export function createFetchTemplateAction(options: {
               renderContents
                 ? templater.renderString(inputFileContents, context)
                 : inputFileContents,
+              { mode: statsObj.mode },
             );
-            await fs.chmod(outputPath, statsObj.mode);
           }
         }
       }

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -264,7 +264,7 @@ export function createFetchTemplateAction(options: {
           } else {
             const statsObj = await fs.stat(inputFilePath);
             ctx.logger.info(
-              `Writing file ${location} to template output path. mode: ${statsObj.mode}`,
+              `Writing file ${location} to template output path with mode ${statsObj.mode}.`,
             );
             const inputFileContents = await fs.readFile(inputFilePath, 'utf-8');
             await fs.outputFile(


### PR DESCRIPTION
## Fix for issue #7021 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This change reads the file permissions of the template file and when writing the contents of the templated file, it includes the mode to preserve the original template file permission.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
