### PR TITLE
[PRFC] feat: support redirecting techdocs-ref to other catalog entities

### DIFF
--- a/.changeset/tiny-keys-report.md
+++ b/.changeset/tiny-keys-report.md
@@ -1,0 +1,21 @@
+---
+'@backstage/techdocs-common': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-techdocs': patch
+---
+
+Adds support for referencing techdocs owned by another entity using the `backstage/techdocs-ref`
+annotation. This adds a new well known prefix `catalog:` which is used as a pointer to another
+existing entity ref that has techdocs associated with it.
+
+For example another entity (e.g. domain) reference an existing documentation component entity:
+
+```yaml
+kind: Domain
+metadata:
+  name: playback
+  annotations:
+    # Usage kstage.io/techdocs-ref: `catalog:{entityRef}`
+    backstage.io/techdocs-ref: catalog:component:playback-domain-docs
+```

--- a/packages/techdocs-common/src/helpers.ts
+++ b/packages/techdocs-common/src/helpers.ts
@@ -115,6 +115,8 @@ export const getLocationForEntity = (
       return annotation;
     case 'dir':
       return transformDirLocation(entity, annotation, scmIntegration);
+    // TODO: Determine if catalog: refs will cause issues with building techdocs sites
+    case 'catalog':
     default:
       throw new Error(`Invalid reference annotation ${annotation.type}`);
   }

--- a/packages/techdocs-common/src/stages/prepare/types.ts
+++ b/packages/techdocs-common/src/stages/prepare/types.ts
@@ -48,4 +48,4 @@ export type PreparerBuilder = {
   get(entity: Entity): PreparerBase;
 };
 
-export type RemoteProtocol = 'url' | 'dir';
+export type RemoteProtocol = 'url' | 'dir' | 'catalog';

--- a/plugins/catalog-react/src/utils/getTechdocsEntityRef.ts
+++ b/plugins/catalog-react/src/utils/getTechdocsEntityRef.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  EntityName,
+  getEntityName,
+  parseEntityName,
+} from '@backstage/catalog-model';
+import { upperFirst } from 'lodash';
+
+const TECHDOCS_ANNOTATION = 'backstage.io/techdocs-ref';
+const CATALOG_ANNOTATION_PREFIX = 'catalog:';
+
+export function getTechdocsEntityRef(
+  entity: Entity,
+  caseSensitive?: boolean,
+): EntityName {
+  const projectId = entity.metadata.annotations?.[TECHDOCS_ANNOTATION];
+  let entityRef: EntityName = getEntityName(entity);
+
+  if (projectId?.startsWith(CATALOG_ANNOTATION_PREFIX)) {
+    const ref = projectId.substr(CATALOG_ANNOTATION_PREFIX.length);
+    entityRef = parseEntityName(ref);
+
+    // Only do this if app-config techdocs.legacyUseCaseSensitiveTripletPaths is set
+    if (caseSensitive) {
+      entityRef.kind = upperFirst(entityRef.kind);
+    }
+  }
+
+  return entityRef;
+}

--- a/plugins/catalog-react/src/utils/index.ts
+++ b/plugins/catalog-react/src/utils/index.ts
@@ -21,4 +21,5 @@ export {
 export { getEntityRelations } from './getEntityRelations';
 export { getEntitySourceLocation } from './getEntitySourceLocation';
 export type { EntitySourceLocation } from './getEntitySourceLocation';
+export { getTechdocsEntityRef } from './getTechdocsEntityRef';
 export { isOwnerOf } from './isOwnerOf';

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -16,7 +16,6 @@
 
 import {
   Entity,
-  ENTITY_DEFAULT_NAMESPACE,
   LOCATION_ANNOTATION,
   RELATION_CONSUMES_API,
   RELATION_PROVIDES_API,
@@ -38,6 +37,7 @@ import {
   getEntityMetadataEditUrl,
   getEntityRelations,
   getEntitySourceLocation,
+  getTechdocsEntityRef,
   useEntity,
 } from '@backstage/plugin-catalog-react';
 import {
@@ -118,13 +118,7 @@ export function AboutCard({ variant }: AboutCardProps) {
       !entity.metadata.annotations?.['backstage.io/techdocs-ref'] ||
       !viewTechdocLink,
     icon: <DocsIcon />,
-    href:
-      viewTechdocLink &&
-      viewTechdocLink({
-        namespace: entity.metadata.namespace || ENTITY_DEFAULT_NAMESPACE,
-        kind: entity.kind,
-        name: entity.metadata.name,
-      }),
+    href: viewTechdocLink && viewTechdocLink(getTechdocsEntityRef(entity)),
   };
   const viewApi: IconLinkVerticalProps = {
     title: hasApis ? '' : 'No APIs available',

--- a/plugins/techdocs/src/EntityPageDocs.tsx
+++ b/plugins/techdocs/src/EntityPageDocs.tsx
@@ -17,16 +17,15 @@
 import React from 'react';
 import { Entity } from '@backstage/catalog-model';
 import { Reader } from './reader';
+import { getTechdocsEntityRef } from '@backstage/plugin-catalog-react';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
 export const EntityPageDocs = ({ entity }: { entity: Entity }) => {
-  return (
-    <Reader
-      withSearch={false}
-      entityRef={{
-        kind: entity.kind,
-        namespace: entity.metadata.namespace ?? 'default',
-        name: entity.metadata.name,
-      }}
-    />
+  const configApi = useApi(configApiRef);
+  const caseSensitive = configApi.getOptionalBoolean(
+    'techdocs.legacyUseCaseSensitiveTripletPaths',
   );
+  const entityRef = getTechdocsEntityRef(entity, caseSensitive);
+
+  return <Reader withSearch={false} entityRef={entityRef} />;
 };


### PR DESCRIPTION
Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

This may close #6603. Kudos to @dhenneke for the idea.

The general idea here is to have an entity be able to re-use the docs from anther entity. For example, you have an org domain that has a documentation repo. You would register the docs repo as a component (e.g. `component:playback-docs`) and then you also have a domain entity `domain:playback`, which should be able to display those docs when viewing the domain in the `EntityPage`. This is an attempt to do a simple aliasing/redirecting mechanism to accomplish this sort of thing.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
