### PR TITLE
codeowners: add @backstage/reviewers ownership to some paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,18 +8,18 @@
 /docs/features/techdocs                     @backstage/techdocs-core
 /docs/features/search                       @backstage/techdocs-core
 /docs/assets/search                         @backstage/techdocs-core
-/plugins/code-coverage                      @alde @nissayeva
-/plugins/code-coverage-backend              @alde @nissayeva
+/plugins/code-coverage                      @backstage/reviewers @alde @nissayeva
+/plugins/code-coverage-backend              @backstage/reviewers @alde @nissayeva
 /plugins/cost-insights                      @backstage/silver-lining
-/plugins/cloudbuild                         @trivago/ebarrios
+/plugins/cloudbuild                         @backstage/reviewers @trivago/ebarrios
 /plugins/search                             @backstage/techdocs-core
 /plugins/search-*                           @backstage/techdocs-core
 /plugins/techdocs                           @backstage/techdocs-core
 /plugins/techdocs-backend                   @backstage/techdocs-core
-/plugins/ilert                              @yacut
+/plugins/ilert                              @backstage/reviewers @yacut
 /plugins/home                               @backstage/techdocs-core
 /packages/search-common                     @backstage/techdocs-core
 /packages/techdocs-common                   @backstage/techdocs-core
-/.changeset/cost-insights-*                 @backstage/silver-lining
+/.changeset/cost-insights-*                 @backstage/reviewers @backstage/silver-lining
 /.changeset/search-*                        @backstage/techdocs-core
 /.changeset/techdocs-*                      @backstage/techdocs-core


### PR DESCRIPTION
Need this so that we can get things like releases through without needing to urgently contact people x)