### PR TITLE
usePlugin() hook

### DIFF
--- a/.changeset/sharp-mice-sleep.md
+++ b/.changeset/sharp-mice-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Added usePlugin() hook to get plugin information anywhere in the component tree

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -689,6 +689,20 @@ export type PluginHooks = {
   featureFlags: FeatureFlagsHooks;
 };
 
+// Warning: (ae-missing-release-tag) "PluginInfo" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface PluginInfo {
+  // (undocumented)
+  extensionName?: string;
+  // (undocumented)
+  plugin: BackstagePlugin<any, any>;
+  // (undocumented)
+  routeRef?: string;
+}
+
+// Warning: (ae-missing-release-tag) "PluginOutput" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export type PluginOutput = FeatureFlagOutput;
 
@@ -802,6 +816,20 @@ export function useElementFilter<T>(
   dependencies?: any[],
 ): T;
 
+// Warning: (ae-missing-release-tag) "usePlugin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function usePlugin(): PluginInfo | undefined;
+
+// Warning: (ae-missing-release-tag) "UserFlags" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type UserFlags = {};
+
+// Warning: (ae-forgotten-export) The symbol "RouteFunc" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "useRouteRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// Warning: (ae-missing-release-tag) "useRouteRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
 // @public
 export function useRouteRef<Optional extends boolean, Params extends AnyParams>(
   routeRef: ExternalRouteRef<Params, Optional>,

--- a/packages/core-plugin-api/src/extensions/PluginProvider.tsx
+++ b/packages/core-plugin-api/src/extensions/PluginProvider.tsx
@@ -24,7 +24,6 @@ import {
 export interface PluginInfo {
   pluginId: string;
   extensionName?: string;
-  routeRef?: string;
 }
 
 export type PluginProviderProps = PluginInfo;
@@ -35,11 +34,11 @@ type VersionedContextType = { 1: PluginInfo };
 const context = createVersionedContext<VersionedContextType>(CONTEXT_KEY);
 
 export function PluginProvider(props: PropsWithChildren<PluginProviderProps>) {
-  const { pluginId, extensionName, routeRef, children } = props;
+  const { pluginId, extensionName, children } = props;
 
   const versionedValue = useMemo(
-    () => createVersionedValueMap({ 1: { pluginId, extensionName, routeRef } }),
-    [pluginId, extensionName, routeRef],
+    () => createVersionedValueMap({ 1: { pluginId, extensionName } }),
+    [pluginId, extensionName],
   );
 
   return <context.Provider value={versionedValue} children={children} />;

--- a/packages/core-plugin-api/src/extensions/PluginProvider.tsx
+++ b/packages/core-plugin-api/src/extensions/PluginProvider.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useMemo,
+} from 'react';
+import { BackstagePlugin } from '../plugin';
+
+export interface PluginInfo {
+  plugin: BackstagePlugin<any, any>;
+  extensionName?: string;
+  routeRef?: string;
+}
+
+export type PluginProviderProps = PluginInfo;
+
+const context = createContext<PluginInfo | undefined>(undefined);
+
+export function PluginProvider(props: PropsWithChildren<PluginProviderProps>) {
+  const { plugin, extensionName, routeRef, children } = props;
+
+  const value = useMemo(
+    (): PluginInfo => ({ plugin, extensionName, routeRef }),
+    [plugin, extensionName, routeRef],
+  );
+
+  return <context.Provider value={value} children={children} />;
+}
+
+export function usePlugin(): PluginInfo | undefined {
+  return useContext(context);
+}

--- a/packages/core-plugin-api/src/extensions/PluginProvider.tsx
+++ b/packages/core-plugin-api/src/extensions/PluginProvider.tsx
@@ -43,6 +43,10 @@ export function PluginProvider(props: PropsWithChildren<PluginProviderProps>) {
   return <context.Provider value={value} children={children} />;
 }
 
+/**
+ * Gets information about the plugin the current component is part of.
+ * May be `undefined` if the component is mounted outside a plugin scope.
+ */
 export function usePlugin(): PluginInfo | undefined {
   return useContext(context);
 }

--- a/packages/core-plugin-api/src/extensions/extensions.tsx
+++ b/packages/core-plugin-api/src/extensions/extensions.tsx
@@ -189,13 +189,13 @@ export function createReactExtension<
           | undefined;
 
         return (
-          <PluginProvider
-            pluginId={plugin.getId()}
-            extensionName={name}
-            routeRef={mountPoint?.id}
-          >
-            <Suspense fallback={<Progress />}>
-              <PluginErrorBoundary app={app} plugin={plugin}>
+          <PluginErrorBoundary app={app} plugin={plugin}>
+            <PluginProvider
+              pluginId={plugin.getId()}
+              extensionName={name}
+              routeRef={mountPoint?.id}
+            >
+              <Suspense fallback={<Progress />}>
                 <AnalyticsContext
                   attributes={{
                     pluginId: plugin.getId(),
@@ -205,9 +205,9 @@ export function createReactExtension<
                 >
                   <Component {...props} />
                 </AnalyticsContext>
-              </PluginErrorBoundary>
-            </Suspense>
-          </PluginProvider>
+              </Suspense>
+            </PluginProvider>
+          </PluginErrorBoundary>
         );
       };
 

--- a/packages/core-plugin-api/src/extensions/extensions.tsx
+++ b/packages/core-plugin-api/src/extensions/extensions.tsx
@@ -190,7 +190,7 @@ export function createReactExtension<
 
         return (
           <PluginProvider
-            plugin={plugin}
+            pluginId={plugin.getId()}
             extensionName={name}
             routeRef={mountPoint?.id}
           >

--- a/packages/core-plugin-api/src/extensions/extensions.tsx
+++ b/packages/core-plugin-api/src/extensions/extensions.tsx
@@ -190,11 +190,7 @@ export function createReactExtension<
 
         return (
           <PluginErrorBoundary app={app} plugin={plugin}>
-            <PluginProvider
-              pluginId={plugin.getId()}
-              extensionName={name}
-              routeRef={mountPoint?.id}
-            >
+            <PluginProvider pluginId={plugin.getId()} extensionName={name}>
               <Suspense fallback={<Progress />}>
                 <AnalyticsContext
                   attributes={{

--- a/packages/core-plugin-api/src/extensions/extensions.tsx
+++ b/packages/core-plugin-api/src/extensions/extensions.tsx
@@ -21,6 +21,7 @@ import { RouteRef, useRouteRef } from '../routing';
 import { attachComponentData } from './componentData';
 import { Extension, BackstagePlugin } from '../plugin/types';
 import { PluginErrorBoundary } from './PluginErrorBoundary';
+import { PluginProvider } from './PluginProvider';
 
 /**
  * Lazy or synchronous retrieving of extension components.
@@ -188,19 +189,25 @@ export function createReactExtension<
           | undefined;
 
         return (
-          <Suspense fallback={<Progress />}>
-            <PluginErrorBoundary app={app} plugin={plugin}>
-              <AnalyticsContext
-                attributes={{
-                  pluginId: plugin.getId(),
-                  ...(name && { extension: name }),
-                  ...(mountPoint && { routeRef: mountPoint.id }),
-                }}
-              >
-                <Component {...props} />
-              </AnalyticsContext>
-            </PluginErrorBoundary>
-          </Suspense>
+          <PluginProvider
+            plugin={plugin}
+            extensionName={name}
+            routeRef={mountPoint?.id}
+          >
+            <Suspense fallback={<Progress />}>
+              <PluginErrorBoundary app={app} plugin={plugin}>
+                <AnalyticsContext
+                  attributes={{
+                    pluginId: plugin.getId(),
+                    ...(name && { extension: name }),
+                    ...(mountPoint && { routeRef: mountPoint.id }),
+                  }}
+                >
+                  <Component {...props} />
+                </AnalyticsContext>
+              </PluginErrorBoundary>
+            </Suspense>
+          </PluginProvider>
         );
       };
 

--- a/packages/core-plugin-api/src/extensions/index.ts
+++ b/packages/core-plugin-api/src/extensions/index.ts
@@ -23,5 +23,5 @@ export {
 export type { ComponentLoader } from './extensions';
 export { useElementFilter } from './useElementFilter';
 export type { ElementCollection } from './useElementFilter';
-export { usePlugin } from './PluginProvider';
+export { usePluginInfo } from './PluginProvider';
 export type { PluginInfo } from './PluginProvider';

--- a/packages/core-plugin-api/src/extensions/index.ts
+++ b/packages/core-plugin-api/src/extensions/index.ts
@@ -23,3 +23,5 @@ export {
 export type { ComponentLoader } from './extensions';
 export { useElementFilter } from './useElementFilter';
 export type { ElementCollection } from './useElementFilter';
+export { usePlugin } from './PluginProvider';
+export type { PluginInfo } from './PluginProvider';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds a PluginProvider (context) and a usePlugin() hook. It is intentionally placed outside Suspense/Progress so that a custom Progress can read the plugin info to know what plugin is "progressing".

This hook allows components to know "within" which plugin they live (if any), to attach that to error/progress/metrics/analytics handling, etc.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
