### PR TITLE
Do not redact empty/one-character secrets

### DIFF
--- a/.changeset/spicy-rice-build.md
+++ b/.changeset/spicy-rice-build.md
@@ -2,4 +2,4 @@
 '@backstage/backend-common': patch
 ---
 
-Do not redact the empty string, destroying all logs
+Do not redact empty or one-character strings. These imply that it's just a test or local dev, and unnecessarily ruin the log output.

--- a/.changeset/spicy-rice-build.md
+++ b/.changeset/spicy-rice-build.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Do not redact the empty string, destroying all logs

--- a/packages/backend-common/src/logging/rootLogger.test.ts
+++ b/packages/backend-common/src/logging/rootLogger.test.ts
@@ -48,15 +48,15 @@ describe('rootLogger', () => {
     );
   });
 
-  it('redacts but ignores empty secrets', () => {
+  it('redacts but ignores empty and one-character secrets', () => {
     const logger = createRootLogger();
     jest.spyOn(logger, 'write');
-    setRootLoggerRedactionList(['SECRET-1', 'SECRET_2', '']);
-    logger.info('Logging SECRET-1 and SECRET_2');
+    setRootLoggerRedactionList(['SECRET-1', 'SECRET_2', 'Q', '']);
+    logger.info('Logging SECRET-1 and SECRET_2 and Q');
 
     expect(logger.write).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: 'Logging [REDACTED] and [REDACTED]',
+        message: 'Logging [REDACTED] and [REDACTED] and Q',
       }),
     );
   });

--- a/packages/backend-common/src/logging/rootLogger.test.ts
+++ b/packages/backend-common/src/logging/rootLogger.test.ts
@@ -48,6 +48,19 @@ describe('rootLogger', () => {
     );
   });
 
+  it('redacts but ignores empty secrets', () => {
+    const logger = createRootLogger();
+    jest.spyOn(logger, 'write');
+    setRootLoggerRedactionList(['SECRET-1', 'SECRET_2', '']);
+    logger.info('Logging SECRET-1 and SECRET_2');
+
+    expect(logger.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Logging [REDACTED] and [REDACTED]',
+      }),
+    );
+  });
+
   describe('createRootLogger', () => {
     it('creates a new logger', () => {
       const oldLogger = getRootLogger();

--- a/packages/backend-common/src/logging/rootLogger.ts
+++ b/packages/backend-common/src/logging/rootLogger.ts
@@ -34,7 +34,11 @@ export function setRootLogger(newLogger: winston.Logger) {
 }
 
 export function setRootLoggerRedactionList(redactionList: string[]) {
-  const filtered = redactionList.filter(Boolean);
+  // Exclude secrets that are empty or just one character in length. These
+  // typically mean that you are running local dev or tests, or using the
+  // --lax flag which sets things to just 'x'. So exclude those.
+  const filtered = redactionList.filter(r => r.length > 1);
+
   if (filtered.length) {
     redactionRegExp = new RegExp(
       `(${filtered.map(escapeRegExp).join('|')})`,

--- a/packages/backend-common/src/logging/rootLogger.ts
+++ b/packages/backend-common/src/logging/rootLogger.ts
@@ -21,7 +21,7 @@ import { coloredFormat } from './formats';
 import { escapeRegExp } from '../util/escapeRegExp';
 
 let rootLogger: winston.Logger;
-let redactionRegExp: RegExp;
+let redactionRegExp: RegExp | undefined;
 
 /** @public */
 export function getRootLogger(): winston.Logger {
@@ -34,11 +34,14 @@ export function setRootLogger(newLogger: winston.Logger) {
 }
 
 export function setRootLoggerRedactionList(redactionList: string[]) {
-  if (redactionList.length) {
+  const filtered = redactionList.filter(Boolean);
+  if (filtered.length) {
     redactionRegExp = new RegExp(
-      `(${redactionList.map(escapeRegExp).join('|')})`,
+      `(${filtered.map(escapeRegExp).join('|')})`,
       'g',
     );
+  } else {
+    redactionRegExp = undefined;
   }
 }
 


### PR DESCRIPTION
If you ever have the empty string as a secret value, the entire log gets redacted. :)

The drawback of this fix is that if you have the empty string as an _actual_ secret value, then that fact will get logged. But I hope that won't happen in production...

See https://github.com/backstage/backstage/pull/8063 for where this cropped up