### PR TITLE
useAsyncDefaults and useAsyncState to generalize fallback rendering

### DIFF
--- a/packages/app-defaults/src/defaults/components.tsx
+++ b/packages/app-defaults/src/defaults/components.tsx
@@ -16,7 +16,11 @@
 
 import React, { ReactNode } from 'react';
 import Button from '@material-ui/core/Button';
-import { ErrorPanel, Progress, ErrorPage } from '@backstage/core-components';
+import {
+  ErrorPanel,
+  DefaultProgress,
+  ErrorPage,
+} from '@backstage/core-components';
 import {
   MemoryRouter,
   useInRouterContext,
@@ -78,7 +82,7 @@ const DefaultErrorBoundaryFallback = ({
  * @public
  */
 export const components: AppComponents = {
-  Progress,
+  Progress: DefaultProgress,
   Router: BrowserRouter,
   NotFoundErrorPage: DefaultNotFoundPage,
   BootErrorPage: DefaultBootErrorPage,

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -27,6 +27,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { bitbucketAuthApiRef } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { ConfigReader } from '@backstage/config';
+import { CSSProperties } from 'react';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { ErrorApi } from '@backstage/core-plugin-api';
 import { ErrorApiError } from '@backstage/core-plugin-api';
@@ -148,7 +149,10 @@ export class ApiResolver implements ApiHolder {
 export type AppComponents = {
   NotFoundErrorPage: ComponentType<{}>;
   BootErrorPage: ComponentType<BootErrorPageProps>;
-  Progress: ComponentType<{}>;
+  Progress: ComponentType<{
+    className?: string;
+    style?: CSSProperties;
+  }>;
   Router: ComponentType<{}>;
   ErrorBoundaryFallback: ComponentType<ErrorBoundaryFallbackProps>;
   ThemeProvider?: ComponentType<{}>;

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ComponentType } from 'react';
+import { ComponentType, CSSProperties } from 'react';
 import {
   AnyApiFactory,
   AppTheme,
@@ -93,7 +93,7 @@ export type ErrorBoundaryFallbackProps = {
 export type AppComponents = {
   NotFoundErrorPage: ComponentType<{}>;
   BootErrorPage: ComponentType<BootErrorPageProps>;
-  Progress: ComponentType<{}>;
+  Progress: ComponentType<{ className?: string; style?: CSSProperties }>;
   Router: ComponentType<{}>;
   ErrorBoundaryFallback: ComponentType<ErrorBoundaryFallbackProps>;
   ThemeProvider?: ComponentType<{}>;

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -240,6 +240,13 @@ export type CustomProviderClassKey = 'form' | 'button';
 // @public (undocumented)
 export function DashboardIcon(props: IconComponentProps): JSX.Element;
 
+// Warning: (ae-missing-release-tag) "DefaultProgress" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function DefaultProgress(
+  props: PropsWithChildren<LinearProgressProps>,
+): JSX.Element;
+
 // @public
 type DependencyEdge<T = {}> = T & {
   from: string;
@@ -884,15 +891,10 @@ export const SidebarDivider: React_2.ComponentType<
       React_2.HTMLAttributes<HTMLHRElement>,
       HTMLHRElement
     >,
-    | 'hidden'
-    | 'dir'
+    | 'children'
     | 'slot'
     | 'style'
     | 'title'
-    | 'color'
-    | 'translate'
-    | 'prefix'
-    | 'children'
     | 'id'
     | 'defaultChecked'
     | 'defaultValue'
@@ -901,16 +903,20 @@ export const SidebarDivider: React_2.ComponentType<
     | 'accessKey'
     | 'contentEditable'
     | 'contextMenu'
+    | 'dir'
     | 'draggable'
+    | 'hidden'
     | 'lang'
     | 'placeholder'
     | 'spellCheck'
     | 'tabIndex'
+    | 'translate'
     | 'radioGroup'
     | 'role'
     | 'about'
     | 'datatype'
     | 'inlist'
+    | 'prefix'
     | 'property'
     | 'resource'
     | 'typeof'
@@ -918,6 +924,7 @@ export const SidebarDivider: React_2.ComponentType<
     | 'autoCapitalize'
     | 'autoCorrect'
     | 'autoSave'
+    | 'color'
     | 'itemProp'
     | 'itemScope'
     | 'itemType'
@@ -1214,16 +1221,12 @@ export const SidebarScrollWrapper: React_2.ComponentType<
       React_2.HTMLAttributes<HTMLDivElement>,
       HTMLDivElement
     >,
-    | 'hidden'
-    | 'dir'
+    | 'children'
     | 'slot'
     | 'style'
     | 'title'
-    | 'color'
-    | 'translate'
-    | 'prefix'
-    | 'children'
     | 'id'
+    | keyof React_2.ClassAttributes<HTMLDivElement>
     | 'defaultChecked'
     | 'defaultValue'
     | 'suppressContentEditableWarning'
@@ -1231,16 +1234,20 @@ export const SidebarScrollWrapper: React_2.ComponentType<
     | 'accessKey'
     | 'contentEditable'
     | 'contextMenu'
+    | 'dir'
     | 'draggable'
+    | 'hidden'
     | 'lang'
     | 'placeholder'
     | 'spellCheck'
     | 'tabIndex'
+    | 'translate'
     | 'radioGroup'
     | 'role'
     | 'about'
     | 'datatype'
     | 'inlist'
+    | 'prefix'
     | 'property'
     | 'resource'
     | 'typeof'
@@ -1248,6 +1255,7 @@ export const SidebarScrollWrapper: React_2.ComponentType<
     | 'autoCapitalize'
     | 'autoCorrect'
     | 'autoSave'
+    | 'color'
     | 'itemProp'
     | 'itemScope'
     | 'itemType'
@@ -1467,7 +1475,6 @@ export const SidebarScrollWrapper: React_2.ComponentType<
     | 'onAnimationIterationCapture'
     | 'onTransitionEnd'
     | 'onTransitionEndCapture'
-    | keyof React_2.ClassAttributes<HTMLDivElement>
   > &
     StyledComponentProps<'root'> & {
       className?: string | undefined;
@@ -1489,16 +1496,12 @@ export const SidebarSpace: React_2.ComponentType<
       React_2.HTMLAttributes<HTMLDivElement>,
       HTMLDivElement
     >,
-    | 'hidden'
-    | 'dir'
+    | 'children'
     | 'slot'
     | 'style'
     | 'title'
-    | 'color'
-    | 'translate'
-    | 'prefix'
-    | 'children'
     | 'id'
+    | keyof React_2.ClassAttributes<HTMLDivElement>
     | 'defaultChecked'
     | 'defaultValue'
     | 'suppressContentEditableWarning'
@@ -1506,16 +1509,20 @@ export const SidebarSpace: React_2.ComponentType<
     | 'accessKey'
     | 'contentEditable'
     | 'contextMenu'
+    | 'dir'
     | 'draggable'
+    | 'hidden'
     | 'lang'
     | 'placeholder'
     | 'spellCheck'
     | 'tabIndex'
+    | 'translate'
     | 'radioGroup'
     | 'role'
     | 'about'
     | 'datatype'
     | 'inlist'
+    | 'prefix'
     | 'property'
     | 'resource'
     | 'typeof'
@@ -1523,6 +1530,7 @@ export const SidebarSpace: React_2.ComponentType<
     | 'autoCapitalize'
     | 'autoCorrect'
     | 'autoSave'
+    | 'color'
     | 'itemProp'
     | 'itemScope'
     | 'itemType'
@@ -1742,7 +1750,6 @@ export const SidebarSpace: React_2.ComponentType<
     | 'onAnimationIterationCapture'
     | 'onTransitionEnd'
     | 'onTransitionEndCapture'
-    | keyof React_2.ClassAttributes<HTMLDivElement>
   > &
     StyledComponentProps<'root'> & {
       className?: string | undefined;
@@ -1758,16 +1765,12 @@ export const SidebarSpacer: React_2.ComponentType<
       React_2.HTMLAttributes<HTMLDivElement>,
       HTMLDivElement
     >,
-    | 'hidden'
-    | 'dir'
+    | 'children'
     | 'slot'
     | 'style'
     | 'title'
-    | 'color'
-    | 'translate'
-    | 'prefix'
-    | 'children'
     | 'id'
+    | keyof React_2.ClassAttributes<HTMLDivElement>
     | 'defaultChecked'
     | 'defaultValue'
     | 'suppressContentEditableWarning'
@@ -1775,16 +1778,20 @@ export const SidebarSpacer: React_2.ComponentType<
     | 'accessKey'
     | 'contentEditable'
     | 'contextMenu'
+    | 'dir'
     | 'draggable'
+    | 'hidden'
     | 'lang'
     | 'placeholder'
     | 'spellCheck'
     | 'tabIndex'
+    | 'translate'
     | 'radioGroup'
     | 'role'
     | 'about'
     | 'datatype'
     | 'inlist'
+    | 'prefix'
     | 'property'
     | 'resource'
     | 'typeof'
@@ -1792,6 +1799,7 @@ export const SidebarSpacer: React_2.ComponentType<
     | 'autoCapitalize'
     | 'autoCorrect'
     | 'autoSave'
+    | 'color'
     | 'itemProp'
     | 'itemScope'
     | 'itemType'
@@ -2011,7 +2019,6 @@ export const SidebarSpacer: React_2.ComponentType<
     | 'onAnimationIterationCapture'
     | 'onTransitionEnd'
     | 'onTransitionEndCapture'
-    | keyof React_2.ClassAttributes<HTMLDivElement>
   > &
     StyledComponentProps<'root'> & {
       className?: string | undefined;

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -14,9 +14,11 @@ import { CardHeaderProps } from '@material-ui/core/CardHeader';
 import { Column } from '@material-table/core';
 import { ComponentClass } from 'react';
 import { ComponentProps } from 'react';
+import { ComponentType } from 'react';
 import { Context } from 'react';
 import { default as CSS_2 } from 'csstype';
 import { CSSProperties } from 'react';
+import { DependencyList } from 'react';
 import { ElementType } from 'react';
 import { ErrorInfo } from 'react';
 import { IconComponent } from '@backstage/core-plugin-api';
@@ -55,6 +57,45 @@ enum Alignment {
   DOWN_RIGHT = 'DR',
   UP_LEFT = 'UL',
   UP_RIGHT = 'UR',
+}
+
+// Warning: (ae-missing-release-tag) "AsyncFallbackOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface AsyncFallbackOptions {
+  // (undocumented)
+  error?:
+    | JSX.Element
+    | ComponentType<{
+        error: Error;
+      }>;
+  // (undocumented)
+  progress?: JSX.Element | ComponentType<{}>;
+}
+
+// Warning: (ae-missing-release-tag) "AsyncFallbackResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type AsyncFallbackResult<T> =
+  | {
+      fallback: undefined;
+      value: T;
+    }
+  | {
+      fallback: JSX.Element;
+      value: undefined;
+    };
+
+// Warning: (ae-missing-release-tag) "AsyncState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface AsyncState<T> {
+  // (undocumented)
+  error?: Error | undefined;
+  // (undocumented)
+  loading?: boolean | undefined;
+  // (undocumented)
+  value?: T | undefined;
 }
 
 // @public
@@ -2269,6 +2310,28 @@ export function TrendLine(
       title?: string;
     },
 ): JSX.Element | null;
+
+// Warning: (ae-missing-release-tag) "useAsyncDefaults" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useAsyncDefaults<T>(
+  fn: (...args: []) => Promise<T>,
+  deps?: DependencyList,
+  opts?: AsyncFallbackOptions,
+): AsyncFallbackResult<T>;
+
+// Warning: (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
+// Warning: (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
+// Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// Warning: (tsdoc-html-tag-missing-string) The HTML element has an invalid attribute: Expecting an HTML string starting with a single-quote or double-quote character
+// Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+// Warning: (ae-missing-release-tag) "useAsyncState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function useAsyncState<T>(
+  state: AsyncState<T>,
+  opts?: AsyncFallbackOptions,
+): AsyncFallbackResult<T>;
 
 // Warning: (ae-forgotten-export) The symbol "SetQueryParams" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "useQueryParamState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/core-components/src/components/DefaultProgress/Progress.stories.tsx
+++ b/packages/core-components/src/components/DefaultProgress/Progress.stories.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import React, { PropsWithChildren } from 'react';
-import { LinearProgressProps } from '@material-ui/core/LinearProgress';
-import { useApp } from '@backstage/core-plugin-api';
+import React from 'react';
+import { DefaultProgress } from './Progress';
 
-export function Progress(props: PropsWithChildren<LinearProgressProps>) {
-  const { Progress: CustomProgress } = useApp().getComponents();
-  return <CustomProgress {...props} />;
-}
+export default {
+  title: 'Feedback/Progress',
+  component: DefaultProgress,
+};
+
+export const progress = () => <DefaultProgress />;

--- a/packages/core-components/src/components/DefaultProgress/Progress.test.tsx
+++ b/packages/core-components/src/components/DefaultProgress/Progress.test.tsx
@@ -14,11 +14,23 @@
  * limitations under the License.
  */
 
-import React, { PropsWithChildren } from 'react';
-import { LinearProgressProps } from '@material-ui/core/LinearProgress';
-import { useApp } from '@backstage/core-plugin-api';
+import React from 'react';
+import { renderInTestApp } from '@backstage/test-utils';
+import { act } from 'react-dom/test-utils';
 
-export function Progress(props: PropsWithChildren<LinearProgressProps>) {
-  const { Progress: CustomProgress } = useApp().getComponents();
-  return <CustomProgress {...props} />;
-}
+import { DefaultProgress } from './Progress';
+
+describe('<Progress />', () => {
+  it('renders without exploding', async () => {
+    jest.useFakeTimers();
+    const { getByTestId, queryByTestId } = await renderInTestApp(
+      <DefaultProgress />,
+    );
+    expect(queryByTestId('progress')).not.toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(getByTestId('progress')).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});

--- a/packages/core-components/src/components/DefaultProgress/Progress.tsx
+++ b/packages/core-components/src/components/DefaultProgress/Progress.tsx
@@ -14,11 +14,22 @@
  * limitations under the License.
  */
 
-import React, { PropsWithChildren } from 'react';
-import { LinearProgressProps } from '@material-ui/core/LinearProgress';
-import { useApp } from '@backstage/core-plugin-api';
+import React, { useState, useEffect, PropsWithChildren } from 'react';
+import LinearProgress, {
+  LinearProgressProps,
+} from '@material-ui/core/LinearProgress';
 
-export function Progress(props: PropsWithChildren<LinearProgressProps>) {
-  const { Progress: CustomProgress } = useApp().getComponents();
-  return <CustomProgress {...props} />;
+export function DefaultProgress(props: PropsWithChildren<LinearProgressProps>) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setIsVisible(true), 250);
+    return () => clearTimeout(handle);
+  }, []);
+
+  return isVisible ? (
+    <LinearProgress {...props} data-testid="progress" />
+  ) : (
+    <div style={{ display: 'none' }} />
+  );
 }

--- a/packages/core-components/src/components/DefaultProgress/index.ts
+++ b/packages/core-components/src/components/DefaultProgress/index.ts
@@ -14,11 +14,4 @@
  * limitations under the License.
  */
 
-import React, { PropsWithChildren } from 'react';
-import { LinearProgressProps } from '@material-ui/core/LinearProgress';
-import { useApp } from '@backstage/core-plugin-api';
-
-export function Progress(props: PropsWithChildren<LinearProgressProps>) {
-  const { Progress: CustomProgress } = useApp().getComponents();
-  return <CustomProgress {...props} />;
-}
+export { DefaultProgress } from './Progress';

--- a/packages/core-components/src/components/index.ts
+++ b/packages/core-components/src/components/index.ts
@@ -20,6 +20,7 @@ export * from './Button';
 export * from './CodeSnippet';
 export * from './CopyTextButton';
 export * from './CreateButton';
+export * from './DefaultProgress';
 export * from './DependencyGraph';
 export * from './DismissableBanner';
 export * from './EmptyState';

--- a/packages/core-components/src/hooks/index.ts
+++ b/packages/core-components/src/hooks/index.ts
@@ -21,3 +21,9 @@ export type {
   SupportItem,
   SupportItemLink,
 } from './useSupportConfig';
+export { useAsyncState, useAsyncDefaults } from './useAsyncState';
+export type {
+  AsyncFallbackOptions,
+  AsyncFallbackResult,
+  AsyncState,
+} from './useAsyncState';

--- a/packages/core-components/src/hooks/useAsyncState.tsx
+++ b/packages/core-components/src/hooks/useAsyncState.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ComponentType, DependencyList, isValidElement } from 'react';
+import { Alert } from '@material-ui/lab';
+import { useApp } from '@backstage/core-plugin-api';
+import { useAsync } from 'react-use';
+
+export interface AsyncState<T> {
+  loading?: boolean | undefined;
+  error?: Error | undefined;
+  value?: T | undefined;
+}
+
+export interface AsyncFallbackOptions {
+  progress?: JSX.Element | ComponentType<{}>;
+  error?: JSX.Element | ComponentType<{ error: Error }>;
+}
+
+const DefaultErrorComponent: ComponentType<{ error: Error }> = ({ error }) => (
+  <Alert severity="error">{error.message}</Alert>
+);
+
+export type AsyncFallbackResult<T> =
+  | { fallback: undefined; value: T }
+  | {
+      fallback: JSX.Element;
+      value: undefined;
+    };
+
+/**
+ * Extract either a fallback component (progress or error) or the synchronous
+ * _value_ from an _async value_ such as one returned from `useAsync` (in the
+ * `react-use` package).
+ *
+ * An optional second argument can provide the fallback `progress` and/or
+ * `error` component. They will default to what's configured for Backstage, but
+ * can be either a JSX.Element or a React Component. The `error` component can
+ * have an `error` prop.
+ *
+ * **Note: You probably want to use useAsyncDefaults() instead**
+ *
+ * @example
+ *   const users = useAsync(
+ *     () => fetchUsersFromBackend(),
+ *     []
+ *   );
+ *   const state = useAsyncState(users);
+ *   return state.fallback ?? <UserList users={state.value} />;
+ *
+ * @returns
+ *   An object with either a property `fallback` being a JSX.Element to render,
+ *   or a `value` property.
+ */
+export function useAsyncState<T>(
+  state: AsyncState<T>,
+  opts: AsyncFallbackOptions = {},
+): AsyncFallbackResult<T> {
+  const { Progress } = useApp().getComponents();
+
+  const {
+    progress: ProgressComponent = Progress,
+    error: ErrorComponent = DefaultErrorComponent,
+  } = opts;
+
+  if (state.loading) {
+    return {
+      fallback: renderComponentOrElement(ProgressComponent, {}),
+      value: undefined,
+    };
+  } else if (state.error) {
+    return {
+      fallback: renderComponentOrElement(ErrorComponent, {
+        error: state.error,
+      }),
+      value: undefined,
+    };
+  }
+
+  return { fallback: undefined, value: state.value! };
+}
+
+/**
+ * Similar to `useAsync` from `react-use`, this function takes the same first
+ * two arguments, and an optional object which is the same as to
+ * `useAsyncState`.
+ *
+ * It returns the same as `useAsyncState`, and object with a `value` or
+ * `fallback` property, which can act as a type guard. If the `fallback`
+ * property is set, it should be rendered, otherwise `value` contains the
+ * synchronous value.
+ */
+export function useAsyncDefaults<T>(
+  fn: (...args: []) => Promise<T>,
+  deps: DependencyList = [],
+  opts: AsyncFallbackOptions = {},
+): AsyncFallbackResult<T> {
+  const asyncValue = useAsync(fn, deps);
+  return useAsyncState(asyncValue, opts);
+}
+
+function renderComponentOrElement<P extends {}>(
+  componentOrElement: JSX.Element | ComponentType<P>,
+  props: P,
+): JSX.Element {
+  const ComponentAsComponent = componentOrElement as ComponentType<P>;
+
+  return isValidElement(componentOrElement) ? (
+    componentOrElement
+  ) : (
+    <ComponentAsComponent {...props} />
+  );
+}

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -9,6 +9,7 @@ import { BackstagePlugin as BackstagePlugin_2 } from '@backstage/core-plugin-api
 import { BackstageTheme } from '@backstage/theme';
 import { ComponentType } from 'react';
 import { Config } from '@backstage/config';
+import { CSSProperties } from 'react';
 import { IconComponent as IconComponent_2 } from '@backstage/core-plugin-api';
 import { Observable as Observable_2 } from '@backstage/types';
 import { Observer as Observer_2 } from '@backstage/types';
@@ -161,7 +162,10 @@ export type ApiRefType<T> = T extends ApiRef<infer U> ? U : never;
 export type AppComponents = {
   NotFoundErrorPage: ComponentType<{}>;
   BootErrorPage: ComponentType<BootErrorPageProps>;
-  Progress: ComponentType<{}>;
+  Progress: ComponentType<{
+    className?: string;
+    style?: CSSProperties;
+  }>;
   Router: ComponentType<{}>;
   ErrorBoundaryFallback: ComponentType<ErrorBoundaryFallbackProps>;
   ThemeProvider?: ComponentType<{}>;

--- a/plugins/allure/src/components/AllureReportComponent/AllureReportComponent.tsx
+++ b/plugins/allure/src/components/AllureReportComponent/AllureReportComponent.tsx
@@ -24,22 +24,21 @@ import {
 } from '../annotationHelpers';
 import {
   MissingAnnotationEmptyState,
-  Progress,
+  useAsyncDefaults,
 } from '@backstage/core-components';
-import { useAsync } from 'react-use';
 import { Entity } from '@backstage/catalog-model';
 
 const AllureReport = (props: { entity: Entity }) => {
   const allureApi = useApi(allureApiRef);
 
   const allureProjectId = getAllureProjectId(props.entity);
-  const { value, loading } = useAsync(async () => {
+  const { value, fallback } = useAsyncDefaults(async () => {
     const url = await allureApi.getReportUrl(allureProjectId);
     return url;
   });
 
-  if (loading) {
-    return <Progress />;
+  if (fallback) {
+    return fallback;
   }
   return (
     <iframe

--- a/plugins/bazaar/src/components/EntityBazaarInfoCard/EntityBazaarInfoCard.tsx
+++ b/plugins/bazaar/src/components/EntityBazaarInfoCard/EntityBazaarInfoCard.tsx
@@ -31,10 +31,10 @@ import {
   Link,
 } from '@material-ui/core';
 import {
-  Progress,
   HeaderIconLinkRow,
   IconLinkVerticalProps,
   Avatar,
+  useAsyncState,
 } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { AboutField } from '@backstage/plugin-catalog';
@@ -50,7 +50,6 @@ import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import { useApi, identityApiRef } from '@backstage/core-plugin-api';
 import { Member, BazaarProject } from '../../types';
 import { bazaarApiRef } from '../../api';
-import { Alert } from '@material-ui/lab';
 import { useAsyncFn } from 'react-use';
 
 const useStyles = makeStyles({
@@ -127,6 +126,9 @@ export const EntityBazaarInfoCard = () => {
     return null;
   });
 
+  const asyncMembersState = useAsyncState(members);
+  const asyncBazaarProjectState = useAsyncState(bazaarProject);
+
   useEffect(() => {
     fetchMembers();
     fetchBazaarProject();
@@ -190,13 +192,10 @@ export const EntityBazaarInfoCard = () => {
 
   if (!isBazaar) {
     return null;
-  } else if (bazaarProject.loading || members.loading) {
-    return <Progress />;
-  } else if (bazaarProject.error) {
-    return <Alert severity="error">{bazaarProject?.error?.message}</Alert>;
-  } else if (members.error) {
-    return <Alert severity="error">{members?.error?.message}</Alert>;
+  } else if (asyncMembersState.fallback ?? asyncBazaarProjectState.fallback) {
+    return asyncMembersState.fallback ?? asyncBazaarProjectState.fallback;
   }
+
   return (
     <Card>
       {bazaarProject?.value && (

--- a/plugins/bazaar/src/components/SortView/SortView.tsx
+++ b/plugins/bazaar/src/components/SortView/SortView.tsx
@@ -19,7 +19,7 @@ import {
   Content,
   ContentHeader,
   SupportButton,
-  Progress,
+  useAsyncState,
 } from '@backstage/core-components';
 import { AddProjectDialog } from '../AddProjectDialog';
 import { AlertBanner } from '../AlertBanner';
@@ -31,7 +31,6 @@ import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { BazaarProject } from '../../types';
 import { bazaarApiRef } from '../../api';
-import { Alert } from '@material-ui/lab';
 
 const useStyles = makeStyles({
   container: {
@@ -106,6 +105,9 @@ export const SortView = () => {
     return dbProjects;
   });
 
+  const asyncCatalogEntitiesState = useAsyncState(catalogEntities);
+  const asyncBazaarProjectsState = useAsyncState(bazaarProjects);
+
   useEffect(() => {
     fetchCatalogEntities();
     fetchBazaarProjects();
@@ -122,13 +124,12 @@ export const SortView = () => {
     }
   }, [bazaarProjects, catalogEntities]);
 
-  if (catalogEntities.loading || bazaarProjects.loading) return <Progress />;
-
-  if (catalogEntities.error)
-    return <Alert severity="error">{catalogEntities.error.message}</Alert>;
-
-  if (bazaarProjects.error)
-    return <Alert severity="error">{bazaarProjects.error.message}</Alert>;
+  if (asyncCatalogEntitiesState.fallback) {
+    return asyncCatalogEntitiesState.fallback;
+  }
+  if (asyncBazaarProjectsState.fallback) {
+    return asyncBazaarProjectsState.fallback;
+  }
 
   return (
     <Content noPadding>

--- a/plugins/bitrise/src/components/BitriseArtifactsComponent/BitriseArtifactsComponent.tsx
+++ b/plugins/bitrise/src/components/BitriseArtifactsComponent/BitriseArtifactsComponent.tsx
@@ -25,7 +25,7 @@ import {
   ListItemSecondaryAction,
   ListItemText,
 } from '@material-ui/core';
-import { Progress } from '@backstage/core-components';
+import { useAsyncState } from '@backstage/core-components';
 
 type BitriseArtifactsComponentComponentProps = {
   build: BitriseBuildResult;
@@ -34,16 +34,16 @@ type BitriseArtifactsComponentComponentProps = {
 export const BitriseArtifactsComponent = (
   props: BitriseArtifactsComponentComponentProps,
 ) => {
-  const { value, loading, error } = useBitriseArtifacts(
-    props.build.appSlug,
-    props.build.buildSlug,
+  const asyncState = useAsyncState(
+    useBitriseArtifacts(props.build.appSlug, props.build.buildSlug),
   );
 
-  if (loading) {
-    return <Progress />;
-  } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
-  } else if (!value || !value.length) {
+  if (asyncState.fallback) {
+    return asyncState.fallback;
+  }
+  const { value } = asyncState;
+
+  if (!value || !value.length) {
     return <Alert severity="info">No artifacts</Alert>;
   }
 

--- a/plugins/code-coverage/src/components/FileExplorer/FileContent.tsx
+++ b/plugins/code-coverage/src/components/FileExplorer/FileContent.tsx
@@ -18,13 +18,15 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 import { makeStyles, Paper } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import React from 'react';
-import { useAsync } from 'react-use';
 import { codeCoverageApiRef } from '../../api';
 import { FileEntry } from '../../types';
 import { CodeRow } from './CodeRow';
 import { highlightLines } from './Highlighter';
 
-import { Progress, ResponseErrorPanel } from '@backstage/core-components';
+import {
+  ResponseErrorPanel,
+  useAsyncDefaults,
+} from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
 type Props = {
@@ -77,7 +79,7 @@ const FormattedLines = ({
 export const FileContent = ({ filename, coverage }: Props) => {
   const { entity } = useEntity();
   const codeCoverageApi = useApi(codeCoverageApiRef);
-  const { loading, error, value } = useAsync(
+  const { value, fallback } = useAsyncDefaults(
     async () =>
       await codeCoverageApi.getFileContentFromEntity(
         {
@@ -88,15 +90,15 @@ export const FileContent = ({ filename, coverage }: Props) => {
         filename,
       ),
     [entity],
+    {
+      error: ({ error }) => <ResponseErrorPanel error={error} />,
+    },
   );
 
   const classes = useStyles();
 
-  if (loading) {
-    return <Progress />;
-  }
-  if (error) {
-    return <ResponseErrorPanel error={error} />;
+  if (fallback) {
+    return fallback;
   }
   if (!value) {
     return (

--- a/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPage.tsx
+++ b/plugins/cost-insights/src/components/CostInsightsPage/CostInsightsPage.tsx
@@ -60,7 +60,7 @@ import {
   isAlertSnoozed,
 } from '../../utils/alerts';
 
-import { Progress } from '@backstage/core-components';
+import { useAsyncState } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
 export const CostInsightsPage = () => {
@@ -174,12 +174,13 @@ export const CostInsightsPage = () => {
     lastCompleteBillingDate,
   ]);
 
-  if (loadingInitial) {
-    return <Progress />;
-  }
+  const { fallback } = useAsyncState({
+    loading: loadingInitial,
+    error: error || undefined,
+  });
 
-  if (error) {
-    return <MaterialAlert severity="error">{error.message}</MaterialAlert>;
+  if (fallback) {
+    return fallback;
   }
 
   // Loaded but no groups found for the user

--- a/plugins/explore/src/components/ToolExplorerContent/ToolExplorerContent.tsx
+++ b/plugins/explore/src/components/ToolExplorerContent/ToolExplorerContent.tsx
@@ -16,7 +16,6 @@
 
 import { exploreToolsConfigRef } from '@backstage/plugin-explore-react';
 import React from 'react';
-import { useAsync } from 'react-use';
 import { ToolCard } from '../ToolCard';
 
 import {
@@ -24,8 +23,8 @@ import {
   ContentHeader,
   EmptyState,
   ItemCardGrid,
-  Progress,
   SupportButton,
+  useAsyncDefaults,
   WarningPanel,
 } from '@backstage/core-components';
 
@@ -33,23 +32,22 @@ import { useApi } from '@backstage/core-plugin-api';
 
 const Body = () => {
   const exploreToolsConfigApi = useApi(exploreToolsConfigRef);
-  const {
-    value: tools,
-    loading,
-    error,
-  } = useAsync(async () => {
-    return await exploreToolsConfigApi.getTools();
-  }, [exploreToolsConfigApi]);
+  const asyncState = useAsyncDefaults(
+    async () => {
+      return await exploreToolsConfigApi.getTools();
+    },
+    [exploreToolsConfigApi],
+    {
+      error: <WarningPanel title="Failed to load tools" />,
+    },
+  );
 
-  if (loading) {
-    return <Progress />;
+  if (asyncState.fallback) {
+    return asyncState.fallback;
   }
+  const tools = asyncState.value;
 
-  if (error) {
-    return <WarningPanel title="Failed to load tools" />;
-  }
-
-  if (!tools?.length) {
+  if (!tools.length) {
     return (
       <EmptyState
         missing="info"

--- a/plugins/git-release-manager/src/GitReleaseManager.tsx
+++ b/plugins/git-release-manager/src/GitReleaseManager.tsx
@@ -15,11 +15,10 @@
  */
 
 import React from 'react';
-import { useAsync } from 'react-use';
 import { Alert } from '@material-ui/lab';
 import { Box } from '@material-ui/core';
 import { useApi } from '@backstage/core-plugin-api';
-import { ContentHeader, Progress } from '@backstage/core-components';
+import { ContentHeader, useAsyncDefaults } from '@backstage/core-components';
 
 import {
   ComponentConfig,
@@ -82,19 +81,15 @@ export function GitReleaseManager(props: GitReleaseManagerProps) {
         isProvidedViaProps: false,
       };
 
-  const userResponse = useAsync(() =>
+  const userResponse = useAsyncDefaults(() =>
     pluginApiClient.getUser({ owner: project.owner, repo: project.repo }),
   );
 
-  if (userResponse.error) {
-    return <Alert severity="error">{userResponse.error.message}</Alert>;
+  if (userResponse.fallback) {
+    return userResponse.fallback;
   }
 
-  if (userResponse.loading) {
-    return <Progress />;
-  }
-
-  if (!userResponse.value?.user.username) {
+  if (!userResponse.value.user.username) {
     return <Alert severity="error">Unable to retrieve username</Alert>;
   }
 

--- a/plugins/git-release-manager/src/features/Stats/DialogBody.tsx
+++ b/plugins/git-release-manager/src/features/Stats/DialogBody.tsx
@@ -34,7 +34,7 @@ import { Row } from './Row/Row';
 import { useGetStats } from './hooks/useGetStats';
 import { useProjectContext } from '../../contexts/ProjectContext';
 import { Warn } from './Warn';
-import { Progress } from '@backstage/core-components';
+import { useAsyncState } from '@backstage/core-components';
 
 const useStyles = makeStyles({
   table: {
@@ -47,21 +47,21 @@ export function DialogBody() {
   const { stats } = useGetStats();
   const { project } = useProjectContext();
 
-  if (stats.error) {
-    return (
-      <Alert severity="error">Unexpected error: {stats.error.message}</Alert>
-    );
+  const asyncState = useAsyncState(stats, {
+    error: ({ error }) => (
+      <Alert severity="error">Unexpected error: {error.message}</Alert>
+    ),
+  });
+  if (asyncState.fallback) {
+    return asyncState.fallback;
   }
+  const { value } = asyncState;
 
-  if (stats.loading) {
-    return <Progress />;
-  }
-
-  if (!stats.value) {
+  if (!value) {
     return <Alert severity="error">Couldn't find any stats :(</Alert>;
   }
 
-  const { allReleases, allTags } = stats.value;
+  const { allReleases, allTags } = value;
   const { mappedReleases } = getMappedReleases({ allReleases, project });
   const { releaseStats } = getReleaseStats({
     mappedReleases,

--- a/plugins/newrelic/src/components/NewRelicFetchComponent/NewRelicFetchComponent.tsx
+++ b/plugins/newrelic/src/components/NewRelicFetchComponent/NewRelicFetchComponent.tsx
@@ -15,11 +15,13 @@
  */
 
 import React from 'react';
-import Alert from '@material-ui/lab/Alert';
-import { useAsync } from 'react-use';
 import { newRelicApiRef, NewRelicApplications } from '../../api';
 
-import { Progress, Table, TableColumn } from '@backstage/core-components';
+import {
+  Table,
+  TableColumn,
+  useAsyncDefaults,
+} from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
 export const NewRelicAPMTable = ({ applications }: NewRelicApplications) => {
@@ -64,20 +66,18 @@ export const NewRelicAPMTable = ({ applications }: NewRelicApplications) => {
 const NewRelicFetchComponent = () => {
   const api = useApi(newRelicApiRef);
 
-  const { value, loading, error } = useAsync(async () => {
+  const asyncState = useAsyncDefaults(async () => {
     const data = await api.getApplications();
     return data.applications.filter(application => {
       return application.hasOwnProperty('application_summary');
     });
   }, []);
 
-  if (loading) {
-    return <Progress />;
-  } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+  if (asyncState.fallback) {
+    return asyncState.fallback;
   }
 
-  return <NewRelicAPMTable applications={value || []} />;
+  return <NewRelicAPMTable applications={asyncState.value} />;
 };
 
 export default NewRelicFetchComponent;

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -17,7 +17,6 @@ import React, { useCallback, useEffect } from 'react';
 import { FieldProps } from '@rjsf/core';
 import { scaffolderApiRef } from '../../../api';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
-import { useAsync } from 'react-use';
 import Select from '@material-ui/core/Select';
 import InputLabel from '@material-ui/core/InputLabel';
 import Input from '@material-ui/core/Input';
@@ -25,7 +24,7 @@ import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 
 import { useApi } from '@backstage/core-plugin-api';
-import { Progress } from '@backstage/core-components';
+import { useAsyncDefaults } from '@backstage/core-components';
 
 function splitFormData(url: string | undefined) {
   let host = undefined;
@@ -96,9 +95,10 @@ export const RepoUrlPicker = ({
   const integrationApi = useApi(scmIntegrationsApiRef);
   const allowedHosts = uiSchema['ui:options']?.allowedHosts as string[];
 
-  const { value: integrations, loading } = useAsync(async () => {
+  const integrationsState = useAsyncDefaults(async () => {
     return await scaffolderApi.getIntegrationsList({ allowedHosts });
   });
+  const integrations = integrationsState.value;
 
   const { host, owner, repo, organization, workspace, project } =
     splitFormData(formData);
@@ -217,8 +217,8 @@ export const RepoUrlPicker = ({
     project,
   ]);
 
-  if (loading) {
-    return <Progress />;
+  if (integrationsState.fallback) {
+    return integrationsState.fallback;
   }
 
   return (

--- a/plugins/search/src/components/SearchResult/SearchResult.tsx
+++ b/plugins/search/src/components/SearchResult/SearchResult.tsx
@@ -16,8 +16,8 @@
 
 import {
   EmptyState,
-  Progress,
   ResponseErrorPanel,
+  useAsyncState,
 } from '@backstage/core-components';
 import { SearchResult } from '@backstage/search-common';
 import React from 'react';
@@ -28,23 +28,23 @@ type Props = {
 };
 
 export const SearchResultComponent = ({ children }: Props) => {
-  const {
-    result: { loading, error, value },
-  } = useSearch();
+  const { result } = useSearch();
 
-  if (loading) {
-    return <Progress />;
-  }
-  if (error) {
-    return (
+  const asyncState = useAsyncState(result, {
+    error: ({ error }) => (
       <ResponseErrorPanel
         title="Error encountered while fetching search results"
         error={error}
       />
-    );
-  }
+    ),
+  });
 
-  if (!value?.results.length) {
+  if (asyncState.fallback) {
+    return asyncState.fallback;
+  }
+  const { value } = asyncState;
+
+  if (!value.results.length) {
     return <EmptyState missing="data" title="Sorry, no results were found" />;
   }
 


### PR DESCRIPTION
This is a continuation, or potentially replacement for #7269.

The reasoning is that in a lot of places, `useAsync` is used and isn't using the app-configured Progress and errors aren't always handled. Both these should be generalized. The `useAsyncDefaults` as a replacement for `useAsync` gives you either a `fallback` property which should be rendered, or a `value` property which won't be undefined/null (well, unless that's a possibility given what the predicate returns).

This means we can sometimes simplify code, sometimes just generalize, and often get rid of `?` and `!` for the values, since this isn't very strictly typed in `useAsync`.

This PR currently contains commits with:
 * The code for this
 * Implementations in various places
 * and a replacement for Progress for every other place in the codebase (complex `useAsync` cases, `Suspense` etc).

We have quite a few places where `Progress` is imported from core-components rather than being taken from `useApp().getComponents().Progress`. To mitigate this, `Progress` was re-implemented as basically just that, and the fallback component renamed `DefaultProgress`.