### PR TITLE
Export the `DomainCard` to be able to customize the explorer page

### DIFF
--- a/.changeset/brown-brooms-destroy.md
+++ b/.changeset/brown-brooms-destroy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+Export the `DomainCard` to be able to customize the explorer page.

--- a/plugins/explore/api-report.md
+++ b/plugins/explore/api-report.md
@@ -7,6 +7,7 @@
 
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { default as default_2 } from 'react';
+import { DomainEntity } from '@backstage/catalog-model';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { TabProps } from '@material-ui/core';
@@ -22,6 +23,12 @@ export const catalogEntityRouteRef: ExternalRouteRef<
   },
   false
 >;
+
+// Warning: (ae-forgotten-export) The symbol "DomainCardProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "DomainCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const DomainCard: ({ entity }: DomainCardProps) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "DomainExplorerContent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/explore/src/components/index.ts
+++ b/plugins/explore/src/components/index.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
+export { DomainCard } from './DomainCard';
 export { ExploreLayout } from './ExploreLayout';

--- a/plugins/explore/src/index.ts
+++ b/plugins/explore/src/index.ts
@@ -20,7 +20,7 @@
  * @packageDocumentation
  */
 
-export { ExploreLayout } from './components';
+export * from './components';
 export * from './extensions';
 export { explorePlugin, explorePlugin as plugin } from './plugin';
 export * from './routes';


### PR DESCRIPTION
We want to customize the `DomainExplorerContent` and would be happy to be able to reuse the `DomainCard` from the original explore plugin.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
