### PR TITLE
release @backstage/types

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -30,7 +30,7 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@backstage/types": "^0.1.0",
+    "@backstage/types": "^0.1.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/core-plugin-api/package.json
+++ b/packages/core-plugin-api/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@backstage/config": "^0.1.9",
     "@backstage/theme": "^0.2.9",
-    "@backstage/types": "^0.1.0",
+    "@backstage/types": "^0.1.1",
     "@backstage/version-bridge": "^0.1.0",
     "@material-ui/core": "^4.12.2",
     "@types/react": "*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/types",
   "description": "Common TypeScript types used within Backstage",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Because of a mistakenly broken master build, we're issuing this force bump to make the release flow happen for the new `@backstage/types` package. No changeset or `CHANGELOG.md` added, since this is effectively already the initial release.