### PR TITLE
Button Component styling issue 

### DIFF
--- a/packages/core-components/src/components/Button/Button.tsx
+++ b/packages/core-components/src/components/Button/Button.tsx
@@ -40,9 +40,20 @@ export type ButtonProps = MaterialButtonProps &
  */
 declare function ButtonType(props: ButtonProps): JSX.Element;
 
-const ActualButton = React.forwardRef<any, ButtonProps>((props, ref) => (
-  <MaterialButton ref={ref} component={Link} {...props} />
-)) as { (props: ButtonProps): JSX.Element };
+const ActualButton = React.forwardRef<any, ButtonProps>((props, ref) => {
+  /**
+    This temporarily fixes a bug in material-ui where the color of the Link
+    overrides the color of the button
+    https://github.com/mui-org/material-ui/issues/28852
+  */
+  let color;
+  if (props.variant === 'contained') {
+    color = 'white';
+  }
+  return (
+    <MaterialButton ref={ref} component={Link} style={{ color }} {...props} />
+  );
+}) as { (props: ButtonProps): JSX.Element };
 
 // TODO(Rugvip): We use this as a workaround to make the exported type be a
 //               function, which makes our API reference docs much nicer.


### PR DESCRIPTION
Signed-off-by: Emma Indal <emma.indahl@gmail.com>

## Hey, I just made a Pull Request!

This PR fixes a styling issue when using Button component with variant contained

See storybook https://backstage.io/storybook/?path=/story/inputs-button--default where the Button has the same background and text.

reported here: https://github.com/mui-org/material-ui/issues/28852

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
