### PR TITLE
Make table columns consistent

### DIFF
--- a/.changeset/smooth-experts-hunt.md
+++ b/.changeset/smooth-experts-hunt.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-api-docs': patch
+'@backstage/plugin-catalog-react': patch
+---
+
+This makes Type and Lifecycle columns consistent for all table cases and adds a new line in Description column for better readability

--- a/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
+++ b/plugins/api-docs/src/components/ApisCards/HasApisCard.tsx
@@ -39,8 +39,8 @@ type Props = {
 const columns: TableColumn<ApiEntity>[] = [
   EntityTable.columns.createEntityRefColumn({ defaultKind: 'API' }),
   EntityTable.columns.createOwnerColumn(),
-  EntityTable.columns.createSpecLifecycleColumn(),
   createSpecApiTypeColumn(),
+  EntityTable.columns.createSpecLifecycleColumn(),
   EntityTable.columns.createMetadataDescriptionColumn(),
 ];
 

--- a/plugins/api-docs/src/components/ApisCards/presets.tsx
+++ b/plugins/api-docs/src/components/ApisCards/presets.tsx
@@ -36,7 +36,7 @@ export const apiEntityColumns: TableColumn<ApiEntity>[] = [
   EntityTable.columns.createEntityRefColumn({ defaultKind: 'API' }),
   EntityTable.columns.createSystemColumn(),
   EntityTable.columns.createOwnerColumn(),
-  EntityTable.columns.createSpecLifecycleColumn(),
   createSpecApiTypeColumn(),
+  EntityTable.columns.createSpecLifecycleColumn(),
   EntityTable.columns.createMetadataDescriptionColumn(),
 ];

--- a/plugins/catalog-react/src/components/EntityTable/columns.tsx
+++ b/plugins/catalog-react/src/components/EntityTable/columns.tsx
@@ -143,6 +143,7 @@ export function createMetadataDescriptionColumn<
       <OverflowTooltip
         text={entity.metadata.description}
         placement="bottom-start"
+        line={2}
       />
     ),
     width: 'auto',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR switches Lifecycle and Type columns in API related tables to place them as they are in other subcomponents or dependencies tables.
It also adds a new line in description column so more text can be read at once if needed.

![Screenshot 2021-09-16 at 15 55 50](https://user-images.githubusercontent.com/74989179/133627196-2e6bf084-f0a7-46a9-9db5-44669e0098ac.png)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
