### PR TITLE
Skip empty file names during scaffolder

### DIFF
--- a/.changeset/ninety-spies-prove.md
+++ b/.changeset/ninety-spies-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Skip empty file names when scaffolding with nunjucks

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.test.ts
@@ -144,6 +144,7 @@ describe('fetch:template', () => {
             name: 'test-project',
             count: 1234,
             itemList: ['first', 'second', 'third'],
+            showDummyFile: false,
           },
         });
 
@@ -163,6 +164,10 @@ describe('fetch:template', () => {
               },
               '.${{ values.name }}': '${{ values.itemList | dump }}',
               'a-binary-file.png': aBinaryFile,
+              '{% if values.showDummyFile %}dummy-file.txt{% else %}{% endif %}':
+                'dummy file',
+              '${{ "dummy-file2.txt" if values.showDummyFile else "" }}':
+                'some dummy file',
             },
           });
 
@@ -179,6 +184,18 @@ describe('fetch:template', () => {
             fetchUrl: context.input.url,
           }),
         );
+      });
+
+      it('skips empty filename', async () => {
+        await expect(
+          fs.pathExists(`${workspacePath}/target/dummy-file.txt`),
+        ).resolves.toEqual(false);
+      });
+
+      it('skips empty filename syntax #2', async () => {
+        await expect(
+          fs.pathExists(`${workspacePath}/target/dummy-file2.txt`),
+        ).resolves.toEqual(false);
       });
 
       it('copies files with no templating in names or content successfully', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -241,6 +241,11 @@ export function createFetchTemplateAction(options: {
           localOutputPath = templater.renderString(localOutputPath, context);
         }
         const outputPath = resolvePath(outputDir, localOutputPath);
+        // variables have been expanded to make an empty file name
+        // this is due to a conditional like if values.my_condition then file-name.txt else empty string so skip
+        if (outputDir === outputPath) {
+          continue;
+        }
 
         if (!renderContents && !extension) {
           ctx.logger.info(


### PR DESCRIPTION
Signed-off-by: Tim Jacomb <tim.jacomb@hmcts.net>

This worked with cookiecutter (and was picked up when I tried to upgrade our templates).
Discussed with @benjdlambert and @OrkoHunter on discord

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
