### PR TITLE
Fix oauth refresh logic to set new refresh token

### DIFF
--- a/.changeset/thick-rabbits-double.md
+++ b/.changeset/thick-rabbits-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Update OAuth refresh handler to pass updated refresh token to ensure cookie is updated with new value.

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -166,6 +166,7 @@ export class OAuth2AuthProvider implements OAuthHandlers {
         accessToken: result.accessToken,
         scope: result.params.scope,
         expiresInSeconds: result.params.expires_in,
+        refreshToken: result.refreshToken,
       },
       profile,
     };


### PR DESCRIPTION
Signed-off-by: Ryan Hanchett <ryan.hanchett@invitae.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Passes `refreshToken` back from `OAuthResponse` to `OAuthAdapter` in order to ensure `refresh-token` cookie gets updated on refresh. 

Currently, when refresh logic gets called, the updated token is passed properly into the `OAuth2AuthProvider.handleResult`, but it is never set in the response, and therefore the cookie never gets passed back to the adapter / updated in the cookie itself. This is causing the second refresh request to fail, as the it will try to use the original token which will have been rotated / invalidated. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
