### PR TITLE
snyk: move .snyk into each package dir instead of a single root one

### DIFF
--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -21,7 +21,6 @@ jobs:
           command: monitor
           args: >
             --yarn-workspaces
-            --policy-path=.snyk
             --org=backstage-dgh
             --strict-out-of-sync=false
             --remote-repo-url=https://github.com/backstage/backstage

--- a/packages/app/.snyk
+++ b/packages/app/.snyk
@@ -3,7 +3,7 @@ version: v1.22.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JS-ANSIHTML-1296849:
-    - '@backstage/cli > webpack-dev-server > ansi-html':
+    - 'webpack-dev-server > ansi-html':
         reason: Developer tools are not a valid target for ReDoS attacks
         expires: 2022-03-06T17:18:55.019Z
         created: 2021-09-06T17:18:55.027Z


### PR DESCRIPTION
Having the policies in the root turned out to be awkward because you can't include the target package in the dependency path, meaning you'll end up with a hierarchy that is a bit too flat. There could for example be a vulnerability that is fine to ignore in the CLI, but not in `backend-common`. This moves over to having a separate `.snyk` file in each package, which isn't as nice of a collected place to keep all policies, but it may at least play a bit nicer with package publishing in the future.