### PR TITLE
auth-backend: throw error if OIDC IdP does not have a userinfo endpoint

### DIFF
--- a/.changeset/polite-dragons-allow.md
+++ b/.changeset/polite-dragons-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Use a more informative error message if the configured OIDC identity provider does not provide a `userinfo_endpoint` in its metadata.

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -157,6 +157,11 @@ export class OidcAuthProvider implements OAuthHandlers {
         userinfo: UserinfoResponse,
         done: PassportDoneCallback<AuthResult, PrivateInfo>,
       ) => {
+        if (typeof done !== 'function') {
+          throw new Error(
+            'OIDC IdP must provide a userinfo_endpoint in the metadata response',
+          );
+        }
         done(
           undefined,
           { tokenset, userinfo },


### PR DESCRIPTION
Just some interesting communication from the passport provider 😅, see #6945 for more details

Fixes #6945