### PR TITLE
Added ts-node as a dependency for the Snyk Github issues sync script

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "minimist": "^1.2.5",
     "prettier": "^2.2.1",
     "shx": "^0.3.2",
+    "ts-node": "^10.4.0",
     "yarn-lock-check": "^1.0.5"
   },
   "prettier": "@spotify/prettier-config",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27465,7 +27465,7 @@ ts-node@^10.0.0:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-ts-node@^10.2.1:
+ts-node@^10.2.1, ts-node@^10.4.0:
   version "10.4.0"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
   integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==


### PR DESCRIPTION
Signed-off-by: Harry Hogg <hhogg@spotify.com>

Third times a chime. 

This ones stumped me a bit, as I remember seeing it as a dependency being used elsewhere in the codebase, and it was available when testing this on a fork. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
