### PR TITLE
PRFC: Introduce `createBundle` and a `NextCatalogBuilder.register` to add them with.

### DIFF
--- a/.changeset/selfish-islands-glow.md
+++ b/.changeset/selfish-islands-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add the new concept of bundles, which are like "plugins for the plugin". They are used as a nice, named, versioned wrapper for collections of functionality that you want to expose in a catalog.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -113,6 +113,11 @@ export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
   preProcessEntity(entity: Entity, location: LocationSpec): Promise<Entity>;
 }
 
+// Warning: (ae-missing-release-tag) "AnyCatalogBundle" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type AnyCatalogBundle = CatalogBundleV1;
+
 // Warning: (ae-missing-release-tag) "AwsOrganizationCloudAccountProcessor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
@@ -254,6 +259,43 @@ export class CatalogBuilder {
     key: string,
     resolver: PlaceholderResolver,
   ): CatalogBuilder;
+}
+
+// @public
+export interface CatalogBundleV1 {
+  // (undocumented)
+  init(options: {
+    environment: CatalogBundleV1Environment;
+    hooks: CatalogBundleV1Hooks;
+  }): void | Promise<void>;
+  // (undocumented)
+  name: string;
+  // (undocumented)
+  version: 1;
+}
+
+// Warning: (ae-missing-release-tag) "CatalogBundleV1Environment" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface CatalogBundleV1Environment {
+  database: Knex;
+  logger: Logger_2;
+}
+
+// Warning: (ae-missing-release-tag) "CatalogBundleV1Hooks" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface CatalogBundleV1Hooks {
+  addEntityPolicy(...policies: EntityPolicy[]): void;
+  addEntityProvider(...providers: EntityProvider[]): void;
+  addProcessor(...processors: CatalogProcessor[]): void;
+  replaceEntityPolicies(policies: EntityPolicy[]): void;
+  replaceProcessors(processors: CatalogProcessor[]): void;
+  setEntityDataParser(parser: CatalogProcessorParser): void;
+  setFieldFormatValidators(validators: Partial<Validators>): void;
+  setPlaceholderResolver(key: string, resolver: PlaceholderResolver): void;
+  setRefreshInterval(refreshInterval: RefreshIntervalFunction): void;
+  setRefreshIntervalSeconds(seconds: number): void;
 }
 
 // Warning: (ae-missing-release-tag) "CatalogEntityDocument" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -496,6 +538,36 @@ export class CommonDatabase implements Database {
     matchingEtag?: string,
     matchingGeneration?: number,
   ): Promise<DbEntityResponse>;
