### PR TITLE
Fix import for createPlugin in example snippet

### DIFF
--- a/.changeset/grumpy-beds-design.md
+++ b/.changeset/grumpy-beds-design.md
@@ -1,0 +1,5 @@
+---
+"@backstage/plugin-user-settings": patch
+---
+
+Fix import for createPlugin in example snippet

--- a/.changeset/grumpy-beds-design.md
+++ b/.changeset/grumpy-beds-design.md
@@ -1,5 +1,5 @@
 ---
-"@backstage/plugin-user-settings": patch
+'@backstage/plugin-user-settings': patch
 ---
 
-Fix import for createPlugin in example snippet
+Fix import for `createPlugin` in example snippet

--- a/plugins/user-settings/src/components/FeatureFlags/EmptyFlags.tsx
+++ b/plugins/user-settings/src/components/FeatureFlags/EmptyFlags.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { Button, Typography } from '@material-ui/core';
 import { CodeSnippet, EmptyState } from '@backstage/core-components';
 
-const EXAMPLE = `import { createPlugin } from '@backstage/core';
+const EXAMPLE = `import { createPlugin } from '@backstage/core-plugin-api';
 
 export default createPlugin({
   id: 'plugin-name',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixing docs - matching https://backstage.io/docs/reference/createPlugin-feature-flags

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
