### PR TITLE
Make techdocs context search bar width adjust on smaller screens

### DIFF
--- a/.changeset/techdocs-shy-beans-prove.md
+++ b/.changeset/techdocs-shy-beans-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Make techdocs context search bar width adjust on smaller screens.

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -64,6 +64,10 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
     marginLeft: '20rem',
     maxWidth: 'calc(100% - 20rem * 2 - 3rem)',
     marginTop: theme.spacing(1),
+    '@media screen and (max-width: 76.1875em)': {
+      marginLeft: '10rem',
+      maxWidth: 'calc(100% - 10rem)',
+    },
   },
 }));
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/648527/133596110-eab34116-c427-43b5-8366-84bdfda48541.png)

After:

![image](https://user-images.githubusercontent.com/648527/133595914-a6ac3885-6335-44cd-b795-23fead9b1e83.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
