### PR TITLE
Upgrade `@material-ui/lab` to `4.0.0-alpha.57`

### DIFF
--- a/.changeset/polite-houses-clean.md
+++ b/.changeset/polite-houses-clean.md
@@ -1,0 +1,50 @@
+---
+'@backstage/cli': patch
+'@backstage/core-components': patch
+'@backstage/integration-react': patch
+'@backstage/plugin-allure': patch
+'@backstage/plugin-api-docs': patch
+'@backstage/plugin-badges': patch
+'@backstage/plugin-bitrise': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-circleci': patch
+'@backstage/plugin-cloudbuild': patch
+'@backstage/plugin-code-coverage': patch
+'@backstage/plugin-config-schema': patch
+'@backstage/plugin-cost-insights': patch
+'@backstage/plugin-explore': patch
+'@backstage/plugin-firehyrant': patch
+'@backstage/plugin-fossa': patch
+'@backstage/plugin-gcp-projects': patch
+'@backstage/plugin-git-release-manager': patch
+'@backstage/plugin-github-actions': patch
+'@backstage/plugin-github-deployments': patch
+'@backstage/plugin-gitops-profiles': patch
+'@backstage/plugin-graphiql': patch
+'@backstage/plugin-home': patch
+'@backstage/plugin-ilert': patch
+'@backstage/plugin-jenkins': patch
+'@backstage/plugin-kafka': patch
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-lighthouse': patch
+'@backstage/plugin-newrelic': patch
+'@backstage/plugin-org': patch
+'@backstage/plugin-pagerduty': patch
+'@backstage/plugin-rollbar': patch
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-search': patch
+'@backstage/plugin-sentry': patch
+'@backstage/plugin-shortcuts': patch
+'@backstage/plugin-sonarqube': patch
+'@backstage/plugin-splunk-on-call': patch
+'@backstage/plugin-tech-radar': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-todo': patch
+'@backstage/plugin-user-settings': patch
+'@backstage/plugin-welcome': patch
+'@backstage/plugin-xcmetrics': patch
+---
+
+Upgrade `@material-ui/lab` to `4.0.0-alpha.57`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -44,7 +44,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/rest": "^18.5.3",
     "@roadiehq/backstage-plugin-buildkite": "^1.0.8",
     "@roadiehq/backstage-plugin-github-insights": "^1.1.23",

--- a/packages/cli/templates/default-plugin/package.json.hbs
+++ b/packages/cli/templates/default-plugin/package.json.hbs
@@ -29,7 +29,7 @@
     "@backstage/theme": "^{{version '@backstage/theme'}}",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-use": "^17.2.4"

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -36,7 +36,7 @@
     "@material-table/core": "^3.1.0",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@testing-library/react-hooks": "^3.4.2",
     "@types/dagre": "^0.7.44",
     "@types/prop-types": "^15.7.3",

--- a/packages/integration-react/package.json
+++ b/packages/integration-react/package.json
@@ -27,7 +27,7 @@
     "@backstage/theme": "^0.2.9",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-use": "^17.2.4"

--- a/plugins/allure/package.json
+++ b/plugins/allure/package.json
@@ -28,7 +28,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "6.0.0-beta.0",

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -39,7 +39,7 @@
     "@material-icons/font": "^1.0.2",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@types/react": "*",
     "graphiql": "^1.0.0-alpha.10",
     "graphql": "^15.3.0",

