### PR TITLE
Make sure that the server builder propagates init errors properly

### DIFF
--- a/.changeset/rich-pillows-cough.md
+++ b/.changeset/rich-pillows-cough.md
@@ -1,0 +1,12 @@
+---
+'@backstage/backend-common': patch
+---
+
+Make sure that server builder `start()` propagates errors (such as failing to bind to the required port) properly and doesn't resolve the promise prematurely.
+
+After this change, the backend logger will be able to actually capture the error as it happens:
+
+```
+2021-11-11T10:54:21.334Z backstage info Initializing http server
+2021-11-11T10:54:21.335Z backstage error listen EADDRINUSE: address already in use :::7000 code=EADDRINUSE errno=-48 syscall=listen address=:: port=7000
+```

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -140,7 +140,7 @@ async function main() {
 
   await service.start().catch(err => {
     logger.error(err);
-    throw err;
+    process.exit(1);
   });
 }
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -140,7 +140,7 @@ async function main() {
 
   await service.start().catch(err => {
     logger.error(err);
-    process.exit(1);
+    throw err;
   });
 }
 


### PR DESCRIPTION
This is just a small step forward in terms of backend lifecycle management. More work is needed.