### PR TITLE
Only replace the shadow dom if the content is changed to avoid a flickering UI

### DIFF
--- a/.changeset/techdocs-dull-glasses-decide.md
+++ b/.changeset/techdocs-dull-glasses-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Only replace the shadow dom if the content is changed to avoid a flickering UI.

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -397,6 +397,11 @@ const TheReader = ({
   const dom = useTechDocsReaderDom();
   const shadowDomRef = useRef<HTMLDivElement>(null);
 
+  const onReadyRef = useRef<() => void>(onReady);
+  useEffect(() => {
+    onReadyRef.current = onReady;
+  }, [onReady]);
+
   useEffect(() => {
     if (!dom || !shadowDomRef.current) return;
     const shadowDiv = shadowDomRef.current;
@@ -406,8 +411,10 @@ const TheReader = ({
       shadowRoot.removeChild(child),
     );
     shadowRoot.appendChild(dom);
-    onReady();
-  }, [dom, onReady]);
+    onReadyRef.current();
+
+    // this hook must ONLY be triggered by a changed dom
+  }, [dom]);
 
   return (
     <>


### PR DESCRIPTION
The "flickering" UI is back since the refactorings around #7476.

It happens because a navigation changes the hook, which updates the context, which triggers an update to the props of `<TheReader />`, which triggers a reset of the shadow dom. However, the content of `dom` is not stateless because there are some one-time post-processing-hooks.

My workaround is to remove the dependency to the `onReady` prop.

Note: this only happens when the network connection is delayed (e.g. by loading the docs from an S3 bucket). The example videos use a 1 second delay by Chrome.

**Before:**

https://user-images.githubusercontent.com/720821/137511547-f1007591-1121-4dc0-a49e-1f7e9c244652.mov

**After:**

https://user-images.githubusercontent.com/720821/137511561-651ef135-0a1c-40d8-9e0a-223d208b71e9.mov


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
