### PR TITLE
Update DockerFile for Build

### DIFF
--- a/contrib/docker/frontend-with-nginx/Dockerfile.dockerbuild
+++ b/contrib/docker/frontend-with-nginx/Dockerfile.dockerbuild
@@ -54,5 +54,6 @@ COPY --from=build /app/packages/app/dist /usr/share/nginx/html
 COPY docker/default.conf.template /etc/nginx/templates/default.conf.template
 
 COPY docker/inject-config.sh /docker-entrypoint.d/40-inject-config.sh
+RUN chmod +x /docker-entrypoint.d/40-inject-config.sh
 
 ENV PORT 80


### PR DESCRIPTION
Make entrypoint script executable otherwise it wont be launched. See https://github.com/nginxinc/docker-nginx/blob/master/stable/alpine/docker-entrypoint.sh#L20

I had problem with getting configuration injected into container, see Issue
[backstage/backstage] Trying to create a Docker Container to Run Front-End with app-config configurable (#7490)

The change is in /contrib directory and should not impact core features

The change added line to make entrypoint script executable, otherwise it is skipped see:
https://github.com/nginxinc/docker-nginx/blob/master/stable/alpine/docker-entrypoint.sh#L20

Also following log from container without change:
```bash
/docker-entrypoint.sh: Ignoring /docker-entrypoint.d/40-inject-config.sh, not executable
```
Log with change:
```bash
/docker-entrypoint.sh: Launching /docker-entrypoint.d/40-inject-config.sh
Runtime app config: {
....
```

