### PR TITLE
Add MUI Drawer provider helper

### DIFF
--- a/.changeset/slow-avocados-wait.md
+++ b/.changeset/slow-avocados-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added helper provider for MUI Drawers

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -14,11 +14,15 @@ import { CardHeaderProps } from '@material-ui/core/CardHeader';
 import { Column } from '@material-table/core';
 import { ComponentClass } from 'react';
 import { ComponentProps } from 'react';
+import { ComponentType } from 'react';
 import { Context } from 'react';
 import { default as CSS_2 } from 'csstype';
 import { CSSProperties } from 'react';
+import { DetailedHTMLProps } from 'react';
+import { DrawerProps } from '@material-ui/core';
 import { ElementType } from 'react';
 import { ErrorInfo } from 'react';
+import { HTMLAttributes } from 'react';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { LinearProgressProps } from '@material-ui/core/LinearProgress';
 import { LinkProps as LinkProps_2 } from '@material-ui/core/Link';
@@ -154,6 +158,16 @@ export interface CodeSnippetProps {
   text: string;
 }
 
+// Warning: (ae-missing-release-tag) "ConstructedDrawer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface ConstructedDrawer<T> {
+  // (undocumented)
+  Provider: ComponentType<PropsWithChildren<DrawerProviderProps>>;
+  // (undocumented)
+  useDrawer: () => DrawerHook<T>;
+}
+
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Content" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -193,6 +207,16 @@ export type CreateButtonProps = {
   title: string;
 } & Partial<Pick<LinkProps_3, 'to'>>;
 
+// Warning: (ae-missing-release-tag) "createDrawer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function createDrawer<T>(
+  Component: ComponentType<DrawerComponentProps<T>>,
+  wrapperProps?: DrawerWrapperProps,
+): ConstructedDrawer<T>;
+
+// Warning: (ae-missing-release-tag) "DashboardIcon" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export type CustomProviderClassKey = 'form' | 'button';
 
@@ -298,6 +322,41 @@ export type DismissableBannerClassKey =
 // @public @deprecated (undocumented)
 export type DismissbleBannerClassKey = DismissableBannerClassKey;
 
+// Warning: (ae-missing-release-tag) "DrawerComponentProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface DrawerComponentProps<T> {
+  // (undocumented)
+  close: () => void;
+  // (undocumented)
+  value: T;
+}
+
+// Warning: (ae-missing-release-tag) "DrawerHook" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface DrawerHook<T> {
+  // (undocumented)
+  closeDrawer: () => void;
+  // (undocumented)
+  openDrawer: (value: T) => void;
+}
+
+// Warning: (ae-missing-release-tag) "DrawerProviderProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type DrawerProviderProps = Omit<DrawerProps, 'open' | 'onClose'>;
+
+// Warning: (ae-missing-release-tag) "DrawerWrapperProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type DrawerWrapperProps = DetailedHTMLProps<
+  HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+// Warning: (ae-missing-release-tag) "EdgeProperties" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public (undocumented)
 export function DocsIcon(props: IconComponentProps): JSX.Element;
 

--- a/packages/core-components/src/providers/drawer/createDrawer.tsx
+++ b/packages/core-components/src/providers/drawer/createDrawer.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  ComponentType,
+  DetailedHTMLProps,
+  HTMLAttributes,
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { Drawer, DrawerProps } from '@material-ui/core';
+
+export interface DrawerComponentProps<T> {
+  value: T;
+  close: () => void;
+}
+
+export interface DrawerHook<T> {
+  openDrawer: (value: T) => void;
+  closeDrawer: () => void;
+}
+
+export type DrawerProviderProps = Omit<DrawerProps, 'open' | 'onClose'>;
+
+export interface ConstructedDrawer<T> {
+  Provider: ComponentType<PropsWithChildren<DrawerProviderProps>>;
+  useDrawer: () => DrawerHook<T>;
+}
+
+export type DrawerWrapperProps = DetailedHTMLProps<
+  HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+export function createDrawer<T>(
+  Component: ComponentType<DrawerComponentProps<T>>,
+  wrapperProps?: DrawerWrapperProps,
+): ConstructedDrawer<T> {
+  const context = createContext<DrawerHook<T>>(undefined as any);
+
+  function Provider(props: PropsWithChildren<DrawerProviderProps>) {
+    const { children, ...drawerProps } = props;
+    const [openedValue, setOpenedValue] = useState<T | undefined>();
+
+    const closeDrawer = useCallback(
+      () => setOpenedValue(undefined),
+      [setOpenedValue],
+    );
+
+    const hookData = useMemo(
+      (): DrawerHook<T> => ({
+        openDrawer: setOpenedValue,
+        closeDrawer,
+      }),
+      [setOpenedValue, closeDrawer],
+    );
+
+    return (
+      <context.Provider value={hookData}>
+        {children}
+        <Drawer {...drawerProps} open={!!openedValue} onClose={closeDrawer}>
+          <div {...wrapperProps}>
+            {!openedValue ? null : (
+              <Component value={openedValue} close={closeDrawer} />
+            )}
+          </div>
+        </Drawer>
+      </context.Provider>
+    );
+  }
+
+  function useDrawer(): DrawerHook<T> {
+    return useContext(context);
+  }
+
+  return { Provider, useDrawer };
+}

