### PR TITLE
fix: kuber plugin pass id token on getClusters req

### DIFF
--- a/.changeset/clean-fans-change.md
+++ b/.changeset/clean-fans-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+fix: kubernetes plugin shall pass id token on get clusters request if possible

--- a/plugins/kubernetes/src/api/KubernetesBackendClient.ts
+++ b/plugins/kubernetes/src/api/KubernetesBackendClient.ts
@@ -79,10 +79,14 @@ export class KubernetesBackendClient implements KubernetesApi {
   }
 
   async getClusters(): Promise<{ name: string; authProvider: string }[]> {
+    const idToken = await this.identityApi.getIdToken();
     const url = `${await this.discoveryApi.getBaseUrl('kubernetes')}/clusters`;
 
     const response = await fetch(url, {
       method: 'GET',
+      headers: {
+        ...(idToken && { Authorization: `Bearer ${idToken}` }),
+      },
     });
 
     return (await this.handleResponse(response)).items;


### PR DESCRIPTION
Kubernetes plugin should pass id token on `getClusters` request as on other requests, if it is present.  
(code is simply copied [from the other request few lines above](https://github.com/backstage/backstage/blob/master/plugins/kubernetes/src/api/KubernetesBackendClient.ts#L64))

This allows users to hide their clusters setup (corresponding backend endpoint) behind authorization as other endpoints.

I assume it is non-breaking (in guest mode there shall be no token added to request, that's all).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
