### PR TITLE
[TechDocs] Lock default container version for generation

### DIFF
--- a/.changeset/techdocs-sad-songs-waltzes.md
+++ b/.changeset/techdocs-sad-songs-waltzes.md
@@ -1,0 +1,6 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+Locks the version of the default docker image used to generate TechDocs. As of
+this changelog entry, it is v0.3.2!

--- a/packages/techdocs-common/api-report.md
+++ b/packages/techdocs-common/api-report.md
@@ -256,6 +256,7 @@ export class TechdocsGenerator implements GeneratorBase {
     config: Config;
     scmIntegrations: ScmIntegrationRegistry;
   });
+  static readonly defaultDockerImage = 'spotify/techdocs:v0.3.2';
   // (undocumented)
   static fromConfig(
     config: Config,

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -39,7 +39,8 @@ import {
 
 export class TechdocsGenerator implements GeneratorBase {
   /**
-   * The default docker image used to generate cnotent.
+   * The default docker image (and version) used to generate content. Public
+   * and static so that techdocs-common consumers can use the same version.
    */
   public static readonly defaultDockerImage = 'spotify/techdocs:v0.3.2';
   private readonly logger: Logger;

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -37,9 +37,11 @@ import {
   GeneratorRunOptions,
 } from './types';
 
-const defaultDockerImage = 'spotify/techdocs';
-
 export class TechdocsGenerator implements GeneratorBase {
+  /**
+   * The default docker image used to generate cnotent.
+   */
+  public static readonly defaultDockerImage = 'spotify/techdocs:v0.3.2';
   private readonly logger: Logger;
   private readonly containerRunner: ContainerRunner;
   private readonly options: GeneratorConfig;
@@ -124,7 +126,8 @@ export class TechdocsGenerator implements GeneratorBase {
           break;
         case 'docker':
           await this.containerRunner.runContainer({
-            imageName: this.options.dockerImage ?? defaultDockerImage,
+            imageName:
+              this.options.dockerImage ?? TechdocsGenerator.defaultDockerImage,
             args: ['build', '-d', '/output'],
             logStream,
             mountDirs,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Little pre-requisite to a solution to backstage/techdocs-cli#92.  We're locking the version here and exporting the default version as part of the API so that the `techdocs-cli` can also use it as a locked version.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
