### PR TITLE
Add AsyncBoundary (handling useAsync with error/progress)

### DIFF
--- a/.changeset/angry-stingrays-add.md
+++ b/.changeset/angry-stingrays-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added createAsyncBoundary() async boundary helper

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -14,6 +14,7 @@ import { CardHeaderProps } from '@material-ui/core';
 import { Column } from '@material-table/core';
 import { ComponentClass } from 'react';
 import { ComponentProps } from 'react';
+import { ComponentType } from 'react';
 import { Context } from 'react';
 import { default as CSS_2 } from 'csstype';
 import { CSSProperties } from 'react';
@@ -62,6 +63,42 @@ enum Alignment {
   UP_LEFT = 'UL',
   // (undocumented)
   UP_RIGHT = 'UR',
+}
+
+// Warning: (ae-missing-release-tag) "AsyncBoundaryProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface AsyncBoundaryProps<T> {
+  // (undocumented)
+  asyncValue: AsyncState<T>;
+  // (undocumented)
+  error?: ComponentType<{
+    error: Error;
+  }>;
+  // (undocumented)
+  progress?: React_2.ReactNode;
+}
+
+// Warning: (ae-missing-release-tag) "AsyncBoundaryResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface AsyncBoundaryResult<T> {
+  // (undocumented)
+  AsyncBoundary: ComponentType<PropsWithChildren<AsyncBoundaryProps<T>>>;
+  // (undocumented)
+  useAsyncValue: () => T;
+}
+
+// Warning: (ae-missing-release-tag) "AsyncState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface AsyncState<T> {
+  // (undocumented)
+  error: Error | undefined;
+  // (undocumented)
+  loading: boolean;
+  // (undocumented)
+  value: T | undefined;
 }
 
 // Warning: (ae-forgotten-export) The symbol "AvatarProps" needs to be exported by the entry point index.d.ts
@@ -140,6 +177,11 @@ export namespace CopyTextButton {
       tooltipText: PropTypes.Requireable<string>;
     };
 }
+
+// Warning: (ae-missing-release-tag) "createAsyncBoundary" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function createAsyncBoundary<T>(): AsyncBoundaryResult<T>;
 
 // Warning: (ae-forgotten-export) The symbol "CreateButtonProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "CreateButton" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core-components/src/providers/AsyncBoundary/createAsyncBoundary.tsx
+++ b/packages/core-components/src/providers/AsyncBoundary/createAsyncBoundary.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  ComponentType,
+  createContext,
+  PropsWithChildren,
+  useContext,
+} from 'react';
+import { Alert } from '@material-ui/lab';
+import { useApp } from '@backstage/core-plugin-api';
+
+export interface AsyncState<T> {
+  value: T | undefined;
+  loading: boolean;
+  error: Error | undefined;
+}
+
+export interface AsyncBoundaryProps<T> {
+  asyncValue: AsyncState<T>;
+  progress?: React.ReactNode;
+  error?: ComponentType<{ error: Error }>;
+}
+
+export interface AsyncBoundaryResult<T> {
+  AsyncBoundary: ComponentType<PropsWithChildren<AsyncBoundaryProps<T>>>;
+  useAsyncValue: () => T;
+}
+
+const DefaultErrorComponent: ComponentType<{ error: Error }> = ({ error }) => (
+  <Alert severity="error">{error.message}</Alert>
+);
+
+/**
+ * Creates an async boundary provider and hook given a certain type
+ */
+export function createAsyncBoundary<T>(): AsyncBoundaryResult<T> {
+  const context = createContext<T>(undefined as any);
+
+  function AsyncBoundary(props: PropsWithChildren<AsyncBoundaryProps<T>>) {
+    const { Progress } = useApp().getComponents();
+
+    const {
+      children,
+      asyncValue,
+      error: ErrorComponent = DefaultErrorComponent,
+      progress = <Progress />,
+    } = props;
+
+    if (asyncValue.loading) {
+      return <>{progress}</>;
+    } else if (asyncValue.error) {
+      return <ErrorComponent error={asyncValue.error} />;
+    }
+
+    return <context.Provider value={asyncValue.value!} children={children} />;
+  }
+
+  function useAsyncValue(): T {
+    return useContext(context);
+  }
+
+  return { AsyncBoundary, useAsyncValue };
+}

--- a/packages/core-components/src/providers/AsyncBoundary/index.ts
+++ b/packages/core-components/src/providers/AsyncBoundary/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-/**
- * Core components used by Backstage plugins and apps
- *
- * @packageDocumentation
- */
-
-export * from './components';
-export * from './hooks';
-export * from './icons';
-export * from './layout';
-export * from './providers';
+export { createAsyncBoundary } from './createAsyncBoundary';
+export type {
+  AsyncState,
+  AsyncBoundaryProps,
+  AsyncBoundaryResult,
+} from './createAsyncBoundary';

--- a/packages/core-components/src/providers/index.ts
+++ b/packages/core-components/src/providers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,4 @@
  * limitations under the License.
  */
 
-/**
- * Core components used by Backstage plugins and apps
- *
- * @packageDocumentation
- */
-
-export * from './components';
-export * from './hooks';
-export * from './icons';
-export * from './layout';
-export * from './providers';
+export * from './AsyncBoundary';


### PR DESCRIPTION
Signed-off-by: Gustaf Räntilä <g.rantila@gmail.com>

# Async fetching wrapper around error/progress/value state

Following the typesafe provider+hook creation scheme in #7265, this PR provides a way to smoothly decouple async work (e.g. fetching) from displaying error/progress and eventually/hopefully the result view. In the sub components one can then `useSomething` and get the value synchronously.

Where it makes sense, potentially where the actual _work_ hooks are defined, e.g. the actual fetching:

```ts
import { createAsyncBoundary } from '@backstage/core-components';

export const {
  AsyncBoundary: UsersBoundary,
  useAsyncValue: useUsers,
} = createAsyncBoundary<UserType[]>();
```

Then in a component that wants to display users:

```tsx
const asyncUsers = useAsync( fetchUsers ); // This is implemented somewhere

<UsersBoundary asyncValue={ asyncUsers }>
  <UserList />
</UsersBoundary>
```

where `UserList` can get the users using `useUsers` synchronously

```tsx
function UserList() {
  const users = useUsers();

  return <ul>{ users.map( user => { ... } ) }</ul>
}
```

There's no magic here, just abstracting the if/then `<Progress>` / `<Alert>` using the app-specific `Progress` (perhaps we should have one for `Alert` too?). Not always is it practical to write that manually, because you'll then have to pass the value as props deep down the component stack (maybe cross `Routes`), and so sometimes Providerifying such async logic with the progress/error boundary is helpful.

The provider has the optional props for specifying custom error/progress components when necessary, but will fallback to MUI `Alert` and the app-defined `Progress`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
