### PR TITLE
Pagerduty Service ID

### DIFF
--- a/.changeset/lovely-trains-bake.md
+++ b/.changeset/lovely-trains-bake.md
@@ -1,0 +1,17 @@
+---
+'@backstage/plugin-pagerduty': minor
+---
+
+# What is Changing
+
+Switch from Integration-Key to ServiceId in the pagerduty plugin
+
+# Why did this change
+
+Integration key is a secret that shouldn't be committed to source code directly. Service Id is simply an identifier and can be safely committed
+
+# How Does this Change Integrations
+
+Simply change the `pagerduty.com/integration-key` annotation to `pagerduty.com/service-id` instead.
+
+There is a workflow change that accompanies this where a user enters a title and a from email address when creating an incident from the backstage UI.

--- a/plugins/pagerduty/README.md
+++ b/plugins/pagerduty/README.md
@@ -23,13 +23,8 @@ If you need help with this plugin, please reach out on the [Backstage Discord se
 ### Integrating With a PagerDuty Service
 
 1. From the **Configuration** menu, select **Services**.
-2. There are two ways to add an integration to a service:
-   - **If you are adding your integration to an existing service**: Click the **name** of the service you want to add the integration to. Then, select the **Integrations** tab and click the **New Integration** button.
-   - **If you are creating a new service for your integration**: Please read the documentation in section [Configuring Services and Integrations](https://support.pagerduty.com/docs/services-and-integrations#section-configuring-services-and-integrations) and follow the steps outlined in the [Create a New Service](https://support.pagerduty.com/docs/services-and-integrations#section-create-a-new-service) section, selecting **Backstage** as the **Integration Type** in step 4. Continue with the **In Backstage** section (below) once you have finished these steps.
-3. Enter an **Integration Name** in the format `monitoring-tool-service-name` (e.g. `Backstage-Shopping-Cart`) and select **Backstage** from the Integration Type menu.
-4. Click the **Add Integration** button to save your new integration. You will be redirected to the Integrations tab for your service.
-5. An **Integration Key** will be generated on this screen. Keep this key saved in a safe place, as it will be used when you configure the integration with **Backstage** in the next section.
-   ![](https://pdpartner.s3.amazonaws.com/ig-template-copy-integration-key.png)
+2. Get the service id (End of the URL for a specific service <org>.missionlane.com/service-directory/<service-id>)
+3. Add the annotation of `pagerduty.com/service-id: <service-id>` to the catalog-info.yaml
 
 ## In Backstage
 
@@ -91,7 +86,7 @@ First, [annotate](https://backstage.io/docs/features/software-catalog/descriptor
 
 ```yaml
 annotations:
-  pagerduty.com/integration-key: [INTEGRATION_KEY]
+  pagerduty.com/service-id: [SERVICE_ID]
 ```
 
 Next, provide the [API token](https://support.pagerduty.com/docs/generating-api-keys#generating-a-general-access-rest-api-key) that the client will use to make requests to the [PagerDuty API](https://developer.pagerduty.com/docs/rest-api-v2/rest-api/).

--- a/plugins/pagerduty/api-report.md
+++ b/plugins/pagerduty/api-report.md
@@ -61,15 +61,15 @@ export class PagerDutyClient implements PagerDutyApi {
   // Warning: (ae-forgotten-export) The symbol "Service" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
-  getServiceByIntegrationKey(integrationKey: string): Promise<Service[]>;
+  getServiceByServiceId(serviceId: string): Promise<Service>;
   // Warning: (ae-forgotten-export) The symbol "TriggerAlarmRequest" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)
   triggerAlarm({
-    integrationKey,
-    source,
+    serviceId,
+    title,
+    from,
     description,
-    userName,
   }: TriggerAlarmRequest): Promise<Response>;
 }
 

--- a/plugins/pagerduty/src/api/types.ts
+++ b/plugins/pagerduty/src/api/types.ts
@@ -18,18 +18,18 @@ import { Incident, ChangeEvent, OnCall, Service } from '../components/types';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 
 export type TriggerAlarmRequest = {
-  integrationKey: string;
-  source: string;
+  serviceId: string;
+  from: string;
+  title: string;
   description: string;
-  userName: string;
 };
 
 export interface PagerDutyApi {
   /**
-   * Fetches a list of services, filtered by the provided integration key.
+   * Fetches a service via serviceId.
    *
    */
-  getServiceByIntegrationKey(integrationKey: string): Promise<Service[]>;
+  getServiceByServiceId(serviceId: string): Promise<Service>;
 
   /**
    * Fetches a list of incidents a provided service has.
@@ -55,8 +55,8 @@ export interface PagerDutyApi {
   triggerAlarm(request: TriggerAlarmRequest): Promise<Response>;
 }
 
-export type ServicesResponse = {
-  services: Service[];
+export type ServiceResponse = {
+  service: Service;
 };
 
 export type IncidentsResponse = {
@@ -72,7 +72,7 @@ export type OnCallsResponse = {
 };
 
 export type ClientApiConfig = {
-  eventsBaseUrl?: string;
+  apiBaseUrl?: string;
   discoveryApi: DiscoveryApi;
 };
 

--- a/plugins/pagerduty/src/components/ChangeEvents/ChangeEventEmptyState.tsx
+++ b/plugins/pagerduty/src/components/ChangeEvents/ChangeEventEmptyState.tsx
@@ -20,7 +20,12 @@ import EmptyStateImage from '../../assets/emptystate.svg';
 
 export const ChangeEventEmptyState = () => {
   return (
-    <Grid container justify="center" direction="column" alignItems="center">
+    <Grid
+      container
+      justifyContent="center"
+      direction="column"
+      alignItems="center"
+    >
       <Grid item xs={12}>
         <Typography variant="h5">No change events to display yet.</Typography>
       </Grid>

--- a/plugins/pagerduty/src/components/PagerDutyCard/index.tsx
+++ b/plugins/pagerduty/src/components/PagerDutyCard/index.tsx
@@ -26,7 +26,7 @@ import { MissingTokenError } from '../Errors/MissingTokenError';
 import WebIcon from '@material-ui/icons/Web';
 import DateRangeIcon from '@material-ui/icons/DateRange';
 import { usePagerdutyEntity } from '../../hooks';
-import { PAGERDUTY_INTEGRATION_KEY } from '../constants';
+import { PAGERDUTY_SERVICE_ID } from '../constants';
 import { TriggerDialog } from '../TriggerDialog';
 import { ChangeEvents } from '../ChangeEvents';
 
@@ -40,10 +40,10 @@ import {
 } from '@backstage/core-components';
 
 export const isPluginApplicableToEntity = (entity: Entity) =>
-  Boolean(entity.metadata.annotations?.[PAGERDUTY_INTEGRATION_KEY]);
+  Boolean(entity.metadata.annotations?.[PAGERDUTY_SERVICE_ID]);
 
 export const PagerDutyCard = () => {
-  const { integrationKey } = usePagerdutyEntity();
+  const { serviceId } = usePagerdutyEntity();
   const api = useApi(pagerDutyApiRef);
   const [refreshIncidents, setRefreshIncidents] = useState<boolean>(false);
   const [refreshChangeEvents, setRefreshChangeEvents] =
@@ -67,16 +67,16 @@ export const PagerDutyCard = () => {
     loading,
     error,
   } = useAsync(async () => {
-    const services = await api.getServiceByIntegrationKey(
-      integrationKey as string,
+    const returnedService = await api.getServiceByServiceId(
+      serviceId as string,
     );
 
     return {
-      id: services[0].id,
-      name: services[0].name,
-      url: services[0].html_url,
-      policyId: services[0].escalation_policy.id,
-      policyLink: services[0].escalation_policy.html_url,
+      id: returnedService.id,
+      name: returnedService.name,
+      url: returnedService.html_url,
+      policyId: returnedService.escalation_policy.id,
+      policyLink: returnedService.escalation_policy.html_url,
     };
   });
 

--- a/plugins/pagerduty/src/components/TriggerButton/index.test.tsx
+++ b/plugins/pagerduty/src/components/TriggerButton/index.test.tsx
@@ -58,7 +58,7 @@ describe('TriggerButton', () => {
       metadata: {
         name: 'pagerduty-test',
         annotations: {
-          'pagerduty.com/integration-key': 'abc123',
+          'pagerduty.com/service-id': 'abc123',
         },
       },
     };
@@ -97,7 +97,7 @@ describe('TriggerButton', () => {
       metadata: {
         name: 'pagerduty-test',
         annotations: {
-          'pagerduty.com/integration-key': 'abc123',
+          'pagerduty.com/service-id': 'abc123',
         },
       },
     };
@@ -113,7 +113,7 @@ describe('TriggerButton', () => {
     expect(screen.getByText('Send an alert')).toBeInTheDocument();
   });
 
-  it('renders a disabled trigger button if entity does not include key', async () => {
+  it('renders a disabled trigger button if entity does not include serviceId', async () => {
     const entity: Entity = {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'Component',
@@ -130,7 +130,7 @@ describe('TriggerButton', () => {
       </ApiProvider>,
     );
 
-    const triggerButton = screen.getByText('Missing integration key');
+    const triggerButton = screen.getByText('Missing Service Id');
 
     await act(async () => {
       fireEvent.click(triggerButton);

--- a/plugins/pagerduty/src/components/TriggerButton/index.tsx
+++ b/plugins/pagerduty/src/components/TriggerButton/index.tsx
@@ -36,7 +36,7 @@ export function TriggerButton({
   children,
 }: PropsWithChildren<TriggerButtonProps>) {
   const { buttonStyle } = useStyles();
-  const { integrationKey } = usePagerdutyEntity();
+  const { serviceId } = usePagerdutyEntity();
   const [dialogShown, setDialogShown] = useState<boolean>(false);
 
   const showDialog = useCallback(() => {
@@ -46,7 +46,7 @@ export function TriggerButton({
     setDialogShown(false);
   }, [setDialogShown]);
 
-  const disabled = !integrationKey;
+  const disabled = !serviceId;
   return (
     <>
       <Button
@@ -55,11 +55,9 @@ export function TriggerButton({
         className={disabled ? '' : buttonStyle}
         disabled={disabled}
       >
-        {integrationKey
-          ? children ?? 'Create Incident'
-          : 'Missing integration key'}
+        {serviceId ? children ?? 'Create Incident' : 'Missing Service Id'}
       </Button>
-      {integrationKey && (
+      {serviceId && (
         <TriggerDialog showDialog={dialogShown} handleDialog={hideDialog} />
       )}
     </>

--- a/plugins/pagerduty/src/components/TriggerDialog/TriggerDialog.test.tsx
+++ b/plugins/pagerduty/src/components/TriggerDialog/TriggerDialog.test.tsx
@@ -58,7 +58,7 @@ describe('TriggerDialog', () => {
       metadata: {
         name: 'pagerduty-test',
         annotations: {
-          'pagerduty.com/integration-key': 'abc123',
+          'pagerduty.com/service-id': 'abc123',
         },
       },
     };
@@ -81,10 +81,20 @@ describe('TriggerDialog', () => {
         exact: false,
       }),
     ).toBeInTheDocument();
-    const input = getByTestId('trigger-input');
+    const descriptionInput = getByTestId('trigger-description-input');
+    const fromInput = getByTestId('trigger-from-input');
+    const titleInput = getByTestId('trigger-title-input');
     const description = 'Test Trigger Alarm';
+    const title = 'Test Trigger Alarm';
+    const from = 'guest@example.com';
     await act(async () => {
-      fireEvent.change(input, { target: { value: description } });
+      fireEvent.change(descriptionInput, { target: { value: description } });
+    });
+    await act(async () => {
+      fireEvent.change(titleInput, { target: { value: title } });
+    });
+    await act(async () => {
+      fireEvent.change(fromInput, { target: { value: from } });
     });
     const triggerButton = getByTestId('trigger-button');
     await act(async () => {
@@ -92,11 +102,10 @@ describe('TriggerDialog', () => {
     });
     expect(mockTriggerAlarmFn).toHaveBeenCalled();
     expect(mockTriggerAlarmFn).toHaveBeenCalledWith({
-      integrationKey:
-        entity!.metadata!.annotations!['pagerduty.com/integration-key'],
-      source: window.location.toString(),
+      serviceId: entity!.metadata!.annotations!['pagerduty.com/service-id'],
+      title,
       description,
-      userName: 'guest@example.com',
+      from,
     });
   });
 });

--- a/plugins/pagerduty/src/components/TriggerDialog/TriggerDialog.tsx
+++ b/plugins/pagerduty/src/components/TriggerDialog/TriggerDialog.tsx
@@ -46,20 +46,22 @@ export const TriggerDialog = ({
   handleDialog,
   onIncidentCreated: onIncidentCreated,
 }: Props) => {
-  const { name, integrationKey } = usePagerdutyEntity();
+  const { name, serviceId } = usePagerdutyEntity();
   const alertApi = useApi(alertApiRef);
   const identityApi = useApi(identityApiRef);
   const userName = identityApi.getUserId();
   const api = useApi(pagerDutyApiRef);
+  const [title, setTitle] = useState<string>('');
   const [description, setDescription] = useState<string>('');
+  const [from, setFrom] = useState<string>('');
 
   const [{ value, loading, error }, handleTriggerAlarm] = useAsyncFn(
-    async (descriptions: string) =>
+    async (descriptions: string, froms: string, titles: string) =>
       await api.triggerAlarm({
-        integrationKey: integrationKey as string,
-        source: window.location.toString(),
+        serviceId: serviceId as string,
+        from: froms,
+        title: titles,
         description: descriptions,
-        userName,
       }),
   );
 
@@ -67,6 +69,14 @@ export const TriggerDialog = ({
     event: React.ChangeEvent<HTMLTextAreaElement>,
   ) => {
     setDescription(event.target.value);
+  };
+
+  const fromChanged = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setFrom(event.target.value);
+  };
+
+  const titleChanged = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setTitle(event.target.value);
   };
 
   useEffect(() => {
@@ -119,7 +129,7 @@ export const TriggerDialog = ({
           out to you if necessary.
         </Typography>
         <TextField
-          inputProps={{ 'data-testid': 'trigger-input' }}
+          inputProps={{ 'data-testid': 'trigger-description-input' }}
           id="description"
           multiline
           fullWidth
@@ -129,6 +139,22 @@ export const TriggerDialog = ({
           variant="outlined"
           onChange={descriptionChanged}
         />
+        <TextField
+          inputProps={{ 'data-testid': 'trigger-title-input' }}
+          id="title"
+          margin="normal"
+          label="Incident Title"
+          variant="outlined"
+          onChange={titleChanged}
+        />
+        <TextField
+          inputProps={{ 'data-testid': 'trigger-from-input' }}
+          id="from"
+          margin="normal"
+          label="Email of user creating incident. Must be a valid pager duty user"
+          variant="outlined"
+          onChange={fromChanged}
+        />
       </DialogContent>
       <DialogActions>
         <Button
@@ -137,7 +163,7 @@ export const TriggerDialog = ({
           color="secondary"
           disabled={!description || loading}
           variant="contained"
-          onClick={() => handleTriggerAlarm(description)}
+          onClick={() => handleTriggerAlarm(description, from, title)}
           endIcon={loading && <CircularProgress size={16} />}
         >
           Trigger Incident

--- a/plugins/pagerduty/src/components/constants.ts
+++ b/plugins/pagerduty/src/components/constants.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const PAGERDUTY_INTEGRATION_KEY = 'pagerduty.com/integration-key';
+export const PAGERDUTY_SERVICE_ID = 'pagerduty.com/service-id';

--- a/plugins/pagerduty/src/components/types.ts
+++ b/plugins/pagerduty/src/components/types.ts
@@ -51,7 +51,6 @@ export type Service = {
   id: string;
   name: string;
   html_url: string;
-  integrationKey: string;
   escalation_policy: {
     id: string;
     user: User;

--- a/plugins/pagerduty/src/hooks/index.ts
+++ b/plugins/pagerduty/src/hooks/index.ts
@@ -16,13 +16,12 @@
 
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-import { PAGERDUTY_INTEGRATION_KEY } from '../components/constants';
+import { PAGERDUTY_SERVICE_ID } from '../components/constants';
 
 export function usePagerdutyEntity() {
   const { entity } = useEntity();
-  const integrationKey =
-    entity.metadata.annotations?.[PAGERDUTY_INTEGRATION_KEY];
+  const serviceId = entity.metadata.annotations?.[PAGERDUTY_SERVICE_ID];
   const name = entity.metadata.name;
 
-  return { integrationKey, name };
+  return { serviceId, name };
 }


### PR DESCRIPTION
This removes the need to store an integration key in plain text and uses the service ID instead. The integration Key is a secret and shouldn't be stored in plain text

## Hey, I just made a Pull Request!

closes #5223 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
