### PR TITLE
Loosen catalog constraints on entity tag string validity.

### DIFF
--- a/.changeset/spicy-spies-roll.md
+++ b/.changeset/spicy-spies-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Loosen constraints on what's a valid catalog entity tag name (include + and #)

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -50,6 +50,7 @@ export class CommonValidatorFunctions {
     isValidSuffix: (value: string) => boolean,
   ): boolean;
   static isValidString(value: unknown): boolean;
+  static isValidTag(value: unknown): boolean;
   static isValidUrl(value: unknown): boolean;
 }
 

--- a/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.ts
+++ b/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.ts
@@ -78,6 +78,10 @@ export class FieldFormatEntityPolicy implements EntityPolicy {
             expectation =
               'a string that is sequences of [a-z0-9] separated by [-], at most 63 characters in total';
             break;
+          case 'isValidTag':
+            expectation =
+              'a string that is sequences of [a-z0-9+#] separated by [-], at most 63 characters in total';
+            break;
           case 'isValidAnnotationValue':
             expectation = 'a string';
             break;

--- a/packages/catalog-model/src/validation/CommonValidatorFunctions.test.ts
+++ b/packages/catalog-model/src/validation/CommonValidatorFunctions.test.ts
@@ -163,6 +163,31 @@ describe('CommonValidatorFunctions', () => {
   });
 
   it.each([
+    // These are identical to isValidDnsLabel
+    [null, false],
+    [7, false],
+    ['', false],
+    ['a', true],
+    ['a-b', true],
+    ['-a-b', false],
+    ['a-b-', false],
+    ['a--b', false],
+    ['a_b', false],
+    [`${'a'.repeat(63)}`, true],
+    [`${'a'.repeat(64)}`, false],
+    // Tags can have other characters though
+    ['a+b', true],
+    ['+a+b', true],
+    ['a+b+', true],
+    ['a++b', true],
+    ['c++', true],
+    ['c#', true],
+    ['#c++', true],
+  ])(`isValidTag %p ? %p`, (value, result) => {
+    expect(CommonValidatorFunctions.isValidTag(value)).toBe(result);
+  });
+
+  it.each([
     [null, false],
     [7, false],
     ['', false],

--- a/packages/catalog-model/src/validation/CommonValidatorFunctions.ts
+++ b/packages/catalog-model/src/validation/CommonValidatorFunctions.ts
@@ -96,6 +96,20 @@ export class CommonValidatorFunctions {
   }
 
   /**
+   * Checks that the value is a valid tag.
+   *
+   * @param value - The value to check
+   */
+  static isValidTag(value: unknown): boolean {
+    return (
+      typeof value === 'string' &&
+      value.length >= 1 &&
+      value.length <= 63 &&
+      /^[a-z0-9+#]+(\-[a-z0-9+#]+)*$/.test(value)
+    );
+  }
+
+  /**
    * Checks that the value is a valid URL.
    *
    * @param value - The value to check

--- a/packages/catalog-model/src/validation/makeValidator.ts
+++ b/packages/catalog-model/src/validation/makeValidator.ts
@@ -27,7 +27,7 @@ const defaultValidators: Validators = {
   isValidLabelValue: KubernetesValidatorFunctions.isValidLabelValue,
   isValidAnnotationKey: KubernetesValidatorFunctions.isValidAnnotationKey,
   isValidAnnotationValue: KubernetesValidatorFunctions.isValidAnnotationValue,
-  isValidTag: CommonValidatorFunctions.isValidDnsLabel,
+  isValidTag: CommonValidatorFunctions.isValidTag,
 };
 
 /** @public */


### PR DESCRIPTION
Adding `+` and `#` as valid chars, to e.g. allow "c++" and "c#".

Signed-off-by: Gustaf Räntilä <g.rantila@gmail.com>

Given the very example of programming languages here: https://backstage.io/docs/features/software-catalog/descriptor-format#tags-optional we should probably allow more characters in entity tags, such as the ones in the PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
