### PR TITLE
Support rancher with path prefix

### DIFF
--- a/.changeset/proud-coins-laugh.md
+++ b/.changeset/proud-coins-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Support Rancher urls with an existing path component

--- a/.changeset/proud-coins-laugh.md
+++ b/.changeset/proud-coins-laugh.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes': patch
 ---
 
-Support Rancher urls with an existing path component
+Support Rancher URL's with an existing path component

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.test.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.test.ts
@@ -99,4 +99,19 @@ describe('clusterLinks - rancher formatter', () => {
       'https://k8s.foo.com/explorer/autoscaling.horizontalpodautoscaler/bar/foobar',
     );
   });
+  it('should support subpaths in dashboardUrl', () => {
+    const url = rancherFormatter({
+      dashboardUrl: new URL('https://k8s.foo.com/dashboard/c/c-28a4b/'),
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'Deployment',
+    });
+    expect(url.href).toBe(
+      'https://k8s.foo.com/dashboard/c/c-28a4b/explorer/apps.deployment/bar/foobar',
+    );
+  });
 });

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.ts
@@ -28,9 +28,9 @@ export function rancherFormatter(options: ClusterLinksFormatterOptions): URL {
   const namespace = options.object.metadata?.namespace;
   const validKind = kindMappings[options.kind.toLocaleLowerCase('en-US')];
   if (validKind && name && namespace) {
-    result.pathname = `explorer/${validKind}/${namespace}/${name}`;
+    result.pathname += `explorer/${validKind}/${namespace}/${name}`;
   } else if (namespace) {
-    result.pathname = 'explorer/workload';
+    result.pathname += 'explorer/workload';
   }
   return result;
 }


### PR DESCRIPTION
## Support rancher URLs with a path component.

The URLs in our Rancher 2 environment have an existing cluster prefix path. This updates the path logic to preserve the configured path component of the URL instead of just the host name.

This is a followup to #7309, which added initial support for Rancher.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
