### PR TITLE
made more tests async

### DIFF
--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreviewCatalogInfoComponent.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreviewCatalogInfoComponent.test.tsx
@@ -16,7 +16,7 @@
 
 import { Entity } from '@backstage/catalog-model';
 import { makeStyles } from '@material-ui/core';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import { PreviewCatalogInfoComponent } from './PreviewCatalogInfoComponent';
@@ -46,15 +46,17 @@ const entities: Entity[] = [
 
 describe('<PreviewCatalogInfoComponent />', () => {
   it('renders without exploding', async () => {
-    const { getByText, findByText } = render(
+    render(
       <PreviewCatalogInfoComponent
         repositoryUrl="http://my-repository/a/"
         entities={entities}
       />,
     );
 
-    const repositoryUrl = getByText('http://my-repository/a/catalog-info.yaml');
-    const kindText = await findByText('Kind_2');
+    const repositoryUrl = screen.getByText(
+      'http://my-repository/a/catalog-info.yaml',
+    );
+    const kindText = await screen.findByText('Kind_2');
     expect(repositoryUrl).toBeInTheDocument();
     expect(repositoryUrl).toBeVisible();
     expect(kindText).toBeInTheDocument();
@@ -64,7 +66,7 @@ describe('<PreviewCatalogInfoComponent />', () => {
   it('renders card with custom styles', async () => {
     const { result } = renderHook(() => useStyles());
 
-    const { getByText } = render(
+    render(
       <PreviewCatalogInfoComponent
         repositoryUrl="http://my-repository/a/"
         entities={entities}
@@ -72,8 +74,10 @@ describe('<PreviewCatalogInfoComponent />', () => {
       />,
     );
 
-    const repositoryUrl = getByText('http://my-repository/a/catalog-info.yaml');
-    const kindText = getByText('Kind_2');
+    const repositoryUrl = screen.getByText(
+      'http://my-repository/a/catalog-info.yaml',
+    );
+    const kindText = await screen.findByText('Kind_2');
     expect(repositoryUrl).toBeInTheDocument();
     expect(repositoryUrl).not.toBeVisible();
     expect(kindText).toBeInTheDocument();
@@ -83,7 +87,7 @@ describe('<PreviewCatalogInfoComponent />', () => {
   it('renders with custom styles', async () => {
     const { result } = renderHook(() => useStyles());
 
-    const { getByText } = render(
+    render(
       <PreviewCatalogInfoComponent
         repositoryUrl="http://my-repository/a/"
         entities={entities}
@@ -91,8 +95,10 @@ describe('<PreviewCatalogInfoComponent />', () => {
       />,
     );
 
-    const repositoryUrl = getByText('http://my-repository/a/catalog-info.yaml');
-    const kindText = getByText('Kind_2');
+    const repositoryUrl = screen.getByText(
+      'http://my-repository/a/catalog-info.yaml',
+    );
+    const kindText = await screen.findByText('Kind_2');
     expect(repositoryUrl).toBeInTheDocument();
     expect(repositoryUrl).toBeVisible();
     expect(kindText).toBeInTheDocument();


### PR DESCRIPTION
These tests happen to trigger some async import deeper down, and a bit rudely, only the first test used `find` and the others relied on the import being cached when the runner got down there. Made them all async just to be nice.

Was actually looking at the windows master build flakiness but got this instead :)