### PR TITLE
Placed the Custom Actions pre-requisites at the top of the document i…

### DIFF
--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -8,42 +8,9 @@ If you're wanting to extend the functionality of the Scaffolder, you can do so
 by writing custom actions which can be used along side our
 [built-in actions](./builtin-actions.md).
 
-
-> Note: When adding custom actions, the actions array will **replace the built-in actions too**, 
-<<<<<<< HEAD
-> so if you want to have those as well as your new one.
-> See below to include `builtInActions` during registration of your action.
-
-=======
-> so if you want to have those as well as your new one, you'll need to do the following:
-
-```ts
-import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
-import { ScmIntegrations } from '@backstage/integration';
-
-const integrations = ScmIntegrations.fromConfig(config);
-
-const builtInActions = createBuiltinActions({
-  containerRunner,
-  integrations,
-  config,
-  catalogClient,
-  reader,
-});
-
-const actions = [...builtInActions, createNewFileAction()];
-
-return await createRouter({
-  containerRunner,
-  logger,
-  config,
-  database,
-  catalogClient,
-  reader,
-  actions,
-});
-```
->>>>>>> a72c8bf39a (More consistent formatting of the Note block)
+> Note: When adding custom actions, the actions array will **replace the
+> built-in actions too**. To ensure you can continue to include he builtin
+> actions, see below to include them during registration of your action.
 
 ### Writing your Custom Action
 

--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -10,9 +10,40 @@ by writing custom actions which can be used along side our
 
 
 > Note: When adding custom actions, the actions array will **replace the built-in actions too**, 
+<<<<<<< HEAD
 > so if you want to have those as well as your new one.
 > See below to include `builtInActions` during registration of your action.
 
+=======
+> so if you want to have those as well as your new one, you'll need to do the following:
+
+```ts
+import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
+import { ScmIntegrations } from '@backstage/integration';
+
+const integrations = ScmIntegrations.fromConfig(config);
+
+const builtInActions = createBuiltinActions({
+  containerRunner,
+  integrations,
+  config,
+  catalogClient,
+  reader,
+});
+
+const actions = [...builtInActions, createNewFileAction()];
+
+return await createRouter({
+  containerRunner,
+  logger,
+  config,
+  database,
+  catalogClient,
+  reader,
+  actions,
+});
+```
+>>>>>>> a72c8bf39a (More consistent formatting of the Note block)
 
 ### Writing your Custom Action
 

--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -8,11 +8,9 @@ If you're wanting to extend the functionality of the Scaffolder, you can do so
 by writing custom actions which can be used along side our
 [built-in actions](./builtin-actions.md).
 
----
-**NOTE**
 
-When adding custom actions, the actions array will **replace the built-in actions too**, so if you
-want to have those as well as your new one, you'll need to do the following:
+> Note: When adding custom actions, the actions array will **replace the built-in actions too**, 
+> so if you want to have those as well as your new one, you'll need to do the following:
 
 ```ts
 import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
@@ -40,7 +38,6 @@ return await createRouter({
   actions,
 });
 ```
----
 
 ### Writing your Custom Action
 

--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -8,6 +8,40 @@ If you're wanting to extend the functionality of the Scaffolder, you can do so
 by writing custom actions which can be used along side our
 [built-in actions](./builtin-actions.md).
 
+---
+**NOTE**
+
+When adding custom actions, the actions array will **replace the built-in actions too**, so if you
+want to have those as well as your new one, you'll need to do the following:
+
+```ts
+import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
+import { ScmIntegrations } from '@backstage/integration';
+
+const integrations = ScmIntegrations.fromConfig(config);
+
+const builtInActions = createBuiltinActions({
+  containerRunner,
+  integrations,
+  config,
+  catalogClient,
+  reader,
+});
+
+const actions = [...builtInActions, createNewFileAction()];
+
+return await createRouter({
+  containerRunner,
+  logger,
+  config,
+  database,
+  catalogClient,
+  reader,
+  actions,
+});
+```
+---
+
 ### Writing your Custom Action
 
 Your custom action can live where you choose, but simplest is to include it
@@ -115,36 +149,6 @@ will set the available actions that the scaffolder has access to.
 
 ```ts
 const actions = [createNewFileAction()];
-return await createRouter({
-  containerRunner,
-  logger,
-  config,
-  database,
-  catalogClient,
-  reader,
-  actions,
-});
-```
-
-**NOTE** - the actions array will replace the built-in actions too, so if you
-want to have those as well as your new one, you'll need to do the following:
-
-```ts
-import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
-import { ScmIntegrations } from '@backstage/integration';
-
-const integrations = ScmIntegrations.fromConfig(config);
-
-const builtInActions = createBuiltinActions({
-  containerRunner,
-  integrations,
-  config,
-  catalogClient,
-  reader,
-});
-
-const actions = [...builtInActions, createNewFileAction()];
-
 return await createRouter({
   containerRunner,
   logger,

--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -10,34 +10,9 @@ by writing custom actions which can be used along side our
 
 
 > Note: When adding custom actions, the actions array will **replace the built-in actions too**, 
-> so if you want to have those as well as your new one, you'll need to do the following:
+> so if you want to have those as well as your new one.
+> See below to include `builtInActions` during registration of your action.
 
-```ts
-import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
-import { ScmIntegrations } from '@backstage/integration';
-
-const integrations = ScmIntegrations.fromConfig(config);
-
-const builtInActions = createBuiltinActions({
-  containerRunner,
-  integrations,
-  config,
-  catalogClient,
-  reader,
-});
-
-const actions = [...builtInActions, createNewFileAction()];
-
-return await createRouter({
-  containerRunner,
-  logger,
-  config,
-  database,
-  catalogClient,
-  reader,
-  actions,
-});
-```
 
 ### Writing your Custom Action
 
@@ -145,7 +120,17 @@ There's another property you can pass here, which is an array of `actions` which
 will set the available actions that the scaffolder has access to.
 
 ```ts
-const actions = [createNewFileAction()];
+const integrations = ScmIntegrations.fromConfig(config);
+
+const builtInActions = createBuiltinActions({
+  containerRunner,
+  integrations,
+  config,
+  catalogClient,
+  reader,
+});
+
+const actions = [...builtInActions, createNewFileAction()];
 return await createRouter({
   containerRunner,
   logger,

--- a/docs/features/software-templates/writing-custom-actions.md
+++ b/docs/features/software-templates/writing-custom-actions.md
@@ -118,6 +118,9 @@ There's another property you can pass here, which is an array of `actions` which
 will set the available actions that the scaffolder has access to.
 
 ```ts
+import { createBuiltinActions } from '@backstage/plugin-scaffolder-backend';
+import { ScmIntegrations } from '@backstage/integration';
+
 const integrations = ScmIntegrations.fromConfig(config);
 
 const builtInActions = createBuiltinActions({


### PR DESCRIPTION
…nstead of the middle. These **pre-requisites** are easily missed if developers are writing custom actions.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Restructured the location of the "enable built in actions" which is easily missed when developers are overrding the actions array with their own actions.

This would be considered as a pre-requisite when making these changes ergo `prep` meaning before.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
