### PR TITLE
bugfix: include 'techdocs' in types while indexing the documents

### DIFF
--- a/.changeset/stale-cheetahs-check.md
+++ b/.changeset/stale-cheetahs-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+bugfix: add collator type to indexed documents

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
@@ -136,6 +136,7 @@ export class DefaultTechDocsCollator implements DocumentCollator {
               entityTitle: entity.metadata.title,
               componentType: entity.spec?.type?.toString() || 'other',
               lifecycle: (entity.spec?.lifecycle as string) || '',
+              types: [this.type],
               owner:
                 entity.relations?.find(r => r.type === RELATION_OWNED_BY)
                   ?.target?.name || '',


### PR DESCRIPTION
## Hey, I just made a Pull Request!
We need to include 'tecdocs' or the type of the collator to index related types.

Otherwise searching a term inside the document will return always wrong results (always empty)

```
curl 'https://demo.backstage.io/api/search/query?term=CLI&filters%5Bkind%5D=component&filters%5Bnamespace%5D=default&filters%5Bname%5D=backstage&types%5B0%5D=techdocs' \
  -H 'Connection: keep-alive' \
  -H 'sec-ch-ua: "Google Chrome";v="95", "Chromium";v="95", ";Not A Brand";v="99"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'Accept: */*' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'Cookie: _ga=GA1.2.1540529878.1635504645' \
  --compressed
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
