### PR TITLE
Allow url with extension .yml in gitlab processor

### DIFF
--- a/.changeset/great-squids-deliver.md
+++ b/.changeset/great-squids-deliver.md
@@ -2,4 +2,4 @@
 '@backstage/integration': patch
 ---
 
-Allow file extension .yml to be ingested in gitlab processor
+Allow file extension `.yml` to be ingested in GitLab processor

--- a/.changeset/great-squids-deliver.md
+++ b/.changeset/great-squids-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Allow file extension .yml to be ingested in gitlab processor

--- a/packages/integration/src/gitlab/core.test.ts
+++ b/packages/integration/src/gitlab/core.test.ts
@@ -47,7 +47,7 @@ describe('gitlab core', () => {
     baseUrl: '<ignored>',
   };
 
-  describe('getGitLabFileFetchUrl', () => {
+  describe('getGitLabFileFetchUrl with .yaml extension', () => {
     it.each([
       // Project URLs
       {
@@ -86,6 +86,51 @@ describe('gitlab core', () => {
         config: configWithNoToken,
         url: 'https://gitlab.example.com/a/b/blob/master/c.yaml',
         result: 'https://gitlab.example.com/a/b/raw/master/c.yaml',
+      },
+    ])('should handle happy path %#', async ({ config, url, result }) => {
+      await expect(getGitLabFileFetchUrl(url, config)).resolves.toBe(result);
+    });
+  });
+
+  describe('getGitLabFileFetchUrl with .yml extension', () => {
+    it.each([
+      // Project URLs
+      {
+        config: configWithNoToken,
+        url: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file.yml',
+        result:
+          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile.yml/raw?ref=branch',
+      },
+      {
+        config: configWithNoToken,
+        // Works with non URI encoded link
+        url: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path/to/file with spaces.yml',
+        result:
+          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%2Fto%2Ffile%20with%20spaces.yml/raw?ref=branch',
+      },
+      {
+        config: configWithNoToken,
+        url: 'https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path%20with%20spaces/to/file.yml',
+        result:
+          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%20with%20spaces%2Fto%2Ffile.yml/raw?ref=branch',
+      },
+      {
+        config: configWithToken,
+        url: 'https://gitlab.example.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/my/path%20with%20spaces/to/file.yml',
+        result:
+          'https://gitlab.example.com/api/v4/projects/12345/repository/files/my%2Fpath%20with%20spaces%2Fto%2Ffile.yml/raw?ref=branch',
+      },
+      {
+        config: configWithNoToken,
+        url: 'https://gitlab.com/groupA/teams/teamA/repoA/-/blob/branch/my/path%20with%20spaces/to/file.yml', // Repo not in subgroup
+        result:
+          'https://gitlab.com/api/v4/projects/12345/repository/files/my%2Fpath%20with%20spaces%2Fto%2Ffile.yml/raw?ref=branch',
+      },
+      // Raw URLs
+      {
+        config: configWithNoToken,
+        url: 'https://gitlab.example.com/a/b/blob/master/c.yml',
+        result: 'https://gitlab.example.com/a/b/raw/master/c.yml',
       },
     ])('should handle happy path %#', async ({ config, url, result }) => {
       await expect(getGitLabFileFetchUrl(url, config)).resolves.toBe(result);

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -76,7 +76,7 @@ export function buildRawUrl(target: string): URL {
       userOrOrg === '' ||
       repoName === '' ||
       blobKeyword !== 'blob' ||
-      !restOfPath.join('/').match(/\.yaml$/)
+      !restOfPath.join('/').match(/\.(yaml|yml)$/)
     ) {
       throw new Error('Wrong GitLab URL');
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow yaml file url with extension .yml in gitlab processor

#### :heavy_check_mark: Checklist


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
