### PR TITLE
fix: sentry-plugin API parameter name corrected

### DIFF
--- a/.changeset/large-dragons-design.md
+++ b/.changeset/large-dragons-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sentry': patch
+---
+
+fix: parameter name on call to sentry api

--- a/plugins/sentry/src/api/production-api.ts
+++ b/plugins/sentry/src/api/production-api.ts
@@ -32,7 +32,7 @@ export class ProductionSentryApi implements SentryApi {
     const apiUrl = `${await this.discoveryApi.getBaseUrl('proxy')}/sentry/api`;
 
     const response = await fetch(
-      `${apiUrl}/0/projects/${this.organization}/${project}/issues/?statsFor=${statsFor}`,
+      `${apiUrl}/0/projects/${this.organization}/${project}/issues/?statsPeriod=${statsFor}`,
     );
 
     if (response.status >= 400 && response.status < 600) {


### PR DESCRIPTION
### (Minor Fix)

The query parameter in the call to `sentry.io` API is mistaken.

According to documentation https://docs.sentry.io/api/events/list-a-projects-issues/ it is `statsPeriod` rather than `statsFor`.

Without the fix parameter is simply ignored.

_To check manually try setting it to invalid value, e.g. `1d` - if the parameter name is wrong, nothing shall happen. With the fixed name one gets `400` from sentry._

No changes in documentation is needed (it just was broken and will start working, but not very noticeable). No additional tests are provided as it is about external API.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->
