### PR TITLE
Remove the unused UserFlags type

### DIFF
--- a/.changeset/sharp-meals-fetch.md
+++ b/.changeset/sharp-meals-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': minor
+---
+
+Removed the unused `UserFlags` type.

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -800,9 +800,6 @@ export function useElementFilter<T>(
 ): T;
 
 // @public
-export type UserFlags = {};
-
-// @public
 export function useRouteRef<Optional extends boolean, Params extends AnyParams>(
   routeRef: ExternalRouteRef<Params, Optional>,
 ): Optional extends true ? RouteFunc<Params> | undefined : RouteFunc<Params>;

--- a/packages/core-plugin-api/src/apis/definitions/FeatureFlagsApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/FeatureFlagsApi.ts
@@ -62,13 +62,6 @@ export type FeatureFlagsSaveOptions = {
 };
 
 /**
- * User flags alias.
- *
- * @public
- */
-export type UserFlags = {};
-
-/**
  * The feature flags API is used to toggle functionality to users across plugins and Backstage.
  *
  * @remarks


### PR DESCRIPTION
Technically a breaking change - but it's completely unused and empty, so I chose to just tear it out instead of properly deprecating etc.

Part of #7700