### PR TITLE
azure-devops-backend: mark config as required and use mock token

### DIFF
--- a/.changeset/calm-buckets-relax.md
+++ b/.changeset/calm-buckets-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+Marked all configuration values as required in the schema.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -403,5 +403,5 @@ jenkins:
 
 azureDevOps:
   host: dev.azure.com
-  token: ${AZURE_TOKEN}
+  token: my-token
   organization: my-company

--- a/plugins/azure-devops-backend/config.d.ts
+++ b/plugins/azure-devops-backend/config.d.ts
@@ -16,7 +16,7 @@
 
 export interface Config {
   /** Configuration options for the azure-devops-backend plugin */
-  azureDevOps?: {
+  azureDevOps: {
     /**
      * The hostname of the given Azure instance
      */
@@ -25,7 +25,7 @@ export interface Config {
      * Token used to authenticate requests.
      * @visibility secret
      */
-    token?: string;
+    token: string;
     /**
      * The organization of the given Azure instance
      */

--- a/plugins/azure-devops-backend/src/service/router.test.ts
+++ b/plugins/azure-devops-backend/src/service/router.test.ts
@@ -62,10 +62,7 @@ describe('createRouter', () => {
       const response = await request(app).get('/health');
 
       expect(response.status).toEqual(200);
-      expect(response.body).toEqual({
-        status: 'Healthy',
-        details: 'All required config has been provided',
-      });
+      expect(response.body).toEqual({ status: 'ok' });
     });
   });
 

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -36,9 +36,9 @@ export async function createRouter(
   const { logger } = options;
   const config = options.config.getConfig('azureDevOps');
 
-  const token: string = config.getString('token');
-  const host: string = config.getString('host');
-  const organization: string = config.getString('organization');
+  const token = config.getString('token');
+  const host = config.getString('host');
+  const organization = config.getString('organization');
 
   const authHandler = getPersonalAccessTokenHandler(token);
   const webApi = new WebApi(`https://${host}/${organization}`, authHandler);
@@ -49,36 +49,8 @@ export async function createRouter(
   const router = Router();
   router.use(express.json());
 
-  router.get('/health', (_, response) => {
-    let code: number = 200;
-    let status: string = '';
-    let details: string = '';
-
-    if (token && host && organization) {
-      code = 200;
-      status = 'Healthy';
-      details = 'All required config has been provided';
-    }
-
-    if (!token) {
-      code = 500;
-      status = 'Unhealthy';
-      details = 'Token is missing';
-    }
-
-    if (!host) {
-      code = 500;
-      status = 'Unhealthy';
-      details = 'Host is missing';
-    }
-
-    if (!organization) {
-      code = 500;
-      status = 'Unhealthy';
-      details = 'Organization is missing';
-    }
-
-    response.status(code).json({ status: status, details: details });
+  router.get('/health', (_req, res) => {
+    res.status(200).json({ status: 'ok' });
   });
 
   router.get('/repository/:projectName/:repoName', async (req, res) => {


### PR DESCRIPTION
Currently you need to supply `AZURE_TOKEN` through env when you start up the backend in the main repo, which we want to avoid.

I also cleaned up the healthcheck a bit since it's unreachable code