### PR TITLE
feat(kubernetes): add rancher dashboard formatter

### DIFF
--- a/.changeset/twenty-chairs-argue.md
+++ b/.changeset/twenty-chairs-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Add dashboard support for Rancher

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.test.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.test.ts
@@ -15,21 +15,88 @@
  */
 import { rancherFormatter } from './rancher';
 
-describe('clusterLinks - Rancher formatter', () => {
-  it('should return an url on the workloads when there is a namespace only', () => {
-    expect(() =>
-      rancherFormatter({
-        dashboardUrl: new URL('https://k8s.foo.com'),
-        object: {
-          metadata: {
-            name: 'foobar',
-            namespace: 'bar',
-          },
+describe('clusterLinks - rancher formatter', () => {
+  it('should return a url on the workloads when there is a namespace only', () => {
+    const url = rancherFormatter({
+      dashboardUrl: new URL('https://k8s.foo.com'),
+      object: {
+        metadata: {
+          namespace: 'bar',
         },
-        kind: 'Deployment',
-      }),
-    ).toThrowError(
-      'Rancher formatter is not yet implemented. Please, contribute!',
+      },
+      kind: 'foo',
+    });
+    expect(url.href).toBe('https://k8s.foo.com/explorer/workload');
+  });
+  it('should return a url on the workloads when the kind is not recognized', () => {
+    const url = rancherFormatter({
+      dashboardUrl: new URL('https://k8s.foo.com'),
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'UnknownKind',
+    });
+    expect(url.href).toBe('https://k8s.foo.com/explorer/workload');
+  });
+  it('should return a url on the deployment', () => {
+    const url = rancherFormatter({
+      dashboardUrl: new URL('https://k8s.foo.com/'),
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'Deployment',
+    });
+    expect(url.href).toBe(
+      'https://k8s.foo.com/explorer/apps.deployment/bar/foobar',
+    );
+  });
+  it('should return a url on the service', () => {
+    const url = rancherFormatter({
+      dashboardUrl: new URL('https://k8s.foo.com/'),
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'Service',
+    });
+    expect(url.href).toBe('https://k8s.foo.com/explorer/service/bar/foobar');
+  });
+  it('should return a url on the ingress', () => {
+    const url = rancherFormatter({
+      dashboardUrl: new URL('https://k8s.foo.com/'),
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'Ingress',
+    });
+    expect(url.href).toBe(
+      'https://k8s.foo.com/explorer/networking.k8s.io.ingress/bar/foobar',
+    );
+  });
+  it('should return a url on the deployment for a hpa', () => {
+    const url = rancherFormatter({
+      dashboardUrl: new URL('https://k8s.foo.com/'),
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'HorizontalPodAutoscaler',
+    });
+    expect(url.href).toBe(
+      'https://k8s.foo.com/explorer/autoscaling.horizontalpodautoscaler/bar/foobar',
     );
   });
 });

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.ts
@@ -15,8 +15,22 @@
  */
 import { ClusterLinksFormatterOptions } from '../../../types/types';
 
-export function rancherFormatter(_options: ClusterLinksFormatterOptions): URL {
-  throw new Error(
-    'Rancher formatter is not yet implemented. Please, contribute!',
-  );
+const kindMappings: Record<string, string> = {
+  deployment: 'apps.deployment',
+  ingress: 'networking.k8s.io.ingress',
+  service: 'service',
+  horizontalpodautoscaler: 'autoscaling.horizontalpodautoscaler',
+};
+
+export function rancherFormatter(options: ClusterLinksFormatterOptions): URL {
+  const result = new URL(options.dashboardUrl.href);
+  const name = options.object.metadata?.name;
+  const namespace = options.object.metadata?.namespace;
+  const validKind = kindMappings[options.kind.toLocaleLowerCase('en-US')];
+  if (validKind && name && namespace) {
+    result.pathname = `explorer/${validKind}/${namespace}/${name}`;
+  } else if (namespace) {
+    result.pathname = 'explorer/workload';
+  }
+  return result;
 }


### PR DESCRIPTION
Signed-off-by: Branch Vincent <branchevincent@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

First, thanks so much for the project!

This is a follow up to #6782 to add support for the [Rancher](https://github.com/rancher/dashboard) dashboard (aka cluster explorer). Note that there is also the [older dashboard](https://github.com/rancher/ui) (aka the cluster manager) that I did not add support for here.

