### PR TITLE
Don't require a validation pattern for the jenkins base URL

### DIFF
--- a/.changeset/flat-dodos-bake.md
+++ b/.changeset/flat-dodos-bake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins-backend': patch
+---
+
+Don't require a validation pattern for the Jenkins base URL.

--- a/plugins/jenkins-backend/config.d.ts
+++ b/plugins/jenkins-backend/config.d.ts
@@ -17,7 +17,6 @@ export interface Config {
   jenkins?: {
     /**
      * Default instance baseUrl, can be specified on a named instance called "default"
-     * @pattern "^https?://"
      */
     baseUrl?: string;
     /**
@@ -39,9 +38,6 @@ export interface Config {
        */
       name: string;
 
-      /**
-       * @pattern "^https?://"
-       */
       baseUrl: string;
       username: string;
       /** @visibility secret */


### PR DESCRIPTION
We use the following config:

```yaml
jenkins:
  baseUrl: ${JENKINS_URL}
  username: ${JENKINS_API_USERNAME}
  apiKey: ${JENKINS_API_KEY}
```

When we execute the config validation with the `--lax` flag, it is resolved to:

```yaml
jenkins:
  baseUrl: x
  username: x
  apiKey: x
```

and doesn't match the `^https?://` pattern.

An alternative could be to disable all patterns if a variable was replaced by the `lax` function.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
