### PR TITLE
Allow singleton and flexibly nested EntityFilters

### DIFF
--- a/.changeset/slimy-days-leave.md
+++ b/.changeset/slimy-days-leave.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Allow nested EntityFilters
+Allow singleton and flexibly nested EntityFilters

--- a/.changeset/slimy-days-leave.md
+++ b/.changeset/slimy-days-leave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow nested EntityFilters

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -870,11 +870,14 @@ export type EntityAncestryResponse = {
 // Warning: (ae-missing-release-tag) "EntityFilter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export type EntityFilter = {
-  anyOf: {
-    allOf: (EntitiesSearchFilter | EntityFilter)[];
-  }[];
-};
+export type EntityFilter =
+  | {
+      allOf: EntityFilter[];
+    }
+  | {
+      anyOf: EntityFilter[];
+    }
+  | EntitiesSearchFilter;
 
 // Warning: (ae-missing-release-tag) "EntityPagination" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -872,7 +872,7 @@ export type EntityAncestryResponse = {
 // @public
 export type EntityFilter = {
   anyOf: {
-    allOf: EntitiesSearchFilter[];
+    allOf: (EntitiesSearchFilter | EntityFilter)[];
   }[];
 };
 

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -23,7 +23,7 @@ import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
  * individual filters must match.
  */
 export type EntityFilter = {
-  anyOf: { allOf: EntitiesSearchFilter[] }[];
+  anyOf: { allOf: (EntitiesSearchFilter | EntityFilter)[] }[];
 };
 
 /**

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -22,9 +22,10 @@ import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
  * Any (at least one) of the outer sets must match, within which all of the
  * individual filters must match.
  */
-export type EntityFilter = {
-  anyOf: { allOf: (EntitiesSearchFilter | EntityFilter)[] }[];
-};
+export type EntityFilter =
+  | { allOf: EntityFilter[] }
+  | { anyOf: EntityFilter[] }
+  | EntitiesSearchFilter;
 
 /**
  * A pagination rule for entities.

--- a/plugins/catalog-backend/src/service/NextEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/NextEntitiesCatalog.test.ts
@@ -284,9 +284,7 @@ describe('NextEntitiesCatalog', () => {
           key: 'spec.test',
           matchValueExists: true,
         };
-        const request = {
-          filter: { anyOf: [{ allOf: [testFilter] }] },
-        };
+        const request = { filter: testFilter };
         const { entities } = await catalog.entities(request);
 
         expect(entities.length).toBe(1);
@@ -344,14 +342,10 @@ describe('NextEntitiesCatalog', () => {
         };
         const request = {
           filter: {
-            anyOf: [
+            allOf: [
+              testFilter1,
               {
-                allOf: [
-                  testFilter1,
-                  {
-                    anyOf: [{ allOf: [testFilter2] }, { allOf: [testFilter3] }],
-                  },
-                ],
+                anyOf: [testFilter2, testFilter3],
               },
             ],
           },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This makes the format of EntityFilters more flexible, and paves the way for the permissions system, which requires composing multiple _collections_ of filters. See #7730 for more details.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
