### PR TITLE
FIX: Stop sed escaping numbers 2 and 7 in Docker

### DIFF
--- a/contrib/docker/frontend-with-nginx/docker/inject-config.sh
+++ b/contrib/docker/frontend-with-nginx/docker/inject-config.sh
@@ -23,7 +23,7 @@ function inject_config() {
 
   # escape ' and " twice, for both sed and json
   local config_escaped_1
-  config_escaped_1="$(echo "$config" | jq -cM . | sed -e 's/[\\"\x27]/\\&/g')" # \x27 = '
+  config_escaped_1="$(echo "$config" | jq -cM . | sed -e 's/[\\"'\'']/\\&/g')"
   # escape / and & for sed
   local config_escaped_2
   config_escaped_2="$(echo "$config_escaped_1" | sed -e 's/[\/&]/\\&/g')"


### PR DESCRIPTION
## Fix sed escaping the numbers 2 and 7 in APP_CONFIG_* overrides when using frontend-with-nginx example

An interesting edge case has come up whilst using BackStage.

When using the example `frontend-with-nginx` work to run a separate frontend, whilst then providing an override for the
`googleAnalyticsTrackingId` in yaml config via `APP_CONFIG_app_googleAnalyticsTrackingId`. I received an `"Octal escape
sequences are not allowed in strict mode"` error in the browser dev console.

After looking into it it appears that the sed used escapes the numbers `2` and `7` if they are present in an `APP_CONFIG_*` `ENV` override value. I happened to have both a `2` and a `7` in my GA ids, hence the edge case part! 🙄 

### Before Fix
> No real `G-*` ids have been used in the below examples
> Before Fix: Running `40-inject-config.sh` script on `nginx:mainline` Docker container with a few echos added
```
/docker-entrypoint.d # ./40-inject-config.sh
Runtime app config: {
  "app": {
    "title": "ben",
    "googleAnalyticsTrackingId": "G-2HHHHH7FGH"
  }
}
{\\"app\\":{\\"title\\":\\"ben\\",\\"googleAnalyticsTrackingId\\":\\"G-\\2HHHHH\\7FGH\\"}}

```

### After Fix
> After Fix: Running `40-inject-config.sh` script on `nginx:mainline` Docker container with a few echos added
```
/docker-entrypoint.d # ./40-inject-config.sh
Runtime app config: {
  "app": {
    "title": "ben",
    "googleAnalyticsTrackingId": "G-2HHHHH7FGH"
  }
}
{\\"app\\":{\\"title\\":\\"ben\\",\\"googleAnalyticsTrackingId\\":\\"G-2HHHHH7FGH\\"}}

```
> With single and double quotes
```
/docker-entrypoint.d # ./40-inject-config.sh
Runtime app config: {
  "app": {
    "title": "ben",
    "googleAnalyticsTrackingId": "'G-2HHHHH7FGH'"
  }
}
{\\"app\\":{\\"title\\":\\"ben\\",\\"googleAnalyticsTrackingId\\":\\"\\'G-2HHHHH7FGH\\'\\"}}
```

Of note this did not happen on my mac but it is present inside of the `nginx:mainline` Docker container used in the example.

This fix simply removes the hex from the sed substitution regex and replaces it with a single quote '


#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
> `yarn changeset` ran no packages effected
- [x] Added or updated documentation
> none added
- [x] Tests for new functionality and regression tests for bug fixes
> If there are tests around this please point me to them and I will add work