### PR TITLE
Change default port of backend from 7000 to 7007

### DIFF
--- a/.changeset/pretty-trains-appear.md
+++ b/.changeset/pretty-trains-appear.md
@@ -1,12 +1,8 @@
 ---
-'example-app': patch
-'example-backend': patch
 '@backstage/backend-common': patch
 '@backstage/cli': patch
 '@backstage/core-app-api': patch
 '@backstage/create-app': patch
-'e2e-test': patch
-'storybook': patch
 '@backstage/techdocs-common': patch
 '@backstage/plugin-auth-backend': patch
 '@backstage/plugin-azure-devops-backend': patch
@@ -23,4 +19,16 @@
 '@backstage/plugin-techdocs-backend': patch
 ---
 
-Change default port of backend from 7000 to 7007
+Change default port of backend from 7000 to 7007.
+
+This is due to the AirPlay Receiver process occupying port 7000 and preventing local Backstage instances on MacOS to start.
+
+You can change the port back to 7000 or any other value by providing an `app-config.yaml` with the following values:
+
+```
+backend:
+  listen: 0.0.0.0:7123
+  baseUrl: http://localhost:7123
+```
+
+More information can be found here: https://backstage.io/docs/conf/writing

--- a/.changeset/pretty-trains-appear.md
+++ b/.changeset/pretty-trains-appear.md
@@ -1,0 +1,26 @@
+---
+'example-app': patch
+'example-backend': patch
+'@backstage/backend-common': patch
+'@backstage/cli': patch
+'@backstage/core-app-api': patch
+'@backstage/create-app': patch
+'e2e-test': patch
+'storybook': patch
+'@backstage/techdocs-common': patch
+'@backstage/plugin-auth-backend': patch
+'@backstage/plugin-azure-devops-backend': patch
+'@backstage/plugin-badges-backend': patch
+'@backstage/plugin-bazaar-backend': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-code-coverage-backend': patch
+'@backstage/plugin-github-actions': patch
+'@backstage/plugin-jenkins-backend': patch
+'@backstage/plugin-proxy-backend': patch
+'@backstage/plugin-rollbar-backend': patch
+'@backstage/plugin-search-backend': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Change default port of backend from 7000 to 7007

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,7 +1,7 @@
 services:
   backstage:
     image: tugboatqa/node:lts
-    expose: 7000
+    expose: 7007
     default: true
     commands:
       init:
@@ -14,4 +14,4 @@ services:
         - yarn workspace example-app build
       start:
         # wget the endpoint. Will retry every 2 seconds. 30 retries = 1m for service to come up. Plenty.
-        - wget -O /dev/null -o /dev/null --tries=30 --timeout=5 --retry-connrefused http://localhost:7000
+        - wget -O /dev/null -o /dev/null --tries=30 --timeout=5 --retry-connrefused http://localhost:7007

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -23,9 +23,9 @@ app:
             title: '#backstage'
 
 backend:
-  baseUrl: http://localhost:7000
+  baseUrl: http://localhost:7007
   listen:
-    port: 7000
+    port: 7007
   database:
     client: sqlite3
     connection: ':memory:'

--- a/contrib/chart/backstage/files/app-config.development.yaml.tpl
+++ b/contrib/chart/backstage/files/app-config.development.yaml.tpl
@@ -1,7 +1,7 @@
 backend:
   lighthouseHostname: {{ include "lighthouse.serviceName" . | quote }}
   listen:
-      port: {{ .Values.appConfig.backend.listen.port | default 7000 }}
+      port: {{ .Values.appConfig.backend.listen.port | default 7007 }}
   database:
     client: {{ .Values.appConfig.backend.database.client | quote }}
     connection:

--- a/contrib/chart/backstage/values.yaml
+++ b/contrib/chart/backstage/values.yaml
@@ -26,7 +26,7 @@ backend:
     repository: martinaif/backstage-k8s-demo-backend
     tag: 20210423T1550
     pullPolicy: IfNotPresent
-  containerPort: 7000
+  containerPort: 7007
   serviceType: ClusterIP
   postgresCertMountEnabled: true
   resources:
@@ -96,7 +96,7 @@ appConfig:
   backend:
     baseUrl: https://demo.example.com
     listen:
-      port: 7000
+      port: 7007
     cors:
       origin: https://demo.example.com
     database:

--- a/contrib/docker/devops/makefile
+++ b/contrib/docker/devops/makefile
@@ -9,8 +9,8 @@ docker_name_prefix := backstage-make
 # to the host computer
 frontend_port      := 3000
 frontend_host_port := 3000
