### PR TITLE
fix(SignInPage): avoid executing side effects in render

### DIFF
--- a/.changeset/wicked-dryers-grow.md
+++ b/.changeset/wicked-dryers-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+SignInPage: move the initial invocation of `login` away from the render method

--- a/packages/core-components/src/layout/SignInPage/SignInPage.tsx
+++ b/packages/core-components/src/layout/SignInPage/SignInPage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@backstage/core-plugin-api';
 import { Button, Grid, Typography } from '@material-ui/core';
 import React, { useState } from 'react';
+import { useMount } from 'react-use';
 import { Progress } from '../../components/Progress';
 import { Content } from '../Content/Content';
 import { ContentHeader } from '../ContentHeader/ContentHeader';
@@ -93,7 +94,6 @@ export const SingleSignInPage = ({
   const configApi = useApi(configApiRef);
 
   const [error, setError] = useState<Error>();
-  const [loginCount, setLoginCount] = useState(0);
 
   // The SignIn component takes some time to decide whether the user is logged-in or not.
   // showLoginPage is used to prevent a glitch-like experience where the sign-in page is
@@ -102,7 +102,6 @@ export const SingleSignInPage = ({
 
   type LoginOpts = { checkExisting?: boolean; showPopup?: boolean };
   const login = async ({ checkExisting, showPopup }: LoginOpts) => {
-    setLoginCount(prev => prev + 1);
     try {
       let identity: BackstageIdentity | undefined;
       if (checkExisting) {
@@ -151,9 +150,8 @@ export const SingleSignInPage = ({
       setShowLoginPage(true);
     }
   };
-  if (loginCount === 0) {
-    login({ checkExisting: true });
-  }
+
+  useMount(() => login({ checkExisting: true }));
 
   return showLoginPage ? (
     <Page themeId="home">


### PR DESCRIPTION
Signed-off-by: Vincenzo Scamporlino <me@vinzscam.dev>

## Hey, I just made a Pull Request!

In #7255 an important issue was fixed. This PR moves the initial invocation of `login()` away from the react render lifecycle, since it's a side effect and it violates one of the main React rules.

Tested in Safari for iOS v15.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
