### PR TITLE
Github-discovery - document the default scan option

### DIFF
--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -22,7 +22,7 @@ catalog:
     # (since 0.13.5) Scan all repositories for a catalog-info.yaml in the root of the default branch
     - type: github-discovery
       target: https://github.com/myorg
-    # Or use a custom pattern for a subset of all repositories
+    # Or use a custom pattern for a subset of all repositories with default repository
     - type: github-discovery
       target: https://github.com/myorg/service-*/blob/-/catalog-info.yaml
     # Or use a custom file format and location
@@ -44,7 +44,8 @@ When using a custom pattern, the target is composed of three parts:
 - The path within each repository to find the catalog YAML file. This will
   usually be `/blob/main/catalog-info.yaml`, `/blob/master/catalog-info.yaml` or
   a similar variation for catalog files stored in the root directory of each
-  repository. You could also use a dash (`-`) for referring to the default branch.
+  repository. You could also use a dash (`-`) for referring to the default
+  branch.
 
 ## GitHub API Rate Limits
 

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -22,9 +22,15 @@ catalog:
     # (since 0.13.5) Scan all repositories for a catalog-info.yaml in the root of the default branch
     - type: github-discovery
       target: https://github.com/myorg
-    # Or use a custom pattern for discovering catalog entity descriptor files
+    # Or use a custom pattern for a subset of all repositories
     - type: github-discovery
-      target: https://github.com/myorg/service-*/blob/main/your-own-format.yaml
+      target: https://github.com/myorg/service-*/blob/-/catalog-info.yaml
+    # Or use a custom file format and location
+    - type: github-discovery
+      target: https://github.com/*/blob/-/docs/your-own-format.yaml
+    # Or use a specific branch-name
+    - type: github-discovery
+      target: https://github.com/*/blob/backstage-docs/catalog-info.yaml
 ```
 
 Note the `github-discovery` type, as this is not a regular `url` processor.

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -19,13 +19,17 @@ to the catalog configuration:
 ```yaml
 catalog:
   locations:
+    # (since 0.13.5) Scan all repositories for a catalog-info.yaml in the root of the default branch
     - type: github-discovery
-      target: https://github.com/myorg/service-*/blob/main/catalog-info.yaml
+      target: https://github.com/myorg
+    # Or use a custom pattern for discovering catalog entity descriptor files
+    - type: github-discovery
+      target: https://github.com/myorg/service-*/blob/main/your-own-format.yaml
 ```
 
 Note the `github-discovery` type, as this is not a regular `url` processor.
 
-The target is composed of three parts:
+When using a custom pattern, the target is composed of three parts:
 
 - The base organization URL, `https://github.com/myorg` in this case
 - The repository blob to scan, which accepts \* wildcard tokens. This can simply
@@ -34,7 +38,7 @@ The target is composed of three parts:
 - The path within each repository to find the catalog YAML file. This will
   usually be `/blob/main/catalog-info.yaml`, `/blob/master/catalog-info.yaml` or
   a similar variation for catalog files stored in the root directory of each
-  repository.
+  repository. You could also use a dash (`-`) for referring to the default branch.
 
 ## GitHub API Rate Limits
 


### PR DESCRIPTION
## Document the default github-discovery scan option

I suggest a slight change to the docs. I stumbled upon the option to scan all default branches in an org, but couldn't find it in the docs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
