### PR TITLE
Added Shortcuts to Plugin Marketplace

### DIFF
--- a/microsite/data/plugins/shortcuts.yaml
+++ b/microsite/data/plugins/shortcuts.yaml
@@ -1,0 +1,9 @@
+---
+title: Shortcuts
+author: Spotify
+authorUrl: https://github.com/spotify
+category: Utility
+description: The shortcuts plugin allows a user to have easy access to pages within a Backstage app by storing them as "shortcuts" in the Sidebar.
+documentation: https://github.com/backstage/backstage/blob/master/plugins/shortcuts/README.md
+iconUrl: img/shortcuts.svg
+npmPackageName: '@backstage/plugin-shortcuts'

--- a/microsite/static/img/shortcuts.svg
+++ b/microsite/static/img/shortcuts.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#FFFFFF"><g><rect fill="none" height="24" width="24"/></g><g><path d="M14,10H3v2h11V10z M14,6H3v2h11V6z M18,14v-4h-2v4h-4v2h4v4h2v-4h4v-2H18z M3,16h7v-2H3V16z"/></g></svg>


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <awanlin@rapidrtc.com>

## Hey, I just made a Pull Request!

This adds the Shortcuts plugin to the Plugin Marketplace. 
 
@marcuseide should I use your name or Spotify as the author for this? Is that okay with you?  From looking at the history you are the one who contributed this. We've been using it for our Backstage instance and find it very handy. It seems odd that it's not in the Plugin Marketplace!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
