### PR TITLE
Read config from remote server and replace `remote-app-config.yaml`

### DIFF
--- a/packages/backend-common/src/index.ts
+++ b/packages/backend-common/src/index.ts
@@ -22,6 +22,7 @@
 
 export * from './cache';
 export * from './config';
+export * from './remoteConfig';
 export * from './database';
 export * from './discovery';
 export * from './hot';

--- a/packages/backend-common/src/remoteConfig.ts
+++ b/packages/backend-common/src/remoteConfig.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import parseArgs from 'minimist';
+import {Logger} from 'winston';
+import {findPaths} from '@backstage/cli-common';
+import {Config, ConfigReader, JsonValue} from '@backstage/config';
+import {loadConfig} from '@backstage/config-loader';
+
+class RemoteObservableConfigProxy implements Config {
+  private config: Config = new ConfigReader({});
+
+  private readonly subscribers: (() => void)[] = [];
+
+  constructor(private readonly logger: Logger) {
+  }
+
+  setConfig(config: Config) {
+    this.config = config;
+    for (const subscriber of this.subscribers) {
+      try {
+        subscriber();
+      } catch (error) {
+        this.logger.error(`Config subscriber threw error, ${error}`);
+      }
+    }
+  }
+
+  subscribe(onChange: () => void): { unsubscribe: () => void } {
+    this.subscribers.push(onChange);
+    return {
+      unsubscribe: () => {
+        const index = this.subscribers.indexOf(onChange);
+        if (index >= 0) {
+          this.subscribers.splice(index, 1);
+        }
+      },
+    };
+  }
+
+  has(key: string): boolean {
+    return this.config.has(key);
+  }
+
+  keys(): string[] {
+    return this.config.keys();
+  }
+
+  get<T = JsonValue>(key?: string): T {
+    return this.config.get(key);
+  }
+
+  getOptional<T = JsonValue>(key?: string): T | undefined {
+    return this.config.getOptional(key);
+  }
+
+  getConfig(key: string): Config {
+    return this.config.getConfig(key);
+  }
+
+  getOptionalConfig(key: string): Config | undefined {
+    return this.config.getOptionalConfig(key);
+  }
+
+  getConfigArray(key: string): Config[] {
+    return this.config.getConfigArray(key);
+  }
+
+  getOptionalConfigArray(key: string): Config[] | undefined {
+    return this.config.getOptionalConfigArray(key);
+  }
+
+  getNumber(key: string): number {
+    return this.config.getNumber(key);
+  }
+
+  getOptionalNumber(key: string): number | undefined {
+    return this.config.getOptionalNumber(key);
+  }
+
+  getBoolean(key: string): boolean {
+    return this.config.getBoolean(key);
+  }
+
+  getOptionalBoolean(key: string): boolean | undefined {
+    return this.config.getOptionalBoolean(key);
+  }
+
+  getString(key: string): string {
+    return this.config.getString(key);
+  }
+
+  getOptionalString(key: string): string | undefined {
+    return this.config.getOptionalString(key);
+  }
+
+  getStringArray(key: string): string[] {
+    return this.config.getStringArray(key);
+  }
+
+  getOptionalStringArray(key: string): string[] | undefined {
+    return this.config.getOptionalStringArray(key);
+  }
+}
+
+// A global used to ensure that only a single file watcher is active at a time.
+let currentCancelFunc: () => void;
+
+/**
+ * Load configuration for a Backend.
+ *
+ * This function should only be called once, during the initialization of the backend.
+ *
+ * @public
+ */
+export async function loadRemoteBackendConfig(options: {
+  logger: Logger;
+  // process.argv or any other overrides
+  argv: string[];
+}): Promise<Config> {
+  const args = parseArgs(options.argv);
+  const configPaths: string[] = [args.config ?? []].flat();
+  const configUrls: string[] = [args.config ?? []].flat();
+
+  const config = new RemoteObservableConfigProxy(options.logger);
+
+  /* eslint-disable-next-line no-restricted-syntax */
+  const paths = findPaths(__dirname);
+
+  const configs = await loadConfig({
+    configRoot: paths.targetRoot,
+    configPaths: configPaths,
+    configUrls: configUrls,
+    watch: {
+      onChange(newConfigs) {
+        options.logger.info(
+          `Reloaded config from ${newConfigs.map(c => c.context).join(', ')}`,
+        );
+
+        config.setConfig(ConfigReader.fromConfigs(newConfigs));
+      },
+      stopSignal: new Promise(resolve => {
+        if (currentCancelFunc) {
+          currentCancelFunc();
+        }
+        currentCancelFunc = resolve;
+
+        // For reloads of this module we need to use a dispose handler rather than the global.
+        if (module.hot) {
+          module.hot.addDisposeHandler(resolve);
+        }
+      }),
+    },
+  });
+
+  options.logger.info(
+    `Loaded config from ${configs.map(c => c.context).join(', ')}`,
+  );
+
+  config.setConfig(ConfigReader.fromConfigs(configs));
+
+  return config;
+}

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -26,17 +26,17 @@ import Router from 'express-promise-router';
 import {
   CacheManager,
   createServiceBuilder,
-  getRootLogger,
-  loadBackendConfig,
-  notFoundHandler,
   DatabaseManager,
+  getRootLogger,
+  loadRemoteBackendConfig,
+  notFoundHandler,
   SingleHostDiscovery,
   UrlReaders,
   useHotMemoize,
 } from '@backstage/backend-common';
