### PR TITLE
cli: add support for test execution from project root

### DIFF
--- a/.changeset/empty-oranges-roll.md
+++ b/.changeset/empty-oranges-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The default jest configuration used by the `test` command now supports yarn workspaces. By running `backstage-cli test` in the root of a monorepo, all packages will now automatically be included in the test suite and it will run just like it does within a package. Each package in the monorepo will still use its own local jest configuration, and only packages that have `backstage-cli test` in the `test` script within `package.json` will be included.

--- a/.changeset/young-ways-trade.md
+++ b/.changeset/young-ways-trade.md
@@ -1,0 +1,12 @@
+---
+'@backstage/create-app': patch
+---
+
+Switched the default `test` script in the package root to use `backstage-cli test` rather than `lerna run test`. This is thanks to the `@backstage/cli` now supporting running the test command from the project root.
+
+To apply this change to an existing project, apply the following change to your root `package.json`:
+
+```diff
+-    "test": "lerna run test --since origin/master -- --coverage",
++    "test": "backstage-cli test",
+```

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -424,7 +424,10 @@ This command uses a default Jest configuration that is included in the CLI,
 which is set up with similar goals for speed, scale, and working within a
 monorepo. The configuration sets the `src` as the root directory, enforces the
 `.test.` infix for tests, and uses `src/setupTests.ts` as the test setup
-location.
+location. The included configuration also supports test execution at the root of
+a yarn workspaces monorepo by automatically creating one grouped configuration
+that includes all packages that have `backstage-cli test` in their package
+`test` script.
 
 If needed, the configuration can be extended using a `"jest"` field in
 `package.json`, both within the target package and the monorepo root, with

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tsc:full": "backstage-cli clean && tsc --skipLibCheck false --incremental false",
     "clean": "backstage-cli clean && lerna run clean",
     "diff": "lerna run diff --",
-    "test": "lerna run test --since origin/master -- --coverage",
+    "test": "backstage-cli test",
     "test:all": "lerna run test -- --coverage",
     "lint": "lerna run lint --since origin/master --",
     "lint:docs": "node ./scripts/check-docs-quality",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,6 +76,7 @@
     "express": "^4.17.1",
     "fork-ts-checker-webpack-plugin": "^4.0.5",
     "fs-extra": "9.1.0",
+    "glob": "^7.1.7",
     "handlebars": "^4.7.3",
     "html-webpack-plugin": "^5.3.1",
     "inquirer": "^7.0.4",

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -15,7 +15,7 @@
     "tsc:full": "tsc --skipLibCheck false --incremental false",
     "clean": "backstage-cli clean && lerna run clean",
     "diff": "lerna run diff --",
-    "test": "lerna run test --since origin/master -- --coverage",
+    "test": "backstage-cli test",
     "test:all": "lerna run test -- --coverage",
     "lint": "lerna run lint --since origin/master --",
     "lint:all": "lerna run lint --",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes so that you no longer need to `cd` into package dirs to run tests effectively. It's a little bit slower to start executing of course, as it includes the entire project. It's a regular `jest` run though, so all the regular options work, including patterns to narrow the test run.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
