### PR TITLE
Add check for Kubernetes annotation on entity

### DIFF
--- a/.changeset/smart-cooks-drop.md
+++ b/.changeset/smart-cooks-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Added a check for the Kubernetes annotation on the entity

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -33,6 +33,11 @@ export function formatClusterLink(
   options: FormatClusterLinkOptions,
 ): string | undefined;
 
+// Warning: (ae-missing-release-tag) "isKubernetesAvailable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const isKubernetesAvailable: (entity: Entity) => boolean;
+
 // Warning: (ae-forgotten-export) The symbol "KubernetesAuthProvidersApi" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "KubernetesAuthProviders" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/kubernetes/src/Router.tsx
+++ b/plugins/kubernetes/src/Router.tsx
@@ -27,6 +27,12 @@ const KUBERNETES_ANNOTATION = 'backstage.io/kubernetes-id';
 const KUBERNETES_LABEL_SELECTOR_QUERY_ANNOTATION =
   'backstage.io/kubernetes-label-selector';
 
+export const isKubernetesAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[KUBERNETES_ANNOTATION]) ||
+  Boolean(
+    entity.metadata.annotations?.[KUBERNETES_LABEL_SELECTOR_QUERY_ANNOTATION],
+  );
+
 type Props = {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: Entity;

--- a/plugins/kubernetes/src/index.ts
+++ b/plugins/kubernetes/src/index.ts
@@ -25,6 +25,6 @@ export {
   kubernetesPlugin as plugin,
   EntityKubernetesContent,
 } from './plugin';
-export { Router } from './Router';
+export { Router, isKubernetesAvailable } from './Router';
 export * from './kubernetes-auth-provider';
 export * from './utils/clusterLinks';


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <awanlin@rapidrtc.com>

## Hey, I just made a Pull Request!

This adds a check that can optionally be used in the EntityPage to determine if the entity has the Kubernetes annotation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
