### PR TITLE
Add a new endpoint for consuming logs from the Scaffolder that uses long polling instead of Server Sent Events

### DIFF
--- a/.changeset/selfish-countries-prove.md
+++ b/.changeset/selfish-countries-prove.md
@@ -1,0 +1,42 @@
+---
+'@backstage/plugin-scaffolder': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Adds a new endpoint for consuming logs from the Scaffolder that uses long polling instead of Server Sent Events.
+
+This is useful if Backstage is accessed from an environment that doesn't support SSE correctly, which happens in combination with certain enterprise HTTP Proxy servers.
+
+It is intended to switch the endpoint globally for the whole instance.
+If you want to use it, you can provide a reconfigured API to the `scaffolderApiRef`:
+
+```tsx
+// packages/app/src/apis.ts
+
+// ...
+import {
+  scaffolderApiRef,
+  ScaffolderClient,
+} from '@backstage/plugin-scaffolder';
+
+export const apis: AnyApiFactory[] = [
+  // ...
+
+  createApiFactory({
+    api: scaffolderApiRef,
+    deps: {
+      discoveryApi: discoveryApiRef,
+      identityApi: identityApiRef,
+      scmIntegrationsApi: scmIntegrationsApiRef,
+    },
+    factory: ({ discoveryApi, identityApi, scmIntegrationsApi }) =>
+      new ScaffolderClient({
+        discoveryApi,
+        identityApi,
+        scmIntegrationsApi,
+        // use long polling instead of an eventsource
+        useLongPollingLogs: true,
+      }),
+  }),
+];
+```

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -319,7 +319,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
     });
   });
 
