### PR TITLE
feat: allow custom location analyzer in next catalog builder

### DIFF
--- a/.changeset/brave-icons-shop.md
+++ b/.changeset/brave-icons-shop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow custom LocationAnalyzer in NextCatalogBuilder

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -1295,6 +1295,7 @@ export class NextCatalogBuilder {
   setEntityDataParser(parser: CatalogProcessorParser): NextCatalogBuilder;
   // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   setFieldFormatValidators(validators: Partial<Validators>): NextCatalogBuilder;
+  setLocationAnalyzer(locationAnalyzer: LocationAnalyzer): NextCatalogBuilder;
   // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   setPlaceholderResolver(

--- a/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
@@ -122,6 +122,7 @@ export class NextCatalogBuilder {
       minSeconds: 100,
       maxSeconds: 150,
     });
+  private locationAnalyzer: LocationAnalyzer | undefined = undefined;
 
   constructor(env: CatalogEnvironment) {
     this.env = env;
@@ -173,6 +174,14 @@ export class NextCatalogBuilder {
     refreshInterval: RefreshIntervalFunction,
   ): NextCatalogBuilder {
     this.refreshInterval = refreshInterval;
+    return this;
+  }
+
+  /**
+   * Overwrites the default location analyzer.
+   */
+  setLocationAnalyzer(locationAnalyzer: LocationAnalyzer): NextCatalogBuilder {
+    this.locationAnalyzer = locationAnalyzer;
     return this;
   }
 
@@ -338,7 +347,8 @@ export class NextCatalogBuilder {
     );
 
     const locationsCatalog = new DatabaseLocationsCatalog(db);
-    const locationAnalyzer = new RepoLocationAnalyzer(logger, integrations);
+    const locationAnalyzer =
+      this.locationAnalyzer ?? new RepoLocationAnalyzer(logger, integrations);
     const locationService = new DefaultLocationService(
       locationStore,
       orchestrator,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `createRouter` function in `catalog-backend` is flagged as deprecated. However the new `NextCatalogBuilder` does not support changing the default LocationAnalyzer (e.g. RepoLocationAnalyzer). This exposes this so it can be customized using the new builder.

Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
