### PR TITLE
cli: fix for backend bundle building all packages

### DIFF
--- a/.changeset/sour-cameras-hide.md
+++ b/.changeset/sour-cameras-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed a bug where calling `backstage-cli backend:bundle --build-dependencies` with no dependencies to be built would cause all monorepo packages to be built instead.

--- a/packages/cli/src/lib/packager/index.ts
+++ b/packages/cli/src/lib/packager/index.ts
@@ -106,18 +106,19 @@ export async function createDistWorkspace(
 
   if (options.buildDependencies) {
     const exclude = options.buildExcludes ?? [];
-    const scopeArgs = targets
-      .filter(target => !exclude.includes(target.name))
-      .flatMap(target => ['--scope', target.name]);
 
-    const lernaArgs =
-      options.parallel && Number.isInteger(options.parallel)
-        ? ['--concurrency', options.parallel.toString()]
-        : [];
+    const toBuild = targets.filter(target => !exclude.includes(target.name));
+    if (toBuild.length > 0) {
+      const scopeArgs = toBuild.flatMap(target => ['--scope', target.name]);
+      const lernaArgs =
+        options.parallel && Number.isInteger(options.parallel)
+          ? ['--concurrency', options.parallel.toString()]
+          : [];
 
-    await run('yarn', ['lerna', ...lernaArgs, 'run', ...scopeArgs, 'build'], {
-      cwd: paths.targetRoot,
-    });
+      await run('yarn', ['lerna', ...lernaArgs, 'run', ...scopeArgs, 'build'], {
+        cwd: paths.targetRoot,
+      });
+    }
   }
 
   await moveToDistWorkspace(targetDir, targets);


### PR DESCRIPTION
This bug would particularly show up as a bloated bundle when using a multi-stage docker build.