--- a/plugins/badges/package.json
+++ b/plugins/badges/package.json
@@ -28,7 +28,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/bitrise/package.json
+++ b/plugins/bitrise/package.json
@@ -27,7 +27,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "cross-fetch": "^3.0.6",
     "lodash": "^4.17.21",
     "luxon": "^2.0.2",

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -40,7 +40,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/rest": "^18.5.3",
     "@types/react": "*",
     "git-url-parse": "^11.6.0",

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -37,7 +37,7 @@
     "@backstage/version-bridge": "^0.1.0",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@types/react": "*",
     "jwt-decode": "^3.1.0",
     "lodash": "^4.17.15",

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -71,7 +71,7 @@ export const EntityLifecyclePicker = () => {
   return (
     <Box pb={1} pt={1}>
       <Typography variant="button">Lifecycle</Typography>
-      <Autocomplete<string>
+      <Autocomplete
         aria-label="Lifecycle"
         multiple
         options={availableLifecycles}

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -75,7 +75,7 @@ export const EntityOwnerPicker = () => {
   return (
     <Box pb={1} pt={1}>
       <Typography variant="button">Owner</Typography>
-      <Autocomplete<string>
+      <Autocomplete
         multiple
         aria-label="Owner"
         options={availableOwners}

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -67,7 +67,7 @@ export const EntityTagPicker = () => {
   return (
     <Box pb={1} pt={1}>
       <Typography variant="button">Tags</Typography>
-      <Autocomplete<string>
+      <Autocomplete
         multiple
         aria-label="Tags"
         options={availableTags}

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -41,7 +41,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@types/react": "*",
     "classnames": "^2.2.6",
     "git-url-parse": "^11.6.0",

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -38,7 +38,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "circleci-api": "^4.0.0",
     "dayjs": "^1.9.4",
     "lodash": "^4.17.15",

--- a/plugins/cloudbuild/package.json
+++ b/plugins/cloudbuild/package.json
@@ -37,7 +37,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "luxon": "^2.0.2",
     "qs": "^6.9.4",
     "react": "^16.13.1",

--- a/plugins/code-coverage/package.json
+++ b/plugins/code-coverage/package.json
@@ -29,7 +29,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@material-ui/styles": "^4.11.0",
     "highlight.js": "^10.6.0",
     "react": "^16.13.1",

--- a/plugins/config-schema/package.json
+++ b/plugins/config-schema/package.json
@@ -27,7 +27,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "jsonschema": "^1.2.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -36,7 +36,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@material-ui/styles": "^4.9.6",
     "@types/react": "*",
     "@types/recharts": "^1.8.14",

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -38,7 +38,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@types/react": "*",
     "classnames": "^2.2.6",
     "react": "^16.13.1",

--- a/plugins/firehydrant/package.json
+++ b/plugins/firehydrant/package.json
@@ -27,7 +27,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "luxon": "^1.27.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/fossa/package.json
+++ b/plugins/fossa/package.json
@@ -39,7 +39,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "cross-fetch": "^3.0.6",
     "luxon": "^2.0.2",
     "p-limit": "^3.0.2",

--- a/plugins/gcp-projects/package.json
+++ b/plugins/gcp-projects/package.json
@@ -35,7 +35,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^6.0.0-beta.0",

--- a/plugins/git-release-manager/package.json
+++ b/plugins/git-release-manager/package.json
@@ -26,7 +26,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/rest": "^18.5.3",
     "@types/react": "*",
     "luxon": "^2.0.2",

--- a/plugins/github-actions/package.json
+++ b/plugins/github-actions/package.json
@@ -40,7 +40,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/rest": "^18.5.3",
     "luxon": "^2.0.2",
     "react": "^16.13.1",

--- a/plugins/github-deployments/package.json
+++ b/plugins/github-deployments/package.json
@@ -30,7 +30,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@octokit/graphql": "^4.5.8",
     "luxon": "^2.0.2",
     "react": "^16.13.1",

--- a/plugins/gitops-profiles/package.json
+++ b/plugins/gitops-profiles/package.json
@@ -36,7 +36,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "6.0.0-beta.0",

--- a/plugins/graphiql/package.json
+++ b/plugins/graphiql/package.json
@@ -36,7 +36,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "graphiql": "^1.0.0-alpha.10",
     "graphql": "15.5.0",
     "react": "^16.13.1",

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -25,7 +25,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@types/react": "*",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/ilert/package.json
+++ b/plugins/ilert/package.json
@@ -29,7 +29,7 @@
     "@date-io/luxon": "2.x",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@material-ui/pickers": "^3.3.10",
     "humanize-duration": "^3.26.0",
     "luxon": "^2.0.2",

--- a/plugins/jenkins/package.json
+++ b/plugins/jenkins/package.json
@@ -38,7 +38,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "luxon": "^2.0.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/kafka/package.json
+++ b/plugins/kafka/package.json
@@ -27,7 +27,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -40,7 +40,7 @@
     "@kubernetes/client-node": "^0.15.0",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.21",
     "luxon": "^2.0.2",

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -39,7 +39,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@testing-library/react-hooks": "^3.4.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/lighthouse/src/components/AuditList/index.tsx
+++ b/plugins/lighthouse/src/components/AuditList/index.tsx
@@ -16,7 +16,7 @@
 
 import { Button, Grid } from '@material-ui/core';
 import Pagination from '@material-ui/lab/Pagination';
-import React, { ReactNode, useMemo, useState } from 'react';
+import React, { ChangeEvent, ReactNode, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAsync, useLocalStorage } from 'react-use';
 import { lighthouseApiRef } from '../../api';
@@ -78,7 +78,7 @@ const AuditList = () => {
           <Pagination
             page={page}
             count={pageCount}
-            onChange={(_event: Event, newPage: number) => {
+            onChange={(_event: ChangeEvent<unknown>, newPage: number) => {
               navigate(`?page=${newPage}`);
             }}
           />

--- a/plugins/newrelic/package.json
+++ b/plugins/newrelic/package.json
@@ -36,7 +36,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-use": "^17.2.4"

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -27,7 +27,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/pagerduty/package.json
+++ b/plugins/pagerduty/package.json
@@ -37,7 +37,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@types/react": "*",
     "classnames": "^2.2.6",
     "luxon": "2.0.2",

--- a/plugins/rollbar/package.json
+++ b/plugins/rollbar/package.json
@@ -38,7 +38,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "lodash": "^4.17.15",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -42,7 +42,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@rjsf/core": "^3.0.0",
     "@rjsf/material-ui": "^3.0.0",
     "@types/react": "*",

--- a/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.tsx
+++ b/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.tsx
@@ -54,7 +54,7 @@ export const TemplateTypePicker = () => {
   return (
     <Box pb={1} pt={1}>
       <Typography variant="button">Categories</Typography>
-      <Autocomplete<string>
+      <Autocomplete
         multiple
         aria-label="Categories"
         options={availableTypes}

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -39,7 +39,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@types/react": "*",
     "qs": "^6.9.4",
     "react": "^16.13.1",

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -38,7 +38,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "luxon": "^2.0.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/shortcuts/package.json
+++ b/plugins/shortcuts/package.json
@@ -25,7 +25,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@types/zen-observable": "^0.8.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -39,7 +39,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@material-ui/styles": "^4.10.0",
     "cross-fetch": "^3.0.6",
     "rc-progress": "^3.0.0",

--- a/plugins/splunk-on-call/package.json
+++ b/plugins/splunk-on-call/package.json
@@ -37,7 +37,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "classnames": "^2.2.6",
     "luxon": "^2.0.2",
     "react": "^16.13.1",

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -35,7 +35,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "color": "^4.0.1",
     "d3-force": "^2.0.1",
     "prop-types": "^15.7.2",

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -44,7 +44,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "@material-ui/styles": "^4.10.0",
     "@types/react": "*",
     "dompurify": "^2.2.9",

--- a/plugins/todo/package.json
+++ b/plugins/todo/package.json
@@ -34,7 +34,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-use": "^17.2.4"

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -35,7 +35,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/welcome/package.json
+++ b/plugins/welcome/package.json
@@ -35,7 +35,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "6.0.0-beta.0",

--- a/plugins/xcmetrics/package.json
+++ b/plugins/xcmetrics/package.json
@@ -26,7 +26,7 @@
     "@backstage/theme": "^0.2.10",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.45",
+    "@material-ui/lab": "4.0.0-alpha.57",
     "luxon": "^2.0.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
Noticed that the version is quite old and the newer version contains some bug fixes and improvements in the autocomplete.

I think a lot of these packages aren't actually using the dependency 🤔  Maybe something like `depcheck` could be added to CI (we use that in our instance).

The old version is still in use due to external plugins.

Btw, there are even newer versions of the package available, but I couldn't find a changelog for them, so I thought it's better to stay safe.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
