### PR TITLE
core-app-api: do not call connector.removeSession in StaticAuthSessionManager.removeSession

### DIFF
--- a/.changeset/sixty-shrimps-kneel.md
+++ b/.changeset/sixty-shrimps-kneel.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Stop calling connector.removeSession in StaticAuthSessionManager, instead just discarding the
+session locally.

--- a/packages/core-app-api/src/lib/AuthSessionManager/StaticAuthSessionManager.test.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/StaticAuthSessionManager.test.ts
@@ -83,7 +83,7 @@ describe('StaticAuthSessionManager', () => {
     expect(createSession).toHaveBeenCalledTimes(2);
   });
 
-  it('should remove session and reload', async () => {
+  it('should clear the local session', async () => {
     const removeSession = jest.fn();
     const manager = new StaticAuthSessionManager({
       connector: { removeSession },
@@ -91,7 +91,17 @@ describe('StaticAuthSessionManager', () => {
     } as any);
 
     await manager.removeSession();
-    expect(removeSession).toHaveBeenCalled();
     expect(await manager.getSession({ optional: true })).toBe(undefined);
+  });
+
+  it('should not remove the session via the connector', async () => {
+    const removeSession = jest.fn();
+    const manager = new StaticAuthSessionManager({
+      connector: { removeSession },
+      ...defaultOptions,
+    } as any);
+
+    await manager.removeSession();
+    expect(removeSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/core-app-api/src/lib/AuthSessionManager/StaticAuthSessionManager.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/StaticAuthSessionManager.ts
@@ -71,9 +71,14 @@ export class StaticAuthSessionManager<T> implements MutableSessionManager<T> {
     return this.currentSession;
   }
 
+  /**
+   * We don't call this.connector.removeSession here, since this session manager
+   * is intended to be static. As such there's no need to hit the remote logout
+   * endpoint - simply discarding the local session state when signing out is
+   * enough.
+   */
   async removeSession() {
     this.currentSession = undefined;
-    await this.connector.removeSession();
     this.stateTracker.setIsSignedIn(false);
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

cc @Rugvip 

Stop calling connector.removeSession in StaticAuthSessionManager, instead just discarding the session locally. This call is not necessary since the static session doesn't care about the refresh token, and including it results in multiple requests to log out when using the [`OptionalRefreshSessionManagerMux`](https://github.com/backstage/backstage/blob/master/packages/core-app-api/src/lib/AuthSessionManager/OptionalRefreshSessionManagerMux.ts).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
