### PR TITLE
change appId: 1 to appId: app id in the docs

### DIFF
--- a/docs/plugins/github-apps.md
+++ b/docs/plugins/github-apps.md
@@ -60,7 +60,7 @@ The YAML file must include the following information. Please note that the
 indentation for the `privateKey` is required.
 
 ```yaml
-appId: 1
+appId: app id
 clientId: client id
 clientSecret: client secret
 webhookSecret: webhook secret
@@ -95,7 +95,7 @@ If you want to limit the GitHub app installations visible to backstage you may
 optionally include the `allowedInstallationOwners` option.
 
 ```yaml
-appId: 1
+appId: app id
 allowedInstallationOwners: ['GlobexCorp']
 clientId: client id
 clientSecret: client secret


### PR DESCRIPTION
Since in the docs appId was set to 1 (and the other values clearly tell you to put your secrets/ids in instead), I assumed this id was a backstage value. This change should clarify things and bring that field in line with the rest of the doc