### PR TITLE
fix: Adding corrected code for custom field extension documentation

### DIFF
--- a/docs/features/software-templates/writing-custom-field-extensions.md
+++ b/docs/features/software-templates/writing-custom-field-extensions.md
@@ -34,14 +34,20 @@ import { KubernetesValidatorFunctions } from '@backstage/catalog-model';
 /*
  This is the actual component that will get rendered in the form
 */
-export const MyCustomExtension = ({ onChange, rawErrors, required, formData }: FieldProps<string>) => {
-    return (
-        <FormControl
-            margin="normal"
-            required={required}
-            error={rawErrors?.length > 0 && !formData}
-            onChange={onChange} />
-    )
+export const MyCustomExtension = ({
+  onChange,
+  rawErrors,
+  required,
+  formData,
+}: FieldProps<string>) => {
+  return (
+    <FormControl
+      margin="normal"
+      required={required}
+      error={rawErrors?.length > 0 && !formData}
+      onChange={onChange}
+    />
+  );
 };
 
 /*
@@ -50,14 +56,14 @@ export const MyCustomExtension = ({ onChange, rawErrors, required, formData }: F
 */
 
 export const myCustomValidation = (
-    value: string,
-    validation: FieldValidation,
+  value: string,
+  validation: FieldValidation,
 ) => {
-    if (!KubernetesValidatorFunctions.isValidObjectName(value)) {
-        validation.addError(
-            'must start and end with an alphanumeric character, and contain only alphanumeric characters, hyphens, underscores, and periods. Maximum length is 63 characters.',
-        );
-    }
+  if (!KubernetesValidatorFunctions.isValidObjectName(value)) {
+    validation.addError(
+      'must start and end with an alphanumeric character, and contain only alphanumeric characters, hyphens, underscores, and periods. Maximum length is 63 characters.',
+    );
+  }
 };
 ```
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding corrected code for custom field extension documentation.

Little fix to the code in the documentation so that when a user wants to start a custom field extension the code is passing linting.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
