### PR TITLE
Internal components theme overrides

### DIFF
--- a/.changeset/spicy-pumas-mate.md
+++ b/.changeset/spicy-pumas-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Support `material-ui` overrides in Backstage internal components

--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -162,14 +162,9 @@ wouldn't be enough to alter the `box-shadow` property or to add css rules that
 aren't already defined like a margin. For these cases you should also create an
 override.
 
-_Creating your custom overrides_
-
 ```ts
-import {
-  BackstageTheme,
-  createThemeOverrides as createBackstageOverrides,
-} from '@backstage/theme';
-
+import { createApp } from '@backstage/core-app-api';
+import { BackstageTheme, lightTheme } from '@backstage/theme';
 /**
  * The `@backstage/core-components` package exposes this type that
  * contains all Backstage and `material-ui` components that can be
@@ -178,84 +173,38 @@ import {
 import { BackstageOverrides } from '@backstage/core-components';
 
 export const createCustomThemeOverrides = (
-  _: BackstageTheme,
+  theme: BackstageTheme,
 ): BackstageOverrides => {
   return {
-    /**
-     * You can reference the component by the name it passed to the makeStyles function.
-     * in the previous example it was { name: 'BackstageHeader' }
-     */
     BackstageHeader: {
       header: {
+        width: 'auto',
         margin: '20px',
         boxShadow: 'none',
+        borderBottom: `4px solid ${theme.palette.primary.main}`,
       },
     },
   };
 };
 
-export const createOverrides = (theme: BackstageTheme): BackstageOverrides => ({
-  ...createBackstageOverrides(theme), // These are the overrides that Backstage applies to `material-ui` components
-  ...createCustomThemeOverrides(theme), // These are your custom overrides, either to `material-ui` components or to Backstage components.
-});
-```
-
-_Your custom theme that uses the overrides_
-
-```ts
-import { createTheme as createMuiTheme } from '@material-ui/core';
-import { AppTheme } from '@backstage/core-plugin-api';
-import {
-  BackstagePaletteOptions,
-  BackstageTheme,
-  BackstageThemeOptions,
-  PageTheme,
-  shapes,
-} from '@backstage/theme';
-
-import { createOverrides } from './customThemeOverrides';
-import { THEME_OPTIONS } from './themeOptions'; // This is the object created in the "Example of a custom theme" section
-
-export const createTheme = (
-  paletteOptions: BackstagePaletteOptions,
-): BackstageTheme => {
-  const pageTheme: PageTheme = {
-    colors: [],
-    shape: shapes.round,
-    backgroundImage: '',
-  };
-
-  const themeOptions: BackstageThemeOptions = {
-    palette: paletteOptions,
-    page: pageTheme,
-    getPageTheme: _ => pageTheme,
-  };
-
-  const baseTheme = createMuiTheme(themeOptions) as BackstageTheme;
-  const overrides = createOverrides(baseTheme);
-
-  return { ...baseTheme, overrides } as BackstageTheme;
-};
-
-export const CustomTheme: AppTheme = {
-  id: 'custom-theme',
-  title: 'Custom Theme',
-  variant: 'light',
-  theme: createTheme(THEME_OPTIONS),
-};
-```
-
-_Applying your custom theme with overrides_
-
-```ts
-import { createApp } from '@backstage/core-app-api';
-import { CustomTheme } from './theme/customTheme';
-
 const app = createApp({
-  apis,
-  themes: [CustomTheme],
-  plugins: Object.values(plugins),
-  ...
+  apis: ...,
+  plugins: ...,
+  themes: [{
+    id: 'my-theme',
+    title: 'My Custom Theme',
+    variant: 'light',
+    theme: {
+      ...lightTheme,
+      overrides: {
+        // These are the overrides that Backstage applies to `material-ui` components
+        ...lightTheme.overrides,
+        // These are your custom overrides, either to `material-ui` or Backstage components.
+        ...createCustomThemeOverrides(lightTheme),
+      },
+    },
+  }]
+});
 ```
 
 ## Custom Logo

