### PR TITLE
Added runson command to fix the snyk github issue sync workflow config

### DIFF
--- a/.github/workflows/snyk-github-issue-sync.yml
+++ b/.github/workflows/snyk-github-issue-sync.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   sync:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Create Snyk report


### PR DESCRIPTION
Signed-off-by: Harry Hogg <hhogg@spotify.com>

## Hey, I just made a Pull Request!

Adds the runson command to the workflow (causing it to fail atm). 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
