### PR TITLE
fix: sentry plugin can pass id token

### DIFF
--- a/.changeset/nasty-actors-push.md
+++ b/.changeset/nasty-actors-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-sentry': patch
+---
+
+fix: sentry-plugin can forward identity token to backend (for case when it requires authorization)

--- a/plugins/sentry/api-report.md
+++ b/plugins/sentry/api-report.md
@@ -9,6 +9,7 @@ import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { IdentityApi } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
 import { RouteRef } from '@backstage/core-plugin-api';
 
@@ -34,7 +35,22 @@ export class MockSentryApi implements SentryApi {
 //
 // @public (undocumented)
 export class ProductionSentryApi implements SentryApi {
-  constructor(discoveryApi: DiscoveryApi, organization: string);
+  constructor(
+    discoveryApi: DiscoveryApi,
+    organization: string,
+    identityApi?: IdentityApi | undefined,
+  );
+  // (undocumented)
+  authOptions(): Promise<
+    | {
+        headers?: undefined;
+      }
+    | {
+        headers: {
+          authorization: string;
+        };
+      }
+  >;
   // (undocumented)
   fetchIssues(
     project: string,

--- a/plugins/sentry/api-report.md
+++ b/plugins/sentry/api-report.md
@@ -41,17 +41,6 @@ export class ProductionSentryApi implements SentryApi {
     identityApi?: IdentityApi | undefined,
   );
   // (undocumented)
-  authOptions(): Promise<
-    | {
-        headers?: undefined;
-      }
-    | {
-        headers: {
-          authorization: string;
-        };
-      }
-  >;
-  // (undocumented)
   fetchIssues(
     project: string,
     statsFor: string,

--- a/plugins/sentry/src/api/production-api.ts
+++ b/plugins/sentry/src/api/production-api.ts
@@ -16,12 +16,13 @@
 
 import { SentryIssue } from './sentry-issue';
 import { SentryApi } from './sentry-api';
-import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
 
 export class ProductionSentryApi implements SentryApi {
   constructor(
     private readonly discoveryApi: DiscoveryApi,
     private readonly organization: string,
+    private readonly identityApi?: IdentityApi,
   ) {}
 
   async fetchIssues(
@@ -34,11 +35,13 @@ export class ProductionSentryApi implements SentryApi {
     }
 
     const apiUrl = `${await this.discoveryApi.getBaseUrl('proxy')}/sentry/api`;
+    const options = await this.authOptions();
 
     const queryPart = query ? `&query=${query}` : '';
 
     const response = await fetch(
       `${apiUrl}/0/projects/${this.organization}/${project}/issues/?statsPeriod=${statsFor}${queryPart}`,
+      options,
     );
 
     if (response.status >= 400 && response.status < 600) {
@@ -46,5 +49,21 @@ export class ProductionSentryApi implements SentryApi {
     }
 
     return (await response.json()) as SentryIssue[];
+  }
+
+  async authOptions() {
+    if (!this.identityApi) {
+      return {};
+    }
+    try {
+      const token = await this.identityApi.getIdToken();
+      return {
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      };
+    } catch (e) {
+      return {};
+    }
   }
 }

--- a/plugins/sentry/src/api/production-api.ts
+++ b/plugins/sentry/src/api/production-api.ts
@@ -51,7 +51,7 @@ export class ProductionSentryApi implements SentryApi {
     return (await response.json()) as SentryIssue[];
   }
 
-  async authOptions() {
+  private async authOptions() {
     if (!this.identityApi) {
       return {};
     }

--- a/plugins/sentry/src/api/production-api.ts
+++ b/plugins/sentry/src/api/production-api.ts
@@ -55,15 +55,11 @@ export class ProductionSentryApi implements SentryApi {
     if (!this.identityApi) {
       return {};
     }
-    try {
-      const token = await this.identityApi.getIdToken();
-      return {
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      };
-    } catch (e) {
-      return {};
-    }
+    const token = await this.identityApi.getIdToken();
+    return {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    };
   }
 }

--- a/plugins/sentry/src/plugin.ts
+++ b/plugins/sentry/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   createPlugin,
   createRouteRef,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({
@@ -33,11 +34,16 @@ export const sentryPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: sentryApiRef,
-      deps: { configApi: configApiRef, discoveryApi: discoveryApiRef },
-      factory: ({ configApi, discoveryApi }) =>
+      deps: {
+        configApi: configApiRef,
+        discoveryApi: discoveryApiRef,
+        identityApi: identityApiRef,
+      },
+      factory: ({ configApi, discoveryApi, identityApi }) =>
         new ProductionSentryApi(
           discoveryApi,
           configApi.getString('sentry.organization'),
+          identityApi,
         ),
     }),
   ],


### PR DESCRIPTION
### minor fix

With this change sentry-plugin shall pass identity-token to backend/proxy, which is useful if backend
middleware requires authorization for proxy. It doesn't affect flow if no auth is required for proxy or if
guest auth is used at all etc.

_Code is almost copied from the other plugins (particularly [TodoClient.ts](https://github.com/backstage/backstage/blob/master/plugins/todo/src/api/TodoClient.ts#L76)) - just with attempt to leave `identityApi` parameter optional in constructor to ensure compatibility._

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
