### PR TITLE
org: include users groups on OwnershipCard link qs

### DIFF
--- a/.changeset/eight-elephants-agree.md
+++ b/.changeset/eight-elephants-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Change the OwnershipCard link on an user profile, including the user's groups on the filters.

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
+import { Entity, UserEntity } from '@backstage/catalog-model';
 import {
   InfoCard,
   InfoCardVariants,
@@ -109,13 +109,18 @@ const getQueryParams = (
 ): string => {
   const ownerName = formatEntityRefTitle(owner, { defaultKind: 'group' });
   const { kind, type } = selectedEntity;
+  const filters = {
+    kind,
+    type,
+    owners: [ownerName],
+    user: 'all',
+  };
+  if (owner.kind === 'User') {
+    const user = owner as UserEntity;
+    filters.owners = [...filters.owners, ...user.spec.memberOf];
+  }
   const queryParams = qs.stringify({
-    filters: {
-      kind,
-      type,
-      owners: ownerName,
-      user: 'all',
-    },
+    filters,
   });
 
   return queryParams;


### PR DESCRIPTION
Signed-off-by: Guilherme Vierno <guilhermevierno@gmail.com>

This PR aims to solve #7254 , making the UI consistent when the `OwnershipCard` links are used. The solution used was to include the user's groups on the filter query string.
