### PR TITLE
core-app-api: explicitly do not export TargetRouteMap and friends

### DIFF
--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -219,10 +219,6 @@ export type AppOptions = {
   bindRoutes?(context: { bind: AppRouteBinder }): void;
 };
 
-// Warning: (ae-forgotten-export) The symbol "PartialKeys" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "TargetRouteMap" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "KeysWithType" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type AppRouteBinder = <
   ExternalRoutes extends {

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -152,6 +152,8 @@ export type AppConfigLoader = () => Promise<AppConfig[]>;
 
 /**
  * Extracts a union of the keys in a map whose value extends the given type
+ *
+ * @ignore
  */
 type KeysWithType<Obj extends { [key in string]: any }, Type> = {
   [key in keyof Obj]: Obj[key] extends Type ? key : never;
@@ -159,6 +161,8 @@ type KeysWithType<Obj extends { [key in string]: any }, Type> = {
 
 /**
  * Takes a map Map required values and makes all keys matching Keys optional
+ *
+ * @ignore
  */
 type PartialKeys<
   Map extends { [name in string]: any },
@@ -167,6 +171,8 @@ type PartialKeys<
 
 /**
  * Creates a map of target routes with matching parameters based on a map of external routes.
+ *
+ * @ignore
  */
 type TargetRouteMap<
   ExternalRoutes extends { [name: string]: ExternalRouteRef },


### PR DESCRIPTION
We want these utility types so that we can have the declarations be cleaner, but we don't want to export the types.

Builds on top of #8077