### PR TITLE
Allow overriding colour in Gauge components

### DIFF
--- a/.changeset/grumpy-pugs-report.md
+++ b/.changeset/grumpy-pugs-report.md
@@ -1,0 +1,23 @@
+---
+'@backstage/core-components': patch
+---
+
+Add new way to override color selection to progress bar/gauge components.
+
+`Gauge`, `LinearGauge` and `GaugeCard` all accept a `getColor` prop,
+which is a function of the type:
+
+```ts
+export type GetColor = (args: {
+  palette: Palette;
+  value: number;
+  inverse?: boolean;
+  max?: number;
+}) => string | PaletteColor;
+```
+
+Either return a standard Material UI palette color object or a CSS color
+string (e.g. "red", "#f02020"), and the gauge will be set to that color.
+
+If the prop is omitted, the default implementation is unchanged from previous
+versions.

--- a/.changeset/grumpy-pugs-report.md
+++ b/.changeset/grumpy-pugs-report.md
@@ -8,16 +8,16 @@ Add new way to override color selection to progress bar/gauge components.
 which is a function of the type:
 
 ```ts
-export type GetColor = (args: {
+export type GaugePropsGetColor = (args: {
   palette: Palette;
   value: number;
   inverse?: boolean;
   max?: number;
-}) => string | PaletteColor;
+}) => string;
 ```
 
-Either return a standard Material UI palette color object or a CSS color
-string (e.g. "red", "#f02020"), and the gauge will be set to that color.
+Return a standard CSS color string (e.g. "red", "#f02020"), and the gauge will
+be set to that color.
 
 If the prop is omitted, the default implementation is unchanged from previous
 versions.

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -7,6 +7,7 @@
 
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstageIdentityApi } from '@backstage/core-plugin-api';
+import { BackstagePalette } from '@backstage/theme';
 import { BackstageTheme } from '@backstage/theme';
 import { ButtonProps as ButtonProps_2 } from '@material-ui/core/Button';
 import { CardHeaderProps } from '@material-ui/core/CardHeader';
