### PR TITLE
Add parent group entity for GitHub org

### DIFF
--- a/.changeset/curvy-teachers-behave.md
+++ b/.changeset/curvy-teachers-behave.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-backend': minor
 ---
 
-Modified the GutHub Multiorg Processor to add a new org group entity as a parent of the team group entities.
+Modified the GitHub MultiOrg Processor to add a new org group entity as a parent of the team group entities.

--- a/.changeset/curvy-teachers-behave.md
+++ b/.changeset/curvy-teachers-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Modified the GutHub Multiorg Processor to add a new org group entity as a parent of the team group entities.

--- a/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
@@ -128,21 +128,18 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
         let prefix: string = orgConfig.userNamespace ?? '';
         if (prefix.length > 0) prefix += '/';
 
-        users.forEach(u => {
-          if (!allUsersMap.has(prefix + u.metadata.name)) {
-            allUsersMap.set(prefix + u.metadata.name, u);
-          }
-        });
-
-        // add org group to member users
+        // Add org group to member users, accounts for org users not part of a team
         const orgUserNames: string[] = [];
         groupMemberUsers.set(
           orgConfig.groupNamespace || orgConfig.name,
           orgUserNames,
         );
 
-        users.forEach(user => {
-          orgUserNames.push(user.metadata.name);
+        users.forEach(u => {
+          if (!allUsersMap.has(prefix + u.metadata.name)) {
+            allUsersMap.set(prefix + u.metadata.name, u);
+          }
+          orgUserNames.push(u.metadata.name);
         });
 
         for (const [groupName, userNames] of groupMemberUsers.entries()) {

--- a/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
@@ -134,6 +134,17 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
           }
         });
 
