### PR TITLE
Fix sample data in example Cost Insights client

### DIFF
--- a/.changeset/cost-insights-two-crabs-evolve.md
+++ b/.changeset/cost-insights-two-crabs-evolve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Fixed generation of sample data in the example Cost Insights client

--- a/plugins/cost-insights/src/testUtils/testUtils.ts
+++ b/plugins/cost-insights/src/testUtils/testUtils.ts
@@ -61,7 +61,7 @@ export function aggregationFor(
   const days = DateTime.fromISO(endDate).diff(
     DateTime.fromISO(inclusiveStartDateOf(duration, inclusiveEndDate)),
     'days',
-  );
+  ).days;
 
   function nextDelta(): number {
     const varianceFromBaseline = 0.15;


### PR DESCRIPTION
The Cost Insights page with the example client was only displaying daily cost data for a single day (see the [demo site](https://demo.backstage.io/cost-insights?group=pied-piper)):

![Screen Shot 2021-11-16 at 08 32 56](https://user-images.githubusercontent.com/556258/142015559-1a622735-dae3-4e98-8060-d793139e1546.png)

This was caused inadvertently by the Luxon switch in #6159. The computed value is a Luxon duration rather than day count, so the `reduce` below only had one cycle.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
