### PR TITLE
Fix chromatic build error on SearchBar Component

### DIFF
--- a/plugins/search/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.test.tsx
@@ -21,7 +21,11 @@ import { SearchContextProvider } from '../SearchContext';
 
 import { SearchBar } from './SearchBar';
 import { configApiRef } from '@backstage/core-plugin-api';
-import { ApiProvider, ApiRegistry } from '@backstage/core-app-api';
+import {
+  ApiProvider,
+  ApiRegistry,
+  ConfigReader,
+} from '@backstage/core-app-api';
 import { searchApiRef } from '../../apis';
 
 jest.mock('@backstage/core-plugin-api', () => ({
@@ -37,10 +41,9 @@ describe('SearchBar', () => {
   };
 
   const query = jest.fn().mockResolvedValue({});
-  const getOptionalString = jest.fn().mockReturnValue('Mock title');
 
   const apiRegistry = ApiRegistry.from([
-    [configApiRef, { getOptionalString }],
+    [configApiRef, new ConfigReader({ app: { title: 'Mock title' } })],
     [searchApiRef, { query }],
   ]);
 

--- a/plugins/search/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.test.tsx
@@ -37,10 +37,10 @@ describe('SearchBar', () => {
   };
 
   const query = jest.fn().mockResolvedValue({});
-  const getString = jest.fn().mockReturnValue('Mock title');
+  const getOptionalString = jest.fn().mockReturnValue('Mock title');
 
   const apiRegistry = ApiRegistry.from([
-    [configApiRef, { getString }],
+    [configApiRef, { getOptionalString }],
     [searchApiRef, { query }],
   ]);
 

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -55,7 +55,8 @@ export const SearchBarBase = ({
   }, [onChange]);
 
   const placeholder =
-    overridePlaceholder ?? `Search in ${configApi.getString('app.title')}`;
+    overridePlaceholder ??
+    `Search in ${configApi.getOptionalString('app.title') || 'Backstage'}`;
 
   return (
     <InputBase


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up to #7013 that fixes [this, for example](https://www.chromatic.com/test?appId=5eafd13eaebb8f00227540f4&id=613519637d9795003afb43a1)

![Screenshot 2021-09-05 at 21 46 49](https://user-images.githubusercontent.com/3496491/132139603-2d3ceba0-9882-4b4c-a44a-b4e2b218ed48.png)

Thinking a changeset is not needed, since it's basically covered by the changeset introduced in #7013.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
