### PR TITLE
[TechDocs] Update default techdocs docker image to latest version

### DIFF
--- a/.changeset/techdocs-chilled-pans-fix.md
+++ b/.changeset/techdocs-chilled-pans-fix.md
@@ -2,4 +2,4 @@
 '@backstage/techdocs-common': patch
 ---
 
-sets the default techdocs docker image to the [latest released version - 0.3.3](https://github.com/backstage/techdocs-container/releases/tag/0.3.3).
+Sets the default techdocs docker image to the [latest released version - v0.3.3](https://github.com/backstage/techdocs-container/releases/tag/v0.3.3).

--- a/.changeset/techdocs-chilled-pans-fix.md
+++ b/.changeset/techdocs-chilled-pans-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+sets the default techdocs docker image to the [latest released version - 0.3.3](https://github.com/backstage/techdocs-container/releases/tag/0.3.3).

--- a/packages/techdocs-common/api-report.md
+++ b/packages/techdocs-common/api-report.md
@@ -256,7 +256,7 @@ export class TechdocsGenerator implements GeneratorBase {
     config: Config;
     scmIntegrations: ScmIntegrationRegistry;
   });
-  static readonly defaultDockerImage = 'spotify/techdocs:v0.3.2';
+  static readonly defaultDockerImage = 'spotify/techdocs:v0.3.3';
   // (undocumented)
   static fromConfig(
     config: Config,

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -42,7 +42,7 @@ export class TechdocsGenerator implements GeneratorBase {
    * The default docker image (and version) used to generate content. Public
    * and static so that techdocs-common consumers can use the same version.
    */
-  public static readonly defaultDockerImage = 'spotify/techdocs:v0.3.2';
+  public static readonly defaultDockerImage = 'spotify/techdocs:0.3.3';
   private readonly logger: Logger;
   private readonly containerRunner: ContainerRunner;
   private readonly options: GeneratorConfig;

--- a/packages/techdocs-common/src/stages/generate/techdocs.ts
+++ b/packages/techdocs-common/src/stages/generate/techdocs.ts
@@ -42,7 +42,7 @@ export class TechdocsGenerator implements GeneratorBase {
    * The default docker image (and version) used to generate content. Public
    * and static so that techdocs-common consumers can use the same version.
    */
-  public static readonly defaultDockerImage = 'spotify/techdocs:0.3.3';
+  public static readonly defaultDockerImage = 'spotify/techdocs:v0.3.3';
   private readonly logger: Logger;
   private readonly containerRunner: ContainerRunner;
   private readonly options: GeneratorConfig;

--- a/plugins/techdocs-backend/examples/documented-component/docs/extensions.md
+++ b/plugins/techdocs-backend/examples/documented-component/docs/extensions.md
@@ -87,3 +87,20 @@ I've read a lot of documentation, but I love :heart: this document.
 Weather: :sunny: :umbrella: :cloud: :snowflake:
 
 Animals: :tiger: :horse: :turtle: :wolf: :frog:
+
+### MDX truly sane lists
+
+- attributes
+
+- customer
+  - first_name
+    - test
+  - family_name
+  - email
+- person
+  - first_name
+  - family_name
+  - birth_date
+- subscription_id
+
+- request


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR sets the default techdocs docker image to the [latest released version](https://github.com/backstage/techdocs-container/releases/tag/0.3.3). It also adds a example to the docs of a newly introduced extension used for lists. 

**Before**
<img width="1439" alt="Screen Shot 2021-10-05 at 12 09 35 PM" src="https://user-images.githubusercontent.com/25153114/136007003-efb76f26-af59-4667-9884-67366af79a8a.png">

**After**
<img width="1440" alt="Screen Shot 2021-10-05 at 12 27 52 PM" src="https://user-images.githubusercontent.com/25153114/136007013-b4137be6-1c1a-404d-bc0e-fd9b6e142341.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
