### PR TITLE
docs: add missing bitbucket sidebar link

### DIFF
--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -210,6 +210,7 @@
         "label": "Included providers",
         "ids": [
           "auth/auth0/provider",
+          "auth/bitbucket/provider",
           "auth/microsoft/provider",
           "auth/github/provider",
           "auth/gitlab/provider",


### PR DESCRIPTION
Noticed that Bitbucket page exists but isn't shown in the sidebar. https://backstage.io/docs/auth/bitbucket/provider
<img width="287" alt="Screenshot 2021-10-11 at 4 01 58 PM" src="https://user-images.githubusercontent.com/8065913/136803433-f1910648-acff-43d2-8f2e-d6e2ba190b01.png">

