### PR TITLE
Detect GitHub rate limits in GithubUrlReader

### DIFF
--- a/.changeset/mean-glasses-play.md
+++ b/.changeset/mean-glasses-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Add "rate limit exceeded" to error from GithubUrlReader if that is the cause of a read failure

--- a/packages/backend-common/src/reading/GithubUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.test.ts
@@ -221,6 +221,32 @@ describe('GithubUrlReader', () => {
       ).rejects.toThrow(NotModifiedError);
     });
 
+    it('should throw Error with ratelimit exceeded if GitHub responds with 403 and rate limit is exceeded', async () => {
+      expect.assertions(1);
+
+      worker.use(
+        rest.get(
+          'https://ghe.github.com/api/v3/repos/backstage/mock/tree/contents/',
+          (_req, res, ctx) => {
+            return res(
+              ctx.status(403),
+              ctx.set('X-RateLimit-Remaining', '0'),
+              ctx.body(
+                '{"message": "API rate limit exceeded for xxx.xxx.xxx.xxx..."}',
+              ),
+            );
+          },
+        ),
+      );
+
+      await expect(
+        gheProcessor.readUrl(
+          'https://github.com/backstage/mock/tree/blob/main',
+          { etag: 'foo' },
+        ),
+      ).rejects.toThrow(/rate limit exceeded/);
+    });
+
     it('should return etag from the response', async () => {
       (mockCredentialsProvider.getCredentials as jest.Mock).mockResolvedValue({
         headers: {


### PR DESCRIPTION
Currently there is no way of knowing whether a 403 error from the
GithubUrlReader is due to bad credentials or GitHub rate limits.

This change appends the text " (rate limit exceeded)" to the thrown error to
help operators understand that this is the case.

This closes #7628 .

Signed-off-by: Crevil <bjoern.soerensen@gmail.com>

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
