### PR TITLE
Scaffolder: change the component of  categories filter

### DIFF
--- a/.changeset/poor-weeks-act.md
+++ b/.changeset/poor-weeks-act.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': patch
 ---
 
-Change the catagories filter to a dropdown component
+Change the Categories filter to a dropdown component

--- a/.changeset/poor-weeks-act.md
+++ b/.changeset/poor-weeks-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Change the catagories filter to a dropdown component

--- a/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.test.tsx
+++ b/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.test.tsx
@@ -94,6 +94,7 @@ describe('<TemplateTypePicker/>', () => {
       </ApiProvider>,
     );
     expect(rendered.getByText('Categories')).toBeInTheDocument();
+    fireEvent.click(rendered.getByTestId('categories-picker-expand'));
 
     entities.forEach(entity => {
       expect(
@@ -116,22 +117,27 @@ describe('<TemplateTypePicker/>', () => {
       </ApiProvider>,
     );
 
+    fireEvent.click(rendered.getByTestId('categories-picker-expand'));
     expect(rendered.getByLabelText('Service')).not.toBeChecked();
     expect(rendered.getByLabelText('Website')).not.toBeChecked();
 
     fireEvent.click(rendered.getByLabelText('Service'));
+    fireEvent.click(rendered.getByTestId('categories-picker-expand'));
     expect(rendered.getByLabelText('Service')).toBeChecked();
     expect(rendered.getByLabelText('Website')).not.toBeChecked();
 
     fireEvent.click(rendered.getByLabelText('Website'));
+    fireEvent.click(rendered.getByTestId('categories-picker-expand'));
     expect(rendered.getByLabelText('Service')).toBeChecked();
     expect(rendered.getByLabelText('Website')).toBeChecked();
 
     fireEvent.click(rendered.getByLabelText('Service'));
+    fireEvent.click(rendered.getByTestId('categories-picker-expand'));
     expect(rendered.getByLabelText('Service')).not.toBeChecked();
     expect(rendered.getByLabelText('Website')).toBeChecked();
 
     fireEvent.click(rendered.getByLabelText('Website'));
+    fireEvent.click(rendered.getByTestId('categories-picker-expand'));
     expect(rendered.getByLabelText('Service')).not.toBeChecked();
     expect(rendered.getByLabelText('Website')).not.toBeChecked();
   });

--- a/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.tsx
+++ b/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.tsx
@@ -21,22 +21,20 @@ import {
   Box,
   Checkbox,
   FormControlLabel,
-  FormGroup,
-  makeStyles,
-  Theme,
+  TextField,
   Typography,
 } from '@material-ui/core';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { Autocomplete } from '@material-ui/lab';
 import { useEntityTypeFilter } from '@backstage/plugin-catalog-react';
 import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 
-const useStyles = makeStyles<Theme>(theme => ({
-  checkbox: {
-    padding: theme.spacing(1, 1, 1, 2),
-  },
-}));
+const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
+const checkedIcon = <CheckBoxIcon fontSize="small" />;
 
 export const TemplateTypePicker = () => {
-  const classes = useStyles();
   const alertApi = useApi(alertApiRef);
   const { error, loading, availableTypes, selectedTypes, setSelectedTypes } =
     useEntityTypeFilter();
@@ -53,32 +51,31 @@ export const TemplateTypePicker = () => {
     return null;
   }
 
-  function toggleSelection(type: string) {
-    setSelectedTypes(
-      selectedTypes.includes(type)
-        ? selectedTypes.filter(t => t !== type)
-        : [...selectedTypes, type],
-    );
-  }
-
   return (
     <Box pb={1} pt={1}>
       <Typography variant="button">Categories</Typography>
-      <FormGroup>
-        {availableTypes.map(type => (
+      <Autocomplete<string>
+        multiple
+        aria-label="Categories"
+        options={availableTypes}
+        value={selectedTypes}
+        onChange={(_: object, value: string[]) => setSelectedTypes(value)}
+        renderOption={(option, { selected }) => (
           <FormControlLabel
             control={
               <Checkbox
-                checked={selectedTypes.includes(type)}
-                onChange={() => toggleSelection(type)}
-                className={classes.checkbox}
+                icon={icon}
+                checkedIcon={checkedIcon}
+                checked={selected}
               />
             }
-            label={capitalize(type)}
-            key={type}
+            label={option}
           />
-        ))}
-      </FormGroup>
+        )}
+        size="small"
+        popupIcon={<ExpandMoreIcon data-testid="categories-picker-expand" />}
+        renderInput={params => <TextField {...params} variant="outlined" />}
+      />
     </Box>
   );
 };

--- a/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.tsx
+++ b/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.tsx
@@ -69,7 +69,7 @@ export const TemplateTypePicker = () => {
                 checked={selected}
               />
             }
-            label={option}
+            label={capitalize(option)}
           />
         )}
         size="small"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Change the list component for categories filter that is currently use on ScaffolderPage to a Dropdown with the autocomplete in order to keep the same structure of the filters on that page. For more information please refer to [#7063](https://github.com/backstage/backstage/issues/7063)

<img width="1679" alt="Screen Shot 2021-09-08 at 11 16 22" src="https://user-images.githubusercontent.com/40499017/132554802-64813ad5-c9c5-4b3b-9183-fd5a920eef1c.png">
<img width="1676" alt="Screen Shot 2021-09-08 at 11 16 33" src="https://user-images.githubusercontent.com/40499017/132554812-0f6086d6-50be-45d4-91c4-ea3504e95ab9.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
