### PR TITLE
auth-backend: remove default bitbucket sign-in provider

### DIFF
--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -120,7 +120,7 @@ export type BitbucketPassportProfile = Profile & {
 // @public (undocumented)
 export type BitbucketProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
-  signIn: {
+  signIn?: {
     resolver: SignInResolver<OAuthResult>;
   };
 };
@@ -139,7 +139,7 @@ export const bitbucketUsernameSignInResolver: SignInResolver<BitbucketOAuthResul
 //
 // @public (undocumented)
 export const createBitbucketProvider: (
-  options: BitbucketProviderOptions,
+  options?: BitbucketProviderOptions | undefined,
 ) => AuthProviderFactory;
 
 // Warning: (ae-missing-release-tag) "createGithubProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/auth-backend/src/providers/bitbucket/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.ts
@@ -253,7 +253,7 @@ export type BitbucketProviderOptions = {
   /**
    * Configure sign-in for this provider, without it the provider can not be used to sign users in.
    */
-  signIn: {
+  signIn?: {
     /**
      * Maps an auth result to a Backstage identity for the user.
      */
@@ -262,7 +262,7 @@ export type BitbucketProviderOptions = {
 };
 
 export const createBitbucketProvider = (
-  options: BitbucketProviderOptions,
+  options?: BitbucketProviderOptions,
 ): AuthProviderFactory => {
   return ({
     providerId,
@@ -289,18 +289,11 @@ export const createBitbucketProvider = (
               profile: makeProfileInfo(fullProfile, params.id_token),
             });
 
-      const signInResolver: SignInResolver<BitbucketOAuthResult> = info =>
-        options.signIn.resolver(info, {
-          catalogIdentityClient,
-          tokenIssuer,
-          logger,
-        });
-
       const provider = new BitbucketAuthProvider({
         clientId,
         clientSecret,
         callbackUrl,
-        signInResolver,
+        signInResolver: options?.signIn?.resolver,
         authHandler,
         tokenIssuer,
         catalogIdentityClient,

--- a/plugins/auth-backend/src/providers/factories.ts
+++ b/plugins/auth-backend/src/providers/factories.ts
@@ -26,10 +26,7 @@ import { createMicrosoftProvider } from './microsoft';
 import { createOneLoginProvider } from './onelogin';
 import { AuthProviderFactory } from './types';
 import { createAwsAlbProvider } from './aws-alb';
-import {
-  createBitbucketProvider,
-  bitbucketUsernameSignInResolver,
-} from './bitbucket';
+import { createBitbucketProvider } from './bitbucket';
 
 export const factories: { [providerId: string]: AuthProviderFactory } = {
   google: createGoogleProvider(),
@@ -43,7 +40,5 @@ export const factories: { [providerId: string]: AuthProviderFactory } = {
   oidc: createOidcProvider(),
   onelogin: createOneLoginProvider(),
   awsalb: createAwsAlbProvider(),
-  bitbucket: createBitbucketProvider({
-    signIn: { resolver: bitbucketUsernameSignInResolver },
-  }),
+  bitbucket: createBitbucketProvider(),
 };


### PR DESCRIPTION
This is a followup for #7308, so no changeset