### PR TITLE
Chore: Add a comment about backstage-cli info command in the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -38,6 +38,8 @@ labels: bug
 
 <!--- Include as many relevant details about the environment you experienced the bug in -->
 
+<!-- ProTip: You can use `yarn backstage-cli info` command in your Backstage App for this section. -->
+
 - NodeJS Version (v14):
 - Operating System and Version (e.g. Ubuntu 14.04):
 - Browser Information:


### PR DESCRIPTION
Looks neat!

```
▶ yarn backstage-cli info
yarn run v1.22.1
$ /Users/himanshum/workspace/github.com/backstage/backstage/node_modules/.bin/backstage-cli info
OS:   Darwin 20.6.0 - darwin/x64
node: v14.15.5
yarn: 1.22.1
cli:  0.7.14 (local)

Dependencies:
  @backstage/catalog-client       0.3.19
  @backstage/core-api             0.2.23
  @backstage/core-components      0.3.3, 0.4.2, 0.5.0
  @backstage/core                 0.7.14
  @backstage/plugin-catalog-react 0.4.6
✨  Done in 2.75s.
```