### PR TITLE
cli: dynamically determine which packages are unsafe to repack

### DIFF
--- a/.changeset/angry-countries-cheat.md
+++ b/.changeset/angry-countries-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switched to dynamically determining the packages that are unsafe to repack when executing the CLI within the Backstage main repo.

--- a/packages/cli/src/lib/packager/index.ts
+++ b/packages/cli/src/lib/packager/index.ts
@@ -24,14 +24,16 @@ import { tmpdir } from 'os';
 import tar, { CreateOptions } from 'tar';
 import { paths } from '../paths';
 import { run } from '../run';
-import { packageVersions } from '../version';
 import { ParallelOption } from '../parallel';
+import {
+  dependencies as cliDependencies,
+  devDependencies as cliDevDependencies,
+} from '../../../package.json';
 
 // These packages aren't safe to pack in parallel since the CLI depends on them
 const UNSAFE_PACKAGES = [
-  ...Object.keys(packageVersions),
-  '@backstage/cli-common',
-  '@backstage/config-loader',
+  ...Object.keys(cliDependencies),
+  ...Object.keys(cliDevDependencies),
 ];
 
 type LernaPackage = {


### PR DESCRIPTION
Cleaning up some hardcoded stuff, and possibly fixes the CI issues in #7612