### PR TITLE
Add ability to override github app callback url

### DIFF
--- a/.changeset/pretty-feet-explode.md
+++ b/.changeset/pretty-feet-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Allow users to override callback url of Github provider

--- a/.changeset/pretty-feet-explode.md
+++ b/.changeset/pretty-feet-explode.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-Allow users to override callback url of Github provider
+Allow users to override callback url of GitHub provider

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -41,8 +41,6 @@ auth:
         clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
         ## uncomment if using GitHub Enterprise
         # enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
-        ## uncomment if intermediate service is used when using github apps
-        # callbackUrl: ${AUTH_GITHUB_CALLBACK_URL}
 ```
 
 The GitHub provider is a structure with three configuration keys:

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -41,6 +41,8 @@ auth:
         clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
         ## uncomment if using GitHub Enterprise
         # enterpriseInstanceUrl: ${AUTH_GITHUB_ENTERPRISE_INSTANCE_URL}
+        ## uncomment if intermediate service is used when using github apps
+        # callbackUrl: ${AUTH_GITHUB_CALLBACK_URL}
 ```
 
 The GitHub provider is a structure with three configuration keys:
@@ -50,6 +52,10 @@ The GitHub provider is a structure with three configuration keys:
 - `clientSecret`: The client secret tied to the generated client ID.
 - `enterpriseInstanceUrl` (optional): The base URL for a GitHub Enterprise
   instance, e.g. `https://ghe.<company>.com`. Only needed for GitHub Enterprise.
+- `callbackUrl` (optional): The callback url that GitHub will use when
+  initiating an OAuth flow, e.g.
+  `https://your-intermediate-service.com/handler`. Only needed if Backstage is
+  not the immediate receiver (e.g. one OAuth app for many backstage instances).
 
 ## Adding the provider to the Backstage frontend
 

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -223,9 +223,8 @@ export const createGithubProvider = (
       const enterpriseInstanceUrl = envConfig.getOptionalString(
         'enterpriseInstanceUrl',
       );
-      const customCallbackUrl = envConfig.getOptionalString(
-        'customCallbackUrl',
-      );
+      const customCallbackUrl =
+        envConfig.getOptionalString('customCallbackUrl');
       const authorizationUrl = enterpriseInstanceUrl
         ? `${enterpriseInstanceUrl}/login/oauth/authorize`
         : undefined;
@@ -235,8 +234,9 @@ export const createGithubProvider = (
       const userProfileUrl = enterpriseInstanceUrl
         ? `${enterpriseInstanceUrl}/api/v3/user`
         : undefined;
-      const callbackUrl = customCallbackUrl ||
-       `${globalConfig.baseUrl}/${providerId}/handler/frame`;
+      const callbackUrl =
+        customCallbackUrl ||
+        `${globalConfig.baseUrl}/${providerId}/handler/frame`;
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -223,8 +223,7 @@ export const createGithubProvider = (
       const enterpriseInstanceUrl = envConfig.getOptionalString(
         'enterpriseInstanceUrl',
       );
-      const customCallbackUrl =
-        envConfig.getOptionalString('customCallbackUrl');
+      const customCallbackUrl = envConfig.getOptionalString('callbackUrl');
       const authorizationUrl = enterpriseInstanceUrl
         ? `${enterpriseInstanceUrl}/login/oauth/authorize`
         : undefined;

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -223,6 +223,9 @@ export const createGithubProvider = (
       const enterpriseInstanceUrl = envConfig.getOptionalString(
         'enterpriseInstanceUrl',
       );
+      const customCallbackUrl = envConfig.getOptionalString(
+        'customCallbackUrl',
+      );
       const authorizationUrl = enterpriseInstanceUrl
         ? `${enterpriseInstanceUrl}/login/oauth/authorize`
         : undefined;
@@ -232,7 +235,8 @@ export const createGithubProvider = (
       const userProfileUrl = enterpriseInstanceUrl
         ? `${enterpriseInstanceUrl}/api/v3/user`
         : undefined;
-      const callbackUrl = `${globalConfig.baseUrl}/${providerId}/handler/frame`;
+      const callbackUrl = customCallbackUrl ||
+       `${globalConfig.baseUrl}/${providerId}/handler/frame`;
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,


### PR DESCRIPTION
By default, the github app provider redirects back to the base url.
This change allows a user to override the GitHub App url using the config field `callbackUrl`.

It will look like this in the configuration:
```
auth:
  providers:
    github:
      development:
        clientId: SUPER ID
        clientSecret: SUPER SECRET
        callbackUrl: https://some-url.com/callback
```

Signed-off-by: Nicolas Arnold <nic@roadie.io>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
