### PR TITLE
[auth-backend] Only use settings that have a value when creating a FirestoreKeyStore

### DIFF
--- a/.changeset/modern-beers-tickle.md
+++ b/.changeset/modern-beers-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Only use settings that have a value when creating a new FirestoreKeyStore instance

--- a/plugins/auth-backend/src/identity/KeyStores.ts
+++ b/plugins/auth-backend/src/identity/KeyStores.ts
@@ -15,6 +15,7 @@
  */
 
 import { Logger } from 'winston';
+import { pickBy } from 'lodash';
 
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
@@ -64,16 +65,20 @@ export class KeyStores {
     if (provider === 'firestore') {
       const settings = ks?.getConfig(provider);
 
-      const keyStore = await FirestoreKeyStore.create({
-        projectId: settings?.getOptionalString('projectId'),
-        keyFilename: settings?.getOptionalString('keyFilename'),
-        host: settings?.getOptionalString('host'),
-        port: settings?.getOptionalNumber('port'),
-        ssl: settings?.getOptionalBoolean('ssl'),
-        path: settings?.getOptionalString('path'),
-        timeout: settings?.getOptionalNumber('timeout'),
-      });
-
+      const keyStore = await FirestoreKeyStore.create(
+        pickBy(
+          {
+            projectId: settings?.getOptionalString('projectId'),
+            keyFilename: settings?.getOptionalString('keyFilename'),
+            host: settings?.getOptionalString('host'),
+            port: settings?.getOptionalNumber('port'),
+            ssl: settings?.getOptionalBoolean('ssl'),
+            path: settings?.getOptionalString('path'),
+            timeout: settings?.getOptionalNumber('timeout'),
+          },
+          value => value !== undefined,
+        ),
+      );
       await FirestoreKeyStore.verifyConnection(keyStore, logger);
 
       return keyStore;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a bug where omitted app-config settings for `auth.keyStore.firestore` where being used with the value of `undefined` instead of being absent from the config entirely.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
