### PR TITLE
Make styling of groups tab in the explore page use the Backstage theme

### DIFF
--- a/.changeset/brave-eggs-rush.md
+++ b/.changeset/brave-eggs-rush.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+---
+
+Change the styling of the `<DependencyGraph>` to have more contrast in light
+mode. Nodes now have a design similar to material UI buttons.

--- a/.changeset/ten-dolls-ring.md
+++ b/.changeset/ten-dolls-ring.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Make styling of groups tab in the explore page use the Backstage theme instead
+of hard coded colors. Change the layout to be full screen.

--- a/packages/core-components/src/components/DependencyGraph/DefaultNode.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DefaultNode.tsx
@@ -21,11 +21,11 @@ import { RenderNodeProps } from './types';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   node: {
-    fill: theme.palette.background.paper,
-    stroke: theme.palette.border,
+    fill: theme.palette.primary.light,
+    stroke: theme.palette.primary.light,
   },
   text: {
-    fill: theme.palette.textContrast,
+    fill: theme.palette.primary.contrastText,
   },
 }));
 

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -26,7 +26,7 @@ import {
   getEntityRelations,
   formatEntityRefTitle,
 } from '@backstage/plugin-catalog-react';
-import { makeStyles, Typography } from '@material-ui/core';
+import { makeStyles, Typography, useTheme } from '@material-ui/core';
 import ZoomOutMap from '@material-ui/icons/ZoomOutMap';
 import React from 'react';
 import { useAsync } from 'react-use';
@@ -42,16 +42,20 @@ import {
 import { useApi, useRouteRef, configApiRef } from '@backstage/core-plugin-api';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
+  graph: {
+    flex: 1,
+    minHeight: 0,
+  },
   organizationNode: {
-    fill: 'coral',
-    stroke: theme.palette.border,
+    fill: theme.palette.background.paper,
+    stroke: theme.palette.primary.main,
   },
   groupNode: {
-    fill: 'yellowgreen',
+    fill: theme.palette.background.paper,
     stroke: theme.palette.border,
   },
   centeredContent: {
-    padding: '10px',
+    padding: theme.spacing(1),
     height: '100%',
     display: 'flex',
     alignItems: 'center',
@@ -59,6 +63,7 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
     color: 'black',
   },
   textWrapper: {
+    color: theme.palette.textContrast,
     display: '-webkit-box',
     WebkitBoxOrient: 'vertical',
     WebkitLineClamp: 2,
@@ -70,14 +75,10 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
   },
 }));
 
-const dimensions = {
-  nodeWidth: 180,
-  nodeHeight: 90,
-  nodeCornerRadius: 20,
-  nodeAligmentShift: 5,
-};
-
 function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
+  const nodeWidth = 180;
+  const nodeHeight = 80;
+  const theme = useTheme();
   const classes = useStyles();
   const catalogEntityRoute = useRouteRef(entityRouteRef);
 
@@ -85,16 +86,13 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
     return (
       <g>
         <rect
-          width={dimensions.nodeWidth}
-          height={dimensions.nodeHeight}
-          rx={dimensions.nodeCornerRadius}
+          width={nodeWidth}
+          height={nodeHeight}
+          rx={theme.shape.borderRadius}
           className={classes.organizationNode}
         />
         <title>{props.node.name}</title>
-        <foreignObject
-          width={dimensions.nodeWidth}
-          height={dimensions.nodeHeight}
-        >
+        <foreignObject width={nodeWidth} height={nodeHeight}>
           <div className={classes.centeredContent}>
             <div className={classes.textWrapper}>{props.node.name}</div>
           </div>
@@ -108,9 +106,9 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
   return (
     <g>
       <rect
-        width={dimensions.nodeWidth}
-        height={dimensions.nodeHeight}
-        rx={dimensions.nodeCornerRadius}
+        width={nodeWidth}
+        height={nodeHeight}
+        rx={theme.shape.borderRadius}
         className={classes.groupNode}
       />
       <title>{props.node.name}</title>
@@ -122,10 +120,7 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
           name: ref.name,
         })}
       >
-        <foreignObject
-          width={dimensions.nodeWidth}
-          height={dimensions.nodeHeight}
-        >
+        <foreignObject width={nodeWidth} height={nodeHeight}>
           <div className={classes.centeredContent}>
             <div className={classes.textWrapper}>{props.node.name}</div>
           </div>
@@ -146,6 +141,7 @@ export function GroupsDiagram() {
   }>();
   const edges = new Array<{ from: string; to: string; label: string }>();
 
+  const classes = useStyles();
   const configApi = useApi(configApiRef);
   const catalogApi = useApi(catalogApiRef);
   const organizationName =
