### PR TITLE
catalog-backend: add processing cache

### DIFF
--- a/.changeset/seven-bulldogs-grin.md
+++ b/.changeset/seven-bulldogs-grin.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Introduced a new `CatalogProcessorCache` that is available to catalog processors. It allows arbitrary values to be saved that will then be visible during the next run. The cache is scoped to each individual processor and entity, but is shared across processing steps in a single processor.
+
+The cache is available as a new argument to each of the processing steps, except for `validateEntityKind` and `handleError`.
+
+This also introduces an optional `getProcessorName` to the `CatalogProcessor` interface, which is used to provide a stable identifier for the processor. While it is currently optional it will move to be required in the future.
+
+The breaking part of this change is the modification of the `state` field in the `EntityProcessingRequest` and `EntityProcessingResult` types. This is unlikely to have any impact as the `state` field was previously unused, but could require some minor updates.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -17,6 +17,7 @@ import { EntityPolicy } from '@backstage/catalog-model';
 import { EntityRelationSpec } from '@backstage/catalog-model';
 import express from 'express';
 import { IndexableDocument } from '@backstage/search-common';
+import { JsonObject } from '@backstage/config';
 import { JsonValue } from '@backstage/config';
 import { Knex } from 'knex';
 import { Location as Location_2 } from '@backstage/catalog-model';
