### PR TITLE
Update how-to-guides.md

### DIFF
--- a/docs/features/search/how-to-guides.md
+++ b/docs/features/search/how-to-guides.md
@@ -55,7 +55,10 @@ The purpose of this guide is to walk you through how to register the
 in your App, so that you can get TechDocs documents indexed.
 
 If you have been through the
-[Getting Started with Search guide](https://backstage.io/docs/features/search/getting-started), you should have the `packages/backend/src/plugins/search.ts` file available. If so, you can go ahead and follow this guide - if not, start by going through the getting started guide.
+[Getting Started with Search guide](https://backstage.io/docs/features/search/getting-started),
+you should have the `packages/backend/src/plugins/search.ts` file available. If
+so, you can go ahead and follow this guide - if not, start by going through the
+getting started guide.
 
 1. Import the DefaultTechDocsCollator from `@backstage/plugin-techdocs-backend`.
 


### PR DESCRIPTION
Small updates:

- changed "techdocs-plugin" to "TechDocs plugin", for consistency with how Search plugin is mentioned earlier in the doc
- changed reference to "getting started guide" to correspond w the guide's heading (Getting Started with Search)
- minor text edits

Signed-off-by: Bodil Björklund <bodilb@spotify.com>