### PR TITLE
config-loader: collect schemas from each package version

### DIFF
--- a/.changeset/nervous-months-teach.md
+++ b/.changeset/nervous-months-teach.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Allow collection of configuration schemas from multiple versions of the same package.


### PR DESCRIPTION
Followup for #7326

The explainer is in the removed comment. We used to not allow duplicates of packages so loading schema from each of those duplicates was not a concern. Now we do support duplicates so gotta make sure we load in all the schemas :grin: