### PR TITLE
catalog-backend: avoid duplicate logging of catalog processing errors

### DIFF
--- a/.changeset/spotty-carpets-help.md
+++ b/.changeset/spotty-carpets-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Avoid duplicate logging of entity processing errors.

--- a/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/next/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -160,7 +160,6 @@ export class DefaultCatalogProcessingOrchestrator
         ok: collectorResults.errors.length === 0,
       };
     } catch (error) {
-      this.options.logger.warn(error.message);
       return {
         ok: false,
         errors: collector.results().errors.concat(error),


### PR DESCRIPTION
🧹 

It's logged with more context outside: https://github.com/backstage/backstage/blob/09d8329052230bece93e153d874bf680e15aef5f/plugins/catalog-backend/src/next/DefaultCatalogProcessingEngine.ts#L182