### PR TITLE
Export components so developers can customize the scaffolder page

### DIFF
--- a/.changeset/friendly-olives-drop.md
+++ b/.changeset/friendly-olives-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Surfacing all components of the ScaffolderPage outside of the plugin so you can customize the page

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -240,6 +240,29 @@ const scaffolderPlugin: BackstagePlugin<
 export { scaffolderPlugin as plugin };
 export { scaffolderPlugin };
 
+// Warning: (ae-missing-release-tag) "TemplateList" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const TemplateList: ({
+  TemplateCardComponent,
+}: TemplateListProps) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "TemplateListProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TemplateListProps = {
+  TemplateCardComponent?:
+    | ComponentType<{
+        template: TemplateEntityV1beta2;
+      }>
+    | undefined;
+};
+
+// Warning: (ae-missing-release-tag) "TemplateTypePicker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const TemplateTypePicker: () => JSX.Element | null;
+
 // Warning: (ae-missing-release-tag) "TextValuePicker" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/plugins/scaffolder/src/components/TemplateList/index.ts
+++ b/plugins/scaffolder/src/components/TemplateList/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { TemplateList } from './TemplateList';
+export type { TemplateListProps } from './TemplateList';

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -44,3 +44,6 @@ export {
   TextValuePicker,
 } from './components/fields';
 export { FavouriteTemplate } from './components/FavouriteTemplate';
+export { TemplateList } from './components/TemplateList';
+export type { TemplateListProps } from './components/TemplateList';
+export { TemplateTypePicker } from './components/TemplateTypePicker';


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This is the first step to allow developers to customize the scaffolder
page. With this work all the scaffolder page is now available to
backstage developers and they can customize the current scaffolder
page how they like similar to what is available for the catalog page
and other plugin pages.

Future work that has been discussed is possibly allowing for SwimLane
components that will allow developers to surface specific templates
or organize templates in specific ways

Signed-off-by: jrusso1020 <jrusso@brex.com>



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
