### PR TITLE
Extend `StorageApi#set` to support a function argument that provides the old value prior to setting the new value

### DIFF
--- a/.changeset/famous-snakes-taste.md
+++ b/.changeset/famous-snakes-taste.md
@@ -1,0 +1,11 @@
+---
+'@backstage/core-plugin-api': minor
+'@backstage/core-app-api': patch
+'@backstage/core-components': patch
+'@backstage/test-utils': patch
+'@backstage/plugin-catalog-react': patch
+---
+
+Extend `StorageApi#set` to support a function argument that provides the old value prior to setting the new value.
+
+This pattern was implemented in the provided interface implementations, in the `useStarredEntities` hook, and in the `DismissableBanner` component.

--- a/.changeset/stupid-elephants-invent.md
+++ b/.changeset/stupid-elephants-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Store the namespaced bucket storage for each instance that was created with `MockStorage.create()` instead of globally

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -635,7 +635,7 @@ export class WebStorage implements StorageApi {
   // (undocumented)
   remove(key: string): Promise<void>;
   // (undocumented)
-  set<T>(key: string, data: T): Promise<void>;
+  set<T>(key: string, data: T | ((old: T | undefined) => T)): Promise<void>;
 }
 
 // Warnings were encountered during analysis:

--- a/packages/core-app-api/package.json
+++ b/packages/core-app-api/package.json
@@ -38,6 +38,7 @@
     "@material-ui/icons": "^4.9.1",
     "@types/react": "*",
     "@types/prop-types": "^15.7.3",
+    "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-router-dom": "6.0.0-beta.0",

