### PR TITLE
Resolve a warning in `<Button>` related to not using `React.forwardRef`

### DIFF
--- a/.changeset/hungry-bugs-drop.md
+++ b/.changeset/hungry-bugs-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Resolve a warning in `<Button>` related to not using `React.forwardRef`.

--- a/packages/core-components/src/components/Button/Button.tsx
+++ b/packages/core-components/src/components/Button/Button.tsx
@@ -43,7 +43,9 @@ declare function ButtonType(props: ButtonProps): JSX.Element;
 /**
  * This wrapper is here to reset the color of the Link and make typescript happy.
  */
-const LinkWrapper = (props: LinkProps) => <Link {...props} color="initial" />;
+const LinkWrapper = React.forwardRef<any, LinkProps>((props, ref) => (
+  <Link ref={ref} {...props} color="initial" />
+));
 
 const ActualButton = React.forwardRef<any, ButtonProps>((props, ref) => (
   <MaterialButton ref={ref} component={LinkWrapper} {...props} />


### PR DESCRIPTION
This made React warnings pop up here and there when navigating through Backstage, like:

```
react_devtools_backend.js:2526 Warning: Failed prop type: Invalid prop `component` supplied to `ForwardRef(ButtonBase)`. Expected an element type that can hold a ref. Did you accidentally provide a plain function component instead? For more information see https://material-ui.com/r/caveat-with-refs-guide
    in ForwardRef(ButtonBase) (created by WithStyles(ForwardRef(ButtonBase)))
    in WithStyles(ForwardRef(ButtonBase)) (created by ForwardRef(Button))
    in ForwardRef(Button) (created by WithStyles(ForwardRef(Button)))
    in WithStyles(ForwardRef(Button)) (at Button.tsx:49)
    in ForwardRef (at DomainCard.tsx:70)
    in div (created by ForwardRef(CardActions))
    in ForwardRef(CardActions) (created by WithStyles(ForwardRef(CardActions)))
    in WithStyles(ForwardRef(CardActions)) (at DomainCard.tsx:69)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by ForwardRef(Card))
    in ForwardRef(Card) (created by WithStyles(ForwardRef(Card)))
    in WithStyles(ForwardRef(Card)) (at DomainCard.tsx:55)
    in DomainCard (at DomainExplorerContent.tsx:82)
    in div (at ItemCardGrid.tsx:60)
    in ItemCardGrid (at DomainExplorerContent.tsx:80)
    in Body (at DomainExplorerContent.tsx:100)
    in article (at Content.tsx:59)
    in Content (at DomainExplorerContent.tsx:96)
    in DomainExplorerContent (at DefaultExplorePage.tsx:35)
    in article (at Content.tsx:59)
    in Content (at RoutedTabs.tsx:78)
    in RoutedTabs (at ExploreLayout.tsx:83)
    in div (at Page.tsx:52)
    in ThemeProvider (at Page.tsx:46)
    in Page (at ExploreLayout.tsx:78)
    in ExploreLayout (at DefaultExplorePage.tsx:30)
    in DefaultExplorePage (at ExplorePage.tsx:24)
    in ExplorePage (at extensions.tsx:63)
    in RoutableExtension(ExplorePage) (at extensions.tsx:152)
    in AnalyticsContext (at extensions.tsx:145)
    in PluginErrorBoundary (at extensions.tsx:144)
    in Suspense (at extensions.tsx:143)
    in Extension(ExplorePage) (at App.tsx:183)
    in Route (at App.tsx:183)
    in FlatRoutes (at App.tsx:133)
    in div (at Page.tsx:76)
    in SidebarPage (at Root.tsx:79)
    in Root (at App.tsx:214)
    in Route (at App.tsx:384)
    in Routes (at App.tsx:383)
    in SignInPageWrapper (at App.tsx:382)
    in Router (created by BrowserRouter)
    in BrowserRouter (at App.tsx:380)
    in AppRouter (at App.tsx:213)
    in RoutingProvider (at App.tsx:316)
    in CssBaseline (created by WithStyles(CssBaseline))
    in WithStyles(CssBaseline) (at AppThemeProvider.tsx:94)
    in ThemeProvider (at AppThemeProvider.tsx:93)
    in AppThemeProvider (at App.tsx:315)
    in AppContextProvider (at App.tsx:314)
    in ApiProvider (at App.tsx:160)
    in Provider (at App.tsx:210)
    in App (created by HotExportedApp)
    in AppContainer (created by HotExportedApp)
    in HotExportedApp (at src/index.tsx:22)
overrideMethod @ react_devtools_backend.js:2526
printWarning @ checkPropTypes.js:20
checkPropTypes @ checkPropTypes.js:82
validatePropTypes @ react.development.js:1714
createElementWithValidation @ react.development.js:1813
React$$1.createElement @ react-hot-loader.development.js:2915
WithStyles @ withStyles.js:79
renderWithHooks @ react-dom.development.js:14826
updateForwardRef @ react-dom.development.js:16841
beginWork @ react-dom.development.js:18679
beginWork$1 @ react-dom.development.js:23211
performUnitOfWork @ react-dom.development.js:22186
workLoopSync @ react-dom.development.js:22162
performSyncWorkOnRoot @ react-dom.development.js:21788
eval @ react-dom.development.js:11112
unstable_runWithPriority @ scheduler.development.js:653
runWithPriority$1 @ react-dom.development.js:11062
flushSyncCallbackQueueImpl @ react-dom.development.js:11107
flushSyncCallbackQueue @ react-dom.development.js:11095
scheduleUpdateOnFiber @ react-dom.development.js:21231
dispatchAction @ react-dom.development.js:15683
eval @ useAsyncFn.js:18
Promise.then (async)
eval @ useAsyncFn.js:17
eval @ useAsync.js:9
commitHookEffectListMount @ react-dom.development.js:19765
commitPassiveHookEffects @ react-dom.development.js:19803
callCallback @ react-dom.development.js:189
invokeGuardedCallbackDev @ react-dom.development.js:238
invokeGuardedCallback @ react-dom.development.js:293
flushPassiveEffectsImpl @ react-dom.development.js:22885
unstable_runWithPriority @ scheduler.development.js:653
runWithPriority$1 @ react-dom.development.js:11062
flushPassiveEffects @ react-dom.development.js:22852
eval @ react-dom.development.js:22731
workLoop @ scheduler.development.js:597
flushWork @ scheduler.development.js:552
performWorkUntilDeadline @ scheduler.development.js:164
react_devtools_backend.js:2526 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `ForwardRef(ButtonBase)`.
    in LinkWrapper (created by ForwardRef(ButtonBase))
    in ForwardRef(ButtonBase) (created by WithStyles(ForwardRef(ButtonBase)))
    in WithStyles(ForwardRef(ButtonBase)) (created by ForwardRef(Button))
    in ForwardRef(Button) (created by WithStyles(ForwardRef(Button)))
    in WithStyles(ForwardRef(Button)) (at Button.tsx:49)
    in ForwardRef (at DomainCard.tsx:70)
    in div (created by ForwardRef(CardActions))
    in ForwardRef(CardActions) (created by WithStyles(ForwardRef(CardActions)))
    in WithStyles(ForwardRef(CardActions)) (at DomainCard.tsx:69)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by ForwardRef(Card))
    in ForwardRef(Card) (created by WithStyles(ForwardRef(Card)))
    in WithStyles(ForwardRef(Card)) (at DomainCard.tsx:55)
    in DomainCard (at DomainExplorerContent.tsx:82)
    in div (at ItemCardGrid.tsx:60)
    in ItemCardGrid (at DomainExplorerContent.tsx:80)
    in Body (at DomainExplorerContent.tsx:100)
    in article (at Content.tsx:59)
    in Content (at DomainExplorerContent.tsx:96)
    in DomainExplorerContent (at DefaultExplorePage.tsx:35)
    in article (at Content.tsx:59)
    in Content (at RoutedTabs.tsx:78)
    in RoutedTabs (at ExploreLayout.tsx:83)
    in div (at Page.tsx:52)
    in ThemeProvider (at Page.tsx:46)
    in Page (at ExploreLayout.tsx:78)
    in ExploreLayout (at DefaultExplorePage.tsx:30)
    in DefaultExplorePage (at ExplorePage.tsx:24)
    in ExplorePage (at extensions.tsx:63)
    in RoutableExtension(ExplorePage) (at extensions.tsx:152)
    in AnalyticsContext (at extensions.tsx:145)
    in PluginErrorBoundary (at extensions.tsx:144)
    in Suspense (at extensions.tsx:143)
    in Extension(ExplorePage) (at App.tsx:183)
    in Route (at App.tsx:183)
    in FlatRoutes (at App.tsx:133)
    in div (at Page.tsx:76)
    in SidebarPage (at Root.tsx:79)
    in Root (at App.tsx:214)
    in Route (at App.tsx:384)
    in Routes (at App.tsx:383)
    in SignInPageWrapper (at App.tsx:382)
    in Router (created by BrowserRouter)
    in BrowserRouter (at App.tsx:380)
    in AppRouter (at App.tsx:213)
    in RoutingProvider (at App.tsx:316)
    in CssBaseline (created by WithStyles(CssBaseline))
    in WithStyles(CssBaseline) (at AppThemeProvider.tsx:94)
    in ThemeProvider (at AppThemeProvider.tsx:93)
    in AppThemeProvider (at App.tsx:315)
    in AppContextProvider (at App.tsx:314)
    in ApiProvider (at App.tsx:160)
    in Provider (at App.tsx:210)
    in App (created by HotExportedApp)
    in AppContainer (created by HotExportedApp)
    in HotExportedApp (at src/index.tsx:22)
```



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
