### PR TITLE
scaffolder-backend: fixed register action not returning an entity

### DIFF
--- a/.changeset/tricky-geckos-protect.md
+++ b/.changeset/tricky-geckos-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed a bug where the `catalog:register` action would not return any entity when running towards recent versions of the catalog.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.test.ts
@@ -67,25 +67,40 @@ describe('catalog:register', () => {
   });
 
   it('should register location in catalog', async () => {
-    addLocation.mockResolvedValue({
-      entities: [
-        {
-          metadata: {
-            namespace: 'default',
-            name: 'test',
-          },
-          kind: 'Component',
-        } as Entity,
-      ],
-    });
+    addLocation
+      .mockResolvedValueOnce({
+        entities: [],
+      })
+      .mockResolvedValueOnce({
+        entities: [
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'test',
+            },
+            kind: 'Component',
+          } as Entity,
+        ],
+      });
     await action.handler({
       ...mockContext,
       input: {
         catalogInfoUrl: 'http://foo/var',
       },
     });
-    expect(addLocation).toBeCalledWith(
+
+    expect(addLocation).toHaveBeenNthCalledWith(
+      1,
       {
+        type: 'url',
+        target: 'http://foo/var',
+      },
+      {},
+    );
+    expect(addLocation).toHaveBeenNthCalledWith(
+      2,
+      {
+        dryRun: true,
         type: 'url',
         target: 'http://foo/var',
       },
@@ -94,7 +109,65 @@ describe('catalog:register', () => {
 
     expect(mockContext.output).toBeCalledWith(
       'entityRef',
-      'Component:default/test',
+      'component:default/test',
+    );
+    expect(mockContext.output).toBeCalledWith(
+      'catalogInfoUrl',
+      'http://foo/var',
+    );
+  });
+
+  it('should register location in catalog and return the entity and not the generated location', async () => {
+    addLocation
+      .mockResolvedValueOnce({
+        entities: [],
+      })
+      .mockResolvedValueOnce({
+        entities: [
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'generated-1238',
+            },
+            kind: 'Location',
+          } as Entity,
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'test',
+            },
+            kind: 'Component',
+          } as Entity,
+        ],
+      });
+    await action.handler({
+      ...mockContext,
+      input: {
+        catalogInfoUrl: 'http://foo/var',
+      },
+    });
+
+    expect(addLocation).toHaveBeenNthCalledWith(
+      1,
+      {
+        type: 'url',
+        target: 'http://foo/var',
+      },
+      {},
+    );
+    expect(addLocation).toHaveBeenNthCalledWith(
+      2,
+      {
+        dryRun: true,
+        type: 'url',
+        target: 'http://foo/var',
+      },
+      {},
+    );
+
+    expect(mockContext.output).toBeCalledWith(
+      'entityRef',
+      'component:default/test',
     );
     expect(mockContext.output).toBeCalledWith(
       'catalogInfoUrl',


### PR DESCRIPTION
Co-authored-by: Fredrik Adelöw <freben@gmail.com>
Co-authored-by: blam <ben@blam.sh>
Co-authored-by: Johan Haals <johan.haals@gmail.com>
Signed-off-by: Patrik Oldsberg <poldsberg@gmail.com>

## Hey, I just made a Pull Request!

Fixes #6301

Decided to only fix the bug for now as opposed to returning all the entities in the output. This should be compatible with existing templates out there.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
