### PR TITLE
Catalog: Add `generates` and `generatedBy` relations

### DIFF
--- a/.changeset/flat-bananas-return.md
+++ b/.changeset/flat-bananas-return.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-model': patch
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add `generatedBy` and `generates` relations in the catalog

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -430,6 +430,12 @@ export const RELATION_DEPENDENCY_OF = 'dependencyOf';
 export const RELATION_DEPENDS_ON = 'dependsOn';
 
 // @public (undocumented)
+export const RELATION_GENERATED_BY = 'generatedBy';
+
+// @public
+export const RELATION_GENERATES = 'generates';
+
+// @public (undocumented)
 export const RELATION_HAS_MEMBER = 'hasMember';
 
 // @public (undocumented)

--- a/packages/catalog-model/src/kinds/relations.ts
+++ b/packages/catalog-model/src/kinds/relations.ts
@@ -82,3 +82,11 @@ export const RELATION_HAS_MEMBER = 'hasMember';
 export const RELATION_PART_OF = 'partOf';
 /** @public */
 export const RELATION_HAS_PART = 'hasPart';
+
+/**
+ * A relation denoting entities that are emitted from processing another relation.
+ * @public
+ */
+export const RELATION_GENERATES = 'generates';
+/** @public */
+export const RELATION_GENERATED_BY = 'generatedBy';

--- a/plugins/catalog-backend/src/next/processing/ProcessorOutputCollector.ts
+++ b/plugins/catalog-backend/src/next/processing/ProcessorOutputCollector.ts
@@ -20,8 +20,8 @@ import {
   getEntityName,
   LOCATION_ANNOTATION,
   ORIGIN_LOCATION_ANNOTATION,
-  RELATION_EMITS,
-  RELATION_EMITTED_BY,
+  RELATION_GENERATES,
+  RELATION_GENERATED_BY,
   stringifyLocationReference,
 } from '@backstage/catalog-model';
 import { Logger } from 'winston';
@@ -65,12 +65,12 @@ export class ProcessorOutputCollector {
     this.relations.push({
       source: getEntityName(this.parentEntity),
       target: getEntityName(entity),
-      type: RELATION_EMITS,
+      type: RELATION_GENERATES,
     });
     this.relations.push({
       target: getEntityName(this.parentEntity),
       source: getEntityName(entity),
-      type: RELATION_EMITTED_BY,
+      type: RELATION_GENERATED_BY,
     });
   }
   private receive(i: CatalogProcessorResult) {


### PR DESCRIPTION
Making crawling the chain much easier. Little unsure about doing the `generates` relation for Groups and `ldap` things it could be pretty expensive, but open to thoughts.

`generatedBy` would be enough I think anyway.

Work for #6973