### PR TITLE
Scroll to Top of TechDocs Reader During Page Navigation

### DIFF
--- a/.changeset/dull-news-visit.md
+++ b/.changeset/dull-news-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Reader will now scroll to the top of the page when navigating between pages

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -321,6 +321,7 @@ export const useTechDocsReaderDom = (): Element | null => {
           baseUrl: window.location.origin,
           onClick: (_: MouseEvent, url: string) => {
             const parsedUrl = new URL(url);
+            // hash exists when anchor is clicked on secondary sidebar
             if (parsedUrl.hash) {
               navigate(`${parsedUrl.pathname}${parsedUrl.hash}`);
               // Scroll to hash if it's on the current page
@@ -329,6 +330,10 @@ export const useTechDocsReaderDom = (): Element | null => {
                 ?.scrollIntoView();
             } else {
               navigate(parsedUrl.pathname);
+              // Scroll to top of reader if primary sidebar link is clicked
+              transformedElement
+                ?.querySelector('.md-content__inner')
+                ?.scrollIntoView();
             }
           },
         }),


### PR DESCRIPTION
When navigating between tech-docs pages using the primary sidebar navigation menu, scroll to the top of the generated markdown content via `.scrollIntoView()`.

## Hey, I just made a Pull Request!

This resolves issue #7145.

Taking reference from the scrolling logic of the secondary sidebar, which scrolls to an anchor on a page, this implementation will scroll to the top of the generated markdown content when using the primary sidebar navigation menu.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