--- a/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
+++ b/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
@@ -94,7 +94,10 @@ export const DismissableBanner = (props: Props) => {
   }, [observedItems?.newValue]);
 
   const handleClick = () => {
-    notificationsStore.set('dismissedBanners', [...dismissedBanners, id]);
+    notificationsStore.set<string[]>(
+      'dismissedBanners',
+      (oldDismissedBanners = []) => [...oldDismissedBanners, id],
+    );
   };
 
   return (

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -791,7 +791,8 @@ export interface StorageApi {
   remove(key: string): Promise<void>;
   // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-  set(key: string, data: any): Promise<void>;
+  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+  set<T>(key: string, data: T | ((old: T | undefined) => any)): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "storageApiRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core-plugin-api/src/apis/definitions/StorageApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/StorageApi.ts
@@ -49,8 +49,9 @@ export interface StorageApi {
    * Save persistent data, and emit messages to anyone that is using observe$ for this key
    *
    * @param {String} key Unique key associated with the data.
+   * @param data new data, or a function to construct new data from old data.
    */
-  set(key: string, data: any): Promise<void>;
+  set<T>(key: string, data: T | ((old: T | undefined) => any)): Promise<void>;
 
   /**
    * Observe changes on a particular key in the bucket

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -61,7 +61,7 @@ export class MockStorageApi implements StorageApi {
   // (undocumented)
   remove(key: string): Promise<void>;
   // (undocumented)
-  set<T>(key: string, data: T): Promise<void>;
+  set<T>(key: string, data: T | ((old: T | undefined) => T)): Promise<void>;
 }
 
 // Warning: (ae-missing-release-tag) "MockStorageBucket" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -38,6 +38,7 @@
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^13.1.8",
     "@types/react": "*",
+    "lodash": "^4.17.21",
     "msw": "^0.29.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.test.ts
+++ b/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.test.ts
@@ -51,6 +51,15 @@ describe('WebStorage Storage API', () => {
     expect(storage.get('myfakekey')).toEqual(mockData);
   });
 
+  it('should allow setting via a function', async () => {
+    const storage = createMockStorage();
+
+    await storage.set('myfakekey', 'hello');
+    await storage.set('myfakekey', (old: string = '') => `${old}iamastring`);
+
+    expect(storage.get('myfakekey')).toEqual('helloiamastring');
+  });
+
   it('should subscribe to key changes when setting a new value', async () => {
     const storage = createMockStorage();
 

--- a/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.test.ts
+++ b/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.test.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { MockStorageApi } from './MockStorageApi';
 import { StorageApi } from '@backstage/core-plugin-api';
+import { MockStorageApi } from './MockStorageApi';
 
 describe('WebStorage Storage API', () => {
   const createMockStorage = (): StorageApi => {
@@ -124,7 +124,7 @@ describe('WebStorage Storage API', () => {
     expect(secondStorage.get(keyName)).toBe('deerp');
   });
 
-  it('should not clash with other namesapces when creating buckets', async () => {
+  it('should not clash with other namespaces when creating buckets', async () => {
     const rootStorage = createMockStorage();
 
     // when getting key test2 it will translate to /profile/something/deep/test2
@@ -138,5 +138,18 @@ describe('WebStorage Storage API', () => {
     await firstStorage.set('test2', { error: true });
 
     expect(secondStorage.get('deep/test2')).toBe(undefined);
+  });
+
+  it('should not reuse storage instances between different rootStorages', async () => {
+    const rootStorage1 = createMockStorage();
+    const rootStorage2 = createMockStorage();
+
+    const firstStorage = rootStorage1.forBucket('something');
+    const secondStorage = rootStorage2.forBucket('something');
+
+    await firstStorage.set('test2', true);
+
+    expect(firstStorage.get('test2')).toBe(true);
+    expect(secondStorage.get('test2')).toBe(undefined);
   });
 });

--- a/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.ts
+++ b/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.ts
@@ -23,29 +23,37 @@ import ObservableImpl from 'zen-observable';
 
 export type MockStorageBucket = { [key: string]: any };
 
-const bucketStorageApis = new Map<string, MockStorageApi>();
-
 export class MockStorageApi implements StorageApi {
   private readonly namespace: string;
   private readonly data: MockStorageBucket;
+  private readonly bucketStorageApis: Map<string, MockStorageApi>;
 
-  private constructor(namespace: string, data?: MockStorageBucket) {
+  private constructor(
+    namespace: string,
+    bucketStorageApis: Map<string, MockStorageApi>,
+    data?: MockStorageBucket,
+  ) {
     this.namespace = namespace;
+    this.bucketStorageApis = bucketStorageApis;
     this.data = { ...data };
   }
 
   static create(data?: MockStorageBucket) {
-    return new MockStorageApi('', data);
+    return new MockStorageApi('', new Map(), data);
   }
 
   forBucket(name: string): StorageApi {
-    if (!bucketStorageApis.has(name)) {
-      bucketStorageApis.set(
+    if (!this.bucketStorageApis.has(name)) {
+      this.bucketStorageApis.set(
         name,
-        new MockStorageApi(`${this.namespace}/${name}`, this.data),
+        new MockStorageApi(
+          `${this.namespace}/${name}`,
+          this.bucketStorageApis,
+          this.data,
+        ),
       );
     }
-    return bucketStorageApis.get(name)!;
+    return this.bucketStorageApis.get(name)!;
   }
 
   get<T>(key: string): T | undefined {

--- a/plugins/catalog-react/src/hooks/useStarredEntities.ts
+++ b/plugins/catalog-react/src/hooks/useStarredEntities.ts
@@ -48,15 +48,20 @@ export const useStarredEntities = () => {
   const toggleStarredEntity = useCallback(
     (entity: Entity) => {
       const entityKey = buildEntityKey(entity);
-      if (starredEntities.has(entityKey)) {
-        starredEntities.delete(entityKey);
-      } else {
-        starredEntities.add(entityKey);
-      }
 
-      settingsStore.set('starredEntities', Array.from(starredEntities));
+      settingsStore.set<string[]>('starredEntities', oldStarredEntities => {
+        const starredSet = new Set(oldStarredEntities);
+
+        if (starredSet.has(entityKey)) {
+          starredSet.delete(entityKey);
+        } else {
+          starredSet.add(entityKey);
+        }
+
+        return Array.from(starredSet);
+      });
     },
-    [starredEntities, settingsStore],
+    [settingsStore],
   );
 
   const isStarredEntity = useCallback(


### PR DESCRIPTION
We want to develop a databased-backed implementation of the `StorageApi` and were a bit surprised that the getter of the API is synchronous, but it looks like it was explicitly intended to be this way (see https://github.com/backstage/backstage/issues/1060).

Since there is no async way to request the latest value from the backend store, I propose to let the user do the following: `storageApi.set(oldValue => [...oldValue, newValue])`. This should add some kind of transaction-safeness when running multiple instances of Backstage on different devices/browsers. Especially the `useStarredEntities` hook would otherwise be prone to be inconsistent since there is otherwise no way to update an existing value that is not already mirrored to the local storage of the browser. -> You could star entity **A** in one browser, but if you star **B** in another browser, the starring of **A** might be overridden and forgotten...

What do you think about this idea?



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
