### PR TITLE
Fixes the Snyk github issue workflow to continue when the Snyk CLI ex…

### DIFF
--- a/.github/workflows/snyk-github-issue-sync.yml
+++ b/.github/workflows/snyk-github-issue-sync.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Create Snyk report
         uses: snyk/actions/node@master
+        continue-on-error: true # Snyk CLI exits with error when vulnerabilities are found
         with:
           args: >
             --yarn-workspaces


### PR DESCRIPTION
…its with an error

Signed-off-by: Harry Hogg <hhogg@spotify.com>

## Hey, I just made a Pull Request!

Fixes the Snyk workflow (again) to continue to the Github step with the Snyk CLI exits with an error (which happens when vulnerabilities are found). 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