-import { Config } from '@backstage/config';
+import {Config} from '@backstage/config';
 import healthcheck from './plugins/healthcheck';
-import { metricsInit, metricsHandler } from './metrics';
+import {metricsHandler, metricsInit} from './metrics';
 import auth from './plugins/auth';
 import catalog from './plugins/catalog';
 import codeCoverage from './plugins/codecoverage';
@@ -52,7 +52,7 @@ import graphql from './plugins/graphql';
 import app from './plugins/app';
 import badges from './plugins/badges';
 import jenkins from './plugins/jenkins';
-import { PluginEnvironment } from './types';
+import {PluginEnvironment} from './types';
 
 function makeCreateEnv(config: Config) {
   const root = getRootLogger();
@@ -81,7 +81,7 @@ async function main() {
       `Do NOT deploy this to production. Read more here https://backstage.io/docs/getting-started/`,
   );
 
-  const config = await loadBackendConfig({
+  const config = await loadRemoteBackendConfig({
     argv: process.argv,
     logger,
   });

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -40,7 +40,8 @@
     "json-schema-merge-allof": "^0.8.1",
     "typescript-json-schema": "^0.50.1",
     "yaml": "^1.9.2",
-    "yup": "^0.29.3"
+    "yup": "^0.29.3",
+    "cross-fetch": "^3.1.4"
   },
   "devDependencies": {
     "@types/jest": "^26.0.7",

--- a/packages/config-loader/src/loader.ts
+++ b/packages/config-loader/src/loader.ts
@@ -239,7 +239,8 @@ export async function loadConfig(
           }
         }
         if (reloadConfigRequired) {
-          await loadRemoteConfigFiles();
+          const newRemoteConfigs = await loadRemoteConfigFiles();
+          watch.onChange([...newRemoteConfigs, ...envConfigs]);
         }
       }, remoteReloadingSeconds * 1000);
     } catch (error) {

--- a/packages/config-loader/src/loader.ts
+++ b/packages/config-loader/src/loader.ts
@@ -18,7 +18,7 @@ import fs from 'fs-extra';
 import yaml from 'yaml';
 import chokidar from 'chokidar';
 import {basename, dirname, isAbsolute, resolve as resolvePath} from 'path';
-import {AppConfig, JsonObject} from '@backstage/config';
+import {AppConfig} from '@backstage/config';
 import {
   applyConfigTransforms,
   createIncludeTransform,
@@ -167,7 +167,7 @@ export async function loadConfig(
     return configs;
   };
 
-  let fileConfigs: { data: JsonObject; context: string; }[];
+  let fileConfigs: AppConfig[];
   try {
     fileConfigs = await loadConfigFiles();
   } catch (error) {
@@ -176,7 +176,7 @@ export async function loadConfig(
     );
   }
 
-  let remoteConfigs;
+  let remoteConfigs: AppConfig[];
   try {
     remoteConfigs = await loadRemoteConfigFiles();
   } catch (error) {
@@ -206,7 +206,7 @@ export async function loadConfig(
         }
         currentSerializedConfig = newSerializedConfig;
 
-        watch.onChange([...newConfigs, ...envConfigs]);
+        watch.onChange([...newConfigs, ...remoteConfigs, ...envConfigs]);
       } catch (error) {
         console.error(`Failed to reload configuration files, ${error}`);
       }
@@ -240,7 +240,7 @@ export async function loadConfig(
         }
         if (reloadConfigRequired) {
           const newRemoteConfigs = await loadRemoteConfigFiles();
-          watch.onChange([...newRemoteConfigs, ...envConfigs]);
+          watch.onChange([...newRemoteConfigs, ...fileConfigs, ...envConfigs]);
         }
       }, remoteReloadingSeconds * 1000);
     } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7408,6 +7408,107 @@
     "@types/node" "*"
     rollup "^0.63.4"
 