+}
+
+// Warning: (ae-missing-release-tag) "createBundle" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function createBundle(
+  definition: CreateBundleDefinition,
+): CatalogBundleV1;
+
+// Warning: (ae-missing-release-tag) "CreateBundleDefinition" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export interface CreateBundleDefinition {
+  entityProviders?: Array<
+    | EntityProvider
+    | ((
+        environment: CatalogBundleV1Environment,
+      ) => EntityProvider | Promise<EntityProvider>)
+  >;
+  init?(options: {
+    environment: CatalogBundleV1Environment;
+    hooks: CatalogBundleV1Hooks;
+  }): void | Promise<void>;
+  name: string;
+  processors?: Array<
+    | CatalogProcessor
+    | ((
+        environment: CatalogBundleV1Environment,
+      ) => CatalogProcessor | Promise<CatalogProcessor>)
+  >;
 }
 
 // Warning: (ae-missing-release-tag) "CreateDatabaseOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1273,11 +1345,8 @@ export type LocationUpdateStatus = {
 // @public
 export class NextCatalogBuilder {
   constructor(env: CatalogEnvironment);
-  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   addEntityPolicy(...policies: EntityPolicy[]): NextCatalogBuilder;
-  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   addEntityProvider(...providers: EntityProvider[]): NextCatalogBuilder;
-  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   addProcessor(...processors: CatalogProcessor[]): NextCatalogBuilder;
   build(): Promise<{
     entitiesCatalog: EntitiesCatalog;
@@ -1287,17 +1356,13 @@ export class NextCatalogBuilder {
     locationService: LocationService;
     router: Router;
   }>;
-  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
+  // (undocumented)
+  register(bundle: AnyCatalogBundle): NextCatalogBuilder;
   replaceEntityPolicies(policies: EntityPolicy[]): NextCatalogBuilder;
-  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   replaceProcessors(processors: CatalogProcessor[]): NextCatalogBuilder;
-  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   setEntityDataParser(parser: CatalogProcessorParser): NextCatalogBuilder;
-  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   setFieldFormatValidators(validators: Partial<Validators>): NextCatalogBuilder;
   setLocationAnalyzer(locationAnalyzer: LocationAnalyzer): NextCatalogBuilder;
-  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
-  // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   setPlaceholderResolver(
     key: string,
     resolver: PlaceholderResolver,

--- a/plugins/catalog-backend/src/bundles/createBundle.ts
+++ b/plugins/catalog-backend/src/bundles/createBundle.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CatalogProcessor } from '../ingestion';
+import { EntityProvider } from '../providers';
+import {
+  CatalogBundleV1,
+  CatalogBundleV1Environment,
+  CatalogBundleV1Hooks,
+} from './versions/v1';
+
+/**
+ * The input shape of the current version of bundles.
+ */
+export interface CreateBundleDefinition {
+  /**
+   * A name for this bundle.
+   *
+   * This should be a stable, identifier-like string that may be used in
+   * several subsystems such as monitoring, logging etc.
+   */
+  name: string;
+
+  /**
+   * A list of processors exposed by this bundle.
+   *
+   * You may specify either direct instances or factory functions.
+   */
+  processors?: Array<
+    | CatalogProcessor
+    | ((
+        environment: CatalogBundleV1Environment,
+      ) => CatalogProcessor | Promise<CatalogProcessor>)
+  >;
+
+  /**
+   * A list of entity providers exposed by this bundle.
+   *
+   * You may specify either direct instances or factory functions.
+   */
+  entityProviders?: Array<
+    | EntityProvider
+    | ((
+        environment: CatalogBundleV1Environment,
+      ) => EntityProvider | Promise<EntityProvider>)
+  >;
+
+  /**
+   * Lets your plugin perform more complex startup initialization if needed.
+   *
+   * @param options - The catalog environment and hooks
+   */
+  init?(options: {
+    environment: CatalogBundleV1Environment;
+    hooks: CatalogBundleV1Hooks;
+  }): void | Promise<void>;
+}
+
+/**
+ * Creates a bundle of functionality that can be installed in the catalog.
+ *
+ * @param definition - The definition of the bundle
+ * @returns A bundle that can be installed in the catalog
+ */
+export function createBundle(
+  definition: CreateBundleDefinition,
+): CatalogBundleV1 {
+  const { name, processors, entityProviders, init } = definition;
+
+  return {
+    version: 1,
+    name,
+    async init(options) {
+      if (processors?.length) {
+        for (const processor of processors) {
+          const instance =
+            typeof processor === 'function'
+              ? await processor(options.environment)
+              : processor;
+          options.hooks.addProcessor(instance);
+        }
+      }
+
+      if (entityProviders?.length) {
+        for (const provider of entityProviders) {
+          const instance =
+            typeof provider === 'function'
+              ? await provider(options.environment)
+              : provider;
+          options.hooks.addEntityProvider(instance);
+        }
+      }
+
+      if (init) {
+        await init(options);
+      }
+    },
+  };
+}

--- a/plugins/catalog-backend/src/bundles/index.ts
+++ b/plugins/catalog-backend/src/bundles/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that provides the Backstage catalog
- *
- * @packageDocumentation
- */
-
-export * from './bundles';
-export * from './catalog';
-export * from './ingestion';
-export * from './legacy';
-export * from './search';
-export * from './util';
-export * from './processing';
-export * from './providers';
-export * from './service';
+export { createBundle } from './createBundle';
+export type { CreateBundleDefinition } from './createBundle';
+export * from './versions';

--- a/plugins/catalog-backend/src/bundles/versions/any.ts
+++ b/plugins/catalog-backend/src/bundles/versions/any.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that provides the Backstage catalog
- *
- * @packageDocumentation
- */
+import type { CatalogBundleV1 } from './v1';
 
-export * from './bundles';
-export * from './catalog';
-export * from './ingestion';
-export * from './legacy';
-export * from './search';
-export * from './util';
-export * from './processing';
-export * from './providers';
-export * from './service';
+/**
+ * The collection of all known bundle versions.
+ */
+export type AnyCatalogBundle = CatalogBundleV1;

--- a/plugins/catalog-backend/src/bundles/versions/index.ts
+++ b/plugins/catalog-backend/src/bundles/versions/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that provides the Backstage catalog
- *
- * @packageDocumentation
- */
-
-export * from './bundles';
-export * from './catalog';
-export * from './ingestion';
-export * from './legacy';
-export * from './search';
-export * from './util';
-export * from './processing';
-export * from './providers';
-export * from './service';
+export type { AnyCatalogBundle } from './any';
+export type {
+  CatalogBundleV1,
+  CatalogBundleV1Environment,
+  CatalogBundleV1Hooks,
+} from './v1';

--- a/plugins/catalog-backend/src/bundles/versions/v1.ts
+++ b/plugins/catalog-backend/src/bundles/versions/v1.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EntityPolicy, Validators } from '@backstage/catalog-model';
+import { Knex } from 'knex';
+import { Logger } from 'winston';
+import {
+  CatalogProcessor,
+  CatalogProcessorParser,
+  PlaceholderResolver,
+} from '../../ingestion';
+import { RefreshIntervalFunction } from '../../processing/refresh';
+import { EntityProvider } from '../../providers/types';
+
+/**
+ * The environment that V1 bundles can act within.
+ */
+export interface CatalogBundleV1Environment {
+  /**
+   * The catalog plugin database, initialized and ready.
+   */
+  database: Knex;
+
+  /**
+   * A logger, scoped to the catalog plugin.
+   */
+  logger: Logger;
+}
+
+/**
+ * The environment that V1 bundles can act within.
+ */
+export interface CatalogBundleV1Hooks {
+  /**
+   * Adds policies that are used to validate entities between the pre-
+   * processing and post-processing stages. All such policies must pass for the
+   * entity to be considered valid.
+   *
+   * If what you want to do is to replace the rules for what format is allowed
+   * in various core entity fields (such as metadata.name), you may want to use
+   * {@link CatalogBundleV1Environment#setFieldFormatValidators} instead.
+   *
+   * @param policies - One or more policies
+   */
+  addEntityPolicy(...policies: EntityPolicy[]): void;
+
+  /**
+   * Refresh interval determines how often entities should be refreshed.
+   * Seconds provided will be multiplied by 1.5
+   * The default refresh duration is 100-150 seconds.
+   * setting this too low will potentially deplete request quotas to upstream services.
+   */
+  setRefreshIntervalSeconds(seconds: number): void;
+
+  /**
+   * Overwrites the default refresh interval function used to spread
+   * entity updates in the catalog.
+   */
+  setRefreshInterval(refreshInterval: RefreshIntervalFunction): void;
+
+  /**
+   * Sets what policies to use for validation of entities between the pre-
+   * processing and post-processing stages. All such policies must pass for the
+   * entity to be considered valid.
+   *
+   * If what you want to do is to replace the rules for what format is allowed
+   * in various core entity fields (such as metadata.name), you may want to use
+   * {@link CatalogBundleV1Environment#setFieldFormatValidators} instead.
+   *
+   * This function replaces the default set of policies; use with care.
+   *
+   * @param policies - One or more policies
+   */
+  replaceEntityPolicies(policies: EntityPolicy[]): void;
+
+  /**
+   * Adds, or overwrites, a handler for placeholders (e.g. $file) in entity
+   * definition files.
+   *
+   * @param key - The key that identifies the placeholder, e.g. "file"
+   * @param resolver - The resolver that gets values for this placeholder
+   */
+  setPlaceholderResolver(key: string, resolver: PlaceholderResolver): void;
+
+  /**
+   * Sets the validator function to use for one or more special fields of an
+   * entity. This is useful if the default rules for formatting of fields are
+   * not sufficient.
+   *
+   * This function has no effect if used together with
+   * {@link CatalogBundleV1Environment#replaceEntityPolicies}.
+   *
+   * @param validators - The (subset of) validators to set
+   */
+  setFieldFormatValidators(validators: Partial<Validators>): void;
+
+  /**
+   * Adds or replaces entity providers. These are responsible for bootstrapping
+   * the list of entities out of original data sources. For example, there is
+   * one entity source for the config locations, and one for the database
+   * stored locations. If you ingest entities out of a third party system, you
+   * may want to implement that in terms of an entity provider as well.
+   *
+   * @param providers - One or more entity providers
+   */
+  addEntityProvider(...providers: EntityProvider[]): void;
+
+  /**
+   * Adds entity processors. These are responsible for reading, parsing, and
+   * processing entities before they are persisted in the catalog.
+   *
+   * @param processors - One or more processors
+   */
+  addProcessor(...processors: CatalogProcessor[]): void;
+
+  /**
+   * Sets what entity processors to use. These are responsible for reading,
+   * parsing, and processing entities before they are persisted in the catalog.
+   *
+   * This function replaces the default set of processors; use with care.
+   *
+   * @param processors - One or more processors
+   */
+  replaceProcessors(processors: CatalogProcessor[]): void;
+
+  /**
+   * Sets up the catalog to use a custom parser for entity data.
+   *
+   * This is the function that gets called immediately after some raw entity
+   * specification data has been read from a remote source, and needs to be
+   * parsed and emitted as structured data.
+   *
+   * @param parser - The custom parser
+   */
+  setEntityDataParser(parser: CatalogProcessorParser): void;
+}
+
+/**
+ * The initial bundle output shape, simply inverting control and wrapping the
+ * original builder API.
+ *
+ * @public
+ */
+export interface CatalogBundleV1 {
+  version: 1;
+  name: string;
+  init(options: {
+    environment: CatalogBundleV1Environment;
+    hooks: CatalogBundleV1Hooks;
+  }): void | Promise<void>;
+}


