### PR TITLE
Fix `<ComponentTabs>` to display only the selected tab, not the other way around

### DIFF
--- a/.changeset/two-foxes-marry.md
+++ b/.changeset/two-foxes-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Fix `<ComponentTabs>` to display only the selected tab, not the other way around.

--- a/plugins/home/src/componentRenderers/ComponentTabs/ComponentTabs.test.tsx
+++ b/plugins/home/src/componentRenderers/ComponentTabs/ComponentTabs.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { ComponentTabs } from './ComponentTabs';
+
+describe('<ComponentTabs>', () => {
+  test('should render tabs without exploding', () => {
+    const { getByText } = render(
+      <ComponentTabs
+        title="Random Jokes"
+        tabs={[
+          {
+            label: 'TabA',
+            Component: () => <>ContentA</>,
+          },
+          {
+            label: 'TabB',
+            Component: () => <>ContentB</>,
+          },
+        ]}
+      />,
+    );
+
+    expect(getByText('TabA')).toBeInTheDocument();
+    expect(getByText('TabB')).toBeInTheDocument();
+
+    expect(getByText('ContentA')).toBeInTheDocument();
+    expect(getByText('ContentB')).toHaveStyle({
+      display: 'none',
+    });
+  });
+
+  test('should switch tab on click', () => {
+    const { getByText } = render(
+      <ComponentTabs
+        title="Random Jokes"
+        tabs={[
+          {
+            label: 'TabA',
+            Component: () => <>ContentA</>,
+          },
+          {
+            label: 'TabB',
+            Component: () => <>ContentB</>,
+          },
+        ]}
+      />,
+    );
+
+    expect(getByText('ContentB')).toHaveStyle({
+      display: 'none',
+    });
+
+    userEvent.click(getByText('TabB'));
+
+    expect(getByText('ContentA')).toHaveStyle({
+      display: 'none',
+    });
+  });
+});

--- a/plugins/home/src/componentRenderers/ComponentTabs/ComponentTabs.tsx
+++ b/plugins/home/src/componentRenderers/ComponentTabs/ComponentTabs.tsx
@@ -44,7 +44,10 @@ export const ComponentTabs = ({
         ))}
       </Tabs>
       {tabs.map(({ Component }, idx) => (
-        <div {...(idx === value ? { style: { display: 'none' } } : {})}>
+        <div
+          key={idx}
+          {...(idx !== value ? { style: { display: 'none' } } : {})}
+        >
           <Component />
         </div>
       ))}


### PR DESCRIPTION
I actually just wanted to fix the missing `key` property, but noticed that the issue is a bit bigger. Not sure if the component itself has a really good implementation. Would probably better to remove the content of the tabs instead of hiding them? But the lack of tests for the home plugin is too damn high! So I added one for this case.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
