### PR TITLE
Set doc reader configurable

### DIFF
--- a/.changeset/silver-plums-speak.md
+++ b/.changeset/silver-plums-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Updates reader component used to display techdocs documentation. A previous change made this component not usable out of a page which don't have entityRef in url parameters. Reader component EntityRef parameter is now used instead of url parameters. Techdocs documentation component can now be used in our custom pages.

--- a/.changeset/techdocs-silver-plums-speak.md
+++ b/.changeset/techdocs-silver-plums-speak.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-techdocs': minor
+'@backstage/plugin-techdocs': patch
 ---
 
 Updates reader component used to display techdocs documentation. A previous change made this component not usable out of a page which don't have entityRef in url parameters. Reader component EntityRef parameter is now used instead of url parameters. Techdocs documentation component can now be used in our custom pages.

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -76,8 +76,12 @@ const TechDocsReaderContext = createContext<TechDocsReaderValue>(
   {} as TechDocsReaderValue,
 );
 
-const TechDocsReaderProvider = ({ children }: PropsWithChildren<{}>) => {
-  const { namespace = '', kind = '', name = '', '*': path } = useParams();
+const TechDocsReaderProvider = ({
+  children,
+  entityRef,
+}: PropsWithChildren<{ entityRef: EntityName }>) => {
+  const { '*': path } = useParams();
+  const { kind, namespace, name } = entityRef;
   const value = useReaderState(kind, namespace, name, path);
   return (
     <TechDocsReaderContext.Provider value={value}>
@@ -96,10 +100,10 @@ const TechDocsReaderProvider = ({ children }: PropsWithChildren<{}>) => {
  * @internal
  */
 export const withTechDocsReaderProvider =
-  <T extends {}>(Component: ComponentType<T>) =>
+  <T extends {}>(Component: ComponentType<T>, entityRef: EntityName) =>
   (props: T) =>
     (
-      <TechDocsReaderProvider>
+      <TechDocsReaderProvider entityRef={entityRef}>
         <Component {...props} />
       </TechDocsReaderProvider>
     );
@@ -128,12 +132,12 @@ export const useTechDocsReader = () => useContext(TechDocsReaderContext);
  * todo: Make public or stop exporting (see others: "altReaderExperiments")
  * @internal
  */
-export const useTechDocsReaderDom = (): Element | null => {
+export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
   const navigate = useNavigate();
   const theme = useTheme<BackstageTheme>();
   const techdocsStorageApi = useApi(techdocsStorageApiRef);
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
-  const { namespace = '', kind = '', name = '' } = useParams();
+  const { namespace = '', kind = '', name = '' } = entityRef;
   const { state, path, content: rawPage } = useTechDocsReader();
 
   const [sidebars, setSidebars] = useState<HTMLElement[]>();
@@ -400,7 +404,7 @@ const TheReader = ({
   withSearch = true,
 }: Props) => {
   const classes = useStyles();
-  const dom = useTechDocsReaderDom();
+  const dom = useTechDocsReaderDom(entityRef);
   const shadowDomRef = useRef<HTMLDivElement>(null);
 
   const onReadyRef = useRef<() => void>(onReady);
@@ -440,7 +444,7 @@ export const Reader = ({
   onReady = () => {},
   withSearch = true,
 }: Props) => (
-  <TechDocsReaderProvider>
+  <TechDocsReaderProvider entityRef={entityRef}>
     <TheReader
       entityRef={entityRef}
       onReady={onReady}


### PR DESCRIPTION
Signed-off-by: Stéphane MORI <stephane.mori@gmail.com>

## Hey, I just made a Pull Request!

Updates reader component used to display techdocs documentation. A previous change made this component not usable out of a page which don't have entityRef in url params. Reader component EntityRef parameter is now used instead of url params. Techdocs documentation component can now be used in our custom pages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
