### PR TITLE
Make prettier happy when generating plugins

### DIFF
--- a/.changeset/olive-mayflies-scream.md
+++ b/.changeset/olive-mayflies-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Add semicolon in template to make prettier happy

--- a/packages/cli/templates/default-plugin/src/setupTests.ts
+++ b/packages/cli/templates/default-plugin/src/setupTests.ts
@@ -1,2 +1,2 @@
 import '@testing-library/jest-dom';
-import 'cross-fetch/polyfill'
+import 'cross-fetch/polyfill';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've noticed that creating a plugin and immediately running `prettier check` causes failures due to the missing semicolon in this file.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
