### PR TITLE
Use `resolveSafeChildPath` in the `fetchContents` function

### DIFF
--- a/.changeset/lucky-countries-smile.md
+++ b/.changeset/lucky-countries-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Use `resolveSafeChildPath` in the `fetchContents` function to forbid reading files outside the base directory when a template is registered from a `file:` location.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.test.ts
@@ -67,7 +67,19 @@ describe('fetchContent helper', () => {
         fetchUrl: '/etc/passwd',
       }),
     ).rejects.toThrow(
-      'Fetch URL may not be absolute for file locations, /etc/passwd',
+      'Relative path is not allowed to refer to a directory outside its parent',
+    );
+  });
+
+  it('should reject relative file locations that exit the baseUrl', async () => {
+    await expect(
+      fetchContents({
+        ...options,
+        baseUrl: 'file:///some/path',
+        fetchUrl: '../test',
+      }),
+    ).rejects.toThrow(
+      'Relative path is not allowed to refer to a directory outside its parent',
     );
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/helpers.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import fs from 'fs-extra';
-import { resolve as resolvePath, isAbsolute } from 'path';
-import { UrlReader } from '@backstage/backend-common';
+import { resolveSafeChildPath, UrlReader } from '@backstage/backend-common';
+import { JsonValue } from '@backstage/config';
 import { InputError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
-import { JsonValue } from '@backstage/config';
+import fs from 'fs-extra';
+import * as path from 'path';
 
 export async function fetchContents({
   reader,
@@ -52,12 +52,7 @@ export async function fetchContents({
   // We handle both file locations and url ones
   if (!fetchUrlIsAbsolute && baseUrl?.startsWith('file://')) {
     const basePath = baseUrl.slice('file://'.length);
-    if (isAbsolute(fetchUrl)) {
-      throw new InputError(
-        `Fetch URL may not be absolute for file locations, ${fetchUrl}`,
-      );
-    }
-    const srcDir = resolvePath(basePath, '..', fetchUrl);
+    const srcDir = resolveSafeChildPath(path.dirname(basePath), fetchUrl);
     await fs.copy(srcDir, outputPath);
   } else {
     let readUrl;


### PR DESCRIPTION
I noticed that one could do:
```yaml
  steps:
    - id: fetch
      name: Fetch
      action: fetch:cookiecutter # or fetch:template or fetch:plain
      input:
        url: ../../../root/asdf
```

It's uncommon that a template is registered from a `file:*` location in production, but the `resolveSafeChildPath` correctly recognizes this if someone would do it.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
