### PR TITLE
scaffolder: separate out the Template entity kind from the core catalog-model

### DIFF
--- a/.changeset/funny-dolls-draw.md
+++ b/.changeset/funny-dolls-draw.md
@@ -1,0 +1,19 @@
+---
+'@backstage/create-app': patch
+---
+
+The scaffolder plugin has just released the beta 3 version of software templates, which replaces the handlebars templating syntax. As part of this change, the template entity schema is no longer included in the core catalog-model as with previous versions. The decoupling of the template entities version will allow us to more easily make updates in the future.
+
+In order to use the new beta 3 templates, the following changes are **required** for any existing installation, inside `packages/backend/src/plugins/catalog.ts`:
+
+```diff
++import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
+
+...
+
+   const builder = await CatalogBuilder.create(env);
++  builder.addProcessor(new ScaffolderEntitiesProcessor());
+   const { processingEngine, router } = await builder.build();
+```
+
+If you're interested in learning more about creating custom kinds, please check out the [extending the model](https://backstage.io/docs/features/software-catalog/extending-the-model) documentation.

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -15,6 +15,7 @@
  */
 
 import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
+import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 
@@ -22,6 +23,7 @@ export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
   const builder = await CatalogBuilder.create(env);
+  builder.addProcessor(new ScaffolderEntitiesProcessor());
   const { processingEngine, router } = await builder.build();
   await processingEngine.start();
   return router;

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/catalog.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/catalog.ts
@@ -1,4 +1,5 @@
 import { CatalogBuilder } from '@backstage/plugin-catalog-backend';
+import { ScaffolderEntitiesProcessor } from '@backstage/plugin-scaffolder-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 
@@ -6,6 +7,7 @@ export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
   const builder = await CatalogBuilder.create(env);
+  builder.addProcessor(new ScaffolderEntitiesProcessor());
   const { processingEngine, router } = await builder.build();
   await processingEngine.start();
   return router;

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -36,6 +36,8 @@
     "@backstage/config": "^0.1.10",
     "@backstage/errors": "^0.1.2",
     "@backstage/integration": "^0.6.5",
+    "@backstage/plugin-catalog-backend": "^0.15.0",
+    "@backstage/plugin-scaffolder-common": "^0.1.0",
     "@backstage/plugin-scaffolder-backend-module-cookiecutter": "^0.1.2",
     "@gitbeaker/core": "^30.2.0",
     "@gitbeaker/node": "^30.2.0",

--- a/plugins/scaffolder-backend/src/processor/ScaffolderEntitiesProcessor.test.ts
+++ b/plugins/scaffolder-backend/src/processor/ScaffolderEntitiesProcessor.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
-import { TemplateEntityProcessor } from './TemplateEntityProcessor';
+import { ScaffolderEntitiesProcessor } from './ScaffolderEntitiesProcessor';
 
 const mockLocation = { type: 'a', target: 'b' };
 const mockEntity: TemplateEntityV1beta3 = {
@@ -30,10 +30,10 @@ const mockEntity: TemplateEntityV1beta3 = {
   },
 };
 
