### PR TITLE
WIP: SidebarPage Content element

### DIFF
--- a/.changeset/eight-insects-tan.md
+++ b/.changeset/eight-insects-tan.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/core-components': minor
+'@backstage/core-components': patch
 ---
 
 Add SidebarPageContent component and useContenRef hook to have a reference to content wrapper element

--- a/.changeset/eight-insects-tan.md
+++ b/.changeset/eight-insects-tan.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': minor
 ---
 
-Add SibarPageContent element and Add a Context to store the reference
+Add SidebarPageContent component and useContenRef hook to have a reference to content wrapper element

--- a/.changeset/eight-insects-tan.md
+++ b/.changeset/eight-insects-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Add SibarPageContent element and Add a Context to store the reference

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -40,7 +40,7 @@ import {
   SidebarDivider,
   SidebarSpace,
   SidebarScrollWrapper,
-  SideBarPageContent,
+  SidebarPageContent,
 } from '@backstage/core-components';
 
 const useSidebarLogoStyles = makeStyles({
@@ -102,6 +102,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarDivider />
       <SidebarSettings />
     </Sidebar>
-    <SideBarPageContent>{children}</SideBarPageContent>
+    <SidebarPageContent>{children}</SidebarPageContent>
   </SidebarPage>
 );

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -40,6 +40,7 @@ import {
   SidebarDivider,
   SidebarSpace,
   SidebarScrollWrapper,
+  SideBarPageContent,
 } from '@backstage/core-components';
 
 const useSidebarLogoStyles = makeStyles({
@@ -101,6 +102,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarDivider />
       <SidebarSettings />
     </Sidebar>
-    {children}
+    <SideBarPageContent>{children}</SideBarPageContent>
   </SidebarPage>
 );

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1150,10 +1150,11 @@ export function SidebarPage(props: PropsWithChildren<{}>): JSX.Element;
 //
 // @public (undocumented)
 export type SidebarPageClassKey = 'root';
-// Warning: (ae-missing-release-tag) "SideBarPageContent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+
+// Warning: (ae-missing-release-tag) "SidebarPageContent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function SideBarPageContent(props: PropsWithChildren<{}>): JSX.Element;
+export function SidebarPageContent(props: PropsWithChildren<{}>): JSX.Element;
 
 // Warning: (ae-missing-release-tag) "SidebarPageContextType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1150,6 +1150,22 @@ export function SidebarPage(props: PropsWithChildren<{}>): JSX.Element;
 //
 // @public (undocumented)
 export type SidebarPageClassKey = 'root';
+// Warning: (ae-missing-release-tag) "SideBarPageContent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function SideBarPageContent(props: PropsWithChildren<{}>): JSX.Element;
+
+// Warning: (ae-missing-release-tag) "SidebarPageContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const SidebarPageContext: React_2.Context<SidebarPageContextType>;
+
+// Warning: (ae-missing-release-tag) "SidebarPageContextType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarPageContextType = {
+  contentRef?: React_2.MutableRefObject<HTMLDivElement | null>;
+};
 
 // Warning: (ae-missing-release-tag) "SidebarPinStateContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1155,11 +1155,6 @@ export type SidebarPageClassKey = 'root';
 // @public (undocumented)
 export function SideBarPageContent(props: PropsWithChildren<{}>): JSX.Element;
 
-// Warning: (ae-missing-release-tag) "SidebarPageContext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const SidebarPageContext: React_2.Context<SidebarPageContextType>;
-
 // Warning: (ae-missing-release-tag) "SidebarPageContextType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -2285,6 +2280,13 @@ export function TrendLine(
       title?: string;
     },
 ): JSX.Element | null;
+
+// Warning: (ae-missing-release-tag) "useContentRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function useContentRef():
+  | React_2.MutableRefObject<HTMLDivElement | null>
+  | undefined;
 
 // Warning: (ae-forgotten-export) The symbol "SetQueryParams" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "useQueryParamState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -21,7 +21,7 @@ import Button from '@material-ui/core/Button';
 import clsx from 'clsx';
 import React, { PropsWithChildren, useContext, useRef, useState } from 'react';
 
