### PR TITLE
docs: add a heads up about dockerignore for multi-stage builds

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -113,6 +113,9 @@ browser at `http://localhost:7000`
 
 ## Multi-stage Build
 
+> NOTE: The `.dockerignore` is different in this setup, read on for more
+> details.
+
 This section describes how to set up a multi-stage Docker build that builds the
 entire project within Docker. This is typically slower than a host build, but is
 sometimes desired because Docker in Docker is not available in the build
@@ -137,6 +140,7 @@ WORKDIR /app
 COPY package.json yarn.lock ./
 
 COPY packages packages
+# Comment this out if you don't have any internal plugins
 COPY plugins plugins
 
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
@@ -182,8 +186,9 @@ end up being properly installed.
 
 To speed up the build when not running in a fresh clone of the repo you should
 set up a `.dockerignore`. This one is different than the host build one, because
-we want to have access to the source code of all packages for the build, but can
-ignore any existing build output or dependencies:
+we want to have access to the source code of all packages for the build. We can
+however ignore any existing build output or dependencies on the host. For our
+new `.dockerignore`, replace the contents of your existing one with this:
 
 ```text
 node_modules


### PR DESCRIPTION
A common point of confusion, so adding a note and clarifying the procedure a bit.

Fixes #7107