### PR TITLE
Support optional [path] argument in create-app command-line utility

### DIFF
--- a/.changeset/neat-rings-protect.md
+++ b/.changeset/neat-rings-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': minor
+---
+
+Support optional path argument when generating a project using `create-app`


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added the ability to supply an optional `path` argument when using the `@backstage/create-app` utility.

When this is specified, copy the newly created application to the specified directory, otherwise, copy the application to a folder based on the application name.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
