### PR TITLE
root: clean out existing types first in tsc:full

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:api-reports:only": "ts-node -T -P scripts/tsconfig.json scripts/api-extractor.ts",
     "build:api-docs": "yarn build:api-reports --docs",
     "tsc": "tsc",
-    "tsc:full": "tsc --skipLibCheck false --incremental false",
+    "tsc:full": "backstage-cli clean && tsc --skipLibCheck false --incremental false",
     "clean": "backstage-cli clean && lerna run clean",
     "diff": "lerna run diff --",
     "test": "lerna run test --since origin/master -- --coverage",


### PR DESCRIPTION
Not clearing `dist-types` before running `tsc:full` can lead to confusion since it doesn't by itself clean out old type declarations that are no longer referenced