### PR TITLE
[microsite] Add beta label to TechDocs heading on homepage

### DIFF
--- a/microsite/pages/en/index.js
+++ b/microsite/pages/en/index.js
@@ -306,7 +306,15 @@ class Index extends React.Component {
                 src={`${baseUrl}animations/backstage-techdocs-icon-1.gif`}
               />
 
-              <Block.Subtitle>Backstage TechDocs</Block.Subtitle>
+              <Block.Subtitle>
+                Backstage TechDocs{' '}
+                <a
+                  title="Submit feedback for this feature. Click to learn more about this release."
+                  href="https://backstage.io/blog/2021/09/16/the-techdocs-beta-has-landed"
+                >
+                  (beta)
+                </a>
+              </Block.Subtitle>
               <Block.Title small>Docs like code</Block.Title>
             </Block.TextBox>
             <Breakpoint


### PR DESCRIPTION
Adding a beta label to the heading and a link to the announcement blog post.

Signed-off-by: Jeff Feng <fengypants@gmail.com>

## Hey, I just made a Pull Request!

<img width="893" alt="techdocs-beta-label" src="https://user-images.githubusercontent.com/46946747/133791081-1bbf6ce1-ed27-4efe-870b-38bb58e54362.png">

• added label to section heading for TechDocs
• added tool tip to learn more
• added link to beta blog post

#### :heavy_check_mark: Checklist