-  describe('GET /v2/tasks/:taskId/logs', () => {
+  describe('GET /v2/tasks/:taskId/events', () => {
     it('should return log messages', async () => {
       const unsubscribe = jest.fn();
       MockStorageTaskBroker.prototype.observe.mockImplementation(
@@ -346,7 +346,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
         },
       );
 
-      const response = await request(app).get('/v2/tasks/a-random-id/logs');
+      const response = await request(app).get('/v2/tasks/a-random-id/events');
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual([
@@ -384,7 +384,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       );
 
       const response = await request(app)
-        .get('/v2/tasks/a-random-id/logs')
+        .get('/v2/tasks/a-random-id/events')
         .query({ after: 10 });
 
       expect(response.status).toEqual(200);

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -292,7 +292,7 @@ export async function createRouter(
         logger.debug(`Event stream observing taskId '${taskId}' closed`);
       });
     })
-    .get('/v2/tasks/:taskId/logs', async (req, res) => {
+    .get('/v2/tasks/:taskId/events', async (req, res) => {
       const { taskId } = req.params;
       const after = Number(req.query.after) || undefined;
 

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -14,33 +14,33 @@
  * limitations under the License.
  */
 
-import { Config } from '@backstage/config';
-import express from 'express';
-import Router from 'express-promise-router';
-import { Logger } from 'winston';
-import { CatalogEntityClient } from '../lib/catalog';
-import { validate } from 'jsonschema';
-import {
-  DatabaseTaskStore,
-  TemplateActionRegistry,
-  TaskWorker,
-  TemplateAction,
-  createBuiltinActions,
-} from '../scaffolder';
-import { StorageTaskBroker } from '../scaffolder/tasks/StorageTaskBroker';
-import { getEntityBaseUrl, getWorkingDirectory } from './helpers';
 import {
   ContainerRunner,
   PluginDatabaseManager,
   UrlReader,
 } from '@backstage/backend-common';
-import { InputError, NotFoundError } from '@backstage/errors';
 import { CatalogApi } from '@backstage/catalog-client';
-import { TemplateEntityV1beta2, Entity } from '@backstage/catalog-model';
-import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
-
+import { Entity, TemplateEntityV1beta2 } from '@backstage/catalog-model';
+import { Config } from '@backstage/config';
+import { InputError, NotFoundError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
-import { TaskBroker, TaskSpec } from '../scaffolder/tasks/types';
+import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
+import express from 'express';
+import Router from 'express-promise-router';
+import { validate } from 'jsonschema';
+import { Logger } from 'winston';
+import { CatalogEntityClient } from '../lib/catalog';
+import {
+  createBuiltinActions,
+  DatabaseTaskStore,
+  TaskBroker,
+  TaskSpec,
+  TaskWorker,
+  TemplateAction,
+  TemplateActionRegistry,
+} from '../scaffolder';
+import { StorageTaskBroker } from '../scaffolder/tasks/StorageTaskBroker';
+import { getEntityBaseUrl, getWorkingDirectory } from './helpers';
 
 /**
  * RouterOptions
@@ -278,7 +278,8 @@ export async function createRouter(
               // to automatically reconnect because it lost connection.
             }
           }
-          res.flush();
+          // res.flush() is only available with the compression middleware
+          res.flush?.();
           if (shouldUnsubscribe) unsubscribe();
         },
       );

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -305,7 +305,7 @@ export async function createRouter(
       }, 30_000);
 
       // Get all known events after an id (always includes the completion event) and return the first callback
-      unsubscribe = taskBroker.observe(
+      ({ unsubscribe } = taskBroker.observe(
         { taskId, after },
         (error, { events }) => {
           // stop the timeout
@@ -320,7 +320,7 @@ export async function createRouter(
 
           res.json(events);
         },
-      );
+      ));
 
       // When client closes connection we update the clients list
       // avoiding the disconnected one

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -178,6 +178,7 @@ export class ScaffolderClient implements ScaffolderApi {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
     scmIntegrationsApi: ScmIntegrationRegistry;
+    useLongPollingLogs?: boolean;
   });
   // (undocumented)
   getIntegrationsList(options: { allowedHosts: string[] }): Promise<
@@ -199,13 +200,7 @@ export class ScaffolderClient implements ScaffolderApi {
   // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   scaffold(templateName: string, values: Record<string, any>): Promise<string>;
   // (undocumented)
-  streamLogs({
-    taskId,
-    after,
-  }: {
-    taskId: string;
-    after?: number;
-  }): Observable<LogEvent>;
+  streamLogs(opts: { taskId: string; after?: number }): Observable<LogEvent>;
 }
 
 // Warning: (ae-missing-release-tag) "ScaffolderFieldExtensions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -77,6 +77,7 @@
     "@types/jest": "^26.0.7",
     "@types/node": "^14.14.32",
     "cross-fetch": "^3.0.6",
+    "event-source-polyfill": "^1.0.25",
     "msw": "^0.35.0"
   },
   "files": [

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -55,6 +55,7 @@
     "json-schema": "^0.3.0",
     "lodash": "^4.17.21",
     "luxon": "^2.0.2",
+    "qs": "^6.9.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-lazylog": "^4.5.2",

--- a/plugins/scaffolder/src/api.test.ts
+++ b/plugins/scaffolder/src/api.test.ts
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
+import { ConfigReader } from '@backstage/core-app-api';
 import { ScmIntegrations } from '@backstage/integration';
 import { ScaffolderClient } from './api';
-import { ConfigReader } from '@backstage/core-app-api';
+
+const MockedEventSource = global.EventSource as jest.MockedClass<
+  typeof EventSource
+>;
 
 describe('api', () => {
-  const discoveryApi = {} as any;
+  const mockBaseUrl = 'http://backstage/api';
+
+  const discoveryApi = { getBaseUrl: async () => mockBaseUrl };
   const identityApi = {} as any;
   const scmIntegrationsApi = ScmIntegrations.fromConfig(
     new ConfigReader({
@@ -32,10 +38,14 @@ describe('api', () => {
       },
     }),
   );
-  const apiClient = new ScaffolderClient({
-    scmIntegrationsApi,
-    discoveryApi,
-    identityApi,
+
+  let apiClient: ScaffolderClient;
+  beforeEach(() => {
+    apiClient = new ScaffolderClient({
+      scmIntegrationsApi,
+      discoveryApi,
+      identityApi,
+    });
   });
 
   it('should return default and custom integrations', async () => {
@@ -50,5 +60,59 @@ describe('api', () => {
     integrations.forEach(integration =>
       expect(allowedHosts).toContain(integration.host),
     );
+  });
+
+  describe('streamEvents', () => {
+    describe('eventsource', () => {
+      it('should work', async () => {
+        MockedEventSource.prototype.addEventListener.mockImplementation(
+          (type, fn) => {
+            if (typeof fn !== 'function') {
+              return;
+            }
+
+            if (type === 'log') {
+              fn({
+                data: '{"id":1,"taskId":"a-random-id","type":"log","createdAt":"","body":{"message":"My log message"}}',
+              } as any);
+            } else if (type === 'completion') {
+              fn({
+                data: '{"id":2,"taskId":"a-random-id","type":"completion","createdAt":"","body":{"message":"Finished!"}}',
+              } as any);
+            }
+          },
+        );
+
+        const next = jest.fn();
+
+        await new Promise<void>(complete => {
+          apiClient
+            .streamLogs({ taskId: 'a-random-task-id' })
+            .subscribe({ next, complete });
+        });
+
+        expect(MockedEventSource).toBeCalledWith(
+          'http://backstage/api/v2/tasks/a-random-task-id/eventstream',
+          { withCredentials: true },
+        );
+        expect(MockedEventSource.prototype.close).toBeCalled();
+
+        expect(next).toBeCalledTimes(2);
+        expect(next).toBeCalledWith({
+          id: 1,
+          taskId: 'a-random-id',
+          type: 'log',
+          createdAt: '',
+          body: { message: 'My log message' },
+        });
+        expect(next).toBeCalledWith({
+          id: 2,
+          taskId: 'a-random-id',
+          type: 'completion',
+          createdAt: '',
+          body: { message: 'Finished!' },
+        });
+      });
+    });
   });
 });

--- a/plugins/scaffolder/src/api.test.ts
+++ b/plugins/scaffolder/src/api.test.ts
@@ -133,40 +133,43 @@ describe('api', () => {
 
       it('should work', async () => {
         server.use(
-          rest.get(`${mockBaseUrl}/v2/tasks/:taskId/logs`, (req, res, ctx) => {
-            const { taskId } = req.params;
-            const after = req.url.searchParams.get('after');
+          rest.get(
+            `${mockBaseUrl}/v2/tasks/:taskId/events`,
+            (req, res, ctx) => {
+              const { taskId } = req.params;
+              const after = req.url.searchParams.get('after');
 
-            if (taskId === 'a-random-task-id') {
-              if (!after) {
-                return res(
-                  ctx.json([
-                    {
-                      id: 1,
-                      taskId: 'a-random-id',
-                      type: 'log',
-                      createdAt: '',
-                      body: { message: 'My log message' },
-                    },
-                  ]),
-                );
-              } else if (after === '1') {
-                return res(
-                  ctx.json([
-                    {
-                      id: 2,
-                      taskId: 'a-random-id',
-                      type: 'completion',
-                      createdAt: '',
-                      body: { message: 'Finished!' },
-                    },
-                  ]),
-                );
+              if (taskId === 'a-random-task-id') {
+                if (!after) {
+                  return res(
+                    ctx.json([
+                      {
+                        id: 1,
+                        taskId: 'a-random-id',
+                        type: 'log',
+                        createdAt: '',
+                        body: { message: 'My log message' },
+                      },
+                    ]),
+                  );
+                } else if (after === '1') {
+                  return res(
+                    ctx.json([
+                      {
+                        id: 2,
+                        taskId: 'a-random-id',
+                        type: 'completion',
+                        createdAt: '',
+                        body: { message: 'Finished!' },
+                      },
+                    ]),
+                  );
+                }
               }
-            }
 
-            return res(ctx.status(500));
-          }),
+              return res(ctx.status(500));
+            },
+          ),
         );
 
         const next = jest.fn();
@@ -198,30 +201,33 @@ describe('api', () => {
         expect.assertions(3);
 
         server.use(
-          rest.get(`${mockBaseUrl}/v2/tasks/:taskId/logs`, (req, res, ctx) => {
-            const { taskId } = req.params;
+          rest.get(
+            `${mockBaseUrl}/v2/tasks/:taskId/events`,
+            (req, res, ctx) => {
+              const { taskId } = req.params;
 
-            const after = req.url.searchParams.get('after');
+              const after = req.url.searchParams.get('after');
 
-            // use assertion to make sure it is not called after unsubscribing
-            expect(after).toBe(null);
+              // use assertion to make sure it is not called after unsubscribing
+              expect(after).toBe(null);
 
-            if (taskId === 'a-random-task-id') {
-              return res(
-                ctx.json([
-                  {
-                    id: 1,
-                    taskId: 'a-random-id',
-                    type: 'log',
-                    createdAt: '',
-                    body: { message: 'My log message' },
-                  },
-                ]),
-              );
-            }
+              if (taskId === 'a-random-task-id') {
+                return res(
+                  ctx.json([
+                    {
+                      id: 1,
+                      taskId: 'a-random-id',
+                      type: 'log',
+                      createdAt: '',
+                      body: { message: 'My log message' },
+                    },
+                  ]),
+                );
+              }
 
-            return res(ctx.status(500));
-          }),
+              return res(ctx.status(500));
+            },
+          ),
         );
 
         const next = jest.fn();
@@ -252,25 +258,28 @@ describe('api', () => {
         const called = jest.fn();
 
         server.use(
-          rest.get(`${mockBaseUrl}/v2/tasks/:taskId/logs`, (_req, res, ctx) => {
-            called();
+          rest.get(
+            `${mockBaseUrl}/v2/tasks/:taskId/events`,
+            (_req, res, ctx) => {
+              called();
 
-            if (called.mock.calls.length > 1) {
-              return res(
-                ctx.json([
-                  {
-                    id: 2,
-                    taskId: 'a-random-id',
-                    type: 'completion',
-                    createdAt: '',
-                    body: { message: 'Finished!' },
-                  },
-                ]),
-              );
-            }
+              if (called.mock.calls.length > 1) {
+                return res(
+                  ctx.json([
+                    {
+                      id: 2,
+                      taskId: 'a-random-id',
+                      type: 'completion',
+                      createdAt: '',
+                      body: { message: 'Finished!' },
+                    },
+                  ]),
+                );
+              }
 
-            return res(ctx.status(500));
-          }),
+              return res(ctx.status(500));
+            },
+          ),
         );
 
         const next = jest.fn();

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -15,17 +15,18 @@
  */
 
 import { EntityName } from '@backstage/catalog-model';
-import { JsonObject, JsonValue, Observable } from '@backstage/types';
-import { ResponseError } from '@backstage/errors';
-import { ScmIntegrationRegistry } from '@backstage/integration';
-import { Field, FieldValidation } from '@rjsf/core';
-import ObservableImpl from 'zen-observable';
-import { ListActionsResponse, ScaffolderTask, Status } from './types';
 import {
   createApiRef,
   DiscoveryApi,
   IdentityApi,
 } from '@backstage/core-plugin-api';
+import { ResponseError } from '@backstage/errors';
+import { ScmIntegrationRegistry } from '@backstage/integration';
+import { JsonObject, JsonValue, Observable } from '@backstage/types';
+import { Field, FieldValidation } from '@rjsf/core';
+import qs from 'qs';
+import ObservableImpl from 'zen-observable';
+import { ListActionsResponse, ScaffolderTask, Status } from './types';
 
 export const scaffolderApiRef = createApiRef<ScaffolderApi>({
   id: 'plugin.scaffolder.service',
@@ -94,15 +95,18 @@ export class ScaffolderClient implements ScaffolderApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly identityApi: IdentityApi;
   private readonly scmIntegrationsApi: ScmIntegrationRegistry;
+  private readonly useLongPollingLogs: boolean;
 
   constructor(options: {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
     scmIntegrationsApi: ScmIntegrationRegistry;
+    useLongPollingLogs?: boolean;
   }) {
     this.discoveryApi = options.discoveryApi;
     this.identityApi = options.identityApi;
     this.scmIntegrationsApi = options.scmIntegrationsApi;
+    this.useLongPollingLogs = options.useLongPollingLogs ?? false;
   }
 
   async getIntegrationsList(options: { allowedHosts: string[] }) {
@@ -189,7 +193,15 @@ export class ScaffolderClient implements ScaffolderApi {
     return await response.json();
   }
 
-  streamLogs({
+  streamLogs(opts: { taskId: string; after?: number }): Observable<LogEvent> {
+    if (this.useLongPollingLogs) {
+      return this.streamLogsPolling(opts);
+    }
+
+    return this.streamLogsEventStream(opts);
+  }
+
+  private streamLogsEventStream({
     taskId,
     after,
   }: {
@@ -236,6 +248,46 @@ export class ScaffolderClient implements ScaffolderApi {
           subscriber.error(error);
         },
       );
+    });
+  }
+
+  private streamLogsPolling({
+    taskId,
+    after: inputAfter,
+  }: {
+    taskId: string;
+    after?: number;
+  }): Observable<LogEvent> {
+    let after = inputAfter;
+
+    return new ObservableImpl(subscriber => {
+      this.discoveryApi.getBaseUrl('scaffolder').then(async baseUrl => {
+        while (!subscriber.closed) {
+          const url = `${baseUrl}/v2/tasks/${encodeURIComponent(
+            taskId,
+          )}/logs?${qs.stringify({ after })}`;
+          const response = await fetch(url);
+
+          if (!response.ok) {
+            // wait for one second to not run into an
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            continue;
+          }
+
+          const logs = (await response.json()) as LogEvent[];
+
+          for (const event of logs) {
+            after = Number(event.id);
+
+            subscriber.next(event);
+
+            if (event.type === 'completion') {
+              subscriber.complete();
+              return;
+            }
+          }
+        }
+      });
     });
   }
 

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -265,7 +265,7 @@ export class ScaffolderClient implements ScaffolderApi {
         while (!subscriber.closed) {
           const url = `${baseUrl}/v2/tasks/${encodeURIComponent(
             taskId,
-          )}/logs?${qs.stringify({ after })}`;
+          )}/events?${qs.stringify({ after })}`;
           const response = await fetch(url);
 
           if (!response.ok) {

--- a/plugins/scaffolder/src/setupTests.ts
+++ b/plugins/scaffolder/src/setupTests.ts
@@ -15,3 +15,6 @@
  */
 
 import '@testing-library/jest-dom';
+
+const { EventSourcePolyfill } = jest.requireMock('event-source-polyfill');
+global.EventSource = EventSourcePolyfill;

--- a/plugins/scaffolder/src/setupTests.ts
+++ b/plugins/scaffolder/src/setupTests.ts
@@ -15,6 +15,7 @@
  */
 
 import '@testing-library/jest-dom';
+import 'cross-fetch/polyfill';
 
 const { EventSourcePolyfill } = jest.requireMock('event-source-polyfill');
 global.EventSource = EventSourcePolyfill;


### PR DESCRIPTION
Relates to #7579 (solves only the Scaffolder part).

---

This includes different things:

1. Add backend and frontend tests for the logs event stream.
2. Adds a new `/v2/tasks/:taskId/logs` as a long-polling variant of `/v2/tasks/:taskId/eventstream`.
3. Adds a `useLongPollingLogs` flag to the `ScaffolderClient`.

The current implementation is a global switch. In the future, it could also be helpful to add an automated fallback that recognizes that the eventstream is not working. But I left this out in this PR because the current variant is sufficient for us.

PS: I'm not too attached to the naming of the property/route name so feel free to give feedback on that 😉.

---

Adds a new endpoint for consuming logs from the Scaffolder that uses long polling instead of Server Sent Events.

This is useful if Backstage is accessed from an environment that doesn't support SSE correctly, which happens in combination with certain enterprise HTTP Proxy servers.

It is intended to switch the endpoint globally for the whole instance. If you want to use it, you can provide a reconfigured API to the `scaffolderApiRef`:

```tsx
// packages/app/src/apis.ts
// ...
import {
  scaffolderApiRef,
  ScaffolderClient,
} from '@backstage/plugin-scaffolder';
export const apis: AnyApiFactory[] = [
  // ...
  createApiFactory({
    api: scaffolderApiRef,
    deps: {
      discoveryApi: discoveryApiRef,
      identityApi: identityApiRef,
      scmIntegrationsApi: scmIntegrationsApiRef,
    },
    factory: ({ discoveryApi, identityApi, scmIntegrationsApi }) =>
      new ScaffolderClient({
        discoveryApi,
        identityApi,
        scmIntegrationsApi,
        // use long polling instead of an eventsource
        useLongPollingLogs: true,
      }),
  }),
];
```

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
