### PR TITLE
[Mini PRFC] EntitiesSearchFilter type refactor

### DIFF
--- a/.changeset/smart-fans-complain.md
+++ b/.changeset/smart-fans-complain.md
@@ -1,0 +1,42 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+**BREAKING** EntitiesSearchFilter fields have changed.
+
+EntitiesSearchFilter now has only two fields: `key` and `value`. The `matchValueIn` and `matchValueExists` fields are no longer are supported. Previous filters written using the `matchValueIn` and `matchValueExists` fields can be rewritten as follows:
+
+Filtering by existence of key only:
+
+```diff
+  filter: {
+    {
+      key: 'abc',
+-     matchValueExists: true,
+    },
+  }
+```
+
+Filtering by key and values:
+
+```diff
+  filter: {
+    {
+      key: 'abc',
+-     matchValueExists: true,
+-     matchValueIn: ['xyz'],
++     values: ['xyz'],
+    },
+  }
+```
+
+Negation of filters can now be achieved through a `not` object:
+
+```
+filter: {
+  not: {
+    key: 'abc',
+    values: ['xyz'],
+  },
+}
+```

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -846,8 +846,7 @@ export type EntitiesResponse = {
 // @public
 export type EntitiesSearchFilter = {
   key: string;
-  matchValueIn?: string[];
-  matchValueExists?: boolean;
+  values?: string[];
 };
 
 // Warning: (ae-missing-release-tag) "entity" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -876,6 +875,9 @@ export type EntityFilter =
     }
   | {
       anyOf: EntityFilter[];
+    }
+  | {
+      not: EntityFilter;
     }
   | EntitiesSearchFilter;
 
