### PR TITLE
Add a new SearchFilter.SelectMultiple to let users select multiple options

### DIFF
--- a/.changeset/search-six-forks-drop.md
+++ b/.changeset/search-six-forks-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Add a new `SearchFilter.SelectMultiple` to let users select multiple options.

--- a/plugins/search/api-report.md
+++ b/plugins/search/api-report.md
@@ -107,8 +107,9 @@ export const SearchContextProvider: ({
 // @public (undocumented)
 export const SearchFilter: {
   ({ component: Element, ...props }: Props_2): JSX.Element;
-  Checkbox(props: Omit<Props_2, 'component'> & Component): JSX.Element;
-  Select(props: Omit<Props_2, 'component'> & Component): JSX.Element;
+  Checkbox(props: Omit<Props_2, 'component'>): JSX.Element;
+  Select(props: Omit<Props_2, 'component'>): JSX.Element;
+  SelectMultiple(props: Omit<Props_2, 'component'>): JSX.Element;
 };
 
 // Warning: (ae-missing-release-tag) "SearchFilterNext" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -116,8 +117,9 @@ export const SearchFilter: {
 // @public @deprecated (undocumented)
 export const SearchFilterNext: {
   ({ component: Element, ...props }: Props_2): JSX.Element;
-  Checkbox(props: Omit<Props_2, 'component'> & Component): JSX.Element;
-  Select(props: Omit<Props_2, 'component'> & Component): JSX.Element;
+  Checkbox(props: Omit<Props_2, 'component'>): JSX.Element;
+  Select(props: Omit<Props_2, 'component'>): JSX.Element;
+  SelectMultiple(props: Omit<Props_2, 'component'>): JSX.Element;
 };
 
 // Warning: (ae-missing-release-tag) "SearchPage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -183,5 +185,4 @@ export const useSearch: () => SearchContextValue;
 //
 // src/components/SearchContext/SearchContext.d.ts:21:5 - (ae-forgotten-export) The symbol "SettableSearchContext" needs to be exported by the entry point index.d.ts
 // src/components/SearchFilter/SearchFilter.d.ts:13:5 - (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
-// src/components/SearchFilter/SearchFilter.d.ts:14:5 - (ae-forgotten-export) The symbol "Component" needs to be exported by the entry point index.d.ts
 ```

--- a/plugins/search/src/components/SearchFilter/SearchFilter.stories.tsx
+++ b/plugins/search/src/components/SearchFilter/SearchFilter.stories.tsx
@@ -67,3 +67,23 @@ export const SelectFilter = () => {
     </MemoryRouter>
   );
 };
+
+export const SelectMultipleFilter = () => {
+  return (
+    <MemoryRouter>
+      {/* @ts-ignore (defaultValue requires more than what is used here) */}
+      <SearchContext.Provider value={defaultValue}>
+        <Grid container direction="row">
+          <Grid item xs={4}>
+            <Paper style={{ padding: 10 }}>
+              <SearchFilter.SelectMultiple
+                name="Search Select Filter"
+                values={['value1', 'value2']}
+              />
+            </Paper>
+          </Grid>
+        </Grid>
+      </SearchContext.Provider>
+    </MemoryRouter>
+  );
+};

--- a/plugins/search/src/components/SearchFilter/SearchFilter.stories.tsx
+++ b/plugins/search/src/components/SearchFilter/SearchFilter.stories.tsx
@@ -14,21 +14,23 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { Grid, Paper } from '@material-ui/core';
-import { SearchFilter, SearchContext } from '../index';
+import React, { useState } from 'react';
 import { MemoryRouter } from 'react-router';
+import { SearchContext, SearchFilter } from '../index';
 
 export default {
   title: 'Plugins/Search/SearchFilter',
   component: SearchFilter,
 };
 
-const defaultValue = {
-  filters: {},
-};
-
 export const CheckBoxFilter = () => {
+  const [filters, setFilters] = useState({});
+  const defaultValue = {
+    filters,
+    setFilters,
+  };
+
   return (
     <MemoryRouter>
       {/* @ts-ignore (defaultValue requires more than what is used here) */}
@@ -49,6 +51,12 @@ export const CheckBoxFilter = () => {
 };
 
 export const SelectFilter = () => {
+  const [filters, setFilters] = useState({});
+  const defaultValue = {
+    filters,
+    setFilters,
+  };
+
   return (
     <MemoryRouter>
       {/* @ts-ignore (defaultValue requires more than what is used here) */}
@@ -69,6 +77,12 @@ export const SelectFilter = () => {
 };
 
 export const SelectMultipleFilter = () => {
+  const [filters, setFilters] = useState({});
+  const defaultValue = {
+    filters,
+    setFilters,
+  };
+
   return (
     <MemoryRouter>
       {/* @ts-ignore (defaultValue requires more than what is used here) */}

--- a/plugins/search/src/components/SearchFilter/SearchFilter.tsx
+++ b/plugins/search/src/components/SearchFilter/SearchFilter.tsx
@@ -207,9 +207,11 @@ const SelectMultipleFilter = ({
       target: { value },
     } = e;
 
+    const v = value as string[];
+
     setFilters(prevFilters => {
       const { [name]: filter, ...others } = prevFilters;
-      return value ? { ...others, [name]: value as string[] } : others;
+      return v.length ? { ...others, [name]: v } : others;
     });
   };
 


### PR DESCRIPTION
This is a copy of the `SearchType` filter but it can be used on any field.

![image](https://user-images.githubusercontent.com/720821/133996530-50adf210-da20-44ee-9416-ab3da22b1173.png)

![image](https://user-images.githubusercontent.com/720821/133996555-c68cce73-5b23-4b51-884a-7f6dc0d8efe7.png)


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