-import { SidebarPageContext } from '.';
+import { useContentRef } from '.';
 import { sidebarConfig, SidebarContext } from './config';
 import { SidebarPinStateContext } from './Page';
 
@@ -105,7 +105,7 @@ export function Sidebar(props: PropsWithChildren<Props>) {
   const [state, setState] = useState(State.Closed);
   const hoverTimerRef = useRef<number>();
   const { isPinned } = useContext(SidebarPinStateContext);
-  const { contentRef } = useContext(SidebarPageContext);
+  const contentRef = useContentRef();
 
   const focusContent = () => {
     contentRef?.current?.focus();

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -1,3 +1,4 @@
+import { BackstageTheme } from '@backstage/theme';
 /*
  * Copyright 2020 The Backstage Authors
  *
@@ -16,10 +17,12 @@
 
 import { makeStyles } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
+import Button from '@material-ui/core/Button';
 import clsx from 'clsx';
-import React, { useRef, useState, useContext, PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useContext, useRef, useState } from 'react';
+
+import { SidebarPageContext } from '.';
 import { sidebarConfig, SidebarContext } from './config';
-import { BackstageTheme } from '@backstage/theme';
 import { SidebarPinStateContext } from './Page';
 
 export type SidebarClassKey = 'root' | 'drawer' | 'drawerOpen';
@@ -27,7 +30,7 @@ export type SidebarClassKey = 'root' | 'drawer' | 'drawerOpen';
 const useStyles = makeStyles<BackstageTheme>(
   theme => ({
     root: {
-      zIndex: 1000,
+      zIndex: 1,
       position: 'relative',
       overflow: 'visible',
       width: theme.spacing(7) + 1,
@@ -65,6 +68,15 @@ const useStyles = makeStyles<BackstageTheme>(
         duration: theme.transitions.duration.shorter,
       }),
     },
+    visuallyHidden: {
+      top: 0,
+      position: 'absolute',
+      zIndex: 2,
+      transform: 'translateY(-200%)',
+      '&:focus': {
+        transform: 'translateY(5px)',
+      },
+    },
   }),
   { name: 'BackstageSidebar' },
 );
@@ -93,6 +105,11 @@ export function Sidebar(props: PropsWithChildren<Props>) {
   const [state, setState] = useState(State.Closed);
   const hoverTimerRef = useRef<number>();
   const { isPinned } = useContext(SidebarPinStateContext);
+  const { contentRef } = useContext(SidebarPageContext);
+
+  const focusContent = () => {
+    contentRef?.current?.focus();
+  };
 
   const handleOpen = () => {
     if (isPinned) {
@@ -116,6 +133,7 @@ export function Sidebar(props: PropsWithChildren<Props>) {
     if (isPinned) {
       return;
     }
+    focusContent();
     if (hoverTimerRef.current) {
       clearTimeout(hoverTimerRef.current);
       hoverTimerRef.current = undefined;
@@ -133,27 +151,36 @@ export function Sidebar(props: PropsWithChildren<Props>) {
   const isOpen = (state === State.Open && !isSmallScreen) || isPinned;
 
   return (
-    <div
-      className={classes.root}
-      onMouseEnter={handleOpen}
-      onFocus={handleOpen}
-      onMouseLeave={handleClose}
-      onBlur={handleClose}
-      data-testid="sidebar-root"
-    >
-      <SidebarContext.Provider
-        value={{
-          isOpen,
-        }}
+    <div style={{}}>
+      <Button
+        onClick={focusContent}
+        variant="contained"
+        className={clsx(classes.visuallyHidden)}
       >
-        <div
-          className={clsx(classes.drawer, {
-            [classes.drawerOpen]: isOpen,
-          })}
+        Skip to content
+      </Button>
+      <div
+        className={classes.root}
+        onMouseEnter={handleOpen}
+        onFocus={handleOpen}
+        onMouseLeave={handleClose}
+        onBlur={handleClose}
+        data-testid="sidebar-root"
+      >
+        <SidebarContext.Provider
+          value={{
+            isOpen,
+          }}
         >
-          {children}
-        </div>
-      </SidebarContext.Provider>
+          <div
+            className={clsx(classes.drawer, {
+              [classes.drawerOpen]: isOpen,
+            })}
+          >
+            {children}
+          </div>
+        </SidebarContext.Provider>
+      </div>
     </div>
   );
 }

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -162,9 +162,9 @@ export function Sidebar(props: PropsWithChildren<Props>) {
       <div
         className={classes.root}
         onMouseEnter={handleOpen}
-        onFocus={handleOpen}
+        onFocus={ignoreChildEvent(handleOpen)}
         onMouseLeave={handleClose}
-        onBlur={handleClose}
+        onBlur={ignoreChildEvent(handleClose)}
         data-testid="sidebar-root"
       >
         <SidebarContext.Provider
@@ -183,4 +183,14 @@ export function Sidebar(props: PropsWithChildren<Props>) {
       </div>
     </div>
   );
+}
+
+function ignoreChildEvent(handlerFn: (e?: any) => void) {
+  // TODO type the event
+  return (event: any) => {
+    const currentTarget = event?.currentTarget as HTMLElement;
+    if (!currentTarget?.contains(event.relatedTarget as HTMLElement)) {
+      handlerFn(event);
+    }
+  };
 }

--- a/packages/core-components/src/layout/Sidebar/Page.tsx
+++ b/packages/core-components/src/layout/Sidebar/Page.tsx
@@ -98,7 +98,7 @@ export function SidebarPage(props: PropsWithChildren<{}>) {
   );
 }
 
-export function SideBarPageContent(props: PropsWithChildren<{}>) {
+export function SidebarPageContent(props: PropsWithChildren<{}>) {
   const { contentRef } = useContext(SidebarPageContext);
   const classes = useStyles({});
 

--- a/packages/core-components/src/layout/Sidebar/Page.tsx
+++ b/packages/core-components/src/layout/Sidebar/Page.tsx
@@ -69,7 +69,7 @@ export const SidebarPinStateContext = createContext<SidebarPinStateContextType>(
   },
 );
 
-export const SidebarPageContext = createContext<SidebarPageContextType>({});
+const SidebarPageContext = createContext<SidebarPageContextType>({});
 
 export function SidebarPage(props: PropsWithChildren<{}>) {
   const [isPinned, setIsPinned] = useState(() =>
@@ -107,4 +107,9 @@ export function SideBarPageContent(props: PropsWithChildren<{}>) {
       {props.children}
     </div>
   );
+}
+
+export function useContentRef() {
+  const { contentRef } = useContext(SidebarPageContext);
+  return contentRef;
 }

--- a/packages/core-components/src/layout/Sidebar/SidebarPage.stories.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarPage.stories.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
+import HomeOutlinedIcon from '@material-ui/icons/HomeOutlined';
+import React, { useCallback } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  Sidebar,
+  SidebarDivider,
+  SidebarIntro,
+  SidebarItem,
+  SidebarSearchField,
+  SidebarSpace,
+  SidebarPage,
+  SidebarPageContent,
+  useContentRef,
+} from '.';
+import { PluginWithTable } from '../Page/Page.stories';
+
+export default {
+  title: 'Layout/SidebarPage',
+  component: SidebarPage,
+  decorators: [
+    (storyFn: () => JSX.Element) => (
+      <MemoryRouter initialEntries={['/']}>{storyFn()}</MemoryRouter>
+    ),
+  ],
+};
+
+export const SampleSidebarPage = () => {
+  return (
+    <SidebarPage>
+      <CustomSidebar />
+      <SidebarPageContent>
+        <PluginWithTable />
+      </SidebarPageContent>
+    </SidebarPage>
+  );
+};
+
+function CustomSidebar() {
+  const contentRef = useContentRef();
+
+  const handleSearch = useCallback(
+    (input: string) => {
+      contentRef?.current?.focus();
+      // eslint-disable-next-line no-console
+      console.log(input);
+    },
+    [contentRef],
+  );
+
+  return (
+    <Sidebar>
+      <SidebarSearchField onSearch={handleSearch} to="/search" />
+      <SidebarDivider />
+      <SidebarItem icon={HomeOutlinedIcon} to="#" text="Home" />
+      <SidebarItem icon={HomeOutlinedIcon} to="#" text="Plugins" />
+      <SidebarItem icon={AddCircleOutlineIcon} to="#" text="Create..." />
+      <SidebarDivider />
+      <SidebarIntro />
+      <SidebarSpace />
+    </Sidebar>
+  );
+}

--- a/packages/core-components/src/layout/Sidebar/index.ts
+++ b/packages/core-components/src/layout/Sidebar/index.ts
@@ -19,7 +19,7 @@ export type { SidebarClassKey } from './Bar';
 export {
   SidebarPage,
   SidebarPinStateContext,
-  SideBarPageContent,
+  SidebarPageContent,
   useContentRef,
 } from './Page';
 

--- a/packages/core-components/src/layout/Sidebar/index.ts
+++ b/packages/core-components/src/layout/Sidebar/index.ts
@@ -16,7 +16,13 @@
 
 export { Sidebar } from './Bar';
 export type { SidebarClassKey } from './Bar';
-export { SidebarPage, SidebarPinStateContext } from './Page';
+export {
+  SidebarPage,
+  SidebarPinStateContext,
+  SideBarPageContent,
+  useContentRef,
+} from './Page';
+
 export type {
   SidebarPinStateContextType,
   SidebarPageContextType,

--- a/packages/core-components/src/layout/Sidebar/index.ts
+++ b/packages/core-components/src/layout/Sidebar/index.ts
@@ -17,7 +17,12 @@
 export { Sidebar } from './Bar';
 export type { SidebarClassKey } from './Bar';
 export { SidebarPage, SidebarPinStateContext } from './Page';
-export type { SidebarPinStateContextType, SidebarPageClassKey } from './Page';
+export type {
+  SidebarPinStateContextType,
+  SidebarPageContextType,
+  SidebarPageClassKey,
+} from './Page';
+
 export {
   SidebarDivider,
   SidebarItem,

--- a/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
+++ b/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
@@ -18,19 +18,20 @@ import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { rootRouteRef } from '../../plugin';
 
-import { SidebarSearchField } from '@backstage/core-components';
+import { SidebarSearchField, useContentRef } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 
 export const SidebarSearch = () => {
   const searchRoute = useRouteRef(rootRouteRef);
+  const contentRef = useContentRef();
   const navigate = useNavigate();
   const handleSearch = useCallback(
     (query: string): void => {
       const queryString = qs.stringify({ query }, { addQueryPrefix: true });
-
+      contentRef?.current?.focus();
       navigate(`${searchRoute()}${queryString}`);
     },
-    [navigate, searchRoute],
+    [navigate, searchRoute, contentRef],
   );
 
   return <SidebarSearchField onSearch={handleSearch} to="/search" />;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Creates a Sidebar content Element and stores a ref to that element in a context and creates a "skip to content" hidden button to follow this [accessibility recommendation](https://www.w3.org/TR/WCAG20-TECHS/G1.html) 

#### Accessibility Demo
https://user-images.githubusercontent.com/1770453/135339890-08b318c1-d06b-48ab-be3a-691f9875f86c.mp4


#### Focus content
This also enables the possibility to set focus directly on the page content element using the `useContentRef` hook and  `contentRef.current.focus()`


### TODO
- [x] Test if there are no breaking changes
- [x] Update the example app
- [x] Update docs (storybook)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