### PR DESCRIPTION
So this is a suggestion for what the inversion of control could look like when building bundles of functionality that want to expose themselves into the catalog. It also makes it possible to version the surface between the catalog and bundles, such that it should be possible to evolve the catalog while installing both old and new bundles.

Ultimately, I want the environment given to the bundle to also contain the router. That way, we can look at for example breaking out the entire analysis functionality, or the ancestry, as bundles in separate folders including their API surfaces.

One of the selling points of this, I think, would be that 

```ts
// plugins/scaffolder-backend/src/plugin.ts
import { createBundle } from '@backstage/plugin-catalog-backend';

// Could consider making `processors` an object instead, so that you
// could more easily then schedule calls to bundle.entityProviders.myKeyHere.run()
// or whatnot?
export catalogBundle = createBundle({
  name: 'scaffolder',
  processors: [env => new ScaffolderEntitiesProcessor(env.logger)],
});
```

```ts
// packages/backend/src/plugins/catalog.ts
import { catalogBundle as scaffolderCatalogBundle } from '@backstage/plugin-scaffolder-backend';

export default async function createPlugin(env: PluginEnvironment): Promise<Router> {
  const builder = await CatalogBuilder.create(env);

  // Maybe this should be adding one more level of indirection,
  // such as calling the bundle like a factory function. If we did,
  // then we could make sure that bundle.processors.x always was
  // the actual created instance, rather than the supported factory
  // functions above. Another possible solution would be that `register`
  // accepts the bundle like in the line below, but returns a `BundleInstance`
  // that has everything instantiated and settled. But I wanted to make it
  // possible to defer the creation of things until build() time
  builder.register(scaffolderCatalogBundle);

  const { processingEngine, router } = await builder.build();
  await processingEngine.start();

  return router;
}
```