@@ -1546,9 +1548,9 @@ export class UrlReaderProcessor implements CatalogProcessor {
 
 // Warnings were encountered during analysis:
 //
-// src/catalog/types.d.ts:97:8 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
-// src/catalog/types.d.ts:98:8 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
-// src/catalog/types.d.ts:99:8 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
+// src/catalog/types.d.ts:94:8 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
+// src/catalog/types.d.ts:95:8 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
+// src/catalog/types.d.ts:96:8 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
 // src/ingestion/processors/GithubMultiOrgReaderProcessor.d.ts:23:9 - (ae-forgotten-export) The symbol "GithubMultiOrgConfig" needs to be exported by the entry point index.d.ts
 // src/ingestion/types.d.ts:8:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/legacy/database/types.d.ts:98:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/plugins/catalog-backend/src/catalog/index.ts
+++ b/plugins/catalog-backend/src/catalog/index.ts
@@ -23,6 +23,8 @@ export type {
   EntityUpsertResponse,
   PageInfo,
   EntitiesSearchFilter,
+  EntitiesKeyFilter,
+  EntitiesValuesFilter,
   EntityFilter,
   EntityPagination,
 } from './types';

--- a/plugins/catalog-backend/src/catalog/index.ts
+++ b/plugins/catalog-backend/src/catalog/index.ts
@@ -23,8 +23,6 @@ export type {
   EntityUpsertResponse,
   PageInfo,
   EntitiesSearchFilter,
-  EntitiesKeyFilter,
-  EntitiesValuesFilter,
   EntityFilter,
   EntityPagination,
 } from './types';

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -39,7 +39,7 @@ export type EntityPagination = {
 /**
  * Matches rows in the entities_search table.
  */
-export type EntitiesSearchFilter = {
+export type EntitiesValuesFilter = {
   /**
    * The key to match on.
    *
@@ -50,17 +50,27 @@ export type EntitiesSearchFilter = {
   /**
    * Match on plain equality of values.
    *
-   * If undefined, this factor is not taken into account. Otherwise, match on
+   * Match on
    * values that are equal to any of the given array items. Matches are always
    * case insensitive.
    */
-  matchValueIn?: string[];
+  values: string[];
 
-  /**
-   * Match on existence of key.
-   */
-  matchValueExists?: boolean;
+  negate?: boolean;
 };
+
+export type EntitiesKeyFilter = {
+  /**
+   * The key to match on.
+   *
+   * Matches are always case insensitive.
+   */
+  key: string;
+
+  negate?: boolean;
+};
+
+export type EntitiesSearchFilter = EntitiesValuesFilter | EntitiesKeyFilter;
 
 export type PageInfo =
   | {

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -25,6 +25,7 @@ import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
 export type EntityFilter =
   | { allOf: EntityFilter[] }
   | { anyOf: EntityFilter[] }
+  | { not: EntityFilter }
   | EntitiesSearchFilter;
 
 /**
@@ -39,7 +40,7 @@ export type EntityPagination = {
 /**
  * Matches rows in the entities_search table.
  */
-export type EntitiesValuesFilter = {
+export type EntitiesSearchFilter = {
   /**
    * The key to match on.
    *
@@ -50,27 +51,11 @@ export type EntitiesValuesFilter = {
   /**
    * Match on plain equality of values.
    *
-   * Match on
-   * values that are equal to any of the given array items. Matches are always
-   * case insensitive.
+   * Match on values that are equal to any of the given array items. Matches are
+   * always case insensitive.
    */
-  values: string[];
-
-  negate?: boolean;
+  values?: string[];
 };
-
-export type EntitiesKeyFilter = {
-  /**
-   * The key to match on.
-   *
-   * Matches are always case insensitive.
-   */
-  key: string;
-
-  negate?: boolean;
-};
-
-export type EntitiesSearchFilter = EntitiesValuesFilter | EntitiesKeyFilter;
 
 export type PageInfo =
   | {

--- a/plugins/catalog-backend/src/legacy/database/CommonDatabase.test.ts
+++ b/plugins/catalog-backend/src/legacy/database/CommonDatabase.test.ts
@@ -536,9 +536,7 @@ describe('CommonDatabase', () => {
           filter: {
             anyOf: [
               {
-                allOf: [
-                  { key: 'metadata.annotations.foo', matchValueExists: true },
-                ],
+                allOf: [{ key: 'metadata.annotations.foo' }],
               },
             ],
           },
@@ -555,30 +553,6 @@ describe('CommonDatabase', () => {
           {
             locationId: undefined,
             entity: expect.objectContaining({ kind: 'k2' }),
-          },
-        ]),
-      );
-
-      const nonExistRows = await db.transaction(async tx =>
-        db.entities(tx, {
-          filter: {
-            anyOf: [
-              {
-                allOf: [
-                  { key: 'metadata.annotations.foo', matchValueExists: false },
-                ],
-              },
-            ],
-          },
-        }),
-      );
-
-      expect(nonExistRows.entities.length).toEqual(1);
-      expect(nonExistRows.entities).toEqual(
-        expect.arrayContaining([
-          {
-            locationId: undefined,
-            entity: expect.objectContaining({ kind: 'k3' }),
           },
         ]),
       );

--- a/plugins/catalog-backend/src/legacy/service/router.test.ts
+++ b/plugins/catalog-backend/src/legacy/service/router.test.ts
@@ -115,11 +115,11 @@ describe('createRouter readonly disabled', () => {
           anyOf: [
             {
               allOf: [
-                { key: 'a', matchValueIn: ['1', '2'] },
-                { key: 'b', matchValueIn: ['3'] },
+                { key: 'a', values: ['1', '2'] },
+                { key: 'b', values: ['3'] },
               ],
             },
-            { allOf: [{ key: 'c', matchValueIn: ['4'] }] },
+            { allOf: [{ key: 'c', values: ['4'] }] },
           ],
         },
       });

--- a/plugins/catalog-backend/src/service/NextEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/NextEntitiesCatalog.test.ts
@@ -282,13 +282,47 @@ describe('NextEntitiesCatalog', () => {
 
         const testFilter = {
           key: 'spec.test',
-          matchValueExists: true,
         };
         const request = { filter: testFilter };
         const { entities } = await catalog.entities(request);
 
         expect(entities.length).toBe(1);
         expect(entities[0]).toEqual(entity2);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return correct entity for negation filter',
+      async databaseId => {
+        const { knex } = await createDatabase(databaseId);
+        const entity1: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'one' },
+          spec: {},
+        };
+        const entity2: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'two' },
+          spec: {
+            test: 'test value',
+          },
+        };
+        await addEntityToSearch(knex, entity1);
+        await addEntityToSearch(knex, entity2);
+        const catalog = new NextEntitiesCatalog(knex);
+
+        const testFilter = {
+          not: {
+            key: 'spec.test',
+          },
+        };
+        const request = { filter: testFilter };
+        const { entities } = await catalog.entities(request);
+
+        expect(entities.length).toBe(1);
+        expect(entities[0]).toEqual(entity1);
       },
     );
 
@@ -328,24 +362,27 @@ describe('NextEntitiesCatalog', () => {
 
         const testFilter1 = {
           key: 'metadata.org',
-          matchValueExists: true,
-          matchValueIn: ['b'],
+          values: ['b'],
         };
         const testFilter2 = {
           key: 'metadata.desc',
-          matchValueExists: true,
         };
         const testFilter3 = {
           key: 'metadata.color',
-          matchValueExists: true,
-          matchValueIn: ['blue'],
+          values: ['blue'],
+        };
+        const testFilter4 = {
+          not: {
+            key: 'metadata.color',
+            values: ['red'],
+          },
         };
         const request = {
           filter: {
             allOf: [
               testFilter1,
               {
-                anyOf: [testFilter2, testFilter3],
+                anyOf: [testFilter2, testFilter3, testFilter4],
               },
             ],
           },

--- a/plugins/catalog-backend/src/service/NextEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/NextEntitiesCatalog.ts
@@ -100,7 +100,6 @@ function addCondition(
         }
       }
     });
-  // Explicitly evaluate matchValueExists as a boolean since it may be undefined
   queryBuilder.andWhere('entity_id', negate ? 'not in' : 'in', matchQuery);
 }
 

--- a/plugins/catalog-backend/src/service/NextEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/NextEntitiesCatalog.ts
@@ -78,33 +78,30 @@ function stringifyPagination(input: { limit: number; offset: number }) {
 function addCondition(
   queryBuilder: Knex.QueryBuilder,
   db: Knex,
-  { key, matchValueIn, matchValueExists }: EntitiesSearchFilter,
+  filter: EntitiesSearchFilter,
+  negate: boolean = false,
 ) {
   // NOTE(freben): This used to be a set of OUTER JOIN, which may seem to
   // make a lot of sense. However, it had abysmal performance on sqlite
   // when datasets grew large, so we're using IN instead.
   const matchQuery = db<DbSearchRow>('search')
     .select('entity_id')
-    .where(function keyFilter() {
-      this.andWhere({ key: key.toLowerCase() });
-      if (matchValueExists !== false && matchValueIn) {
-        if (matchValueIn.length === 1) {
-          this.andWhere({ value: matchValueIn[0].toLowerCase() });
-        } else if (matchValueIn.length > 1) {
+    .where({ key: filter.key.toLowerCase() })
+    .andWhere(function keyFilter() {
+      if (filter.values) {
+        if (filter.values.length === 1) {
+          this.where({ value: filter.values[0].toLowerCase() });
+        } else if (filter.values.length > 1) {
           this.andWhere(
             'value',
             'in',
-            matchValueIn.map(v => v.toLowerCase()),
+            filter.values.map(v => v.toLowerCase()),
           );
         }
       }
     });
   // Explicitly evaluate matchValueExists as a boolean since it may be undefined
-  queryBuilder.andWhere(
-    'entity_id',
-    matchValueExists === false ? 'not in' : 'in',
-    matchQuery,
-  );
+  queryBuilder.andWhere('entity_id', negate ? 'not in' : 'in', matchQuery);
 }
 
 function isEntitiesSearchFilter(
@@ -125,21 +122,32 @@ function isOrEntityFilter(
   return filter.hasOwnProperty('anyOf');
 }
 
+function isNegationEntityFilter(
+  filter: { not: EntityFilter } | EntityFilter,
+): filter is { not: EntityFilter } {
+  return filter.hasOwnProperty('not');
+}
+
 function parseFilter(
   filter: EntityFilter,
   query: Knex.QueryBuilder,
   db: Knex,
+  negate: boolean = false,
 ): Knex.QueryBuilder {
   if (isEntitiesSearchFilter(filter)) {
     return query.andWhere(function filterFunction() {
-      addCondition(this, db, filter);
+      addCondition(this, db, filter, negate);
     });
+  }
+
+  if (isNegationEntityFilter(filter)) {
+    return parseFilter(filter.not, query, db, true);
   }
 
   if (isOrEntityFilter(filter)) {
     return query.andWhere(function filterFunction() {
       for (const subFilter of filter.anyOf ?? []) {
-        this.orWhere(subQuery => parseFilter(subFilter, subQuery, db));
+        this.orWhere(subQuery => parseFilter(subFilter, subQuery, db, negate));
       }
     });
   }
@@ -147,7 +155,7 @@ function parseFilter(
   if (isAndEntityFilter(filter)) {
     return query.andWhere(function filterFunction() {
       for (const subFilter of filter.allOf ?? []) {
-        this.andWhere(subQuery => parseFilter(subFilter, subQuery, db));
+        this.andWhere(subQuery => parseFilter(subFilter, subQuery, db, negate));
       }
     });
   }

--- a/plugins/catalog-backend/src/service/NextRouter.test.ts
+++ b/plugins/catalog-backend/src/service/NextRouter.test.ts
@@ -104,11 +104,11 @@ describe('createNextRouter readonly disabled', () => {
           anyOf: [
             {
               allOf: [
-                { key: 'a', matchValueIn: ['1', '2'] },
-                { key: 'b', matchValueIn: ['3'] },
+                { key: 'a', values: ['1', '2'] },
+                { key: 'b', values: ['3'] },
               ],
             },
-            { allOf: [{ key: 'c', matchValueIn: ['4'] }] },
+            { allOf: [{ key: 'c', values: ['4'] }] },
           ],
         },
       });

--- a/plugins/catalog-backend/src/service/request/basicEntityFilter.ts
+++ b/plugins/catalog-backend/src/service/request/basicEntityFilter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EntitiesSearchFilter, EntityFilter } from '../../catalog';
+import { EntitiesValuesFilter, EntityFilter } from '../../catalog';
 
 /**
  * Forms a full EntityFilter based on a single key-value(s) object.
@@ -22,7 +22,7 @@ import { EntitiesSearchFilter, EntityFilter } from '../../catalog';
 export function basicEntityFilter(
   items: Record<string, string | string[]>,
 ): EntityFilter {
-  const filtersByKey: Record<string, EntitiesSearchFilter> = {};
+  const filtersByKey: Record<string, EntitiesValuesFilter> = {};
 
   for (const [key, value] of Object.entries(items)) {
     const values = [value].flat();
@@ -30,9 +30,9 @@ export function basicEntityFilter(
     const f =
       key in filtersByKey
         ? filtersByKey[key]
-        : (filtersByKey[key] = { key, matchValueIn: [] });
+        : (filtersByKey[key] = { key, values: [] });
 
-    f.matchValueIn!.push(...values);
+    f.values!.push(...values);
   }
 
   return { anyOf: [{ allOf: Object.values(filtersByKey) }] };

--- a/plugins/catalog-backend/src/service/request/basicEntityFilter.ts
+++ b/plugins/catalog-backend/src/service/request/basicEntityFilter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EntitiesValuesFilter, EntityFilter } from '../../catalog';
+import { EntitiesSearchFilter, EntityFilter } from '../../catalog';
 
 /**
  * Forms a full EntityFilter based on a single key-value(s) object.
@@ -22,7 +22,7 @@ import { EntitiesValuesFilter, EntityFilter } from '../../catalog';
 export function basicEntityFilter(
   items: Record<string, string | string[]>,
 ): EntityFilter {
-  const filtersByKey: Record<string, EntitiesValuesFilter> = {};
+  const filtersByKey: Record<string, EntitiesSearchFilter> = {};
 
   for (const [key, value] of Object.entries(items)) {
     const values = [value].flat();

--- a/plugins/catalog-backend/src/service/request/parseEntityFilterParams.test.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFilterParams.test.ts
@@ -28,7 +28,7 @@ describe('parseEntityFilterParams', () => {
   it('supports single-string format', () => {
     const result = parseEntityFilterParams({ filter: 'a=1' })!;
     expect(result).toEqual({
-      anyOf: [{ allOf: [{ key: 'a', matchValueIn: ['1'] }] }],
+      anyOf: [{ allOf: [{ key: 'a', values: ['1'] }] }],
     });
   });
 
@@ -38,8 +38,8 @@ describe('parseEntityFilterParams', () => {
     });
     expect(result).toEqual({
       anyOf: [
-        { allOf: [{ key: 'a', matchValueIn: ['1'] }] },
-        { allOf: [{ key: 'b', matchValueIn: ['2'] }] },
+        { allOf: [{ key: 'a', values: ['1'] }] },
+        { allOf: [{ key: 'b', values: ['2'] }] },
       ],
     });
   });
@@ -50,11 +50,11 @@ describe('parseEntityFilterParams', () => {
     });
     expect(result).toEqual({
       anyOf: [
-        { allOf: [{ key: 'a', matchValueIn: ['1'] }] },
+        { allOf: [{ key: 'a', values: ['1'] }] },
         {
           allOf: [
-            { key: 'b', matchValueIn: ['2', '3'] },
-            { key: 'c', matchValueIn: ['4'] },
+            { key: 'b', values: ['2', '3'] },
+            { key: 'c', values: ['4'] },
           ],
         },
       ],
@@ -70,17 +70,17 @@ describe('parseEntityFilterString', () => {
   it('works for the happy path', () => {
     expect(parseEntityFilterString('')).toBeUndefined();
     expect(parseEntityFilterString('a=1,b=2,a=3,c,d=')).toEqual([
-      { key: 'a', matchValueIn: ['1', '3'] },
-      { key: 'b', matchValueIn: ['2'] },
-      { key: 'c', matchValueExists: true },
-      { key: 'd', matchValueIn: [''] },
+      { key: 'a', values: ['1', '3'] },
+      { key: 'b', values: ['2'] },
+      { key: 'c' },
+      { key: 'd', values: [''] },
     ]);
   });
 
   it('trims values', () => {
     expect(parseEntityFilterString(' a = 1 , b = 2 , a = 3 ')).toEqual([
-      { key: 'a', matchValueIn: ['1', '3'] },
-      { key: 'b', matchValueIn: ['2'] },
+      { key: 'a', values: ['1', '3'] },
+      { key: 'b', values: ['2'] },
     ]);
   });
 

--- a/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
@@ -15,7 +15,11 @@
  */
 
 import { InputError } from '@backstage/errors';
-import { EntitiesSearchFilter, EntityFilter } from '../../catalog';
+import {
+  EntitiesSearchFilter,
+  EntitiesValuesFilter,
+  EntityFilter,
+} from '../../catalog';
 import { parseStringsParam } from './common';
 
 /**
@@ -75,11 +79,10 @@ export function parseEntityFilterString(
     const f =
       key in filtersByKey ? filtersByKey[key] : (filtersByKey[key] = { key });
 
-    if (value === undefined) {
-      f.matchValueExists = true;
-    } else {
-      f.matchValueIn = f.matchValueIn || [];
-      f.matchValueIn.push(value);
+    if (value !== undefined) {
+      const valuesFilter = f as EntitiesValuesFilter;
+      valuesFilter.values = valuesFilter.values || [];
+      valuesFilter.values.push(value);
     }
   }
 

--- a/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
@@ -15,11 +15,7 @@
  */
 
 import { InputError } from '@backstage/errors';
-import {
-  EntitiesSearchFilter,
-  EntitiesValuesFilter,
-  EntityFilter,
-} from '../../catalog';
+import { EntitiesSearchFilter, EntityFilter } from '../../catalog';
 import { parseStringsParam } from './common';
 
 /**
@@ -80,9 +76,8 @@ export function parseEntityFilterString(
       key in filtersByKey ? filtersByKey[key] : (filtersByKey[key] = { key });
 
     if (value !== undefined) {
-      const valuesFilter = f as EntitiesValuesFilter;
-      valuesFilter.values = valuesFilter.values || [];
-      valuesFilter.values.push(value);
+      f.values = f.values || [];
+      f.values.push(value);
     }
   }
 


### PR DESCRIPTION
The current EntitiesSearchFilter's matchValueExists field is a bit confusing - it's not immediately clear the nuances of its behavior until you closely examine the implementation in NextEntitiesCatalog. By splitting the filter into to distinct types (one for key and another for key + value) as well as renaming the fields, I think this expresses the intent of the filters more cleanly. This also allows filtering by negation for key + value filters, which is not possible with the current implementation).
