### PR TITLE
Add CronJobs, Jobs, DaemonSets and StatefulSets as default objects fo…

### DIFF
--- a/.changeset/add-additional-k8s-objects.md
+++ b/.changeset/add-additional-k8s-objects.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-kubernetes-backend': minor
+'@backstage/plugin-kubernetes-common': minor
+---
+
+Include the following objects as part of the kubernetes backend:
+
+- CronJobs (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/)
+- Jobs (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/)
+- DaemonSets (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/)
+- StatefullSets (https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/)

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -74,6 +74,30 @@ export const DEFAULT_OBJECTS: ObjectToFetch[] = [
     plural: 'ingresses',
     objectType: 'ingresses',
   },
+  {
+    group: 'batch',
+    apiVersion: 'v1',
+    plural: 'cronjobs',
+    objectType: 'cronjobs',
+  },
+  {
+    group: 'batch',
+    apiVersion: 'v1',
+    plural: 'jobs',
+    objectType: 'jobs',
+  },
+  {
+    group: 'apps',
+    apiVersion: 'v1',
+    plural: 'daemonsets',
+    objectType: 'daemonsets',
+  },
+  {
+    group: 'apps',
+    apiVersion: 'v1',
+    plural: 'statefulsets',
+    objectType: 'statefulsets',
+  },
 ];
 
 export interface KubernetesFanOutHandlerOptions

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -68,7 +68,11 @@ export type KubernetesObjectTypes =
   | 'replicasets'
   | 'horizontalpodautoscalers'
   | 'ingresses'
-  | 'customresources';
+  | 'customresources'
+  | 'cronjobs'
+  | 'jobs'
+  | 'daemonsets'
+  | 'statefulsets';
 
 // Used to load cluster details from different sources
 export interface KubernetesClustersSupplier {

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -17,11 +17,15 @@
 import {
   ExtensionsV1beta1Ingress,
   V1ConfigMap,
+  V1CronJob,
+  V1DaemonSet,
   V1Deployment,
   V1HorizontalPodAutoscaler,
+  V1Job,
   V1Pod,
   V1ReplicaSet,
   V1Service,
+  V1StatefulSet,
 } from '@kubernetes/client-node';
 import { Entity } from '@backstage/catalog-model';
 
@@ -84,7 +88,11 @@ export type FetchResponse =
   | ReplicaSetsFetchResponse
   | HorizontalPodAutoscalersFetchResponse
   | IngressesFetchResponse
-  | CustomResourceFetchResponse;
+  | CustomResourceFetchResponse
+  | CronJobFetchResponse
+  | JobFetchResponse
+  | DaemonSetFetchResponse
+  | StatefulSetFetchResponse;
 
 export interface PodFetchResponse {
   type: 'pods';
@@ -124,6 +132,26 @@ export interface IngressesFetchResponse {
 export interface CustomResourceFetchResponse {
   type: 'customresources';
   resources: Array<any>;
+}
+
+export interface CronJobFetchResponse {
+  type: 'ingresses';
+  resources: Array<V1CronJob>;
+}
+
+export interface JobFetchResponse {
+  type: 'ingresses';
+  resources: Array<V1Job>;
+}
+
+export interface DaemonSetFetchResponse {
+  type: 'ingresses';
+  resources: Array<V1DaemonSet>;
+}
+
+export interface StatefulSetFetchResponse {
+  type: 'ingresses';
+  resources: Array<V1StatefulSet>;
 }
 
 export interface KubernetesFetchError {


### PR DESCRIPTION
## Hey, I just made a Pull Request!
We included k8s resources in the backend:
- CronJob
- Job
- DaemonSet
- StatefulSet

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
