### PR TITLE
lock "history" package version to 5.0.1

### DIFF
--- a/.changeset/metal-apes-reply.md
+++ b/.changeset/metal-apes-reply.md
@@ -1,0 +1,8 @@
+---
+'example-app': patch
+'@backstage/core-plugin-api': patch
+'@backstage/create-app': patch
+'@backstage/plugin-cost-insights': patch
+---
+
+"history" version locked to 5.0.1

--- a/.changeset/metal-apes-reply.md
+++ b/.changeset/metal-apes-reply.md
@@ -1,5 +1,4 @@
 ---
-'example-app': patch
 '@backstage/core-plugin-api': patch
 '@backstage/create-app': patch
 '@backstage/plugin-cost-insights': patch

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -52,7 +52,7 @@
     "@roadiehq/backstage-plugin-github-insights": "^1.1.23",
     "@roadiehq/backstage-plugin-github-pull-requests": "^1.0.13",
     "@roadiehq/backstage-plugin-travis-ci": "^1.0.11",
-    "history": "^5.0.0",
+    "history": "5.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/packages/core-plugin-api/package.json
+++ b/packages/core-plugin-api/package.json
@@ -35,7 +35,7 @@
     "@backstage/version-bridge": "^0.1.0",
     "@material-ui/core": "^4.12.2",
     "@types/react": "*",
-    "history": "^5.0.0",
+    "history": "5.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-router-dom": "6.0.0-beta.0",

--- a/packages/create-app/templates/default-app/packages/app/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/app/package.json.hbs
@@ -25,7 +25,7 @@
     "@backstage/theme": "^{{version '@backstage/theme'}}",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "history": "^5.0.0",
+    "history": "5.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -42,7 +42,7 @@
     "@types/react": "*",
     "@types/recharts": "^1.8.14",
     "classnames": "^2.2.6",
-    "history": "^5.0.0",
+    "history": "5.0.1",
     "luxon": "^2.0.2",
     "pluralize": "^8.0.0",
     "qs": "^6.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15769,7 +15769,7 @@ highlight.js@~10.7.0:
   resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-history@^5.0.0:
+history@5.0.1, history@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/history/-/history-5.0.1.tgz#de35025ed08bce0db62364b47ebbf9d97b5eb06a"
   integrity sha512-5qC/tFUKfVci5kzgRxZxN5Mf1CV8NmJx9ByaPX0YTLx5Vz3Svh7NYp6eA4CpDq4iA9D0C1t8BNIfvQIrUI3mVw==


### PR DESCRIPTION
Signed-off-by: Alex Rybchenko <arybchenko@box.com>

## Hey, I just made a Pull Request!

Recent changes in "history" package are incompatible with "react-router-dom@6.0.0-beta.0" (`State` type removed https://github.com/remix-run/history/compare/v5.0.1...v5.0.2#diff-1caf4c08131a3efeb1e49c0ce896aa4a488a13b1b743613a99f4a5c5aff91d8fL57)

and e2e now fails:
https://github.com/backstage/backstage/runs/4077499724?check_suite_focus=true

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
