### PR TITLE
Bugfix/duplicate backstage token

### DIFF
--- a/.changeset/ninety-grapes-love.md
+++ b/.changeset/ninety-grapes-love.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-auth-backend': patch
+---
+
+Update OAuthAdapter to create identity.token from identity.idToken if it does not exist, and prevent overwrites to identity.toke. Update login page commonProvider to prefer .token over .idToken

--- a/packages/core-components/src/layout/SignInPage/commonProvider.tsx
+++ b/packages/core-components/src/layout/SignInPage/commonProvider.tsx
@@ -49,7 +49,9 @@ const Component: ProviderComponent = ({ config, onResult }) => {
         userId: identity!.id,
         profile: profile!,
         getIdToken: () => {
-          return authApi.getBackstageIdentity().then(i => i!.idToken);
+          return authApi
+            .getBackstageIdentity()
+            .then(i => i!.token ?? i!.idToken);
         },
         signOut: async () => {
           await authApi.signOut();

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
@@ -22,7 +22,7 @@ import { OAuthHandlers } from './types';
 const mockResponseData = {
   providerInfo: {
     accessToken: 'ACCESS_TOKEN',
-    idToken: 'ID_TOKEN',
+    token: 'ID_TOKEN',
     expiresInSeconds: 10,
     scope: 'email',
   },
@@ -216,7 +216,7 @@ describe('OAuthAdapter', () => {
       ...mockResponseData,
       backstageIdentity: {
         id: mockResponseData.backstageIdentity.id,
-        idToken: 'my-id-token',
+        token: 'my-id-token',
       },
     });
   });

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -233,10 +233,12 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
       return;
     }
 
-    if (!identity.idToken) {
-      identity.idToken = await this.options.tokenIssuer.issueToken({
+    if (!(identity.token || identity.idToken)) {
+      identity.token = await this.options.tokenIssuer.issueToken({
         claims: { sub: identity.id },
       });
+    } else if (!identity.token && identity.idToken) {
+      identity.token = identity.idToken;
     }
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Per conversation on Discord with @Rugvip, updated the backend OAuthAdapter to fix a bug that overwrote Backstage tokens generated during identity resolver step. 

Previous code relied on a deprecated `.idToken` property that was renamed to `.token`. An overlooked checker was re-issuing the token when `.idToken` was not found. 

New code checks for both `.token` and `.idToken`, prefers `.token`, and will convert `.idToken` to `.token` if only `.idToken` is found. 

Also updated LoginPage `commonProvider.ts` to prefer `.token` over `.idToken`  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
