### PR TITLE
auth-backend: explicit pickBy type

### DIFF
--- a/plugins/auth-backend/src/lib/oauth/helpers.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.ts
@@ -36,7 +36,7 @@ export const readState = (stateString: string): OAuthState => {
 
 export const encodeState = (state: OAuthState): string => {
   const stateString = new URLSearchParams(
-    pickBy(state, value => value !== undefined),
+    pickBy<string>(state, value => value !== undefined),
   ).toString();
 
   return Buffer.from(stateString, 'utf-8').toString('hex');


### PR DESCRIPTION
Explicit `<string>` type argument for `pickBy`, in case it fixes #7286. No changeset or anything since there's no actual change in master