-backend_port       := 7000
-backend_host_port  := 7000
+backend_port       := 7007
+backend_host_port  := 7007
 
 # path to this "makefile"
 my_dir_path = $(dir $(CURDIR)/$(firstword $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
@@ -191,10 +191,10 @@ test: check-tests
 check: check-code check-docs check-type-dependencies check-styles
 
 # run development instance
-# BUG: the frontend seems to run on "$(backend_port)" (7000 default).
+# BUG: the frontend seems to run on "$(backend_port)" (7007 default).
 #      The documentation states "This is going to start two things, 
-#      the frontend (:3000) and the backend (:7000)."
-#      However, the frontend seems to end up running on 7000.
+#      the frontend (:3000) and the backend (:7007)."
+#      However, the frontend seems to end up running on 7007.
 .PHONY: dev
 dev: build
 	@docker run --rm -it \

--- a/contrib/kubernetes/basic_kubernetes_example_with_helm/backend.yaml
+++ b/contrib/kubernetes/basic_kubernetes_example_with_helm/backend.yaml
@@ -22,6 +22,6 @@ spec:
           image: spotify/backstage-backend:latest
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 7000
+            - containerPort: 7007
               name: backend
               protocol: TCP

--- a/contrib/kubernetes/basic_kubernetes_example_with_helm/backstage/values.yaml
+++ b/contrib/kubernetes/basic_kubernetes_example_with_helm/backstage/values.yaml
@@ -63,7 +63,7 @@ backend:
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP
-    port: 7000
+    port: 7007
   ingress:
     enabled: false
     annotations:

--- a/contrib/kubernetes/basic_kubernetes_example_with_helm/service.yaml
+++ b/contrib/kubernetes/basic_kubernetes_example_with_helm/service.yaml
@@ -30,6 +30,6 @@ spec:
     component: backend
   ports:
     - name: backend
-      port: 7000
+      port: 7007
       protocol: TCP
       targetPort: backend

--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:7000",
+  "baseUrl": "http://localhost:7007",
   "integrationFolder": "./src/integration",
   "supportFile": "./src/support",
   "fixturesFolder": "./src/fixtures",

--- a/docs/auth/add-auth-provider.md
+++ b/docs/auth/add-auth-provider.md
@@ -229,7 +229,7 @@ name.
 
 ### Test the new provider
 
-You can `curl -i localhost:7000/api/auth/providerA/start` and which should
+You can `curl -i localhost:7007/api/auth/providerA/start` and which should
 provide a `302` redirect with a `Location` header. Paste the url from that
 header into a web browser and you should be able to trigger the authorization
 flow.

--- a/docs/auth/atlassian/provider.md
+++ b/docs/auth/atlassian/provider.md
@@ -28,7 +28,7 @@ Name your integration and click on the `Create` button.
 
 Settings for local development:
 
-- Callback URL: `http://localhost:7000/api/auth/atlassian`
+- Callback URL: `http://localhost:7007/api/auth/atlassian`
 - Use rotating refresh tokens
 - For permissions, you **must** enable `View user profile` for the currently
   logged-in user, under `User identity API`

--- a/docs/auth/auth0/provider.md
+++ b/docs/auth/auth0/provider.md
@@ -17,7 +17,7 @@ provider that can authenticate users using OAuth.
    - Application type: Single Page Web Application
 4. Click on the Settings tab
 5. Add under `Application URIs` > `Allowed Callback URLs`:
-   `http://localhost:7000/api/auth/auth0/handler/frame`
+   `http://localhost:7007/api/auth/auth0/handler/frame`
 6. Click `Save Changes`
 
 ## Configuration

--- a/docs/auth/bitbucket/provider.md
+++ b/docs/auth/bitbucket/provider.md
@@ -20,7 +20,7 @@ Click Add Consumer.
 Settings for local development:
 
 - Application name: Backstage (or your custom app name)
-- Callback URL: `http://localhost:7000/api/auth/bitbucket`
+- Callback URL: `http://localhost:7007/api/auth/bitbucket`
 - Other are optional
 - (IMPORTANT) **Permissions: Account - Read, Workspace membership - Read**
 

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -24,7 +24,7 @@ Settings for local development:
 
 - Application name: Backstage (or your custom app name)
 - Homepage URL: `http://localhost:3000`
-- Authorization callback URL: `http://localhost:7000/api/auth/github`
+- Authorization callback URL: `http://localhost:7007/api/auth/github`
 
 ## Configuration
 

--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -17,7 +17,7 @@ should point to your Backstage backend auth handler.
 Settings for local development:
 
 - Name: Backstage (or your custom app name)
-- Redirect URI: `http://localhost:7000/api/auth/gitlab/handler/frame`
+- Redirect URI: `http://localhost:7007/api/auth/gitlab/handler/frame`
 - Scopes: read_user
 
 ## Configuration

--- a/docs/auth/google/provider.md
+++ b/docs/auth/google/provider.md
@@ -26,7 +26,7 @@ To support Google authentication, you must create OAuth credentials:
    - `Name`: Backstage (or your custom app name)
    - `Authorized JavaScript origins`: http://localhost:3000
    - `Authorized Redirect URIs`:
-     http://localhost:7000/api/auth/google/handler/frame
+     http://localhost:7007/api/auth/google/handler/frame
 7. Click Create
 
 ## Configuration

--- a/docs/auth/microsoft/provider.md
+++ b/docs/auth/microsoft/provider.md
@@ -21,7 +21,7 @@ To support Azure authentication, you must create an App Registration:
 4. Register an application
    - Name: Backstage (or your custom app name)
    - Redirect URI: Web >
-     `http://localhost:7000/api/auth/microsoft/handler/frame`
+     `http://localhost:7007/api/auth/microsoft/handler/frame`
 5. Navigate to **Certificates & secrets > New client secret** to create a secret
 
 ## Configuration

--- a/docs/auth/okta/provider.md
+++ b/docs/auth/okta/provider.md
@@ -22,8 +22,8 @@ To add Okta authentication, you must create an Application from Okta:
    - `App integration name`: `Backstage` (or your custom app name)
    - `Grant type`: `Authorization Code` & `Refresh Token`
    - `Sign-in redirect URIs`:
-     `http://localhost:7000/api/auth/okta/handler/frame`
-   - `Sign-out redirect URIs`: `http://localhost:7000`
+     `http://localhost:7007/api/auth/okta/handler/frame`
+   - `Sign-out redirect URIs`: `http://localhost:7007`
    - `Controlled access`: (select as appropriate)
    - Click Save
 

--- a/docs/auth/onelogin/provider.md
+++ b/docs/auth/onelogin/provider.md
@@ -18,7 +18,7 @@ To support OneLogin authentication, you must create an Application:
 3. Click Save
 4. Go to the Configuration tab for the Application and set:
    - `Login Url`: `http://localhost:3000`
-   - `Redirect URIs`: `http://localhost:7000/api/auth/onelogin/handler/frame`
+   - `Redirect URIs`: `http://localhost:7007/api/auth/onelogin/handler/frame`
 5. Click Save
 6. Go to the SSO tab for the Application and set:
    - `Token Endpoint` > `Authentication Method`: `POST`

--- a/docs/conf/writing.md
+++ b/docs/conf/writing.md
@@ -16,8 +16,8 @@ app:
   baseUrl: http://localhost:3000
 
 backend:
-  listen: 0.0.0.0:7000
-  baseUrl: http://localhost:7000
+  listen: 0.0.0.0:7007
+  baseUrl: http://localhost:7007
 
 organization:
   name: CNCF

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -105,11 +105,11 @@ docker image build . -f packages/backend/Dockerfile --tag backstage
 To try out the image locally you can run the following:
 
 ```sh
-docker run -it -p 7000:7000 backstage
+docker run -it -p 7007:7007 backstage
 ```
 
 You should then start to get logs in your terminal, and then you can open your
-browser at `http://localhost:7000`
+browser at `http://localhost:7007`
 
 ## Multi-stage Build
 
@@ -208,11 +208,11 @@ docker image build -t backstage .
 To try out the image locally you can run the following:
 
 ```sh
-docker run -it -p 7000:7000 backstage
+docker run -it -p 7007:7007 backstage
 ```
 
 You should then start to get logs in your terminal, and then you can open your
-browser at `http://localhost:7000`
+browser at `http://localhost:7007`
 
 ## Separate Frontend
 

--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -351,7 +351,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
-              containerPort: 7000
+              containerPort: 7007
           envFrom:
             - secretRef:
                 name: postgres-secrets
@@ -361,11 +361,11 @@ spec:
 # https://backstage.io/docs/plugins/observability#health-checks
 #          readinessProbe:
 #            httpGet:
-#              port: 7000
+#              port: 7007
 #              path: /healthcheck
 #          livenessProbe:
 #            httpGet:
-#              port: 7000
+#              port: 7007
 #              path: /healthcheck
 ```
 
@@ -449,7 +449,7 @@ spec:
 ```
 
 The `selector` here is telling the Service which pods to target, and the port
-mapping translates normal HTTP port 80 to the backend http port (7000) on the
+mapping translates normal HTTP port 80 to the backend http port (7007) on the
 pod.
 
 Apply this Service to the Kubernetes cluster:
@@ -464,10 +464,10 @@ reveal**_, you can forward a local port to the service:
 
 ```shell
 $ sudo kubectl port-forward --namespace=backstage svc/backstage 80:80
-Forwarding from 127.0.0.1:80 -> 7000
+Forwarding from 127.0.0.1:80 -> 7007
 ```
 
-This shows port 7000 since `port-forward` doesn't _really_ support services, so
+This shows port 7007 since `port-forward` doesn't _really_ support services, so
 it cheats by looking up the first pod for a service and connecting to the mapped
 pod port.
 
@@ -486,7 +486,7 @@ organization:
 backend:
   baseUrl: http://localhost
   listen:
-    port: 7000
+    port: 7007
   cors:
     origin: http://localhost
 ```

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -138,11 +138,11 @@ techdocs:
   # (Optional and Legacy) TechDocs makes API calls to techdocs-backend using this URL. e.g. get docs of an entity, get metadata, etc.
   # You don't have to specify this anymore.
 
-  requestUrl: http://localhost:7000/api/techdocs
+  requestUrl: http://localhost:7007/api/techdocs
 
   # (Optional and Legacy) Just another route in techdocs-backend where TechDocs requests the static files from. This URL uses an HTTP middleware
   # to serve files from either a local directory or an External storage provider.
   # You don't have to specify this anymore.
 
-  storageUrl: http://localhost:7000/api/techdocs/static/docs
+  storageUrl: http://localhost:7007/api/techdocs/static/docs
 ```

--- a/docs/getting-started/contributors.md
+++ b/docs/getting-started/contributors.md
@@ -43,7 +43,7 @@ the project root. Make sure you have run the above mentioned commands first.
 $ yarn dev
 ```
 
-This is going to start two things, the frontend (:3000) and the backend (:7000).
+This is going to start two things, the frontend (:3000) and the backend (:7007).
 
 This should open a local instance of Backstage in your browser, otherwise open
 one of the URLs printed in the terminal.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -37,7 +37,7 @@ guide to do a repository-based installation.
 - `docker` [installation](https://docs.docker.com/engine/install/)
 - `git` [installation](https://github.com/git-guides/install-git)
 - If the system is not directly accessible over your network, the following
-  ports need to be opened: 3000, 7000
+  ports need to be opened: 3000, 7007
 
 ### Create your Backstage App
 

--- a/docs/getting-started/running-backstage-locally.md
+++ b/docs/getting-started/running-backstage-locally.md
@@ -70,7 +70,7 @@ cd packages/backend
 yarn start
 ```
 
-That starts up a backend instance on port 7000.
+That starts up a backend instance on port 7007.
 
 In the other window, we will then launch the frontend. This command is run from
 the project root, not inside the backend directory.

--- a/docs/openapi/definitions/auth.yaml
+++ b/docs/openapi/definitions/auth.yaml
@@ -21,7 +21,7 @@ externalDocs:
   description: Backstage official documentation
   url: https://github.com/backstage/backstage/blob/master/docs/README.md
 servers:
-  - url: http://localhost:7000/api/auth/
+  - url: http://localhost:7007/api/auth/
 tags:
   - name: provider
     description: List of endpoints per provider

--- a/docs/plugins/backend-plugin.md
+++ b/docs/plugins/backend-plugin.md
@@ -44,11 +44,11 @@ cd plugins/carmen-backend
 yarn start
 ```
 
-This will think for a bit, and then say `Listening on :7000`. In a different
+This will think for a bit, and then say `Listening on :7007`. In a different
 terminal window, now run
 
 ```sh
-curl localhost:7000/carmen/health
+curl localhost:7007/carmen/health
 ```
 
 This should return `{"status":"ok"}`. Success! Press `Ctrl + c` to kill it
@@ -107,7 +107,7 @@ root), you should be able to fetch data from it.
 
 ```sh
 # Note the extra /api here
-curl localhost:7000/api/carmen/health
+curl localhost:7007/api/carmen/health
 ```
 
 This should return `{"status":"ok"}` like before. Success!

--- a/packages/app/cypress/integration/components/search/SearchPage.js
+++ b/packages/app/cypress/integration/components/search/SearchPage.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const API_ENDPOINT = 'http://localhost:7000/api/search/query';
+const API_ENDPOINT = 'http://localhost:7007/api/search/query';
 
 describe('SearchPage', () => {
   describe('Given a search context with a term, results, and filter values', () => {

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -27,14 +27,14 @@ describe('App', () => {
           data: {
             app: {
               title: 'Test',
-              support: { url: 'http://localhost:7000/support' },
+              support: { url: 'http://localhost:7007/support' },
             },
-            backend: { baseUrl: 'http://localhost:7000' },
+            backend: { baseUrl: 'http://localhost:7007' },
             lighthouse: {
               baseUrl: 'http://localhost:3003',
             },
             techdocs: {
-              storageUrl: 'http://localhost:7000/api/techdocs/static/docs',
+              storageUrl: 'http://localhost:7007/api/techdocs/static/docs',
             },
           },
           context: 'test',

--- a/packages/backend-common/src/discovery/SingleHostDiscovery.ts
+++ b/packages/backend-common/src/discovery/SingleHostDiscovery.ts
@@ -37,7 +37,7 @@ export class SingleHostDiscovery implements PluginEndpointDiscovery {
    * for the internal one.
    *
    * The basePath defaults to `/api`, meaning the default full internal
-   * path for the `catalog` plugin will be `http://localhost:7000/api/catalog`.
+   * path for the `catalog` plugin will be `http://localhost:7007/api/catalog`.
    */
   static fromConfig(config: Config, options?: { basePath?: string }) {
     const basePath = options?.basePath ?? '/api';

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -40,7 +40,7 @@ import {
 } from './config';
 import { createHttpServer, createHttpsServer } from './hostFactory';
 
-export const DEFAULT_PORT = 7000;
+export const DEFAULT_PORT = 7007;
 // '' is express default, which listens to all interfaces
 const DEFAULT_HOST = '';
 // taken from the helmet source code - don't seem to be exported

--- a/packages/backend-common/src/service/lib/config.ts
+++ b/packages/backend-common/src/service/lib/config.ts
@@ -63,8 +63,8 @@ type CustomOrigin = (
  * @example
  * ```json
  * {
- *   baseUrl: "http://localhost:7000",
- *   listen: "0.0.0.0:7000"
+ *   baseUrl: "http://localhost:7007",
+ *   listen: "0.0.0.0:7007"
  * }
  * ```
  */

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -34,7 +34,7 @@ export type ServiceBuilder = {
    *
    * If no port is specified, the service will first look for an environment
    * variable named PORT and use that if present, otherwise it picks a default
-   * port (7000).
+   * port (7007).
    *
    * @param port - The port to listen on
    */

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -37,7 +37,7 @@ Substitute `x` for actual values, or leave them as
 dummy values just to try out the backend without using the auth or sentry features.
 You can also, instead of using dummy values for a huge number of environment variables, remove those config directly from app-config.yaml file located in the root folder.
 
-The backend starts up on port 7000 per default.
+The backend starts up on port 7007 per default.
 
 ### Debugging
 

--- a/packages/cli/templates/default-backend-plugin/src/run.ts.hbs
+++ b/packages/cli/templates/default-backend-plugin/src/run.ts.hbs
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/packages/core-app-api/src/apis/implementations/DiscoveryApi/UrlPatternDiscovery.test.ts
+++ b/packages/core-app-api/src/apis/implementations/DiscoveryApi/UrlPatternDiscovery.test.ts
@@ -26,10 +26,10 @@ describe('UrlPatternDiscovery', () => {
 
   it('should use a plain pattern', async () => {
     const discoveryApi = UrlPatternDiscovery.compile(
-      'http://localhost:7000/{{ pluginId }}',
+      'http://localhost:7007/{{ pluginId }}',
     );
     await expect(discoveryApi.getBaseUrl('my-plugin')).resolves.toBe(
-      'http://localhost:7000/my-plugin',
+      'http://localhost:7007/my-plugin',
     );
   });
 

--- a/packages/core-app-api/src/apis/implementations/DiscoveryApi/UrlPatternDiscovery.ts
+++ b/packages/core-app-api/src/apis/implementations/DiscoveryApi/UrlPatternDiscovery.ts
@@ -30,7 +30,7 @@ export class UrlPatternDiscovery implements DiscoveryApi {
    * interpolation done for the template is to replace instances of `{{pluginId}}`
    * with the ID of the plugin being requested.
    *
-   * Example pattern: `http://localhost:7000/api/{{ pluginId }}`
+   * Example pattern: `http://localhost:7007/api/{{ pluginId }}`
    */
   static compile(pattern: string): UrlPatternDiscovery {
     const parts = pattern.split(/\{\{\s*pluginId\s*\}\}/);

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1149,9 +1149,9 @@
   // app-config.yaml
 
   backend:
-    baseUrl: http://localhost:7007
+    baseUrl: http://localhost:7000
     listen:
-      port: 7007
+      port: 7000
     database:
       client: sqlite3
       connection: ':memory:'
@@ -2238,9 +2238,9 @@ For more information and the background to this change, see the [composability s
       {
         data: {
           app: { title: 'Test' },
-          backend: { baseUrl: 'http://localhost:7007' },
+          backend: { baseUrl: 'http://localhost:7000' },
           techdocs: {
-            storageUrl: 'http://localhost:7007/api/techdocs/static/docs',
+            storageUrl: 'http://localhost:7000/api/techdocs/static/docs',
           },
         },
         context: 'test',
@@ -3444,12 +3444,12 @@ For more information and the background to this change, see the [composability s
   ```yaml
   app:
     # Should be the same as backend.baseUrl when using the `app-backend` plugin
-    baseUrl: http://localhost:7007
+    baseUrl: http://localhost:7000
 
   backend:
-    baseUrl: http://localhost:7007
+    baseUrl: http://localhost:7000
     listen:
-      port: 7007
+      port: 7000
   ```
 
   In order to load in the new configuration at runtime, the command in the `Dockerfile` at the repo root was changed to the following:

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1149,9 +1149,9 @@
   // app-config.yaml
 
   backend:
-    baseUrl: http://localhost:7000
+    baseUrl: http://localhost:7007
     listen:
-      port: 7000
+      port: 7007
     database:
       client: sqlite3
       connection: ':memory:'
@@ -2238,9 +2238,9 @@ For more information and the background to this change, see the [composability s
       {
         data: {
           app: { title: 'Test' },
-          backend: { baseUrl: 'http://localhost:7000' },
+          backend: { baseUrl: 'http://localhost:7007' },
           techdocs: {
-            storageUrl: 'http://localhost:7000/api/techdocs/static/docs',
+            storageUrl: 'http://localhost:7007/api/techdocs/static/docs',
           },
         },
         context: 'test',
@@ -3444,12 +3444,12 @@ For more information and the background to this change, see the [composability s
   ```yaml
   app:
     # Should be the same as backend.baseUrl when using the `app-backend` plugin
-    baseUrl: http://localhost:7000
+    baseUrl: http://localhost:7007
 
   backend:
-    baseUrl: http://localhost:7000
+    baseUrl: http://localhost:7007
     listen:
-      port: 7000
+      port: 7007
   ```
 
   In order to load in the new configuration at runtime, the command in the `Dockerfile` at the repo root was changed to the following:

--- a/packages/create-app/templates/default-app/app-config.production.yaml
+++ b/packages/create-app/templates/default-app/app-config.production.yaml
@@ -1,8 +1,8 @@
 app:
   # Should be the same as backend.baseUrl when using the `app-backend` plugin
-  baseUrl: http://localhost:7000
+  baseUrl: http://localhost:7007
 
 backend:
-  baseUrl: http://localhost:7000
+  baseUrl: http://localhost:7007
   listen:
-    port: 7000
+    port: 7007

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -6,9 +6,9 @@ organization:
   name: My Company
 
 backend:
-  baseUrl: http://localhost:7000
+  baseUrl: http://localhost:7007
   listen:
-    port: 7000
+    port: 7007
   csp:
     connect-src: ["'self'", 'http:', 'https:']
     # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference

--- a/packages/create-app/templates/default-app/packages/app/src/App.test.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.test.tsx
@@ -10,9 +10,9 @@ describe('App', () => {
         {
           data: {
             app: { title: 'Test' },
-            backend: { baseUrl: 'http://localhost:7000' },
+            backend: { baseUrl: 'http://localhost:7007' },
             techdocs: {
-              storageUrl: 'http://localhost:7000/api/techdocs/static/docs',
+              storageUrl: 'http://localhost:7007/api/techdocs/static/docs',
             },
           },
           context: 'test',

--- a/packages/create-app/templates/default-app/packages/backend/README.md
+++ b/packages/create-app/templates/default-app/packages/backend/README.md
@@ -36,7 +36,7 @@ yarn start
 Substitute `x` for actual values, or leave them as dummy values just to try out
 the backend without using the auth or sentry features.
 
-The backend starts up on port 7000 per default.
+The backend starts up on port 7007 per default.
 
 ## Populating The Catalog
 

--- a/packages/e2e-test/src/commands/run.ts
+++ b/packages/e2e-test/src/commands/run.ts
@@ -471,7 +471,7 @@ async function testBackendStart(appDir: string, isPostgres: boolean) {
 
     print('Try to fetch entities from the backend');
     // Try fetch entities, should be ok
-    await fetch('http://localhost:7000/api/catalog/entities').then(res =>
+    await fetch('http://localhost:7007/api/catalog/entities').then(res =>
       res.json(),
     );
     print('Entities fetched successfully');

--- a/packages/embedded-techdocs-app/app-config.dev.yaml
+++ b/packages/embedded-techdocs-app/app-config.dev.yaml
@@ -5,8 +5,8 @@ app:
   baseUrl: http://localhost:3000
 
 backend:
-  baseUrl: http://localhost:7000
+  baseUrl: http://localhost:7007
 
 techdocs:
   builder: 'external'
-  requestUrl: http://localhost:7000/api
+  requestUrl: http://localhost:7007/api

--- a/packages/embedded-techdocs-app/src/App.test.tsx
+++ b/packages/embedded-techdocs-app/src/App.test.tsx
@@ -26,9 +26,9 @@ describe('App', () => {
         {
           data: {
             app: { title: 'Test' },
-            backend: { baseUrl: 'http://localhost:7000' },
+            backend: { baseUrl: 'http://localhost:7007' },
             techdocs: {
-              storageUrl: 'http://localhost:7000/api/techdocs/static/docs',
+              storageUrl: 'http://localhost:7007/api/techdocs/static/docs',
             },
           },
           context: 'test',

--- a/packages/storybook/.storybook/apis.js
+++ b/packages/storybook/.storybook/apis.js
@@ -50,7 +50,7 @@ const oauthRequestApi = builder.add(
 builder.add(
   googleAuthApiRef,
   GoogleAuth.create({
-    apiOrigin: 'http://localhost:7000',
+    apiOrigin: 'http://localhost:7007',
     basePath: '/auth/',
     oauthRequestApi,
   }),
@@ -59,7 +59,7 @@ builder.add(
 builder.add(
   githubAuthApiRef,
   GithubAuth.create({
-    apiOrigin: 'http://localhost:7000',
+    apiOrigin: 'http://localhost:7007',
     basePath: '/auth/',
     oauthRequestApi,
   }),
@@ -68,7 +68,7 @@ builder.add(
 builder.add(
   gitlabAuthApiRef,
   GitlabAuth.create({
-    apiOrigin: 'http://localhost:7000',
+    apiOrigin: 'http://localhost:7007',
     basePath: '/auth/',
     oauthRequestApi,
   }),
@@ -77,7 +77,7 @@ builder.add(
 builder.add(
   oktaAuthApiRef,
   OktaAuth.create({
-    apiOrigin: 'http://localhost:7000',
+    apiOrigin: 'http://localhost:7007',
     basePath: '/auth/',
     oauthRequestApi,
   }),
@@ -86,7 +86,7 @@ builder.add(
 builder.add(
   auth0AuthApiRef,
   Auth0Auth.create({
-    apiOrigin: 'http://localhost:7000',
+    apiOrigin: 'http://localhost:7007',
     basePath: '/auth/',
     oauthRequestApi,
   }),
@@ -95,7 +95,7 @@ builder.add(
 builder.add(
   oauth2ApiRef,
   OAuth2.create({
-    apiOrigin: 'http://localhost:7000',
+    apiOrigin: 'http://localhost:7007',
     basePath: '/auth/',
     oauthRequestApi,
   }),

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -36,7 +36,7 @@ export default async function serve(cmd: Command) {
   // a backstage app, we define app.baseUrl in the app-config.yaml.
   // Hence, it is complicated to make this configurable.
   const backstagePort = 3000;
-  const backstageBackendPort = 7000;
+  const backstageBackendPort = 7007;
 
   const mkdocsDockerAddr = `http://0.0.0.0:${cmd.mkdocsPort}`;
   const mkdocsLocalAddr = `http://127.0.0.1:${cmd.mkdocsPort}`;

--- a/packages/techdocs-cli/src/lib/PublisherConfig.ts
+++ b/packages/techdocs-cli/src/lib/PublisherConfig.ts
@@ -55,9 +55,9 @@ export class PublisherConfig {
     return new ConfigReader({
       // This backend config is not used at all. Just something needed a create a mock discovery instance.
       backend: {
-        baseUrl: 'http://localhost:7000',
+        baseUrl: 'http://localhost:7007',
         listen: {
-          port: 7000,
+          port: 7007,
         },
       },
       techdocs: {

--- a/packages/techdocs-common/CHANGELOG.md
+++ b/packages/techdocs-common/CHANGELOG.md
@@ -865,7 +865,7 @@
 
   Based on the config `techdocs.publisher.type`, the publisher could be either Local publisher or Google Cloud Storage publisher.
 
-  4. `techdocs.storageUrl` is now a required config. Should be `http://localhost:7000/api/techdocs/static/docs` in most setups.
+  4. `techdocs.storageUrl` is now a required config. Should be `http://localhost:7007/api/techdocs/static/docs` in most setups.
 
   5. Parts of `@backstage/plugin-techdocs-backend` have been moved to a new package `@backstage/techdocs-common` to generate docs. Also to publish docs
      to-and-fro between TechDocs and a storage (either local or external). However, a Backstage app does NOT need to import the `techdocs-common` package -

--- a/packages/techdocs-common/src/stages/publish/awsS3.test.ts
+++ b/packages/techdocs-common/src/stages/publish/awsS3.test.ts
@@ -54,7 +54,7 @@ const createPublisherFromConfig = ({
 } = {}) => {
   const mockConfig = new ConfigReader({
     techdocs: {
-      requestUrl: 'http://localhost:7000',
+      requestUrl: 'http://localhost:7007',
       publisher: {
         type: 'awsS3',
         awsS3: {

--- a/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/azureBlobStorage.test.ts
@@ -51,7 +51,7 @@ const createPublisherFromConfig = ({
 } = {}) => {
   const config = new ConfigReader({
     techdocs: {
-      requestUrl: 'http://localhost:7000',
+      requestUrl: 'http://localhost:7007',
       publisher: {
         type: 'azureBlobStorage',
         azureBlobStorage: {

--- a/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
+++ b/packages/techdocs-common/src/stages/publish/googleStorage.test.ts
@@ -52,7 +52,7 @@ const createPublisherFromConfig = ({
 } = {}) => {
   const config = new ConfigReader({
     techdocs: {
-      requestUrl: 'http://localhost:7000',
+      requestUrl: 'http://localhost:7007',
       publisher: {
         type: 'googleGcs',
         googleGcs: {

--- a/packages/techdocs-common/src/stages/publish/local.test.ts
+++ b/packages/techdocs-common/src/stages/publish/local.test.ts
@@ -39,7 +39,7 @@ const createMockEntity = (annotations = {}, lowerCase = false) => {
 };
 
 const testDiscovery: jest.Mocked<PluginEndpointDiscovery> = {
-  getBaseUrl: jest.fn().mockResolvedValue('http://localhost:7000/api/techdocs'),
+  getBaseUrl: jest.fn().mockResolvedValue('http://localhost:7007/api/techdocs'),
   getExternalBaseUrl: jest.fn(),
 };
 

--- a/packages/techdocs-common/src/stages/publish/openStackSwift.test.ts
+++ b/packages/techdocs-common/src/stages/publish/openStackSwift.test.ts
@@ -84,7 +84,7 @@ beforeEach(() => {
   mockFs.restore();
   const mockConfig = new ConfigReader({
     techdocs: {
-      requestUrl: 'http://localhost:7000',
+      requestUrl: 'http://localhost:7007',
       publisher: {
         type: 'openStackSwift',
         openStackSwift: {
@@ -114,7 +114,7 @@ describe('OpenStackSwiftPublish', () => {
     it('should reject incorrect config', async () => {
       const mockConfig = new ConfigReader({
         techdocs: {
-          requestUrl: 'http://localhost:7000',
+          requestUrl: 'http://localhost:7007',
           publisher: {
             type: 'openStackSwift',
             openStackSwift: {

--- a/packages/techdocs-common/src/stages/publish/publish.test.ts
+++ b/packages/techdocs-common/src/stages/publish/publish.test.ts
@@ -27,7 +27,7 @@ import { OpenStackSwiftPublish } from './openStackSwift';
 
 const logger = getVoidLogger();
 const discovery: jest.Mocked<PluginEndpointDiscovery> = {
-  getBaseUrl: jest.fn().mockResolvedValueOnce('http://localhost:7000'),
+  getBaseUrl: jest.fn().mockResolvedValueOnce('http://localhost:7007'),
   getExternalBaseUrl: jest.fn(),
 };
 
@@ -39,7 +39,7 @@ describe('Publisher', () => {
   it('should create local publisher by default', async () => {
     const mockConfig = new ConfigReader({
       techdocs: {
-        requestUrl: 'http://localhost:7000',
+        requestUrl: 'http://localhost:7007',
       },
     });
 
@@ -53,7 +53,7 @@ describe('Publisher', () => {
   it('should create local publisher from config', async () => {
     const mockConfig = new ConfigReader({
       techdocs: {
-        requestUrl: 'http://localhost:7000',
+        requestUrl: 'http://localhost:7007',
         publisher: {
           type: 'local',
         },
@@ -70,7 +70,7 @@ describe('Publisher', () => {
   it('should create google gcs publisher from config', async () => {
     const mockConfig = new ConfigReader({
       techdocs: {
-        requestUrl: 'http://localhost:7000',
+        requestUrl: 'http://localhost:7007',
         publisher: {
           type: 'googleGcs',
           googleGcs: {
@@ -91,7 +91,7 @@ describe('Publisher', () => {
   it('should create AWS S3 publisher from config', async () => {
     const mockConfig = new ConfigReader({
       techdocs: {
-        requestUrl: 'http://localhost:7000',
+        requestUrl: 'http://localhost:7007',
         publisher: {
           type: 'awsS3',
           awsS3: {
@@ -115,7 +115,7 @@ describe('Publisher', () => {
   it('should create Azure Blob Storage publisher from config', async () => {
     const mockConfig = new ConfigReader({
       techdocs: {
-        requestUrl: 'http://localhost:7000',
+        requestUrl: 'http://localhost:7007',
         publisher: {
           type: 'azureBlobStorage',
           azureBlobStorage: {
@@ -143,7 +143,7 @@ describe('Publisher', () => {
 
     const mockConfig = new ConfigReader({
       techdocs: {
-        requestUrl: 'http://localhost:7000',
+        requestUrl: 'http://localhost:7007',
         publisher: {
           type: 'azureBlobStorage',
           azureBlobStorage: {
@@ -166,7 +166,7 @@ describe('Publisher', () => {
   it('should create Open Stack Swift publisher from config', async () => {
     const mockConfig = new ConfigReader({
       techdocs: {
-        requestUrl: 'http://localhost:7000',
+        requestUrl: 'http://localhost:7007',
         publisher: {
           type: 'openStackSwift',
           openStackSwift: {

--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -34,7 +34,7 @@ Follow this link, [Create new OAuth App](https://github.com/settings/application
 1. Set Application Name to `backstage-dev` or something along those lines.
 1. You can set the Homepage URL to whatever you want to.
 1. The Authorization Callback URL should match the redirect URI set in Backstage.
-   1. Set this to `http://localhost:7000/api/auth/github` for local development.
+   1. Set this to `http://localhost:7007/api/auth/github` for local development.
    1. Set this to `http://{APP_FQDN}:{APP_BACKEND_PORT}/api/auth/github` for non-local deployments.
 
 ```bash
@@ -58,7 +58,7 @@ Follow this link, [Add new application](https://gitlab.com/-/profile/application
 
 1. Set Application Name to `backstage-dev` or something along those lines.
 1. The Authorization Callback URL should match the redirect URI set in Backstage.
-   1. Set this to `http://localhost:7000/api/auth/gitlab/handler/frame` for local development.
+   1. Set this to `http://localhost:7007/api/auth/gitlab/handler/frame` for local development.
    1. Set this to `http://{APP_FQDN}:{APP_BACKEND_PORT}/api/auth/gitlab/handler/frame` for non-local deployments.
    1. Select the following scopes from the list:
       - [x] `read_user` Grants read-only access to the authenticated user's profile through the /user API endpoint, which includes username, public email, and full name. Also grants access to read-only API endpoints under /users.
@@ -91,9 +91,9 @@ export AUTH_GITLAB_CLIENT_SECRET=x
 
 Add a new Okta application using the following URI conventions:
 
-Login redirect URI's: `http://localhost:7000/api/auth/okta/handler/frame`
-Logout redirect URI's: `http://localhost:7000/api/auth/okta/logout`
-Initiate login URI's: `http://localhost:7000/api/auth/okta/start`
+Login redirect URI's: `http://localhost:7007/api/auth/okta/handler/frame`
+Logout redirect URI's: `http://localhost:7007/api/auth/okta/logout`
+Initiate login URI's: `http://localhost:7007/api/auth/okta/start`
 
 Then configure the following environment variables to be used in the `app-config.yaml` file:
 
@@ -122,7 +122,7 @@ Click [here](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMe
 - Give the app a name. e.g. `backstage-dev`
 - Select `Accounts in this organizational directory only` under supported account types.
 - Enter the callback URL for your backstage backend instance:
-  - For local development, this is likely `http://localhost:7000/api/auth/microsoft/handler/frame`
+  - For local development, this is likely `http://localhost:7007/api/auth/microsoft/handler/frame`
   - For non-local deployments, this will be `https://{APP_FQDN}:{APP_BACKEND_PORT}/auth/microsoft/handler/frame`
 - Click `Register`.
 

--- a/plugins/auth-backend/scripts/start-saml-idp.sh
+++ b/plugins/auth-backend/scripts/start-saml-idp.sh
@@ -18,4 +18,4 @@ fi
 
 echo "Downloading and starting SAML-IdP"
 export NPM_CONFIG_REGISTRY=https://registry.npmjs.org
-exec npx saml-idp --acsUrl "http://localhost:7000/api/auth/saml/handler/frame" --audience "http://localhost:7000" --port 7001
+exec npx saml-idp --acsUrl "http://localhost:7007/api/auth/saml/handler/frame" --audience "http://localhost:7007" --port 7001

--- a/plugins/azure-devops-backend/README.md
+++ b/plugins/azure-devops-backend/README.md
@@ -63,7 +63,7 @@ Here's how to get the backend up and running:
    ```
 
 4. Now run `yarn start-backend` from the repo root
-5. Finally open `http://localhost:7000/api/azure-devops/health` in a browser and it should return `{"status":"ok"}`
+5. Finally open `http://localhost:7007/api/azure-devops/health` in a browser and it should return `{"status":"ok"}`
 
 ## Links
 

--- a/plugins/azure-devops-backend/src/run.ts
+++ b/plugins/azure-devops-backend/src/run.ts
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/plugins/badges-backend/src/run.ts
+++ b/plugins/badges-backend/src/run.ts
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/plugins/badges-backend/src/service/router.test.ts
+++ b/plugins/badges-backend/src/service/router.test.ts
@@ -73,7 +73,7 @@ describe('createRouter', () => {
     config = new ConfigReader({
       backend: {
         baseUrl: 'http://127.0.0.1',
-        listen: { port: 7000 },
+        listen: { port: 7007 },
       },
     });
     discovery = SingleHostDiscovery.fromConfig(config);

--- a/plugins/bazaar-backend/src/run.ts
+++ b/plugins/bazaar-backend/src/run.ts
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/plugins/catalog-backend/src/run.ts
+++ b/plugins/catalog-backend/src/run.ts
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.test.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.test.ts
@@ -59,7 +59,7 @@ describe('DefaultCatalogCollator', () => {
 
   beforeAll(() => {
     mockDiscoveryApi = {
-      getBaseUrl: jest.fn().mockResolvedValue('http://localhost:7000'),
+      getBaseUrl: jest.fn().mockResolvedValue('http://localhost:7007'),
       getExternalBaseUrl: jest.fn(),
     };
     collator = new DefaultCatalogCollator({ discovery: mockDiscoveryApi });
@@ -67,7 +67,7 @@ describe('DefaultCatalogCollator', () => {
   });
   beforeEach(() => {
     server.use(
-      rest.get('http://localhost:7000/entities', (req, res, ctx) => {
+      rest.get('http://localhost:7007/entities', (req, res, ctx) => {
         if (req.url.searchParams.has('filter')) {
           const filter = req.url.searchParams.get('filter');
           if (filter === 'kind=Foo,kind=Bar') {

--- a/plugins/code-coverage-backend/README.md
+++ b/plugins/code-coverage-backend/README.md
@@ -31,11 +31,11 @@ POST a Cobertura XML file to `/report`
 Example:
 
 ```json
-// curl -X POST -H "Content-Type:text/xml" -d @cobertura.xml "localhost:7000/api/code-coverage/report?entity=component:default/entity-name&coverageType=cobertura"
+// curl -X POST -H "Content-Type:text/xml" -d @cobertura.xml "localhost:7007/api/code-coverage/report?entity=component:default/entity-name&coverageType=cobertura"
 {
   "links": [
     {
-      "href": "http://localhost:7000/api/code-coverage/report?entity=component:default/entity-name",
+      "href": "http://localhost:7007/api/code-coverage/report?entity=component:default/entity-name",
       "rel": "coverage"
     }
   ]
@@ -49,11 +49,11 @@ POST a JaCoCo XML file to `/report`
 Example:
 
 ```json
-// curl -X POST -H "Content-Type:text/xml" -d @jacoco.xml "localhost:7000/api/code-coverage/report?entity=component:default/entity-name&coverageType=jacoco"
+// curl -X POST -H "Content-Type:text/xml" -d @jacoco.xml "localhost:7007/api/code-coverage/report?entity=component:default/entity-name&coverageType=jacoco"
 {
   "links": [
     {
-      "href": "http://localhost:7000/api/code-coverage/report?entity=component:default/entity-name",
+      "href": "http://localhost:7007/api/code-coverage/report?entity=component:default/entity-name",
       "rel": "coverage"
     }
   ]
@@ -67,7 +67,7 @@ GET `/report`
 Example:
 
 ```json
-// curl localhost:7000/api/code-coverage/report?entity=component:default/entity-name
+// curl localhost:7007/api/code-coverage/report?entity=component:default/entity-name
 {
   "aggregate": {
     "branch": {
@@ -111,7 +111,7 @@ GET `/history`
 Example
 
 ```json
-// curl localhost:7000/api/code-coverage/history?entity=component:default/entity-name
+// curl localhost:7007/api/code-coverage/history?entity=component:default/entity-name
 {
   "entity": {
     "kind": "Component",

--- a/plugins/code-coverage-backend/src/run.ts
+++ b/plugins/code-coverage-backend/src/run.ts
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/plugins/code-coverage-backend/src/service/router.test.ts
+++ b/plugins/code-coverage-backend/src/service/router.test.ts
@@ -42,7 +42,7 @@ function createDatabase(): PluginDatabaseManager {
 const testDiscovery: jest.Mocked<PluginEndpointDiscovery> = {
   getBaseUrl: jest
     .fn()
-    .mockResolvedValue('http://localhost:7000/api/code-coverage'),
+    .mockResolvedValue('http://localhost:7007/api/code-coverage'),
   getExternalBaseUrl: jest.fn(),
 };
 const mockUrlReader = UrlReaders.default({

--- a/plugins/github-actions/README.md
+++ b/plugins/github-actions/README.md
@@ -11,7 +11,7 @@ TBD
 ### Generic Requirements
 
 1. Provide OAuth credentials:
-   1. [Create an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) with the callback URL set to `http://localhost:7000/api/auth/github`.
+   1. [Create an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) with the callback URL set to `http://localhost:7007/api/auth/github`.
    2. Take the Client ID and Client Secret from the newly created app's settings page and put them into `AUTH_GITHUB_CLIENT_ID` and `AUTH_GITHUB_CLIENT_SECRET` environment variables.
 2. Annotate your component with a correct GitHub Actions repository and owner:
 

--- a/plugins/jenkins-backend/src/run.ts
+++ b/plugins/jenkins-backend/src/run.ts
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/plugins/proxy-backend/src/run.ts
+++ b/plugins/proxy-backend/src/run.ts
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/plugins/proxy-backend/src/service/router.test.ts
+++ b/plugins/proxy-backend/src/service/router.test.ts
@@ -34,9 +34,9 @@ describe('createRouter', () => {
     const logger = getVoidLogger();
     const config = new ConfigReader({
       backend: {
-        baseUrl: 'https://example.com:7000',
+        baseUrl: 'https://example.com:7007',
         listen: {
-          port: 7000,
+          port: 7007,
         },
       },
     });

--- a/plugins/rollbar-backend/src/run.ts
+++ b/plugins/rollbar-backend/src/run.ts
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/plugins/search-backend/src/run.ts
+++ b/plugins/search-backend/src/run.ts
@@ -18,7 +18,7 @@ import { getRootLogger } from '@backstage/backend-common';
 import yn from 'yn';
 import { startStandaloneServer } from './service/standaloneServer';
 
-const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7000;
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
 const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -227,14 +227,14 @@ export interface Config {
         };
 
     /**
-     * @example http://localhost:7000/api/techdocs
+     * @example http://localhost:7007/api/techdocs
      * @visibility frontend
      * @deprecated
      */
     requestUrl?: string;
 
     /**
-     * @example http://localhost:7000/api/techdocs/static/docs
+     * @example http://localhost:7007/api/techdocs/static/docs
      * @deprecated
      */
     storageUrl?: string;

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -34,7 +34,7 @@ export interface Config {
     legacyUseCaseSensitiveTripletPaths?: boolean;
 
     /**
-     * @example http://localhost:7000/api/techdocs
+     * @example http://localhost:7007/api/techdocs
      * @visibility frontend
      * @deprecated
      */

--- a/scripts/migrate-location-types.js
+++ b/scripts/migrate-location-types.js
@@ -20,7 +20,7 @@
 // catalog API endpoint and execute the script. It will delete and add
 // back the locations with the correct type one by one.
 
-const BASE_URL = 'http://localhost:7000/api/catalog'; // Change me
+const BASE_URL = 'http://localhost:7007/api/catalog'; // Change me
 
 const deprecatedTypes = [
   'github',
@@ -81,9 +81,9 @@ async function request(method, url, body) {
             return;
           }
           try {
-            const body = Buffer.concat(chunks).toString('utf8').trim();
-            if (body) {
-              resolve(JSON.parse(body));
+            const responseBody = Buffer.concat(chunks).toString('utf8').trim();
+            if (responseBody) {
+              resolve(JSON.parse(responseBody));
             } else {
               resolve();
             }


### PR DESCRIPTION
By default, the Backstage backend is bound to port ´7000´.

Some users who upgraded to MacOS Monterey might have experienced troubles while trying to start a Backstage instance locally with following error:

> EADDRINUSE: address already in use 127.0.0.1:7000

Even when no other Backstage instance is running or a previous one hasn't been terminated correctly. This is due to another process occupying port `7000` which is MacOS' Control Center and AirPlay Receiver, see link here: https://developer.apple.com/forums/thread/682332

A local workaround is to disable AirPlay Receiver on a contributor's local machine as described in the linked post, however this might not be feasible in all scenarios.

Hence this PR is aiming to change the default port from `7000` to **`7007`**.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
