### PR TITLE
create-app: default to making new plugins private

### DIFF
--- a/.changeset/nine-dots-suffer.md
+++ b/.changeset/nine-dots-suffer.md
@@ -1,0 +1,14 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated the app template to no longer include the `--no-private` flag for the `create-plugin` command.
+
+To apply this change to an existing application, remove the `--no-private` flag from the `create-plugin` command in the root `package.json`:
+
+```diff
+   "prettier:check": "prettier --check .",
+-  "create-plugin": "backstage-cli create-plugin --scope internal --no-private",
++  "create-plugin": "backstage-cli create-plugin --scope internal",
+   "remove-plugin": "backstage-cli remove-plugin"
+```

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -20,7 +20,7 @@
     "lint": "lerna run lint --since origin/master --",
     "lint:all": "lerna run lint --",
     "prettier:check": "prettier --check .",
-    "create-plugin": "backstage-cli create-plugin --scope internal --no-private",
+    "create-plugin": "backstage-cli create-plugin --scope internal",
     "remove-plugin": "backstage-cli remove-plugin"
   },
   "resolutions": {


### PR DESCRIPTION
Feeling that this makes sense as plugins are generally gonna be internal only, and also not published to an internal registry

Related to #7893