### PR TITLE
Added 'Blessed' icons for core plugins

### DIFF
--- a/.changeset/spicy-panthers-thank.md
+++ b/.changeset/spicy-panthers-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+I have added default icons for the catalog, scaffolder, techdocs, and search.

--- a/packages/core-app-api/src/app/icons.tsx
+++ b/packages/core-app-api/src/app/icons.tsx
@@ -18,6 +18,9 @@ import { IconComponent } from '@backstage/core-plugin-api';
 import MuiApartmentIcon from '@material-ui/icons/Apartment';
 import MuiBrokenImageIcon from '@material-ui/icons/BrokenImage';
 import MuiCategoryIcon from '@material-ui/icons/Category';
+import MuiCreateNewFolderIcon from '@material-ui/icons/CreateNewFolder';
+import MuiSubjectIcon from '@material-ui/icons/Subject';
+import MuiSearchIcon from '@material-ui/icons/Search';
 import MuiChatIcon from '@material-ui/icons/Chat';
 import MuiDashboardIcon from '@material-ui/icons/Dashboard';
 import MuiDocsIcon from '@material-ui/icons/Description';
@@ -35,6 +38,9 @@ import MuiWarningIcon from '@material-ui/icons/Warning';
 type AppIconsKey =
   | 'brokenImage'
   | 'catalog'
+  | 'scaffolder'
+  | 'techdocs'
+  | 'search'
   | 'chat'
   | 'dashboard'
   | 'docs'
@@ -58,6 +64,9 @@ export const defaultAppIcons: AppIcons = {
   brokenImage: MuiBrokenImageIcon,
   // To be confirmed: see https://github.com/backstage/backstage/issues/4970
   catalog: MuiMenuBookIcon,
+  scaffolder: MuiCreateNewFolderIcon,
+  techdocs: MuiSubjectIcon,
+  search: MuiSearchIcon,
   chat: MuiChatIcon,
   dashboard: MuiDashboardIcon,
   docs: MuiDocsIcon,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In this Pull Request, I have selected a few icons from v4 MUI Icons set to represent major parts of Backstage, for use in buttons and links into these components: 
catalog: MenuBook Icon
scaffolder & templates: CreateNewFolder Icon
techdocs: Subject Icon
search: Search Icon

I have added these icons to the list.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))