--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -37,9 +37,7 @@ exported by [@backstage/theme](https://www.npmjs.com/package/@backstage/theme)
 in combination with
 [createTheme](https://material-ui.com/customization/theming/#createmuitheme-options-args-theme)
 from [@material-ui/core](https://www.npmjs.com/package/@material-ui/core). See
-the
-[@backstage/theme source](https://github.com/backstage/backstage/tree/master/packages/theme/src)
-and the implementation of the `createTheme` function for how this is done.
+the "Overriding Backstage and Material UI css rules" section below.
 
 You can also create a theme from scratch that matches the `BackstageTheme` type
 exported by [@backstage/theme](https://www.npmjs.com/package/@backstage/theme).
@@ -134,6 +132,130 @@ const themeOptions = createThemeOptions({
     apis: genPageTheme(['#123456', '#123456'], shapes.wave),
   },
 });
+```
+
+## Overriding Backstage and Material UI components styles
+
+When creating a custom theme you would be applying different values to
+component's css rules that use the theme object. For example, a Backstage
+component's styles might look like this:
+
+```ts
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    header: {
+      padding: theme.spacing(3),
+      boxShadow: '0 0 8px 3px rgba(20, 20, 20, 0.3)',
+      backgroundImage: theme.page.backgroundImage,
+    },
+  }),
+  { name: 'BackstageHeader' },
+);
+```
+
+Notice how the `padding` is getting its value from `theme.spacing`, that means
+that setting a value for spacing in your custom theme would affect this
+component padding property and the same goes for `backgroundImage` which uses
+`theme.page.backgroundImage`. However, the `boxShadow` property doesn't
+reference any value from the theme, that means that creating a custom theme
+wouldn't be enough to alter the `box-shadow` property or to add css rules that
+aren't already defined like a margin. For these cases you should also create an
+override.
+
+_Creating your custom overrides_
+
+```ts
+import {
+  BackstageTheme,
+  createThemeOverrides as createBackstageOverrides,
+} from '@backstage/theme';
+
+/**
+ * The `@backstage/core-components` package exposes this type that
+ * contains all Backstage and `material-ui` components that can be
+ * overridden along with the classes key those components use.
+ */
+import { BackstageOverrides } from '@backstage/core-components';
+
+export const createCustomThemeOverrides = (
+  _: BackstageTheme,
+): BackstageOverrides => {
+  return {
+    /**
+     * You can reference the component by the name it passed to the makeStyles function.
+     * in the previous example it was { name: 'BackstageHeader' }
+     */
+    BackstageHeader: {
+      header: {
+        margin: '20px',
+        boxShadow: 'none',
+      },
+    },
+  };
+};
+
+export const createOverrides = (theme: BackstageTheme): BackstageOverrides => ({
+  ...createBackstageOverrides(theme), // These are the overrides that Backstage applies to `material-ui` components
+  ...createCustomThemeOverrides(theme), // These are your custom overrides, either to `material-ui` components or to Backstage components.
+});
+```
+
+_Your custom theme that uses the overrides_
+
+```ts
+import { createTheme as createMuiTheme } from '@material-ui/core';
+import { AppTheme } from '@backstage/core-plugin-api';
+import {
+  BackstagePaletteOptions,
+  BackstageTheme,
+  BackstageThemeOptions,
+  PageTheme,
+  shapes,
+} from '@backstage/theme';
+
+import { createOverrides } from './customThemeOverrides';
+import { THEME_OPTIONS } from './themeOptions'; // This is the object created in the "Example of a custom theme" section
+
+export const createTheme = (
+  paletteOptions: BackstagePaletteOptions,
+): BackstageTheme => {
+  const pageTheme: PageTheme = {
+    colors: [],
+    shape: shapes.round,
+    backgroundImage: '',
+  };
+
+  const themeOptions: BackstageThemeOptions = {
+    palette: paletteOptions,
+    page: pageTheme,
+    getPageTheme: _ => pageTheme,
+  };
+
+  const baseTheme = createMuiTheme(themeOptions) as BackstageTheme;
+  const overrides = createOverrides(baseTheme);
+
+  return { ...baseTheme, overrides } as BackstageTheme;
+};
+
+export const CustomTheme: AppTheme = {
+  id: 'custom-theme',
+  title: 'Custom Theme',
+  variant: 'light',
+  theme: createTheme(THEME_OPTIONS),
+};
+```
+
+_Aplying your custom theme with overrides_
+
+```ts
+import { createApp } from '@backstage/core-app-api';
+import { CustomTheme } from './theme/customTheme';
+
+const app = createApp({
+  apis,
+  themes: [CustomTheme],
+  plugins: Object.values(plugins),
+  ...
 ```
 
 ## Custom Logo

--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -245,7 +245,7 @@ export const CustomTheme: AppTheme = {
 };
 ```
 
-_Aplying your custom theme with overrides_
+_Applying your custom theme with overrides_
 
 ```ts
 import { createApp } from '@backstage/core-app-api';

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -26,6 +26,7 @@ import { LinkProps as LinkProps_2 } from '@material-ui/core';
 import { LinkProps as LinkProps_3 } from 'react-router-dom';
 import { MaterialTableProps } from '@material-table/core';
 import { NavLinkProps } from 'react-router-dom';
+import { Overrides } from '@material-ui/core/styles/overrides';
 import { ProfileInfoApi } from '@backstage/core-plugin-api';
 import { PropsWithChildren } from 'react';
 import PropTypes from 'prop-types';
@@ -39,6 +40,7 @@ import { SparklinesLineProps } from 'react-sparklines';
 import { SparklinesProps } from 'react-sparklines';
 import { StyledComponentProps } from '@material-ui/core';
 import { StyleRules } from '@material-ui/styles';
+import { StyleRules as StyleRules_2 } from '@material-ui/core/styles/withStyles';
 import { TabProps } from '@material-ui/core';
 import { TextTruncateProps } from 'react-text-truncate';
 import { Theme } from '@material-ui/core';
@@ -70,11 +72,65 @@ enum Alignment {
 // @public (undocumented)
 export function Avatar(props: AvatarProps): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "AvatarClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type AvatarClassKey = 'avatar';
+
+// Warning: (ae-missing-release-tag) "BackstageContentClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type BackstageContentClassKey = 'root' | 'stretch' | 'noPadding';
+
+// Warning: (ae-forgotten-export) The symbol "BackstageComponentsNameToClassKey" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "BackstageOverrides" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type BackstageOverrides = Overrides & {
+  [Name in keyof BackstageComponentsNameToClassKey]?: Partial<
+    StyleRules_2<BackstageComponentsNameToClassKey[Name]>
+  >;
+};
+
+// Warning: (ae-missing-release-tag) "BoldHeaderClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type BoldHeaderClassKey = 'root' | 'title' | 'subheader';
+
+// Warning: (ae-missing-release-tag) "BottomLink" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function BottomLink(props: BottomLinkProps): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "BottomLinkClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type BottomLinkClassKey = 'root' | 'boxTitle' | 'arrow';
+
+// Warning: (ae-missing-release-tag) "BottomLinkProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type BottomLinkProps = {
+  link: string;
+  title: string;
+  onClick?: (event: React_2.MouseEvent<HTMLAnchorElement>) => void;
+};
+
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Breadcrumbs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function Breadcrumbs(props: Props_24): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "BreadcrumbsClickableTextClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type BreadcrumbsClickableTextClassKey = 'root';
+
+// Warning: (ae-missing-release-tag) "BreadcrumbsStyledBoxClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type BreadcrumbsStyledBoxClassKey = 'root';
 
 // Warning: (ae-forgotten-export) The symbol "IconComponentProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "BrokenImageIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -88,11 +144,21 @@ export function BrokenImageIcon(props: IconComponentProps): JSX.Element;
 // @public (undocumented)
 export function Button(props: Props): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "CardActionsTopRightClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CardActionsTopRightClassKey = 'root';
+
 // Warning: (ae-forgotten-export) The symbol "CardTabProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "CardTab" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function CardTab(props: PropsWithChildren<CardTabProps>): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "CardTabClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CardTabClassKey = 'root' | 'selected';
 
 // Warning: (ae-missing-release-tag) "CatalogIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -103,6 +169,27 @@ export function CatalogIcon(props: IconComponentProps): JSX.Element;
 //
 // @public (undocumented)
 export function ChatIcon(props: IconComponentProps): JSX.Element;
+
+// Warning: (ae-forgotten-export) The symbol "CheckboxTreeProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "CheckboxTree" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public @deprecated (undocumented)
+export function CheckboxTree(props: CheckboxTreeProps): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "CheckboxTreeClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CheckboxTreeClassKey =
+  | 'root'
+  | 'nested'
+  | 'listItemIcon'
+  | 'listItem'
+  | 'text';
+
+// Warning: (ae-missing-release-tag) "ClosedDropdownClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ClosedDropdownClassKey = 'icon';
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "CodeSnippet" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -123,6 +210,16 @@ export function Content(props: PropsWithChildren<Props_17>): JSX.Element;
 export function ContentHeader(
   props: PropsWithChildren<ContentHeaderProps>,
 ): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "ContentHeaderClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ContentHeaderClassKey =
+  | 'container'
+  | 'leftItemsBox'
+  | 'rightItemsBox'
+  | 'description'
+  | 'title';
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "CopyTextButton" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -147,6 +244,11 @@ export namespace CopyTextButton {
 // @public (undocumented)
 export function CreateButton(props: CreateButtonProps): JSX.Element | null;
 
+// Warning: (ae-missing-release-tag) "CustomProviderClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CustomProviderClassKey = 'form' | 'button';
+
 // Warning: (ae-missing-release-tag) "DashboardIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -166,6 +268,26 @@ type DependencyEdge<T = CustomType> = T & {
 //
 // @public (undocumented)
 export function DependencyGraph(props: DependencyGraphProps): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "DependencyGraphDefaultLabelClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type DependencyGraphDefaultLabelClassKey = 'text';
+
+// Warning: (ae-missing-release-tag) "DependencyGraphDefaultNodeClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type DependencyGraphDefaultNodeClassKey = 'node' | 'text';
+
+// Warning: (ae-missing-release-tag) "DependencyGraphEdgeClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type DependencyGraphEdgeClassKey = 'path' | 'label';
+
+// Warning: (ae-missing-release-tag) "DependencyGraphNodeClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type DependencyGraphNodeClassKey = 'node';
 
 // Warning: (ae-missing-release-tag) "DependencyGraphProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -238,6 +360,18 @@ enum Direction {
 // @public (undocumented)
 export const DismissableBanner: (props: Props_4) => JSX.Element;
 
+// Warning: (ae-missing-release-tag) "DismissbleBannerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type DismissbleBannerClassKey =
+  | 'root'
+  | 'topPosition'
+  | 'icon'
+  | 'content'
+  | 'message'
+  | 'info'
+  | 'error';
+
 // Warning: (ae-missing-release-tag) "DocsIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -268,6 +402,16 @@ export function EmailIcon(props: IconComponentProps): JSX.Element;
 // @public (undocumented)
 export function EmptyState(props: Props_5): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "EmptyStateClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type EmptyStateClassKey = 'root' | 'action' | 'imageContainer';
+
+// Warning: (ae-missing-release-tag) "EmptyStateImageClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type EmptyStateImageClassKey = 'generalImg';
+
 // Warning: (ae-forgotten-export) The symbol "State" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ErrorBoundary" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -288,12 +432,22 @@ export type ErrorBoundaryProps = {
 // @public (undocumented)
 export function ErrorPage(props: IErrorPageProps): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "ErrorPageClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ErrorPageClassKey = 'container' | 'title' | 'subtitle';
+
 // Warning: (ae-missing-release-tag) "ErrorPanel" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function ErrorPanel(
   props: PropsWithChildren<ErrorPanelProps>,
 ): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "ErrorPanelClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ErrorPanelClassKey = 'text' | 'divider';
 
 // Warning: (ae-missing-release-tag) "ErrorPanelProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -304,6 +458,18 @@ export type ErrorPanelProps = {
   title?: string;
 };
 
+// Warning: (ae-missing-release-tag) "FeatureCalloutCircleClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type FeatureCalloutCircleClassKey =
+  | '@keyframes pulsateSlightly'
+  | '@keyframes pulsateAndFade'
+  | 'featureWrapper'
+  | 'backdrop'
+  | 'dot'
+  | 'pulseCircle'
+  | 'text';
+
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "FeatureCalloutCircular" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -311,6 +477,11 @@ export type ErrorPanelProps = {
 export function FeatureCalloutCircular(
   props: PropsWithChildren<Props_7>,
 ): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "FiltersContainerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type FiltersContainerClassKey = 'root' | 'title';
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Gauge" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -323,6 +494,16 @@ export function Gauge(props: Props_14): JSX.Element;
 //
 // @public (undocumented)
 export function GaugeCard(props: Props_13): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "GaugeCardClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type GaugeCardClassKey = 'root';
+
+// Warning: (ae-missing-release-tag) "GaugeClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type GaugeClassKey = 'root' | 'overlay' | 'circle' | 'colorUnknown';
 
 // Warning: (ae-missing-release-tag) "GitHubIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -352,11 +533,30 @@ export function GroupIcon(props: IconComponentProps): JSX.Element;
 // @public (undocumented)
 export function Header(props: PropsWithChildren<Props_18>): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "HeaderClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type HeaderClassKey =
+  | 'header'
+  | 'leftItemsBox'
+  | 'rightItemsBox'
+  | 'title'
+  | 'subtitle'
+  | 'type'
+  | 'breadcrumb'
+  | 'breadcrumbType'
+  | 'breadcrumbTitle';
+
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "HeaderIconLinkRow" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function HeaderIconLinkRow(props: Props_8): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "HeaderIconLinkRowClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type HeaderIconLinkRowClassKey = 'links';
 
 // Warning: (ae-forgotten-export) The symbol "HeaderLabelProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "HeaderLabel" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -364,11 +564,25 @@ export function HeaderIconLinkRow(props: Props_8): JSX.Element;
 // @public (undocumented)
 export function HeaderLabel(props: HeaderLabelProps): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "HeaderLabelClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type HeaderLabelClassKey = 'root' | 'label' | 'value';
+
 // Warning: (ae-forgotten-export) The symbol "HeaderTabsProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "HeaderTabs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function HeaderTabs(props: HeaderTabsProps): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "HeaderTabsClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type HeaderTabsClassKey =
+  | 'tabsWrapper'
+  | 'defaultTab'
+  | 'selected'
+  | 'tabRoot';
 
 // Warning: (ae-missing-release-tag) "HelpIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -388,6 +602,30 @@ export function HorizontalScrollGrid(
   props: PropsWithChildren<Props_9>,
 ): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "HorizontalScrollGridClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type HorizontalScrollGridClassKey =
+  | 'root'
+  | 'container'
+  | 'fade'
+  | 'fadeLeft'
+  | 'fadeRight'
+  | 'fadeHidden'
+  | 'button'
+  | 'buttonLeft'
+  | 'buttonRight';
+
+// Warning: (ae-missing-release-tag) "IconLinkVerticalClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type IconLinkVerticalClassKey =
+  | 'link'
+  | 'disabled'
+  | 'primary'
+  | 'secondary'
+  | 'label';
+
 // Warning: (ae-missing-release-tag) "IconLinkVerticalProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -406,6 +644,18 @@ export type IconLinkVerticalProps = {
 //
 // @public (undocumented)
 export function InfoCard(props: Props_19): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "InfoCardClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type InfoCardClassKey =
+  | 'noPadding'
+  | 'header'
+  | 'headerTitle'
+  | 'headerSubheader'
+  | 'headerAvatar'
+  | 'headerAction'
+  | 'headerContent';
 
 // Warning: (ae-missing-release-tag) "InfoCardVariants" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -437,6 +687,11 @@ export function ItemCard(props: ItemCardProps): JSX.Element;
 // @public
 export function ItemCardGrid(props: ItemCardGridProps): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "ItemCardGridClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ItemCardGridClassKey = 'root';
+
 // Warning: (ae-forgotten-export) The symbol "styles" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ItemCardGridProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -455,6 +710,11 @@ export type ItemCardGridProps = Partial<WithStyles<typeof styles>> & {
 //
 // @public
 export function ItemCardHeader(props: ItemCardHeaderProps): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "ItemCardHeaderClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ItemCardHeaderClassKey = 'root';
 
 // Warning: (ae-forgotten-export) The symbol "styles" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ItemCardHeaderProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -484,6 +744,11 @@ enum LabelPosition {
 // @public (undocumented)
 export function Lifecycle(props: Props_10): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "LifecycleClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type LifecycleClassKey = 'alpha' | 'beta';
+
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "LinearGauge" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -503,11 +768,46 @@ export type LinkProps = LinkProps_2 &
     component?: ElementType<any>;
   };
 
+// Warning: (ae-missing-release-tag) "LoginRequestListItemClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type LoginRequestListItemClassKey = 'root';
+
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "MarkdownContent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
 export function MarkdownContent(props: Props_11): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "MarkdownContentClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type MarkdownContentClassKey = 'markdown';
+
+// Warning: (ae-missing-release-tag) "MetadataTableCellClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type MetadataTableCellClassKey = 'root';
+
+// Warning: (ae-missing-release-tag) "MetadataTableListClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type MetadataTableListClassKey = 'root';
+
+// Warning: (ae-missing-release-tag) "MetadataTableListItemClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type MetadataTableListItemClassKey = 'root' | 'random';
+
+// Warning: (ae-missing-release-tag) "MetadataTableTitleCellClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type MetadataTableTitleCellClassKey = 'root';
+
+// Warning: (ae-missing-release-tag) "MicDropClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type MicDropClassKey = 'micDrop';
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "MissingAnnotationEmptyState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -515,10 +815,29 @@ export function MarkdownContent(props: Props_11): JSX.Element;
 // @public (undocumented)
 export function MissingAnnotationEmptyState(props: Props_6): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "MissingAnnotationEmptyStateClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type MissingAnnotationEmptyStateClassKey = 'code';
+
 // Warning: (ae-missing-release-tag) "OAuthRequestDialog" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function OAuthRequestDialog(_props: {}): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "OAuthRequestDialogClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type OAuthRequestDialogClassKey =
+  | 'dialog'
+  | 'title'
+  | 'contentList'
+  | 'actionButtons';
+
+// Warning: (ae-missing-release-tag) "OpenedDropdownClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type OpenedDropdownClassKey = 'icon';
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "OverflowTooltip" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -526,11 +845,21 @@ export function OAuthRequestDialog(_props: {}): JSX.Element;
 // @public (undocumented)
 export function OverflowTooltip(props: Props_12): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "OverflowTooltipClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type OverflowTooltipClassKey = 'container';
+
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Page" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function Page(props: PropsWithChildren<Props_20>): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "PageClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type PageClassKey = 'root';
 
 // Warning: (ae-forgotten-export) The symbol "PageWithHeaderProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "PageWithHeader" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -588,6 +917,11 @@ type RenderNodeProps<T = CustomType> = {
 // @public
 export function ResponseErrorPanel(props: ErrorPanelProps): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "ResponseErrorPanelClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type ResponseErrorPanelClassKey = 'text' | 'divider';
+
 // Warning: (ae-missing-release-tag) "RoutedTabs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -598,6 +932,22 @@ export function RoutedTabs(props: { routes: SubRoute_2[] }): JSX.Element;
 //
 // @public (undocumented)
 export function Select(props: SelectProps): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "SelectClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SelectClassKey =
+  | 'formControl'
+  | 'label'
+  | 'chips'
+  | 'chip'
+  | 'checkbox'
+  | 'root';
+
+// Warning: (ae-missing-release-tag) "SelectInputBaseClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SelectInputBaseClassKey = 'root' | 'input';
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Sidebar" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -610,6 +960,11 @@ export function Sidebar(props: PropsWithChildren<Props_21>): JSX.Element;
 // @public (undocumented)
 export const SIDEBAR_INTRO_LOCAL_STORAGE =
   '@backstage/core/sidebar-intro-dismissed';
+
+// Warning: (ae-missing-release-tag) "SidebarClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarClassKey = 'root' | 'drawer' | 'drawerOpen';
 
 // Warning: (ae-missing-release-tag) "sidebarConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -915,6 +1270,16 @@ export const SidebarDivider: React_2.ComponentType<
 // @public (undocumented)
 export function SidebarIntro(_props: {}): JSX.Element | null;
 
+// Warning: (ae-missing-release-tag) "SidebarIntroClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarIntroClassKey =
+  | 'introCard'
+  | 'introDismiss'
+  | 'introDismissLink'
+  | 'introDismissText'
+  | 'introDismissIcon';
+
 // Warning: (ae-forgotten-export) The symbol "SidebarItemProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "SidebarItem" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -923,10 +1288,32 @@ export const SidebarItem: React_2.ForwardRefExoticComponent<
   SidebarItemProps & React_2.RefAttributes<any>
 >;
 
+// Warning: (ae-missing-release-tag) "SidebarItemClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarItemClassKey =
+  | 'root'
+  | 'buttonItem'
+  | 'closed'
+  | 'open'
+  | 'label'
+  | 'iconContainer'
+  | 'searchRoot'
+  | 'searchField'
+  | 'searchFieldHTMLInput'
+  | 'searchContainer'
+  | 'secondaryAction'
+  | 'selected';
+
 // Warning: (ae-missing-release-tag) "SidebarPage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function SidebarPage(props: PropsWithChildren<{}>): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "SidebarPageClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarPageClassKey = 'root';
 
 // Warning: (ae-missing-release-tag) "SidebarPinStateContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1760,6 +2147,11 @@ export const SidebarSpacer: React_2.ComponentType<
 // @public (undocumented)
 export function SignInPage(props: Props_22): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "SignInPageClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SignInPageClassKey = 'container' | 'item';
+
 // Warning: (ae-missing-release-tag) "SignInProviderConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -1778,6 +2170,11 @@ export function SimpleStepper(
   props: PropsWithChildren<StepperProps>,
 ): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "SimpleStepperFooterClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SimpleStepperFooterClassKey = 'root';
+
 // Warning: (ae-forgotten-export) The symbol "StepProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "SimpleStepperStep" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1786,10 +2183,27 @@ export function SimpleStepperStep(
   props: PropsWithChildren<StepProps>,
 ): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "SimpleStepperStepClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SimpleStepperStepClassKey = 'end';
+
 // Warning: (ae-missing-release-tag) "StatusAborted" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function StatusAborted(props: PropsWithChildren<{}>): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "StatusClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type StatusClassKey =
+  | 'status'
+  | 'ok'
+  | 'warning'
+  | 'error'
+  | 'pending'
+  | 'running'
+  | 'aborted';
 
 // Warning: (ae-missing-release-tag) "StatusError" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1822,17 +2236,37 @@ export function StatusWarning(props: PropsWithChildren<{}>): JSX.Element;
 // @public (undocumented)
 export function StructuredMetadataTable(props: Props_16): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "StructuredMetadataTableListClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type StructuredMetadataTableListClassKey = 'root';
+
+// Warning: (ae-missing-release-tag) "StructuredMetadataTableNestedListClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type StructuredMetadataTableNestedListClassKey = 'root';
+
 // Warning: (ae-forgotten-export) The symbol "SubvalueCellProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "SubvalueCell" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function SubvalueCell(props: SubvalueCellProps): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "SubvalueCellClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SubvalueCellClassKey = 'value' | 'subvalue';
+
 // Warning: (ae-forgotten-export) The symbol "SupportButtonProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "SupportButton" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function SupportButton(props: SupportButtonProps): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "SupportButtonClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SupportButtonClassKey = 'popoverList';
 
 // Warning: (ae-missing-release-tag) "SupportConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1873,11 +2307,21 @@ export type Tab = {
   >;
 };
 
+// Warning: (ae-missing-release-tag) "TabBarClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TabBarClassKey = 'indicator' | 'flexContainer' | 'root';
+
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "TabbedCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function TabbedCard(props: PropsWithChildren<Props_23>): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "TabbedCardClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TabbedCardClassKey = 'root' | 'indicator';
 
 // Warning: (ae-missing-release-tag) "TabbedLayout" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 // Warning: (ae-missing-release-tag) "TabbedLayout" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1893,10 +2337,20 @@ export namespace TabbedLayout {
     Route: (props: SubRoute) => null;
 }
 
+// Warning: (ae-missing-release-tag) "TabIconClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TabIconClassKey = 'root';
+
 // Warning: (ae-missing-release-tag) "Table" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function Table<T extends object = {}>(props: TableProps<T>): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "TableClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TableClassKey = 'root';
 
 // Warning: (ae-missing-release-tag) "TableColumn" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1915,6 +2369,16 @@ export type TableFilter = {
   column: string;
   type: 'select' | 'multiple-select';
 };
+
+// Warning: (ae-missing-release-tag) "TableFiltersClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TableFiltersClassKey = 'root' | 'value' | 'heder' | 'filters';
+
+// Warning: (ae-missing-release-tag) "TableHeaderClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TableHeaderClassKey = 'header';
 
 // Warning: (ae-missing-release-tag) "TableProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1944,11 +2408,21 @@ export type TableState = {
   filters?: SelectedFilters;
 };
 
+// Warning: (ae-missing-release-tag) "TableToolbarClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TableToolbarClassKey = 'root' | 'title' | 'searchField';
+
 // Warning: (ae-forgotten-export) The symbol "TabsProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Tabs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function Tabs(props: TabsProps): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "TabsClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TabsClassKey = 'root' | 'styledTabs' | 'appbar';
 
 // Warning: (ae-missing-release-tag) "TrendLine" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2002,9 +2476,19 @@ export function WarningIcon(props: IconComponentProps): JSX.Element;
 // @public
 export function WarningPanel(props: WarningProps): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "WarningPanelClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type WarningPanelClassKey =
+  | 'panel'
+  | 'summary'
+  | 'summaryText'
+  | 'message'
+  | 'details';
+
 // Warnings were encountered during analysis:
 //
 // src/components/TabbedLayout/RoutedTabs.d.ts:9:5 - (ae-forgotten-export) The symbol "SubRoute" needs to be exported by the entry point index.d.ts
-// src/components/Table/Table.d.ts:15:5 - (ae-forgotten-export) The symbol "SelectedFilters" needs to be exported by the entry point index.d.ts
+// src/components/Table/Table.d.ts:19:5 - (ae-forgotten-export) The symbol "SelectedFilters" needs to be exported by the entry point index.d.ts
 // src/layout/ErrorBoundary/ErrorBoundary.d.ts:7:5 - (ae-forgotten-export) The symbol "SlackChannel" needs to be exported by the entry point index.d.ts
 ```

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -170,22 +170,6 @@ export function CatalogIcon(props: IconComponentProps): JSX.Element;
 // @public (undocumented)
 export function ChatIcon(props: IconComponentProps): JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "CheckboxTreeProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "CheckboxTree" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public @deprecated (undocumented)
-export function CheckboxTree(props: CheckboxTreeProps): JSX.Element;
-
-// Warning: (ae-missing-release-tag) "CheckboxTreeClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export type CheckboxTreeClassKey =
-  | 'root'
-  | 'nested'
-  | 'listItemIcon'
-  | 'listItem'
-  | 'text';
-
 // Warning: (ae-missing-release-tag) "ClosedDropdownClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/core-components/src/components/Avatar/Avatar.tsx
+++ b/packages/core-components/src/components/Avatar/Avatar.tsx
@@ -22,17 +22,21 @@ import {
 } from '@material-ui/core';
 import { extractInitials, stringToColor } from './utils';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    avatar: {
-      width: '4rem',
-      height: '4rem',
-      color: '#fff',
-      fontWeight: theme.typography.fontWeightBold,
-      letterSpacing: '1px',
-      textTransform: 'uppercase',
-    },
-  }),
+export type AvatarClassKey = 'avatar';
+
+const useStyles = makeStyles(
+  (theme: Theme) =>
+    createStyles({
+      avatar: {
+        width: '4rem',
+        height: '4rem',
+        color: '#fff',
+        fontWeight: theme.typography.fontWeightBold,
+        letterSpacing: '1px',
+        textTransform: 'uppercase',
+      },
+    }),
+  { name: 'BackstageAvatar' },
 );
 
 export type AvatarProps = {

--- a/packages/core-components/src/components/Avatar/index.ts
+++ b/packages/core-components/src/components/Avatar/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { Avatar } from './Avatar';
+export type { AvatarClassKey } from './Avatar';

--- a/packages/core-components/src/components/DependencyGraph/DefaultLabel.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DefaultLabel.tsx
@@ -19,11 +19,16 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 import { BackstageTheme } from '@backstage/theme';
 import { RenderLabelProps } from './types';
 
-const useStyles = makeStyles((theme: BackstageTheme) => ({
-  text: {
-    fill: theme.palette.textContrast,
-  },
-}));
+export type DependencyGraphDefaultLabelClassKey = 'text';
+
+const useStyles = makeStyles(
+  (theme: BackstageTheme) => ({
+    text: {
+      fill: theme.palette.textContrast,
+    },
+  }),
+  { name: 'BackstageDependencyGraphDefaultLabel' },
+);
 
 export function DefaultLabel({ edge: { label } }: RenderLabelProps) {
   const classes = useStyles();

--- a/packages/core-components/src/components/DependencyGraph/DefaultNode.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DefaultNode.tsx
@@ -19,15 +19,20 @@ import { makeStyles } from '@material-ui/core/styles';
 import { BackstageTheme } from '@backstage/theme';
 import { RenderNodeProps } from './types';
 
-const useStyles = makeStyles((theme: BackstageTheme) => ({
-  node: {
-    fill: theme.palette.primary.light,
-    stroke: theme.palette.primary.light,
-  },
-  text: {
-    fill: theme.palette.primary.contrastText,
-  },
-}));
+export type DependencyGraphDefaultNodeClassKey = 'node' | 'text';
+
+const useStyles = makeStyles(
+  (theme: BackstageTheme) => ({
+    node: {
+      fill: theme.palette.primary.light,
+      stroke: theme.palette.primary.light,
+    },
+    text: {
+      fill: theme.palette.primary.contrastText,
+    },
+  }),
+  { name: 'BackstageDependencyGraphDefaultNode' },
+);
 
 export function DefaultNode({ node: { id } }: RenderNodeProps) {
   const classes = useStyles();

--- a/packages/core-components/src/components/DependencyGraph/Edge.tsx
+++ b/packages/core-components/src/components/DependencyGraph/Edge.tsx
@@ -28,17 +28,22 @@ import {
 import { ARROW_MARKER_ID, EDGE_TEST_ID, LABEL_TEST_ID } from './constants';
 import { DefaultLabel } from './DefaultLabel';
 
-const useStyles = makeStyles((theme: BackstageTheme) => ({
-  path: {
-    strokeWidth: 2,
-    stroke: theme.palette.textSubtle,
-    fill: 'none',
-    transition: `${theme.transitions.duration.shortest}ms`,
-  },
-  label: {
-    transition: `${theme.transitions.duration.shortest}ms`,
-  },
-}));
+export type DependencyGraphEdgeClassKey = 'path' | 'label';
+
+const useStyles = makeStyles(
+  (theme: BackstageTheme) => ({
+    path: {
+      strokeWidth: 2,
+      stroke: theme.palette.textSubtle,
+      fill: 'none',
+      transition: `${theme.transitions.duration.shortest}ms`,
+    },
+    label: {
+      transition: `${theme.transitions.duration.shortest}ms`,
+    },
+  }),
+  { name: 'BackstageDependencyGraphEdge' },
+);
 
 type EdgePoint = dagre.GraphEdge['points'][0];
 

--- a/packages/core-components/src/components/DependencyGraph/Node.tsx
+++ b/packages/core-components/src/components/DependencyGraph/Node.tsx
@@ -20,11 +20,16 @@ import { DefaultNode } from './DefaultNode';
 import { RenderNodeFunction, RenderNodeProps, GraphNode } from './types';
 import { NODE_TEST_ID } from './constants';
 
-const useStyles = makeStyles(theme => ({
-  node: {
-    transition: `${theme.transitions.duration.shortest}ms`,
-  },
-}));
+export type DependencyGraphNodeClassKey = 'node';
+
+const useStyles = makeStyles(
+  theme => ({
+    node: {
+      transition: `${theme.transitions.duration.shortest}ms`,
+    },
+  }),
+  { name: 'BackstageDependencyGraphNode' },
+);
 
 export type NodeComponentProps<T = any> = {
   node: GraphNode<T>;

--- a/packages/core-components/src/components/DependencyGraph/index.ts
+++ b/packages/core-components/src/components/DependencyGraph/index.ts
@@ -19,3 +19,8 @@ import * as DependencyGraphTypes from './types';
 export { DependencyGraph } from './DependencyGraph';
 export type { DependencyGraphProps } from './DependencyGraph';
 export { DependencyGraphTypes };
+
+export type { DependencyGraphDefaultLabelClassKey } from './DefaultLabel';
+export type { DependencyGraphDefaultNodeClassKey } from './DefaultNode';
+export type { DependencyGraphEdgeClassKey } from './Edge';
+export type { DependencyGraphNodeClassKey } from './Node';

--- a/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
+++ b/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
@@ -25,43 +25,55 @@ import SnackbarContent from '@material-ui/core/SnackbarContent';
 import IconButton from '@material-ui/core/IconButton';
 import Close from '@material-ui/icons/Close';
 
-const useStyles = makeStyles((theme: BackstageTheme) => ({
-  root: {
-    padding: theme.spacing(0),
-    marginBottom: theme.spacing(0),
-    marginTop: theme.spacing(0),
-    display: 'flex',
-    flexFlow: 'row nowrap',
-  },
-  // showing on top
-  topPosition: {
-    position: 'relative',
-    marginBottom: theme.spacing(6),
-    marginTop: -theme.spacing(3),
-    zIndex: 'unset',
-  },
-  icon: {
-    fontSize: 20,
-  },
-  content: {
-    width: '100%',
-    maxWidth: 'inherit',
-  },
-  message: {
-    display: 'flex',
-    alignItems: 'center',
-    color: theme.palette.banner.text,
-    '& a': {
-      color: theme.palette.banner.link,
+export type DismissbleBannerClassKey =
+  | 'root'
+  | 'topPosition'
+  | 'icon'
+  | 'content'
+  | 'message'
+  | 'info'
+  | 'error';
+
+const useStyles = makeStyles(
+  (theme: BackstageTheme) => ({
+    root: {
+      padding: theme.spacing(0),
+      marginBottom: theme.spacing(0),
+      marginTop: theme.spacing(0),
+      display: 'flex',
+      flexFlow: 'row nowrap',
     },
-  },
-  info: {
-    backgroundColor: theme.palette.banner.info,
-  },
-  error: {
-    backgroundColor: theme.palette.banner.error,
-  },
-}));
+    // showing on top
+    topPosition: {
+      position: 'relative',
+      marginBottom: theme.spacing(6),
+      marginTop: -theme.spacing(3),
+      zIndex: 'unset',
+    },
+    icon: {
+      fontSize: 20,
+    },
+    content: {
+      width: '100%',
+      maxWidth: 'inherit',
+    },
+    message: {
+      display: 'flex',
+      alignItems: 'center',
+      color: theme.palette.banner.text,
+      '& a': {
+        color: theme.palette.banner.link,
+      },
+    },
+    info: {
+      backgroundColor: theme.palette.banner.info,
+    },
+    error: {
+      backgroundColor: theme.palette.banner.error,
+    },
+  }),
+  { name: 'BackstageDismissableBanner' },
+);
 
 type Props = {
   variant: 'info' | 'error';

--- a/packages/core-components/src/components/DismissableBanner/index.ts
+++ b/packages/core-components/src/components/DismissableBanner/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { DismissableBanner } from './DismissableBanner';
+export type { DismissbleBannerClassKey } from './DismissableBanner';

--- a/packages/core-components/src/components/EmptyState/EmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/EmptyState.tsx
@@ -18,18 +18,23 @@ import React from 'react';
 import { makeStyles, Typography, Grid } from '@material-ui/core';
 import { EmptyStateImage } from './EmptyStateImage';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    backgroundColor: theme.palette.background.default,
-    padding: theme.spacing(2, 0, 0, 0),
-  },
-  action: {
-    marginTop: theme.spacing(2),
-  },
-  imageContainer: {
-    position: 'relative',
-  },
-}));
+export type EmptyStateClassKey = 'root' | 'action' | 'imageContainer';
+
+const useStyles = makeStyles(
+  theme => ({
+    root: {
+      backgroundColor: theme.palette.background.default,
+      padding: theme.spacing(2, 0, 0, 0),
+    },
+    action: {
+      marginTop: theme.spacing(2),
+    },
+    imageContainer: {
+      position: 'relative',
+    },
+  }),
+  { name: 'BackstageEmptyState' },
+);
 
 type Props = {
   title: string;

--- a/packages/core-components/src/components/EmptyState/EmptyStateImage.tsx
+++ b/packages/core-components/src/components/EmptyState/EmptyStateImage.tsx
@@ -25,16 +25,21 @@ type Props = {
   missing: 'field' | 'info' | 'content' | 'data';
 };
 
-const useStyles = makeStyles({
-  generalImg: {
-    width: '95%',
-    zIndex: 2,
-    position: 'relative',
-    left: '50%',
-    top: '50%',
-    transform: 'translate(-50%, 15%)',
+export type EmptyStateImageClassKey = 'generalImg';
+
+const useStyles = makeStyles(
+  {
+    generalImg: {
+      width: '95%',
+      zIndex: 2,
+      position: 'relative',
+      left: '50%',
+      top: '50%',
+      transform: 'translate(-50%, 15%)',
+    },
   },
-});
+  { name: 'BackstageEmptyStateImage' },
+);
 
 export const EmptyStateImage = ({ missing }: Props) => {
   const classes = useStyles();

--- a/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
+++ b/packages/core-components/src/components/EmptyState/MissingAnnotationEmptyState.tsx
@@ -37,13 +37,18 @@ type Props = {
   annotation: string;
 };
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  code: {
-    borderRadius: 6,
-    margin: `${theme.spacing(2)}px 0px`,
-    background: theme.palette.type === 'dark' ? '#444' : '#fff',
-  },
-}));
+export type MissingAnnotationEmptyStateClassKey = 'code';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    code: {
+      borderRadius: 6,
+      margin: `${theme.spacing(2)}px 0px`,
+      background: theme.palette.type === 'dark' ? '#444' : '#fff',
+    },
+  }),
+  { name: 'BackstageMissingAnnotationEmptyState' },
+);
 
 export function MissingAnnotationEmptyState(props: Props) {
   const { annotation } = props;

--- a/packages/core-components/src/components/EmptyState/index.ts
+++ b/packages/core-components/src/components/EmptyState/index.ts
@@ -15,4 +15,7 @@
  */
 
 export { EmptyState } from './EmptyState';
+export type { EmptyStateClassKey } from './EmptyState';
+export type { EmptyStateImageClassKey } from './EmptyStateImage';
 export { MissingAnnotationEmptyState } from './MissingAnnotationEmptyState';
+export type { MissingAnnotationEmptyStateClassKey } from './MissingAnnotationEmptyState';

--- a/packages/core-components/src/components/ErrorPanel/ErrorPanel.tsx
+++ b/packages/core-components/src/components/ErrorPanel/ErrorPanel.tsx
@@ -19,17 +19,22 @@ import React, { PropsWithChildren } from 'react';
 import { CopyTextButton } from '../CopyTextButton';
 import { WarningPanel } from '../WarningPanel';
 
-const useStyles = makeStyles(theme => ({
-  text: {
-    fontFamily: 'monospace',
-    whiteSpace: 'pre',
-    overflowX: 'auto',
-    marginRight: theme.spacing(2),
-  },
-  divider: {
-    margin: theme.spacing(2),
-  },
-}));
+export type ErrorPanelClassKey = 'text' | 'divider';
+
+const useStyles = makeStyles(
+  theme => ({
+    text: {
+      fontFamily: 'monospace',
+      whiteSpace: 'pre',
+      overflowX: 'auto',
+      marginRight: theme.spacing(2),
+    },
+    divider: {
+      margin: theme.spacing(2),
+    },
+  }),
+  { name: 'BackstageErrorPanel' },
+);
 
 type ErrorListProps = {
   error: string;

--- a/packages/core-components/src/components/ErrorPanel/index.ts
+++ b/packages/core-components/src/components/ErrorPanel/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { ErrorPanel } from './ErrorPanel';
-export type { ErrorPanelProps } from './ErrorPanel';
+export type { ErrorPanelProps, ErrorPanelClassKey } from './ErrorPanel';

--- a/packages/core-components/src/components/FeatureDiscovery/FeatureCalloutCircular.tsx
+++ b/packages/core-components/src/components/FeatureDiscovery/FeatureCalloutCircular.tsx
@@ -27,55 +27,67 @@ import { createPortal } from 'react-dom';
 import { usePortal } from './lib/usePortal';
 import { useShowCallout } from './lib/useShowCallout';
 
-const useStyles = makeStyles({
-  '@keyframes pulsateSlightly': {
-    '0%': { transform: 'scale(1.0)' },
-    '100%': { transform: 'scale(1.1)' },
+export type FeatureCalloutCircleClassKey =
+  | '@keyframes pulsateSlightly'
+  | '@keyframes pulsateAndFade'
+  | 'featureWrapper'
+  | 'backdrop'
+  | 'dot'
+  | 'pulseCircle'
+  | 'text';
+
+const useStyles = makeStyles(
+  {
+    '@keyframes pulsateSlightly': {
+      '0%': { transform: 'scale(1.0)' },
+      '100%': { transform: 'scale(1.1)' },
+    },
+    '@keyframes pulsateAndFade': {
+      '0%': { transform: 'scale(1.0)', opacity: 0.9 },
+      '100%': { transform: 'scale(1.5)', opacity: 0 },
+    },
+    featureWrapper: {
+      position: 'relative',
+    },
+    backdrop: {
+      zIndex: 2000,
+      position: 'fixed',
+      overflow: 'hidden',
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+    },
+    dot: {
+      position: 'absolute',
+      backgroundColor: 'transparent',
+      borderRadius: '100%',
+      border: '1px solid rgba(103, 146, 180, 0.98)',
+      boxShadow: '0px 0px 0px 20000px rgba(0, 0, 0, 0.5)',
+      zIndex: 2001,
+      transformOrigin: 'center center',
+      animation:
+        '$pulsateSlightly 1744ms 1.2s cubic-bezier(0.4, 0, 0.2, 1) alternate infinite',
+    },
+    pulseCircle: {
+      width: '100%',
+      height: '100%',
+      backgroundColor: 'transparent',
+      borderRadius: '100%',
+      border: '2px solid white',
+      zIndex: 2001,
+      transformOrigin: 'center center',
+      animation:
+        '$pulsateAndFade 872ms 1.2s cubic-bezier(0.4, 0, 0.2, 1) infinite',
+    },
+    text: {
+      position: 'absolute',
+      color: 'white',
+      zIndex: 2003,
+    },
   },
-  '@keyframes pulsateAndFade': {
-    '0%': { transform: 'scale(1.0)', opacity: 0.9 },
-    '100%': { transform: 'scale(1.5)', opacity: 0 },
-  },
-  featureWrapper: {
-    position: 'relative',
-  },
-  backdrop: {
-    zIndex: 2000,
-    position: 'fixed',
-    overflow: 'hidden',
-    left: 0,
-    right: 0,
-    top: 0,
-    bottom: 0,
-  },
-  dot: {
-    position: 'absolute',
-    backgroundColor: 'transparent',
-    borderRadius: '100%',
-    border: '1px solid rgba(103, 146, 180, 0.98)',
-    boxShadow: '0px 0px 0px 20000px rgba(0, 0, 0, 0.5)',
-    zIndex: 2001,
-    transformOrigin: 'center center',
-    animation:
-      '$pulsateSlightly 1744ms 1.2s cubic-bezier(0.4, 0, 0.2, 1) alternate infinite',
-  },
-  pulseCircle: {
-    width: '100%',
-    height: '100%',
-    backgroundColor: 'transparent',
-    borderRadius: '100%',
-    border: '2px solid white',
-    zIndex: 2001,
-    transformOrigin: 'center center',
-    animation:
-      '$pulsateAndFade 872ms 1.2s cubic-bezier(0.4, 0, 0.2, 1) infinite',
-  },
-  text: {
-    position: 'absolute',
-    color: 'white',
-    zIndex: 2003,
-  },
-});
+  { name: 'BackstageFeatureCalloutCircular' },
+);
 
 export type Props = {
   featureId: string;

--- a/packages/core-components/src/components/FeatureDiscovery/index.ts
+++ b/packages/core-components/src/components/FeatureDiscovery/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { FeatureCalloutCircular } from './FeatureCalloutCircular';
+export type { FeatureCalloutCircleClassKey } from './FeatureCalloutCircular';

--- a/packages/core-components/src/components/HeaderIconLinkRow/HeaderIconLinkRow.tsx
+++ b/packages/core-components/src/components/HeaderIconLinkRow/HeaderIconLinkRow.tsx
@@ -17,15 +17,20 @@ import React from 'react';
 import { IconLinkVertical, IconLinkVerticalProps } from './IconLinkVertical';
 import { makeStyles } from '@material-ui/core';
 
-const useStyles = makeStyles(theme => ({
-  links: {
-    margin: theme.spacing(2, 0),
-    display: 'grid',
-    gridAutoFlow: 'column',
-    gridAutoColumns: 'min-content',
-    gridGap: theme.spacing(3),
-  },
-}));
+export type HeaderIconLinkRowClassKey = 'links';
+
+const useStyles = makeStyles(
+  theme => ({
+    links: {
+      margin: theme.spacing(2, 0),
+      display: 'grid',
+      gridAutoFlow: 'column',
+      gridAutoColumns: 'min-content',
+      gridGap: theme.spacing(3),
+    },
+  }),
+  { name: 'BackstageHeaderIconLinkRow' },
+);
 
 type Props = {
   links: IconLinkVerticalProps[];

--- a/packages/core-components/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
+++ b/packages/core-components/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
@@ -29,30 +29,40 @@ export type IconLinkVerticalProps = {
   title?: string;
 };
 
-const useIconStyles = makeStyles(theme => ({
-  link: {
-    display: 'grid',
-    justifyItems: 'center',
-    gridGap: 4,
-    textAlign: 'center',
-  },
-  disabled: {
-    color: 'gray',
-    cursor: 'default',
-  },
-  primary: {
-    color: theme.palette.primary.main,
-  },
-  secondary: {
-    color: theme.palette.secondary.main,
-  },
-  label: {
-    fontSize: '0.7rem',
-    textTransform: 'uppercase',
-    fontWeight: 600,
-    letterSpacing: 1.2,
-  },
-}));
+export type IconLinkVerticalClassKey =
+  | 'link'
+  | 'disabled'
+  | 'primary'
+  | 'secondary'
+  | 'label';
+
+const useIconStyles = makeStyles(
+  theme => ({
+    link: {
+      display: 'grid',
+      justifyItems: 'center',
+      gridGap: 4,
+      textAlign: 'center',
+    },
+    disabled: {
+      color: 'gray',
+      cursor: 'default',
+    },
+    primary: {
+      color: theme.palette.primary.main,
+    },
+    secondary: {
+      color: theme.palette.secondary.main,
+    },
+    label: {
+      fontSize: '0.7rem',
+      textTransform: 'uppercase',
+      fontWeight: 600,
+      letterSpacing: 1.2,
+    },
+  }),
+  { name: 'BackstageIconLinkVertical' },
+);
 
 export function IconLinkVertical({
   color = 'primary',

--- a/packages/core-components/src/components/HeaderIconLinkRow/index.ts
+++ b/packages/core-components/src/components/HeaderIconLinkRow/index.ts
@@ -15,5 +15,8 @@
  */
 
 export { HeaderIconLinkRow } from './HeaderIconLinkRow';
-
-export type { IconLinkVerticalProps } from './IconLinkVertical';
+export type { HeaderIconLinkRowClassKey } from './HeaderIconLinkRow';
+export type {
+  IconLinkVerticalProps,
+  IconLinkVerticalClassKey,
+} from './IconLinkVertical';

--- a/packages/core-components/src/components/HorizontalScrollGrid/HorizontalScrollGrid.tsx
+++ b/packages/core-components/src/components/HorizontalScrollGrid/HorizontalScrollGrid.tsx
@@ -54,52 +54,66 @@ type Props = {
   minScrollDistance?: number; // limits how small steps the scroll can take in px
 };
 
-const useStyles = makeStyles<Theme>(theme => ({
-  root: {
-    position: 'relative',
-    display: 'flex',
-    flexFlow: 'row nowrap',
-    alignItems: 'center',
-  },
-  container: {
-    overflow: 'auto',
-    scrollbarWidth: 0 as any, // hide in FF
-    '&::-webkit-scrollbar': {
-      display: 'none', // hide in Chrome
+export type HorizontalScrollGridClassKey =
+  | 'root'
+  | 'container'
+  | 'fade'
+  | 'fadeLeft'
+  | 'fadeRight'
+  | 'fadeHidden'
+  | 'button'
+  | 'buttonLeft'
+  | 'buttonRight';
+
+const useStyles = makeStyles<Theme>(
+  theme => ({
+    root: {
+      position: 'relative',
+      display: 'flex',
+      flexFlow: 'row nowrap',
+      alignItems: 'center',
     },
-  },
-  fade: {
-    position: 'absolute',
-    width: fadeSize,
-    height: `calc(100% + ${fadePadding}px)`,
-    transition: 'opacity 300ms',
-    pointerEvents: 'none',
-  },
-  fadeLeft: {
-    left: -fadePadding,
-    background: `linear-gradient(90deg, ${generateGradientStops(
-      theme.palette.type,
-    )})`,
-  },
-  fadeRight: {
-    right: -fadePadding,
-    background: `linear-gradient(270deg, ${generateGradientStops(
-      theme.palette.type,
-    )})`,
-  },
-  fadeHidden: {
-    opacity: 0,
-  },
-  button: {
-    position: 'absolute',
-  },
-  buttonLeft: {
-    left: -theme.spacing(2),
-  },
-  buttonRight: {
-    right: -theme.spacing(2),
-  },
-}));
+    container: {
+      overflow: 'auto',
+      scrollbarWidth: 0 as any, // hide in FF
+      '&::-webkit-scrollbar': {
+        display: 'none', // hide in Chrome
+      },
+    },
+    fade: {
+      position: 'absolute',
+      width: fadeSize,
+      height: `calc(100% + ${fadePadding}px)`,
+      transition: 'opacity 300ms',
+      pointerEvents: 'none',
+    },
+    fadeLeft: {
+      left: -fadePadding,
+      background: `linear-gradient(90deg, ${generateGradientStops(
+        theme.palette.type,
+      )})`,
+    },
+    fadeRight: {
+      right: -fadePadding,
+      background: `linear-gradient(270deg, ${generateGradientStops(
+        theme.palette.type,
+      )})`,
+    },
+    fadeHidden: {
+      opacity: 0,
+    },
+    button: {
+      position: 'absolute',
+    },
+    buttonLeft: {
+      left: -theme.spacing(2),
+    },
+    buttonRight: {
+      right: -theme.spacing(2),
+    },
+  }),
+  { name: 'BackstageHorizontalScrollGrid' },
+);
 
 // Returns scroll distance from left and right
 function useScrollDistance(

--- a/packages/core-components/src/components/HorizontalScrollGrid/index.tsx
+++ b/packages/core-components/src/components/HorizontalScrollGrid/index.tsx
@@ -15,3 +15,4 @@
  */
 
 export { HorizontalScrollGrid } from './HorizontalScrollGrid';
+export type { HorizontalScrollGridClassKey } from './HorizontalScrollGrid';

--- a/packages/core-components/src/components/Lifecycle/Lifecycle.tsx
+++ b/packages/core-components/src/components/Lifecycle/Lifecycle.tsx
@@ -23,20 +23,25 @@ type Props = CSS.Properties & {
   alpha?: boolean;
 };
 
-const useStyles = makeStyles({
-  alpha: {
-    color: '#ffffff',
-    fontFamily: 'serif',
-    fontWeight: 'normal',
-    fontStyle: 'italic',
+export type LifecycleClassKey = 'alpha' | 'beta';
+
+const useStyles = makeStyles(
+  {
+    alpha: {
+      color: '#ffffff',
+      fontFamily: 'serif',
+      fontWeight: 'normal',
+      fontStyle: 'italic',
+    },
+    beta: {
+      color: '#4d65cc',
+      fontFamily: 'serif',
+      fontWeight: 'normal',
+      fontStyle: 'italic',
+    },
   },
-  beta: {
-    color: '#4d65cc',
-    fontFamily: 'serif',
-    fontWeight: 'normal',
-    fontStyle: 'italic',
-  },
-});
+  { name: 'BackstageLifecycle' },
+);
 
 export function Lifecycle(props: Props) {
   const classes = useStyles(props);

--- a/packages/core-components/src/components/Lifecycle/index.ts
+++ b/packages/core-components/src/components/Lifecycle/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { Lifecycle } from './Lifecycle';
+export type { LifecycleClassKey } from './Lifecycle';

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -21,43 +21,48 @@ import React from 'react';
 import { BackstageTheme } from '@backstage/theme';
 import { CodeSnippet } from '../CodeSnippet';
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  markdown: {
-    '& table': {
-      borderCollapse: 'collapse',
-      border: `1px solid ${theme.palette.border}`,
-    },
-    '& th, & td': {
-      border: `1px solid ${theme.palette.border}`,
-      padding: theme.spacing(1),
-    },
-    '& td': {
-      wordBreak: 'break-word',
-      overflow: 'hidden',
-      verticalAlign: 'middle',
-      lineHeight: '1',
-      margin: 0,
-      padding: theme.spacing(3, 2, 3, 2.5),
-      borderBottom: 0,
-    },
-    '& th': {
-      backgroundColor: theme.palette.background.paper,
-    },
-    '& tr': {
-      backgroundColor: theme.palette.background.paper,
-    },
-    '& tr:nth-child(odd)': {
-      backgroundColor: theme.palette.background.default,
-    },
+export type MarkdownContentClassKey = 'markdown';
 
-    '& a': {
-      color: theme.palette.link,
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    markdown: {
+      '& table': {
+        borderCollapse: 'collapse',
+        border: `1px solid ${theme.palette.border}`,
+      },
+      '& th, & td': {
+        border: `1px solid ${theme.palette.border}`,
+        padding: theme.spacing(1),
+      },
+      '& td': {
+        wordBreak: 'break-word',
+        overflow: 'hidden',
+        verticalAlign: 'middle',
+        lineHeight: '1',
+        margin: 0,
+        padding: theme.spacing(3, 2, 3, 2.5),
+        borderBottom: 0,
+      },
+      '& th': {
+        backgroundColor: theme.palette.background.paper,
+      },
+      '& tr': {
+        backgroundColor: theme.palette.background.paper,
+      },
+      '& tr:nth-child(odd)': {
+        backgroundColor: theme.palette.background.default,
+      },
+
+      '& a': {
+        color: theme.palette.link,
+      },
+      '& img': {
+        maxWidth: '100%',
+      },
     },
-    '& img': {
-      maxWidth: '100%',
-    },
-  },
-}));
+  }),
+  { name: 'BackstageMarkdownContent' },
+);
 
 type Props = {
   content: string;

--- a/packages/core-components/src/components/MarkdownContent/index.ts
+++ b/packages/core-components/src/components/MarkdownContent/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { MarkdownContent } from './MarkdownContent';
+export type { MarkdownContentClassKey } from './MarkdownContent';

--- a/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
+++ b/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
@@ -26,11 +26,16 @@ import {
 import React, { useState } from 'react';
 import { PendingAuthRequest } from '@backstage/core-plugin-api';
 
-const useItemStyles = makeStyles<Theme>(theme => ({
-  root: {
-    paddingLeft: theme.spacing(3),
-  },
-}));
+export type LoginRequestListItemClassKey = 'root';
+
+const useItemStyles = makeStyles<Theme>(
+  theme => ({
+    root: {
+      paddingLeft: theme.spacing(3),
+    },
+  }),
+  { name: 'BackstageLoginRequestListItem' },
+);
 
 type RowProps = {
   request: PendingAuthRequest;

--- a/packages/core-components/src/components/OAuthRequestDialog/OAuthRequestDialog.tsx
+++ b/packages/core-components/src/components/OAuthRequestDialog/OAuthRequestDialog.tsx
@@ -29,20 +29,29 @@ import { useObservable } from 'react-use';
 import LoginRequestListItem from './LoginRequestListItem';
 import { useApi, oauthRequestApiRef } from '@backstage/core-plugin-api';
 
-const useStyles = makeStyles<Theme>(theme => ({
-  dialog: {
-    paddingTop: theme.spacing(1),
-  },
-  title: {
-    minWidth: 0,
-  },
-  contentList: {
-    padding: 0,
-  },
-  actionButtons: {
-    padding: theme.spacing(2, 0),
-  },
-}));
+export type OAuthRequestDialogClassKey =
+  | 'dialog'
+  | 'title'
+  | 'contentList'
+  | 'actionButtons';
+
+const useStyles = makeStyles<Theme>(
+  theme => ({
+    dialog: {
+      paddingTop: theme.spacing(1),
+    },
+    title: {
+      minWidth: 0,
+    },
+    contentList: {
+      padding: 0,
+    },
+    actionButtons: {
+      padding: theme.spacing(2, 0),
+    },
+  }),
+  { name: 'OAuthRequestDialog' },
+);
 
 export function OAuthRequestDialog(_props: {}) {
   const classes = useStyles();

--- a/packages/core-components/src/components/OAuthRequestDialog/index.ts
+++ b/packages/core-components/src/components/OAuthRequestDialog/index.ts
@@ -15,3 +15,5 @@
  */
 
 export { OAuthRequestDialog } from './OAuthRequestDialog';
+export type { OAuthRequestDialogClassKey } from './OAuthRequestDialog';
+export type { LoginRequestListItemClassKey } from './LoginRequestListItem';

--- a/packages/core-components/src/components/OverflowTooltip/OverflowTooltip.tsx
+++ b/packages/core-components/src/components/OverflowTooltip/OverflowTooltip.tsx
@@ -26,11 +26,16 @@ type Props = {
   placement?: TooltipProps['placement'];
 };
 
-const useStyles = makeStyles({
-  container: {
-    overflow: 'visible !important',
+export type OverflowTooltipClassKey = 'container';
+
+const useStyles = makeStyles(
+  {
+    container: {
+      overflow: 'visible !important',
+    },
   },
-});
+  { name: 'BackstageOverflowTooltip' },
+);
 
 export function OverflowTooltip(props: Props) {
   const [hover, setHover] = useState(false);

--- a/packages/core-components/src/components/OverflowTooltip/index.ts
+++ b/packages/core-components/src/components/OverflowTooltip/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { OverflowTooltip } from './OverflowTooltip';
+export type { OverflowTooltipClassKey } from './OverflowTooltip';

--- a/packages/core-components/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.tsx
@@ -19,26 +19,31 @@ import { BackstageTheme } from '@backstage/theme';
 import { Circle } from 'rc-progress';
 import React from 'react';
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  root: {
-    position: 'relative',
-    lineHeight: 0,
-  },
-  overlay: {
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -60%)',
-    fontSize: 45,
-    fontWeight: 'bold',
-    color: theme.palette.textContrast,
-  },
-  circle: {
-    width: '80%',
-    transform: 'translate(10%, 0)',
-  },
-  colorUnknown: {},
-}));
+export type GaugeClassKey = 'root' | 'overlay' | 'circle' | 'colorUnknown';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    root: {
+      position: 'relative',
+      lineHeight: 0,
+    },
+    overlay: {
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -60%)',
+      fontSize: 45,
+      fontWeight: 'bold',
+      color: theme.palette.textContrast,
+    },
+    circle: {
+      width: '80%',
+      transform: 'translate(10%, 0)',
+    },
+    colorUnknown: {},
+  }),
+  { name: 'BackstageGauge' },
+);
 
 type Props = {
   value: number;

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
@@ -30,12 +30,17 @@ type Props = {
   deepLink?: BottomLinkProps;
 };
 
-const useStyles = makeStyles({
-  root: {
-    height: '100%',
-    width: 250,
+export type GaugeCardClassKey = 'root';
+
+const useStyles = makeStyles(
+  {
+    root: {
+      height: '100%',
+      width: 250,
+    },
   },
-});
+  { name: 'BackstageGaugeCard' },
+);
 
 export function GaugeCard(props: Props) {
   const classes = useStyles(props);

--- a/packages/core-components/src/components/ProgressBars/index.ts
+++ b/packages/core-components/src/components/ProgressBars/index.ts
@@ -15,5 +15,7 @@
  */
 
 export { GaugeCard } from './GaugeCard';
+export type { GaugeCardClassKey } from './GaugeCard';
 export { Gauge } from './Gauge';
+export type { GaugeClassKey } from './Gauge';
 export { LinearGauge } from './LinearGauge';

--- a/packages/core-components/src/components/ResponseErrorPanel/ResponseErrorPanel.tsx
+++ b/packages/core-components/src/components/ResponseErrorPanel/ResponseErrorPanel.tsx
@@ -21,17 +21,22 @@ import { CodeSnippet } from '../CodeSnippet';
 import { CopyTextButton } from '../CopyTextButton';
 import { ErrorPanel, ErrorPanelProps } from '../ErrorPanel';
 
-const useStyles = makeStyles(theme => ({
-  text: {
-    fontFamily: 'monospace',
-    whiteSpace: 'pre',
-    overflowX: 'auto',
-    marginRight: theme.spacing(2),
-  },
-  divider: {
-    margin: theme.spacing(2),
-  },
-}));
+export type ResponseErrorPanelClassKey = 'text' | 'divider';
+
+const useStyles = makeStyles(
+  theme => ({
+    text: {
+      fontFamily: 'monospace',
+      whiteSpace: 'pre',
+      overflowX: 'auto',
+      marginRight: theme.spacing(2),
+    },
+    divider: {
+      margin: theme.spacing(2),
+    },
+  }),
+  { name: 'BackstageResponseErrorPanel' },
+);
 
 /**
  * Renders a warning panel as the effect of a failed server request.

--- a/packages/core-components/src/components/ResponseErrorPanel/index.ts
+++ b/packages/core-components/src/components/ResponseErrorPanel/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { ResponseErrorPanel } from './ResponseErrorPanel';
+export type { ResponseErrorPanelClassKey } from './ResponseErrorPanel';

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -34,59 +34,73 @@ import React, { useEffect, useState } from 'react';
 import ClosedDropdown from './static/ClosedDropdown';
 import OpenedDropdown from './static/OpenedDropdown';
 
-const BootstrapInput = withStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      'label + &': {
-        marginTop: theme.spacing(3),
+export type SelectInputBaseClassKey = 'root' | 'input';
+
+const BootstrapInput = withStyles(
+  (theme: Theme) =>
+    createStyles({
+      root: {
+        'label + &': {
+          marginTop: theme.spacing(3),
+        },
       },
-    },
-    input: {
-      borderRadius: 4,
-      position: 'relative',
-      backgroundColor: theme.palette.background.paper,
-      border: '1px solid #ced4da',
-      fontSize: 16,
-      padding: '10px 26px 10px 12px',
-      transition: theme.transitions.create(['border-color', 'box-shadow']),
-      fontFamily: 'Helvetica Neue',
-      '&:focus': {
-        background: theme.palette.background.paper,
+      input: {
         borderRadius: 4,
+        position: 'relative',
+        backgroundColor: theme.palette.background.paper,
+        border: '1px solid #ced4da',
+        fontSize: 16,
+        padding: '10px 26px 10px 12px',
+        transition: theme.transitions.create(['border-color', 'box-shadow']),
+        fontFamily: 'Helvetica Neue',
+        '&:focus': {
+          background: theme.palette.background.paper,
+          borderRadius: 4,
+        },
       },
-    },
-  }),
+    }),
+  { name: 'BackstageSelectInputBase' },
 )(InputBase);
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    formControl: {
-      margin: `${theme.spacing(1)} 0px`,
-      maxWidth: 300,
-    },
-    label: {
-      transform: 'initial',
-      fontWeight: 'bold',
-      fontSize: 14,
-      fontFamily: theme.typography.fontFamily,
-      color: theme.palette.text.primary,
-      '&.Mui-focused': {
-        color: theme.palette.text.primary,
+export type SelectClassKey =
+  | 'formControl'
+  | 'label'
+  | 'chips'
+  | 'chip'
+  | 'checkbox'
+  | 'root';
+
+const useStyles = makeStyles(
+  (theme: Theme) =>
+    createStyles({
+      formControl: {
+        margin: `${theme.spacing(1)} 0px`,
+        maxWidth: 300,
       },
-    },
-    chips: {
-      display: 'flex',
-      flexWrap: 'wrap',
-    },
-    chip: {
-      margin: 2,
-    },
-    checkbox: {},
-    root: {
-      display: 'flex',
-      flexDirection: 'column',
-    },
-  }),
+      label: {
+        transform: 'initial',
+        fontWeight: 'bold',
+        fontSize: 14,
+        fontFamily: theme.typography.fontFamily,
+        color: theme.palette.text.primary,
+        '&.Mui-focused': {
+          color: theme.palette.text.primary,
+        },
+      },
+      chips: {
+        display: 'flex',
+        flexWrap: 'wrap',
+      },
+      chip: {
+        margin: 2,
+      },
+      checkbox: {},
+      root: {
+        display: 'flex',
+        flexDirection: 'column',
+      },
+    }),
+  { name: 'BackstageSelect' },
 );
 
 type Item = {

--- a/packages/core-components/src/components/Select/index.tsx
+++ b/packages/core-components/src/components/Select/index.tsx
@@ -15,3 +15,6 @@
  */
 
 export { SelectComponent as Select } from './Select';
+export type { SelectClassKey, SelectInputBaseClassKey } from './Select';
+export type { ClosedDropdownClassKey } from './static/ClosedDropdown';
+export type { OpenedDropdownClassKey } from './static/OpenedDropdown';

--- a/packages/core-components/src/components/Select/static/ClosedDropdown.tsx
+++ b/packages/core-components/src/components/Select/static/ClosedDropdown.tsx
@@ -16,14 +16,18 @@
 import React from 'react';
 import { SvgIcon, makeStyles, createStyles } from '@material-ui/core';
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    icon: {
-      position: 'absolute',
-      right: '4px',
-      pointerEvents: 'none',
-    },
-  }),
+export type ClosedDropdownClassKey = 'icon';
+
+const useStyles = makeStyles(
+  () =>
+    createStyles({
+      icon: {
+        position: 'absolute',
+        right: '4px',
+        pointerEvents: 'none',
+      },
+    }),
+  { name: 'BackstageClosedDropdown' },
 );
 
 const ClosedDropdown = () => {

--- a/packages/core-components/src/components/Select/static/OpenedDropdown.tsx
+++ b/packages/core-components/src/components/Select/static/OpenedDropdown.tsx
@@ -16,14 +16,18 @@
 import React from 'react';
 import { SvgIcon, makeStyles, createStyles } from '@material-ui/core';
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    icon: {
-      position: 'absolute',
-      right: '4px',
-      pointerEvents: 'none',
-    },
-  }),
+export type OpenedDropdownClassKey = 'icon';
+
+const useStyles = makeStyles(
+  () =>
+    createStyles({
+      icon: {
+        position: 'absolute',
+        right: '4px',
+        pointerEvents: 'none',
+      },
+    }),
+  { name: 'BackstageOpenedDropdown' },
 );
 
 const OpenedDropdown = () => {

--- a/packages/core-components/src/components/SimpleStepper/SimpleStepperFooter.tsx
+++ b/packages/core-components/src/components/SimpleStepper/SimpleStepperFooter.tsx
@@ -18,14 +18,19 @@ import { Button, makeStyles } from '@material-ui/core';
 import { StepActions } from './types';
 import { VerticalStepperContext } from './SimpleStepper';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    marginTop: theme.spacing(3),
-    '& button': {
-      marginRight: theme.spacing(1),
+export type SimpleStepperFooterClassKey = 'root';
+
+const useStyles = makeStyles(
+  theme => ({
+    root: {
+      marginTop: theme.spacing(3),
+      '& button': {
+        marginRight: theme.spacing(1),
+      },
     },
-  },
-}));
+  }),
+  { name: 'BackstageSimpleStepperFooter' },
+);
 
 interface CommonBtnProps {
   text?: string;

--- a/packages/core-components/src/components/SimpleStepper/SimpleStepperStep.tsx
+++ b/packages/core-components/src/components/SimpleStepper/SimpleStepperStep.tsx
@@ -24,11 +24,16 @@ import {
 import { SimpleStepperFooter } from './SimpleStepperFooter';
 import { StepProps } from './types';
 
-const useStyles = makeStyles(theme => ({
-  end: {
-    padding: theme.spacing(3),
-  },
-}));
+export type SimpleStepperStepClassKey = 'end';
+
+const useStyles = makeStyles(
+  theme => ({
+    end: {
+      padding: theme.spacing(3),
+    },
+  }),
+  { name: 'SimpleStepperStep' },
+);
 
 export function SimpleStepperStep(props: PropsWithChildren<StepProps>) {
   const { title, children, end, actions, ...muiProps } = props;

--- a/packages/core-components/src/components/SimpleStepper/index.ts
+++ b/packages/core-components/src/components/SimpleStepper/index.ts
@@ -15,4 +15,6 @@
  */
 
 export { SimpleStepper } from './SimpleStepper';
+export type { SimpleStepperFooterClassKey } from './SimpleStepperFooter';
 export { SimpleStepperStep } from './SimpleStepperStep';
+export type { SimpleStepperStepClassKey } from './SimpleStepperStep';

--- a/packages/core-components/src/components/Status/Status.tsx
+++ b/packages/core-components/src/components/Status/Status.tsx
@@ -19,49 +19,61 @@ import { BackstageTheme } from '@backstage/theme';
 import classNames from 'classnames';
 import React, { PropsWithChildren } from 'react';
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  status: {
-    fontWeight: 500,
-    '&::before': {
-      width: '0.7em',
-      height: '0.7em',
-      display: 'inline-block',
-      marginRight: 8,
-      borderRadius: '50%',
-      content: '""',
+export type StatusClassKey =
+  | 'status'
+  | 'ok'
+  | 'warning'
+  | 'error'
+  | 'pending'
+  | 'running'
+  | 'aborted';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    status: {
+      fontWeight: 500,
+      '&::before': {
+        width: '0.7em',
+        height: '0.7em',
+        display: 'inline-block',
+        marginRight: 8,
+        borderRadius: '50%',
+        content: '""',
+      },
     },
-  },
-  ok: {
-    '&::before': {
-      backgroundColor: theme.palette.status.ok,
+    ok: {
+      '&::before': {
+        backgroundColor: theme.palette.status.ok,
+      },
     },
-  },
-  warning: {
-    '&::before': {
-      backgroundColor: theme.palette.status.warning,
+    warning: {
+      '&::before': {
+        backgroundColor: theme.palette.status.warning,
+      },
     },
-  },
-  error: {
-    '&::before': {
-      backgroundColor: theme.palette.status.error,
+    error: {
+      '&::before': {
+        backgroundColor: theme.palette.status.error,
+      },
     },
-  },
-  pending: {
-    '&::before': {
-      backgroundColor: theme.palette.status.pending,
+    pending: {
+      '&::before': {
+        backgroundColor: theme.palette.status.pending,
+      },
     },
-  },
-  running: {
-    '&::before': {
-      backgroundColor: theme.palette.status.running,
+    running: {
+      '&::before': {
+        backgroundColor: theme.palette.status.running,
+      },
     },
-  },
-  aborted: {
-    '&::before': {
-      backgroundColor: theme.palette.status.aborted,
+    aborted: {
+      '&::before': {
+        backgroundColor: theme.palette.status.aborted,
+      },
     },
-  },
-}));
+  }),
+  { name: 'BackstageStatus' },
+);
 
 export function StatusOK(props: PropsWithChildren<{}>) {
   const classes = useStyles(props);

--- a/packages/core-components/src/components/Status/index.ts
+++ b/packages/core-components/src/components/Status/index.ts
@@ -22,3 +22,5 @@ export {
   StatusRunning,
   StatusWarning,
 } from './Status';
+
+export type { StatusClassKey } from './Status';

--- a/packages/core-components/src/components/StructuredMetadataTable/MetadataTable.tsx
+++ b/packages/core-components/src/components/StructuredMetadataTable/MetadataTable.tsx
@@ -26,6 +26,8 @@ import {
   Theme,
 } from '@material-ui/core';
 
+export type MetadataTableTitleCellClassKey = 'root';
+
 const tableTitleCellStyles = (theme: Theme) =>
   createStyles({
     root: {
@@ -37,12 +39,16 @@ const tableTitleCellStyles = (theme: Theme) =>
     },
   });
 
+export type MetadataTableCellClassKey = 'root';
+
 const tableContentCellStyles = {
   root: {
     border: '0',
     verticalAlign: 'top',
   },
 };
+
+export type MetadataTableListClassKey = 'root';
 
 const listStyles = (theme: Theme) =>
   createStyles({
@@ -53,6 +59,8 @@ const listStyles = (theme: Theme) =>
     },
   });
 
+export type MetadataTableListItemClassKey = 'root' | 'random';
+
 const listItemStyles = (theme: Theme) =>
   createStyles({
     root: {
@@ -61,8 +69,12 @@ const listItemStyles = (theme: Theme) =>
     random: {},
   });
 
-const TitleCell = withStyles(tableTitleCellStyles)(TableCell);
-const ContentCell = withStyles(tableContentCellStyles)(TableCell);
+const TitleCell = withStyles(tableTitleCellStyles, {
+  name: 'BackstageMetadataTableTitleCell',
+})(TableCell);
+const ContentCell = withStyles(tableContentCellStyles, {
+  name: 'BackstageMetadataTableCell',
+})(TableCell);
 
 export const MetadataTable = ({
   dense,
@@ -96,14 +108,14 @@ interface StyleProps extends WithStyles {
   children?: React.ReactNode;
 }
 
-export const MetadataList = withStyles(listStyles)(
-  ({ classes, children }: StyleProps) => (
-    <ul className={classes.root}>{children}</ul>
-  ),
-);
+export const MetadataList = withStyles(listStyles, {
+  name: 'BackstageMetadataTableList',
+})(({ classes, children }: StyleProps) => (
+  <ul className={classes.root}>{children}</ul>
+));
 
-export const MetadataListItem = withStyles(listItemStyles)(
-  ({ classes, children }: StyleProps) => (
-    <li className={classes.root}>{children}</li>
-  ),
-);
+export const MetadataListItem = withStyles(listItemStyles, {
+  name: 'BackstageMetadataTableListItem',
+})(({ classes, children }: StyleProps) => (
+  <li className={classes.root}>{children}</li>
+));

--- a/packages/core-components/src/components/StructuredMetadataTable/StructuredMetadataTable.tsx
+++ b/packages/core-components/src/components/StructuredMetadataTable/StructuredMetadataTable.tsx
@@ -25,12 +25,16 @@ import {
   MetadataListItem,
 } from './MetadataTable';
 
+export type StructuredMetadataTableListClassKey = 'root';
+
 const listStyle = createStyles({
   root: {
     margin: '0 0',
     listStyleType: 'none',
   },
 });
+
+export type StructuredMetadataTableNestedListClassKey = 'root';
 
 const nestedListStyle = (theme: Theme) =>
   createStyles({
@@ -44,16 +48,16 @@ interface StyleProps extends WithStyles {
   children?: React.ReactNode;
 }
 // Sub Components
-const StyledList = withStyles(listStyle)(
-  ({ classes, children }: StyleProps) => (
-    <MetadataList classes={classes}>{children}</MetadataList>
-  ),
-);
-const StyledNestedList = withStyles(nestedListStyle)(
-  ({ classes, children }: StyleProps) => (
-    <MetadataList classes={classes}>{children}</MetadataList>
-  ),
-);
+const StyledList = withStyles(listStyle, {
+  name: 'BackstageStructuredMetadataTableList',
+})(({ classes, children }: StyleProps) => (
+  <MetadataList classes={classes}>{children}</MetadataList>
+));
+const StyledNestedList = withStyles(nestedListStyle, {
+  name: 'BackstageStructuredMetadataTableNestedList',
+})(({ classes, children }: StyleProps) => (
+  <MetadataList classes={classes}>{children}</MetadataList>
+));
 
 function renderList(list: Array<any>, nested?: boolean) {
   const values = list.map((item: any, index: number) => (

--- a/packages/core-components/src/components/StructuredMetadataTable/index.tsx
+++ b/packages/core-components/src/components/StructuredMetadataTable/index.tsx
@@ -14,4 +14,14 @@
  * limitations under the License.
  */
 
+export type {
+  MetadataTableCellClassKey,
+  MetadataTableTitleCellClassKey,
+  MetadataTableListClassKey,
+  MetadataTableListItemClassKey,
+} from './MetadataTable';
 export { StructuredMetadataTable } from './StructuredMetadataTable';
+export type {
+  StructuredMetadataTableListClassKey,
+  StructuredMetadataTableNestedListClassKey,
+} from './StructuredMetadataTable';

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -40,12 +40,17 @@ type SupportButtonProps = {
   children?: React.ReactNode;
 };
 
-const useStyles = makeStyles({
-  popoverList: {
-    minWidth: 260,
-    maxWidth: 400,
+export type SupportButtonClassKey = 'popoverList';
+
+const useStyles = makeStyles(
+  {
+    popoverList: {
+      minWidth: 260,
+      maxWidth: 400,
+    },
   },
-});
+  { name: 'BackstageSupportButton' },
+);
 
 const SupportIcon = ({ icon }: { icon: string | undefined }) => {
   const app = useApp();

--- a/packages/core-components/src/components/SupportButton/index.ts
+++ b/packages/core-components/src/components/SupportButton/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { SupportButton } from './SupportButton';
+export type { SupportButtonClassKey } from './SupportButton';

--- a/packages/core-components/src/components/Table/Filters.tsx
+++ b/packages/core-components/src/components/Table/Filters.tsx
@@ -20,33 +20,38 @@ import { Button, makeStyles } from '@material-ui/core';
 import { Select } from '../Select';
 import { SelectProps } from '../Select/Select';
 
-const useSubvalueCellStyles = makeStyles<BackstageTheme>(theme => ({
-  root: {
-    height: '100%',
-    width: '315px',
-    display: 'flex',
-    flexDirection: 'column',
-    marginRight: theme.spacing(3),
-  },
-  value: {
-    fontWeight: 'bold',
-    fontSize: 18,
-  },
-  header: {
-    display: 'flex',
-    alignItems: 'center',
-    height: '60px',
-    justifyContent: 'space-between',
-    borderBottom: `1px solid ${theme.palette.grey[500]}`,
-  },
-  filters: {
-    display: 'flex',
-    flexDirection: 'column',
-    '& > *': {
-      marginTop: theme.spacing(2),
+export type TableFiltersClassKey = 'root' | 'value' | 'heder' | 'filters';
+
+const useFilterStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    root: {
+      height: '100%',
+      width: '315px',
+      display: 'flex',
+      flexDirection: 'column',
+      marginRight: theme.spacing(3),
     },
-  },
-}));
+    value: {
+      fontWeight: 'bold',
+      fontSize: 18,
+    },
+    header: {
+      display: 'flex',
+      alignItems: 'center',
+      height: '60px',
+      justifyContent: 'space-between',
+      borderBottom: `1px solid ${theme.palette.grey[500]}`,
+    },
+    filters: {
+      display: 'flex',
+      flexDirection: 'column',
+      '& > *': {
+        marginTop: theme.spacing(2),
+      },
+    },
+  }),
+  { name: 'BackstageTableFilters' },
+);
 
 export type Without<T, K> = Pick<T, Exclude<keyof T, K>>;
 
@@ -66,7 +71,7 @@ type Props = {
 };
 
 export const Filters = (props: Props) => {
-  const classes = useSubvalueCellStyles();
+  const classes = useFilterStyles();
 
   const { onChangeFilters } = props;
 

--- a/packages/core-components/src/components/Table/SubvalueCell.tsx
+++ b/packages/core-components/src/components/Table/SubvalueCell.tsx
@@ -18,15 +18,20 @@ import React from 'react';
 import { BackstageTheme } from '@backstage/theme';
 import { makeStyles } from '@material-ui/core';
 
-const useSubvalueCellStyles = makeStyles<BackstageTheme>(theme => ({
-  value: {
-    marginBottom: '6px',
-  },
-  subvalue: {
-    color: theme.palette.textSubtle,
-    fontWeight: 'normal',
-  },
-}));
+export type SubvalueCellClassKey = 'value' | 'subvalue';
+
+const useSubvalueCellStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    value: {
+      marginBottom: '6px',
+    },
+    subvalue: {
+      color: theme.palette.textSubtle,
+      fontWeight: 'normal',
+    },
+  }),
+  { name: 'BackstageSubvalueCell' },
+);
 
 type SubvalueCellProps = {
   value: React.ReactNode;

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -100,52 +100,72 @@ function extractValueByField(data: any, field: string): any | undefined {
   return value;
 }
 
-const StyledMTableHeader = withStyles(theme => ({
-  header: {
-    padding: theme.spacing(1, 2, 1, 2.5),
-    borderTop: `1px solid ${theme.palette.grey.A100}`,
-    borderBottom: `1px solid ${theme.palette.grey.A100}`,
-    // withStyles hasn't a generic overload for theme
-    color: (theme as BackstageTheme).palette.textSubtle,
-    fontWeight: theme.typography.fontWeightBold,
-    position: 'static',
-    wordBreak: 'normal',
-  },
-}))(MTableHeader);
+export type TableHeaderClassKey = 'header';
 
-const StyledMTableToolbar = withStyles(theme => ({
-  root: {
-    padding: theme.spacing(3, 0, 2.5, 2.5),
-  },
-  title: {
-    '& > h6': {
-      fontWeight: 'bold',
+const StyledMTableHeader = withStyles(
+  theme => ({
+    header: {
+      padding: theme.spacing(1, 2, 1, 2.5),
+      borderTop: `1px solid ${theme.palette.grey.A100}`,
+      borderBottom: `1px solid ${theme.palette.grey.A100}`,
+      // withStyles hasn't a generic overload for theme
+      color: (theme as BackstageTheme).palette.textSubtle,
+      fontWeight: theme.typography.fontWeightBold,
+      position: 'static',
+      wordBreak: 'normal',
     },
-  },
-  searchField: {
-    paddingRight: theme.spacing(2),
-  },
-}))(MTableToolbar);
+  }),
+  { name: 'BackstageTableHeader' },
+)(MTableHeader);
 
-const useFilterStyles = makeStyles<BackstageTheme>(() => ({
-  root: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  title: {
-    fontWeight: 'bold',
-    fontSize: 18,
-    whiteSpace: 'nowrap',
-  },
-}));
+export type TableToolbarClassKey = 'root' | 'title' | 'searchField';
 
-const useTableStyles = makeStyles<BackstageTheme>(() => ({
-  root: {
-    display: 'flex',
-    alignItems: 'start',
-  },
-}));
+const StyledMTableToolbar = withStyles(
+  theme => ({
+    root: {
+      padding: theme.spacing(3, 0, 2.5, 2.5),
+    },
+    title: {
+      '& > h6': {
+        fontWeight: 'bold',
+      },
+    },
+    searchField: {
+      paddingRight: theme.spacing(2),
+    },
+  }),
+  { name: 'BackstageTableToolbar' },
+)(MTableToolbar);
+
+export type FiltersContainerClassKey = 'root' | 'title';
+
+const useFilterStyles = makeStyles<BackstageTheme>(
+  () => ({
+    root: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    title: {
+      fontWeight: 'bold',
+      fontSize: 18,
+      whiteSpace: 'nowrap',
+    },
+  }),
+  { name: 'BackstageTableFiltersContainer' },
+);
+
+export type TableClassKey = 'root';
+
+const useTableStyles = makeStyles<BackstageTheme>(
+  () => ({
+    root: {
+      display: 'flex',
+      alignItems: 'start',
+    },
+  }),
+  { name: 'BackstageTable' },
+);
 
 function convertColumns<T extends object>(
   columns: TableColumn<T>[],

--- a/packages/core-components/src/components/Table/index.ts
+++ b/packages/core-components/src/components/Table/index.ts
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+export type { TableFiltersClassKey } from './Filters';
 export { SubvalueCell } from './SubvalueCell';
+export type { SubvalueCellClassKey } from './SubvalueCell';
 export { Table } from './Table';
+export type {
+  TableClassKey,
+  FiltersContainerClassKey,
+  TableHeaderClassKey,
+} from './Table';
 export type { TableColumn, TableFilter, TableProps, TableState } from './Table';

--- a/packages/core-components/src/components/Table/index.ts
+++ b/packages/core-components/src/components/Table/index.ts
@@ -19,8 +19,12 @@ export { SubvalueCell } from './SubvalueCell';
 export type { SubvalueCellClassKey } from './SubvalueCell';
 export { Table } from './Table';
 export type {
+  TableColumn,
+  TableFilter,
+  TableProps,
+  TableState,
   TableClassKey,
   FiltersContainerClassKey,
   TableHeaderClassKey,
+  TableToolbarClassKey,
 } from './Table';
-export type { TableColumn, TableFilter, TableProps, TableState } from './Table';

--- a/packages/core-components/src/components/Tabs/TabBar.tsx
+++ b/packages/core-components/src/components/Tabs/TabBar.tsx
@@ -24,22 +24,27 @@ interface StyledTabsProps {
   onChange: (event: React.ChangeEvent<{}>, newValue: number) => void;
 }
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  indicator: {
-    display: 'flex',
-    justifyContent: 'center',
-    backgroundColor: theme.palette.tabbar.indicator,
-    height: '4px',
-  },
-  flexContainer: {
-    alignItems: 'center',
-  },
-  root: {
-    '&:last-child': {
-      marginLeft: 'auto',
+export type TabBarClassKey = 'indicator' | 'flexContainer' | 'root';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    indicator: {
+      display: 'flex',
+      justifyContent: 'center',
+      backgroundColor: theme.palette.tabbar.indicator,
+      height: '4px',
     },
-  },
-}));
+    flexContainer: {
+      alignItems: 'center',
+    },
+    root: {
+      '&:last-child': {
+        marginLeft: 'auto',
+      },
+    },
+  }),
+  { name: 'BackstageTabBar' },
+);
 
 export const StyledTabs = (props: PropsWithChildren<StyledTabsProps>) => {
   const classes = useStyles(props);

--- a/packages/core-components/src/components/Tabs/TabIcon.tsx
+++ b/packages/core-components/src/components/Tabs/TabIcon.tsx
@@ -25,22 +25,27 @@ interface StyledIconProps {
   onClick: any;
 }
 
-const useStyles = makeStyles<BackstageTheme, StyledIconProps>(() => ({
-  root: {
-    color: '#6E6E6E',
-    overflow: 'visible',
-    fontSize: '1.5rem',
-    textAlign: 'center',
-    borderRadius: '50%',
-    backgroundColor: '#E6E6E6',
-    marginLeft: props => (props.isNext ? 'auto' : '0'),
-    marginRight: props => (props.isNext ? '0' : '10px'),
-    '&:hover': {
+export type TabIconClassKey = 'root';
+
+const useStyles = makeStyles<BackstageTheme, StyledIconProps>(
+  () => ({
+    root: {
+      color: '#6E6E6E',
+      overflow: 'visible',
+      fontSize: '1.5rem',
+      textAlign: 'center',
+      borderRadius: '50%',
       backgroundColor: '#E6E6E6',
-      opacity: '1',
+      marginLeft: props => (props.isNext ? 'auto' : '0'),
+      marginRight: props => (props.isNext ? '0' : '10px'),
+      '&:hover': {
+        backgroundColor: '#E6E6E6',
+        opacity: '1',
+      },
     },
-  },
-}));
+  }),
+  { name: 'BackstageTabIcon' },
+);
 
 export const StyledIcon = (props: StyledIconProps) => {
   const classes = useStyles(props);

--- a/packages/core-components/src/components/Tabs/Tabs.tsx
+++ b/packages/core-components/src/components/Tabs/Tabs.tsx
@@ -42,21 +42,26 @@ export interface TabsProps {
   tabs: TabProps[];
 }
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  root: {
-    flexGrow: 1,
-    width: '100%',
-  },
-  styledTabs: {
-    backgroundColor: theme.palette.background.paper,
-  },
-  appbar: {
-    boxShadow: 'none',
-    backgroundColor: theme.palette.background.paper,
-    paddingLeft: '10px',
-    paddingRight: '10px',
-  },
-}));
+export type TabsClassKey = 'root' | 'styledTabs' | 'appbar';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    root: {
+      flexGrow: 1,
+      width: '100%',
+    },
+    styledTabs: {
+      backgroundColor: theme.palette.background.paper,
+    },
+    appbar: {
+      boxShadow: 'none',
+      backgroundColor: theme.palette.background.paper,
+      paddingLeft: '10px',
+      paddingRight: '10px',
+    },
+  }),
+  { name: 'BackstageTabs' },
+);
 
 export function Tabs(props: TabsProps) {
   const { tabs } = props;

--- a/packages/core-components/src/components/Tabs/index.ts
+++ b/packages/core-components/src/components/Tabs/index.ts
@@ -15,3 +15,7 @@
  */
 
 export { Tabs } from './Tabs';
+export type { TabsClassKey } from './Tabs';
+
+export type { TabBarClassKey } from './TabBar';
+export type { TabIconClassKey } from './TabIcon';

--- a/packages/core-components/src/components/WarningPanel/WarningPanel.tsx
+++ b/packages/core-components/src/components/WarningPanel/WarningPanel.tsx
@@ -64,56 +64,66 @@ const ExpandMoreIconStyled = ({ severity }: Pick<WarningProps, 'severity'>) => {
   return <ExpandMoreIcon classes={classes} />;
 };
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  panel: {
-    backgroundColor: ({ severity }: WarningProps) =>
-      getWarningBackgroundColor(
-        severity as NonNullable<WarningProps['severity']>,
-        theme,
-      ),
-    color: ({ severity }: WarningProps) =>
-      getWarningTextColor(
-        severity as NonNullable<WarningProps['severity']>,
-        theme,
-      ),
-    verticalAlign: 'middle',
-  },
-  summary: {
-    display: 'flex',
-    flexDirection: 'row',
-  },
-  summaryText: {
-    color: ({ severity }: WarningProps) =>
-      getWarningTextColor(
-        severity as NonNullable<WarningProps['severity']>,
-        theme,
-      ),
-    fontWeight: 'bold',
-  },
-  message: {
-    width: '100%',
-    display: 'block',
-    color: ({ severity }: WarningProps) =>
-      getWarningTextColor(
-        severity as NonNullable<WarningProps['severity']>,
-        theme,
-      ),
-    backgroundColor: ({ severity }: WarningProps) =>
-      getWarningBackgroundColor(
-        severity as NonNullable<WarningProps['severity']>,
-        theme,
-      ),
-  },
-  details: {
-    width: '100%',
-    display: 'block',
-    color: theme.palette.textContrast,
-    backgroundColor: theme.palette.background.default,
-    border: `1px solid ${theme.palette.border}`,
-    padding: theme.spacing(2.0),
-    fontFamily: 'sans-serif',
-  },
-}));
+export type WarningPanelClassKey =
+  | 'panel'
+  | 'summary'
+  | 'summaryText'
+  | 'message'
+  | 'details';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    panel: {
+      backgroundColor: ({ severity }: WarningProps) =>
+        getWarningBackgroundColor(
+          severity as NonNullable<WarningProps['severity']>,
+          theme,
+        ),
+      color: ({ severity }: WarningProps) =>
+        getWarningTextColor(
+          severity as NonNullable<WarningProps['severity']>,
+          theme,
+        ),
+      verticalAlign: 'middle',
+    },
+    summary: {
+      display: 'flex',
+      flexDirection: 'row',
+    },
+    summaryText: {
+      color: ({ severity }: WarningProps) =>
+        getWarningTextColor(
+          severity as NonNullable<WarningProps['severity']>,
+          theme,
+        ),
+      fontWeight: 'bold',
+    },
+    message: {
+      width: '100%',
+      display: 'block',
+      color: ({ severity }: WarningProps) =>
+        getWarningTextColor(
+          severity as NonNullable<WarningProps['severity']>,
+          theme,
+        ),
+      backgroundColor: ({ severity }: WarningProps) =>
+        getWarningBackgroundColor(
+          severity as NonNullable<WarningProps['severity']>,
+          theme,
+        ),
+    },
+    details: {
+      width: '100%',
+      display: 'block',
+      color: theme.palette.textContrast,
+      backgroundColor: theme.palette.background.default,
+      border: `1px solid ${theme.palette.border}`,
+      padding: theme.spacing(2.0),
+      fontFamily: 'sans-serif',
+    },
+  }),
+  { name: 'BackstageWarningPanel' },
+);
 
 export type WarningProps = {
   title?: string;

--- a/packages/core-components/src/components/WarningPanel/index.ts
+++ b/packages/core-components/src/components/WarningPanel/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { WarningPanel } from './WarningPanel';
+export type { WarningPanelClassKey } from './WarningPanel';

--- a/packages/core-components/src/components/index.ts
+++ b/packages/core-components/src/components/index.ts
@@ -17,6 +17,7 @@
 export * from './AlertDisplay';
 export * from './Avatar';
 export * from './Button';
+export * from './CheckboxTree';
 export * from './CodeSnippet';
 export * from './CopyTextButton';
 export * from './CreateButton';

--- a/packages/core-components/src/components/index.ts
+++ b/packages/core-components/src/components/index.ts
@@ -17,7 +17,6 @@
 export * from './AlertDisplay';
 export * from './Avatar';
 export * from './Button';
-export * from './CheckboxTree';
 export * from './CodeSnippet';
 export * from './CopyTextButton';
 export * from './CreateButton';

--- a/packages/core-components/src/index.ts
+++ b/packages/core-components/src/index.ts
@@ -24,3 +24,4 @@ export * from './components';
 export * from './hooks';
 export * from './icons';
 export * from './layout';
+export * from './overridableComponents';

--- a/packages/core-components/src/layout/BottomLink/BottomLink.tsx
+++ b/packages/core-components/src/layout/BottomLink/BottomLink.tsx
@@ -21,19 +21,24 @@ import { BackstageTheme } from '@backstage/theme';
 import Box from '@material-ui/core/Box';
 import { Link } from '../../components/Link';
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  root: {
-    maxWidth: 'fit-content',
-    padding: theme.spacing(2, 2, 2, 2.5),
-  },
-  boxTitle: {
-    margin: 0,
-    color: theme.palette.textSubtle,
-  },
-  arrow: {
-    color: theme.palette.textSubtle,
-  },
-}));
+export type BottomLinkClassKey = 'root' | 'boxTitle' | 'arrow';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    root: {
+      maxWidth: 'fit-content',
+      padding: theme.spacing(2, 2, 2, 2.5),
+    },
+    boxTitle: {
+      margin: 0,
+      color: theme.palette.textSubtle,
+    },
+    arrow: {
+      color: theme.palette.textSubtle,
+    },
+  }),
+  { name: 'BackstageBottomLink' },
+);
 
 export type BottomLinkProps = {
   link: string;

--- a/packages/core-components/src/layout/BottomLink/index.ts
+++ b/packages/core-components/src/layout/BottomLink/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { BottomLink } from './BottomLink';
-export type { BottomLinkProps } from './BottomLink';
+export type { BottomLinkClassKey, BottomLinkProps } from './BottomLink';

--- a/packages/core-components/src/layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/core-components/src/layout/Breadcrumbs/Breadcrumbs.tsx
@@ -27,19 +27,29 @@ import React, { ComponentProps, Fragment } from 'react';
 
 type Props = ComponentProps<typeof MaterialBreadcrumbs>;
 
-const ClickableText = withStyles({
-  root: {
-    textDecoration: 'underline',
-    cursor: 'pointer',
-  },
-})(Typography);
+export type BreadcrumbsClickableTextClassKey = 'root';
 
-const StyledBox = withStyles({
-  root: {
-    textDecoration: 'underline',
-    color: 'inherit',
+const ClickableText = withStyles(
+  {
+    root: {
+      textDecoration: 'underline',
+      cursor: 'pointer',
+    },
   },
-})(Box);
+  { name: 'BackstageBreadcrumbsClickableText' },
+)(Typography);
+
+export type BreadcrumbsStyledBoxClassKey = 'root';
+
+const StyledBox = withStyles(
+  {
+    root: {
+      textDecoration: 'underline',
+      color: 'inherit',
+    },
+  },
+  { name: 'BackstageBreadcrumbsStyledBox' },
+)(Box);
 
 export function Breadcrumbs(props: Props) {
   const { children, ...restProps } = props;

--- a/packages/core-components/src/layout/Breadcrumbs/index.ts
+++ b/packages/core-components/src/layout/Breadcrumbs/index.ts
@@ -15,3 +15,7 @@
  */
 
 export { Breadcrumbs } from './Breadcrumbs';
+export type {
+  BreadcrumbsClickableTextClassKey,
+  BreadcrumbsStyledBoxClassKey,
+} from './Breadcrumbs';

--- a/packages/core-components/src/layout/Content/Content.tsx
+++ b/packages/core-components/src/layout/Content/Content.tsx
@@ -18,28 +18,33 @@ import React, { PropsWithChildren } from 'react';
 import classNames from 'classnames';
 import { Theme, makeStyles } from '@material-ui/core';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    gridArea: 'pageContent',
-    minWidth: 0,
-    paddingTop: theme.spacing(3),
-    paddingBottom: theme.spacing(3),
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
-    [theme.breakpoints.up('sm')]: {
-      paddingLeft: theme.spacing(3),
-      paddingRight: theme.spacing(3),
+export type BackstageContentClassKey = 'root' | 'stretch' | 'noPadding';
+
+const useStyles = makeStyles(
+  (theme: Theme) => ({
+    root: {
+      gridArea: 'pageContent',
+      minWidth: 0,
+      paddingTop: theme.spacing(3),
+      paddingBottom: theme.spacing(3),
+      paddingLeft: theme.spacing(2),
+      paddingRight: theme.spacing(2),
+      [theme.breakpoints.up('sm')]: {
+        paddingLeft: theme.spacing(3),
+        paddingRight: theme.spacing(3),
+      },
     },
-  },
-  stretch: {
-    display: 'flex',
-    flexDirection: 'column',
-    flexGrow: 1,
-  },
-  noPadding: {
-    padding: 0,
-  },
-}));
+    stretch: {
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: 1,
+    },
+    noPadding: {
+      padding: 0,
+    },
+  }),
+  { name: 'BackstageContent' },
+);
 
 type Props = {
   stretch?: boolean;

--- a/packages/core-components/src/layout/Content/index.ts
+++ b/packages/core-components/src/layout/Content/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { Content } from './Content';
+export type { BackstageContentClassKey } from './Content';

--- a/packages/core-components/src/layout/ContentHeader/ContentHeader.tsx
+++ b/packages/core-components/src/layout/ContentHeader/ContentHeader.tsx
@@ -22,39 +22,49 @@ import React, { PropsWithChildren, ReactNode } from 'react';
 import { Typography, makeStyles } from '@material-ui/core';
 import { Helmet } from 'react-helmet';
 
+export type ContentHeaderClassKey =
+  | 'container'
+  | 'leftItemsBox'
+  | 'rightItemsBox'
+  | 'description'
+  | 'title';
+
 const useStyles = (props: ContentHeaderProps) =>
-  makeStyles(theme => ({
-    container: {
-      width: '100%',
-      display: 'flex',
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      justifyContent: 'flex-end',
-      alignItems: 'center',
-      marginBottom: theme.spacing(2),
-      textAlign: props.textAlign,
-    },
-    leftItemsBox: {
-      flex: '1 1 auto',
-      minWidth: 0,
-      overflow: 'visible',
-    },
-    rightItemsBox: {
-      flex: '0 1 auto',
-      display: 'flex',
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      alignItems: 'center',
-      marginLeft: theme.spacing(1),
-      minWidth: 0,
-      overflow: 'visible',
-    },
-    description: {},
-    title: {
-      display: 'inline-flex',
-      marginBottom: 0,
-    },
-  }));
+  makeStyles(
+    theme => ({
+      container: {
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+        marginBottom: theme.spacing(2),
+        textAlign: props.textAlign,
+      },
+      leftItemsBox: {
+        flex: '1 1 auto',
+        minWidth: 0,
+        overflow: 'visible',
+      },
+      rightItemsBox: {
+        flex: '0 1 auto',
+        display: 'flex',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        marginLeft: theme.spacing(1),
+        minWidth: 0,
+        overflow: 'visible',
+      },
+      description: {},
+      title: {
+        display: 'inline-flex',
+        marginBottom: 0,
+      },
+    }),
+    { name: 'BackstageContentHeader' },
+  );
 
 type ContentHeaderTitleProps = {
   title?: string;

--- a/packages/core-components/src/layout/ContentHeader/index.ts
+++ b/packages/core-components/src/layout/ContentHeader/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { ContentHeader } from './ContentHeader';
+export type { ContentHeaderClassKey } from './ContentHeader';

--- a/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
+++ b/packages/core-components/src/layout/ErrorPage/ErrorPage.tsx
@@ -28,24 +28,29 @@ interface IErrorPageProps {
   additionalInfo?: string;
 }
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  container: {
-    padding: theme.spacing(8),
-    [theme.breakpoints.down('xs')]: {
-      padding: theme.spacing(2),
+export type ErrorPageClassKey = 'container' | 'title' | 'subtitle';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    container: {
+      padding: theme.spacing(8),
+      [theme.breakpoints.down('xs')]: {
+        padding: theme.spacing(2),
+      },
     },
-  },
-  title: {
-    paddingBottom: theme.spacing(5),
-    [theme.breakpoints.down('xs')]: {
-      paddingBottom: theme.spacing(4),
-      fontSize: 32,
+    title: {
+      paddingBottom: theme.spacing(5),
+      [theme.breakpoints.down('xs')]: {
+        paddingBottom: theme.spacing(4),
+        fontSize: 32,
+      },
     },
-  },
-  subtitle: {
-    color: theme.palette.textSubtle,
-  },
-}));
+    subtitle: {
+      color: theme.palette.textSubtle,
+    },
+  }),
+  { name: 'BackstageErrorPage' },
+);
 
 export function ErrorPage(props: IErrorPageProps) {
   const { status, statusMessage, additionalInfo } = props;

--- a/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
+++ b/packages/core-components/src/layout/ErrorPage/MicDrop.tsx
@@ -18,21 +18,26 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core';
 import MicDropSvgUrl from './mic-drop.svg';
 
-const useStyles = makeStyles(theme => ({
-  micDrop: {
-    maxWidth: '60%',
-    position: 'absolute',
-    bottom: theme.spacing(2),
-    right: theme.spacing(2),
-    [theme.breakpoints.down('xs')]: {
-      maxWidth: '96%',
-      position: 'relative',
-      bottom: 'unset',
-      right: 'unset',
-      margin: `${theme.spacing(10)}px auto ${theme.spacing(4)}px`,
+const useStyles = makeStyles(
+  theme => ({
+    micDrop: {
+      maxWidth: '60%',
+      position: 'absolute',
+      bottom: theme.spacing(2),
+      right: theme.spacing(2),
+      [theme.breakpoints.down('xs')]: {
+        maxWidth: '96%',
+        position: 'relative',
+        bottom: 'unset',
+        right: 'unset',
+        margin: `${theme.spacing(10)}px auto ${theme.spacing(4)}px`,
+      },
     },
-  },
-}));
+  }),
+  { name: 'BackstageErrorPageMicDrop' },
+);
+
+export type MicDropClassKey = 'micDrop';
 
 export const MicDrop = () => {
   const classes = useStyles();

--- a/packages/core-components/src/layout/ErrorPage/index.ts
+++ b/packages/core-components/src/layout/ErrorPage/index.ts
@@ -15,3 +15,5 @@
  */
 
 export { ErrorPage } from './ErrorPage';
+export type { ErrorPageClassKey } from './ErrorPage';
+export type { MicDropClassKey } from './MicDrop';

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -209,22 +209,20 @@ export function Header(props: PropsWithChildren<Props>) {
     <>
       <Helmet titleTemplate={titleTemplate} defaultTitle={defaultTitle} />
       <header style={style} className={classes.header}>
-        <div style={{ border: '2px solid green' }}>
-          <Box className={classes.leftItemsBox}>
-            <TypeFragment
-              classes={classes}
-              type={type}
-              typeLink={typeLink}
-              pageTitle={pageTitle}
-            />
-            <TitleFragment
-              classes={classes}
-              pageTitle={pageTitle}
-              tooltip={tooltip}
-            />
-            <SubtitleFragment classes={classes} subtitle={subtitle} />
-          </Box>
-        </div>
+        <Box className={classes.leftItemsBox}>
+          <TypeFragment
+            classes={classes}
+            type={type}
+            typeLink={typeLink}
+            pageTitle={pageTitle}
+          />
+          <TitleFragment
+            classes={classes}
+            pageTitle={pageTitle}
+            tooltip={tooltip}
+          />
+          <SubtitleFragment classes={classes} subtitle={subtitle} />
+        </Box>
         <Grid container className={classes.rightItemsBox} spacing={4}>
           {children}
         </Grid>

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -22,64 +22,78 @@ import { Helmet } from 'react-helmet';
 import { Link } from '../../components/Link';
 import { Breadcrumbs } from '../Breadcrumbs';
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  header: {
-    gridArea: 'pageHeader',
-    padding: theme.spacing(3),
-    width: '100%',
-    boxShadow: '0 0 8px 3px rgba(20, 20, 20, 0.3)',
-    position: 'relative',
-    zIndex: 100,
-    display: 'flex',
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    alignItems: 'center',
-    backgroundImage: theme.page.backgroundImage,
-    backgroundPosition: 'center',
-    backgroundSize: 'cover',
-  },
-  leftItemsBox: {
-    maxWidth: '100%',
-    flexGrow: 1,
-  },
-  rightItemsBox: {
-    width: 'auto',
-  },
-  title: {
-    color: theme.palette.bursts.fontColor,
-    wordBreak: 'break-all',
-    fontSize: 'calc(24px + 6 * ((100vw - 320px) / 680))',
-    marginBottom: 0,
-  },
-  subtitle: {
-    color: 'rgba(255, 255, 255, 0.8)',
-    lineHeight: '1.0em',
-    display: 'inline-block', // prevents margin collapse of adjacent siblings
-    marginTop: theme.spacing(1),
-  },
-  type: {
-    textTransform: 'uppercase',
-    fontSize: 11,
-    opacity: 0.8,
-    marginBottom: theme.spacing(1),
-    color: theme.palette.bursts.fontColor,
-  },
-  breadcrumb: {
-    fontSize: 'calc(15px + 1 * ((100vw - 320px) / 680))',
-    color: theme.palette.bursts.fontColor,
-  },
-  breadcrumbType: {
-    fontSize: 'inherit',
-    opacity: 0.7,
-    marginRight: -theme.spacing(0.3),
-    marginBottom: theme.spacing(0.3),
-  },
-  breadcrumbTitle: {
-    fontSize: 'inherit',
-    marginLeft: -theme.spacing(0.3),
-    marginBottom: theme.spacing(0.3),
-  },
-}));
+export type HeaderClassKey =
+  | 'header'
+  | 'leftItemsBox'
+  | 'rightItemsBox'
+  | 'title'
+  | 'subtitle'
+  | 'type'
+  | 'breadcrumb'
+  | 'breadcrumbType'
+  | 'breadcrumbTitle';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    header: {
+      gridArea: 'pageHeader',
+      padding: theme.spacing(3),
+      width: '100%',
+      boxShadow: '0 0 8px 3px rgba(20, 20, 20, 0.3)',
+      position: 'relative',
+      zIndex: 100,
+      display: 'flex',
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      backgroundImage: theme.page.backgroundImage,
+      backgroundPosition: 'center',
+      backgroundSize: 'cover',
+    },
+    leftItemsBox: {
+      maxWidth: '100%',
+      flexGrow: 1,
+    },
+    rightItemsBox: {
+      width: 'auto',
+    },
+    title: {
+      color: theme.palette.bursts.fontColor,
+      wordBreak: 'break-all',
+      fontSize: 'calc(24px + 6 * ((100vw - 320px) / 680))',
+      marginBottom: 0,
+    },
+    subtitle: {
+      color: 'rgba(255, 255, 255, 0.8)',
+      lineHeight: '1.0em',
+      display: 'inline-block', // prevents margin collapse of adjacent siblings
+      marginTop: theme.spacing(1),
+    },
+    type: {
+      textTransform: 'uppercase',
+      fontSize: 11,
+      opacity: 0.8,
+      marginBottom: theme.spacing(1),
+      color: theme.palette.bursts.fontColor,
+    },
+    breadcrumb: {
+      fontSize: 'calc(15px + 1 * ((100vw - 320px) / 680))',
+      color: theme.palette.bursts.fontColor,
+    },
+    breadcrumbType: {
+      fontSize: 'inherit',
+      opacity: 0.7,
+      marginRight: -theme.spacing(0.3),
+      marginBottom: theme.spacing(0.3),
+    },
+    breadcrumbTitle: {
+      fontSize: 'inherit',
+      marginLeft: -theme.spacing(0.3),
+      marginBottom: theme.spacing(0.3),
+    },
+  }),
+  { name: 'BackstageHeader' },
+);
 
 type HeaderStyles = ReturnType<typeof useStyles>;
 
