### PR TITLE
Fix BottomLink warning

### DIFF
--- a/.changeset/bright-birds-jog.md
+++ b/.changeset/bright-birds-jog.md
@@ -1,0 +1,14 @@
+---
+'@backstage/core-components': patch
+---
+
+Fix warning produced by BottomLink component
+
+During development, we noticed warnings such as:
+
+```
+react_devtools_backend.js:2842 Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
+```
+
+The BottomLink component renders a Box component within a Typography component which leads to a div tag within a p tag.
+This change inverts that ordering without changing the visual appearance.

--- a/packages/core-components/src/layout/BottomLink/BottomLink.tsx
+++ b/packages/core-components/src/layout/BottomLink/BottomLink.tsx
@@ -49,11 +49,11 @@ export const BottomLink = ({ link, title, onClick }: BottomLinkProps) => {
       <Divider />
       <Link to={link} onClick={onClick} underline="none">
         <Box display="flex" alignItems="center" className={classes.root}>
-          <Typography>
-            <Box className={classes.boxTitle} fontWeight="fontWeightBold" m={1}>
-              {title}
-            </Box>
-          </Typography>
+          <Box className={classes.boxTitle} fontWeight="fontWeightBold" m={1}>
+            <Typography>
+              <strong>{title}</strong>
+            </Typography>
+          </Box>
           <ArrowIcon className={classes.arrow} />
         </Box>
       </Link>


### PR DESCRIPTION
During local development the component causes a warning to be logged due to a div being rendered inside a p tag.
This doesn't affect prod deployments seems to be dev mode only.

This change inverts the tags whilst maintaining appearance (a strong tag is also added to maintain the heavier font-weight - it could be a style though)

Before:
<img width="409" alt="before-visual" src="https://user-images.githubusercontent.com/1415599/132008471-129d1ace-397e-4266-8c7d-2276217ce595.png">
<img width="584" alt="before-styles" src="https://user-images.githubusercontent.com/1415599/132008483-ff75afa0-7376-47ac-a7f4-98e4b4d67add.png">


After:
<img width="413" alt="after-visual" src="https://user-images.githubusercontent.com/1415599/132008496-3b94ce40-9ef7-4a0a-81cd-d99368f09c7f.png">
<img width="574" alt="after-styles" src="https://user-images.githubusercontent.com/1415599/132008518-fe9fb532-8beb-49e3-b785-ad56b5a6e71c.png">

Alternatives:

I tried simply removing the typography element but this affected the final line height.


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
