### PR TITLE
Minor UI updates to make numbers and dates a bit more human friendly

### DIFF
--- a/.changeset/neat-pugs-wait.md
+++ b/.changeset/neat-pugs-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage': patch
+---
+
+Change represented test date from epoch to something more human friendly. Round test coverage to 2 decimal places.

--- a/plugins/code-coverage/package.json
+++ b/plugins/code-coverage/package.json
@@ -33,7 +33,7 @@
     "@material-ui/lab": "4.0.0-alpha.57",
     "@material-ui/styles": "^4.11.0",
     "highlight.js": "^10.6.0",
-    "luxon": "^2.1.0",
+    "luxon": "^2.0.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/code-coverage/package.json
+++ b/plugins/code-coverage/package.json
@@ -33,6 +33,7 @@
     "@material-ui/lab": "4.0.0-alpha.57",
     "@material-ui/styles": "^4.11.0",
     "highlight.js": "^10.6.0",
+    "luxon": "^2.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
+++ b/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
@@ -46,6 +46,8 @@ import { codeCoverageApiRef } from '../../api';
 import { Progress, ResponseErrorPanel } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
+import { DateTime } from 'luxon';
+
 type Coverage = 'line' | 'branch';
 
 const useStyles = makeStyles<BackstageTheme>(theme => ({
@@ -71,7 +73,9 @@ const getTrendIcon = (trend: number, classes: ClassNameMap) => {
 
 // convert timestamp to human friendly form
 function formatDateToHuman(timeStamp: string | number) {
-  return new Date(timeStamp).toUTCString();
+  return DateTime.fromMillis(Number(timeStamp)).toLocaleString(
+    DateTime.DATETIME_MED,
+  );
 }
 
 export const CoverageHistoryChart = () => {

--- a/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
+++ b/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
@@ -69,6 +69,11 @@ const getTrendIcon = (trend: number, classes: ClassNameMap) => {
   }
 };
 
+// convert timestamp to human friendly form
+function formatDateToHuman(timeStamp: string | number) {
+  return new Date(timeStamp).toUTCString();
+}
+
 export const CoverageHistoryChart = () => {
   const { entity } = useEntity();
   const codeCoverageApi = useApi(codeCoverageApiRef);
@@ -149,10 +154,10 @@ export const CoverageHistoryChart = () => {
             margin={{ right: 48, top: 32 }}
           >
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="timestamp" />
+            <XAxis dataKey="timestamp" tickFormatter={formatDateToHuman} />
             <YAxis dataKey="line.percentage" />
             <YAxis dataKey="branch.percentage" />
-            <Tooltip />
+            <Tooltip labelFormatter={formatDateToHuman} />
             <Legend />
             <Line
               type="monotone"

--- a/plugins/code-coverage/src/components/FileExplorer/FileExplorer.tsx
+++ b/plugins/code-coverage/src/components/FileExplorer/FileExplorer.tsx
@@ -232,7 +232,7 @@ export const FileExplorer = () => {
       title: 'Coverage',
       type: 'numeric',
       field: 'coverage',
-      render: (row: CoverageTableRow) => `${row.coverage}%`,
+      render: (row: CoverageTableRow) => `${row.coverage.toFixed(2)}%`,
     },
     {
       title: 'Missing lines',


### PR DESCRIPTION
Signed-off-by: Jeremy Guarini <jguarini@paloaltonetworks.com>

## Hey, I just made a Pull Request!

Test dates are in epoch and code coverage percentages go out to 14th decimal place. These are not very useful or human friendly IMHO. This PR updates the date and coverage percentages.

Here we can see the test dates and coverage percentage before the change
<img width="1660" alt="Screen Shot 2021-11-03 at 1 10 58 PM" src="https://user-images.githubusercontent.com/23618053/140385306-dcdb27f9-cadb-4a08-b70a-a1ad4c529f54.png">

post-change dates
<img width="1508" alt="Screen Shot 2021-11-04 at 10 04 57 AM" src="https://user-images.githubusercontent.com/23618053/140385658-5638f288-eda8-4084-875a-697a9f721150.png">

post-change code coverage values
<img width="1516" alt="Screen Shot 2021-11-03 at 2 09 16 PM" src="https://user-images.githubusercontent.com/23618053/140385845-0a94db4f-7d4e-42f2-8369-4b133681f4d8.png">

