### PR TITLE
Add auth token to KafkaBackendClient via IdentityApi

### DIFF
--- a/.changeset/long-bugs-kiss.md
+++ b/.changeset/long-bugs-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kafka': patch
+---
+
+Use IdentityApi to provide Auth Token for KafkaBackendClient Api calls

--- a/plugins/kafka/src/api/KafkaBackendClient.ts
+++ b/plugins/kafka/src/api/KafkaBackendClient.ts
@@ -15,21 +15,28 @@
  */
 
 import { KafkaApi, ConsumerGroupOffsetsResponse } from './types';
-import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
 
 export class KafkaBackendClient implements KafkaApi {
   private readonly discoveryApi: DiscoveryApi;
+  private readonly identityApi: IdentityApi;
 
-  constructor(options: { discoveryApi: DiscoveryApi }) {
+  constructor(options: {
+    discoveryApi: DiscoveryApi;
+    identityApi: IdentityApi;
+  }) {
     this.discoveryApi = options.discoveryApi;
+    this.identityApi = options.identityApi;
   }
 
   private async internalGet(path: string): Promise<any> {
     const url = `${await this.discoveryApi.getBaseUrl('kafka')}${path}`;
+    const idToken = await this.identityApi.getIdToken();
     const response = await fetch(url, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        ...(idToken && { Authorization: `Bearer ${idToken}` }),
       },
     });
 

--- a/plugins/kafka/src/plugin.ts
+++ b/plugins/kafka/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   createRoutableExtension,
   createRouteRef,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 
 export const rootCatalogKafkaRouteRef = createRouteRef({
@@ -33,8 +34,9 @@ export const kafkaPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: kafkaApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new KafkaBackendClient({ discoveryApi }),
+      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
+      factory: ({ discoveryApi, identityApi }) =>
+        new KafkaBackendClient({ discoveryApi, identityApi }),
     }),
   ],
   routes: {


### PR DESCRIPTION
# Add Authentication for Kafka plugin

Use IdentityApi to provide Auth Token for KafkaBackendClient Api calls

Following this documentation [Authenticate API requests](https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md) and having this PR https://github.com/backstage/backstage/pull/6719 as reference.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
