### PR TITLE
Sort imports with Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,10 +1,10 @@
-.yarn
-dist
-microsite
-coverage
 *.hbs
-templates
-api-report.md
-plugins/scaffolder-backend/sample-templates
 .vscode
+.yarn
+api-report.md
+contrib
+coverage
+dist
 dist-types
+microsite
+plugins/scaffolder-backend/sample-templates

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "@microsoft/tsdoc": "^0.13.2"
   },
   "devDependencies": {
-    "@types/webpack": "^5.28.0",
     "@changesets/cli": "^2.14.0",
     "@spotify/prettier-config": "^11.0.0",
+    "@types/webpack": "^5.28.0",
     "command-exists": "^1.2.9",
     "concurrently": "^6.0.0",
     "eslint-plugin-notice": "^0.9.10",
@@ -69,6 +69,7 @@
     "lerna": "^4.0.0",
     "lint-staged": "^11.1.2",
     "prettier": "^2.2.1",
+    "prettier-plugin-organize-imports": "^2.3.4",
     "shx": "^0.3.2",
     "yarn-lock-check": "^1.0.5"
   },

--- a/packages/create-app/src/createApp.ts
+++ b/packages/create-app/src/createApp.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import fs from 'fs-extra';
-import { promisify } from 'util';
-import chalk from 'chalk';
-import { Command } from 'commander';
-import inquirer, { Answers, Question } from 'inquirer';
-import { exec as execCb } from 'child_process';
-import { resolve as resolvePath } from 'path';
 import { findPaths } from '@backstage/cli-common';
+import chalk from 'chalk';
+import { exec as execCb } from 'child_process';
+import { Command } from 'commander';
+import fs from 'fs-extra';
+import inquirer, { Answers, Question } from 'inquirer';
 import os from 'os';
+import { resolve as resolvePath } from 'path';
+import { promisify } from 'util';
 import { Task, templatingTask } from './lib/tasks';
 
 const exec = promisify(execCb);

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -21,9 +21,9 @@
  */
 
 import program from 'commander';
-import { exitWithError } from './lib/errors';
 import { version } from '../package.json';
 import createApp from './createApp';
