### PR TITLE
Fix Template Load Error

### DIFF
--- a/.changeset/strong-pears-wink.md
+++ b/.changeset/strong-pears-wink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fix display error when it fails to load a template (/create) page

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -136,7 +136,7 @@ export class ScaffolderClient implements ScaffolderApi {
     });
 
     if (!response.ok) {
-      throw ResponseError.fromResponse(response);
+      throw await ResponseError.fromResponse(response);
     }
 
     const schema: TemplateParameterSchema = await response.json();


### PR DESCRIPTION
Signed-off-by: OscarDHdz <v-ohernandez@expediagroup.com>

## Hey, I just made a Pull Request!

Adding missing `await` to properly show errors when opening a Template in the /create page.
Without it, it shows:
> ![Screen Shot 2021-09-03 at 9 39 39](https://user-images.githubusercontent.com/18434722/132023482-5854f012-a083-4d79-bde4-5feb5062256c.png)

After change it shows:
> ![Screen Shot 2021-09-03 at 9 41 10](https://user-images.githubusercontent.com/18434722/132023742-d6ac24c9-37d2-4809-bc12-2fd2281a0674.png)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
