### PR TITLE
feat: add middleware to the backend (express app)

### DIFF
--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -65,6 +65,7 @@ export class ServiceBuilderImpl implements ServiceBuilder {
   private cspOptions: Record<string, string[] | false> | undefined;
   private httpsSettings: HttpsSettings | undefined;
   private routers: [string, Router][];
+  private middlewares: [];
   private requestLoggingHandler: RequestLoggingHandlerFactory | undefined;
   // Reference to the module where builder is created - needed for hot module
   // reloading
@@ -72,6 +73,7 @@ export class ServiceBuilderImpl implements ServiceBuilder {
 
   constructor(moduleRef: NodeModule) {
     this.routers = [];
+    this.middlewares = [];
     this.module = moduleRef;
   }
 
@@ -145,6 +147,11 @@ export class ServiceBuilderImpl implements ServiceBuilder {
     return this;
   }
 
+  addMiddleware(fnct: Function) {
+    this.middlewares.push(fnct);
+    return this;
+  }
+
   setRequestLoggingHandler(
     requestLoggingHandler: RequestLoggingHandlerFactory,
   ) {
@@ -165,6 +172,9 @@ export class ServiceBuilderImpl implements ServiceBuilder {
     app.use(
       (this.requestLoggingHandler ?? defaultRequestLoggingHandler)(logger),
     );
+    for (const fnct of this.middlewares) {
+      app.use(fnct);
+    }
     for (const [root, route] of this.routers) {
       app.use(root, route);
     }

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -88,6 +88,13 @@ export type ServiceBuilder = {
   addRouter(root: string, router: Router | RequestHandler): ServiceBuilder;
 
   /**
+   * Adds a middleware to the Express app.
+   *
+   * @param fnct - The function to add as a middleware, for example : setheader on response object
+   */
+  addMiddleware(fnct: Function): ServiceBuilder;
+
+  /**
    * Set the request logging handler
    *
    * If no handler is given the default one is used


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We give the possibility to add middleware to the backend express app.
It's useful for example when you manage process as authentication and you need to specify some value into header.
Here an example how to use ServiceBuilder and middleware:
```javascript
const service = createServiceBuilder(module)
    .loadConfig(config)
    .addRouter('', await healthcheck(healthcheckEnv))
    .addRouter('/api', apiRouter)
    .addRouter('', await app(appEnv))
    .addMiddleware((req: Request, res: Response, next: NextFunction) => {
      res.set('X-My-Header-Name', 'myvalue');
      next();
    });
```


#### :heavy_check_mark: Checklist

- Changeset : Modification into backend-common with no impact, just another option for a builder. 
- Added or updated documentation : no documentation, just comment
- Tests for new functionality and regression tests for bug fixes : No unit test on this builder yet
- Screenshots attached (for UI changes) : No
- All your commits have a `Signed-off-by` : Ok
