### PR TITLE
Escape pipe character `|` in api docs

### DIFF
--- a/scripts/api-extractor.ts
+++ b/scripts/api-extractor.ts
@@ -372,6 +372,18 @@ async function buildDocs({
   // This is where we actually write the markdown and where we can hook
   // in the rendering of our own nodes.
   class CustomCustomMarkdownEmitter extends CustomMarkdownEmitter {
+    // Until https://github.com/microsoft/rushstack/issues/2914 gets fixed or we change markdown renderer we need a fix
+    // to render pipe | character correctly.
+    protected getEscapedText(text: string): string {
+      return text
+        .replace(/\\/g, '\\\\') // first replace the escape character
+        .replace(/[*#[\]_`~]/g, x => `\\${x}`) // then escape any special characters
+        .replace(/---/g, '\\-\\-\\-') // hyphens only if it's 3 or more
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\|/g, '&#124;');
+    }
     /** @override */
     protected writeNode(
       docNode: DocNode,


### PR DESCRIPTION
Signed-off-by: Tomasz Szuba <tszuba@box.com>

## Hey, I just made a Pull Request!

api-documenter currently does not escape pipe character `|` in tables. For example when used to describe unions as property types.
I have created issue for them, but no response: https://github.com/microsoft/rushstack/issues/2914

Stumbled upon this, when started some work on https://github.com/backstage/backstage/issues/7162

We can wait for upstream instead to fix it (syntax itself is valid, it's remarkable used by docusaurus that does not understand it), or wait for upgrade to docusaurus v2 and see if it will help (but that was already attempted and seems non-trivial).

As we already provide custom MarkdowEmmiter, this was the easiest way.

Before:
![image](https://user-images.githubusercontent.com/603853/135094095-6aba7583-aab2-43d5-8166-b42e601e592b.png)
After:
![image](https://user-images.githubusercontent.com/603853/135094363-18abc217-5305-4255-8821-5b4afdbdd833.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
