### PR TITLE
feat(plugin-scaffolder-backend): Validate webhook event names

### DIFF
--- a/.changeset/long-walls-tie.md
+++ b/.changeset/long-walls-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+GitHub Webhook action in Scaffolder Backend has been improved to validate event names against Octokit Webhook event names list.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -179,7 +179,7 @@ export function createRouter(options: RouterOptions): Promise<express.Router>;
 // @public (undocumented)
 export const createTemplateAction: <
   Input extends Partial<{
-    [name: string]: JsonValue | Partial<JsonObject> | undefined;
+    [name: string]: Partial<JsonObject> | JsonValue | undefined;
   }>,
 >(
   templateAction: TemplateAction<Input>,

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -179,7 +179,7 @@ export function createRouter(options: RouterOptions): Promise<express.Router>;
 // @public (undocumented)
 export const createTemplateAction: <
   Input extends Partial<{
-    [name: string]: Partial<JsonObject> | JsonValue | undefined;
+    [name: string]: JsonValue | Partial<JsonObject> | undefined;
   }>,
 >(
   templateAction: TemplateAction<Input>,

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -39,6 +39,7 @@
     "@gitbeaker/core": "^30.2.0",
     "@gitbeaker/node": "^30.2.0",
     "@octokit/rest": "^18.5.3",
+    "@octokit/webhooks": "^9.14.1",
     "@types/express": "^4.17.6",
     "azure-devops-node-api": "^11.0.1",
     "command-exists": "^1.2.9",

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
@@ -205,4 +205,62 @@ describe('github:repository:webhook:create', () => {
       },
     });
   });
+
+  it('should validate input', async () => {
+    const Validator = require('jsonschema').Validator;
+    const v = new Validator();
+
+    // validate default input without events specified
+    expect(v.validate(mockContext.input, action.schema?.input).valid).toBe(
+      true,
+    );
+
+    const inputWithValidEvent = {
+      ...mockContext.input,
+      events: ['push'],
+    };
+    expect(v.validate(inputWithValidEvent, action.schema?.input).valid).toBe(
+      true,
+    );
+
+    const inputWithMultipleValidEvents = {
+      ...mockContext.input,
+      events: ['push', 'pull_request'],
+    };
+    expect(
+      v.validate(inputWithMultipleValidEvents, action.schema?.input).valid,
+    ).toBe(true);
+
+    const inputWithInvalidEvent = {
+      ...mockContext.input,
+      events: ['unexpected_event'],
+    };
+    expect(v.validate(inputWithInvalidEvent, action.schema?.input).valid).toBe(
+      false,
+    );
+
+    const inputWithOneInvalidEvent = {
+      ...mockContext.input,
+      events: ['push', 'unexpected_event'],
+    };
+    expect(
+      v.validate(inputWithOneInvalidEvent, action.schema?.input).valid,
+    ).toBe(false);
+
+    const inputWithAllEvents = {
+      ...mockContext.input,
+      events: ['*'],
+    };
+    expect(v.validate(inputWithAllEvents, action.schema?.input).valid).toBe(
+      true,
+    );
+
+    const inputWithAllEventsAndMore = {
+      ...mockContext.input,
+      events: ['*', 'push'],
+    };
+    expect(
+      v.validate(inputWithAllEventsAndMore, action.schema?.input).valid,
+    ).toBe(false);
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
@@ -16,6 +16,7 @@
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { createTemplateAction } from '../../createTemplateAction';
 import { OctokitProvider } from './OctokitProvider';
+import { emitterEventNames } from '@octokit/webhooks';
 
 type ContentType = 'form' | 'json';
 
@@ -25,6 +26,7 @@ export function createGithubWebhookAction(options: {
 }) {
   const { integrations, defaultWebhookSecret } = options;
   const octokitProvider = new OctokitProvider(integrations);
+  const eventNames = emitterEventNames.filter(event => !event.includes('.'));
 
   return createTemplateAction<{
     repoUrl: string;
@@ -63,9 +65,20 @@ export function createGithubWebhookAction(options: {
             description:
               'Determines what events the hook is triggered for. Default: push',
             type: 'array',
-            items: {
-              type: 'string',
-            },
+            oneOf: [
+              {
+                items: {
+                  type: 'string',
+                  enum: eventNames,
+                },
+              },
+              {
+                items: {
+                  type: 'string',
+                  const: '*',
+                },
+              },
+            ],
           },
           active: {
             title: 'Active',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4861,7 +4861,7 @@
     "@octokit/types" "^6.16.2"
     deprecation "^2.3.1"
 
-"@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
+"@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.2", "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
   version "2.1.0"
   resolved "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
   integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
@@ -4905,6 +4905,26 @@
   integrity sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==
   dependencies:
     "@octokit/openapi-types" "^7.3.2"
+
+"@octokit/webhooks-methods@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-2.0.0.tgz#1108b9ea661ca6c81e4a8bfa63a09eb27d5bc2db"
+  integrity sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig==
+
+"@octokit/webhooks-types@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-4.4.0.tgz#0985964b72d577221574cca614770e0743fe0830"
+  integrity sha512-gK9L2pWLZ1CWWlf9zwzFBQeA3dgyWdRe6gqAedR5T7adFZpoHg4De6GeXIFySV796ooQtKhW4eFfQLFQF5ydAA==
+
+"@octokit/webhooks@^9.14.1":
+  version "9.14.1"
+  resolved "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.14.1.tgz#d1b8fcc4c1c18ee46ec30cef9e84043b57c8d2dd"
+  integrity sha512-INsqtHKQJys5NbuE71kq6uR8BMSSkZ2L9dLanAc1jylGroQ80SW1TYXLuJlcYNakNrHCCe4c5qvNKfR/KJXrJA==
+  dependencies:
+    "@octokit/request-error" "^2.0.2"
+    "@octokit/webhooks-methods" "^2.0.0"
+    "@octokit/webhooks-types" "4.4.0"
+    aggregate-error "^3.1.0"
 
 "@open-draft/until@^1.0.3":
   version "1.0.3"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Webhook event names are validated against Octokit Webhooks `emitterEventNames`. Note `emitterEventNames` contains event/action combinations as well that are comma delimited:https://github.com/octokit/webhooks.js/blob/master/README.md#emittereventnames. Therefore, extracting strings without '.' provides list of all events.

"@octokit/webhooks" version 9.14.0 is the minimum requirement because this is a version where I introduced exported `emitterEventNames` to be used here.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
