### PR TITLE
fix: make techdocs s3 credentials optional in config schema

### DIFF
--- a/.changeset/bright-taxis-stare.md
+++ b/.changeset/bright-taxis-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Make techdocs s3 publisher credentials config schema optional.

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -83,12 +83,12 @@ export interface Config {
                * User access key id
                * @visibility secret
                */
-              accessKeyId: string;
+              accessKeyId?: string;
               /**
                * User secret access key
                * @visibility secret
                */
-              secretAccessKey: string;
+              secretAccessKey?: string;
               /**
                * ARN of role to be assumed
                * @visibility backend


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Started getting errors for not providing the `techdocs.publisher.awsS3.credentials.accessKeyId` & `secretAccessKey`. These are actually optionally used in the code https://github.com/backstage/backstage/blob/master/packages/techdocs-common/src/stages/publish/awsS3.ts#L131 and should not be required when using a `roleArn`. This makes them all optional and actually matches how the s3 reader in integration is setup https://github.com/backstage/backstage/blob/master/packages/integration/config.d.ts#L178.

**NOTE: There doesn't seem to be a workaround for this, so a hotfix release would be very welcome.**

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

Signed-off-by: Andrew Thauer <athauer@wealthsimple.com>

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
