### PR TITLE
Update how-to-guides.md

### DIFF
--- a/docs/features/search/how-to-guides.md
+++ b/docs/features/search/how-to-guides.md
@@ -56,9 +56,7 @@ in your App, so that you can get TechDocs documents indexed.
 
 If you have been through the
 [Getting Started with Search](https://backstage.io/docs/features/search/getting-started)
-guide, you should have the `packages/backend/src/plugins/search.ts` file
-available. If so, you can go ahead and follow this guide - if
-not, start by going through the getting started guide.
+guide, you should have the `packages/backend/src/plugins/search.ts` file available. If so, you can go ahead and follow this guide - if not, start by going through the getting started guide.
 
 1. Import the DefaultTechDocsCollator from `@backstage/plugin-techdocs-backend`.
 


### PR DESCRIPTION
Some small updates: 
- changed "techdocs-plugin" to "TechDocs plugin", for consistency with how Search plugin is mentioned earlier in the doc
- changed reference to "getting started guide" to correspond w the guide's heading (Getting Started with Search)
- minor text edits

Signed-off-by: Bodil Björklund <bodilb@spotify.com>
