### PR TITLE
Ownerships card page theme

### DIFF
--- a/.changeset/lucky-lies-count.md
+++ b/.changeset/lucky-lies-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Make ownership card style customizable via custom `theme.getPageTheme()`.

--- a/.changeset/sour-bees-pretend.md
+++ b/.changeset/sour-bees-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Use correct `Link` in ownership card to avoid a full reload of the app while navigating.

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -29,7 +29,7 @@ import {
   isOwnerOf,
   useEntity,
 } from '@backstage/plugin-catalog-react';
-import { BackstageTheme, genPageTheme } from '@backstage/theme';
+import { BackstageTheme } from '@backstage/theme';
 import {
   Box,
   createStyles,
@@ -47,16 +47,6 @@ type EntityTypeProps = {
   kind: string;
   type: string;
   count: number;
-};
-
-const createPageTheme = (
-  theme: BackstageTheme,
-  shapeKey: string,
-  colorsKey: string,
-) => {
-  const { colors } = theme.getPageTheme({ themeId: colorsKey });
-  const { shape } = theme.getPageTheme({ themeId: shapeKey });
-  return genPageTheme(colors, shape).backgroundImage;
 };
 
 const useStyles = makeStyles((theme: BackstageTheme) =>
@@ -77,7 +67,7 @@ const useStyles = makeStyles((theme: BackstageTheme) =>
     },
     entityTypeBox: {
       background: (props: { type: string }) =>
-        createPageTheme(theme, props.type, props.type),
+        theme.getPageTheme({ themeId: props.type }).backgroundImage,
     },
   }),
 );

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -18,6 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 import {
   InfoCard,
   InfoCardVariants,
+  Link,
   Progress,
   ResponseErrorPanel,
 } from '@backstage/core-components';
@@ -34,13 +35,11 @@ import {
   Box,
   createStyles,
   Grid,
-  Link,
   makeStyles,
   Typography,
 } from '@material-ui/core';
 import qs from 'qs';
 import React from 'react';
-import { generatePath } from 'react-router';
 import { useAsync } from 'react-use';
 
 type EntityTypeProps = {
@@ -86,7 +85,7 @@ const EntityCountTile = ({
   const classes = useStyles({ type });
 
   return (
-    <Link href={url} variant="body2">
+    <Link to={url} variant="body2">
       <Box
         className={`${classes.card} ${classes.entityTypeBox}`}
         display="flex"
@@ -208,7 +207,7 @@ export const OwnershipCard = ({
               counter={c.counter}
               type={c.type}
               name={c.name}
-              url={generatePath(`${catalogLink()}/?${c.queryParams}`)}
+              url={`${catalogLink()}/?${c.queryParams}`}
             />
           </Grid>
         ))}


### PR DESCRIPTION
This PR includes two changes:

1. It fixed the ownership card to use the Backstage `Link` component to make sure that routing happens without a page refresh. I missed that when removing `target=_blank` some days ago.
2. It changes the styling of the ownership card to come fully out of the page theme (`createPageTheme`). Previously it still called the default page theme function (`genPageTheme`) instead of using the one from the theme. Not sure why 🤔 But that way it's very difficult to apply fully custom styling. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
