### PR TITLE
kubernetes: add isolatated plugin dev setup

### DIFF
--- a/.changeset/rotten-dryers-bathe.md
+++ b/.changeset/rotten-dryers-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Exported `KubernetesApi`, `kubernetesApiRef`, and `KubernetesAuthProvidersApi`.

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -10,6 +10,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { OAuthApi } from '@backstage/core-plugin-api';
+import { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // Warning: (ae-forgotten-export) The symbol "ClusterLinksFormatter" needs to be exported by the entry point index.d.ts
@@ -38,12 +39,44 @@ export function formatClusterLink(
 // @public (undocumented)
 export const isKubernetesAvailable: (entity: Entity) => boolean;
 
-// Warning: (ae-forgotten-export) The symbol "KubernetesAuthProvidersApi" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "KubernetesApi" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface KubernetesApi {
+  // (undocumented)
+  getClusters(): Promise<
+    {
+      name: string;
+      authProvider: string;
+    }[]
+  >;
+  // (undocumented)
+  getObjectsByEntity(
+    requestBody: KubernetesRequestBody,
+  ): Promise<ObjectsByEntityResponse>;
+}
+
+// Warning: (ae-missing-release-tag) "kubernetesApiRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const kubernetesApiRef: ApiRef<KubernetesApi>;
+
 // Warning: (ae-missing-release-tag) "KubernetesAuthProviders" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
   constructor(options: { googleAuthApi: OAuthApi });
+  // (undocumented)
+  decorateRequestBodyForAuth(
+    authProvider: string,
+    requestBody: KubernetesRequestBody,
+  ): Promise<KubernetesRequestBody>;
+}
+
+// Warning: (ae-missing-release-tag) "KubernetesAuthProvidersApi" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface KubernetesAuthProvidersApi {
   // (undocumented)
   decorateRequestBodyForAuth(
     authProvider: string,

--- a/plugins/kubernetes/dev/index.tsx
+++ b/plugins/kubernetes/dev/index.tsx
@@ -13,7 +13,100 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import React from 'react';
+import { Entity } from '@backstage/catalog-model';
 import { createDevApp } from '@backstage/dev-utils';
-import { kubernetesPlugin } from '../src';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import {
+  EntityKubernetesContent,
+  kubernetesPlugin,
+  kubernetesApiRef,
+  KubernetesApi,
+} from '../src';
+import {
+  FetchResponse,
+  ObjectsByEntityResponse,
+} from '@backstage/plugin-kubernetes-common';
+import fixture1 from '../src/__fixtures__/1-deployments.json';
+import fixture2 from '../src/__fixtures__/2-deployments.json';
+import { ApiProvider, ApiRegistry } from '@backstage/core-app-api';
 
-createDevApp().registerPlugin(kubernetesPlugin).render();
+const mockEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'backstage',
+    description: 'backstage.io',
+    annotations: {
+      'backstage.io/kubernetes-id': 'dice-roller',
+    },
+  },
+  spec: {
+    lifecycle: 'production',
+    type: 'service',
+    owner: 'user:guest',
+  },
+};
+
+class MockKubernetesClient implements KubernetesApi {
+  readonly resources: FetchResponse[];
+
+  constructor(fixtureData: { [resourceType: string]: any[] }) {
+    this.resources = Object.entries(fixtureData).flatMap(
+      ([type, resources]) =>
+        ({ type: type.toLocaleLowerCase('en-US'), resources } as FetchResponse),
+    );
+  }
+
+  async getObjectsByEntity(): Promise<ObjectsByEntityResponse> {
+    return {
+      items: [
+        {
+          cluster: { name: 'mock-cluster' },
+          resources: this.resources,
+          errors: [],
+        },
+      ],
+    };
+  }
+
+  async getClusters(): Promise<{ name: string; authProvider: string }[]> {
+    return [{ name: 'mock-cluster', authProvider: 'serviceAccount' }];
+  }
+}
+
+createDevApp()
+  .addPage({
+    path: '/fixture-1',
+    title: 'Fixture 1',
+    element: (
+      <ApiProvider
+        apis={ApiRegistry.with(
+          kubernetesApiRef,
+          new MockKubernetesClient(fixture1),
+        )}
+      >
+        <EntityProvider entity={mockEntity}>
+          <EntityKubernetesContent />
+        </EntityProvider>
+      </ApiProvider>
+    ),
+  })
+  .addPage({
+    path: '/fixture-2',
+    title: 'Fixture 2',
+    element: (
+      <ApiProvider
+        apis={ApiRegistry.with(
+          kubernetesApiRef,
+          new MockKubernetesClient(fixture2),
+        )}
+      >
+        <EntityProvider entity={mockEntity}>
+          <EntityKubernetesContent />
+        </EntityProvider>
+      </ApiProvider>
+    ),
+  })
+  .registerPlugin(kubernetesPlugin)
+  .render();

--- a/plugins/kubernetes/src/api/index.ts
+++ b/plugins/kubernetes/src/api/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,5 @@
  * limitations under the License.
  */
 
-/**
- * A Backstage plugin that integrates towards Kubernetes
- *
- * @packageDocumentation
- */
-
-export {
-  kubernetesPlugin,
-  kubernetesPlugin as plugin,
-  EntityKubernetesContent,
-} from './plugin';
-export { Router, isKubernetesAvailable } from './Router';
-export * from './api';
-export * from './kubernetes-auth-provider';
-export * from './utils/clusterLinks';
+export { kubernetesApiRef } from './types';
+export type { KubernetesApi } from './types';

--- a/plugins/kubernetes/src/kubernetes-auth-provider/index.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { kubernetesAuthProvidersApiRef } from './types';
+export type { KubernetesAuthProvidersApi } from './types';
 export { KubernetesAuthProviders } from './KubernetesAuthProviders';


### PR DESCRIPTION
A simple isolated plugin dev setup for the k8s plugin, using the existing test fixtures

![image](https://user-images.githubusercontent.com/4984472/135270038-1339da70-6a3f-4646-938a-e2d965aade48.png)
