### PR TITLE
feat(catalog): remove "View Api" from AboutCard

### DIFF
--- a/.changeset/big-months-float.md
+++ b/.changeset/big-months-float.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Remove the "View Api" icon in the AboutCard, as the information is misleading for some users and is
+duplicated in the tabs above.

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -18,8 +18,6 @@ import {
   Entity,
   ENTITY_DEFAULT_NAMESPACE,
   LOCATION_ANNOTATION,
-  RELATION_CONSUMES_API,
-  RELATION_PROVIDES_API,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import {
@@ -36,7 +34,6 @@ import {
 import {
   catalogApiRef,
   getEntityMetadataEditUrl,
-  getEntityRelations,
   getEntitySourceLocation,
   useEntity,
 } from '@backstage/plugin-catalog-react';
@@ -51,7 +48,6 @@ import {
 import CachedIcon from '@material-ui/icons/Cached';
 import DocsIcon from '@material-ui/icons/Description';
 import EditIcon from '@material-ui/icons/Edit';
-import ExtensionIcon from '@material-ui/icons/Extension';
 import React, { useCallback } from 'react';
 import { viewTechDocRouteRef } from '../../routes';
 import { AboutContent } from './AboutContent';
@@ -95,16 +91,6 @@ export function AboutCard({ variant }: AboutCardProps) {
     scmIntegrationsApi,
   );
   const entityMetadataEditUrl = getEntityMetadataEditUrl(entity);
-  const providesApiRelations = getEntityRelations(
-    entity,
-    RELATION_PROVIDES_API,
-  );
-  const consumesApiRelations = getEntityRelations(
-    entity,
-    RELATION_CONSUMES_API,
-  );
-  const hasApis =
-    providesApiRelations.length > 0 || consumesApiRelations.length > 0;
 
   const viewInSource: IconLinkVerticalProps = {
     label: 'View Source',
@@ -125,13 +111,6 @@ export function AboutCard({ variant }: AboutCardProps) {
         kind: entity.kind,
         name: entity.metadata.name,
       }),
-  };
-  const viewApi: IconLinkVerticalProps = {
-    title: hasApis ? '' : 'No APIs available',
-    label: 'View API',
-    disabled: !hasApis,
-    icon: <ExtensionIcon />,
-    href: 'api',
   };
 
   let cardClass = '';
@@ -181,9 +160,7 @@ export function AboutCard({ variant }: AboutCardProps) {
             </IconButton>
           </>
         }
-        subheader={
-          <HeaderIconLinkRow links={[viewInSource, viewInTechDocs, viewApi]} />
-        }
+        subheader={<HeaderIconLinkRow links={[viewInSource, viewInTechDocs]} />}
       />
       <Divider />
       <CardContent className={cardContentClass}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The "View Api" icon in the AboutCard is duplicated, as it will also be shown in the tabs. As the icon is misleading for some users, we remove it completely from the AboutCard.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
