### PR TITLE
Modify TechDocsCollator and Search to be aware of new urls

### DIFF
--- a/.changeset/fluffy-peas-care.md
+++ b/.changeset/fluffy-peas-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Modify TechDocsCollator to be aware of new TechDocs URL pattern

--- a/.changeset/fluffy-peas-care.md
+++ b/.changeset/fluffy-peas-care.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/plugin-techdocs-backend': patch
+'@backstage/plugin-techdocs': patch
 ---
 
-Modify TechDocsCollator to be aware of new TechDocs URL pattern
+Modify TechDocsCollator to be aware of new TechDocs URL pattern. Modify tech docs in context search to use correct casing when creating initial filter.

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -76,10 +76,6 @@ export default async function createPlugin({
     collator: DefaultTechDocsCollator.fromConfig(config, {
       discovery,
       logger,
-      legacyPathCasing:
-        config.getOptionalBoolean(
-          'techdocs.legacyUseCaseSensitiveTripletPaths',
-        ) || false,
     }),
   });
 

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -73,7 +73,14 @@ export default async function createPlugin({
 
   indexBuilder.addCollator({
     defaultRefreshIntervalSeconds: 600,
-    collator: new DefaultTechDocsCollator({ discovery, logger }),
+    collator: new DefaultTechDocsCollator({
+      discovery,
+      logger,
+      legacyPathCasing:
+        config.getOptionalBoolean(
+          'techdocs.legacyUseCaseSensitiveTripletPaths',
+        ) || false,
+    }),
   });
 
   // The scheduler controls when documents are gathered from collators and sent

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -73,7 +73,7 @@ export default async function createPlugin({
 
   indexBuilder.addCollator({
     defaultRefreshIntervalSeconds: 600,
-    collator: new DefaultTechDocsCollator({
+    collator: DefaultTechDocsCollator.fromConfig(config, {
       discovery,
       logger,
       legacyPathCasing:

--- a/plugins/techdocs-backend/api-report.md
+++ b/plugins/techdocs-backend/api-report.md
@@ -25,6 +25,9 @@ export function createRouter(options: RouterOptions): Promise<express.Router>;
 //
 // @public (undocumented)
 export class DefaultTechDocsCollator implements DocumentCollator {
+  // Warning: (ae-forgotten-export) The symbol "TechDocsCollatorOptions" needs to be exported by the entry point index.d.ts
+  //
+  // @deprecated
   constructor({
     discovery,
     locationTemplate,
@@ -32,14 +35,7 @@ export class DefaultTechDocsCollator implements DocumentCollator {
     catalogClient,
     parallelismLimit,
     legacyPathCasing,
-  }: {
-    discovery: PluginEndpointDiscovery;
-    logger: Logger_2;
-    locationTemplate?: string;
-    catalogClient?: CatalogApi;
-    parallelismLimit?: number;
-    legacyPathCasing?: boolean;
-  });
+  }: TechDocsCollatorOptions);
   // (undocumented)
   protected applyArgsToFormat(
     format: string,
@@ -49,6 +45,11 @@ export class DefaultTechDocsCollator implements DocumentCollator {
   protected discovery: PluginEndpointDiscovery;
   // (undocumented)
   execute(): Promise<TechDocsDocument[]>;
+  // (undocumented)
+  static fromConfig(
+    _config: Config,
+    options: TechDocsCollatorOptions,
+  ): DefaultTechDocsCollator;
   // (undocumented)
   protected locationTemplate: string;
   // (undocumented)

--- a/plugins/techdocs-backend/api-report.md
+++ b/plugins/techdocs-backend/api-report.md
@@ -31,12 +31,14 @@ export class DefaultTechDocsCollator implements DocumentCollator {
     logger,
     catalogClient,
     parallelismLimit,
+    legacyPathCasing,
   }: {
     discovery: PluginEndpointDiscovery;
     logger: Logger_2;
     locationTemplate?: string;
     catalogClient?: CatalogApi;
     parallelismLimit?: number;
+    legacyPathCasing?: boolean;
   });
   // (undocumented)
   protected applyArgsToFormat(

--- a/plugins/techdocs-backend/api-report.md
+++ b/plugins/techdocs-backend/api-report.md
@@ -47,7 +47,7 @@ export class DefaultTechDocsCollator implements DocumentCollator {
   execute(): Promise<TechDocsDocument[]>;
   // (undocumented)
   static fromConfig(
-    _config: Config,
+    config: Config,
     options: TechDocsCollatorOptions,
   ): DefaultTechDocsCollator;
   // (undocumented)

--- a/plugins/techdocs-backend/api-report.md
+++ b/plugins/techdocs-backend/api-report.md
@@ -25,8 +25,6 @@ export function createRouter(options: RouterOptions): Promise<express.Router>;
 //
 // @public (undocumented)
 export class DefaultTechDocsCollator implements DocumentCollator {
-  // Warning: (ae-forgotten-export) The symbol "TechDocsCollatorOptions" needs to be exported by the entry point index.d.ts
-  //
   // @deprecated
   constructor({
     discovery,
@@ -55,6 +53,18 @@ export class DefaultTechDocsCollator implements DocumentCollator {
   // (undocumented)
   readonly type: string;
 }
+
+// Warning: (ae-missing-release-tag) "TechDocsCollatorOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TechDocsCollatorOptions = {
+  discovery: PluginEndpointDiscovery;
+  logger: Logger_2;
+  locationTemplate?: string;
+  catalogClient?: CatalogApi;
+  parallelismLimit?: number;
+  legacyPathCasing?: boolean;
+};
 
 export { TechDocsDocument };
 

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.test.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.test.ts
@@ -83,7 +83,7 @@ const expectedEntities: Entity[] = [
   },
 ];
 
-describe('DefaultTechDocsCollator', () => {
+describe('DefaultTechDocsCollator with legacyPathCasing configuration', () => {
   let mockDiscoveryApi: jest.Mocked<PluginEndpointDiscovery>;
   let collator: DefaultTechDocsCollator;
 
@@ -97,6 +97,7 @@ describe('DefaultTechDocsCollator', () => {
     collator = new DefaultTechDocsCollator({
       discovery: mockDiscoveryApi,
       logger,
+      legacyPathCasing: true,
     });
 
     worker.use(
@@ -124,6 +125,50 @@ describe('DefaultTechDocsCollator', () => {
       expect(document).toMatchObject({
         title: mockSearchDocIndex.docs[idx].title,
         location: `/docs/default/Component/${entity.metadata.name}/${mockSearchDocIndex.docs[idx].location}`,
+        text: mockSearchDocIndex.docs[idx].text,
+        namespace: 'default',
+        componentType: entity!.spec!.type,
+        lifecycle: entity!.spec!.lifecycle,
+        owner: '',
+      });
+    });
+  });
+});
+
+describe('DefaultTechDocsCollator', () => {
+  let mockDiscoveryApi: jest.Mocked<PluginEndpointDiscovery>;
+  let collator: DefaultTechDocsCollator;
+
+  const worker = setupServer();
+  msw.setupDefaultHandlers(worker);
+  beforeEach(() => {
+    mockDiscoveryApi = {
+      getBaseUrl: jest.fn().mockResolvedValue('http://test-backend'),
+      getExternalBaseUrl: jest.fn(),
+    };
+    collator = new DefaultTechDocsCollator({
+      discovery: mockDiscoveryApi,
+      logger,
+    });
+
+    worker.use(
+      rest.get(
+        'http://test-backend/static/docs/default/component/test-entity-with-docs/search/search_index.json',
+        (_, res, ctx) => res(ctx.status(200), ctx.json(mockSearchDocIndex)),
+      ),
+      rest.get('http://test-backend/entities', (_, res, ctx) =>
+        res(ctx.status(200), ctx.json(expectedEntities)),
+      ),
+    );
+  });
+
+  it('should create documents for each tech docs search index', async () => {
+    const documents = await collator.execute();
+    const entity = expectedEntities[0];
+    documents.forEach((document, idx) => {
+      expect(document).toMatchObject({
+        title: mockSearchDocIndex.docs[idx].title,
+        location: `/docs/default/component/${entity.metadata.name}/${mockSearchDocIndex.docs[idx].location}`,
         text: mockSearchDocIndex.docs[idx].text,
         namespace: 'default',
         componentType: entity!.spec!.type,

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.test.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.test.ts
@@ -23,6 +23,7 @@ import { DefaultTechDocsCollator } from './DefaultTechDocsCollator';
 import { msw } from '@backstage/test-utils';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
+import { ConfigReader } from '@backstage/config';
 
 const logger = getVoidLogger();
 
@@ -94,7 +95,12 @@ describe('DefaultTechDocsCollator with legacyPathCasing configuration', () => {
       getBaseUrl: jest.fn().mockResolvedValue('http://test-backend'),
       getExternalBaseUrl: jest.fn(),
     };
-    collator = new DefaultTechDocsCollator({
+    const mockConfig = new ConfigReader({
+      techdocs: {
+        legacyUseCaseSensitiveTripletPaths: true,
+      },
+    });
+    collator = DefaultTechDocsCollator.fromConfig(mockConfig, {
       discovery: mockDiscoveryApi,
       logger,
       legacyPathCasing: true,
@@ -146,7 +152,7 @@ describe('DefaultTechDocsCollator', () => {
       getBaseUrl: jest.fn().mockResolvedValue('http://test-backend'),
       getExternalBaseUrl: jest.fn(),
     };
-    collator = new DefaultTechDocsCollator({
+    collator = DefaultTechDocsCollator.fromConfig(new ConfigReader({}), {
       discovery: mockDiscoveryApi,
       logger,
     });

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
@@ -76,8 +76,12 @@ export class DefaultTechDocsCollator implements DocumentCollator {
     this.legacyPathCasing = legacyPathCasing;
   }
 
-  static fromConfig(_config: Config, options: TechDocsCollatorOptions) {
-    return new DefaultTechDocsCollator(options);
+  static fromConfig(config: Config, options: TechDocsCollatorOptions) {
+    const legacyPathCasing =
+      config.getOptionalBoolean(
+        'techdocs.legacyUseCaseSensitiveTripletPaths',
+      ) || false;
+    return new DefaultTechDocsCollator({ ...options, legacyPathCasing });
   }
 
   async execute() {

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
@@ -31,7 +31,7 @@ interface MkSearchIndexDoc {
   location: string;
 }
 
-type TechDocsCollatorOptions = {
+export type TechDocsCollatorOptions = {
   discovery: PluginEndpointDiscovery;
   logger: Logger;
   locationTemplate?: string;
@@ -173,7 +173,7 @@ export class DefaultTechDocsCollator implements DocumentCollator {
     return legacyPaths
       ? entityInfo
       : Object.entries(entityInfo).reduce((acc, [key, value]) => {
-          return { ...acc, [key]: value.toLowerCase() };
+          return { ...acc, [key]: value.toLocaleLowerCase('en-US') };
         }, {} as EntityInfo);
   }
 }

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
@@ -36,6 +36,7 @@ export class DefaultTechDocsCollator implements DocumentCollator {
   private readonly logger: Logger;
   private readonly catalogClient: CatalogApi;
   private readonly parallelismLimit: number;
+  private readonly legacyPathCasing: boolean;
   public readonly type: string = 'techdocs';
 
   constructor({
@@ -44,12 +45,14 @@ export class DefaultTechDocsCollator implements DocumentCollator {
     logger,
     catalogClient,
     parallelismLimit = 10,
+    legacyPathCasing = false,
   }: {
     discovery: PluginEndpointDiscovery;
     logger: Logger;
     locationTemplate?: string;
     catalogClient?: CatalogApi;
     parallelismLimit?: number;
+    legacyPathCasing?: boolean;
   }) {
     this.discovery = discovery;
     this.locationTemplate =
@@ -58,6 +61,7 @@ export class DefaultTechDocsCollator implements DocumentCollator {
     this.catalogClient =
       catalogClient || new CatalogClient({ discoveryApi: discovery });
     this.parallelismLimit = parallelismLimit;
+    this.legacyPathCasing = legacyPathCasing;
   }
 
   async execute() {
@@ -80,7 +84,9 @@ export class DefaultTechDocsCollator implements DocumentCollator {
       .map((entity: Entity) =>
         limit(async (): Promise<TechDocsDocument[]> => {
           const entityInfo = {
-            kind: entity.kind,
+            kind: this.legacyPathCasing
+              ? entity.kind
+              : entity.kind.toLowerCase(),
             namespace: entity.metadata.namespace || 'default',
             name: entity.metadata.name,
           };

--- a/plugins/techdocs-backend/src/search/index.ts
+++ b/plugins/techdocs-backend/src/search/index.ts
@@ -15,6 +15,8 @@
  */
 export { DefaultTechDocsCollator } from './DefaultTechDocsCollator';
 
+export type { TechDocsCollatorOptions } from './DefaultTechDocsCollator';
+
 /**
  * @deprecated Use directly from @backstage/techdocs-common
  */

--- a/plugins/techdocs/src/reader/components/TechDocsSearch.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsSearch.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import { TechDocsSearch } from './TechDocsSearch';
+import { buildInitialFilters, TechDocsSearch } from './TechDocsSearch';
 import {
   act,
   fireEvent,
@@ -89,7 +89,7 @@ describe('<TechDocsPage />', () => {
       await singleResult;
       expect(querySpy).toBeCalledWith({
         filters: {
-          kind: 'Testable',
+          kind: 'testable',
           name: 'test',
           namespace: 'testspace',
         },
@@ -108,7 +108,7 @@ describe('<TechDocsPage />', () => {
       await waitFor(() =>
         expect(querySpy).toBeCalledWith({
           filters: {
-            kind: 'Testable',
+            kind: 'testable',
             name: 'test',
             namespace: 'testspace',
           },
@@ -117,6 +117,26 @@ describe('<TechDocsPage />', () => {
           types: ['techdocs'],
         }),
       );
+    });
+  });
+});
+
+describe('buildInitialFilters', () => {
+  const filterEnt = {
+    name: 'Test',
+    kind: 'TestKind',
+    namespace: 'TeStNaMeSpAcE',
+  };
+  it('should use filters as is when legacy path', () => {
+    const filters = buildInitialFilters(true, filterEnt);
+    expect(filters).toStrictEqual(filterEnt);
+  });
+  it('should lowercase all filters for new approach', () => {
+    const filters = buildInitialFilters(false, filterEnt);
+    expect(filters).toStrictEqual({
+      name: 'test',
+      kind: 'testkind',
+      namespace: 'testnamespace',
     });
   });
 });

--- a/plugins/techdocs/src/reader/components/TechDocsSearch.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsSearch.tsx
@@ -61,7 +61,7 @@ export const buildInitialFilters = (
   return legacyPaths
     ? entityId
     : Object.entries(entityId).reduce((acc, [key, value]) => {
-        return { ...acc, [key]: value.toLowerCase() };
+        return { ...acc, [key]: value.toLocaleLowerCase('en-US') };
       }, {});
 };
 

--- a/plugins/techdocs/src/reader/components/TechDocsSearch.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsSearch.tsx
@@ -16,11 +16,11 @@
 
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import {
+  CircularProgress,
   Grid,
   IconButton,
   InputAdornment,
   TextField,
-  CircularProgress,
 } from '@material-ui/core';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import { SearchContextProvider, useSearch } from '@backstage/plugin-search';
@@ -28,13 +28,15 @@ import { DocsResultListItem } from '../../components/DocsResultListItem';
 import SearchIcon from '@material-ui/icons/Search';
 import { useDebounce } from 'react-use';
 import { useNavigate } from 'react-router';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
+type EntityId = {
+  name: string;
+  namespace: string;
+  kind: string;
+};
 type TechDocsSearchProps = {
-  entityId: {
-    name: string;
-    namespace: string;
-    kind: string;
-  };
+  entityId: EntityId;
   debounceTime?: number;
 };
 
@@ -50,6 +52,17 @@ type TechDocsDoc = {
 type TechDocsSearchResult = {
   type: string;
   document: TechDocsDoc;
+};
+
+export const buildInitialFilters = (
+  legacyPaths: boolean,
+  entityId: EntityId,
+) => {
+  return legacyPaths
+    ? entityId
+    : Object.entries(entityId).reduce((acc, [key, value]) => {
+        return { ...acc, [key]: value.toLowerCase() };
+      }, {});
 };
 
 const TechDocsSearchBar = ({
@@ -161,12 +174,17 @@ const TechDocsSearchBar = ({
     </Grid>
   );
 };
+
 const TechDocsSearch = (props: TechDocsSearchProps) => {
+  const configApi = useApi(configApiRef);
+  const legacyPaths = configApi.getOptionalBoolean(
+    'techdocs.legacyUseCaseSensitiveTripletPaths',
+  );
   const initialState = {
     term: '',
     types: ['techdocs'],
     pageCursor: '',
-    filters: props.entityId,
+    filters: buildInitialFilters(legacyPaths || false, props.entityId),
   };
   return (
     <SearchContextProvider initialState={initialState}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* Add boolean constructor param to define if to use legacy paths
* Swap urls to match new pattern
* Add few tests
* Modify tech docs search initial filter to be aware of new url patterns

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