+import { exitWithError } from './lib/errors';
 
 const main = (argv: string[]) => {
   program

--- a/packages/create-app/src/lib/versions.ts
+++ b/packages/create-app/src/lib/versions.ts
@@ -30,6 +30,29 @@ Rollup will extract the value of the version field in each package at build time
 leaving any imports in place.
 */
 
+import { version as pluginApiDocs } from '../../../../plugins/api-docs/package.json';
+import { version as pluginAppBackend } from '../../../../plugins/app-backend/package.json';
+import { version as pluginAuthBackend } from '../../../../plugins/auth-backend/package.json';
+import { version as pluginCatalogBackend } from '../../../../plugins/catalog-backend/package.json';
+import { version as pluginCatalogImport } from '../../../../plugins/catalog-import/package.json';
+import { version as pluginCatalogReact } from '../../../../plugins/catalog-react/package.json';
+import { version as pluginCatalog } from '../../../../plugins/catalog/package.json';
+import { version as pluginCircleci } from '../../../../plugins/circleci/package.json';
+import { version as pluginExplore } from '../../../../plugins/explore/package.json';
+import { version as pluginGithubActions } from '../../../../plugins/github-actions/package.json';
+import { version as pluginLighthouse } from '../../../../plugins/lighthouse/package.json';
+import { version as pluginOrg } from '../../../../plugins/org/package.json';
+import { version as pluginProxyBackend } from '../../../../plugins/proxy-backend/package.json';
+import { version as pluginRollbarBackend } from '../../../../plugins/rollbar-backend/package.json';
+import { version as pluginScaffolderBackend } from '../../../../plugins/scaffolder-backend/package.json';
+import { version as pluginScaffolder } from '../../../../plugins/scaffolder/package.json';
+import { version as pluginSearchBackendNode } from '../../../../plugins/search-backend-node/package.json';
+import { version as pluginSearchBackend } from '../../../../plugins/search-backend/package.json';
+import { version as pluginSearch } from '../../../../plugins/search/package.json';
+import { version as pluginTechRadar } from '../../../../plugins/tech-radar/package.json';
+import { version as pluginTechdocsBackend } from '../../../../plugins/techdocs-backend/package.json';
+import { version as pluginTechdocs } from '../../../../plugins/techdocs/package.json';
+import { version as pluginUserSettings } from '../../../../plugins/user-settings/package.json';
 import { version as backendCommon } from '../../../backend-common/package.json';
 import { version as catalogClient } from '../../../catalog-client/package.json';
 import { version as catalogModel } from '../../../catalog-model/package.json';
@@ -42,30 +65,6 @@ import { version as errors } from '../../../errors/package.json';
 import { version as integrationReact } from '../../../integration-react/package.json';
 import { version as testUtils } from '../../../test-utils/package.json';
 import { version as theme } from '../../../theme/package.json';
-
-import { version as pluginApiDocs } from '../../../../plugins/api-docs/package.json';
-import { version as pluginAppBackend } from '../../../../plugins/app-backend/package.json';
-import { version as pluginAuthBackend } from '../../../../plugins/auth-backend/package.json';
-import { version as pluginCatalog } from '../../../../plugins/catalog/package.json';
-import { version as pluginCatalogReact } from '../../../../plugins/catalog-react/package.json';
-import { version as pluginCatalogBackend } from '../../../../plugins/catalog-backend/package.json';
-import { version as pluginCatalogImport } from '../../../../plugins/catalog-import/package.json';
-import { version as pluginCircleci } from '../../../../plugins/circleci/package.json';
-import { version as pluginExplore } from '../../../../plugins/explore/package.json';
-import { version as pluginGithubActions } from '../../../../plugins/github-actions/package.json';
-import { version as pluginLighthouse } from '../../../../plugins/lighthouse/package.json';
-import { version as pluginOrg } from '../../../../plugins/org/package.json';
-import { version as pluginProxyBackend } from '../../../../plugins/proxy-backend/package.json';
-import { version as pluginRollbarBackend } from '../../../../plugins/rollbar-backend/package.json';
-import { version as pluginScaffolder } from '../../../../plugins/scaffolder/package.json';
-import { version as pluginScaffolderBackend } from '../../../../plugins/scaffolder-backend/package.json';
-import { version as pluginSearch } from '../../../../plugins/search/package.json';
-import { version as pluginSearchBackend } from '../../../../plugins/search-backend/package.json';
-import { version as pluginSearchBackendNode } from '../../../../plugins/search-backend-node/package.json';
-import { version as pluginTechRadar } from '../../../../plugins/tech-radar/package.json';
-import { version as pluginTechdocs } from '../../../../plugins/techdocs/package.json';
-import { version as pluginTechdocsBackend } from '../../../../plugins/techdocs-backend/package.json';
-import { version as pluginUserSettings } from '../../../../plugins/user-settings/package.json';
 
 export const packageVersions = {
   '@backstage/backend-common': backendCommon,

--- a/packages/create-app/templates/default-app/packages/app/src/App.test.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { renderWithEffects } from '@backstage/test-utils';
+import React from 'react';
 import App from './App';
 
 describe('App', () => {

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Navigate, Route } from 'react-router';
+import { createApp, FlatRoutes } from '@backstage/core-app-api';
+import { AlertDisplay, OAuthRequestDialog } from '@backstage/core-components';
 import { apiDocsPlugin, ApiExplorerPage } from '@backstage/plugin-api-docs';
 import {
   CatalogEntityPage,
@@ -20,13 +20,12 @@ import {
   TechDocsReaderPage,
 } from '@backstage/plugin-techdocs';
 import { UserSettingsPage } from '@backstage/plugin-user-settings';
+import React from 'react';
+import { Navigate, Route } from 'react-router';
 import { apis } from './apis';
 import { entityPage } from './components/catalog/EntityPage';
-import { searchPage } from './components/search/SearchPage';
 import { Root } from './components/Root';
-
-import { AlertDisplay, OAuthRequestDialog } from '@backstage/core-components';
-import { createApp, FlatRoutes } from '@backstage/core-app-api';
+import { searchPage } from './components/search/SearchPage';
 
 const app = createApp({
   apis,

--- a/packages/create-app/templates/default-app/packages/app/src/apis.ts
+++ b/packages/create-app/templates/default-app/packages/app/src/apis.ts
@@ -1,13 +1,13 @@
 import {
-  ScmIntegrationsApi,
-  scmIntegrationsApiRef,
-  ScmAuth,
-} from '@backstage/integration-react';
-import {
   AnyApiFactory,
   configApiRef,
   createApiFactory,
 } from '@backstage/core-plugin-api';
+import {
+  ScmAuth,
+  ScmIntegrationsApi,
+  scmIntegrationsApiRef,
+} from '@backstage/integration-react';
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/LogoFull.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/LogoFull.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { makeStyles } from '@material-ui/core';
+import React from 'react';
 
 const useStyles = makeStyles({
   svg: {

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/LogoIcon.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/LogoIcon.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { makeStyles } from '@material-ui/core';
+import React from 'react';
 
 const useStyles = makeStyles({
   svg: {

--- a/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/Root/Root.tsx
@@ -14,28 +14,28 @@
  * limitations under the License.
  */
 
-import React, { useContext, PropsWithChildren } from 'react';
-import { Link, makeStyles } from '@material-ui/core';
-import HomeIcon from '@material-ui/icons/Home';
-import ExtensionIcon from '@material-ui/icons/Extension';
-import MapIcon from '@material-ui/icons/MyLocation';
-import LibraryBooks from '@material-ui/icons/LibraryBooks';
-import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
-import LogoFull from './LogoFull';
-import LogoIcon from './LogoIcon';
-import { NavLink } from 'react-router-dom';
-import { Settings as SidebarSettings } from '@backstage/plugin-user-settings';
-import { SidebarSearch } from '@backstage/plugin-search';
 import {
   Sidebar,
-  SidebarPage,
   sidebarConfig,
   SidebarContext,
-  SidebarItem,
   SidebarDivider,
-  SidebarSpace,
+  SidebarItem,
+  SidebarPage,
   SidebarScrollWrapper,
+  SidebarSpace,
 } from '@backstage/core-components';
+import { SidebarSearch } from '@backstage/plugin-search';
+import { Settings as SidebarSettings } from '@backstage/plugin-user-settings';
+import { Link, makeStyles } from '@material-ui/core';
+import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
+import ExtensionIcon from '@material-ui/icons/Extension';
+import HomeIcon from '@material-ui/icons/Home';
+import LibraryBooks from '@material-ui/icons/LibraryBooks';
+import MapIcon from '@material-ui/icons/MyLocation';
+import React, { PropsWithChildren, useContext } from 'react';
+import { NavLink } from 'react-router-dom';
+import LogoFull from './LogoFull';
+import LogoIcon from './LogoIcon';
 
 const useSidebarLogoStyles = makeStyles({
   root: {

--- a/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { Button, Grid } from '@material-ui/core';
+import { EmptyState } from '@backstage/core-components';
 import {
   EntityApiDefinitionCard,
   EntityConsumedApisCard,
@@ -27,33 +26,34 @@ import {
   EntityAboutCard,
   EntityDependsOnComponentsCard,
   EntityDependsOnResourcesCard,
-  EntitySystemDiagramCard,
   EntityHasComponentsCard,
   EntityHasResourcesCard,
   EntityHasSubcomponentsCard,
   EntityHasSystemsCard,
   EntityLayout,
   EntityLinksCard,
-  EntitySwitch,
   EntityOrphanWarning,
   EntityProcessingErrorsPanel,
+  EntitySwitch,
+  EntitySystemDiagramCard,
+  hasCatalogProcessingErrors,
   isComponentType,
   isKind,
-  hasCatalogProcessingErrors,
   isOrphan,
 } from '@backstage/plugin-catalog';
 import {
-  isGithubActionsAvailable,
   EntityGithubActionsContent,
+  isGithubActionsAvailable,
 } from '@backstage/plugin-github-actions';
 import {
-  EntityUserProfileCard,
   EntityGroupProfileCard,
   EntityMembersListCard,
   EntityOwnershipCard,
+  EntityUserProfileCard,
 } from '@backstage/plugin-org';
 import { EntityTechdocsContent } from '@backstage/plugin-techdocs';
-import { EmptyState } from '@backstage/core-components';
+import { Button, Grid } from '@material-ui/core';
+import React from 'react';
 
 const cicdContent = (
   // This is an example of how you can implement your company's logic in entity page.

--- a/packages/create-app/templates/default-app/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/search/SearchPage.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
-import { makeStyles, Theme, Grid, List, Paper } from '@material-ui/core';
-
+import { Content, Header, Page } from '@backstage/core-components';
 import { CatalogResultListItem } from '@backstage/plugin-catalog';
 import {
+  DefaultResultListItem,
   SearchBar,
   SearchFilter,
   SearchResult,
-  DefaultResultListItem,
 } from '@backstage/plugin-search';
-import { Content, Header, Page } from '@backstage/core-components';
+import { Grid, List, makeStyles, Paper, Theme } from '@material-ui/core';
+import React from 'react';
 
 const useStyles = makeStyles((theme: Theme) => ({
   bar: {

--- a/packages/create-app/templates/default-app/packages/backend/src/index.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/index.ts
@@ -6,26 +6,26 @@
  * Happy hacking!
  */
 
-import Router from 'express-promise-router';
 import {
-  createServiceBuilder,
-  loadBackendConfig,
-  getRootLogger,
-  useHotMemoize,
-  notFoundHandler,
   CacheManager,
+  createServiceBuilder,
   DatabaseManager,
+  getRootLogger,
+  loadBackendConfig,
+  notFoundHandler,
   SingleHostDiscovery,
   UrlReaders,
+  useHotMemoize,
 } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
+import Router from 'express-promise-router';
 import app from './plugins/app';
 import auth from './plugins/auth';
 import catalog from './plugins/catalog';
-import scaffolder from './plugins/scaffolder';
 import proxy from './plugins/proxy';
-import techdocs from './plugins/techdocs';
+import scaffolder from './plugins/scaffolder';
 import search from './plugins/search';
+import techdocs from './plugins/techdocs';
 import { PluginEnvironment } from './types';
 
 function makeCreateEnv(config: Config) {

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/search.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/search.ts
@@ -1,11 +1,11 @@
 import { useHotCleanup } from '@backstage/backend-common';
+import { DefaultCatalogCollator } from '@backstage/plugin-catalog-backend';
 import { createRouter } from '@backstage/plugin-search-backend';
 import {
   IndexBuilder,
   LunrSearchEngine,
 } from '@backstage/plugin-search-backend-node';
 import { PluginEnvironment } from '../types';
-import { DefaultCatalogCollator } from '@backstage/plugin-catalog-backend';
 
 export default async function createPlugin({
   logger,

--- a/packages/create-app/templates/default-app/packages/backend/src/types.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/types.ts
@@ -1,11 +1,11 @@
-import { Logger } from 'winston';
-import { Config } from '@backstage/config';
 import {
   PluginCacheManager,
   PluginDatabaseManager,
   PluginEndpointDiscovery,
   UrlReader,
 } from '@backstage/backend-common';
+import { Config } from '@backstage/config';
+import { Logger } from 'winston';
 
 export type PluginEnvironment = {
   logger: Logger;

--- a/yarn.lock
+++ b/yarn.lock
@@ -22854,6 +22854,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier-plugin-organize-imports@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.4.tgz#65473861ae5ab7960439fff270a2258558fbe9ba"
+  integrity sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==
+
 prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Add prettier-plugin-organize-imports to sort imports in TS code. This removes ambiguity, eases reading source code, but is most useful for diffing code during upgrading Backstage apps to newer releases - code generated by create-app is sorted and it’s easier to spot changes and align them with local project, which has the imports sorted. For this reason, the `.prettierignore` file is also modified to allow prettifying template directories.

https://github.com/simonhaenisch/prettier-plugin-organize-imports

I know that this change can bring in a lot of diffs in every file and may be controversial, so I’m open for discussion.

There is also an alternative prettier plugin, https://github.com/trivago/prettier-plugin-sort-imports, but it turns out that it garbles TypeScript code embedded in documentation code blocks in .md files.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
