### PR TITLE
Make theme banner warning color optional

### DIFF
--- a/.changeset/dry-spies-cover.md
+++ b/.changeset/dry-spies-cover.md
@@ -3,4 +3,6 @@
 '@backstage/theme': patch
 ---
 
-Will Add warning variant to `DismissableBanner` component.
+Added a warning variant to `DismissableBanner` component. If you are using a
+custom theme, you will need to add the optional `palette.banner.warning` color,
+otherwise this variant will fall back to the `palette.banner.error` color.

--- a/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
+++ b/packages/core-components/src/components/DismissableBanner/DismissableBanner.tsx
@@ -80,7 +80,8 @@ const useStyles = makeStyles(
       backgroundColor: theme.palette.banner.error,
     },
     warning: {
-      backgroundColor: theme.palette.banner.warning,
+      backgroundColor:
+        theme.palette.banner.warning ?? theme.palette.banner.error,
     },
   }),
   { name: 'BackstageDismissableBanner' },

--- a/packages/theme/api-report.md
+++ b/packages/theme/api-report.md
@@ -64,7 +64,7 @@ export type BackstagePaletteAdditions = {
     error: string;
     text: string;
     link: string;
-    warning: string;
+    warning?: string;
   };
 };
 

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -76,7 +76,7 @@ export type BackstagePaletteAdditions = {
     error: string;
     text: string;
     link: string;
-    warning: string;
+    warning?: string;
   };
 };
 


### PR DESCRIPTION
#7842 inadvertently introduced a breaking change to the `@backstage/theme` package, which is [stability index 2](https://backstage.io/docs/overview/stability-index#theme-githubhttpsgithubcombackstagebackstagetreemasterpackagestheme) and should avoid breaking changes without a migration phase.

This makes the `warning` color optional in theme definitions, and falls back to `error` when it is not available.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
