### PR TITLE
Makes CatalogPage buttons optional

### DIFF
--- a/.changeset/neat-brooms-sip.md
+++ b/.changeset/neat-brooms-sip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+This makes Create Component and Support buttons optional to use with default true

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -48,12 +48,18 @@ export type CatalogPageProps = {
   initiallySelectedFilter?: UserListFilterKind;
   columns?: TableColumn<EntityRow>[];
   actions?: TableProps<EntityRow>['actions'];
+  createButton?: boolean;
+  supportButton?: boolean;
+  createButtonTitle?: string;
 };
 
 export const CatalogPage = ({
   columns,
   actions,
   initiallySelectedFilter = 'owned',
+  createButton = true,
+  supportButton = true,
+  createButtonTitle = 'Create Component',
 }: CatalogPageProps) => {
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
@@ -64,11 +70,15 @@ export const CatalogPage = ({
       <EntityListProvider>
         <Content>
           <ContentHeader titleComponent={<CatalogKindHeader />}>
-            <CreateButton
-              title="Create Component"
-              to={createComponentLink && createComponentLink()}
-            />
-            <SupportButton>All your software catalog entities</SupportButton>
+            {createButton && (
+              <CreateButton
+                title={createButtonTitle}
+                to={createComponentLink && createComponentLink()}
+              />
+            )}
+            {supportButton && (
+              <SupportButton>All your software catalog entities</SupportButton>
+            )}
           </ContentHeader>
           <FilteredEntityLayout>
             <FilterContainer>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR makes Create Component and Support buttons optional to use with default to true. It also allows to change the create component button's title. 
Before:

<img width="1440" alt="Screenshot 2021-09-10 at 15 44 34" src="https://user-images.githubusercontent.com/74989179/132863364-c5a00615-fb62-4a85-96d9-e7fcb41bbce0.png">

Possible option:

<img width="1440" alt="Screenshot 2021-09-10 at 15 45 11" src="https://user-images.githubusercontent.com/74989179/132863400-dbbe528a-61d3-49a6-87dd-94163aab2600.png">


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