+"@types/rx-core-binding@*":
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz#d969d32f15a62b89e2862c17b3ee78fe329818d3"
+  integrity sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==
+  dependencies:
+    "@types/rx-core" "*"
+
+"@types/rx-core@*":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/@types/rx-core/-/rx-core-4.0.3.tgz#0b3354b1238cedbe2b74f6326f139dbc7a591d60"
+  integrity sha1-CzNUsSOM7b4rdPYybxOdvHpZHWA=
+
+"@types/rx-lite-aggregates@*":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz#6efb2b7f3d5f07183a1cb2bd4b1371d7073384c2"
+  integrity sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-async@*":
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz#27fbf0caeff029f41e2d2aae638b05e91ceb600c"
+  integrity sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-backpressure@*":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz#05abb19bdf87cc740196c355e5d0b37bb50b5d56"
+  integrity sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-coincidence@*":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz#80bd69acc4054a15cdc1638e2dc8843498cd85c0"
+  integrity sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-experimental@*":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz#c532f5cbdf3f2c15da16ded8930d1b2984023cbd"
+  integrity sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-joinpatterns@*":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz#f70fe370518a8432f29158cc92ffb56b4e4afc3e"
+  integrity sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-testing@*":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz#21b19d11f4dfd6ffef5a9d1648e9c8879bfe21e9"
+  integrity sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=
+  dependencies:
+    "@types/rx-lite-virtualtime" "*"
+
+"@types/rx-lite-time@*":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz#0eda65474570237598f3448b845d2696f2dbb1c4"
+  integrity sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-virtualtime@*":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz#4b30cacd0fe2e53af29f04f7438584c7d3959537"
+  integrity sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite@*":
+  version "4.0.6"
+  resolved "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.6.tgz#3c02921c4244074234f26b772241bcc20c18c253"
+  integrity sha512-oYiDrFIcor9zDm0VDUca1UbROiMYBxMLMaM6qzz4ADAfOmA9r1dYEcAFH+2fsPI5BCCjPvV9pWC3X3flbrvs7w==
+  dependencies:
+    "@types/rx-core" "*"
+    "@types/rx-core-binding" "*"
+
+"@types/rx@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/@types/rx/-/rx-4.1.2.tgz#a4061b3d72b03cf11a38d69e2022a17334c54dc0"
+  integrity sha512-1r8ZaT26Nigq7o4UBGl+aXB2UMFUIdLPP/8bLIP0x3d0pZL46ybKKjhWKaJQWIkLl5QCLD0nK3qTOO1QkwdFaA==
+  dependencies:
+    "@types/rx-core" "*"
+    "@types/rx-core-binding" "*"
+    "@types/rx-lite" "*"
+    "@types/rx-lite-aggregates" "*"
+    "@types/rx-lite-async" "*"
+    "@types/rx-lite-backpressure" "*"
+    "@types/rx-lite-coincidence" "*"
+    "@types/rx-lite-experimental" "*"
+    "@types/rx-lite-joinpatterns" "*"
+    "@types/rx-lite-testing" "*"
+    "@types/rx-lite-time" "*"
+    "@types/rx-lite-virtualtime" "*"
+
 "@types/scheduler@*":
   version "0.16.1"
   resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"


### PR DESCRIPTION
This is not ready yet, more work is required to read the config from url without saving to remote-app-config.yaml

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
