### PR TITLE
Fix techinsights docs: replaced DefaultTechInsightsBuilder with buildTechInsightsContext

### DIFF
--- a/.changeset/curly-points-hide.md
+++ b/.changeset/curly-points-hide.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-tech-insights-backend': patch
+'@backstage/plugin-tech-insights-backend-module-jsonfc': patch
+---
+
+Update README docs to use correct function/parameter names

--- a/plugins/tech-insights-backend-module-jsonfc/README.md
+++ b/plugins/tech-insights-backend-module-jsonfc/README.md
@@ -24,7 +24,7 @@ and modify the `techInsights.ts` file to contain a reference to the FactCheckers
 +   logger,
 +}),
 
- const builder = new DefaultTechInsightsBuilder({
+ const builder = buildTechInsightsContext({
    logger,
    config,
    database,

--- a/plugins/tech-insights-backend-module-jsonfc/README.md
+++ b/plugins/tech-insights-backend-module-jsonfc/README.md
@@ -59,7 +59,7 @@ export const exampleCheck: TechInsightJsonRuleCheck = {
   name: 'demodatacheck', // A human readable name of this check to be displayed in the UI
   type: JSON_RULE_ENGINE_CHECK_TYPE, // Type identifier of the check. Used to run logic against, determine persistence option to use and render correct components on the UI
   description: 'A fact check for demoing purposes', // A description to be displayed in the UI
-  factRefs: ['demo-poc.factretriever'], // References to fact containers that this check uses. See documentation on FactRetrievers for more information on these
+  factIds: ['documentation-number-factretriever'], // References to fact ids that this check uses. See documentation on FactRetrievers for more information on these
   rule: {
     // The actual rule
     conditions: {

--- a/plugins/tech-insights-backend/README.md
+++ b/plugins/tech-insights-backend/README.md
@@ -22,7 +22,7 @@ do this by creating a file called `packages/backend/src/plugins/techInsights.ts`
 ```ts
 import {
   createRouter,
-  DefaultTechInsightsBuilder,
+  buildTechInsightsContext,
 } from '@backstage/plugin-tech-insights-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
@@ -33,7 +33,7 @@ export default async function createPlugin({
   discovery,
   database,
 }: PluginEnvironment): Promise<Router> {
-  const builder = new DefaultTechInsightsBuilder({
+  const builder = buildTechInsightsContext({
     logger,
     config,
     database,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just changing README docs for tech-insights as the documented func does not exist.

@Xantier this one might be for you to review?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
