### PR TITLE
Change hardcoded master to $defaultBranch

### DIFF
--- a/.changeset/loud-hounds-listen.md
+++ b/.changeset/loud-hounds-listen.md
@@ -1,6 +1,5 @@
 ---
-"@backstage/plugin-scaffolder-backend": patch
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
-Change hardcoded branch `master` to $defaultBranch
-
+Change hardcoded branch `master` to $defaultBranch in GitLab provider

--- a/.changeset/loud-hounds-listen.md
+++ b/.changeset/loud-hounds-listen.md
@@ -1,0 +1,6 @@
+---
+"@backstage/plugin-scaffolder-backend": patch
+---
+
+Change hardcoded branch `master` to $defaultBranch
+

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -97,6 +97,7 @@ GraphQL
 graphviz
 Hackathons
 haproxy
+hardcoded
 Helidon
 Heroku
 hoc

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -127,7 +127,7 @@ export function createPublishGitlabAction(options: {
       });
 
       const remoteUrl = (http_url_to_repo as string).replace(/\.git$/, '');
-      const repoContentsUrl = `${remoteUrl}/-/blob/master`;
+      const repoContentsUrl = `${remoteUrl}/-/blob/${defaultBranch}`;
 
       const gitAuthorInfo = {
         name: config.getOptionalString('scaffolder.defaultAuthor.name'),


### PR DESCRIPTION
Since we pass over the defaultBranch argument in our templates, this seems to break because of the hardcoded master values. Probably this affects other providers as well.