### PR TITLE
github/workflows: add snyk monitoring workflow

### DIFF
--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -1,0 +1,29 @@
+name: Snyk Monitoring
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - '.snyk'
+      - '.github/workflows/snyk-monitor.yml'
+      - '**/package.json'
+      - 'yarn.lock'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Monitor and Synchronize Snyk Policies
+        uses: snyk/actions/node@master
+        with:
+          command: monitor
+          args: >
+            --yarn-workspaces
+            --policy-path=.snyk
+            --org=backstage-dgh
+            --strict-out-of-sync=false
+            --remote-repo-url=https://github.com/backstage/backstage
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Been toying around quite a bit and this seems the way to go with vulnerability scanning for now.

This will let us manage policies for all packages through the root `.snyk` file, which means that anyone that wants to copy that set of policies can do so. The maintainer team  will get notified whenever a new vulnerability is detected, but we will not have vulnerability scanning on PRs.

We could run tests on PRs using the snyk CLI, but that check only looks if there are any vulnerabilities at all, not just if a PR introduces any. That means that PRs could suddenly start breaking when a new vulnerability is published, which I think we should avoid.

The nicer check from Snyk is the GitHub integration one, but unfortunately it doesn't seem to play well with `.snyk` config files or yarn workspaces. Which is why I'm thinking we settle on this for now 
