### PR TITLE
create-app: fix windows file copy and mocking

### DIFF
--- a/packages/create-app/src/createApp.test.ts
+++ b/packages/create-app/src/createApp.test.ts
@@ -25,7 +25,7 @@ jest.mock('./lib/tasks');
 
 beforeAll(() => {
   mockFs({
-    'package.json': '', // required by `findPaths(__dirname)`
+    [`${__dirname}/package.json`]: '', // required by `findPaths(__dirname)`
     'templates/': mockFs.load(path.resolve(__dirname, '../templates/')),
   });
 });

--- a/packages/create-app/src/lib/tasks.ts
+++ b/packages/create-app/src/lib/tasks.ts
@@ -19,7 +19,12 @@ import fs from 'fs-extra';
 import handlebars from 'handlebars';
 import ora from 'ora';
 import recursive from 'recursive-readdir';
-import { basename, dirname, resolve as resolvePath } from 'path';
+import {
+  basename,
+  dirname,
+  resolve as resolvePath,
+  relative as relativePath,
+} from 'path';
 import { exec as execCb } from 'child_process';
 import { packageVersions } from './versions';
 import { promisify } from 'util';
@@ -85,7 +90,10 @@ export async function templatingTask(
   });
 
   for (const file of files) {
-    const destinationFile = file.replace(templateDir, destinationDir);
+    const destinationFile = resolvePath(
+      destinationDir,
+      relativePath(templateDir, file),
+    );
     await fs.ensureDir(dirname(destinationFile));
 
     if (file.endsWith('.hbs')) {


### PR DESCRIPTION
Fixes the failing Windows tests

Piggybacking on changeset from #7844, even though it didn't touch the path resolution logic. Could've adjusted the test as well but I feel that using only path operations rather than string operations is more robust.