### PR TITLE
core-components: clearer error message for auth providers without sign-in support

### DIFF
--- a/.changeset/cool-bags-appear.md
+++ b/.changeset/cool-bags-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Provide a clearer error message when a authentication provider used by the `SignInPage` has not been configured to support sign-in.

--- a/packages/core-components/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core-components/src/layout/SignInPage/SignInPage.tsx
@@ -120,6 +120,11 @@ export const SingleSignInPage = ({
         identity = await authApi.getBackstageIdentity({
           instantPopup: true,
         });
+        if (!identity) {
+          throw new Error(
+            `The ${provider.title} provider is not configured to support sign-in`,
+          );
+        }
       }
 
       if (!identity) {

--- a/packages/core-components/src/layout/SignInPage/auth0Provider.tsx
+++ b/packages/core-components/src/layout/SignInPage/auth0Provider.tsx
@@ -33,6 +33,11 @@ const Component: ProviderComponent = ({ onResult }) => {
       const identity = await auth0AuthApi.getBackstageIdentity({
         instantPopup: true,
       });
+      if (!identity) {
+        throw new Error(
+          'The Auth0 provider is not configured to support sign-in',
+        );
+      }
 
       const profile = await auth0AuthApi.getProfile();
 

--- a/packages/core-components/src/layout/SignInPage/commonProvider.tsx
+++ b/packages/core-components/src/layout/SignInPage/commonProvider.tsx
@@ -36,6 +36,11 @@ const Component: ProviderComponent = ({ config, onResult }) => {
       const identity = await authApi.getBackstageIdentity({
         instantPopup: true,
       });
+      if (!identity) {
+        throw new Error(
+          `The ${title} provider is not configured to support sign-in`,
+        );
+      }
 
       const profile = await authApi.getProfile();
       onResult({


### PR DESCRIPTION
Looking to start continuing the migration to more clearly separated sign-in providers. This helps clarify when an auth provider hasn't been configured to support sign-in in the auth backend.