@@ -195,20 +209,22 @@ export function Header(props: PropsWithChildren<Props>) {
     <>
       <Helmet titleTemplate={titleTemplate} defaultTitle={defaultTitle} />
       <header style={style} className={classes.header}>
-        <Box className={classes.leftItemsBox}>
-          <TypeFragment
-            classes={classes}
-            type={type}
-            typeLink={typeLink}
-            pageTitle={pageTitle}
-          />
-          <TitleFragment
-            classes={classes}
-            pageTitle={pageTitle}
-            tooltip={tooltip}
-          />
-          <SubtitleFragment classes={classes} subtitle={subtitle} />
-        </Box>
+        <div style={{ border: '2px solid green' }}>
+          <Box className={classes.leftItemsBox}>
+            <TypeFragment
+              classes={classes}
+              type={type}
+              typeLink={typeLink}
+              pageTitle={pageTitle}
+            />
+            <TitleFragment
+              classes={classes}
+              pageTitle={pageTitle}
+              tooltip={tooltip}
+            />
+            <SubtitleFragment classes={classes} subtitle={subtitle} />
+          </Box>
+        </div>
         <Grid container className={classes.rightItemsBox} spacing={4}>
           {children}
         </Grid>

--- a/packages/core-components/src/layout/Header/index.ts
+++ b/packages/core-components/src/layout/Header/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { Header } from './Header';
+export type { HeaderClassKey } from './Header';

--- a/packages/core-components/src/layout/HeaderLabel/HeaderLabel.tsx
+++ b/packages/core-components/src/layout/HeaderLabel/HeaderLabel.tsx
@@ -17,24 +17,29 @@
 import { Link, makeStyles, Typography, Grid } from '@material-ui/core';
 import React from 'react';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    textAlign: 'left',
-  },
-  label: {
-    color: theme.palette.common.white,
-    fontWeight: 'bold',
-    letterSpacing: 0,
-    fontSize: theme.typography.fontSize,
-    marginBottom: theme.spacing(1) / 2,
-    lineHeight: 1,
-  },
-  value: {
-    color: 'rgba(255, 255, 255, 0.8)',
-    fontSize: theme.typography.fontSize,
-    lineHeight: 1,
-  },
-}));
+export type HeaderLabelClassKey = 'root' | 'label' | 'value';
+
+const useStyles = makeStyles(
+  theme => ({
+    root: {
+      textAlign: 'left',
+    },
+    label: {
+      color: theme.palette.common.white,
+      fontWeight: 'bold',
+      letterSpacing: 0,
+      fontSize: theme.typography.fontSize,
+      marginBottom: theme.spacing(1) / 2,
+      lineHeight: 1,
+    },
+    value: {
+      color: 'rgba(255, 255, 255, 0.8)',
+      fontSize: theme.typography.fontSize,
+      lineHeight: 1,
+    },
+  }),
+  { name: 'BackstageHeaderLabel' },
+);
 
 type HeaderLabelContentProps = {
   value: React.ReactNode;

--- a/packages/core-components/src/layout/HeaderLabel/index.ts
+++ b/packages/core-components/src/layout/HeaderLabel/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { HeaderLabel } from './HeaderLabel';
+export type { HeaderLabelClassKey } from './HeaderLabel';

--- a/packages/core-components/src/layout/HeaderTabs/HeaderTabs.tsx
+++ b/packages/core-components/src/layout/HeaderTabs/HeaderTabs.tsx
@@ -20,29 +20,38 @@
 import React, { useState, useEffect } from 'react';
 import { makeStyles, Tabs, Tab as TabUI, TabProps } from '@material-ui/core';
 
-const useStyles = makeStyles(theme => ({
-  tabsWrapper: {
-    gridArea: 'pageSubheader',
-    backgroundColor: theme.palette.background.paper,
-    paddingLeft: theme.spacing(3),
-  },
-  defaultTab: {
-    padding: theme.spacing(3, 3),
-    ...theme.typography.caption,
-    textTransform: 'uppercase',
-    fontWeight: 'bold',
-    color: theme.palette.text.secondary,
-  },
-  selected: {
-    color: theme.palette.text.primary,
-  },
-  tabRoot: {
-    '&:hover': {
-      backgroundColor: theme.palette.background.default,
+export type HeaderTabsClassKey =
+  | 'tabsWrapper'
+  | 'defaultTab'
+  | 'selected'
+  | 'tabRoot';
+
+const useStyles = makeStyles(
+  theme => ({
+    tabsWrapper: {
+      gridArea: 'pageSubheader',
+      backgroundColor: theme.palette.background.paper,
+      paddingLeft: theme.spacing(3),
+    },
+    defaultTab: {
+      padding: theme.spacing(3, 3),
+      ...theme.typography.caption,
+      textTransform: 'uppercase',
+      fontWeight: 'bold',
+      color: theme.palette.text.secondary,
+    },
+    selected: {
       color: theme.palette.text.primary,
     },
-  },
-}));
+    tabRoot: {
+      '&:hover': {
+        backgroundColor: theme.palette.background.default,
+        color: theme.palette.text.primary,
+      },
+    },
+  }),
+  { name: 'BackstageHeaderTabs' },
+);
 
 export type Tab = {
   id: string;

--- a/packages/core-components/src/layout/HeaderTabs/index.tsx
+++ b/packages/core-components/src/layout/HeaderTabs/index.tsx
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export type { Tab } from './HeaderTabs';
+export type { Tab, HeaderTabsClassKey } from './HeaderTabs';
 export { HeaderTabs } from './HeaderTabs';

--- a/packages/core-components/src/layout/InfoCard/InfoCard.tsx
+++ b/packages/core-components/src/layout/InfoCard/InfoCard.tsx
@@ -29,34 +29,51 @@ import classNames from 'classnames';
 import { ErrorBoundary, ErrorBoundaryProps } from '../ErrorBoundary';
 import { BottomLink, BottomLinkProps } from '../BottomLink';
 
-const useStyles = makeStyles(theme => ({
-  noPadding: {
-    padding: 0,
-    '&:last-child': {
-      paddingBottom: 0,
-    },
-  },
-  header: {
-    padding: theme.spacing(2, 2, 2, 2.5),
-  },
-  headerTitle: {
-    fontWeight: 700,
-  },
-  headerSubheader: {
-    paddingTop: theme.spacing(1),
-  },
-  headerAvatar: {},
-  headerAction: {},
-  headerContent: {},
-}));
+export type InfoCardClassKey =
+  | 'noPadding'
+  | 'header'
+  | 'headerTitle'
+  | 'headerSubheader'
+  | 'headerAvatar'
+  | 'headerAction'
+  | 'headerContent';
 
-const CardActionsTopRight = withStyles(theme => ({
-  root: {
-    display: 'inline-block',
-    padding: theme.spacing(8, 8, 0, 0),
-    float: 'right',
-  },
-}))(CardActions);
+const useStyles = makeStyles(
+  theme => ({
+    noPadding: {
+      padding: 0,
+      '&:last-child': {
+        paddingBottom: 0,
+      },
+    },
+    header: {
+      padding: theme.spacing(2, 2, 2, 2.5),
+    },
+    headerTitle: {
+      fontWeight: 700,
+    },
+    headerSubheader: {
+      paddingTop: theme.spacing(1),
+    },
+    headerAvatar: {},
+    headerAction: {},
+    headerContent: {},
+  }),
+  { name: 'BackstageInfoCard' },
+);
+
+export type CardActionsTopRightClassKey = 'root';
+
+const CardActionsTopRight = withStyles(
+  theme => ({
+    root: {
+      display: 'inline-block',
+      padding: theme.spacing(8, 8, 0, 0),
+      float: 'right',
+    },
+  }),
+  { name: 'BackstageInfoCardCardActionsTopRight' },
+)(CardActions);
 
 const VARIANT_STYLES = {
   card: {

--- a/packages/core-components/src/layout/InfoCard/index.ts
+++ b/packages/core-components/src/layout/InfoCard/index.ts
@@ -15,4 +15,8 @@
  */
 
 export { InfoCard } from './InfoCard';
-export type { InfoCardVariants } from './InfoCard';
+export type {
+  InfoCardVariants,
+  InfoCardClassKey,
+  CardActionsTopRightClassKey,
+} from './InfoCard';

--- a/packages/core-components/src/layout/ItemCard/ItemCardGrid.tsx
+++ b/packages/core-components/src/layout/ItemCard/ItemCardGrid.tsx
@@ -17,6 +17,8 @@
 import { createStyles, makeStyles, Theme, WithStyles } from '@material-ui/core';
 import React from 'react';
 
+export type ItemCardGridClassKey = 'root';
+
 const styles = (theme: Theme) =>
   createStyles({
     root: {
@@ -27,7 +29,7 @@ const styles = (theme: Theme) =>
     },
   });
 
-const useStyles = makeStyles(styles);
+const useStyles = makeStyles(styles, { name: 'BackstageItemCardGrid' });
 
 export type ItemCardGridProps = Partial<WithStyles<typeof styles>> & {
   /**

--- a/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
+++ b/packages/core-components/src/layout/ItemCard/ItemCardHeader.tsx
@@ -23,6 +23,8 @@ import {
 import React from 'react';
 import { BackstageTheme } from '@backstage/theme';
 
+export type ItemCardHeaderClassKey = 'root';
+
 const styles = (theme: BackstageTheme) =>
   createStyles({
     root: {
@@ -34,7 +36,7 @@ const styles = (theme: BackstageTheme) =>
     },
   });
 
-const useStyles = makeStyles(styles);
+const useStyles = makeStyles(styles, { name: 'BackstageItemCardHeader' });
 
 export type ItemCardHeaderProps = Partial<WithStyles<typeof styles>> & {
   /**

--- a/packages/core-components/src/layout/ItemCard/index.ts
+++ b/packages/core-components/src/layout/ItemCard/index.ts
@@ -16,6 +16,9 @@
 
 export { ItemCard } from './ItemCard';
 export { ItemCardGrid } from './ItemCardGrid';
-export type { ItemCardGridProps } from './ItemCardGrid';
+export type { ItemCardGridProps, ItemCardGridClassKey } from './ItemCardGrid';
 export { ItemCardHeader } from './ItemCardHeader';
-export type { ItemCardHeaderProps } from './ItemCardHeader';
+export type {
+  ItemCardHeaderProps,
+  ItemCardHeaderClassKey,
+} from './ItemCardHeader';

--- a/packages/core-components/src/layout/Page/Page.tsx
+++ b/packages/core-components/src/layout/Page/Page.tsx
@@ -18,17 +18,22 @@ import React, { PropsWithChildren } from 'react';
 import { BackstageTheme } from '@backstage/theme';
 import { makeStyles, ThemeProvider } from '@material-ui/core';
 
-const useStyles = makeStyles(() => ({
-  root: {
-    display: 'grid',
-    gridTemplateAreas:
-      "'pageHeader pageHeader pageHeader' 'pageSubheader pageSubheader pageSubheader' 'pageNav pageContent pageSidebar'",
-    gridTemplateRows: 'max-content auto 1fr',
-    gridTemplateColumns: 'auto 1fr auto',
-    height: '100vh',
-    overflowY: 'auto',
-  },
-}));
+export type PageClassKey = 'root';
+
+const useStyles = makeStyles(
+  () => ({
+    root: {
+      display: 'grid',
+      gridTemplateAreas:
+        "'pageHeader pageHeader pageHeader' 'pageSubheader pageSubheader pageSubheader' 'pageNav pageContent pageSidebar'",
+      gridTemplateRows: 'max-content auto 1fr',
+      gridTemplateColumns: 'auto 1fr auto',
+      height: '100vh',
+      overflowY: 'auto',
+    },
+  }),
+  { name: 'BackstagePage' },
+);
 
 type Props = {
   themeId: string;

--- a/packages/core-components/src/layout/Page/index.ts
+++ b/packages/core-components/src/layout/Page/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { Page } from './Page';
+export type { PageClassKey } from './Page';
 export { PageWithHeader } from './PageWithHeader';

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -21,47 +21,52 @@ import { sidebarConfig, SidebarContext } from './config';
 import { BackstageTheme } from '@backstage/theme';
 import { SidebarPinStateContext } from './Page';
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  root: {
-    zIndex: 1000,
-    position: 'relative',
-    overflow: 'visible',
-    width: theme.spacing(7) + 1,
-  },
-  drawer: {
-    display: 'flex',
-    flexFlow: 'column nowrap',
-    alignItems: 'flex-start',
-    position: 'fixed',
-    left: 0,
-    top: 0,
-    bottom: 0,
-    padding: 0,
-    background: theme.palette.navigation.background,
-    overflowX: 'hidden',
-    msOverflowStyle: 'none',
-    scrollbarWidth: 'none',
-    width: sidebarConfig.drawerWidthClosed,
-    borderRight: `1px solid #383838`,
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.shortest,
-    }),
-    '& > *': {
-      flexShrink: 0,
+export type SidebarClassKey = 'root' | 'drawer' | 'drawerOpen';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    root: {
+      zIndex: 1000,
+      position: 'relative',
+      overflow: 'visible',
+      width: theme.spacing(7) + 1,
     },
-    '&::-webkit-scrollbar': {
-      display: 'none',
+    drawer: {
+      display: 'flex',
+      flexFlow: 'column nowrap',
+      alignItems: 'flex-start',
+      position: 'fixed',
+      left: 0,
+      top: 0,
+      bottom: 0,
+      padding: 0,
+      background: theme.palette.navigation.background,
+      overflowX: 'hidden',
+      msOverflowStyle: 'none',
+      scrollbarWidth: 'none',
+      width: sidebarConfig.drawerWidthClosed,
+      borderRight: `1px solid #383838`,
+      transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.shortest,
+      }),
+      '& > *': {
+        flexShrink: 0,
+      },
+      '&::-webkit-scrollbar': {
+        display: 'none',
+      },
     },
-  },
-  drawerOpen: {
-    width: sidebarConfig.drawerWidthOpen,
-    transition: theme.transitions.create('width', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.shorter,
-    }),
-  },
-}));
+    drawerOpen: {
+      width: sidebarConfig.drawerWidthOpen,
+      transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.shorter,
+      }),
+    },
+  }),
+  { name: 'BackstageSidebar' },
+);
 
 enum State {
   Closed,

--- a/packages/core-components/src/layout/Sidebar/Intro.tsx
+++ b/packages/core-components/src/layout/Sidebar/Intro.tsx
@@ -26,48 +26,58 @@ import {
 } from './config';
 import { SidebarDivider } from './Items';
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
-  introCard: {
-    color: '#b5b5b5',
-    // XXX (@koroeskohr): should I be using a Mui theme variable?
-    fontSize: 12,
-    width: sidebarConfig.drawerWidthOpen,
-    marginTop: 18,
-    marginBottom: 12,
-    paddingLeft: sidebarConfig.iconPadding,
-    paddingRight: sidebarConfig.iconPadding,
-  },
-  introDismiss: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    marginTop: 12,
-  },
-  introDismissLink: {
-    color: '#dddddd',
-    display: 'flex',
-    alignItems: 'center',
-    marginBottom: 4,
-    '&:hover': {
-      color: theme.palette.linkHover,
-      transition: theme.transitions.create('color', {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.shortest,
-      }),
+export type SidebarIntroClassKey =
+  | 'introCard'
+  | 'introDismiss'
+  | 'introDismissLink'
+  | 'introDismissText'
+  | 'introDismissIcon';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => ({
+    introCard: {
+      color: '#b5b5b5',
+      // XXX (@koroeskohr): should I be using a Mui theme variable?
+      fontSize: 12,
+      width: sidebarConfig.drawerWidthOpen,
+      marginTop: 18,
+      marginBottom: 12,
+      paddingLeft: sidebarConfig.iconPadding,
+      paddingRight: sidebarConfig.iconPadding,
     },
-  },
-  introDismissText: {
-    fontSize: '0.7rem',
-    fontWeight: 'bold',
-    textTransform: 'uppercase',
-    letterSpacing: 1,
-  },
-  introDismissIcon: {
-    width: 18,
-    height: 18,
-    marginRight: 12,
-  },
-}));
+    introDismiss: {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+      marginTop: 12,
+    },
+    introDismissLink: {
+      color: '#dddddd',
+      display: 'flex',
+      alignItems: 'center',
+      marginBottom: 4,
+      '&:hover': {
+        color: theme.palette.linkHover,
+        transition: theme.transitions.create('color', {
+          easing: theme.transitions.easing.sharp,
+          duration: theme.transitions.duration.shortest,
+        }),
+      },
+    },
+    introDismissText: {
+      fontSize: '0.7rem',
+      fontWeight: 'bold',
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+    },
+    introDismissIcon: {
+      width: 18,
+      height: 18,
+      marginRight: 12,
+    },
+  }),
+  { name: 'BackstageSidebarIntro' },
+);
 
 type IntroCardProps = {
   text: string;

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -42,90 +42,107 @@ import {
 } from 'react-router-dom';
 import { sidebarConfig, SidebarContext } from './config';
 
-const useStyles = makeStyles<BackstageTheme>(theme => {
-  const {
-    selectedIndicatorWidth,
-    drawerWidthClosed,
-    drawerWidthOpen,
-    iconContainerWidth,
-  } = sidebarConfig;
-  return {
-    root: {
-      color: theme.palette.navigation.color,
-      display: 'flex',
-      flexFlow: 'row nowrap',
-      alignItems: 'center',
-      height: 48,
-      cursor: 'pointer',
-    },
-    buttonItem: {
-      background: 'none',
-      border: 'none',
-      width: 'auto',
-      margin: 0,
-      padding: 0,
-      textAlign: 'inherit',
-      font: 'inherit',
-    },
-    closed: {
-      width: drawerWidthClosed,
-      justifyContent: 'center',
-    },
-    open: {
-      width: drawerWidthOpen,
-    },
-    label: {
-      // XXX (@koroeskohr): I can't seem to achieve the desired font-weight from the designs
-      fontWeight: 'bold',
-      whiteSpace: 'nowrap',
-      lineHeight: 'auto',
-      flex: '3 1 auto',
-      width: '110px',
-      overflow: 'hidden',
-      'text-overflow': 'ellipsis',
-    },
-    iconContainer: {
-      boxSizing: 'border-box',
-      height: '100%',
-      width: iconContainerWidth,
-      marginRight: -theme.spacing(2),
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    searchRoot: {
-      marginBottom: 12,
-    },
-    searchField: {
-      color: '#b5b5b5',
-      fontWeight: 'bold',
-      fontSize: theme.typography.fontSize,
-    },
-    searchFieldHTMLInput: {
-      padding: `${theme.spacing(2)} 0 ${theme.spacing(2)}`,
-    },
-    searchContainer: {
-      width: drawerWidthOpen - iconContainerWidth,
-    },
-    secondaryAction: {
-      width: theme.spacing(6),
-      textAlign: 'center',
-      marginRight: theme.spacing(1),
-    },
-    selected: {
-      '&$root': {
-        borderLeft: `solid ${selectedIndicatorWidth}px ${theme.palette.navigation.indicator}`,
-        color: theme.palette.navigation.selectedColor,
+export type SidebarItemClassKey =
+  | 'root'
+  | 'buttonItem'
+  | 'closed'
+  | 'open'
+  | 'label'
+  | 'iconContainer'
+  | 'searchRoot'
+  | 'searchField'
+  | 'searchFieldHTMLInput'
+  | 'searchContainer'
+  | 'secondaryAction'
+  | 'selected';
+
+const useStyles = makeStyles<BackstageTheme>(
+  theme => {
+    const {
+      selectedIndicatorWidth,
+      drawerWidthClosed,
+      drawerWidthOpen,
+      iconContainerWidth,
+    } = sidebarConfig;
+    return {
+      root: {
+        color: theme.palette.navigation.color,
+        display: 'flex',
+        flexFlow: 'row nowrap',
+        alignItems: 'center',
+        height: 48,
+        cursor: 'pointer',
       },
-      '&$closed': {
-        width: drawerWidthClosed - selectedIndicatorWidth,
+      buttonItem: {
+        background: 'none',
+        border: 'none',
+        width: 'auto',
+        margin: 0,
+        padding: 0,
+        textAlign: 'inherit',
+        font: 'inherit',
       },
-      '& $iconContainer': {
-        marginLeft: -selectedIndicatorWidth,
+      closed: {
+        width: drawerWidthClosed,
+        justifyContent: 'center',
       },
-    },
-  };
-});
+      open: {
+        width: drawerWidthOpen,
+      },
+      label: {
+        // XXX (@koroeskohr): I can't seem to achieve the desired font-weight from the designs
+        fontWeight: 'bold',
+        whiteSpace: 'nowrap',
+        lineHeight: 'auto',
+        flex: '3 1 auto',
+        width: '110px',
+        overflow: 'hidden',
+        'text-overflow': 'ellipsis',
+      },
+      iconContainer: {
+        boxSizing: 'border-box',
+        height: '100%',
+        width: iconContainerWidth,
+        marginRight: -theme.spacing(2),
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+      searchRoot: {
+        marginBottom: 12,
+      },
+      searchField: {
+        color: '#b5b5b5',
+        fontWeight: 'bold',
+        fontSize: theme.typography.fontSize,
+      },
+      searchFieldHTMLInput: {
+        padding: `${theme.spacing(2)} 0 ${theme.spacing(2)}`,
+      },
+      searchContainer: {
+        width: drawerWidthOpen - iconContainerWidth,
+      },
+      secondaryAction: {
+        width: theme.spacing(6),
+        textAlign: 'center',
+        marginRight: theme.spacing(1),
+      },
+      selected: {
+        '&$root': {
+          borderLeft: `solid ${selectedIndicatorWidth}px ${theme.palette.navigation.indicator}`,
+          color: theme.palette.navigation.selectedColor,
+        },
+        '&$closed': {
+          width: drawerWidthClosed - selectedIndicatorWidth,
+        },
+        '& $iconContainer': {
+          marginLeft: -selectedIndicatorWidth,
+        },
+      },
+    };
+  },
+  { name: 'BackstageSidebarItem' },
+);
 
 type SidebarItemBaseProps = {
   icon: IconComponent;

--- a/packages/core-components/src/layout/Sidebar/Page.tsx
+++ b/packages/core-components/src/layout/Sidebar/Page.tsx
@@ -25,17 +25,22 @@ import { sidebarConfig } from './config';
 import { BackstageTheme } from '@backstage/theme';
 import { LocalStorage } from './localStorage';
 
-const useStyles = makeStyles<BackstageTheme, { isPinned: boolean }>({
-  root: {
-    width: '100%',
-    minHeight: '100%',
-    transition: 'padding-left 0.1s ease-out',
-    paddingLeft: ({ isPinned }) =>
-      isPinned
-        ? sidebarConfig.drawerWidthOpen
-        : sidebarConfig.drawerWidthClosed,
+export type SidebarPageClassKey = 'root';
+
+const useStyles = makeStyles<BackstageTheme, { isPinned: boolean }>(
+  {
+    root: {
+      width: '100%',
+      minHeight: '100%',
+      transition: 'padding-left 0.1s ease-out',
+      paddingLeft: ({ isPinned }) =>
+        isPinned
+          ? sidebarConfig.drawerWidthOpen
+          : sidebarConfig.drawerWidthClosed,
+    },
   },
-});
+  { name: 'BackstageSidebarPage' },
+);
 
 export type SidebarPinStateContextType = {
   isPinned: boolean;

--- a/packages/core-components/src/layout/Sidebar/index.ts
+++ b/packages/core-components/src/layout/Sidebar/index.ts
@@ -15,8 +15,9 @@
  */
 
 export { Sidebar } from './Bar';
+export type { SidebarClassKey } from './Bar';
 export { SidebarPage, SidebarPinStateContext } from './Page';
-export type { SidebarPinStateContextType } from './Page';
+export type { SidebarPinStateContextType, SidebarPageClassKey } from './Page';
 export {
   SidebarDivider,
   SidebarItem,
@@ -25,7 +26,9 @@ export {
   SidebarSpacer,
   SidebarScrollWrapper,
 } from './Items';
+export type { SidebarItemClassKey } from './Items';
 export { IntroCard, SidebarIntro } from './Intro';
+export type { SidebarIntroClassKey } from './Intro';
 export {
   SIDEBAR_INTRO_LOCAL_STORAGE,
   SidebarContext,

--- a/packages/core-components/src/layout/SignInPage/customProvider.tsx
+++ b/packages/core-components/src/layout/SignInPage/customProvider.tsx
@@ -32,16 +32,21 @@ import { GridItem } from './styles';
 // accept base64url format according to RFC7515 (https://tools.ietf.org/html/rfc7515#section-3)
 const ID_TOKEN_REGEX = /^[a-z0-9_\-]+\.[a-z0-9_\-]+\.[a-z0-9_\-]+$/i;
 
-const useFormStyles = makeStyles(theme => ({
-  form: {
-    display: 'flex',
-    flexFlow: 'column nowrap',
-  },
-  button: {
-    alignSelf: 'center',
-    marginTop: theme.spacing(2),
-  },
-}));
+export type CustomProviderClassKey = 'form' | 'button';
+
+const useFormStyles = makeStyles(
+  theme => ({
+    form: {
+      display: 'flex',
+      flexFlow: 'column nowrap',
+    },
+    button: {
+      alignSelf: 'center',
+      marginTop: theme.spacing(2),
+    },
+  }),
+  { name: 'BackstageCustomProvider' },
+);
 
 type Data = {
   userId: string;

--- a/packages/core-components/src/layout/SignInPage/index.ts
+++ b/packages/core-components/src/layout/SignInPage/index.ts
@@ -16,3 +16,5 @@
 
 export type { SignInProviderConfig } from './types';
 export { SignInPage } from './SignInPage';
+export type { SignInPageClassKey } from './styles';
+export type { CustomProviderClassKey } from './customProvider';

--- a/packages/core-components/src/layout/SignInPage/styles.tsx
+++ b/packages/core-components/src/layout/SignInPage/styles.tsx
@@ -16,20 +16,25 @@
 import React from 'react';
 import { Grid, makeStyles } from '@material-ui/core';
 
-export const useStyles = makeStyles({
-  container: {
-    padding: 0,
-    listStyle: 'none',
+export type SignInPageClassKey = 'container' | 'item';
+
+export const useStyles = makeStyles(
+  {
+    container: {
+      padding: 0,
+      listStyle: 'none',
+    },
+    item: {
+      display: 'flex',
+      flexDirection: 'column',
+      width: '100%',
+      maxWidth: '400px',
+      margin: 0,
+      padding: 0,
+    },
   },
-  item: {
-    display: 'flex',
-    flexDirection: 'column',
-    width: '100%',
-    maxWidth: '400px',
-    margin: 0,
-    padding: 0,
-  },
-});
+  { name: 'BackstageSignInPage' },
+);
 
 export const GridItem = ({ children }: { children: JSX.Element }) => {
   const classes = useStyles();

--- a/packages/core-components/src/layout/TabbedCard/TabbedCard.tsx
+++ b/packages/core-components/src/layout/TabbedCard/TabbedCard.tsx
@@ -34,22 +34,32 @@ import {
 import { BottomLink, BottomLinkProps } from '../BottomLink';
 import { ErrorBoundary, ErrorBoundaryProps } from '../ErrorBoundary';
 
-const useTabsStyles = makeStyles(theme => ({
-  root: {
-    padding: theme.spacing(0, 2, 0, 2.5),
-    minHeight: theme.spacing(3),
-  },
-  indicator: {
-    backgroundColor: theme.palette.info.main,
-    height: theme.spacing(0.3),
-  },
-}));
+export type TabbedCardClassKey = 'root' | 'indicator';
 
-const BoldHeader = withStyles(theme => ({
-  root: { padding: theme.spacing(2, 2, 2, 2.5), display: 'inline-block' },
-  title: { fontWeight: 700 },
-  subheader: { paddingTop: theme.spacing(1) },
-}))(CardHeader);
+const useTabsStyles = makeStyles(
+  theme => ({
+    root: {
+      padding: theme.spacing(0, 2, 0, 2.5),
+      minHeight: theme.spacing(3),
+    },
+    indicator: {
+      backgroundColor: theme.palette.info.main,
+      height: theme.spacing(0.3),
+    },
+  }),
+  { name: 'BackstageTabbedCard' },
+);
+
+export type BoldHeaderClassKey = 'root' | 'title' | 'subheader';
+
+const BoldHeader = withStyles(
+  theme => ({
+    root: { padding: theme.spacing(2, 2, 2, 2.5), display: 'inline-block' },
+    title: { fontWeight: 700 },
+    subheader: { paddingTop: theme.spacing(1) },
+  }),
+  { name: 'BackstageTabbedCardBoldHeader' },
+)(CardHeader);
 
 type Props = {
   /** @deprecated Use errorBoundaryProps instead */
@@ -114,23 +124,28 @@ export function TabbedCard(props: PropsWithChildren<Props>) {
   );
 }
 
-const useCardTabStyles = makeStyles(theme => ({
-  root: {
-    minWidth: theme.spacing(6),
-    minHeight: theme.spacing(3),
-    margin: theme.spacing(0, 2, 0, 0),
-    padding: theme.spacing(0.5, 0, 0.5, 0),
-    textTransform: 'none',
-    '&:hover': {
-      opacity: 1,
-      backgroundColor: 'transparent',
-      color: theme.palette.text.primary,
+export type CardTabClassKey = 'root' | 'selected';
+
+const useCardTabStyles = makeStyles(
+  theme => ({
+    root: {
+      minWidth: theme.spacing(6),
+      minHeight: theme.spacing(3),
+      margin: theme.spacing(0, 2, 0, 0),
+      padding: theme.spacing(0.5, 0, 0.5, 0),
+      textTransform: 'none',
+      '&:hover': {
+        opacity: 1,
+        backgroundColor: 'transparent',
+        color: theme.palette.text.primary,
+      },
     },
-  },
-  selected: {
-    fontWeight: 'bold',
-  },
-}));
+    selected: {
+      fontWeight: 'bold',
+    },
+  }),
+  { name: 'BackstageCardTab' },
+);
 
 type CardTabProps = TabProps & {
   children: ReactNode;

--- a/packages/core-components/src/layout/TabbedCard/index.ts
+++ b/packages/core-components/src/layout/TabbedCard/index.ts
@@ -15,3 +15,8 @@
  */
 
 export { CardTab, TabbedCard } from './TabbedCard';
+export type {
+  CardTabClassKey,
+  TabbedCardClassKey,
+  BoldHeaderClassKey,
+} from './TabbedCard';

--- a/packages/core-components/src/layout/index.ts
+++ b/packages/core-components/src/layout/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export * from './BottomLink';
 export * from './Content';
 export * from './ContentHeader';
 export * from './ErrorBoundary';

--- a/packages/core-components/src/overridableComponents.ts
+++ b/packages/core-components/src/overridableComponents.ts
@@ -18,7 +18,7 @@ import { StyleRules } from '@material-ui/core/styles/withStyles';
 
 import {
   AvatarClassKey,
-  //   ChecboxTreeClassKey
+  CheckboxTreeClassKey,
   DependencyGraphDefaultLabelClassKey,
   DependencyGraphDefaultNodeClassKey,
   DependencyGraphEdgeClassKey,
@@ -57,17 +57,17 @@ import {
   TableFiltersClassKey,
   SubvalueCellClassKey,
   TableHeaderClassKey,
-  //   TableToolbarClassKey,
+  TableToolbarClassKey,
   FiltersContainerClassKey,
   TableClassKey,
   TabBarClassKey,
   TabIconClassKey,
   TabsClassKey,
   WarningPanelClassKey,
-  //   BottomLinkClassKey,
 } from './components';
 
 import {
+  BottomLinkClassKey,
   BreadcrumbsClickableTextClassKey,
   BreadcrumbsStyledBoxClassKey,
   BackstageContentClassKey,
@@ -93,9 +93,9 @@ import {
   CardTabClassKey,
 } from './layout';
 
-export type BackstageComponentsNameToClassKey = {
+type BackstageComponentsNameToClassKey = {
   BackstageAvatar: AvatarClassKey;
-  //   BackstageCheckboxTree: CheckboxTreeClassKey;
+  BackstageCheckboxTree: CheckboxTreeClassKey;
   BackstageDependencyGraphDefaultLabel: DependencyGraphDefaultLabelClassKey;
   BackstageDependencyGraphDefaultNode: DependencyGraphDefaultNodeClassKey;
   BackstageDependencyGraphEdge: DependencyGraphEdgeClassKey;
@@ -134,14 +134,14 @@ export type BackstageComponentsNameToClassKey = {
   BackstageTableFilters: TableFiltersClassKey;
   BackstageSubvalueCell: SubvalueCellClassKey;
   BackstageTableHeader: TableHeaderClassKey;
-  //   BackstageTableToolbar: TableToolbarClassKey;
+  BackstageTableToolbar: TableToolbarClassKey;
   BackstageTableFiltersContainer: FiltersContainerClassKey;
   BackstageTable: TableClassKey;
   BackstageTabBar: TabBarClassKey;
   BackstageTabIcon: TabIconClassKey;
   BackstageTabs: TabsClassKey;
   BackstageWarningPanel: WarningPanelClassKey;
-  //   BackstageBottomLink: BottomLinkClassKey;
+  BackstageBottomLink: BottomLinkClassKey;
   BackstageBreadcrumbsClickableText: BreadcrumbsClickableTextClassKey;
   BackstageBreadcrumbsStyledBox: BreadcrumbsStyledBoxClassKey;
   BackstageContent: BackstageContentClassKey;

--- a/packages/core-components/src/overridableComponents.ts
+++ b/packages/core-components/src/overridableComponents.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Overrides } from '@material-ui/core/styles/overrides';
+import { StyleRules } from '@material-ui/core/styles/withStyles';
+
+import {
+  AvatarClassKey,
+  //   ChecboxTreeClassKey
+  DependencyGraphDefaultLabelClassKey,
+  DependencyGraphDefaultNodeClassKey,
+  DependencyGraphEdgeClassKey,
+  DependencyGraphNodeClassKey,
+  DismissbleBannerClassKey,
+  EmptyStateClassKey,
+  EmptyStateImageClassKey,
+  MissingAnnotationEmptyStateClassKey,
+  ErrorPanelClassKey,
+  FeatureCalloutCircleClassKey,
+  HeaderIconLinkRowClassKey,
+  IconLinkVerticalClassKey,
+  HorizontalScrollGridClassKey,
+  LifecycleClassKey,
+  MarkdownContentClassKey,
+  LoginRequestListItemClassKey,
+  OAuthRequestDialogClassKey,
+  OverflowTooltipClassKey,
+  GaugeClassKey,
+  GaugeCardClassKey,
+  ResponseErrorPanelClassKey,
+  SelectInputBaseClassKey,
+  SelectClassKey,
+  ClosedDropdownClassKey,
+  OpenedDropdownClassKey,
+  SimpleStepperFooterClassKey,
+  SimpleStepperStepClassKey,
+  StatusClassKey,
+  MetadataTableTitleCellClassKey,
+  MetadataTableCellClassKey,
+  MetadataTableListClassKey,
+  MetadataTableListItemClassKey,
+  StructuredMetadataTableListClassKey,
+  StructuredMetadataTableNestedListClassKey,
+  SupportButtonClassKey,
+  TableFiltersClassKey,
+  SubvalueCellClassKey,
+  TableHeaderClassKey,
+  //   TableToolbarClassKey,
+  FiltersContainerClassKey,
+  TableClassKey,
+  TabBarClassKey,
+  TabIconClassKey,
+  TabsClassKey,
+  WarningPanelClassKey,
+  //   BottomLinkClassKey,
+} from './components';
+
+import {
+  BreadcrumbsClickableTextClassKey,
+  BreadcrumbsStyledBoxClassKey,
+  BackstageContentClassKey,
+  ContentHeaderClassKey,
+  ErrorPageClassKey,
+  MicDropClassKey,
+  HeaderClassKey,
+  HeaderLabelClassKey,
+  HeaderTabsClassKey,
+  InfoCardClassKey,
+  CardActionsTopRightClassKey,
+  ItemCardGridClassKey,
+  ItemCardHeaderClassKey,
+  PageClassKey,
+  SidebarClassKey,
+  SidebarIntroClassKey,
+  SidebarItemClassKey,
+  SidebarPageClassKey,
+  CustomProviderClassKey,
+  SignInPageClassKey,
+  TabbedCardClassKey,
+  BoldHeaderClassKey,
+  CardTabClassKey,
+} from './layout';
+
+export type BackstageComponentsNameToClassKey = {
+  BackstageAvatar: AvatarClassKey;
+  //   BackstageCheckboxTree: CheckboxTreeClassKey;
+  BackstageDependencyGraphDefaultLabel: DependencyGraphDefaultLabelClassKey;
+  BackstageDependencyGraphDefaultNode: DependencyGraphDefaultNodeClassKey;
+  BackstageDependencyGraphEdge: DependencyGraphEdgeClassKey;
+  BackstageDependencyGraphNode: DependencyGraphNodeClassKey;
+  BackstageDismissableBanner: DismissbleBannerClassKey;
+  BackstageEmptyState: EmptyStateClassKey;
+  BackstageEmptyStateImage: EmptyStateImageClassKey;
+  BackstageMissingAnnotationEmptyState: MissingAnnotationEmptyStateClassKey;
+  BackstageErrorPanel: ErrorPanelClassKey;
+  BackstageFeatureCalloutCircular: FeatureCalloutCircleClassKey;
+  BackstageHeaderIconLinkRow: HeaderIconLinkRowClassKey;
+  BackstageIconLinkVertical: IconLinkVerticalClassKey;
+  BackstageHorizontalScrollGrid: HorizontalScrollGridClassKey;
+  BackstageLifecycle: LifecycleClassKey;
+  BackstageMarkdownContent: MarkdownContentClassKey;
+  BackstageLoginRequestListItem: LoginRequestListItemClassKey;
+  OAuthRequestDialog: OAuthRequestDialogClassKey;
+  BackstageOverflowTooltip: OverflowTooltipClassKey;
+  BackstageGauge: GaugeClassKey;
+  BackstageGaugeCard: GaugeCardClassKey;
+  BackstageResponseErrorPanel: ResponseErrorPanelClassKey;
+  BackstageSelectInputBase: SelectInputBaseClassKey;
+  BackstageSelect: SelectClassKey;
+  BackstageClosedDropdown: ClosedDropdownClassKey;
+  BackstageOpenedDropdown: OpenedDropdownClassKey;
+  BackstageSimpleStepperFooter: SimpleStepperFooterClassKey;
+  SimpleStepperStep: SimpleStepperStepClassKey;
+  BackstageStatus: StatusClassKey;
+  BackstageMetadataTableTitleCell: MetadataTableTitleCellClassKey;
+  BackstageMetadataTableCell: MetadataTableCellClassKey;
+  BackstageMetadataTableList: MetadataTableListClassKey;
+  BackstageMetadataTableListItem: MetadataTableListItemClassKey;
+  BackstageStructuredMetadataTableList: StructuredMetadataTableListClassKey;
+  BackstageStructuredMetadataTableNestedList: StructuredMetadataTableNestedListClassKey;
+  BackstageSupportButton: SupportButtonClassKey;
+  BackstageTableFilters: TableFiltersClassKey;
+  BackstageSubvalueCell: SubvalueCellClassKey;
+  BackstageTableHeader: TableHeaderClassKey;
+  //   BackstageTableToolbar: TableToolbarClassKey;
+  BackstageTableFiltersContainer: FiltersContainerClassKey;
+  BackstageTable: TableClassKey;
+  BackstageTabBar: TabBarClassKey;
+  BackstageTabIcon: TabIconClassKey;
+  BackstageTabs: TabsClassKey;
+  BackstageWarningPanel: WarningPanelClassKey;
+  //   BackstageBottomLink: BottomLinkClassKey;
+  BackstageBreadcrumbsClickableText: BreadcrumbsClickableTextClassKey;
+  BackstageBreadcrumbsStyledBox: BreadcrumbsStyledBoxClassKey;
+  BackstageContent: BackstageContentClassKey;
+  BackstageContentHeader: ContentHeaderClassKey;
+  BackstageErrorPage: ErrorPageClassKey;
+  BackstageErrorPageMicDrop: MicDropClassKey;
+  BackstageHeader: HeaderClassKey;
+  BackstageHeaderLabel: HeaderLabelClassKey;
+  BackstageHeaderTabs: HeaderTabsClassKey;
+  BackstageInfoCard: InfoCardClassKey;
+  BackstageInfoCardCardActionsTopRight: CardActionsTopRightClassKey;
+  BackstageItemCardGrid: ItemCardGridClassKey;
+  BackstageItemCardHeader: ItemCardHeaderClassKey;
+  BackstagePage: PageClassKey;
+  BackstageSidebar: SidebarClassKey;
+  BackstageSidebarIntro: SidebarIntroClassKey;
+  BackstageSidebarItem: SidebarItemClassKey;
+  BackstageSidebarPage: SidebarPageClassKey;
+  BackstageCustomProvider: CustomProviderClassKey;
+  BackstageSignInPage: SignInPageClassKey;
+  BackstageTabbedCard: TabbedCardClassKey;
+  BackstageTabbedCardBoldHeader: BoldHeaderClassKey;
+  BackstageCardTab: CardTabClassKey;
+};
+
+export type BackstageOverrides = Overrides & {
+  [Name in keyof BackstageComponentsNameToClassKey]?: Partial<
+    StyleRules<BackstageComponentsNameToClassKey[Name]>
+  >;
+};

--- a/packages/core-components/src/overridableComponents.ts
+++ b/packages/core-components/src/overridableComponents.ts
@@ -18,7 +18,6 @@ import { StyleRules } from '@material-ui/core/styles/withStyles';
 
 import {
   AvatarClassKey,
-  CheckboxTreeClassKey,
   DependencyGraphDefaultLabelClassKey,
   DependencyGraphDefaultNodeClassKey,
   DependencyGraphEdgeClassKey,
@@ -95,7 +94,6 @@ import {
 
 type BackstageComponentsNameToClassKey = {
   BackstageAvatar: AvatarClassKey;
-  BackstageCheckboxTree: CheckboxTreeClassKey;
   BackstageDependencyGraphDefaultLabel: DependencyGraphDefaultLabelClassKey;
   BackstageDependencyGraphDefaultNode: DependencyGraphDefaultNodeClassKey;
   BackstageDependencyGraphEdge: DependencyGraphEdgeClassKey;


### PR DESCRIPTION
# Problem description

At VMWare we would like to customize some Backstage's internal components styles that are not using the `material-ui` theme, an example of this is the Backstage internal `Header` component `box-shadow` property [which value is hard-coded](https://github.com/backstage/backstage/blob/7f00902d976297bb03b1ff6c27d2fac424243319/packages/core-components/src/layout/Header/Header.tsx#L33). 

For these cases (_a css rule that isn't affected by the theme_) `material-ui` [provides "overrides"](https://github.com/mui-org/material-ui/blob/next/packages/mui-styles/src/getStylesCreator/getStylesCreator.js#L49) so any needed styles can be applied.

However, for overrides to work a component name must be provided to `material-ui` `withStyles` or `makeStyles` functions and Backstage  internal components like `Header` [are not passing this information](https://github.com/backstage/backstage/blob/7f00902d976297bb03b1ff6c27d2fac424243319/packages/core-components/src/layout/Header/Header.tsx#L27).

When `name` is not passed to these function no overrides would be applied and classnames generation for production environments doesn't add any constant value we can reference from the overrides level [since it would be entirely generated](https://github.com/mui-org/material-ui/blob/next/packages/mui-styles/src/createGenerateClassName/createGenerateClassName.js#L69) and this means that we don't have a consistent way to override the component styles.

# Possible solution

Provide a component name from Backstage internal components to `material-ui` style functions, this would improve the library flexibility with no harm to it.

# How to review
The first two commits are a little noisy since they add a name to components under "components" and "layout" domains therefore reviewing those commits indiviadully will make the changes easier to read.

# Open discussions

- Maybe the `@backstage/theme` package should be the one responsible to export the `overridableComponents`, but that would required to add the `@backstage/core-components` package as dependency.
- A more automated way to achieve this would be ideal, probably some kind of script to extract the types from the components and export the overrides.

<!--- Please include the following in your Pull Request when applicable: -->

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- <del> Tests for new functionality and regression tests for bug fixes</del>
- <del> Screenshots attached (for UI changes) </del>
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))