### PR TITLE
Fix: [backstage-common] AWSS3UrlReader should throw NotModifiedError when etag matches

### DIFF
--- a/.changeset/few-waves-dream.md
+++ b/.changeset/few-waves-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+AWSS3UrlReader now throws a `NotModifiedError` (exported from @backstage/backend-common) when s3 returns a 304 response.

--- a/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
@@ -27,6 +27,7 @@ import { UrlReaderPredicateTuple } from './types';
 import AWSMock from 'aws-sdk-mock';
 import aws from 'aws-sdk';
 import path from 'path';
+import { NotModifiedError } from '@backstage/errors';
 
 const treeResponseFactory = DefaultReadTreeResponseFactory.create({
   config: new ConfigReader({}),
@@ -131,29 +132,37 @@ describe('AwsS3UrlReader', () => {
   });
 
   describe('read', () => {
-    AWSMock.setSDKInstance(aws);
-    AWSMock.mock(
-      'S3',
-      'getObject',
-      Buffer.from(
-        require('fs').readFileSync(
-          path.resolve(__dirname, '__fixtures__/awsS3/awsS3-mock-object.yaml'),
+    let awsS3UrlReader: AwsS3UrlReader;
+
+    beforeAll(() => {
+      AWSMock.setSDKInstance(aws);
+      AWSMock.mock(
+        'S3',
+        'getObject',
+        Buffer.from(
+          require('fs').readFileSync(
+            path.resolve(
+              __dirname,
+              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+            ),
+          ),
         ),
-      ),
-    );
-    const s3 = new aws.S3();
-    const awsS3UrlReader = new AwsS3UrlReader(
-      new AwsS3Integration(
-        readAwsS3IntegrationConfig(
-          new ConfigReader({
-            host: 'amazonaws.com',
-            accessKeyId: 'fake-access-key',
-            secretAccessKey: 'fake-secret-key',
-          }),
+      );
+
+      const s3 = new aws.S3();
+      awsS3UrlReader = new AwsS3UrlReader(
+        new AwsS3Integration(
+          readAwsS3IntegrationConfig(
+            new ConfigReader({
+              host: 'amazonaws.com',
+              accessKeyId: 'fake-access-key',
+              secretAccessKey: 'fake-secret-key',
+            }),
+          ),
         ),
-      ),
-      { s3, treeResponseFactory },
-    );
+        { s3, treeResponseFactory },
+      );
+    });
 
     it('returns contents of an object in a bucket', async () => {
       const response = await awsS3UrlReader.read(
@@ -176,32 +185,39 @@ describe('AwsS3UrlReader', () => {
   });
 
   describe('readUrl', () => {
-    AWSMock.setSDKInstance(aws);
+    let awsS3UrlReader: AwsS3UrlReader;
 
-    AWSMock.mock(
-      'S3',
-      'getObject',
-      Buffer.from(
-        require('fs').readFileSync(
-          path.resolve(__dirname, '__fixtures__/awsS3/awsS3-mock-object.yaml'),
+    beforeAll(() => {
+      AWSMock.setSDKInstance(aws);
+
+      AWSMock.mock(
+        'S3',
+        'getObject',
+        Buffer.from(
+          require('fs').readFileSync(
+            path.resolve(
+              __dirname,
+              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+            ),
+          ),
         ),
-      ),
-    );
+      );
 
-    const s3 = new aws.S3();
+      const s3 = new aws.S3();
 
-    const awsS3UrlReader = new AwsS3UrlReader(
-      new AwsS3Integration(
-        readAwsS3IntegrationConfig(
-          new ConfigReader({
-            host: 'amazonaws.com',
-            accessKeyId: 'fake-access-key',
-            secretAccessKey: 'fake-secret-key',
-          }),
+      awsS3UrlReader = new AwsS3UrlReader(
+        new AwsS3Integration(
+          readAwsS3IntegrationConfig(
+            new ConfigReader({
+              host: 'amazonaws.com',
+              accessKeyId: 'fake-access-key',
+              secretAccessKey: 'fake-secret-key',
+            }),
+          ),
         ),
-      ),
-      { s3, treeResponseFactory },
-    );
+        { s3, treeResponseFactory },
+      );
+    });
 
     it('returns contents of an object in a bucket', async () => {
       const response = await awsS3UrlReader.readUrl(
@@ -223,40 +239,89 @@ describe('AwsS3UrlReader', () => {
       );
     });
   });
+
+  describe('readUrl with etag', () => {
+    let awsS3UrlReader: AwsS3UrlReader;
+
+    beforeAll(() => {
+      AWSMock.setSDKInstance(aws);
+
+      AWSMock.mock('S3', 'getObject', (_, callback) => {
+        callback({ statusCode: 304 }, null);
+      });
+
+      const s3 = new aws.S3();
+
+      awsS3UrlReader = new AwsS3UrlReader(
+        new AwsS3Integration(
+          readAwsS3IntegrationConfig(
+            new ConfigReader({
+              host: 'amazonaws.com',
+              accessKeyId: 'fake-access-key',
+              secretAccessKey: 'fake-secret-key',
+            }),
+          ),
+        ),
+        { s3, treeResponseFactory },
+      );
+    });
+
+    it('returns contents of an object in a bucket', async () => {
+      await expect(
+        awsS3UrlReader.readUrl(
+          'https://test-bucket.s3.us-east-2.amazonaws.com/awsS3-mock-object.yaml',
+          {
+            etag: 'abc123',
+          },
+        ),
+      ).rejects.toThrow(NotModifiedError);
+    });
+  });
+
   describe('readTree', () => {
-    const object: aws.S3.Types.Object = {
-      Key: 'awsS3-mock-object.yaml',
-    };
-    const objectList: aws.S3.ObjectList = [object];
-    const output: aws.S3.Types.ListObjectsV2Output = {
-      Contents: objectList,
-    };
-    AWSMock.setSDKInstance(aws);
-    AWSMock.mock('S3', 'listObjectsV2', output);
+    let awsS3UrlReader: AwsS3UrlReader;
 
-    AWSMock.mock(
-      'S3',
-      'getObject',
-      Buffer.from(
-        require('fs').readFileSync(
-          path.resolve(__dirname, '__fixtures__/awsS3/awsS3-mock-object.yaml'),
-        ),
-      ),
-    );
+    beforeAll(() => {
+      const object: aws.S3.Types.Object = {
+        Key: 'awsS3-mock-object.yaml',
+      };
 
-    const s3 = new aws.S3();
-    const awsS3UrlReader = new AwsS3UrlReader(
-      new AwsS3Integration(
-        readAwsS3IntegrationConfig(
-          new ConfigReader({
-            host: '.amazonaws.com',
-            accessKeyId: 'fake-access-key',
-            secretAccessKey: 'fake-secret-key',
-          }),
+      const objectList: aws.S3.ObjectList = [object];
+      const output: aws.S3.Types.ListObjectsV2Output = {
+        Contents: objectList,
+      };
+
+      AWSMock.setSDKInstance(aws);
+      AWSMock.mock('S3', 'listObjectsV2', output);
+
+      AWSMock.mock(
+        'S3',
+        'getObject',
+        Buffer.from(
+          require('fs').readFileSync(
+            path.resolve(
+              __dirname,
+              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+            ),
+          ),
         ),
-      ),
-      { s3, treeResponseFactory },
-    );
+      );
+
+      const s3 = new aws.S3();
+      awsS3UrlReader = new AwsS3UrlReader(
+        new AwsS3Integration(
+          readAwsS3IntegrationConfig(
+            new ConfigReader({
+              host: '.amazonaws.com',
+              accessKeyId: 'fake-access-key',
+              secretAccessKey: 'fake-secret-key',
+            }),
+          ),
+        ),
+        { s3, treeResponseFactory },
+      );
+    });
+
     it('returns contents of an object in a bucket', async () => {
       const response = await awsS3UrlReader.readTree(
         'https://test.s3.us-east-2.amazonaws.com',

--- a/packages/backend-common/src/reading/AwsS3UrlReader.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.ts
@@ -27,7 +27,7 @@ import {
 } from './types';
 import getRawBody from 'raw-body';
 import { AwsS3Integration, ScmIntegrations } from '@backstage/integration';
-import { ForwardedError } from '@backstage/errors';
+import { ForwardedError, NotModifiedError } from '@backstage/errors';
 import { ListObjectsV2Output, ObjectList } from 'aws-sdk/clients/s3';
 
 const parseURL = (
@@ -163,6 +163,10 @@ export class AwsS3UrlReader implements UrlReader {
         etag: etag,
       };
     } catch (e) {
+      if (e.statusCode === 304) {
+        throw new NotModifiedError();
+      }
+
       throw new ForwardedError('Could not retrieve file from S3', e);
     }
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When providing an etag to the URLReader for an S3 resource I was seeing an error that the resource could not be fetched.
From what I can see this is because AWS returns a 304 and no data, trying to get the rawbody from the response stream throws an error which is caught and forwarded to the caller.
Based on [these docs](https://github.com/stream-utils/raw-body#errors), raw-body returns the status code in the error and so we can use that to check for `304` and throw a `NotModifiedError` in line with the other URL readers.

Note: I've not done much jest testing before so would appreciate any comments on this. I had to move a lot of setup into `beforeAll` callbacks as the mocks were interfering with each other. I'm not sure if there is a better way of doing this.

I also wasn't sure if the change set should touch only the package I updated or if I need to put in a change set for all the other packages that get bumped.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