-describe('TemplateEntityProcessor', () => {
+describe('ScaffolderEntitiesProcessor', () => {
   describe('validateEntityKind', () => {
     it('validates the entity kind', async () => {
-      const processor = new TemplateEntityProcessor();
+      const processor = new ScaffolderEntitiesProcessor();
 
       await expect(processor.validateEntityKind(mockEntity)).resolves.toBe(
         true,
@@ -52,7 +52,7 @@ describe('TemplateEntityProcessor', () => {
 
   describe('postProcessEntity', () => {
     it('generates relations for component entities', async () => {
-      const processor = new TemplateEntityProcessor();
+      const processor = new ScaffolderEntitiesProcessor();
 
       const emit = jest.fn();
 

--- a/plugins/scaffolder-backend/src/processor/ScaffolderEntitiesProcessor.ts
+++ b/plugins/scaffolder-backend/src/processor/ScaffolderEntitiesProcessor.ts
@@ -33,7 +33,7 @@ import {
   templateEntityV1beta3Schema,
 } from '@backstage/plugin-scaffolder-common';
 
-export class TemplateEntityProcessor implements CatalogProcessor {
+export class ScaffolderEntitiesProcessor implements CatalogProcessor {
   private readonly validators = [
     entityKindSchemaValidator(templateEntityV1beta3Schema),
   ];

--- a/plugins/scaffolder-backend/src/processor/TemplateEntityProcessor.test.ts
+++ b/plugins/scaffolder-backend/src/processor/TemplateEntityProcessor.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
+import { TemplateEntityProcessor } from './TemplateEntityProcessor';
+
+const mockLocation = { type: 'a', target: 'b' };
+const mockEntity: TemplateEntityV1beta3 = {
+  apiVersion: 'templates.backstage.io/v1beta3',
+  kind: 'Template',
+  metadata: { name: 'n' },
+  spec: {
+    parameters: {},
+    steps: [],
+    type: 'service',
+    owner: 'o',
+  },
+};
+
+describe('TemplateEntityProcessor', () => {
+  describe('validateEntityKind', () => {
+    it('validates the entity kind', async () => {
+      const processor = new TemplateEntityProcessor();
+
+      await expect(processor.validateEntityKind(mockEntity)).resolves.toBe(
+        true,
+      );
+      await expect(
+        processor.validateEntityKind({
+          ...mockEntity,
+          apiVersion: 'backstage.io/v1beta3',
+        }),
+      ).resolves.toBe(false);
+      await expect(
+        processor.validateEntityKind({ ...mockEntity, kind: 'Component' }),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe('postProcessEntity', () => {
+    it('generates relations for component entities', async () => {
+      const processor = new TemplateEntityProcessor();
+
+      const emit = jest.fn();
+
+      await processor.postProcessEntity(mockEntity, mockLocation, emit);
+
+      expect(emit).toBeCalledTimes(2);
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Group', namespace: 'default', name: 'o' },
+          type: 'ownerOf',
+          target: { kind: 'Template', namespace: 'default', name: 'n' },
+        },
+      });
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Template', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'o' },
+        },
+      });
+    });
+  });
+});

--- a/plugins/scaffolder-backend/src/processor/TemplateEntityProcessor.test.ts
+++ b/plugins/scaffolder-backend/src/processor/TemplateEntityProcessor.test.ts
@@ -19,7 +19,7 @@ import { TemplateEntityProcessor } from './TemplateEntityProcessor';
 
 const mockLocation = { type: 'a', target: 'b' };
 const mockEntity: TemplateEntityV1beta3 = {
-  apiVersion: 'templates.backstage.io/v1beta3',
+  apiVersion: 'scaffolder.backstage.io/v1beta3',
   kind: 'Template',
   metadata: { name: 'n' },
   spec: {

--- a/plugins/scaffolder-backend/src/processor/TemplateEntityProcessor.ts
+++ b/plugins/scaffolder-backend/src/processor/TemplateEntityProcessor.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  getEntityName,
+  LocationSpec,
+  parseEntityRef,
+  RELATION_OWNED_BY,
+  RELATION_OWNER_OF,
+  entityKindSchemaValidator,
+} from '@backstage/catalog-model';
+import {
+  CatalogProcessor,
+  CatalogProcessorEmit,
+  results,
+} from '@backstage/plugin-catalog-backend';
+import {
+  TemplateEntityV1beta3,
+  templateEntityV1beta3Schema,
+} from '@backstage/plugin-scaffolder-common';
+
+export class TemplateEntityProcessor implements CatalogProcessor {
+  private readonly validators = [
+    entityKindSchemaValidator(templateEntityV1beta3Schema),
+  ];
+
+  async validateEntityKind(entity: Entity): Promise<boolean> {
+    for (const validator of this.validators) {
+      if (validator(entity)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  async postProcessEntity(
+    entity: Entity,
+    _location: LocationSpec,
+    emit: CatalogProcessorEmit,
+  ): Promise<Entity> {
+    const selfRef = getEntityName(entity);
+
+    if (
+      entity.apiVersion === 'templates.backstage.io/v1beta3' &&
+      entity.kind === 'Template'
+    ) {
+      const template = entity as TemplateEntityV1beta3;
+
+      const target = template.spec.owner;
+      if (target) {
+        const targetRef = parseEntityRef(target, {
+          defaultKind: 'Group',
+          defaultNamespace: selfRef.namespace,
+        });
+        emit(
+          results.relation({
+            source: selfRef,
+            type: RELATION_OWNED_BY,
+            target: {
+              kind: targetRef.kind,
+              namespace: targetRef.namespace,
+              name: targetRef.name,
+            },
+          }),
+        );
+        emit(
+          results.relation({
+            source: {
+              kind: targetRef.kind,
+              namespace: targetRef.namespace,
+              name: targetRef.name,
+            },
+            type: RELATION_OWNER_OF,
+            target: selfRef,
+          }),
+        );
+      }
+    }
+
+    return entity;
+  }
+}

--- a/plugins/scaffolder-backend/src/processor/TemplateEntityProcessor.ts
+++ b/plugins/scaffolder-backend/src/processor/TemplateEntityProcessor.ts
@@ -56,7 +56,7 @@ export class TemplateEntityProcessor implements CatalogProcessor {
     const selfRef = getEntityName(entity);
 
     if (
-      entity.apiVersion === 'templates.backstage.io/v1beta3' &&
+      entity.apiVersion === 'scaffolder.backstage.io/v1beta3' &&
       entity.kind === 'Template'
     ) {
       const template = entity as TemplateEntityV1beta3;

--- a/plugins/scaffolder-backend/src/processor/index.ts
+++ b/plugins/scaffolder-backend/src/processor/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,4 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that helps you create new things
- *
- * @packageDocumentation
- */
-
-export * from './scaffolder';
-export * from './service/router';
-export * from './lib/catalog';
-export * from './processor';
+export { TemplateEntityProcessor } from './TemplateEntityProcessor';

--- a/plugins/scaffolder-backend/src/processor/index.ts
+++ b/plugins/scaffolder-backend/src/processor/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { TemplateEntityProcessor } from './TemplateEntityProcessor';
+export { ScaffolderEntitiesProcessor } from './ScaffolderEntitiesProcessor';

--- a/plugins/scaffolder-common/.eslintrc.js
+++ b/plugins/scaffolder-common/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint.backend')],
+};

--- a/plugins/scaffolder-common/README.md
+++ b/plugins/scaffolder-common/README.md
@@ -1,0 +1,3 @@
+# @backstage/plugin-scaffolder-common
+
+Common types and functionalities for the scaffolder, to be shared between scaffolder and scaffolder-backend.

--- a/plugins/scaffolder-common/package.json
+++ b/plugins/scaffolder-common/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@backstage/plugin-scaffolder-common",
+  "description": "Common functionalities for the scaffolder, to be shared between scaffolder and scaffolder-backend plugin",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugin/scaffolder-common"
+  },
+  "keywords": [
+    "techdocs",
+    "scaffolder"
+  ],
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "backstage-cli build",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
+    "clean": "backstage-cli clean"
+  },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
+  "dependencies": {
+    "@backstage/catalog-model": "^0.9.3",
+    "@backstage/config": "^0.1.10"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.7.13"
+  }
+}

--- a/plugins/scaffolder-common/src/Template.v1beta3.schema.json
+++ b/plugins/scaffolder-common/src/Template.v1beta3.schema.json
@@ -4,7 +4,7 @@
   "description": "A Template describes a scaffolding task for use with the Scaffolder. It describes the required parameters as well as a series of steps that will be taken to execute the scaffolding task.",
   "examples": [
     {
-      "apiVersion": "templates.backstage.io/v1beta3",
+      "apiVersion": "scaffolder.backstage.io/v1beta3",
       "kind": "Template",
       "metadata": {
         "name": "react-ssr-template",
@@ -68,7 +68,7 @@
       "required": ["spec"],
       "properties": {
         "apiVersion": {
-          "enum": ["templates.backstage.io/v1beta3"]
+          "enum": ["scaffolder.backstage.io/v1beta3"]
         },
         "kind": {
           "enum": ["Template"]

--- a/plugins/scaffolder-common/src/Template.v1beta3.schema.json
+++ b/plugins/scaffolder-common/src/Template.v1beta3.schema.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "TemplateV1beta3",
+  "description": "A Template describes a scaffolding task for use with the Scaffolder. It describes the required parameters as well as a series of steps that will be taken to execute the scaffolding task.",
+  "examples": [
+    {
+      "apiVersion": "templates.backstage.io/v1beta3",
+      "kind": "Template",
+      "metadata": {
+        "name": "react-ssr-template",
+        "title": "React SSR Template",
+        "description": "Next.js application skeleton for creating isomorphic web applications.",
+        "tags": ["recommended", "react"]
+      },
+      "spec": {
+        "owner": "artist-relations-team",
+        "parameters": {
+          "required": ["name", "description", "repoUrl"],
+          "properties": {
+            "name": {
+              "title": "Name",
+              "type": "string",
+              "description": "Unique name of the component"
+            },
+            "description": {
+              "title": "Description",
+              "type": "string",
+              "description": "Description of the component"
+            },
+            "repoUrl": {
+              "title": "Pick a repository",
+              "type": "string",
+              "ui:field": "RepoUrlPicker"
+            }
+          }
+        },
+        "steps": [
+          {
+            "id": "fetch",
+            "name": "Fetch",
+            "action": "fetch:plain",
+            "parameters": {
+              "url": "./template"
+            }
+          },
+          {
+            "id": "publish",
+            "name": "Publish to GitHub",
+            "action": "publish:github",
+            "parameters": {
+              "repoUrl": "${{ parameters.repoUrl }}"
+            },
+            "if": "${{ parameters.repoUrl }}"
+          }
+        ],
+        "output": {
+          "catalogInfoUrl": "${{ steps.publish.output.catalogInfoUrl }}"
+        }
+      }
+    }
+  ],
+  "allOf": [
+    {
+      "$ref": "Entity"
+    },
+    {
+      "type": "object",
+      "required": ["spec"],
+      "properties": {
+        "apiVersion": {
+          "enum": ["templates.backstage.io/v1beta3"]
+        },
+        "kind": {
+          "enum": ["Template"]
+        },
+        "spec": {
+          "type": "object",
+          "required": ["type", "steps"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The type of component created by the template. The software catalog accepts any type value, but an organization should take great care to establish a proper taxonomy for these. Tools including Backstage itself may read this field and behave differently depending on its value. For example, a website type component may present tooling in the Backstage interface that is specific to just websites.",
+              "examples": ["service", "website", "library"],
+              "minLength": 1
+            },
+            "parameters": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "description": "The JSONSchema describing the inputs for the template."
+                },
+                {
+                  "type": "array",
+                  "description": "A list of separate forms to collect parameters.",
+                  "items": {
+                    "type": "object",
+                    "description": "The JSONSchema describing the inputs for the template."
+                  }
+                }
+              ]
+            },
+            "steps": {
+              "type": "array",
+              "description": "A list of steps to execute.",
+              "items": {
+                "type": "object",
+                "description": "A description of the step to execute.",
+                "required": ["action"],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The ID of the step, which can be used to refer to its outputs."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the step, which will be displayed in the UI during the scaffolding process."
+                  },
+                  "action": {
+                    "type": "string",
+                    "description": "The name of the action to execute."
+                  },
+                  "input": {
+                    "type": "object",
+                    "description": "A templated object describing the inputs to the action."
+                  },
+                  "if": {
+                    "type": ["string", "boolean"],
+                    "description": "A templated condition that skips the step when evaluated to false. If the condition is true or not defined, the step is executed. The condition is true, if the input is not `false`, `undefined`, `null`, `\"\"`, `0`, or `[]`."
+                  }
+                }
+              }
+            },
+            "output": {
+              "type": "object",
+              "description": "A templated object describing the outputs of the scaffolding task.",
+              "properties": {
+                "links": {
+                  "type": "array",
+                  "description": "A list of external hyperlinks, typically pointing to resources created or updated by the template",
+                  "items": {
+                    "type": "object",
+                    "required": [],
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "description": "A url in a standard uri format.",
+                        "examples": ["https://github.com/my-org/my-new-repo"],
+                        "minLength": 1
+                      },
+                      "entityRef": {
+                        "type": "string",
+                        "description": "An entity reference to an entity in the catalog.",
+                        "examples": ["Component:default/my-app"],
+                        "minLength": 1
+                      },
+                      "title": {
+                        "type": "string",
+                        "description": "A user friendly display name for the link.",
+                        "examples": ["View new repo"],
+                        "minLength": 1
+                      },
+                      "icon": {
+                        "type": "string",
+                        "description": "A key representing a visual icon to be displayed in the UI.",
+                        "examples": ["dashboard"],
+                        "minLength": 1
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "owner": {
+              "type": "string",
+              "description": "The user (or group) owner of the template",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/plugins/scaffolder-common/src/TemplateEntityV1beta3.test.ts
+++ b/plugins/scaffolder-common/src/TemplateEntityV1beta3.test.ts
@@ -25,7 +25,7 @@ describe('templateEntityV1beta3Validator', () => {
 
   beforeEach(() => {
     entity = {
-      apiVersion: 'templates.backstage.io/v1beta3',
+      apiVersion: 'scaffolder.backstage.io/v1beta3',
       kind: 'Template',
       metadata: {
         name: 'test',

--- a/plugins/scaffolder-common/src/TemplateEntityV1beta3.test.ts
+++ b/plugins/scaffolder-common/src/TemplateEntityV1beta3.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { entityKindSchemaValidator } from '@backstage/catalog-model';
+import type { TemplateEntityV1beta3 } from './TemplateEntityV1beta3';
+import schema from './Template.v1beta3.schema.json';
+
+const validator = entityKindSchemaValidator(schema);
+
+describe('templateEntityV1beta3Validator', () => {
+  let entity: TemplateEntityV1beta3;
+
+  beforeEach(() => {
+    entity = {
+      apiVersion: 'templates.backstage.io/v1beta3',
+      kind: 'Template',
+      metadata: {
+        name: 'test',
+      },
+      spec: {
+        type: 'website',
+        parameters: {
+          required: ['storePath', 'owner'],
+          properties: {
+            owner: {
+              type: 'string',
+              title: 'Owner',
+              description: 'Who is going to own this component',
+            },
+          },
+        },
+        steps: [
+          {
+            id: 'fetch',
+            name: 'Fetch',
+            action: 'fetch:plan',
+            input: {
+              url: './template',
+            },
+            if: '${{ parameters.owner }}',
+          },
+        ],
+        output: {
+          fetchUrl: '${{ steps.fetch.output.targetUrl }}',
+        },
+        owner: 'team-b@example.com',
+      },
+    };
+  });
+
+  it('happy path: accepts valid data', async () => {
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('ignores unknown apiVersion', async () => {
+    (entity as any).apiVersion = 'backstage.io/v1beta0';
+    expect(validator(entity)).toBe(false);
+  });
+
+  it('ignores unknown kind', async () => {
+    (entity as any).kind = 'Wizard';
+    expect(validator(entity)).toBe(false);
+  });
+
+  it('rejects missing type', async () => {
+    delete (entity as any).spec.type;
+    expect(() => validator(entity)).toThrow(/type/);
+  });
+
+  it('accepts any other type', async () => {
+    (entity as any).spec.type = 'hallo';
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('accepts missing parameters', async () => {
+    delete (entity as any).spec.parameters;
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('accepts missing outputs', async () => {
+    delete (entity as any).spec.outputs;
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('rejects empty type', async () => {
+    (entity as any).spec.type = '';
+    expect(() => validator(entity)).toThrow(/type/);
+  });
+
+  it('rejects missing steps', async () => {
+    delete (entity as any).spec.steps;
+    expect(() => validator(entity)).toThrow(/steps/);
+  });
+
+  it('accepts step with missing id', async () => {
+    delete (entity as any).spec.steps[0].id;
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('accepts step with missing name', async () => {
+    delete (entity as any).spec.steps[0].name;
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('rejects step with missing action', async () => {
+    delete (entity as any).spec.steps[0].action;
+    expect(() => validator(entity)).toThrow(/action/);
+  });
+
+  it('accepts missing owner', async () => {
+    delete (entity as any).spec.owner;
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('rejects empty owner', async () => {
+    (entity as any).spec.owner = '';
+    expect(() => validator(entity)).toThrow(/owner/);
+  });
+
+  it('rejects wrong type owner', async () => {
+    (entity as any).spec.owner = 5;
+    expect(() => validator(entity)).toThrow(/owner/);
+  });
+
+  it('accepts missing if', async () => {
+    delete (entity as any).spec.steps[0].if;
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('accepts boolean in if', async () => {
+    (entity as any).spec.steps[0].if = true;
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('accepts empty if', async () => {
+    (entity as any).spec.steps[0].if = '';
+    expect(validator(entity)).toBe(entity);
+  });
+
+  it('rejects wrong type if', async () => {
+    (entity as any).spec.steps[0].if = 5;
+    expect(() => validator(entity)).toThrow(/if/);
+  });
+});

--- a/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
+++ b/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
@@ -19,7 +19,7 @@ import { Entity } from '@backstage/catalog-model';
 
 /** @public */
 export interface TemplateEntityV1beta3 extends Entity {
-  apiVersion: 'templates.backstage.io/v1beta3';
+  apiVersion: 'scaffolder.backstage.io/v1beta3';
   kind: 'Template';
   spec: {
     type: string;

--- a/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
+++ b/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/config';
+import { Entity } from '@backstage/catalog-model';
+
+/** @public */
+export interface TemplateEntityV1beta3 extends Entity {
+  apiVersion: 'templates.backstage.io/v1beta3';
+  kind: 'Template';
+  spec: {
+    type: string;
+    parameters?: JsonObject | JsonObject[];
+    steps: Array<{
+      id?: string;
+      name?: string;
+      action: string;
+      input?: JsonObject;
+      if?: string | boolean;
+    }>;
+    output?: { [name: string]: string };
+    owner?: string;
+  };
+}

--- a/plugins/scaffolder-common/src/index.ts
+++ b/plugins/scaffolder-common/src/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common functionalities for the scaffolder, to be shared between scaffolder and scaffolder-backend plugin
+ *
+ * @packageDocumentation
+ */
+
+// The `{ default as ...}` re-export does not seem to work for json in tests
+import templateEntityV1beta3Schema from './Template.v1beta3.schema.json';
+
+export type { TemplateEntityV1beta3 } from './TemplateEntityV1beta3';
+export { templateEntityV1beta3Schema };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This replaces parts of #7355, but also depends on it.

As part of iterating on the scaffolder template schema we've realized there's a version scoping issue. The core catalog-model has been receiving version bumps quite quickly, but the only new additions have been changes to the template entity kind. The template kind itself is also very closely tied to the scaffolder implementation, and arguably doesn't belong in the core model.

To solve this we move the `Template` kind into the scaffolder plugin. The type and JSONSchema end up in a new `@backstage/plugin-scaffolder-common` package for consumption in both the frontend and the backend. We also export a new `ScaffolderEntitiesProcessor` from `@backstage/plugin-scaffolder-backend`, which is similar to the `BuiltinKindsEntityProcessor` in the catalog, but only handles the latest version of the `Template` kind. This new processor enables the usage of template entities and needs to be installed in the catalog backend like any other custom processor.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
