### PR TITLE
Allow loading users using group membership

### DIFF
--- a/.changeset/chilly-pumpkins-invent.md
+++ b/.changeset/chilly-pumpkins-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Allow loading users using group membership

--- a/plugins/catalog-backend-module-msgraph/README.md
+++ b/plugins/catalog-backend-module-msgraph/README.md
@@ -55,14 +55,19 @@ catalog:
           # Optional filter for user, see Microsoft Graph API for the syntax
           # See https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties
           # and for the syntax https://docs.microsoft.com/en-us/graph/query-parameters#filter-parameter
+          # This and userGroupMemberFilter are mutually exclusive, only one can be specified
           userFilter: accountEnabled eq true and userType eq 'member'
-          # Optional filter for users, use group membership to get users
-          # This appends the users to the list of users retrieved via userFilter
+          # Optional filter for users, use group membership to get users.
+          # This and userFilter are mutually exclusive, only one can be specified
           userGroupMemberFilter: "displayName eq 'Backstage Users'"
           # Optional filter for group, see Microsoft Graph API for the syntax
           # See https://docs.microsoft.com/en-us/graph/api/resources/group?view=graph-rest-1.0#properties
           groupFilter: securityEnabled eq false and mailEnabled eq true and groupTypes/any(c:c+eq+'Unified')
 ```
+
+`userFilter` and `userGroupMemberFilter` are mutually exclusive, only one can be provided. If both are provided, an error will be thrown.
+
+By default, all users are loaded. If you want to filter users based on their attributes, use `userFilter`. `userGroupMemberFilter` can be used if you want to load users based on their group membership.
 
 5. Add a location that ingests from Microsoft Graph:
 

--- a/plugins/catalog-backend-module-msgraph/README.md
+++ b/plugins/catalog-backend-module-msgraph/README.md
@@ -56,6 +56,9 @@ catalog:
           # See https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties
           # and for the syntax https://docs.microsoft.com/en-us/graph/query-parameters#filter-parameter
           userFilter: accountEnabled eq true and userType eq 'member'
+          # Optional filter for users, use group membership to get users
+          # This appends the users to the list of users retrieved via userFilter
+          userGroupMemberFilter: "displayName eq 'Backstage Users'"
           # Optional filter for group, see Microsoft Graph API for the syntax
           # See https://docs.microsoft.com/en-us/graph/api/resources/group?view=graph-rest-1.0#properties
           groupFilter: securityEnabled eq false and mailEnabled eq true and groupTypes/any(c:c+eq+'Unified')

--- a/plugins/catalog-backend-module-msgraph/api-report.md
+++ b/plugins/catalog-backend-module-msgraph/api-report.md
@@ -143,6 +143,7 @@ export type MicrosoftGraphProviderConfig = {
   clientId: string;
   clientSecret: string;
   userFilter?: string;
+  userGroupMemberFilter?: string;
   groupFilter?: string;
 };
 
@@ -173,6 +174,7 @@ export function readMicrosoftGraphOrg(
   tenantId: string,
   options: {
     userFilter?: string;
+    userGroupMemberFilter?: string;
     groupFilter?: string;
     userTransformer?: UserTransformer;
     groupTransformer?: GroupTransformer;

--- a/plugins/catalog-backend-module-msgraph/config.d.ts
+++ b/plugins/catalog-backend-module-msgraph/config.d.ts
@@ -73,6 +73,12 @@ export interface Config {
            * E.g. "securityEnabled eq false and mailEnabled eq true"
            */
           groupFilter?: string;
+          /**
+           * The filter to apply to extract users by groups memberships.
+           *
+           * E.g. "displayName eq 'Backstage Users'"
+           */
+          userGroupMemberFilter?: string;
         }>;
       };
     };

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
@@ -52,6 +52,12 @@ export type MicrosoftGraphProviderConfig = {
    */
   userFilter?: string;
   /**
+   * The filter to apply to extract users by groups memberships.
+   *
+   * E.g. "displayName eq 'Backstage Users'"
+   */
+  userGroupMemberFilter?: string;
+  /**
    * The filter to apply to extract groups.
    *
    * E.g. "securityEnabled eq false and mailEnabled eq true"
@@ -74,6 +80,9 @@ export function readMicrosoftGraphConfig(
     const clientId = providerConfig.getString('clientId');
     const clientSecret = providerConfig.getString('clientSecret');
     const userFilter = providerConfig.getOptionalString('userFilter');
+    const userGroupMemberFilter = providerConfig.getOptionalString(
+      'userGroupMemberFilter',
+    );
     const groupFilter = providerConfig.getOptionalString('groupFilter');
 
     providers.push({
@@ -83,6 +92,7 @@ export function readMicrosoftGraphConfig(
       clientId,
       clientSecret,
       userFilter,
+      userGroupMemberFilter,
       groupFilter,
     });
   }

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
@@ -125,6 +125,95 @@ export async function readMicrosoftGraphUsers(
   return { users };
 }
 
+export async function readMicrosoftGraphUsersInGroups(
+  client: MicrosoftGraphClient,
+  options: {
+    userGroupMemberFilter?: string;
+    transformer?: UserTransformer;
+    logger: Logger;
+  },
+): Promise<{
+  users: UserEntity[]; // With all relations empty
+}> {
+  const users: UserEntity[] = [];
+
+  if (!options.userGroupMemberFilter) {
+    return { users };
+  }
+
+  const limiter = limiterFactory(10);
+
+  const transformer = options?.transformer ?? defaultUserTransformer;
+  const userGroupMemberPromises: Promise<void>[] = [];
+  const userPromises: Promise<void>[] = [];
+
+  const groupMemberUsers: Set<string> = new Set();
+
+  for await (const group of client.getGroups({
+    filter: options?.userGroupMemberFilter,
+  })) {
+    // Process all groups in parallel, otherwise it can take quite some time
+    userGroupMemberPromises.push(
+      limiter(async () => {
+        for await (const member of client.getGroupMembers(group.id!)) {
+          if (!member.id) {
+            continue;
+          }
+
+          if (member['@odata.type'] === '#microsoft.graph.user') {
+            if (!groupMemberUsers.has(member.id)) {
+              groupMemberUsers.add(member.id);
+            }
+          }
+        }
+      }),
+    );
+  }
+
+  // Wait for all group members
+  await Promise.all(userGroupMemberPromises);
+
+  options.logger.info(`groupMemberUsers ${groupMemberUsers.size}`);
+  for (const userId of groupMemberUsers) {
+    // Process all users in parallel, otherwise it can take quite some time
+    userPromises.push(
+      limiter(async () => {
+        let user;
+        let userPhoto;
+        try {
+          user = await client.getUserProfile(userId);
+        } catch (e) {
+          options.logger.warn(`Unable to load user for ${userId}`);
+        }
+        if (user) {
+          try {
+            userPhoto = await client.getUserPhotoWithSizeLimit(
+              user.id!,
+              // We are limiting the photo size, as users with full resolution photos
+              // can make the Backstage API slow
+              120,
+            );
+          } catch (e) {
+            options.logger.warn(`Unable to load userphoto for ${userId}`);
+          }
+
+          const entity = await transformer(user, userPhoto);
+
+          if (!entity) {
+            return;
+          }
+          users.push(entity);
+        }
+      }),
+    );
+  }
+
+  // Wait for all users and photos to be downloaded
+  await Promise.all(userPromises);
+
+  return { users };
+}
+
 export async function defaultOrganizationTransformer(
   organization: MicrosoftGraph.Organization,
 ): Promise<GroupEntity | undefined> {
@@ -387,6 +476,7 @@ export async function readMicrosoftGraphOrg(
   tenantId: string,
   options: {
     userFilter?: string;
+    userGroupMemberFilter?: string;
     groupFilter?: string;
     userTransformer?: UserTransformer;
     groupTransformer?: GroupTransformer;
@@ -394,11 +484,23 @@ export async function readMicrosoftGraphOrg(
     logger: Logger;
   },
 ): Promise<{ users: UserEntity[]; groups: GroupEntity[] }> {
-  const { users } = await readMicrosoftGraphUsers(client, {
+  const { users: usersInGroups } = await readMicrosoftGraphUsersInGroups(
+    client,
+    {
+      userGroupMemberFilter: options.userGroupMemberFilter,
+      transformer: options.userTransformer,
+      logger: options.logger,
+    },
+  );
+
+  const { users: usersWithFilter } = await readMicrosoftGraphUsers(client, {
     userFilter: options.userFilter,
     transformer: options.userTransformer,
     logger: options.logger,
   });
+
+  const users: UserEntity[] = usersWithFilter.concat(usersInGroups);
+
   const { groups, rootGroup, groupMember, groupMemberOf } =
     await readMicrosoftGraphGroups(client, tenantId, {
       groupFilter: options?.groupFilter,

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
@@ -101,6 +101,7 @@ export class MicrosoftGraphOrgReaderProcessor implements CatalogProcessor {
       provider.tenantId,
       {
         userFilter: provider.userFilter,
+        userGroupMemberFilter: provider.userGroupMemberFilter,
         groupFilter: provider.groupFilter,
         userTransformer: this.userTransformer,
         groupTransformer: this.groupTransformer,

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
@@ -90,6 +90,12 @@ export class MicrosoftGraphOrgReaderProcessor implements CatalogProcessor {
       );
     }
 
+    if (provider.userFilter && provider.userGroupMemberFilter) {
+      throw new Error(
+        `userFilter and userGroupMemberFilter are mutually exclusive, only one can be specified.`,
+      );
+    }
+
     // Read out all of the raw data
     const startTimestamp = Date.now();
     this.logger.info('Reading Microsoft Graph users and groups');


### PR DESCRIPTION
The userFilter loads users by filtering on their attributes only.
This allows to load users based on group membership e.g. for cases
where only a certain set of users should be loaded using their
group membership

Signed-off-by: Mustansar Anwar ul Samad <mustansar.samad@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
