### PR TITLE
Pin version of ElasticSearch client to 7.13.0

### DIFF
--- a/.changeset/late-walls-cry.md
+++ b/.changeset/late-walls-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Pinning version of elastic search client to 7.13.0 to prevent breaking change towards third party ElasticSearch clusters on 7.14.0.

--- a/plugins/search-backend-module-elasticsearch/package.json
+++ b/plugins/search-backend-module-elasticsearch/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@backstage/config": "^0.1.8",
     "@backstage/search-common": "^0.2.0",
-    "@elastic/elasticsearch": "^7.13.0",
+    "@elastic/elasticsearch": "7.13.0",
     "@acuris/aws-es-connection": "^2.2.0",
     "aws-sdk": "^2.948.0",
     "elastic-builder": "^2.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2717,7 +2717,7 @@
     find-my-way "^2.2.2"
     into-stream "^5.1.1"
 
-"@elastic/elasticsearch@^7.13.0":
+"@elastic/elasticsearch@7.13.0":
   version "7.13.0"
   resolved "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.13.0.tgz#6dcf511dfa91187e22c81e54f41f4bd0fd96b4d6"
   integrity sha512-WgwLWo2p9P2tdqzBGX9fHeG8p5IOTXprXNTECQG2mJ7z9n93N5AFBJpEw4d35tWWeCWi9jI13A2wzQZH7XZ/xw==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Pinning ElasticSearch client to 7.13.0 so that third party clusters can be used. Elastic introduced functionality to break AWS OpenSearch on 7.14.0. With this change we can continue supporting AWS OpenSearch without a need to externally enforce client versions. Likely need to be revisited in the future if there is some functionality needed that we'd receive by updating the client.

Refs:
* https://aws.amazon.com/blogs/opensource/keeping-clients-of-opensearch-and-elasticsearch-compatible-with-open-source/
* https://github.com/backstage/backstage/issues/7839

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or updated documentation
- [n/a] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
