### PR TITLE
fix check null error

### DIFF
--- a/.changeset/hip-suns-fix.md
+++ b/.changeset/hip-suns-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+update the null check to use the optional chaining operator in case of non-null assertion operator is not working in function extractInitials(values: string)

--- a/packages/core-components/src/components/Avatar/utils.ts
+++ b/packages/core-components/src/components/Avatar/utils.ts
@@ -28,5 +28,5 @@ export function stringToColor(str: string) {
 }
 
 export function extractInitials(value: string) {
-  return value.match(/\b\w/g)!.join('').substring(0, 2);
+  return value.match(/\b\w/g)?.join('').substring(0, 2);
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Fix the error when navigate to /catalog/default/group/group-name
```
Error
TypeError

Message
Cannot read properties of null (reading 'join')

Stack Trace
TypeError: Cannot read properties of null (reading 'join')
    at extractInitials (webpack-internal:///../core-components/src/components/Avatar/utils.ts:37:30)
    at Avatar (webpack-internal:///../core-components/src/components/Avatar/Avatar.tsx:85:79)
    ...
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
