### PR TITLE
fix: remove hardcoded min height in page header

### DIFF
--- a/.changeset/six-crabs-sit.md
+++ b/.changeset/six-crabs-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+remove hard coded min height in page header

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -41,7 +41,6 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
   leftItemsBox: {
     maxWidth: '100%',
     flexGrow: 1,
-    marginBottom: theme.spacing(1),
   },
   rightItemsBox: {
     width: 'auto',
@@ -50,11 +49,13 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
     color: theme.palette.bursts.fontColor,
     wordBreak: 'break-all',
     fontSize: 'calc(24px + 6 * ((100vw - 320px) / 680))',
-    marginBottom: theme.spacing(1),
+    marginBottom: 0,
   },
   subtitle: {
     color: 'rgba(255, 255, 255, 0.8)',
     lineHeight: '1.0em',
+    display: 'inline-block', // prevents margin collapse of adjacent siblings
+    marginTop: theme.spacing(1),
   },
   type: {
     textTransform: 'uppercase',

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -22,13 +22,10 @@ import { Helmet } from 'react-helmet';
 import { Link } from '../../components/Link';
 import { Breadcrumbs } from '../Breadcrumbs';
 
-const minHeaderHeight = 118;
-
 const useStyles = makeStyles<BackstageTheme>(theme => ({
   header: {
     gridArea: 'pageHeader',
     padding: theme.spacing(3),
-    minHeight: minHeaderHeight,
     width: '100%',
     boxShadow: '0 0 8px 3px rgba(20, 20, 20, 0.3)',
     position: 'relative',


### PR DESCRIPTION
Signed-off-by: Ryan Vazquez <ryanv@spotify.com>

## Hey, I just made a Pull Request!

The `min-height` property set on the `<Header />` component in `@backstage/core-components` is causing the header to overflow into the page content area. This value is currently hardcoded 🙀 

## Before
<img width="1350" alt="Screen Shot 2021-09-10 at 5 42 58 PM" src="https://user-images.githubusercontent.com/3030003/132920826-22154e6d-cd10-4231-b43c-9eb597d7ee76.png">

## After
<img width="1349" alt="Screen Shot 2021-09-10 at 5 43 11 PM" src="https://user-images.githubusercontent.com/3030003/132920834-0c158425-0e37-43b2-908f-f40255d76b6a.png">

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
