### PR TITLE
techdocs-backend: release schema hotfix

### DIFF
--- a/.changeset/bright-taxis-stare.md
+++ b/.changeset/bright-taxis-stare.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-techdocs-backend': patch
----
-
-Make techdocs s3 publisher credentials config schema optional.

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @backstage/create-app
 
+## 0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/create-app",
   "description": "A CLI that helps you create your own Backstage app",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/plugins/techdocs-backend/CHANGELOG.md
+++ b/plugins/techdocs-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-techdocs-backend
 
+## 0.10.7
+
+### Patch Changes
+
+- b45607a2ec: Make techdocs s3 publisher credentials config schema optional.
+
 ## 0.10.6
 
 ### Patch Changes

--- a/plugins/techdocs-backend/package.json
+++ b/plugins/techdocs-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-techdocs-backend",
   "description": "The Backstage backend plugin that renders technical documentation for your components",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This release contains a fix for the `@backstage/plugin-techdocs-backend` configuration schema. It switches some of the S3 credentials options that where optional at runtime to also be optional in the schema.