### PR TITLE
Add is TechDocs available

### DIFF
--- a/.changeset/pink-windows-suffer.md
+++ b/.changeset/pink-windows-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Added a check for the TechDocs annotation on the entity

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -167,6 +167,11 @@ export const EntityTechdocsContent: (_props: {
   entity?: Entity | undefined;
 }) => JSX.Element;
 
+// Warning: (ae-missing-release-tag) "isTechDocsAvailable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const isTechDocsAvailable: (entity: Entity) => boolean;
+
 // Warning: (ae-missing-release-tag) "PanelType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/plugins/techdocs/src/Router.tsx
+++ b/plugins/techdocs/src/Router.tsx
@@ -25,6 +25,9 @@ import { MissingAnnotationEmptyState } from '@backstage/core-components';
 
 const TECHDOCS_ANNOTATION = 'backstage.io/techdocs-ref';
 
+export const isTechDocsAvailable = (entity: Entity) =>
+  Boolean(entity?.metadata?.annotations?.[TECHDOCS_ANNOTATION]);
+
 export const Router = () => {
   return (
     <Routes>

--- a/plugins/techdocs/src/index.ts
+++ b/plugins/techdocs/src/index.ts
@@ -44,4 +44,4 @@ export {
   TechDocsReaderPage,
 } from './plugin';
 export * from './reader';
-export { EmbeddedDocsRouter, Router } from './Router';
+export { EmbeddedDocsRouter, Router, isTechDocsAvailable } from './Router';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a check that can optionally be used in the EntityPage to determine if the entity has the TechDocs annotation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
