### PR TITLE
fix(catalog:register): support optional locations

### DIFF
--- a/.changeset/fair-jeans-heal.md
+++ b/.changeset/fair-jeans-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Allow `catalog:register` action to register optional locations

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.test.ts
@@ -174,4 +174,42 @@ describe('catalog:register', () => {
       'http://foo/var',
     );
   });
+
+  it('should ignore failures when dry running the location in the catalog if `optional` is set', async () => {
+    addLocation
+      .mockResolvedValueOnce({
+        entities: [],
+      })
+      .mockRejectedValueOnce(new Error('Not found'));
+    await action.handler({
+      ...mockContext,
+      input: {
+        catalogInfoUrl: 'http://foo/var',
+        optional: true,
+      },
+    });
+
+    expect(addLocation).toHaveBeenNthCalledWith(
+      1,
+      {
+        type: 'url',
+        target: 'http://foo/var',
+      },
+      {},
+    );
+    expect(addLocation).toHaveBeenNthCalledWith(
+      2,
+      {
+        dryRun: true,
+        type: 'url',
+        target: 'http://foo/var',
+      },
+      {},
+    );
+
+    expect(mockContext.output).toBeCalledWith(
+      'catalogInfoUrl',
+      'http://foo/var',
+    );
+  });
 });


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!
A recent change (https://github.com/backstage/backstage/commit/ca3086a7ad54c14ef4661040e759fd73c580b67f) updated `catalog:register` to perform a dry run of the registered location to retrieve the `entityRef`. However this breaks workflows (error is thrown by the dry run) such as when `catalog:register` is called on pending locations created using `publish:github:pull-request` that have not been merged into the registered location (default branch). This change adds an `optional` flag on the register action to re-support this use case.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
