### PR TITLE
update datatogRum browser agent version

### DIFF
--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -83,7 +83,7 @@
         window,
         document,
         'script',
-        'https://www.datadoghq-browser-agent.com/datadog-rum.js',
+        'https://www.datadoghq-browser-agent.com/datadog-rum-v3.js',
         'DD_RUM',
       );
       DD_RUM.onReady(function () {


### PR DESCRIPTION
Update datadogRum browser agent to version 3, as official Datadog documentation [indicates](https://docs.datadoghq.com/real_user_monitoring/browser/#cdn-async) now.

Since actual usage is minimal (only a basic setup on example application), there is no breaking change.

Datadog RUM agent has been improved in stability, functionality and security [since version 2](https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md)

I've run some tests and got RUM data without any issue.

![image](https://user-images.githubusercontent.com/6618757/138282527-e8ae653e-8570-4906-a86b-7ef291f4516b.png)


#### :heavy_check_mark: Checklist

- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
