### PR TITLE
Rely on the default `Link` behavior for opening external links in a new window in the `SupportButton`

### DIFF
--- a/.changeset/plenty-feet-pay.md
+++ b/.changeset/plenty-feet-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Stop forcing `target="_blank"` in the `SupportButton` but instead use the default logic of the `Link` component, that opens external targets in a new window and relative targets in the same window.

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -54,9 +54,7 @@ const SupportIcon = ({ icon }: { icon: string | undefined }) => {
 };
 
 const SupportLink = ({ link }: { link: SupportItemLink }) => (
-  <Link to={link.url} target="_blank" rel="noreferrer noopener">
-    {link.title ?? link.url}
-  </Link>
+  <Link to={link.url}>{link.title ?? link.url}</Link>
 );
 
 const SupportListItem = ({ item }: { item: SupportItem }) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
