### PR TITLE
catalog-backend: ensure subqueries are isolated from one another

### DIFF
--- a/.changeset/orange-experts-approve.md
+++ b/.changeset/orange-experts-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Adjust entity query construction to ensure sub-queries are always isolated from one another.

--- a/plugins/catalog-backend/src/service/NextEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/NextEntitiesCatalog.ts
@@ -131,29 +131,25 @@ function parseFilter(
   db: Knex,
 ): Knex.QueryBuilder {
   if (isEntitiesSearchFilter(filter)) {
-    return query.where(function filterFunction() {
+    return query.andWhere(function filterFunction() {
       addCondition(this, db, filter);
     });
   }
 
   if (isOrEntityFilter(filter)) {
-    let cumulativeQuery = query;
-    for (const subFilter of filter.anyOf ?? []) {
-      cumulativeQuery = cumulativeQuery.orWhere(subQuery =>
-        parseFilter(subFilter, subQuery, db),
-      );
-    }
-    return cumulativeQuery;
+    return query.andWhere(function filterFunction() {
+      for (const subFilter of filter.anyOf ?? []) {
+        this.orWhere(subQuery => parseFilter(subFilter, subQuery, db));
+      }
+    });
   }
 
   if (isAndEntityFilter(filter)) {
-    let cumulativeQuery = query;
-    for (const subFilter of filter.allOf ?? []) {
-      cumulativeQuery = cumulativeQuery.andWhere(subQuery =>
-        parseFilter(subFilter, subQuery, db),
-      );
-    }
-    return cumulativeQuery;
+    return query.andWhere(function filterFunction() {
+      for (const subFilter of filter.allOf ?? []) {
+        this.andWhere(subQuery => parseFilter(subFilter, subQuery, db));
+      }
+    });
   }
 
   return query;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ensures that independent calls to `parseFilter` are isolated from one
another, by always wrapping additional clauses to the query in
`andWhere`. I think that the bug in the previous incarnation is strictly
theoretical, as long as parseFilters is only called once for a given
filter (which today, it is). When authorization lands in catalog-backend
though, we'll need to call it multiple times - once to add the authz
filters, and once to add the filters requested by the caller, which
would expose this bug.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
