### PR TITLE
display X-axis in ascending order

### DIFF
--- a/.changeset/perfect-avocados-mate.md
+++ b/.changeset/perfect-avocados-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage': patch
+---
+
+Make dates in X-Axis sort in ascending order

--- a/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
+++ b/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
@@ -158,7 +158,11 @@ export const CoverageHistoryChart = () => {
             margin={{ right: 48, top: 32 }}
           >
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="timestamp" tickFormatter={formatDateToHuman} />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={formatDateToHuman}
+              reversed
+            />
             <YAxis dataKey="line.percentage" />
             <YAxis dataKey="branch.percentage" />
             <Tooltip labelFormatter={formatDateToHuman} />


### PR DESCRIPTION
Signed-off-by: Jeremy Guarini <jguarini@paloaltonetworks.com>

## Hey, I just made a Pull Request!

Dates along the X-Axis are presented in descending order, this seems counter-intuitive to how charts are normally presented.

pre-change
<img width="1488" alt="Screen Shot 2021-11-08 at 3 03 30 PM" src="https://user-images.githubusercontent.com/23618053/140834606-2bea01bc-ad08-45ce-8414-dd865ade7e3e.png">

post-change
<img width="1527" alt="Screen Shot 2021-11-08 at 3 17 35 PM" src="https://user-images.githubusercontent.com/23618053/140834623-ca36018d-3144-406a-ab76-04f09fddc526.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
