### PR TITLE
Improve UX for Login modal

### DIFF
--- a/.changeset/short-mugs-drive.md
+++ b/.changeset/short-mugs-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Improve UX for Login pop-up

--- a/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
+++ b/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
@@ -21,6 +21,7 @@ import {
   makeStyles,
   Typography,
   Theme,
+  Button,
 } from '@material-ui/core';
 import React, { useState } from 'react';
 import { PendingAuthRequest } from '@backstage/core-plugin-api';
@@ -55,12 +56,7 @@ const LoginRequestListItem = ({ request, busy, setBusy }: RowProps) => {
   const IconComponent = request.provider.icon;
 
   return (
-    <ListItem
-      button
-      disabled={busy}
-      onClick={handleContinue}
-      classes={{ root: classes.root }}
-    >
+    <ListItem button disabled={busy} classes={{ root: classes.root }}>
       <ListItemAvatar>
         <IconComponent fontSize="large" />
       </ListItemAvatar>
@@ -74,6 +70,9 @@ const LoginRequestListItem = ({ request, busy, setBusy }: RowProps) => {
           )
         }
       />
+      <Button color="primary" variant="contained" onClick={handleContinue}>
+        Log in
+      </Button>
     </ListItem>
   );
 };

--- a/packages/core-components/src/components/OAuthRequestDialog/OAuthRequestDialog.tsx
+++ b/packages/core-components/src/components/OAuthRequestDialog/OAuthRequestDialog.tsx
@@ -39,6 +39,9 @@ const useStyles = makeStyles<Theme>(theme => ({
   contentList: {
     padding: 0,
   },
+  actionButtons: {
+    padding: theme.spacing(2),
+  },
 }));
 
 export const OAuthRequestDialog = () => {
@@ -65,7 +68,7 @@ export const OAuthRequestDialog = () => {
         Login Required
       </DialogTitle>
 
-      <DialogContent classes={{ root: classes.contentList }}>
+      <DialogContent dividers classes={{ root: classes.contentList }}>
         <List>
           {requests.map(request => (
             <LoginRequestListItem
@@ -78,8 +81,10 @@ export const OAuthRequestDialog = () => {
         </List>
       </DialogContent>
 
-      <DialogActions>
-        <Button onClick={handleRejectAll}>Reject All</Button>
+      <DialogActions classes={{ root: classes.actionButtons }}>
+        <Button variant="contained" color="secondary" onClick={handleRejectAll}>
+          Reject All
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/packages/core-components/src/components/OAuthRequestDialog/OAuthRequestDialog.tsx
+++ b/packages/core-components/src/components/OAuthRequestDialog/OAuthRequestDialog.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles<Theme>(theme => ({
     padding: 0,
   },
   actionButtons: {
-    padding: theme.spacing(2),
+    padding: theme.spacing(2, 0),
   },
 }));
 
@@ -82,9 +82,7 @@ export const OAuthRequestDialog = () => {
       </DialogContent>
 
       <DialogActions classes={{ root: classes.actionButtons }}>
-        <Button variant="contained" color="secondary" onClick={handleRejectAll}>
-          Reject All
-        </Button>
+        <Button onClick={handleRejectAll}>Reject All</Button>
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is a suggestion to include more obvious CTA in login popup, it is a small change, but may be an improvement for overall UX  :) 

Currently 

<img width="1418" alt="Screenshot 2021-09-10 at 14 02 22" src="https://user-images.githubusercontent.com/7230518/132857246-4355508c-2335-47ef-8c23-6093524b6e28.png">

Suggestion

<img width="1417" alt="Screenshot 2021-09-10 at 14 02 55" src="https://user-images.githubusercontent.com/7230518/132857277-d90dc10f-aae6-4aba-8876-3910754b9439.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
