### PR TITLE
Fix home page package issues

### DIFF
--- a/.changeset/techdocs-small-bugs-exist.md
+++ b/.changeset/techdocs-small-bugs-exist.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Adjust dependencies to `@types/react` and `react-router` to follow the pattern
+used by all other Backstage packages.

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -43,14 +43,9 @@ import { HomepageCompositionRoot } from '@backstage/plugin-home';
 import { HomePage } from './components/home/HomePage';
 
 // ...
-<Route
-  path="/"
-  element={
-    <HomepageCompositionRoot>
-      <HomePage />
-    </HomepageCompositionRoot>
-  }
-/>;
+<Route path="/" element={<HomepageCompositionRoot />}>
+  <HomePage />
+</Route>;
 // ...
 ```
 

--- a/plugins/home/README.md
+++ b/plugins/home/README.md
@@ -43,9 +43,14 @@ import { HomepageCompositionRoot } from '@backstage/plugin-home';
 import { HomePage } from './components/home/HomePage';
 
 // ...
-<Route path="/" element={<HomepageCompositionRoot />}>
-  <HomePage />
-</Route>;
+<Route
+  path="/"
+  element={
+    <HomepageCompositionRoot>
+      <HomePage />
+    </HomepageCompositionRoot>
+  }
+/>;
 // ...
 ```
 

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -26,10 +26,10 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
-    "@types/react": "^16.9",
+    "@types/react": "*",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-router": "^6.0.0-beta.0",
+    "react-router": "6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
The dependencies for `@types/react` and `react-router` differ from all other packages. Also, following the readme to add it doesn't work as there is a mistake in the readme.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