@@ -368,8 +369,6 @@ export function FeatureCalloutCircular(
 // @public (undocumented)
 export type FiltersContainerClassKey = 'root' | 'title';
 
-// Warning: (ae-forgotten-export) The symbol "GaugeProps" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export function Gauge(props: GaugeProps): JSX.Element;
 
@@ -383,6 +382,27 @@ export type GaugeCardClassKey = 'root';
 
 // @public (undocumented)
 export type GaugeClassKey = 'root' | 'overlay' | 'circle' | 'colorUnknown';
+
+// @public (undocumented)
+export type GaugeProps = {
+  value: number;
+  fractional?: boolean;
+  inverse?: boolean;
+  unit?: string;
+  max?: number;
+  getColor?: GaugePropsGetColor;
+};
+
+// @public (undocumented)
+export type GaugePropsGetColor = (args: GaugePropsGetColorOptions) => string;
+
+// @public (undocumented)
+export type GaugePropsGetColorOptions = {
+  palette: BackstagePalette;
+  value: number;
+  inverse?: boolean;
+  max?: number;
+};
 
 // @public (undocumented)
 export function GitHubIcon(props: IconComponentProps): JSX.Element;

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -100,7 +100,7 @@ export type BottomLinkProps = {
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function Breadcrumbs(props: Props_21): JSX.Element;
+export function Breadcrumbs(props: Props_20): JSX.Element;
 
 // @public (undocumented)
 export type BreadcrumbsClickableTextClassKey = 'root';
@@ -157,7 +157,7 @@ export interface CodeSnippetProps {
 // Warning: (ae-missing-release-tag) "Content" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function Content(props: PropsWithChildren<Props_14>): JSX.Element;
+export function Content(props: PropsWithChildren<Props_13>): JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "ContentHeaderProps" needs to be exported by the entry point index.d.ts
 //
@@ -368,10 +368,10 @@ export function FeatureCalloutCircular(
 // @public (undocumented)
 export type FiltersContainerClassKey = 'root' | 'title';
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "GaugeProps" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function Gauge(props: Props_11): JSX.Element;
+export function Gauge(props: GaugeProps): JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 //
@@ -393,7 +393,7 @@ export function GroupIcon(props: IconComponentProps): JSX.Element;
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function Header(props: PropsWithChildren<Props_15>): JSX.Element;
+export function Header(props: PropsWithChildren<Props_14>): JSX.Element;
 
 // @public (undocumented)
 export type HeaderClassKey =
@@ -484,7 +484,7 @@ export type IconLinkVerticalProps = {
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export function InfoCard(props: Props_16): JSX.Element;
+export function InfoCard(props: Props_15): JSX.Element;
 
 // @public (undocumented)
 export type InfoCardClassKey =
@@ -565,7 +565,7 @@ export type LifecycleClassKey = 'alpha' | 'beta';
 // Warning: (ae-missing-release-tag) "LinearGauge" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function LinearGauge(props: Props_12): JSX.Element | null;
+export function LinearGauge(props: Props_11): JSX.Element | null;
 
 // Warning: (ae-missing-release-tag) "LinkType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -666,7 +666,7 @@ export type OverflowTooltipClassKey = 'container';
 // Warning: (ae-missing-release-tag) "Page" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function Page(props: PropsWithChildren<Props_17>): JSX.Element;
+export function Page(props: PropsWithChildren<Props_16>): JSX.Element;
 
 // Warning: (ae-missing-release-tag) "PageClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -771,7 +771,7 @@ export type SelectInputBaseClassKey = 'root' | 'input';
 // Warning: (ae-missing-release-tag) "Sidebar" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function Sidebar(props: PropsWithChildren<Props_18>): JSX.Element;
+export function Sidebar(props: PropsWithChildren<Props_17>): JSX.Element;
 
 // Warning: (ae-missing-release-tag) "SIDEBAR_INTRO_LOCAL_STORAGE" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1961,7 +1961,7 @@ export const SidebarSpacer: React_2.ComponentType<
 // Warning: (ae-missing-release-tag) "SignInPage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function SignInPage(props: Props_19): JSX.Element;
+export function SignInPage(props: Props_18): JSX.Element;
 
 // Warning: (ae-missing-release-tag) "SignInPageClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2050,7 +2050,7 @@ export function StatusWarning(props: PropsWithChildren<{}>): JSX.Element;
 // Warning: (ae-missing-release-tag) "StructuredMetadataTable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function StructuredMetadataTable(props: Props_13): JSX.Element;
+export function StructuredMetadataTable(props: Props_12): JSX.Element;
 
 // Warning: (ae-missing-release-tag) "StructuredMetadataTableListClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2132,7 +2132,7 @@ export type TabBarClassKey = 'indicator' | 'flexContainer' | 'root';
 // Warning: (ae-missing-release-tag) "TabbedCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export function TabbedCard(props: PropsWithChildren<Props_20>): JSX.Element;
+export function TabbedCard(props: PropsWithChildren<Props_19>): JSX.Element;
 
 // Warning: (ae-missing-release-tag) "TabbedCardClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/packages/core-components/src/components/ProgressBars/Gauge.stories.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.stories.tsx
@@ -53,3 +53,9 @@ export const AbsoluteProgress = () => (
     <Gauge value={89.2} fractional={false} unit="m/s" />
   </div>
 );
+
+export const StaticColor = () => (
+  <div style={containerStyle}>
+    <Gauge getColor={() => '#f0f'} value={0.5} />
+  </div>
+);

--- a/packages/core-components/src/components/ProgressBars/Gauge.test.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.test.tsx
@@ -56,16 +56,26 @@ describe('<Gauge />', () => {
   };
 
   it('colors the progress correctly', () => {
-    expect(getProgressColor(palette, 'Not a Number' as any)).toBe('#ddd');
-    expect(getProgressColor(palette, 10)).toBe(error);
-    expect(getProgressColor(palette, 50)).toBe(warning);
-    expect(getProgressColor(palette, 90)).toBe(ok);
+    expect(getProgressColor({ palette, value: 'Not a Number' as any })).toBe(
+      '#ddd',
+    );
+    expect(getProgressColor({ palette, value: 10 })).toBe(error);
+    expect(getProgressColor({ palette, value: 50 })).toBe(warning);
+    expect(getProgressColor({ palette, value: 90 })).toBe(ok);
   });
 
   it('colors the inverse progress correctly', () => {
-    expect(getProgressColor(palette, 'Not a Number' as any)).toBe('#ddd');
-    expect(getProgressColor(palette, 10, true)).toBe(ok);
-    expect(getProgressColor(palette, 50, true)).toBe(warning);
-    expect(getProgressColor(palette, 90, true)).toBe(error);
+    expect(
+      getProgressColor({
+        palette,
+        value: 'Not a Number' as any,
+        inverse: true,
+      }),
+    ).toBe('#ddd');
+    expect(getProgressColor({ palette, value: 10, inverse: true })).toBe(ok);
+    expect(getProgressColor({ palette, value: 50, inverse: true })).toBe(
+      warning,
+    );
+    expect(getProgressColor({ palette, value: 90, inverse: true })).toBe(error);
   });
 });

--- a/packages/core-components/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.tsx
@@ -62,9 +62,7 @@ type GetColorArgs = {
   max?: number;
 };
 
-export type GetColor = (
-  args: GetColorArgs,
-) => string | BackstageTheme['palette']['error'];
+export type GetColor = (args: GetColorArgs) => string;
 
 const defaultGaugeProps = {
   fractional: true,

--- a/packages/core-components/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.tsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles<BackstageTheme>(
   { name: 'BackstageGauge' },
 );
 
-type Props = {
+export type GaugeProps = {
   value: number;
   fractional?: boolean;
   inverse?: boolean;
@@ -66,7 +66,7 @@ export type GetColor = (
   args: GetColorArgs,
 ) => string | BackstageTheme['palette']['error'];
 
-const defaultProps = {
+const defaultGaugeProps = {
   fractional: true,
   inverse: false,
   unit: '%',
@@ -83,7 +83,7 @@ export const getProgressColor: GetColor = ({
     return '#ddd';
   }
 
-  const actualMax = max ? max : defaultProps.max;
+  const actualMax = max ? max : defaultGaugeProps.max;
   const actualValue = inverse ? actualMax - value : value;
 
   if (actualValue < actualMax / 3) {
@@ -96,12 +96,12 @@ export const getProgressColor: GetColor = ({
 };
 
 /** @public */
-export function Gauge(props: Props) {
+export function Gauge(props: GaugeProps) {
   const { getColor = getProgressColor } = props;
   const classes = useStyles(props);
   const { palette } = useTheme<BackstageTheme>();
   const { value, fractional, inverse, unit, max } = {
-    ...defaultProps,
+    ...defaultGaugeProps,
     ...props,
   };
 

--- a/packages/core-components/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.tsx
@@ -15,7 +15,7 @@
  */
 
 import { makeStyles, useTheme } from '@material-ui/core/styles';
-import { BackstageTheme } from '@backstage/theme';
+import { BackstagePalette, BackstageTheme } from '@backstage/theme';
 import { Circle } from 'rc-progress';
 import React from 'react';
 
@@ -52,17 +52,17 @@ export type GaugeProps = {
   inverse?: boolean;
   unit?: string;
   max?: number;
-  getColor?: GetColor;
+  getColor?: GaugePropsGetColor;
 };
 
-type GetColorArgs = {
-  palette: BackstageTheme['palette'];
+export type GaugePropsGetColorOptions = {
+  palette: BackstagePalette;
   value: number;
   inverse?: boolean;
   max?: number;
 };
 
-export type GetColor = (args: GetColorArgs) => string;
+export type GaugePropsGetColor = (args: GaugePropsGetColorOptions) => string;
 
 const defaultGaugeProps = {
   fractional: true,
@@ -71,7 +71,7 @@ const defaultGaugeProps = {
   max: 100,
 };
 
-export const getProgressColor: GetColor = ({
+export const getProgressColor: GaugePropsGetColor = ({
   palette,
   value,
   inverse,

--- a/packages/core-components/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.tsx
@@ -55,12 +55,16 @@ type Props = {
   getColor?: GetColor;
 };
 
-export type GetColor = (args: {
+type GetColorArgs = {
   palette: BackstageTheme['palette'];
   value: number;
   inverse?: boolean;
   max?: number;
-}) => string | BackstageTheme['palette']['error'];
+};
+
+export type GetColor = (
+  args: GetColorArgs,
+) => string | BackstageTheme['palette']['error'];
 
 const defaultProps = {
   fractional: true,
@@ -69,12 +73,12 @@ const defaultProps = {
   max: 100,
 };
 
-export function getProgressColor(
-  palette: BackstageTheme['palette'],
-  value: number,
-  inverse?: boolean,
-  max?: number,
-) {
+export const getProgressColor: GetColor = ({
+  palette,
+  value,
+  inverse,
+  max,
+}) => {
   if (isNaN(value)) {
     return '#ddd';
   }
@@ -89,18 +93,11 @@ export function getProgressColor(
   }
 
   return palette.status.ok;
-}
-
-export const defaultGetProgressColor: GetColor = ({
-  palette,
-  value,
-  inverse,
-  max,
-}) => getProgressColor(palette, value, inverse, max);
+};
 
 /** @public */
 export function Gauge(props: Props) {
-  const { getColor = defaultGetProgressColor } = props;
+  const { getColor = getProgressColor } = props;
   const classes = useStyles(props);
   const { palette } = useTheme<BackstageTheme>();
   const { value, fractional, inverse, unit, max } = {

--- a/packages/core-components/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.tsx
@@ -52,7 +52,15 @@ type Props = {
   inverse?: boolean;
   unit?: string;
   max?: number;
+  getColor?: GetColor;
 };
+
+export type GetColor = (args: {
+  palette: BackstageTheme['palette'];
+  value: number;
+  inverse?: boolean;
+  max?: number;
+}) => string | BackstageTheme['palette']['error'];
 
 const defaultProps = {
   fractional: true,
@@ -83,10 +91,18 @@ export function getProgressColor(
   return palette.status.ok;
 }
 
+export const defaultGetProgressColor: GetColor = ({
+  palette,
+  value,
+  inverse,
+  max,
+}) => getProgressColor(palette, value, inverse, max);
+
 /** @public */
 export function Gauge(props: Props) {
+  const { getColor = defaultGetProgressColor } = props;
   const classes = useStyles(props);
-  const theme = useTheme<BackstageTheme>();
+  const { palette } = useTheme<BackstageTheme>();
   const { value, fractional, inverse, unit, max } = {
     ...defaultProps,
     ...props,
@@ -102,7 +118,7 @@ export function Gauge(props: Props) {
         percent={asPercentage}
         strokeWidth={12}
         trailWidth={12}
-        strokeColor={getProgressColor(theme.palette, asActual, inverse, max)}
+        strokeColor={getColor({ palette, value: asActual, inverse, max })}
         className={classes.circle}
       />
       <div className={classes.overlay}>

--- a/packages/core-components/src/components/ProgressBars/Gauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/Gauge.tsx
@@ -46,6 +46,7 @@ const useStyles = makeStyles<BackstageTheme>(
   { name: 'BackstageGauge' },
 );
 
+/** @public */
 export type GaugeProps = {
   value: number;
   fractional?: boolean;
@@ -55,6 +56,7 @@ export type GaugeProps = {
   getColor?: GaugePropsGetColor;
 };
 
+/** @public */
 export type GaugePropsGetColorOptions = {
   palette: BackstagePalette;
   value: number;
@@ -62,6 +64,7 @@ export type GaugePropsGetColorOptions = {
   max?: number;
 };
 
+/** @public */
 export type GaugePropsGetColor = (args: GaugePropsGetColorOptions) => string;
 
 const defaultGaugeProps = {

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
@@ -111,8 +111,8 @@ export const StaticColor = () => (
     </Grid>
     <Grid item>
       <GaugeCard
-        getColor={({ palette }) => palette.error}
-        title="palette.error"
+        getColor={({ palette }) => palette.status.error}
+        title="palette.status.error"
         progress={0.5}
       />
     </Grid>

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.stories.tsx
@@ -97,3 +97,24 @@ export const LinkInFooter = () => (
     </Grid>
   </Wrapper>
 );
+
+export const StaticColor = () => (
+  <Wrapper>
+    <Grid item>
+      <GaugeCard getColor={() => '#f00'} title="Red" progress={0.5} />
+    </Grid>
+    <Grid item>
+      <GaugeCard getColor={() => '#0f0'} title="Green" progress={0.5} />
+    </Grid>
+    <Grid item>
+      <GaugeCard getColor={() => '#00f'} title="Blue" progress={0.5} />
+    </Grid>
+    <Grid item>
+      <GaugeCard
+        getColor={({ palette }) => palette.error}
+        title="palette.error"
+        progress={0.5}
+      />
+    </Grid>
+  </Wrapper>
+);

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { InfoCard, InfoCardVariants } from '../../layout/InfoCard';
 import { BottomLinkProps } from '../../layout/BottomLink';
-import { Gauge } from './Gauge';
+import { Gauge, GetColor } from './Gauge';
 
 type Props = {
   title: string;
@@ -28,6 +28,7 @@ type Props = {
   progress: number;
   inverse?: boolean;
   deepLink?: BottomLinkProps;
+  getColor?: GetColor;
 };
 
 /** @public */
@@ -46,7 +47,14 @@ const useStyles = makeStyles(
 /** @public */
 export function GaugeCard(props: Props) {
   const classes = useStyles(props);
-  const { title, subheader, progress, inverse, deepLink, variant } = props;
+  const { title, subheader, progress, inverse, deepLink, variant, getColor } =
+    props;
+
+  const gaugeProps = {
+    inverse,
+    getColor,
+    value: progress,
+  };
 
   return (
     <div className={classes.root}>
@@ -56,7 +64,7 @@ export function GaugeCard(props: Props) {
         deepLink={deepLink}
         variant={variant}
       >
-        <Gauge value={progress} inverse={inverse} />
+        <Gauge {...gaugeProps} />
       </InfoCard>
     </div>
   );

--- a/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
+++ b/packages/core-components/src/components/ProgressBars/GaugeCard.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { InfoCard, InfoCardVariants } from '../../layout/InfoCard';
 import { BottomLinkProps } from '../../layout/BottomLink';
-import { Gauge, GetColor } from './Gauge';
+import { Gauge, GaugePropsGetColor } from './Gauge';
 
 type Props = {
   title: string;
@@ -28,7 +28,7 @@ type Props = {
   progress: number;
   inverse?: boolean;
   deepLink?: BottomLinkProps;
-  getColor?: GetColor;
+  getColor?: GaugePropsGetColor;
 };
 
 /** @public */

--- a/packages/core-components/src/components/ProgressBars/LinearGauge.stories.tsx
+++ b/packages/core-components/src/components/ProgressBars/LinearGauge.stories.tsx
@@ -41,3 +41,9 @@ export const LowProgress = () => (
     <LinearGauge value={0.2} />
   </div>
 );
+
+export const StaticColor = () => (
+  <div style={containerStyle}>
+    <LinearGauge getColor={() => '#f0f'} value={0.5} />
+  </div>
+);

--- a/packages/core-components/src/components/ProgressBars/LinearGauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/LinearGauge.tsx
@@ -20,7 +20,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 // @ts-ignore
 import { Line } from 'rc-progress';
 import { BackstageTheme } from '@backstage/theme';
-import { defaultGetProgressColor, GetColor } from './Gauge';
+import { getProgressColor, GetColor } from './Gauge';
 
 type Props = {
   /**
@@ -31,7 +31,7 @@ type Props = {
 };
 
 export function LinearGauge(props: Props) {
-  const { value, getColor = defaultGetProgressColor } = props;
+  const { value, getColor = getProgressColor } = props;
   const { palette } = useTheme<BackstageTheme>();
   if (isNaN(value)) {
     return null;

--- a/packages/core-components/src/components/ProgressBars/LinearGauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/LinearGauge.tsx
@@ -20,18 +20,19 @@ import Tooltip from '@material-ui/core/Tooltip';
 // @ts-ignore
 import { Line } from 'rc-progress';
 import { BackstageTheme } from '@backstage/theme';
-import { getProgressColor } from './Gauge';
+import { defaultGetProgressColor, GetColor } from './Gauge';
 
 type Props = {
   /**
    * Progress value between 0.0 - 1.0.
    */
   value: number;
+  getColor?: GetColor;
 };
 
 export function LinearGauge(props: Props) {
-  const { value } = props;
-  const theme = useTheme<BackstageTheme>();
+  const { value, getColor = defaultGetProgressColor } = props;
+  const { palette } = useTheme<BackstageTheme>();
   if (isNaN(value)) {
     return null;
   }
@@ -39,7 +40,12 @@ export function LinearGauge(props: Props) {
   if (percent > 100) {
     percent = 100;
   }
-  const strokeColor = getProgressColor(theme.palette, percent, false, 100);
+  const strokeColor = getColor({
+    palette,
+    value: percent,
+    inverse: false,
+    max: 100,
+  });
   return (
     <Tooltip title={`${percent}%`}>
       <span>

--- a/packages/core-components/src/components/ProgressBars/LinearGauge.tsx
+++ b/packages/core-components/src/components/ProgressBars/LinearGauge.tsx
@@ -20,14 +20,14 @@ import Tooltip from '@material-ui/core/Tooltip';
 // @ts-ignore
 import { Line } from 'rc-progress';
 import { BackstageTheme } from '@backstage/theme';
-import { getProgressColor, GetColor } from './Gauge';
+import { getProgressColor, GaugePropsGetColor } from './Gauge';
 
 type Props = {
   /**
    * Progress value between 0.0 - 1.0.
    */
   value: number;
-  getColor?: GetColor;
+  getColor?: GaugePropsGetColor;
 };
 
 export function LinearGauge(props: Props) {

--- a/packages/core-components/src/components/ProgressBars/index.ts
+++ b/packages/core-components/src/components/ProgressBars/index.ts
@@ -17,5 +17,10 @@
 export { GaugeCard } from './GaugeCard';
 export type { GaugeCardClassKey } from './GaugeCard';
 export { Gauge } from './Gauge';
+export type {
+  GaugeProps,
+  GaugePropsGetColor,
+  GaugePropsGetColorOptions,
+} from './Gauge';
 export type { GaugeClassKey } from './Gauge';
 export { LinearGauge } from './LinearGauge';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #7705. Adds a `color` prop to `Gauge`, `LinearGauge` and `GaugeCard` so the color of the gauge can be arbitrarily set. Obviously this behaviour is hard to screenshot, so it basically looks exactly like the existing ones except with whatever color you like whenever you like. Here's one in fetching magenta, anyway:

![Screenshot 2021-10-21 at 15 54 30](https://user-images.githubusercontent.com/2285130/138303778-ba6cdbeb-b33e-457d-be6c-0c325ce79695.png)

And `LinearGauge`:

![Screenshot 2021-10-21 at 16 02 37](https://user-images.githubusercontent.com/2285130/138305141-9deed281-b171-4f84-b83a-af96a31fb97a.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
