### PR TITLE
cli: make sure JSS styles receive the highest priority

### DIFF
--- a/.changeset/moody-snails-admire.md
+++ b/.changeset/moody-snails-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+Tweaked style insertion logic to make sure that JSS stylesheets always receive the highest priority.


### PR DESCRIPTION
Build on top of previous changes from #7865

This makes sure that any dynamically loaded styles or styles that are added through hot loading end up being inserted before any JSS style elements, giving the JSS styles the highest priority. JSS having the highest priority is generally what we want and what people would expect, and the fact that some stylesheets end up with lower priority right now is a bit broken. Apart from inserting dynamic styles before JSS styles, the insertion logic is unchanged. Styles still get inserted at the bottom of the `<head>` element, but just before the JSS ones.

As discussed in #7865 it's usually best to have CSS selectors with enough specificity that stylesheet ordering is not an issue, but this still feels like an improvement over the current state.

Thoughts on this solution @Fox32? :grin: