### PR TITLE
catalog-react: export loadIdentityOwnerRefs and loadCatalogOwnerRefs all the way

### DIFF
--- a/.changeset/smart-penguins-compete.md
+++ b/.changeset/smart-penguins-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+export `loadIdentityOwnerRefs` and `loadCatalogOwnerRefs` all the way

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -727,17 +727,13 @@ export function getEntitySourceLocation(
 // @public
 export function isOwnerOf(owner: Entity, owned: Entity): boolean;
 
-// Warning: (ae-missing-release-tag) "loadCatalogOwnerRefs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export function loadCatalogOwnerRefs(
   catalogApi: CatalogApi,
   identityOwnerRefs: string[],
 ): Promise<string[]>;
 
-// Warning: (ae-missing-release-tag) "loadIdentityOwnerRefs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export function loadIdentityOwnerRefs(
   identityApi: IdentityApi,
 ): Promise<string[]>;
@@ -829,8 +825,6 @@ export function useEntityListProvider<
   EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
 >(): EntityListContextProps<EntityFilters>;
 
-// Warning: (ae-missing-release-tag) "useEntityOwnership" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export function useEntityOwnership(): {
   loading: boolean;

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -15,6 +15,7 @@ import { Context } from 'react';
 import { Entity } from '@backstage/catalog-model';
 import { EntityName } from '@backstage/catalog-model';
 import { IconButton } from '@material-ui/core';
+import { IdentityApi } from '@backstage/core-plugin-api';
 import { LinkProps } from '@backstage/core-components';
 import { Observable } from '@backstage/types';
 import { PropsWithChildren } from 'react';
@@ -725,6 +726,21 @@ export function getEntitySourceLocation(
 //
 // @public
 export function isOwnerOf(owner: Entity, owned: Entity): boolean;
+
+// Warning: (ae-missing-release-tag) "loadCatalogOwnerRefs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function loadCatalogOwnerRefs(
+  catalogApi: CatalogApi,
+  identityOwnerRefs: string[],
+): Promise<string[]>;
+
+// Warning: (ae-missing-release-tag) "loadIdentityOwnerRefs" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function loadIdentityOwnerRefs(
+  identityApi: IdentityApi,
+): Promise<string[]>;
 
 // Warning: (ae-missing-release-tag) "MockEntityListContextProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/catalog-react/src/hooks/index.ts
+++ b/plugins/catalog-react/src/hooks/index.ts
@@ -37,4 +37,8 @@ export { useOwnUser } from './useOwnUser';
 export { useRelatedEntities } from './useRelatedEntities';
 export { useStarredEntities } from './useStarredEntities';
 export { useStarredEntity } from './useStarredEntity';
-export * from './useEntityOwnership';
+export {
+  loadCatalogOwnerRefs,
+  useEntityOwnership,
+  loadIdentityOwnerRefs,
+} from './useEntityOwnership';

--- a/plugins/catalog-react/src/hooks/index.ts
+++ b/plugins/catalog-react/src/hooks/index.ts
@@ -37,4 +37,4 @@ export { useOwnUser } from './useOwnUser';
 export { useRelatedEntities } from './useRelatedEntities';
 export { useStarredEntities } from './useStarredEntities';
 export { useStarredEntity } from './useStarredEntity';
-export { useEntityOwnership } from './useEntityOwnership';
+export * from './useEntityOwnership';

--- a/plugins/catalog-react/src/hooks/useEntityOwnership.ts
+++ b/plugins/catalog-react/src/hooks/useEntityOwnership.ts
@@ -49,9 +49,16 @@ function extendUserId(id: string): string {
   }
 }
 
-// Takes the relevant parts of the Backstage identity, and translates them into
-// a list of entity refs on string form that represent the user's ownership
-// connections.
+/**
+ * Takes the relevant parts of the Backstage identity, and translates them into
+ * a list of entity refs on string form that represent the user's ownership
+ * connections.
+ *
+ * @public
+ *
+ * @param identityApi - The IdentityApi implementation
+ * @returns IdentityOwner refs as a string array
+ */
 export async function loadIdentityOwnerRefs(
   identityApi: IdentityApi,
 ): Promise<string[]> {
@@ -81,9 +88,17 @@ export async function loadIdentityOwnerRefs(
   return result;
 }
 
-// Takes the relevant parts of the User entity corresponding to the Backstage
-// identity, and translates them into a list of entity refs on string form that
-// represent the user's ownership connections.
+/**
+ * Takes the relevant parts of the User entity corresponding to the Backstage
+ * identity, and translates them into a list of entity refs on string form that
+ * represent the user's ownership connections.
+ *
+ * @public
+ *
+ * @param catalogApi - The Catalog API implementation
+ * @param identityOwnerRefs - List of identity owner refs as strings
+ * @returns OwnerRefs as a string array
+ */
 export async function loadCatalogOwnerRefs(
   catalogApi: CatalogApi,
   identityOwnerRefs: string[],
@@ -113,6 +128,10 @@ export async function loadCatalogOwnerRefs(
  * owner of a given entity. When the hook is initially mounted, the loading
  * flag will be true and the results returned from the function will always be
  * false.
+ *
+ * @public
+ *
+ * @returns a function that checks if the signed in user owns an entity
  */
 export function useEntityOwnership(): {
   loading: boolean;


### PR DESCRIPTION
Useful utility APIs not exported publicly.

Signed-off-by: Himanshu Mishra <himanshu@orkohunter.net>
