### PR TITLE
fix(techdocs): fix copy documentation link to clipboard url

### DIFF
--- a/.changeset/healthy-cycles-exercise.md
+++ b/.changeset/healthy-cycles-exercise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed the URL for the "Click to copy documentation link to clipboard" action

--- a/plugins/techdocs/src/home/components/actions.tsx
+++ b/plugins/techdocs/src/home/components/actions.tsx
@@ -28,12 +28,7 @@ export function createCopyDocsUrlAction(copyToClipboard: Function) {
       icon: () => <ShareIcon fontSize="small" />,
       tooltip: 'Click to copy documentation link to clipboard',
       onClick: () =>
-        copyToClipboard(
-          `${window.location.origin}${window.location.pathname.replace(
-            /\/?$/,
-            '/',
-          )}${row.resolved.docsUrl}`,
-        ),
+        copyToClipboard(`${window.location.origin}${row.resolved.docsUrl}`),
     };
   };
 }


### PR DESCRIPTION
Signed-off-by: Johan Hammar <johan.hammar@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR fixes #7104 - The URL that is copied to the clipboard when clicking on the "Click to copy documentation link to clipboard" has been fixed. I don't know enough about the TechDocs internals so please let me know if I'm missing something

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
