### PR TITLE
cli: fix for config:check only validating frontend config

### DIFF
--- a/.changeset/chilled-pandas-leave.md
+++ b/.changeset/chilled-pandas-leave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed the `config:check` command that was incorrectly only validating frontend configuration. Also added a `--frontend` flag to the command which maintains that behavior.

--- a/docs/local-dev/cli-commands.md
+++ b/docs/local-dev/cli-commands.md
@@ -512,7 +512,8 @@ Usage: backstage-cli config:check [options]
 
 Options:
   --package &lt;name&gt;  Only load config schema that applies to the given package
-  --lax                   Do not require environment variables to be set
+  --lax             Do not require environment variables to be set
+  --frontend        Only validate the frontend configuration
   --config &lt;path&gt;   Config files to load instead of app-config.yaml (default: [])
   -h, --help        display help for command
 ```

--- a/packages/cli/src/commands/config/print.ts
+++ b/packages/cli/src/commands/config/print.ts
@@ -25,6 +25,7 @@ export default async (cmd: Command) => {
     args: cmd.config,
     fromPackage: cmd.package,
     mockEnv: cmd.lax,
+    fullVisibility: !cmd.frontend,
   });
   const visibility = getVisibilityOption(cmd);
   const data = serializeConfigData(appConfigs, schema, visibility);

--- a/packages/cli/src/commands/config/validate.ts
+++ b/packages/cli/src/commands/config/validate.ts
@@ -22,5 +22,6 @@ export default async (cmd: Command) => {
     args: cmd.config,
     fromPackage: cmd.package,
     mockEnv: cmd.lax,
+    fullVisibility: !cmd.frontend,
   });
 };

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -172,6 +172,7 @@ export function registerCommands(program: CommanderStatic) {
       'Only load config schema that applies to the given package',
     )
     .option('--lax', 'Do not require environment variables to be set')
+    .option('--frontend', 'Only validate the frontend configuration')
     .option(...configOption)
     .description(
       'Validate that the given configuration loads and matches schema',

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -28,6 +28,7 @@ type Options = {
   fromPackage?: string;
   mockEnv?: boolean;
   withFilteredKeys?: boolean;
+  fullVisibility?: boolean;
 };
 
 export async function loadCliConfig(options: Options) {
@@ -70,7 +71,9 @@ export async function loadCliConfig(options: Options) {
 
   try {
     const frontendAppConfigs = schema.process(appConfigs, {
-      visibility: ['frontend'],
+      visibility: options.fullVisibility
+        ? ['frontend', 'backend', 'secret']
+        : ['frontend'],
       withFilteredKeys: options.withFilteredKeys,
     });
     const frontendConfig = ConfigReader.fromConfigs(frontendAppConfigs);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Broken by #7634, figuring that a `--frontend` flag still makes sense that mirrors `config:print`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
