### PR TITLE
Fix filtering with globs in bitbucket reader

### DIFF
--- a/.changeset/mighty-students-itch.md
+++ b/.changeset/mighty-students-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fix an issue where filtering in search doesn't work correctly for Bitbucket.

--- a/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.test.ts
@@ -360,6 +360,20 @@ describe('BitbucketUrlReader', () => {
       );
     });
 
+    it('works in nested folders', async () => {
+      const result = await bitbucketProcessor.search(
+        'https://bitbucket.org/backstage/mock/src/master/docs/index.*',
+      );
+      expect(result.etag).toBe('12ab34cd56ef');
+      expect(result.files.length).toBe(1);
+      expect(result.files[0].url).toBe(
+        'https://bitbucket.org/backstage/mock/src/master/docs/index.md',
+      );
+      await expect(result.files[0].content()).resolves.toEqual(
+        Buffer.from('# Test\n'),
+      );
+    });
+
     it('throws NotModifiedError when same etag', async () => {
       await expect(
         bitbucketProcessor.search(
@@ -411,6 +425,20 @@ describe('BitbucketUrlReader', () => {
     it('works for the naive case', async () => {
       const result = await hostedBitbucketProcessor.search(
         'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/**/index.*?at=master',
+      );
+      expect(result.etag).toBe('12ab34cd56ef');
+      expect(result.files.length).toBe(1);
+      expect(result.files[0].url).toBe(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs/index.md?at=master',
+      );
+      await expect(result.files[0].content()).resolves.toEqual(
+        Buffer.from('# Test\n'),
+      );
+    });
+
+    it('works in nested folders', async () => {
+      const result = await hostedBitbucketProcessor.search(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs/index.*?at=master',
       );
       expect(result.etag).toBe('12ab34cd56ef');
       expect(result.files.length).toBe(1);

--- a/packages/backend-common/src/reading/BitbucketUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { NotFoundError, NotModifiedError } from '@backstage/errors';
 import {
   BitbucketIntegration,
   getBitbucketDefaultBranch,
@@ -26,18 +27,16 @@ import fetch from 'cross-fetch';
 import parseGitUrl from 'git-url-parse';
 import { Minimatch } from 'minimatch';
 import { Readable } from 'stream';
-import { NotFoundError, NotModifiedError } from '@backstage/errors';
-import { stripFirstDirectoryFromPath } from './tree/util';
 import {
-  ReadTreeResponseFactory,
   ReaderFactory,
   ReadTreeOptions,
   ReadTreeResponse,
+  ReadTreeResponseFactory,
+  ReadUrlOptions,
+  ReadUrlResponse,
   SearchOptions,
   SearchResponse,
   UrlReader,
-  ReadUrlResponse,
-  ReadUrlOptions,
 } from './types';
 
 /**
@@ -154,7 +153,7 @@ export class BitbucketUrlReader implements UrlReader {
 
     const tree = await this.readTree(treeUrl, {
       etag: options?.etag,
-      filter: path => matcher.match(stripFirstDirectoryFromPath(path)),
+      filter: path => matcher.match(path),
     });
     const files = await tree.files();
 


### PR DESCRIPTION
@freben / @Rugvip Right now it strips the first directory from the path, so that explicit globs like `*` don't work.
For example, if I have a file `docs/index.md` and glob for `*/index.md` or `docs/index.*` it's matched against `index.md` instead of  `docs/index.md` which doesn't match. I think the directory was stripped because the archive file used for read tree might contain a top level folder. But that is already handled in the archive reader.
The current test just checks for `**` which still works when the first directory is missing. I think this is similar to #7134 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