@@ -877,7 +878,7 @@ export type EntityPagination = {
 // @public (undocumented)
 export type EntityProcessingRequest = {
   entity: Entity;
-  state?: JsonValue;
+  state?: JsonObject;
 };
 
 // Warning: (ae-missing-release-tag) "EntityProcessingResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -886,7 +887,7 @@ export type EntityProcessingRequest = {
 export type EntityProcessingResult =
   | {
       ok: true;
-      state: JsonValue;
+      state: JsonObject;
       completedEntity: Entity;
       deferredEntities: DeferredEntity[];
       relations: EntityRelationSpec[];

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -17,7 +17,6 @@ import { EntityPolicy } from '@backstage/catalog-model';
 import { EntityRelationSpec } from '@backstage/catalog-model';
 import express from 'express';
 import { IndexableDocument } from '@backstage/search-common';
-import { JsonObject } from '@backstage/config';
 import { JsonValue } from '@backstage/config';
 import { Knex } from 'knex';
 import { Location as Location_2 } from '@backstage/catalog-model';
@@ -302,23 +301,27 @@ export interface CatalogProcessingOrchestrator {
 //
 // @public (undocumented)
 export type CatalogProcessor = {
+  getProcessorName?(): string;
   readLocation?(
     location: LocationSpec,
     optional: boolean,
     emit: CatalogProcessorEmit,
     parser: CatalogProcessorParser,
+    cache: CatalogProcessorCache,
   ): Promise<boolean>;
   preProcessEntity?(
     entity: Entity,
     location: LocationSpec,
     emit: CatalogProcessorEmit,
     originLocation: LocationSpec,
+    cache: CatalogProcessorCache,
   ): Promise<Entity>;
   validateEntityKind?(entity: Entity): Promise<boolean>;
   postProcessEntity?(
     entity: Entity,
     location: LocationSpec,
     emit: CatalogProcessorEmit,
+    cache: CatalogProcessorCache,
   ): Promise<Entity>;
   handleError?(
     error: Error,
@@ -326,6 +329,12 @@ export type CatalogProcessor = {
     emit: CatalogProcessorEmit,
   ): Promise<void>;
 };
+
+// @public
+export interface CatalogProcessorCache {
+  get<ItemType extends JsonValue>(key: string): Promise<ItemType | undefined>;
+  set<ItemType extends JsonValue>(key: string, value: ItemType): Promise<void>;
+}
 
 // Warning: (ae-missing-release-tag) "CatalogProcessorEmit" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -868,7 +877,7 @@ export type EntityPagination = {
 // @public (undocumented)
 export type EntityProcessingRequest = {
   entity: Entity;
-  state: Map<string, JsonObject>;
+  state?: JsonValue;
 };
 
 // Warning: (ae-missing-release-tag) "EntityProcessingResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -877,7 +886,7 @@ export type EntityProcessingRequest = {
 export type EntityProcessingResult =
   | {
       ok: true;
-      state: Map<string, JsonObject>;
+      state: JsonValue;
       completedEntity: Entity;
       deferredEntities: DeferredEntity[];
       relations: EntityRelationSpec[];
@@ -1478,11 +1487,14 @@ export class UrlReaderProcessor implements CatalogProcessor {
   // Warning: (ae-forgotten-export) The symbol "Options" needs to be exported by the entry point index.d.ts
   constructor(options: Options_3);
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   readLocation(
     location: LocationSpec,
     optional: boolean,
     emit: CatalogProcessorEmit,
     parser: CatalogProcessorParser,
+    cache: CatalogProcessorCache,
   ): Promise<boolean>;
 }
 
@@ -1505,21 +1517,6 @@ export class UrlReaderProcessor implements CatalogProcessor {
 // src/database/types.d.ts:164:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/database/types.d.ts:165:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/ingestion/processors/GithubMultiOrgReaderProcessor.d.ts:23:9 - (ae-forgotten-export) The symbol "GithubMultiOrgConfig" needs to be exported by the entry point index.d.ts
-// src/ingestion/processors/types.d.ts:7:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:8:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:9:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:10:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:23:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:24:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:25:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:26:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:36:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:47:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:48:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:49:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:56:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:57:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-// src/ingestion/processors/types.d.ts:58:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/ingestion/types.d.ts:17:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/ingestion/types.d.ts:41:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 ```

--- a/plugins/catalog-backend/src/ingestion/LocationReaders.ts
+++ b/plugins/catalog-backend/src/ingestion/LocationReaders.ts
@@ -52,6 +52,13 @@ type Options = {
   policy: EntityPolicy;
 };
 
+const noopCache = {
+  async get() {
+    return undefined;
+  },
+  async set() {},
+};
+
 /**
  * Implements the reading of a location through a series of processor tasks.
  */
@@ -167,6 +174,7 @@ export class LocationReaders implements LocationReader {
               item.optional,
               validatedEmit,
               this.options.parser,
+              noopCache,
             )
           ) {
             return;
@@ -215,6 +223,7 @@ export class LocationReaders implements LocationReader {
             item.location,
             emit,
             originLocation,
+            noopCache,
           );
         } catch (e) {
           const message = `Processor ${
@@ -285,6 +294,7 @@ export class LocationReaders implements LocationReader {
             current,
             item.location,
             emit,
+            noopCache,
           );
         } catch (e) {
           const message = `Processor ${

--- a/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
@@ -44,6 +44,10 @@ type CacheItem = {
 export class UrlReaderProcessor implements CatalogProcessor {
   constructor(private readonly options: Options) {}
 
+  getProcessorName() {
+    return 'url-reader';
+  }
+
   async readLocation(
     location: LocationSpec,
     optional: boolean,
@@ -74,13 +78,11 @@ export class UrlReaderProcessor implements CatalogProcessor {
         }
       }
 
-      const isOnlyEntities = parseResults.every(
-        (r): r is CatalogProcessorEntityResult => r.type === 'entity',
-      );
+      const isOnlyEntities = parseResults.every(r => r.type === 'entity');
       if (newEtag && isOnlyEntities) {
         await cache.set<CacheItem>(CACHE_KEY, {
           etag: newEtag,
-          value: parseResults,
+          value: parseResults as CatalogProcessorEntityResult[],
         });
       }
     } catch (error) {
@@ -121,7 +123,7 @@ export class UrlReaderProcessor implements CatalogProcessor {
 
     // Otherwise do a plain read, prioritizing readUrl if available
     if (this.options.reader.readUrl) {
-      const data = await this.options.reader.readUrl(location);
+      const data = await this.options.reader.readUrl(location, { etag });
       return [[{ url: location, data: await data.buffer() }], data.etag];
     }
 

--- a/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
@@ -15,7 +15,7 @@
  */
 
 import { UrlReader } from '@backstage/backend-common';
-import { LocationSpec } from '@backstage/catalog-model';
+import { Entity, LocationSpec } from '@backstage/catalog-model';
 import parseGitUrl from 'git-url-parse';
 import limiterFactory from 'p-limit';
 import { Logger } from 'winston';
@@ -36,9 +36,14 @@ type Options = {
   logger: Logger;
 };
 
+// WARNING: If you change this type, you likely need to bump the CACHE_KEY as well
 type CacheItem = {
   etag: string;
-  value: CatalogProcessorEntityResult[];
+  value: {
+    type: 'entity';
+    entity: Entity;
+    location: LocationSpec;
+  }[];
 };
 
 export class UrlReaderProcessor implements CatalogProcessor {

--- a/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/UrlReaderProcessor.ts
@@ -91,7 +91,6 @@ export class UrlReaderProcessor implements CatalogProcessor {
         for (const parseResult of cacheItem.value) {
           emit(parseResult);
         }
-        await cache.set<CacheItem>(CACHE_KEY, cacheItem);
       } else if (error.name === 'NotFoundError') {
         if (!optional) {
           emit(result.notFoundError(location, message));

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -24,7 +24,7 @@ import { JsonValue } from '@backstage/config';
 export type CatalogProcessor = {
   /**
    * A unique identifier for the Catalog Processor.
-   * It's strongly recommended implement getProcessorName as this method will be required in the future.
+   * It's strongly recommended to implement getProcessorName as this method will be required in the future.
    */
   getProcessorName?(): string;
 

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -23,6 +23,12 @@ import { JsonValue } from '@backstage/config';
 
 export type CatalogProcessor = {
   /**
+   * A unique identifier for the Catalog Processor.
+   * It's strongly recommended implement getProcessorName as this method will be required in the future.
+   */
+  getProcessorName?(): string;
+
+  /**
    * Reads the contents of a location.
    *
    * @param location - The location to read

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -137,8 +137,8 @@ export type CatalogProcessorParser = (options: {
  * values from processing runs for other entities.
  *
  * Values that are set during a processing run will only be visible in the directly
- * following run. The cache will be overwritten every run, meaning existing values
- * are removed and need to be set again for them to remain in the cache.
+ * following run. The cache will be overwritten every run unless no new cache items
+ * are written, in which case the existing values remain in the cache.
  *
  * @public
  */

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -19,16 +19,18 @@ import {
   EntityRelationSpec,
   LocationSpec,
 } from '@backstage/catalog-model';
+import { JsonValue } from '@backstage/config';
 
 export type CatalogProcessor = {
   /**
    * Reads the contents of a location.
    *
-   * @param location The location to read
-   * @param optional Whether a missing target should trigger an error
-   * @param emit A sink for items resulting from the read
-   * @param parser A parser, that is able to take the raw catalog descriptor
+   * @param location - The location to read
+   * @param optional - Whether a missing target should trigger an error
+   * @param emit - A sink for items resulting from the read
+   * @param parser - A parser, that is able to take the raw catalog descriptor
    *               data and turn it into the actual result pieces.
+   * @param cache - A cache for storing values local to this processor and the current entity.
    * @returns True if handled by this processor, false otherwise
    */
   readLocation?(
@@ -36,6 +38,7 @@ export type CatalogProcessor = {
     optional: boolean,
     emit: CatalogProcessorEmit,
     parser: CatalogProcessorParser,
+    cache: CatalogProcessorCache,
   ): Promise<boolean>;
 
   /**
@@ -46,12 +49,13 @@ export type CatalogProcessor = {
    * additional data, and the input entity may actually still be incomplete
    * when the processor is invoked.
    *
-   * @param entity The (possibly partial) entity to process
-   * @param location The location that the entity came from
-   * @param emit A sink for auxiliary items resulting from the processing
-   * @param originLocation The location that the entity originally came from.
+   * @param entity - The (possibly partial) entity to process
+   * @param location - The location that the entity came from
+   * @param emit - A sink for auxiliary items resulting from the processing
+   * @param originLocation - The location that the entity originally came from.
    *   While location resolves to the direct parent location, originLocation
    *   tells which location was used to start the ingestion loop.
+   * @param cache - A cache for storing values local to this processor and the current entity.
    * @returns The same entity or a modified version of it
    */
   preProcessEntity?(
@@ -59,13 +63,14 @@ export type CatalogProcessor = {
     location: LocationSpec,
     emit: CatalogProcessorEmit,
     originLocation: LocationSpec,
+    cache: CatalogProcessorCache,
   ): Promise<Entity>;
 
   /**
    * Validates the entity as a known entity kind, after it has been pre-
    * processed and has passed through basic overall validation.
    *
-   * @param entity The entity to validate
+   * @param entity - The entity to validate
    * @returns Resolves to true, if the entity was of a kind that was known and
    *   handled by this processor, and was found to be valid. Resolves to false,
    *   if the entity was not of a kind that was known by this processor.
@@ -77,23 +82,25 @@ export type CatalogProcessor = {
   /**
    * Post-processes an emitted entity, after it has been validated.
    *
-   * @param entity The entity to process
-   * @param location The location that the entity came from
-   * @param emit A sink for auxiliary items resulting from the processing
+   * @param entity - The entity to process
+   * @param location - The location that the entity came from
+   * @param emit - A sink for auxiliary items resulting from the processing
+   * @param cache - A cache for storing values local to this processor and the current entity.
    * @returns The same entity or a modified version of it
    */
   postProcessEntity?(
     entity: Entity,
     location: LocationSpec,
     emit: CatalogProcessorEmit,
+    cache: CatalogProcessorCache,
   ): Promise<Entity>;
 
   /**
    * Handles an emitted error.
    *
-   * @param error The error
-   * @param location The location where the error occurred
-   * @param emit A sink for items resulting from this handling
+   * @param error - The error
+   * @param location - The location where the error occurred
+   * @param emit - A sink for items resulting from this handling
    * @returns Nothing
    */
   handleError?(
@@ -112,6 +119,34 @@ export type CatalogProcessorParser = (options: {
   data: Buffer;
   location: LocationSpec;
 }) => AsyncIterable<CatalogProcessorResult>;
+
+/**
+ * A cache for storing data during processing.
+ *
+ * The values stored in the cache are always local to each processor, meaning
+ * no processor can see cache values from other processors.
+ *
+ * The cache instance provided to the CatalogProcessor is also scoped to the
+ * entity being processed, meaning that each processor run can't see cache
+ * values from processing runs for other entities.
+ *
+ * Values that are set during a processing run will only be visible in the directly
+ * following run. The cache will be overwritten every run, meaning existing values
+ * are removed and need to be set again for them to remain in the cache.
+ *
+ * @public
+ */
+export interface CatalogProcessorCache {
+  /**
+   * Retrieve a value from the cache.
+   */
+  get<ItemType extends JsonValue>(key: string): Promise<ItemType | undefined>;
+
+  /**
+   * Store a value in the cache.
+   */
+  set<ItemType extends JsonValue>(key: string, value: ItemType): Promise<void>;
+}
 
 export type CatalogProcessorEmit = (generated: CatalogProcessorResult) => void;
 

--- a/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.test.ts
+++ b/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.test.ts
@@ -28,6 +28,7 @@ describe('DefaultCatalogProcessingEngine', () => {
     transaction: jest.fn(),
     getProcessableEntities: jest.fn(),
     updateProcessedEntity: jest.fn(),
+    updateEntityCache: jest.fn(),
   } as unknown as jest.Mocked<DefaultProcessingDatabase>;
   const orchestrator: jest.Mocked<CatalogProcessingOrchestrator> = {
     process: jest.fn(),
@@ -84,7 +85,7 @@ describe('DefaultCatalogProcessingEngine', () => {
               metadata: { name: 'test' },
             },
             resultHash: '',
-            state: [],
+            state: [] as any,
             nextUpdateAt: DateTime.now(),
             lastDiscoveryAt: DateTime.now(),
           },
@@ -221,16 +222,100 @@ describe('DefaultCatalogProcessingEngine', () => {
       expect(hash.digest).toBeCalledTimes(1);
       expect(db.updateProcessedEntity).toBeCalledTimes(1);
     });
+    expect(db.updateEntityCache).not.toHaveBeenCalled();
 
     db.getProcessableEntities
       .mockReset()
-      .mockResolvedValueOnce({ items: [refreshState] })
+      .mockResolvedValueOnce({
+        items: [{ ...refreshState, state: { something: 'different' } }],
+      })
       .mockResolvedValue({ items: [] });
 
     await waitForExpect(() => {
       expect(orchestrator.process).toBeCalledTimes(2);
       expect(hash.digest).toBeCalledTimes(2);
       expect(db.updateProcessedEntity).toBeCalledTimes(1);
+      expect(db.updateEntityCache).toBeCalledTimes(1);
+    });
+    expect(db.updateEntityCache).toHaveBeenCalledWith(expect.anything(), {
+      id: '',
+      state: { ttl: 5 },
+    });
+    await engine.stop();
+  });
+
+  it('should decrease the state ttl if there are errors', async () => {
+    const entity = {
+      apiVersion: '1',
+      kind: 'Location',
+      metadata: { name: 'test' },
+    };
+
+    const refreshState = {
+      id: '',
+      entityRef: '',
+      unprocessedEntity: entity,
+      resultHash: 'the matching hash',
+      state: { some: 'value', ttl: 1 },
+      nextUpdateAt: DateTime.now(),
+      lastDiscoveryAt: DateTime.now(),
+    };
+
+    hash.digest.mockReturnValue('the matching hash');
+
+    orchestrator.process.mockResolvedValue({
+      ok: false,
+      errors: [],
+    });
+
+    const engine = new DefaultCatalogProcessingEngine(
+      getVoidLogger(),
+      [],
+      db,
+      orchestrator,
+      stitcher,
+      () => hash,
+    );
+
+    db.transaction.mockImplementation(cb => cb((() => {}) as any));
+
+    await engine.start();
+
+    db.getProcessableEntities
+      .mockResolvedValueOnce({
+        items: [refreshState],
+      })
+      .mockResolvedValue({ items: [] });
+
+    await waitForExpect(() => {
+      expect(db.updateEntityCache).toBeCalledTimes(1);
+    });
+
+    expect(db.updateEntityCache).toHaveBeenCalledWith(expect.anything(), {
+      id: '',
+      state: { some: 'value', ttl: 0 },
+    });
+
+    // Second run, the TTL should now reach 0 and the cache should be cleared
+    db.getProcessableEntities
+      .mockResolvedValueOnce({
+        items: [
+          {
+            ...refreshState,
+            state: db.updateEntityCache.mock.calls[0][1].state,
+          },
+        ],
+      })
+      .mockResolvedValue({ items: [] });
+
+    db.updateEntityCache.mockReset();
+    await waitForExpect(() => {
+      expect(db.updateEntityCache).toBeCalledTimes(1);
+    });
+
+    expect(db.updateEntityCache).toHaveBeenCalledWith(expect.anything(), {
+      id: '',
+      state: {},
     });
 
     await engine.stop();

--- a/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.test.ts
+++ b/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.test.ts
@@ -84,7 +84,7 @@ describe('DefaultCatalogProcessingEngine', () => {
               metadata: { name: 'test' },
             },
             resultHash: '',
-            state: {},
+            state: [],
             nextUpdateAt: DateTime.now(),
             lastDiscoveryAt: DateTime.now(),
           },
@@ -100,7 +100,7 @@ describe('DefaultCatalogProcessingEngine', () => {
           kind: 'Location',
           metadata: { name: 'test' },
         },
-        state: expect.anything(),
+        state: [], // State is forwarded as is, even if it's a bad format
       });
     });
     await engine.stop();
@@ -147,7 +147,7 @@ describe('DefaultCatalogProcessingEngine', () => {
               metadata: { name: 'test' },
             },
             resultHash: '',
-            state: {},
+            state: { cache: { myProcessor: { myKey: 'myValue' } } },
             nextUpdateAt: DateTime.now(),
             lastDiscoveryAt: DateTime.now(),
           },
@@ -163,7 +163,7 @@ describe('DefaultCatalogProcessingEngine', () => {
           kind: 'Location',
           metadata: { name: 'test' },
         },
-        state: expect.anything(),
+        state: { cache: { myProcessor: { myKey: 'myValue' } } },
       });
     });
     await engine.stop();

--- a/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.test.ts
+++ b/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.test.ts
@@ -55,7 +55,7 @@ describe('DefaultCatalogProcessingEngine', () => {
       relations: [],
       errors: [],
       deferredEntities: [],
-      state: new Map(),
+      state: {},
     });
     const engine = new DefaultCatalogProcessingEngine(
       getVoidLogger(),
@@ -84,7 +84,7 @@ describe('DefaultCatalogProcessingEngine', () => {
               metadata: { name: 'test' },
             },
             resultHash: '',
-            state: new Map(),
+            state: {},
             nextUpdateAt: DateTime.now(),
             lastDiscoveryAt: DateTime.now(),
           },
@@ -117,7 +117,7 @@ describe('DefaultCatalogProcessingEngine', () => {
       relations: [],
       errors: [],
       deferredEntities: [],
-      state: new Map(),
+      state: {},
     });
     const engine = new DefaultCatalogProcessingEngine(
       getVoidLogger(),
@@ -147,7 +147,7 @@ describe('DefaultCatalogProcessingEngine', () => {
               metadata: { name: 'test' },
             },
             resultHash: '',
-            state: new Map(),
+            state: {},
             nextUpdateAt: DateTime.now(),
             lastDiscoveryAt: DateTime.now(),
           },
@@ -181,7 +181,7 @@ describe('DefaultCatalogProcessingEngine', () => {
       entityRef: '',
       unprocessedEntity: entity,
       resultHash: 'the matching hash',
-      state: new Map(),
+      state: {},
       nextUpdateAt: DateTime.now(),
       lastDiscoveryAt: DateTime.now(),
     };
@@ -194,7 +194,7 @@ describe('DefaultCatalogProcessingEngine', () => {
       relations: [],
       errors: [],
       deferredEntities: [],
-      state: new Map(),
+      state: {},
     });
 
     const engine = new DefaultCatalogProcessingEngine(

--- a/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
@@ -167,8 +167,7 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
             hashBuilder = hashBuilder
               .update(stableStringify({ ...result.completedEntity }))
               .update(stableStringify([...result.deferredEntities]))
-              .update(stableStringify([...result.relations]))
-              .update(stableStringify(Object.fromEntries(result.state)));
+              .update(stableStringify([...result.relations]));
           }
 
           const resultHash = hashBuilder.digest('hex');

--- a/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts
@@ -167,7 +167,8 @@ export class DefaultCatalogProcessingEngine implements CatalogProcessingEngine {
             hashBuilder = hashBuilder
               .update(stableStringify({ ...result.completedEntity }))
               .update(stableStringify([...result.deferredEntities]))
-              .update(stableStringify([...result.relations]));
+              .update(stableStringify([...result.relations]))
+              .update(stableStringify(result.state));
           }
 
           const resultHash = hashBuilder.digest('hex');

--- a/plugins/catalog-backend/src/next/DefaultLocationService.test.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationService.test.ts
@@ -124,7 +124,7 @@ describe('DefaultLocationServiceTest', () => {
       };
       orchestrator.process.mockResolvedValueOnce({
         ok: true,
-        state: new Map(),
+        state: {},
         completedEntity: {
           apiVersion: 'backstage.io/v1alpha1',
           kind: 'Component',
@@ -151,7 +151,7 @@ describe('DefaultLocationServiceTest', () => {
     it('should return exists false when the location does not exist beforehand', async () => {
       orchestrator.process.mockResolvedValueOnce({
         ok: true,
-        state: new Map(),
+        state: {},
         completedEntity: {
           apiVersion: 'backstage.io/v1alpha1',
           kind: 'Component',

--- a/plugins/catalog-backend/src/next/DefaultLocationService.test.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationService.test.ts
@@ -39,7 +39,7 @@ describe('DefaultLocationServiceTest', () => {
       store.listLocations.mockResolvedValueOnce([]);
       orchestrator.process.mockResolvedValueOnce({
         ok: true,
-        state: new Map(),
+        state: {},
         completedEntity: {
           apiVersion: 'backstage.io/v1alpha1',
           kind: 'Location',
@@ -65,7 +65,7 @@ describe('DefaultLocationServiceTest', () => {
 
       orchestrator.process.mockResolvedValueOnce({
         ok: true,
-        state: new Map(),
+        state: {},
         completedEntity: {
           apiVersion: 'backstage.io/v1alpha1',
           kind: 'Component',

--- a/plugins/catalog-backend/src/next/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/next/DefaultLocationService.ts
@@ -87,7 +87,6 @@ export class DefaultLocationService implements LocationService {
       { entity, locationKey: `${spec.type}:${spec.target}` },
     ];
     const entities: Entity[] = [];
-    const state = new Map(); // ignored
     while (unprocessedEntities.length) {
       const currentEntity = unprocessedEntities.pop();
       if (!currentEntity) {
@@ -95,7 +94,7 @@ export class DefaultLocationService implements LocationService {
       }
       const processed = await this.orchestrator.process({
         entity: currentEntity.entity,
-        state,
+        state: {}, // we process without the existing cache
       });
 
       if (processed.ok) {

--- a/plugins/catalog-backend/src/next/DefaultRefreshService.test.ts
+++ b/plugins/catalog-backend/src/next/DefaultRefreshService.test.ts
@@ -138,7 +138,7 @@ describe('Refresh integration', () => {
             relations: [],
             errors: [],
             deferredEntities,
-            state: new Map(),
+            state: {},
           };
         },
       },

--- a/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.test.ts
@@ -212,7 +212,6 @@ describe('Default Processing Database', () => {
               id,
               processedEntity,
               resultHash: '',
-              state: {},
               relations: [],
               deferredEntities: [],
             }),
@@ -231,7 +230,6 @@ describe('Default Processing Database', () => {
           id,
           processedEntity,
           resultHash: '',
-          state: {},
           relations: [],
           deferredEntities: [],
           locationKey: 'key',
@@ -284,14 +282,11 @@ describe('Default Processing Database', () => {
           last_discovery_at: '2021-04-01 13:37:00',
         });
 
-        const state = { hello: { t: 'something' } };
-
         await db.transaction(tx =>
           db.updateProcessedEntity(tx, {
             id,
             processedEntity,
             resultHash: '',
-            state,
             relations: [],
             deferredEntities: [],
             locationKey: 'key',
@@ -306,7 +301,6 @@ describe('Default Processing Database', () => {
         expect(entities[0].processed_entity).toEqual(
           JSON.stringify(processedEntity),
         );
-        expect(entities[0].cache).toEqual(JSON.stringify(state));
         expect(entities[0].errors).toEqual("['something broke']");
         expect(entities[0].location_key).toEqual('key');
       },
@@ -348,7 +342,6 @@ describe('Default Processing Database', () => {
             id,
             processedEntity,
             resultHash: '',
-            state: {},
             relations: relations,
             deferredEntities: [],
           }),
@@ -400,7 +393,6 @@ describe('Default Processing Database', () => {
             id,
             processedEntity,
             resultHash: '',
-            state: {},
             relations: [],
             deferredEntities,
           }),
@@ -413,6 +405,54 @@ describe('Default Processing Database', () => {
           .select();
 
         expect(refreshStateEntries).toHaveLength(1);
+      },
+      60_000,
+    );
+  });
+
+  describe('updateEntityCache', () => {
+    it.each(databases.eachSupportedId())(
+      'updates the entityCache, %p',
+      async databaseId => {
+        const { knex, db } = await createDatabase(databaseId);
+        const id = '123';
+        await insertRefreshStateRow(knex, {
+          entity_id: id,
+          entity_ref: 'location:default/fakelocation',
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+
+        const state = { hello: { t: 'something' } };
+
+        await db.transaction(tx =>
+          db.updateEntityCache(tx, {
+            id,
+            state,
+          }),
+        );
+
+        const entities = await knex<DbRefreshStateRow>(
+          'refresh_state',
+        ).select();
+        expect(entities.length).toBe(1);
+        expect(entities[0].cache).toEqual(JSON.stringify(state));
+
+        await db.transaction(tx =>
+          db.updateEntityCache(tx, {
+            id,
+            state: undefined,
+          }),
+        );
+
+        const entities2 = await knex<DbRefreshStateRow>(
+          'refresh_state',
+        ).select();
+        expect(entities2.length).toBe(1);
+        expect(entities2[0].cache).toEqual('{}');
       },
       60_000,
     );

--- a/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.test.ts
@@ -17,7 +17,6 @@
 import { getVoidLogger } from '@backstage/backend-common';
 import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
-import { JsonObject } from '@backstage/config';
 import { Knex } from 'knex';
 import * as uuid from 'uuid';
 import { Logger } from 'winston';
@@ -213,7 +212,7 @@ describe('Default Processing Database', () => {
               id,
               processedEntity,
               resultHash: '',
-              state: new Map<string, JsonObject>(),
+              state: {},
               relations: [],
               deferredEntities: [],
             }),
@@ -232,7 +231,7 @@ describe('Default Processing Database', () => {
           id,
           processedEntity,
           resultHash: '',
-          state: new Map<string, JsonObject>(),
+          state: {},
           relations: [],
           deferredEntities: [],
           locationKey: 'key',
@@ -285,8 +284,7 @@ describe('Default Processing Database', () => {
           last_discovery_at: '2021-04-01 13:37:00',
         });
 
-        const state = new Map<string, JsonObject>();
-        state.set('hello', { t: 'something' });
+        const state = { hello: { t: 'something' } };
 
         await db.transaction(tx =>
           db.updateProcessedEntity(tx, {
@@ -308,9 +306,7 @@ describe('Default Processing Database', () => {
         expect(entities[0].processed_entity).toEqual(
           JSON.stringify(processedEntity),
         );
-        expect(entities[0].cache).toEqual(
-          JSON.stringify(Object.fromEntries(state)),
-        );
+        expect(entities[0].cache).toEqual(JSON.stringify(state));
         expect(entities[0].errors).toEqual("['something broke']");
         expect(entities[0].location_key).toEqual('key');
       },
@@ -352,7 +348,7 @@ describe('Default Processing Database', () => {
             id,
             processedEntity,
             resultHash: '',
-            state: new Map<string, JsonObject>(),
+            state: {},
             relations: relations,
             deferredEntities: [],
           }),
@@ -404,7 +400,7 @@ describe('Default Processing Database', () => {
             id,
             processedEntity,
             resultHash: '',
-            state: new Map<string, JsonObject>(),
+            state: {},
             relations: [],
             deferredEntities,
           }),

--- a/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
@@ -40,6 +40,7 @@ import {
   UpdateProcessedEntityOptions,
   ListAncestorsOptions,
   ListAncestorsResult,
+  UpdateEntityCacheOptions,
 } from './types';
 
 // The number of items that are sent per batch to the database layer, when
@@ -69,7 +70,6 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       id,
       processedEntity,
       resultHash,
-      state,
       errors,
       relations,
       deferredEntities,
@@ -79,7 +79,6 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       .update({
         processed_entity: JSON.stringify(processedEntity),
         result_hash: resultHash,
-        cache: JSON.stringify(state),
         errors,
         location_key: locationKey,
       })
@@ -137,6 +136,18 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
         errors,
         result_hash: resultHash,
       })
+      .where('entity_id', id);
+  }
+
+  async updateEntityCache(
+    txOpaque: Transaction,
+    options: UpdateEntityCacheOptions,
+  ): Promise<void> {
+    const tx = txOpaque as Knex.Transaction;
+    const { id, state } = options;
+
+    await tx<DbRefreshStateRow>('refresh_state')
+      .update({ cache: JSON.stringify(state ?? {}) })
       .where('entity_id', id);
   }
 

--- a/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/next/database/DefaultProcessingDatabase.ts
@@ -15,7 +15,6 @@
  */
 
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
-import { JsonObject } from '@backstage/config';
 import { ConflictError, NotFoundError } from '@backstage/errors';
 import { Knex } from 'knex';
 import lodash from 'lodash';
@@ -80,7 +79,7 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       .update({
         processed_entity: JSON.stringify(processedEntity),
         result_hash: resultHash,
-        cache: JSON.stringify(Object.fromEntries(state || [])),
+        cache: JSON.stringify(state),
         errors,
         location_key: locationKey,
       })
@@ -508,9 +507,7 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
             resultHash: i.result_hash || '',
             nextUpdateAt: timestampToDateTime(i.next_update_at),
             lastDiscoveryAt: timestampToDateTime(i.last_discovery_at),
-            state: i.cache
-              ? JSON.parse(i.cache)
-              : new Map<string, JsonObject>(),
+            state: i.cache ? JSON.parse(i.cache) : undefined,
             errors: i.errors,
             locationKey: i.location_key,
           } as RefreshStateItem),

--- a/plugins/catalog-backend/src/next/database/types.ts
+++ b/plugins/catalog-backend/src/next/database/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
-import { JsonObject } from '@backstage/config';
+import { JsonValue } from '@backstage/config';
 import { DateTime } from 'luxon';
 import { Transaction } from '../../database/types';
 import { DeferredEntity } from '../processing/types';
@@ -36,7 +36,7 @@ export type UpdateProcessedEntityOptions = {
   id: string;
   processedEntity: Entity;
   resultHash: string;
-  state?: Map<string, JsonObject>;
+  state?: JsonValue;
   errors?: string;
   relations: EntityRelationSpec[];
   deferredEntities: DeferredEntity[];
@@ -57,7 +57,7 @@ export type RefreshStateItem = {
   resultHash: string;
   nextUpdateAt: DateTime;
   lastDiscoveryAt: DateTime; // remove?
-  state: Map<string, JsonObject>;
+  state?: JsonValue;
   errors?: string;
   locationKey?: string;
 };

--- a/plugins/catalog-backend/src/next/database/types.ts
+++ b/plugins/catalog-backend/src/next/database/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
-import { JsonValue } from '@backstage/config';
+import { JsonObject } from '@backstage/config';
 import { DateTime } from 'luxon';
 import { Transaction } from '../../database/types';
 import { DeferredEntity } from '../processing/types';
@@ -36,11 +36,15 @@ export type UpdateProcessedEntityOptions = {
   id: string;
   processedEntity: Entity;
   resultHash: string;
-  state?: JsonValue;
   errors?: string;
   relations: EntityRelationSpec[];
   deferredEntities: DeferredEntity[];
   locationKey?: string;
+};
+
+export type UpdateEntityCacheOptions = {
+  id: string;
+  state?: JsonObject;
 };
 
 export type UpdateProcessedEntityErrorsOptions = {
@@ -57,7 +61,7 @@ export type RefreshStateItem = {
   resultHash: string;
   nextUpdateAt: DateTime;
   lastDiscoveryAt: DateTime; // remove?
-  state?: JsonValue;
+  state?: JsonObject;
   errors?: string;
   locationKey?: string;
 };
@@ -116,6 +120,14 @@ export interface ProcessingDatabase {
   updateProcessedEntity(
     txOpaque: Transaction,
     options: UpdateProcessedEntityOptions,
+  ): Promise<void>;
+
+  /**
+   * Updates the cache associated with an entity.
+   */
+  updateEntityCache(
+    txOpaque: Transaction,
+    options: UpdateEntityCacheOptions,
   ): Promise<void>;
 
   /**

--- a/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -24,7 +24,7 @@ import {
   stringifyLocationReference,
 } from '@backstage/catalog-model';
 import { ConflictError, InputError, NotAllowedError } from '@backstage/errors';
-import { JsonObject, JsonValue } from '@backstage/config';
+import { JsonValue } from '@backstage/config';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import path from 'path';
 import { Logger } from 'winston';
@@ -33,7 +33,6 @@ import {
   CatalogProcessorParser,
 } from '../../ingestion/processors';
 import * as results from '../../ingestion/processors/results';
-import { CatalogProcessorCache } from '../../ingestion/processors/types';
 import {
   CatalogProcessingOrchestrator,
   EntityProcessingRequest,
@@ -47,77 +46,18 @@ import {
   toAbsoluteUrl,
   validateEntity,
   validateEntityEnvelope,
+  isObject,
 } from './util';
 import { CatalogRulesEnforcer } from '../../ingestion/CatalogRules';
+import { ProcessorCacheManager } from './ProcessorCacheManager';
 
 type Context = {
   entityRef: string;
   location: LocationSpec;
   originLocation: LocationSpec;
   collector: ProcessorOutputCollector;
-  cache: ProcessorCache;
+  cache: ProcessorCacheManager;
 };
-
-function isObject(value: JsonValue | undefined): value is JsonObject {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-class DefaultCatalogProcessorCache implements CatalogProcessorCache {
-  private newState?: JsonObject;
-  constructor(private readonly existingState: JsonObject) {}
-
-  async get<ItemType extends JsonValue>(
-    key: string,
-  ): Promise<ItemType | undefined> {
-    return this.existingState[key] as ItemType | undefined;
-  }
-
-  async set<ItemType extends JsonValue>(
-    key: string,
-    value: ItemType,
-  ): Promise<void> {
-    if (!this.newState) {
-      this.newState = {};
-    }
-
-    this.newState[key] = value;
-  }
-
-  collect(): JsonObject | undefined {
-    return this.newState;
-  }
-}
-
-class ProcessorCache {
-  private caches = new Map<string, DefaultCatalogProcessorCache>();
-
-  constructor(private readonly existingState: JsonObject) {}
-  forProcessor(processor: CatalogProcessor): CatalogProcessorCache {
-    // constructor name will be deprecated in the future when we make `getProcessorName` required in the implementation
-    const name = processor.getProcessorName?.() ?? processor.constructor.name;
-    const cache = this.caches.get(name);
-    if (cache) {
-      return cache;
-    }
-
-    const existing = this.existingState[name];
-
-    const newCache = new DefaultCatalogProcessorCache(
-      isObject(existing) ? existing : {},
-    );
-    this.caches.set(name, newCache);
-    return newCache;
-  }
-
-  collect(): JsonObject {
-    const result: JsonObject = {};
-    for (const [key, value] of this.caches.entries()) {
-      result[key] = value.collect();
-    }
-
-    return result;
-  }
-}
 
 export class DefaultCatalogProcessingOrchestrator
   implements CatalogProcessingOrchestrator
@@ -149,7 +89,7 @@ export class DefaultCatalogProcessingOrchestrator
     );
 
     // Cache that is scoped to the entity and processor
-    const cache = new ProcessorCache(
+    const cache = new ProcessorCacheManager(
       isObject(state) && isObject(state.cache) ? state.cache : {},
     );
 

--- a/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -318,7 +318,7 @@ export class DefaultCatalogProcessingOrchestrator
               false,
               context.collector.onEmit,
               this.options.parser,
-              context.cache.forProcessor(processor),
+              context.cache.forProcessor(processor, target),
             );
             if (read) {
               didRead = true;

--- a/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -24,6 +24,7 @@ import {
   stringifyLocationReference,
 } from '@backstage/catalog-model';
 import { ConflictError, InputError, NotAllowedError } from '@backstage/errors';
+import { JsonObject, JsonValue } from '@backstage/config';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import path from 'path';
 import { Logger } from 'winston';
@@ -32,6 +33,7 @@ import {
   CatalogProcessorParser,
 } from '../../ingestion/processors';
 import * as results from '../../ingestion/processors/results';
+import { CatalogProcessorCache } from '../../ingestion/processors/types';
 import {
   CatalogProcessingOrchestrator,
   EntityProcessingRequest,
@@ -53,7 +55,69 @@ type Context = {
   location: LocationSpec;
   originLocation: LocationSpec;
   collector: ProcessorOutputCollector;
+  cache: ProcessorCache;
 };
+
+function isObject(value: JsonValue | undefined): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+class DefaultCatalogProcessorCache implements CatalogProcessorCache {
+  private newState?: JsonObject;
+  constructor(private readonly existingState: JsonObject) {}
+
+  async get<ItemType extends JsonValue>(
+    key: string,
+  ): Promise<ItemType | undefined> {
+    return this.existingState[key] as ItemType | undefined;
+  }
+
+  async set<ItemType extends JsonValue>(
+    key: string,
+    value: ItemType,
+  ): Promise<void> {
+    if (!this.newState) {
+      this.newState = {};
+    }
+
+    this.newState[key] = value;
+  }
+
+  collect(): JsonObject | undefined {
+    return this.newState;
+  }
+}
+
+class ProcessorCache {
+  private caches = new Map<string, DefaultCatalogProcessorCache>();
+
+  constructor(private readonly existingState: JsonObject) {}
+  forProcessor(processor: CatalogProcessor): CatalogProcessorCache {
+    // constructor name will be deprecated in the future when we make `getProcessorName` required in the implementation
+    const name = processor.getProcessorName?.() ?? processor.constructor.name;
+    const cache = this.caches.get(name);
+    if (cache) {
+      return cache;
+    }
+
+    const existing = this.existingState[name];
+
+    const newCache = new DefaultCatalogProcessorCache(
+      isObject(existing) ? existing : {},
+    );
+    this.caches.set(name, newCache);
+    return newCache;
+  }
+
+  collect(): JsonObject {
+    const result: JsonObject = {};
+    for (const [key, value] of this.caches.entries()) {
+      result[key] = value.collect();
+    }
+
+    return result;
+  }
+}
 
 export class DefaultCatalogProcessingOrchestrator
   implements CatalogProcessingOrchestrator
@@ -72,15 +136,21 @@ export class DefaultCatalogProcessingOrchestrator
   async process(
     request: EntityProcessingRequest,
   ): Promise<EntityProcessingResult> {
-    return this.processSingleEntity(request.entity);
+    return this.processSingleEntity(request.entity, request.state);
   }
 
   private async processSingleEntity(
     unprocessedEntity: Entity,
+    state: JsonValue | undefined,
   ): Promise<EntityProcessingResult> {
     const collector = new ProcessorOutputCollector(
       this.options.logger,
       unprocessedEntity,
+    );
+
+    // Cache that is scoped to the entity and processor
+    const cache = new ProcessorCache(
+      isObject(state) && isObject(state.cache) ? state.cache : {},
     );
 
     try {
@@ -108,6 +178,7 @@ export class DefaultCatalogProcessingOrchestrator
         originLocation: parseLocationReference(
           getEntityOriginLocationRef(entity),
         ),
+        cache,
         collector,
       };
 
@@ -145,7 +216,7 @@ export class DefaultCatalogProcessingOrchestrator
       return {
         ...collectorResults,
         completedEntity: entity,
-        state: new Map(),
+        state: { cache: cache.collect() },
         ok: true,
       };
     } catch (error) {
@@ -173,6 +244,7 @@ export class DefaultCatalogProcessingOrchestrator
             context.location,
             context.collector.onEmit,
             context.originLocation,
+            context.cache.forProcessor(processor),
           );
         } catch (e) {
           throw new InputError(
@@ -306,6 +378,7 @@ export class DefaultCatalogProcessingOrchestrator
               false,
               context.collector.onEmit,
               this.options.parser,
+              context.cache.forProcessor(processor),
             );
             if (read) {
               didRead = true;
@@ -343,6 +416,7 @@ export class DefaultCatalogProcessingOrchestrator
             result,
             context.location,
             context.collector.onEmit,
+            context.cache.forProcessor(processor),
           );
         } catch (e) {
           throw new InputError(

--- a/plugins/catalog-backend/src/next/processing/ProcessorCacheManager.test.ts
+++ b/plugins/catalog-backend/src/next/processing/ProcessorCacheManager.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CatalogProcessor } from '../../ingestion/processors';
+import { ProcessorCacheManager } from './ProcessorCacheManager';
+
+class MyProcessor implements CatalogProcessor {
+  getProcessorName = () => 'my-processor';
+}
+
+class OtherProcessor implements CatalogProcessor {}
+
+describe('ProcessorCacheManager', () => {
+  const myProcessor = new MyProcessor();
+  const otherProcessor = new OtherProcessor();
+
+  it('should forward existing state and collect new state', async () => {
+    const cache = new ProcessorCacheManager({
+      'my-processor': { 'my-key': 'my-value' },
+    });
+
+    // Should be empty to begin with
+    expect(cache.collect()).toEqual({});
+
+    // instance should be cached
+    const processorCache = cache.forProcessor(myProcessor);
+    expect(processorCache).toBe(cache.forProcessor(myProcessor));
+
+    // Initial values should be visible, writes should not
+    await expect(processorCache.get<string>('my-key')).resolves.toBe(
+      'my-value',
+    );
+    processorCache.set('my-key', 'my-new-value');
+    await expect(processorCache.get<string>('my-key')).resolves.toBe(
+      'my-value',
+    );
+
+    // There should be isolation between processors
+    await expect(
+      cache.forProcessor(otherProcessor).get<string>('my-key'),
+    ).resolves.toBeUndefined();
+
+    // Collecting the state and passing it to a new manager should make the new values visible
+    const newCache = new ProcessorCacheManager(cache.collect());
+    await expect(
+      newCache.forProcessor(myProcessor).get<string>('my-key'),
+    ).resolves.toBe('my-new-value');
+  });
+});

--- a/plugins/catalog-backend/src/next/processing/ProcessorCacheManager.test.ts
+++ b/plugins/catalog-backend/src/next/processing/ProcessorCacheManager.test.ts
@@ -43,10 +43,25 @@ describe('ProcessorCacheManager', () => {
     await expect(processorCache.get<string>('my-key')).resolves.toBe(
       'my-value',
     );
-    processorCache.set('my-key', 'my-new-value');
+
+    // If set hasn't been called yet we should get the existing data
+    expect(cache.collect()).toEqual({
+      'my-processor': { 'my-key': 'my-value' },
+    });
+
+    processorCache.set('my-new-key', 'my-new-value');
+    // Once set has been called the old values should disappear
+    expect(cache.collect()).toEqual({
+      'my-processor': { 'my-new-key': 'my-new-value' },
+    });
+
+    // Getting the cache should return the initial state value
     await expect(processorCache.get<string>('my-key')).resolves.toBe(
       'my-value',
     );
+    await expect(
+      processorCache.get<string>('my-new-key'),
+    ).resolves.toBeUndefined();
 
     // There should be isolation between processors
     await expect(
@@ -56,7 +71,7 @@ describe('ProcessorCacheManager', () => {
     // Collecting the state and passing it to a new manager should make the new values visible
     const newCache = new ProcessorCacheManager(cache.collect());
     await expect(
-      newCache.forProcessor(myProcessor).get<string>('my-key'),
+      newCache.forProcessor(myProcessor).get<string>('my-new-key'),
     ).resolves.toBe('my-new-value');
   });
 });

--- a/plugins/catalog-backend/src/next/processing/ProcessorCacheManager.ts
+++ b/plugins/catalog-backend/src/next/processing/ProcessorCacheManager.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject, JsonValue } from '@backstage/config';
+import { CatalogProcessor } from '../../ingestion/processors';
+import { CatalogProcessorCache } from '../../ingestion/processors/types';
+import { isObject } from './util';
+
+class SingleProcessorCache implements CatalogProcessorCache {
+  private newState?: JsonObject;
+  constructor(private readonly existingState: JsonObject) {}
+
+  async get<ItemType extends JsonValue>(
+    key: string,
+  ): Promise<ItemType | undefined> {
+    return this.existingState[key] as ItemType | undefined;
+  }
+
+  async set<ItemType extends JsonValue>(
+    key: string,
+    value: ItemType,
+  ): Promise<void> {
+    if (!this.newState) {
+      this.newState = {};
+    }
+
+    this.newState[key] = value;
+  }
+
+  collect(): JsonObject | undefined {
+    return this.newState;
+  }
+}
+
+export class ProcessorCacheManager {
+  private caches = new Map<string, SingleProcessorCache>();
+
+  constructor(private readonly existingState: JsonObject) {}
+
+  forProcessor(processor: CatalogProcessor): CatalogProcessorCache {
+    // constructor name will be deprecated in the future when we make `getProcessorName` required in the implementation
+    const name = processor.getProcessorName?.() ?? processor.constructor.name;
+    const cache = this.caches.get(name);
+    if (cache) {
+      return cache;
+    }
+
+    const existing = this.existingState[name];
+
+    const newCache = new SingleProcessorCache(
+      isObject(existing) ? existing : {},
+    );
+    this.caches.set(name, newCache);
+    return newCache;
+  }
+
+  collect(): JsonObject {
+    const result: JsonObject = {};
+    for (const [key, value] of this.caches.entries()) {
+      result[key] = value.collect();
+    }
+
+    return result;
+  }
+}

--- a/plugins/catalog-backend/src/next/processing/ProcessorCacheManager.ts
+++ b/plugins/catalog-backend/src/next/processing/ProcessorCacheManager.ts
@@ -21,12 +21,13 @@ import { isObject } from './util';
 
 class SingleProcessorCache implements CatalogProcessorCache {
   private newState?: JsonObject;
-  constructor(private readonly existingState: JsonObject) {}
+
+  constructor(private readonly existingState?: JsonObject) {}
 
   async get<ItemType extends JsonValue>(
     key: string,
   ): Promise<ItemType | undefined> {
-    return this.existingState[key] as ItemType | undefined;
+    return this.existingState?.[key] as ItemType | undefined;
   }
 
   async set<ItemType extends JsonValue>(
@@ -41,7 +42,7 @@ class SingleProcessorCache implements CatalogProcessorCache {
   }
 
   collect(): JsonObject | undefined {
-    return this.newState;
+    return this.newState ?? this.existingState;
   }
 }
 
@@ -61,7 +62,7 @@ export class ProcessorCacheManager {
     const existing = this.existingState[name];
 
     const newCache = new SingleProcessorCache(
-      isObject(existing) ? existing : {},
+      isObject(existing) ? existing : undefined,
     );
     this.caches.set(name, newCache);
     return newCache;

--- a/plugins/catalog-backend/src/next/processing/types.ts
+++ b/plugins/catalog-backend/src/next/processing/types.ts
@@ -15,17 +15,17 @@
  */
 
 import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
-import { JsonValue } from '@backstage/config';
+import { JsonObject } from '@backstage/config';
 
 export type EntityProcessingRequest = {
   entity: Entity;
-  state?: JsonValue; // Versions for multiple deployments etc
+  state?: JsonObject; // Versions for multiple deployments etc
 };
 
 export type EntityProcessingResult =
   | {
       ok: true;
-      state: JsonValue;
+      state: JsonObject;
       completedEntity: Entity;
       deferredEntities: DeferredEntity[];
       relations: EntityRelationSpec[];

--- a/plugins/catalog-backend/src/next/processing/types.ts
+++ b/plugins/catalog-backend/src/next/processing/types.ts
@@ -15,17 +15,17 @@
  */
 
 import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
-import { JsonObject } from '@backstage/config';
+import { JsonValue } from '@backstage/config';
 
 export type EntityProcessingRequest = {
   entity: Entity;
-  state: Map<string, JsonObject>; // Versions for multiple deployments etc
+  state?: JsonValue; // Versions for multiple deployments etc
 };
 
 export type EntityProcessingResult =
   | {
       ok: true;
-      state: Map<string, JsonObject>;
+      state: JsonValue;
       completedEntity: Entity;
       deferredEntities: DeferredEntity[];
       relations: EntityRelationSpec[];

--- a/plugins/catalog-backend/src/next/processing/util.ts
+++ b/plugins/catalog-backend/src/next/processing/util.ts
@@ -24,6 +24,7 @@ import {
   ORIGIN_LOCATION_ANNOTATION,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
+import { JsonObject, JsonValue } from '@backstage/config';
 import { InputError } from '@backstage/errors';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import path from 'path';
@@ -74,6 +75,10 @@ export function toAbsoluteUrl(
   } catch (e) {
     return target;
   }
+}
+
+export function isObject(value: JsonValue | undefined): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 export const validateEntity = entitySchemaValidator();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Mob'd with @benjdlambert, @jhaals and @freben 

This introduces a new `CatalogProcessorCache` that is available to catalog processors. It allows arbitrary values to be saved that will then be visible for the next run. The cache is scoped to each individual processor and entity, but is shared across processing steps in a single processor.

We also implemented caching for the `UrlReaderProcessor`, meaning that any `UrlReader` that implements the new `readUrl` with an `etag` now automatically gets caching in the catalog.

Fixes #3749

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
