### PR TITLE
Set catalog table search field placeholder to "Filter"

### DIFF
--- a/.changeset/nine-laws-run.md
+++ b/.changeset/nine-laws-run.md
@@ -1,0 +1,11 @@
+---
+'@backstage/core-components': patch
+---
+
+Change the Table search field placeholder to "Filter" and change icon accordingly
+
+We had feedback that users expected the catalog table search field to have more sophisticated behaviour
+than simple filtering. This change sets the search field placeholder to read "Filter"
+to avoid confusion with the search feature. The icon is updated to match. This change is applied
+generally in core-components so this change is made consistently across the app given the search
+field is present on all pages via the sidebar.

--- a/packages/core-components/src/components/Table/Table.tsx
+++ b/packages/core-components/src/components/Table/Table.tsx
@@ -32,7 +32,6 @@ import FirstPage from '@material-ui/icons/FirstPage';
 import LastPage from '@material-ui/icons/LastPage';
 import Remove from '@material-ui/icons/Remove';
 import SaveAlt from '@material-ui/icons/SaveAlt';
-import Search from '@material-ui/icons/Search';
 import ViewColumn from '@material-ui/icons/ViewColumn';
 import { isEqual, transform } from 'lodash';
 import MTable, {
@@ -73,7 +72,7 @@ const tableIcons: Icons = {
     <ChevronLeft {...props} ref={ref} />
   )),
   ResetSearch: forwardRef((props, ref) => <Clear {...props} ref={ref} />),
-  Search: forwardRef((props, ref) => <Search {...props} ref={ref} />),
+  Search: forwardRef((props, ref) => <FilterList {...props} ref={ref} />),
   SortArrow: forwardRef((props, ref) => <ArrowUpward {...props} ref={ref} />),
   ThirdStateCheck: forwardRef((props, ref) => <Remove {...props} ref={ref} />),
   ViewColumn: forwardRef((props, ref) => <ViewColumn {...props} ref={ref} />),
@@ -497,6 +496,7 @@ export function Table<T extends object = {}>(props: TableProps<T>) {
         }
         data={typeof data === 'function' ? data : tableData}
         style={{ width: '100%' }}
+        localization={{ toolbar: { searchPlaceholder: 'Filter' } }}
         {...restProps}
       />
     </div>


### PR DESCRIPTION
Fixes #7553 

Full reasoning is in the changeset and issue but in short this is to avoid confusion with the search plugin.

~I've left the icon as the magnifying glass (search) as it'd require a change to the Table component to allow overriding a specific Icon. I can add this if desired.~

Signed-off-by: Iain Billett <iain@roadie.io>

<img width="1626" alt="Screenshot 2021-10-12 at 14 42 52" src="https://user-images.githubusercontent.com/1415599/136967652-c6e4fbf0-d76c-442c-92d2-6950b9a31dbb.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
