### PR TITLE
cli: improve package.json files diff

### DIFF
--- a/.changeset/little-cobras-think.md
+++ b/.changeset/little-cobras-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Improved ´plugin:diff´ check for the `package.json` `"files"` field.

--- a/packages/cli/src/lib/diff/handlers.ts
+++ b/packages/cli/src/lib/diff/handlers.ts
@@ -123,11 +123,41 @@ class PackageJsonHandler {
   }
 
   private async syncFiles() {
-    if (typeof this.targetPkg.configSchema === 'string') {
-      const files = [...this.pkg.files, this.targetPkg.configSchema];
-      await this.syncField('files', { files });
+    const { configSchema } = this.targetPkg;
+    const hasSchemaFile = typeof configSchema === 'string';
+
+    if (!this.targetPkg.files) {
+      const expected = hasSchemaFile ? ['dist', configSchema] : ['dist'];
+      if (
+        await this.prompt(
+          `package.json is missing field "files", set to ${JSON.stringify(
+            expected,
+          )}?`,
+        )
+      ) {
+        this.targetPkg.files = expected;
+        await this.write();
+      }
     } else {
-      await this.syncField('files');
+      const missing = [];
+      if (!this.targetPkg.files.includes('dist')) {
+        missing.push('dist');
+      }
+      if (hasSchemaFile && !this.targetPkg.files.includes(configSchema)) {
+        missing.push(configSchema);
+      }
+      if (missing.length) {
+        if (
+          await this.prompt(
+            `package.json is missing ${JSON.stringify(
+              missing,
+            )} in the "files" field, add?`,
+          )
+        ) {
+          this.targetPkg.files.push(...missing);
+          await this.write();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Reported by @awanlin on Discord. This check was a bit too strict.

We now allow additional entries in `files`, but make sure that `dist` is there, and the config schema file if one is declared.