### PR TITLE
Small adjustments to the Header typography to use theme variables

### DIFF
--- a/.changeset/little-numbers-thank.md
+++ b/.changeset/little-numbers-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Changing the `Header` styles to use more theme variables. With this the title `font-size` will not change on resizing the window.

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles<BackstageTheme>(
       gridArea: 'pageHeader',
       padding: theme.spacing(3),
       width: '100%',
-      boxShadow: theme.shadows[4], // '0 0 8px 3px rgba(20, 20, 20, 0.3)',
+      boxShadow: theme.shadows[4],
       position: 'relative',
       zIndex: 100,
       display: 'flex',

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles<BackstageTheme>(
       gridArea: 'pageHeader',
       padding: theme.spacing(3),
       width: '100%',
-      boxShadow: '0 0 8px 3px rgba(20, 20, 20, 0.3)',
+      boxShadow: theme.shadows[4], // '0 0 8px 3px rgba(20, 20, 20, 0.3)',
       position: 'relative',
       zIndex: 100,
       display: 'flex',
@@ -65,12 +65,12 @@ const useStyles = makeStyles<BackstageTheme>(
     title: {
       color: theme.palette.bursts.fontColor,
       wordBreak: 'break-all',
-      fontSize: 'calc(24px + 6 * ((100vw - 320px) / 680))',
+      fontSize: theme.typography.h3.fontSize,
       marginBottom: 0,
     },
     subtitle: {
-      color: 'rgba(255, 255, 255, 0.8)',
-      lineHeight: '1.0em',
+      color: theme.palette.common.white,
+      opacity: 0.8,
       display: 'inline-block', // prevents margin collapse of adjacent siblings
       marginTop: theme.spacing(1),
     },
@@ -82,7 +82,6 @@ const useStyles = makeStyles<BackstageTheme>(
       color: theme.palette.bursts.fontColor,
     },
     breadcrumb: {
-      fontSize: 'calc(15px + 1 * ((100vw - 320px) / 680))',
       color: theme.palette.bursts.fontColor,
     },
     breadcrumbType: {


### PR DESCRIPTION
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I saw the sizing of the title, which looks like black magic to me & leads to, depending on the screen size, different font sizes, which will never match the overall theme. I could not track down where it was added & what was the reasoning for it, so I replaced it & other variables with theme variables.

```diff
    title: {
    ...
-       fontSize: 'calc(24px + 6 * ((100vw - 320px) / 680))',
+.     fontSize: theme.typography.h3.fontSize,
    ...
   }
```

**Before:**

https://user-images.githubusercontent.com/8904624/141824798-944a424c-d59e-407c-bba7-11ff74637501.mp4

**After:**

https://user-images.githubusercontent.com/8904624/141824778-a6637b08-32a3-447d-bafb-956a4ef78135.mp4


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