@@ -218,6 +214,7 @@ export function GroupsDiagram() {
         nodeMargin={10}
         direction={DependencyGraphTypes.Direction.RIGHT_LEFT}
         renderNode={RenderNode}
+        className={classes.graph}
       />
       <Typography
         variant="caption"

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -15,31 +15,31 @@
  */
 
 import {
+  GroupEntity,
+  parseEntityRef,
   RELATION_CHILD_OF,
   stringifyEntityRef,
-  parseEntityRef,
-  GroupEntity,
 } from '@backstage/catalog-model';
-import {
-  catalogApiRef,
-  entityRouteRef,
-  getEntityRelations,
-  formatEntityRefTitle,
-} from '@backstage/plugin-catalog-react';
-import { makeStyles, Typography, useTheme } from '@material-ui/core';
-import ZoomOutMap from '@material-ui/icons/ZoomOutMap';
-import React from 'react';
-import { useAsync } from 'react-use';
-import { BackstageTheme } from '@backstage/theme';
-
 import {
   DependencyGraph,
   DependencyGraphTypes,
+  Link,
   Progress,
   ResponseErrorPanel,
-  Link,
 } from '@backstage/core-components';
-import { useApi, useRouteRef, configApiRef } from '@backstage/core-plugin-api';
+import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
+import {
+  catalogApiRef,
+  entityRouteRef,
+  formatEntityRefTitle,
+  getEntityRelations,
+} from '@backstage/plugin-catalog-react';
+import { BackstageTheme } from '@backstage/theme';
+import { makeStyles, Typography, useTheme } from '@material-ui/core';
+import ZoomOutMap from '@material-ui/icons/ZoomOutMap';
+import classNames from 'classnames';
+import React from 'react';
+import { useAsync } from 'react-use';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
   graph: {
@@ -47,12 +47,12 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
     minHeight: 0,
   },
   organizationNode: {
-    fill: theme.palette.background.paper,
-    stroke: theme.palette.primary.main,
+    fill: theme.palette.secondary.light,
+    stroke: theme.palette.secondary.light,
   },
   groupNode: {
-    fill: theme.palette.background.paper,
-    stroke: theme.palette.border,
+    fill: theme.palette.primary.light,
+    stroke: theme.palette.primary.light,
   },
   centeredContent: {
     padding: theme.spacing(1),
@@ -62,8 +62,13 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
     justifyContent: 'center',
     color: 'black',
   },
+  textOrganization: {
+    color: theme.palette.secondary.contrastText,
+  },
+  textGroup: {
+    color: theme.palette.primary.contrastText,
+  },
   textWrapper: {
-    color: theme.palette.textContrast,
     display: '-webkit-box',
     WebkitBoxOrient: 'vertical',
     WebkitLineClamp: 2,
@@ -77,7 +82,7 @@ const useStyles = makeStyles((theme: BackstageTheme) => ({
 
 function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
   const nodeWidth = 180;
-  const nodeHeight = 80;
+  const nodeHeight = 60;
   const theme = useTheme();
   const classes = useStyles();
   const catalogEntityRoute = useRouteRef(entityRouteRef);
@@ -94,7 +99,14 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
         <title>{props.node.name}</title>
         <foreignObject width={nodeWidth} height={nodeHeight}>
           <div className={classes.centeredContent}>
-            <div className={classes.textWrapper}>{props.node.name}</div>
+            <div
+              className={classNames(
+                classes.textWrapper,
+                classes.textOrganization,
+              )}
+            >
+              {props.node.name}
+            </div>
           </div>
         </foreignObject>
       </g>
@@ -122,7 +134,9 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
       >
         <foreignObject width={nodeWidth} height={nodeHeight}>
           <div className={classes.centeredContent}>
-            <div className={classes.textWrapper}>{props.node.name}</div>
+            <div className={classNames(classes.textWrapper, classes.textGroup)}>
+              {props.node.name}
+            </div>
           </div>
         </foreignObject>
       </Link>

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.tsx
@@ -21,6 +21,15 @@ import {
   ContentHeader,
   SupportButton,
 } from '@backstage/core-components';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  root: {
+    height: '100%',
+    maxHeight: '100%',
+    minHeight: 0,
+  },
+});
 
 type GroupsExplorerContentProps = {
   title?: string;
@@ -29,8 +38,10 @@ type GroupsExplorerContentProps = {
 export const GroupsExplorerContent = ({
   title,
 }: GroupsExplorerContentProps) => {
+  const classes = useStyles();
+
   return (
-    <Content noPadding>
+    <Content noPadding stretch className={classes.root}>
       <ContentHeader title={title ?? 'Groups'}>
         <SupportButton>Explore your groups.</SupportButton>
       </ContentHeader>


### PR DESCRIPTION
It the current style annoyed my a bit to much 😅 Looks like it was just the [example values from storybook ](https://backstage.io/storybook/?path=/story/data-display-dependencygraph--custom-nodes)😆 
I also changed the layout to be centered full screen. That way big diagram might be hard to read, but you can zoom in them. Previously you had to scroll down the page, which collides with the zooming functionality.

The system diagram has the same (default) look, but we aren't using it internally. We wrote a bigger graph plugin that could replace it once we made it open source.

**Before:**
![image](https://user-images.githubusercontent.com/648527/132481588-71f2cdcd-95b5-40c1-a688-58cda4257f8f.png)

![image](https://user-images.githubusercontent.com/648527/132481540-4f8d42ec-e61b-45f3-9230-dc04c025fe3f.png)

**After:**

![image](https://user-images.githubusercontent.com/648527/132480966-f8627632-3ae0-4945-abdf-0923f5481070.png)

![image](https://user-images.githubusercontent.com/648527/132481006-5b601f9a-a3c2-4c73-b7c2-958f7d364e50.png)



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
