### PR TITLE
feat: additional options for the elasticsearch client

### DIFF
--- a/.changeset/rotten-pears-live.md
+++ b/.changeset/rotten-pears-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Added rejectUnauthorized config option

--- a/plugins/search-backend-module-elasticsearch/config.d.ts
+++ b/plugins/search-backend-module-elasticsearch/config.d.ts
@@ -20,90 +20,103 @@ export interface Config {
     /**
      * Options for ElasticSearch
      */
-    elasticsearch?:
-      | // elastic = Elastic.co ElasticSearch provider
-      {
-          provider: 'elastic';
-
+    elasticsearch?: {
+      /** Miscellaneous options for the client */
+      clientOptions?: {
+        ssl?: {
           /**
-           * Elastic.co CloudID
-           * See: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-connecting.html#authentication
+           * If true the server will reject any connection which is not
+           * authorized with the list of supplied CAs.
+           * @default true
            */
-          cloudId: string;
-
-          auth: {
-            username: string;
+          rejectUnauthorized?: boolean;
+        };
+      } & (
+        | {
+            // elastic = Elastic.co ElasticSearch provider
+            provider: 'elastic';
 
             /**
-             * @visibility secret
+             * Elastic.co CloudID
+             * See: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-connecting.html#authentication
              */
-            password: string;
-          };
-        }
+            cloudId: string;
 
-      /**
-       *  AWS = Amazon Elasticsearch Service provider
-       *
-       *  Authentication is handled using the default AWS credentials provider chain
-       */
-      | {
-          provider: 'aws';
+            auth: {
+              username: string;
 
-          /**
-           * Node configuration.
-           * URL AWS ES endpoint to connect to.
-           * Eg. https://my-es-cluster.eu-west-1.es.amazonaws.com
-           */
-          node: string;
-        }
+              /**
+               * @visibility secret
+               */
+              password: string;
+            };
+          }
 
-      /**
-       * Standard ElasticSearch
-       *
-       * Includes self-hosted clusters and others that provide direct connection via an endpoint
-       * and authentication method (see possible authentication options below)
-       */
-      | {
-          /**
-           * Node configuration.
-           * URL/URLS to ElasticSearch node to connect to.
-           * Either direct URL like 'https://localhost:9200' or with credentials like 'https://username:password@localhost:9200'
-           */
-          node: string | string[];
-
-          /**
-           * Authentication credentials for ElasticSearch
-           * If both ApiKey/Bearer token and username+password is provided, tokens take precedence
-           */
-          auth?:
-            | {
-                username: string;
-
-                /**
-                 * @visibility secret
-                 */
-                password: string;
-              }
-            | {
-                /**
-                 * Base64 Encoded API key to be used to connect to the cluster.
-                 * See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
-                 *
-                 * @visibility secret
-                 */
-                apiKey: string;
-              };
-          /* TODO(kuangp): unsupported until @elastic/elasticsearch@7.14 is released
+        /**
+         *  AWS = Amazon Elasticsearch Service provider
+         *
+         *  Authentication is handled using the default AWS credentials provider chain
+         */
         | {
+            provider: 'aws';
 
-          /**
-           * Bearer authentication token to connect to the cluster.
-           * See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html
-           *
-           * @visibility secret
-           *
-          bearer: string;
-        };*/
-        };
+            /**
+             * Node configuration.
+             * URL AWS ES endpoint to connect to.
+             * Eg. https://my-es-cluster.eu-west-1.es.amazonaws.com
+             */
+            node: string;
+          }
+
+        /**
+         * Standard ElasticSearch
+         *
+         * Includes self-hosted clusters and others that provide direct connection via an endpoint
+         * and authentication method (see possible authentication options below)
+         */
+        | {
+            /**
+             * Node configuration.
+             * URL/URLS to ElasticSearch node to connect to.
+             * Either direct URL like 'https://localhost:9200' or with credentials like 'https://username:password@localhost:9200'
+             */
+            node: string | string[];
+
+            /**
+             * Authentication credentials for ElasticSearch
+             * If both ApiKey/Bearer token and username+password is provided, tokens take precedence
+             */
+            auth?:
+              | {
+                  username: string;
+
+                  /**
+                   * @visibility secret
+                   */
+                  password: string;
+                }
+              | {
+                  /**
+                   * Base64 Encoded API key to be used to connect to the cluster.
+                   * See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
+                   *
+                   * @visibility secret
+                   */
+                  apiKey: string;
+                };
+            /* TODO(kuangp): unsupported until @elastic/elasticsearch@7.14 is released
+    | {
+ 
+      /**
+       * Bearer authentication token to connect to the cluster.
+       * See: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html
+       *
+       * @visibility secret
+       *
+      bearer: string;
+    };*/
+          }
+      );
+    };
   };
 }

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -97,6 +97,9 @@ export class ElasticSearchSearchEngine implements SearchEngine {
       throw new Error('No elastic search config found');
     }
 
+    const clientOptionsConfig = config.getOptionalConfig('clientOptions');
+    const sslConfig = clientOptionsConfig?.getOptionalConfig('ssl');
+
     if (config.getOptionalString('provider') === 'elastic') {
       logger.info('Initializing Elastic.co ElasticSearch search engine.');
       const authConfig = config.getConfig('auth');
@@ -108,6 +111,14 @@ export class ElasticSearchSearchEngine implements SearchEngine {
           username: authConfig.getString('username'),
           password: authConfig.getString('password'),
         },
+        ...(sslConfig
+          ? {
+              ssl: {
+                rejectUnauthorized:
+                  sslConfig?.getOptionalBoolean('rejectUnauthorized'),
+              },
+            }
+          : {}),
       });
     }
     if (config.getOptionalString('provider') === 'aws') {
@@ -117,6 +128,14 @@ export class ElasticSearchSearchEngine implements SearchEngine {
       return new Client({
         node: config.getString('node'),
         ...AWSConnection,
+        ...(sslConfig
+          ? {
+              ssl: {
+                rejectUnauthorized:
+                  sslConfig?.getOptionalBoolean('rejectUnauthorized'),
+              },
+            }
+          : {}),
       });
     }
     logger.info('Initializing ElasticSearch search engine.');
@@ -134,6 +153,14 @@ export class ElasticSearchSearchEngine implements SearchEngine {
     return new Client({
       node: config.getString('node'),
       auth,
+      ...(sslConfig
+        ? {
+            ssl: {
+              rejectUnauthorized:
+                sslConfig?.getOptionalBoolean('rejectUnauthorized'),
+            },
+          }
+        : {}),
     });
   }
 


### PR DESCRIPTION
Enable users to specify additional options for the ElasticSearch client.

Context - we would like to disable certificate validation, but to do so we need a handle on the ClientOptions used to create the client. I imagine there are plenty of other cases where this might be useful.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
