### PR TITLE
catalog-backend/chore: replace regexp with trimEnd

### DIFF
--- a/.changeset/unlucky-guests-relax.md
+++ b/.changeset/unlucky-guests-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Replace slash stripping regexp with trimEnd to remove CodeQL warning

--- a/plugins/catalog-backend/src/ingestion/processors/github/config.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/config.ts
@@ -15,6 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
+import { trimEnd } from 'lodash';
 
 /**
  * The configuration parameters for a single GitHub API provider.
@@ -52,12 +53,12 @@ export function readGithubConfig(config: Config): ProviderConfig[] {
 
   // First read all the explicit providers
   for (const providerConfig of providerConfigs) {
-    const target = providerConfig.getString('target').replace(/\/+$/, '');
+    const target = trimEnd(providerConfig.getString('target'), '/');
     let apiBaseUrl = providerConfig.getOptionalString('apiBaseUrl');
     const token = providerConfig.getOptionalString('token');
 
     if (apiBaseUrl) {
-      apiBaseUrl = apiBaseUrl.replace(/\/+$/, '');
+      apiBaseUrl = trimEnd(apiBaseUrl, '/');
     } else if (target === 'https://github.com') {
       apiBaseUrl = 'https://api.github.com';
     }


### PR DESCRIPTION
Replace slash stripping regexp with trimEnd to remove CodeQL warning

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
