### PR TITLE
Catalog: Replace deprecated material ui components

### DIFF
--- a/.changeset/quick-sheep-decide.md
+++ b/.changeset/quick-sheep-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Replace deprecated material UI components used by LinksCard to remove errors from console log

--- a/plugins/catalog/src/components/EntityLinksCard/LinksGridList.tsx
+++ b/plugins/catalog/src/components/EntityLinksCard/LinksGridList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { GridList, GridListTile } from '@material-ui/core';
+import { ImageList, ImageListItem } from '@material-ui/core';
 import React from 'react';
 import { IconLink } from './IconLink';
 import { ColumnBreakpoints } from './types';
@@ -36,12 +36,12 @@ export const LinksGridList = ({ items, cols = undefined }: Props) => {
   const numOfCols = useDynamicColumns(cols);
 
   return (
-    <GridList cellHeight="auto" cols={numOfCols}>
+    <ImageList rowHeight="auto" cols={numOfCols}>
       {items.map(({ text, href, Icon }, i) => (
-        <GridListTile key={i}>
+        <ImageListItem key={i}>
           <IconLink href={href} text={text ?? href} Icon={Icon} />
-        </GridListTile>
+        </ImageListItem>
       ))}
-    </GridList>
+    </ImageList>
   );
 };


### PR DESCRIPTION
Removes annoying `console.err` by switching replacing deprecated material UI components.

<img width="1465" alt="Screenshot 2021-10-06 at 09 42 21" src="https://user-images.githubusercontent.com/68980/136160871-cf4e9699-d739-4d27-a515-a4c8abe55bef.png">
<img width="447" alt="Screenshot 2021-10-06 at 09 38 48" src="https://user-images.githubusercontent.com/68980/136160877-ff0e7ef4-ddb7-4d69-987f-f3d8b9032499.png">
<img width="447" alt="Screenshot 2021-10-06 at 09 38 29" src="https://user-images.githubusercontent.com/68980/136160878-1467e916-ae70-4709-bfad-5d1eec50f3c7.png">

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