--- a/packages/core-components/src/providers/drawer/createDrawer.tsx
+++ b/packages/core-components/src/providers/drawer/createDrawer.tsx
@@ -25,7 +25,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { Drawer, DrawerProps } from '@material-ui/core';
+import Drawer, { DrawerProps } from '@material-ui/core/Drawer';
 
 export interface DrawerComponentProps<T> {
   value: T;
@@ -53,7 +53,7 @@ export function createDrawer<T>(
   Component: ComponentType<DrawerComponentProps<T>>,
   wrapperProps?: DrawerWrapperProps,
 ): ConstructedDrawer<T> {
-  const context = createContext<DrawerHook<T>>(undefined as any);
+  const context = createContext<DrawerHook<T> | undefined>(undefined);
 
   function Provider(props: PropsWithChildren<DrawerProviderProps>) {
     const { children, ...drawerProps } = props;
@@ -87,7 +87,15 @@ export function createDrawer<T>(
   }
 
   function useDrawer(): DrawerHook<T> {
-    return useContext(context);
+    const drawer = useContext(context);
+
+    if (drawer === undefined) {
+      throw new Error(
+        'No Drawer found. useDrawer must not be called outisde a Drawer Provider.',
+      );
+    }
+
+    return drawer;
   }
 
   return { Provider, useDrawer };

--- a/packages/core-components/src/providers/drawer/index.tsx
+++ b/packages/core-components/src/providers/drawer/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-/**
- * Core components used by Backstage plugins and apps
- *
- * @packageDocumentation
- */
-
-export * from './components';
-export * from './hooks';
-export * from './icons';
-export * from './layout';
-export * from './overridableComponents';
-export * from './providers';
+export { createDrawer } from './createDrawer';
+export type {
+  DrawerComponentProps,
+  DrawerHook,
+  DrawerProviderProps,
+  ConstructedDrawer,
+  DrawerWrapperProps,
+} from './createDrawer';

--- a/packages/core-components/src/providers/index.ts
+++ b/packages/core-components/src/providers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,4 @@
  * limitations under the License.
  */
 
-/**
- * Core components used by Backstage plugins and apps
- *
- * @packageDocumentation
- */
-
-export * from './components';
-export * from './hooks';
-export * from './icons';
-export * from './layout';
-export * from './overridableComponents';
-export * from './providers';
+export * from './drawer';


### PR DESCRIPTION
Signed-off-by: Gustaf Räntilä <g.rantila@gmail.com>

# This is a helper around MUI Drawers.

Like any other *portal*-kind of component, using drawers isn't trivial, and easily leads to a bit of spaghetti, open/closing and providing content, up and down the component hierarchy for shared state.

This commit adds a provider+hook and a typesafe coupling-creator function `createDrawer<T>` which ties the provider and hook together.

 * Provider: You can provide the drawer props directly to the provider, as shown below.
 * Hook: You can typesafely pass a value to the drawer content component.

Imagine a user/profile display component being pulled in in a drawer, you'd likely have a `UserDisplay` component showing the content. In this, or any other suitable file, you can provide:

```ts
import { createDrawer } from '@backstage/core-components';

export function UserDisplay({ value }: { value: { userId: string; } }) { ... }

export const {
  Provider: UserDrawerProvider,
  useDrawer: useUserDrawer,
} = createDrawer(UserDisplay, { style: { width: '25vw' } });
```

The `UserDisplay` can also optionally have a `close()` prop, if the UserDisplay *itself* wants to be able to close the drawer (like with a close button or such).

In a suitable (kind of top-level) part of a page, you can provide the _ability_ to use the drawer from sub components:

```ts
<UserDrawerProvider anchor="right"> // <-- forwards Drawer props
  {
    // the rest of the page content goes here, routers and whatnot
  }
</UserDrawerProvider>
```

Then in a sub component deeper in the component tree you can now display the drawer, and pass the `string` (`userId`) to the UserDisplay component:

```ts
const { openDrawer } = useUserDrawer();

// on some click-action, e.g.:
const onClick = (userId: string) => openDrawer(userId);
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
