### PR TITLE
chore(deps) bump git-url-parse from 11.4.4 to 11.6.0

### DIFF
--- a/.changeset/strong-geese-hope.md
+++ b/.changeset/strong-geese-hope.md
@@ -1,0 +1,13 @@
+---
+'@backstage/backend-common': patch
+'@backstage/integration': patch
+'@backstage/techdocs-common': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Upgrade git-parse-url to v11.6.0

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -49,7 +49,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "fs-extra": "9.1.0",
-    "git-url-parse": "~11.4.4",
+    "git-url-parse": "^11.6.0",
     "helmet": "^4.0.0",
     "isomorphic-git": "^1.8.0",
     "keyv": "^4.0.3",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@backstage/config": "^0.1.8",
     "cross-fetch": "^3.0.6",
-    "git-url-parse": "~11.4.4",
+    "git-url-parse": "^11.6.0",
     "@octokit/rest": "^18.5.3",
     "@octokit/auth-app": "^3.4.0",
     "luxon": "^2.0.2"

--- a/packages/techdocs-common/package.json
+++ b/packages/techdocs-common/package.json
@@ -50,7 +50,7 @@
     "aws-sdk": "^2.840.0",
     "express": "^4.17.1",
     "fs-extra": "9.1.0",
-    "git-url-parse": "~11.4.4",
+    "git-url-parse": "^11.6.0",
     "js-yaml": "^4.0.0",
     "json5": "^2.1.3",
     "mime-types": "^2.1.27",

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -47,7 +47,7 @@
     "express-promise-router": "^4.1.0",
     "fast-json-stable-stringify": "^2.1.0",
     "fs-extra": "9.1.0",
-    "git-url-parse": "~11.4.4",
+    "git-url-parse": "^11.6.0",
     "glob": "^7.1.6",
     "knex": "^0.95.1",
     "lodash": "^4.17.15",

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -43,7 +43,7 @@
     "@material-ui/lab": "4.0.0-alpha.45",
     "@octokit/rest": "^18.5.3",
     "@types/react": "*",
-    "git-url-parse": "~11.4.4",
+    "git-url-parse": "^11.6.0",
     "js-base64": "^3.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -44,7 +44,7 @@
     "@material-ui/lab": "4.0.0-alpha.45",
     "@types/react": "*",
     "classnames": "^2.2.6",
-    "git-url-parse": "~11.4.4",
+    "git-url-parse": "^11.6.0",
     "lodash": "^4.17.21",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -49,7 +49,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "fs-extra": "10.0.0",
-    "git-url-parse": "~11.4.4",
+    "git-url-parse": "^11.6.0",
     "globby": "^11.0.0",
     "handlebars": "^4.7.6",
     "helmet": "^4.0.0",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -47,7 +47,7 @@
     "@rjsf/material-ui": "^3.0.0",
     "@types/react": "*",
     "classnames": "^2.2.6",
-    "git-url-parse": "~11.4.4",
+    "git-url-parse": "^11.6.0",
     "humanize-duration": "^3.25.1",
     "immer": "^9.0.1",
     "json-schema": "^0.3.0",

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -49,7 +49,7 @@
     "@types/react": "*",
     "dompurify": "^2.2.9",
     "event-source-polyfill": "^1.0.25",
-    "git-url-parse": "~11.4.4",
+    "git-url-parse": "^11.6.0",
     "lodash": "^4.17.21",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14466,10 +14466,17 @@ git-up@^4.0.0:
     is-ssh "^1.3.0"
     parse-url "^5.0.0"
 
-git-url-parse@^11.4.4, git-url-parse@~11.4.4:
+git-url-parse@^11.4.4:
   version "11.4.4"
   resolved "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.4.4.tgz#5d747debc2469c17bc385719f7d0427802d83d77"
   integrity sha512-Y4o9o7vQngQDIU9IjyCmRJBin5iYjI5u9ZITnddRZpD7dcCFQj2sL2XuMNbLRE4b4B/4ENPsp2Q8P44fjAZ0Pw==
+  dependencies:
+    git-up "^4.0.0"
+
+git-url-parse@^11.6.0:
+  version "11.6.0"
+  resolved "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.6.0.tgz#c634b8de7faa66498a2b88932df31702c67df605"
+  integrity sha512-WWUxvJs5HsyHL6L08wOusa/IXYtMuCAhrMmnTjQPpBU0TTHyDhnOATNH3xNQz7YOQUsqIIPTGr4xiVti1Hsk5g==
   dependencies:
     git-up "^4.0.0"
 


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

## Hey, I just made a Pull Request!

This pull request will upgrade the git-parse-url library to the latest release that includes a fix for a regression when parsing paths located in subfolders. See https://github.com/IonicaBizau/git-url-parse/pull/131

This will also unlock the work on https://github.com/backstage/backstage/issues/6033

I have skipped the changeset since I saw that other dependency upgrades did not have a changeset. Please let me know if I should add a changeset or not.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
