### PR TITLE
docs: migrate composability migration docs away from migration

### DIFF
--- a/docs/plugins/composability.md
+++ b/docs/plugins/composability.md
@@ -99,9 +99,8 @@ component for the outside world, and is used by other components and plugins
 that wish to link to the routable component.
 
 As of now there are only two extension creation functions in the core library,
-but it is possible to add more of them in the future, but more may be added in
-the future. There are also some plugins that provide ways to extend
-functionality through their own extensions, like
+but more may be added in the future. There are also some plugins that provide
+ways to extend functionality through their own extensions, like
 `createScaffolderFieldExtension` from `@backstage/plugin-scaffolder`. Extensions
 are also not tied to React, and can both be used to model generic JavaScript
 concepts, as well as potentially bridge to rendering libraries and web
@@ -318,7 +317,7 @@ top-level `routes.ts`. This is to avoid circular imports when you use the route
 references from other parts of the same plugin.
 
 Another thing to note is that this indirection in the routing is particularly
-useful for open source plugins than need to leave flexibility in how they are
+useful for open source plugins that need to leave flexibility in how they are
 integrated. For plugins that you build internally for your own Backstage
 application, you can choose to go the route of direct imports or even use
 concrete routes directly. Although there can be some benefits to using the full

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,7 @@ nav:
       - Structure of a plugin: 'plugins/structure-of-a-plugin.md'
       - Plugin Development: 'plugins/plugin-development.md'
       - Integrate into the Software Catalog: 'plugins/integrating-plugin-into-software-catalog.md'
-      - Composability System Migration: 'plugins/composability.md'
+      - Composability System: 'plugins/composability.md'
       - Backends and APIs:
           - Proxying: 'plugins/proxying.md'
           - Backend plugin: 'plugins/backend-plugin.md'


### PR DESCRIPTION
I feel enough time has passed that it's enough to just describe the composability system as a fresh thing, rather than in terms of the old system :grin:

Still kept the migration section at the bottom though, but I think we could remove that too in not too long.