+        // add org group to member users
+        const orgUserNames: string[] = [];
+        groupMemberUsers.set(
+          orgConfig.groupNamespace || orgConfig.name,
+          orgUserNames,
+        );
+
+        users.forEach(user => {
+          orgUserNames.push(user.metadata.name);
+        });
+
         for (const [groupName, userNames] of groupMemberUsers.entries()) {
           for (const userName of userNames) {
             const user = allUsersMap.get(prefix + userName);
@@ -145,7 +156,7 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
             const groupsByName = new Map(groups.map(g => [g.metadata.name, g]));
             const org = groupsByName.get(
               orgConfig.groupNamespace
-                ? orgConfig.groupNamespace
+                ? `${orgConfig.groupNamespace}/${orgConfig.name}`
                 : orgConfig.name,
             );
             if (

--- a/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
@@ -112,6 +112,7 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
           orgConfig.name,
           tokenType,
           orgConfig.userNamespace,
+          orgConfig.groupNamespace,
         );
         const { groups, groupMemberUsers } = await getOrganizationTeams(
           client,
@@ -138,6 +139,21 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
             const user = allUsersMap.get(prefix + userName);
             if (user && !user.spec.memberOf.includes(groupName)) {
               user.spec.memberOf.push(groupName);
+            }
+
+            // Ensure all users are added to org
+            const groupsByName = new Map(groups.map(g => [g.metadata.name, g]));
+            const org = groupsByName.get(
+              orgConfig.groupNamespace
+                ? orgConfig.groupNamespace
+                : orgConfig.name,
+            );
+            if (
+              user &&
+              org &&
+              !org?.spec.members?.includes(prefix + userName)
+            ) {
+              org?.spec.members?.push(prefix + userName);
             }
           }
         }

--- a/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
@@ -151,21 +151,6 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
             if (user && !user.spec.memberOf.includes(groupName)) {
               user.spec.memberOf.push(groupName);
             }
-
-            // Ensure all users are added to org
-            const groupsByName = new Map(groups.map(g => [g.metadata.name, g]));
-            const org = groupsByName.get(
-              orgConfig.groupNamespace
-                ? `${orgConfig.groupNamespace}/${orgConfig.name}`
-                : orgConfig.name,
-            );
-            if (
-              user &&
-              org &&
-              !org?.spec.members?.includes(prefix + userName)
-            ) {
-              org?.spec.members?.push(prefix + userName);
-            }
           }
         }
         buildOrgHierarchy(groups);

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.ts
@@ -221,12 +221,10 @@ export async function getOrganizationTeams(
       entity.spec.profile!.picture = team.avatarUrl;
     }
     if (team.parentTeam) {
-      entity.spec.parent = orgNamespace + '/' + team.parentTeam.slug;
+      entity.spec.parent = `${orgNamespace}/${team.parentTeam.slug}`;
     } else {
       // Add parent org if no parent
-      entity.spec.parent = orgNamespace
-        ? 'default/' + orgNamespace
-        : 'default/' + org;
+      entity.spec.parent = `default/${orgNamespace || org}`;
     }
     if (team.organization) {
       // Set organization name and description if not already defined

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.ts
@@ -130,7 +130,7 @@ export async function getOrganizationUsers(
     if (user.avatarUrl) entity.spec.profile!.picture = user.avatarUrl;
 
     // Add user to org
-    entity.spec.memberOf.push(orgNamespace ? orgNamespace : org);
+    entity.spec.memberOf.push(orgNamespace || org);
 
     return entity;
   };

--- a/plugins/catalog-backend/src/ingestion/processors/github/github.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/github/github.ts
@@ -267,7 +267,7 @@ export async function getOrganizationTeams(
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'Group',
     metadata: {
-      name: orgNamespace ? orgNamespace : org,
+      name: orgNamespace || org,
       namespace: 'default',
       description: orgDescription,
       annotations: {

--- a/plugins/catalog-backend/src/ingestion/processors/util/org.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/util/org.ts
@@ -25,11 +25,13 @@ export function buildOrgHierarchy(groups: GroupEntity[]) {
 
   for (const group of groups) {
     const selfName = group.metadata.name;
+    const selfNamespace = group.metadata.namespace;
+    const selfSlug = selfNamespace ? `${selfNamespace}/${selfName}` : selfName;
     const parentName = group.spec.parent;
     if (parentName) {
       const parent = groupsByName.get(parentName);
-      if (parent && !parent.spec.children.includes(selfName)) {
-        parent.spec.children.push(selfName);
+      if (parent && !parent.spec.children.includes(selfSlug)) {
+        parent.spec.children.push(selfSlug);
       }
     }
   }
@@ -40,10 +42,12 @@ export function buildOrgHierarchy(groups: GroupEntity[]) {
 
   for (const group of groups) {
     const selfName = group.metadata.name;
+    const selfNamespace = group.metadata.namespace;
+    const selfSlug = selfNamespace ? `${selfNamespace}/${selfName}` : selfName;
     for (const childName of group.spec.children) {
       const child = groupsByName.get(childName);
       if (child && !child.spec.parent) {
-        child.spec.parent = selfName;
+        child.spec.parent = selfSlug;
       }
     }
   }

--- a/plugins/catalog-backend/src/ingestion/processors/util/org.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/util/org.ts
@@ -25,13 +25,11 @@ export function buildOrgHierarchy(groups: GroupEntity[]) {
 
   for (const group of groups) {
     const selfName = group.metadata.name;
-    const selfNamespace = group.metadata.namespace;
-    const selfSlug = selfNamespace ? `${selfNamespace}/${selfName}` : selfName;
     const parentName = group.spec.parent;
     if (parentName) {
       const parent = groupsByName.get(parentName);
-      if (parent && !parent.spec.children.includes(selfSlug)) {
-        parent.spec.children.push(selfSlug);
+      if (parent && !parent.spec.children.includes(selfName)) {
+        parent.spec.children.push(selfName);
       }
     }
   }
@@ -42,12 +40,10 @@ export function buildOrgHierarchy(groups: GroupEntity[]) {
 
   for (const group of groups) {
     const selfName = group.metadata.name;
-    const selfNamespace = group.metadata.namespace;
-    const selfSlug = selfNamespace ? `${selfNamespace}/${selfName}` : selfName;
     for (const childName of group.spec.children) {
       const child = groupsByName.get(childName);
       if (child && !child.spec.parent) {
-        child.spec.parent = selfSlug;
+        child.spec.parent = selfName;
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: Spencer, Morgan [USA] <morgan@spencercreative.co>

## Hey, I just made a Pull Request!

Added a parent group for the GitHub MultiOrg Processor to create better hierarchy among groups. Links org team groups to new parent org group by creating a group with `spec.type` of `organization`. Should link all org users and all team groups to the parent org.

Closes #7619 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
