### PR TITLE
BAU: bump react dev tools

### DIFF
--- a/.changeset/fuzzy-berries-march.md
+++ b/.changeset/fuzzy-berries-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Bump react-dev-tools to a version that contains fixes for vulnerabilities found in their Immer dependency

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -109,6 +109,7 @@ http
 https
 Iain
 img
+Immer
 incentivised
 inlined
 inlinehilite

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,7 @@
     "postcss": "^8.1.0",
     "process": "^0.11.10",
     "react": "^16.0.0",
-    "react-dev-utils": "^11.0.4",
+    "react-dev-utils": "^12.0.0-next.47",
     "react-hot-loader": "^4.12.21",
     "recursive-readdir": "^2.2.2",
     "replace-in-file": "^6.0.0",


### PR DESCRIPTION
This bumps react-dev-tools to a version containing a fix for the Immer vulnerabilities:

Prototype Pollution in immer (critical severity): CVE-2021-3757.
Prototype Pollution in immer (high severity): CVE-2021-23436.

More information can be found in:
https://github.com/facebook/create-react-app/pull/11364
https://github.com/facebook/create-react-app/issues/11443

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
