### PR TITLE
core-app-api: deprecate the BackstagePluginWithAnyOutput type

### DIFF
--- a/.changeset/rare-lemons-boil.md
+++ b/.changeset/rare-lemons-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Deprecated the `BackstagePluginWithAnyOutput` type.

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -197,7 +197,14 @@ export type AppOptions = {
   icons: AppIcons & {
     [key in string]: IconComponent;
   };
-  plugins?: BackstagePluginWithAnyOutput[];
+  plugins?: (Omit<BackstagePlugin<any, any>, 'output'> & {
+    output(): (
+      | PluginOutput
+      | {
+          type: string;
+        }
+    )[];
+  })[];
   components: AppComponents;
   themes: (Partial<AppTheme> & Omit<AppTheme, 'theme'>)[];
   configLoader?: AppConfigLoader;
@@ -269,7 +276,7 @@ export type BackstageApp = {
   getRouter(): ComponentType<{}>;
 };
 
-// @public
+// @public @deprecated
 export type BackstagePluginWithAnyOutput = Omit<
   BackstagePlugin<any, any>,
   'output'

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -200,6 +200,7 @@ export type AppRouteBinder = <
  *
  * @public
  * @remarks
+ * @deprecated Will be removed
  *
  * The `type: string` type is there to handle output from newer or older plugin
  * API versions that might not be supported by this version of the app API, but
@@ -246,7 +247,9 @@ export type AppOptions = {
   /**
    * A list of all plugins to include in the app.
    */
-  plugins?: BackstagePluginWithAnyOutput[];
+  plugins?: (Omit<BackstagePlugin<any, any>, 'output'> & {
+    output(): (PluginOutput | { type: string })[];
+  })[];
 
   /**
    * Supply components to the app to override the default ones.


### PR DESCRIPTION
Removing the `BackstagePluginWithAnyOutput` type since outputs as a whole are being removed