### PR TITLE
core,test-utils: deprecate ApiRegistry, add new TestApiProvider and TestApiRegistry

### DIFF
--- a/.changeset/wet-seas-deliver.md
+++ b/.changeset/wet-seas-deliver.md
@@ -31,7 +31,7 @@ render(
 )
 ```
 
-In cases where the `ApiProvider` is used in a more standalone way, for example to reuse a set of APIs across multiple tests, the `TestApiRegistry` can be used instead. Note that the `TestApiRegistry` only has a single static factory method, `.with()`, and it is slightly different from the existing `.with()` method on `ApiRegistry`.
+In cases where the `ApiProvider` is used in a more standalone way, for example to reuse a set of APIs across multiple tests, the `TestApiRegistry` can be used instead. Note that the `TestApiRegistry` only has a single static factory method, `.from()`, and it is slightly different from the existing `.from()` method on `ApiRegistry` in that it doesn't require the API pairs to be wrapped in an outer array.
 
 Usage that looks like this:
 

--- a/.changeset/wet-seas-deliver.md
+++ b/.changeset/wet-seas-deliver.md
@@ -54,7 +54,7 @@ const apis = ApiRegistry.from([
 Would be migrated to this:
 
 ```ts
-const apis = TestApiRegistry.with(
+const apis = TestApiRegistry.from(
   [identityApiRef, mockIdentityApi],
   [configApiRef, new ConfigReader({})],
 );

--- a/.changeset/wet-seas-deliver.md
+++ b/.changeset/wet-seas-deliver.md
@@ -1,0 +1,63 @@
+---
+'@backstage/core-app-api': patch
+'@backstage/test-utils': patch
+---
+
+The `ApiRegistry` from `@backstage/core-app-api` class has been deprecated and will be removed in a future release. To replace it, we have introduced two new helpers that are exported from `@backstage/test-utils`, namely `TestApiProvider` and `TestApiRegistry`.
+
+These two new helpers are more tailored for writing tests and development setups, as they allow for partial implementations of each of the APIs.
+
+When migrating existing code it is typically best to prefer usage of `TestApiProvider` when possible, so for example the following code:
+
+```tsx
+render(
+  <ApiProvider
+    apis={ApiRegistry.from([
+      [identityApiRef, mockIdentityApi as unknown as IdentityApi]
+    ])}
+  >
+    {...}
+  </ApiProvider>
+)
+```
+
+Would be migrated to this:
+
+```tsx
+render(
+  <TestApiProvider apis={[[identityApiRef, mockIdentityApi]]}>
+    {...}
+  </TestApiProvider>
+)
+```
+
+In cases where the `ApiProvider` is used in a more standalone way, for example to reuse a set of APIs across multiple tests, the `TestApiRegistry` can be used instead. Note that the `TestApiRegistry` only has a single static factory method, `.with()`, and it is slightly different from the existing `.with()` method on `ApiRegistry`.
+
+Usage that looks like this:
+
+```ts
+const apis = ApiRegistry.with(
+  identityApiRef,
+  mockIdentityApi as unknown as IdentityApi,
+).with(configApiRef, new ConfigReader({}));
+```
+
+OR like this:
+
+```ts
+const apis = ApiRegistry.from([
+  [identityApiRef, mockIdentityApi as unknown as IdentityApi],
+  [configApiRef, new ConfigReader({})],
+]);
+```
+
+Would be migrated to this:
+
+```ts
+const apis = TestApiRegistry.with(
+  [identityApiRef, mockIdentityApi],
+  [configApiRef, new ConfigReader({})],
+);
+```
+
+If your app is still using the `ApiRegistry` to construct the `apis` for `createApp`, we recommend that you move over to use the new method of supplying API factories instead, using `createApiFactory`.

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -126,7 +126,7 @@ export type ApiProviderProps = {
   children: ReactNode;
 };
 
-// @public
+// @public @deprecated
 export class ApiRegistry implements ApiHolder {
   constructor(apis: Map<string, unknown>);
   // Warning: (ae-forgotten-export) The symbol "ApiRegistryBuilder" needs to be exported by the entry point index.d.ts

--- a/packages/core-app-api/src/apis/system/ApiRegistry.ts
+++ b/packages/core-app-api/src/apis/system/ApiRegistry.ts
@@ -36,6 +36,7 @@ class ApiRegistryBuilder {
  * A registry for utility APIs.
  *
  * @public
+ * @deprecated Will be removed, use {@link @backstage/test-utils#TestApiProvider} instead.
  */
 export class ApiRegistry implements ApiHolder {
   static builder() {

--- a/packages/core-app-api/src/apis/system/ApiRegistry.ts
+++ b/packages/core-app-api/src/apis/system/ApiRegistry.ts
@@ -36,7 +36,7 @@ class ApiRegistryBuilder {
  * A registry for utility APIs.
  *
  * @public
- * @deprecated Will be removed, use {@link @backstage/test-utils#TestApiProvider} instead.
+ * @deprecated Will be removed, use {@link @backstage/test-utils#TestApiProvider} or {@link @backstage/test-utils#TestApiRegistry} instead.
  */
 export class ApiRegistry implements ApiHolder {
   static builder() {

--- a/packages/core-app-api/src/routing/FeatureFlagged.test.tsx
+++ b/packages/core-app-api/src/routing/FeatureFlagged.test.tsx
@@ -16,14 +16,15 @@
 import React from 'react';
 import { FeatureFlagged } from './FeatureFlagged';
 import { render } from '@testing-library/react';
-import { ApiProvider, ApiRegistry, LocalStorageFeatureFlags } from '../apis';
+import { LocalStorageFeatureFlags } from '../apis';
+import { TestApiProvider } from '@backstage/test-utils';
 import { featureFlagsApiRef } from '@backstage/core-plugin-api';
 
 const mockFeatureFlagsApi = new LocalStorageFeatureFlags();
 const Wrapper = ({ children }: { children?: React.ReactNode }) => (
-  <ApiProvider apis={ApiRegistry.with(featureFlagsApiRef, mockFeatureFlagsApi)}>
+  <TestApiProvider apis={[[featureFlagsApiRef, mockFeatureFlagsApi]]}>
     {children}
-  </ApiProvider>
+  </TestApiProvider>
 );
 
 describe('FeatureFlagged', () => {

--- a/packages/core-app-api/src/routing/FlatRoutes.test.tsx
+++ b/packages/core-app-api/src/routing/FlatRoutes.test.tsx
@@ -17,17 +17,18 @@
 import { render, RenderResult } from '@testing-library/react';
 import React, { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes, useOutlet } from 'react-router-dom';
-import { ApiProvider, ApiRegistry, LocalStorageFeatureFlags } from '../apis';
+import { LocalStorageFeatureFlags } from '../apis';
 import { featureFlagsApiRef } from '@backstage/core-plugin-api';
 import { AppContext } from '../app';
 import { AppContextProvider } from '../app/AppContext';
 import { FlatRoutes } from './FlatRoutes';
+import { TestApiProvider } from '@backstage/test-utils';
 
 const mockFeatureFlagsApi = new LocalStorageFeatureFlags();
 const Wrapper = ({ children }: { children?: React.ReactNode }) => (
-  <ApiProvider apis={ApiRegistry.with(featureFlagsApiRef, mockFeatureFlagsApi)}>
+  <TestApiProvider apis={[[featureFlagsApiRef, mockFeatureFlagsApi]]}>
     {children}
-  </ApiProvider>
+  </TestApiProvider>
 );
 
 function makeRouteRenderer(node: ReactNode) {

--- a/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
+++ b/packages/core-components/src/components/CopyTextButton/CopyTextButton.test.tsx
@@ -17,10 +17,9 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { CopyTextButton } from './CopyTextButton';
-import { ApiProvider, ApiRegistry } from '@backstage/core-app-api';
-import { errorApiRef, ErrorApi } from '@backstage/core-plugin-api';
+import { errorApiRef } from '@backstage/core-plugin-api';
 import { useCopyToClipboard } from 'react-use';
 
 jest.mock('popper.js', () => {
@@ -51,22 +50,18 @@ const props = {
   tooltipText: 'mockTooltip',
 };
 
-const apiRegistry = ApiRegistry.from([
-  [
-    errorApiRef,
-    {
-      post: jest.fn(),
-      error$: jest.fn(),
-    } as ErrorApi,
-  ],
-]);
+const mockErrorApi = {
+  post: jest.fn(),
+  error$: jest.fn(),
+};
+const apis = [[errorApiRef, mockErrorApi] as const] as const;
 
 describe('<CopyTextButton />', () => {
   it('renders without exploding', async () => {
     const { getByTitle, queryByText } = await renderInTestApp(
-      <ApiProvider apis={apiRegistry}>
+      <TestApiProvider apis={apis}>
         <CopyTextButton {...props} />
-      </ApiProvider>,
+      </TestApiProvider>,
     );
     expect(getByTitle('mockTooltip')).toBeInTheDocument();
     expect(queryByText('mockTooltip')).not.toBeInTheDocument();
@@ -80,9 +75,9 @@ describe('<CopyTextButton />', () => {
     spy.mockReturnValue([{}, copy]);
 
     const rendered = await renderInTestApp(
-      <ApiProvider apis={apiRegistry}>
+      <TestApiProvider apis={apis}>
         <CopyTextButton {...props} />
-      </ApiProvider>,
+      </TestApiProvider>,
     );
     const button = rendered.getByTitle('mockTooltip');
     fireEvent.click(button);
@@ -101,10 +96,10 @@ describe('<CopyTextButton />', () => {
     spy.mockReturnValue([{ error }, jest.fn()]);
 
     await renderInTestApp(
-      <ApiProvider apis={apiRegistry}>
+      <TestApiProvider apis={apis}>
         <CopyTextButton {...props} />
-      </ApiProvider>,
+      </TestApiProvider>,
     );
-    expect(apiRegistry.get(errorApiRef)?.post).toHaveBeenCalledWith(error);
+    expect(mockErrorApi.post).toHaveBeenCalledWith(error);
   });
 });

--- a/packages/core-components/src/components/DismissableBanner/DismissableBanner.stories.tsx
+++ b/packages/core-components/src/components/DismissableBanner/DismissableBanner.stories.tsx
@@ -18,12 +18,13 @@ import React from 'react';
 import { DismissableBanner } from './DismissableBanner';
 import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
-import { ApiProvider, ApiRegistry, WebStorage } from '@backstage/core-app-api';
+import { WebStorage } from '@backstage/core-app-api';
 import {
   ErrorApi,
   storageApiRef,
   StorageApi,
 } from '@backstage/core-plugin-api';
+import { TestApiProvider } from '@backstage/test-utils';
 
 export default {
   title: 'Feedback/DismissableBanner',
@@ -37,47 +38,47 @@ const createWebStorage = (): StorageApi => {
   return WebStorage.create({ errorApi });
 };
 
-const apis = ApiRegistry.from([[storageApiRef, createWebStorage()]]);
+const apis = [[storageApiRef, createWebStorage()] as const];
 
 export const Default = () => (
   <div style={containerStyle}>
-    <ApiProvider apis={apis}>
+    <TestApiProvider apis={apis}>
       <DismissableBanner
         message="This is a dismissable banner"
         variant="info"
         id="default_dismissable"
       />
-    </ApiProvider>
+    </TestApiProvider>
   </div>
 );
 
 export const Error = () => (
   <div style={containerStyle}>
-    <ApiProvider apis={apis}>
+    <TestApiProvider apis={apis}>
       <DismissableBanner
         message="This is a dismissable banner with an error message"
         variant="error"
         id="error_dismissable"
       />
-    </ApiProvider>
+    </TestApiProvider>
   </div>
 );
 
 export const EmojisIncluded = () => (
   <div style={containerStyle}>
-    <ApiProvider apis={apis}>
+    <TestApiProvider apis={apis}>
       <DismissableBanner
         message="This is a dismissable banner with emojis: 🚀 💚 😆 "
         variant="info"
         id="emojis_dismissable"
       />
-    </ApiProvider>
+    </TestApiProvider>
   </div>
 );
 
 export const WithLink = () => (
   <div style={containerStyle}>
-    <ApiProvider apis={apis}>
+    <TestApiProvider apis={apis}>
       <DismissableBanner
         message={
           <Typography>
@@ -90,29 +91,29 @@ export const WithLink = () => (
         variant="info"
         id="linked_dismissable"
       />
-    </ApiProvider>
+    </TestApiProvider>
   </div>
 );
 export const Fixed = () => (
   <div style={containerStyle}>
-    <ApiProvider apis={apis}>
+    <TestApiProvider apis={apis}>
       <DismissableBanner
         message="This is a dismissable banner with a fixed position fixed at the bottom of the page"
         variant="info"
         id="fixed_dismissable"
         fixed
       />
-    </ApiProvider>
+    </TestApiProvider>
   </div>
 );
 export const Warning = () => (
   <div style={containerStyle}>
-    <ApiProvider apis={apis}>
+    <TestApiProvider apis={apis}>
       <DismissableBanner
         message="This is a dismissable banner with a warning message"
         variant="warning"
         id="warning_dismissable"
       />
-    </ApiProvider>
+    </TestApiProvider>
   </div>
 );

--- a/packages/core-components/src/components/DismissableBanner/DismissableBanner.test.tsx
+++ b/packages/core-components/src/components/DismissableBanner/DismissableBanner.test.tsx
@@ -35,7 +35,7 @@ describe('<DismissableBanner />', () => {
   };
 
   beforeEach(() => {
-    apis = TestApiRegistry.with([storageApiRef, createWebStorage()]);
+    apis = TestApiRegistry.from([storageApiRef, createWebStorage()]);
   });
 
   it('renders the message and the popover', async () => {

--- a/packages/core-components/src/components/DismissableBanner/DismissableBanner.test.tsx
+++ b/packages/core-components/src/components/DismissableBanner/DismissableBanner.test.tsx
@@ -16,13 +16,17 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { renderWithEffects, wrapInTestApp } from '@backstage/test-utils';
+import {
+  renderWithEffects,
+  TestApiRegistry,
+  wrapInTestApp,
+} from '@backstage/test-utils';
 import { DismissableBanner } from './DismissableBanner';
-import { ApiRegistry, ApiProvider, WebStorage } from '@backstage/core-app-api';
+import { ApiProvider, WebStorage } from '@backstage/core-app-api';
 import { storageApiRef, StorageApi } from '@backstage/core-plugin-api';
 
 describe('<DismissableBanner />', () => {
-  let apis: ApiRegistry;
+  let apis: TestApiRegistry;
   const mockErrorApi = { post: jest.fn(), error$: jest.fn() };
   const createWebStorage = (): StorageApi => {
     return WebStorage.create({
@@ -31,7 +35,7 @@ describe('<DismissableBanner />', () => {
   };
 
   beforeEach(() => {
-    apis = ApiRegistry.from([[storageApiRef, createWebStorage()]]);
+    apis = TestApiRegistry.with([storageApiRef, createWebStorage()]);
   });
 
   it('renders the message and the popover', async () => {

--- a/packages/core-components/src/components/Link/Link.test.tsx
+++ b/packages/core-components/src/components/Link/Link.test.tsx
@@ -16,8 +16,11 @@
 
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
-import { MockAnalyticsApi, wrapInTestApp } from '@backstage/test-utils';
-import { ApiProvider, ApiRegistry } from '@backstage/core-app-api';
+import {
+  MockAnalyticsApi,
+  TestApiProvider,
+  wrapInTestApp,
+} from '@backstage/test-utils';
 import { analyticsApiRef } from '@backstage/core-plugin-api';
 import { isExternalUri, Link } from './Link';
 import { Route, Routes } from 'react-router';
@@ -48,11 +51,11 @@ describe('<Link />', () => {
 
     const { getByText } = render(
       wrapInTestApp(
-        <ApiProvider apis={ApiRegistry.from([[analyticsApiRef, analyticsApi]])}>
+        <TestApiProvider apis={[[analyticsApiRef, analyticsApi]]}>
           <Link to="/test" onClick={customOnClick}>
             {linkText}
           </Link>
-        </ApiProvider>,
+        </TestApiProvider>,
       ),
     );
 

--- a/packages/core-components/src/layout/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/core-components/src/layout/ErrorBoundary/ErrorBoundary.test.tsx
@@ -20,9 +20,9 @@ import { ErrorBoundary } from './ErrorBoundary';
 import {
   MockErrorApi,
   renderInTestApp,
+  TestApiProvider,
   withLogCollector,
 } from '@backstage/test-utils';
-import { ApiProvider, ApiRegistry } from '@backstage/core-app-api';
 import { errorApiRef } from '@backstage/core-plugin-api';
 
 type BombProps = {
@@ -41,25 +41,25 @@ const Bomb = ({ shouldThrow }: BombProps) => {
 describe('<ErrorBoundary/>', () => {
   it('should render error boundary with and without error', async () => {
     const { error } = await withLogCollector(['error'], async () => {
-      const apis = ApiRegistry.with(errorApiRef, new MockErrorApi());
+      const errorApi = new MockErrorApi();
       const { rerender, queryByRole, getByRole, getByText } =
         await renderInTestApp(
-          <ApiProvider apis={apis}>
+          <TestApiProvider apis={[[errorApiRef, errorApi]]}>
             <ErrorBoundary>
               <Bomb />
             </ErrorBoundary>
-          </ApiProvider>,
+          </TestApiProvider>,
         );
 
       expect(queryByRole('alert')).not.toBeInTheDocument();
       expect(getByText(/working component/i)).toBeInTheDocument();
 
       rerender(
-        <ApiProvider apis={apis}>
+        <TestApiProvider apis={[[errorApiRef, errorApi]]}>
           <ErrorBoundary>
             <Bomb shouldThrow />
           </ErrorBoundary>
-        </ApiProvider>,
+        </TestApiProvider>,
       );
 
       expect(getByRole('alert')).toBeInTheDocument();

--- a/packages/core-components/src/layout/Header/Header.test.tsx
+++ b/packages/core-components/src/layout/Header/Header.test.tsx
@@ -15,13 +15,9 @@
  */
 
 import React from 'react';
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { Header } from './Header';
-import {
-  ApiRegistry,
-  ConfigReader,
-  ApiProvider,
-} from '@backstage/core-app-api';
+import { ConfigReader } from '@backstage/core-app-api';
 import { configApiRef } from '@backstage/core-plugin-api';
 
 jest.mock('react-helmet', () => {
@@ -72,14 +68,12 @@ describe('<Header/>', () => {
   });
 
   it('should use app.title', async () => {
-    const apiRegistry = ApiRegistry.with(
-      configApiRef,
-      new ConfigReader({ app: { title: 'Blah' } }),
-    );
     const rendered = await renderInTestApp(
-      <ApiProvider apis={apiRegistry}>
+      <TestApiProvider
+        apis={[[configApiRef, new ConfigReader({ app: { title: 'Blah' } })]]}
+      >
         <Header title="Title" type="tool" typeLink="/tool" />,
-      </ApiProvider>,
+      </TestApiProvider>,
     );
     rendered.getAllByText(/Title | Blah/);
   });

--- a/packages/core-components/src/layout/HomepageTimer/HomepageTimer.test.tsx
+++ b/packages/core-components/src/layout/HomepageTimer/HomepageTimer.test.tsx
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-import { renderWithEffects } from '@backstage/test-utils';
+import { renderWithEffects, TestApiProvider } from '@backstage/test-utils';
 import { HomepageTimer } from './HomepageTimer';
 import React from 'react';
 import { lightTheme } from '@backstage/theme';
 import { ThemeProvider } from '@material-ui/core/styles';
-import {
-  ApiProvider,
-  ApiRegistry,
-  ConfigReader,
-} from '@backstage/core-app-api';
+import { ConfigReader } from '@backstage/core-app-api';
 import { ConfigApi, configApiRef } from '@backstage/core-plugin-api';
 
 it('changes default timezone to GMT', async () => {
@@ -41,9 +37,9 @@ it('changes default timezone to GMT', async () => {
 
   const rendered = await renderWithEffects(
     <ThemeProvider theme={lightTheme}>
-      <ApiProvider apis={ApiRegistry.from([[configApiRef, configApi]])}>
+      <TestApiProvider apis={[[configApiRef, configApi]]}>
         <HomepageTimer />
-      </ApiProvider>
+      </TestApiProvider>
     </ThemeProvider>,
   );
 

--- a/packages/core-plugin-api/src/extensions/useElementFilter.test.tsx
+++ b/packages/core-plugin-api/src/extensions/useElementFilter.test.tsx
@@ -18,11 +18,8 @@ import { useElementFilter } from './useElementFilter';
 import { renderHook } from '@testing-library/react-hooks';
 import { attachComponentData } from './componentData';
 import { featureFlagsApiRef } from '../apis';
-import {
-  ApiProvider,
-  ApiRegistry,
-  LocalStorageFeatureFlags,
-} from '@backstage/core-app-api';
+import { LocalStorageFeatureFlags } from '@backstage/core-app-api';
+import { TestApiProvider } from '@backstage/test-utils';
 
 const WRAPPING_COMPONENT_KEY = 'core.blob.testing';
 const INNER_COMPONENT_KEY = 'core.blob2.testing';
@@ -45,9 +42,9 @@ const FeatureFlagComponent = (_props: {
 attachComponentData(FeatureFlagComponent, 'core.featureFlagged', true);
 const mockFeatureFlagsApi = new LocalStorageFeatureFlags();
 const Wrapper = ({ children }: { children?: React.ReactNode }) => (
-  <ApiProvider apis={ApiRegistry.with(featureFlagsApiRef, mockFeatureFlagsApi)}>
+  <TestApiProvider apis={[[featureFlagsApiRef, mockFeatureFlagsApi]]}>
     {children}
-  </ApiProvider>
+  </TestApiProvider>
 );
 
 describe('useElementFilter', () => {

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 import { AnalyticsApi } from '@backstage/core-plugin-api';
 import { AnalyticsEvent } from '@backstage/core-plugin-api';
+import { ApiRef } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { ErrorApi } from '@backstage/core-plugin-api';
 import { ErrorApiError } from '@backstage/core-plugin-api';
@@ -174,6 +175,18 @@ export function setupRequestMockHandlers(worker: {
 
 // @public
 export type SyncLogCollector = () => void;
+
+// @public
+export const TestApiProvider: <T extends any[]>({
+  apis,
+  children,
+}: TestApiProviderProps<T>) => JSX.Element;
+
+// @public
+export type TestApiProviderProps<TApiPairs extends any[]> = {
+  apis: [...TestApiProviderPropsApiPairs<TApiPairs>];
+  children: ReactNode;
+};
 
 // @public
 export type TestAppOptions = {

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -193,7 +193,7 @@ export type TestApiProviderProps<TApiPairs extends any[]> = {
 export class TestApiRegistry implements ApiHolder {
   // (undocumented)
   get<T>(api: ApiRef<T>): T | undefined;
-  static with<TApiPairs extends any[]>(
+  static from<TApiPairs extends any[]>(
     ...apis: readonly [...TestApiProviderPropsApiPairs<TApiPairs>]
   ): TestApiRegistry;
 }

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 import { AnalyticsApi } from '@backstage/core-plugin-api';
 import { AnalyticsEvent } from '@backstage/core-plugin-api';
+import { ApiHolder } from '@backstage/core-plugin-api';
 import { ApiRef } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { ErrorApi } from '@backstage/core-plugin-api';
@@ -184,9 +185,18 @@ export const TestApiProvider: <T extends any[]>({
 
 // @public
 export type TestApiProviderProps<TApiPairs extends any[]> = {
-  apis: [...TestApiProviderPropsApiPairs<TApiPairs>];
+  apis: readonly [...TestApiProviderPropsApiPairs<TApiPairs>];
   children: ReactNode;
 };
+
+// @public
+export class TestApiRegistry implements ApiHolder {
+  // (undocumented)
+  get<T>(api: ApiRef<T>): T | undefined;
+  static with<TApiPairs extends any[]>(
+    ...apis: readonly [...TestApiProviderPropsApiPairs<TApiPairs>]
+  ): TestApiRegistry;
+}
 
 // @public
 export type TestAppOptions = {

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -191,11 +191,10 @@ export type TestApiProviderProps<TApiPairs extends any[]> = {
 
 // @public
 export class TestApiRegistry implements ApiHolder {
-  // (undocumented)
-  get<T>(api: ApiRef<T>): T | undefined;
   static from<TApiPairs extends any[]>(
     ...apis: readonly [...TestApiProviderPropsApiPairs<TApiPairs>]
   ): TestApiRegistry;
+  get<T>(api: ApiRef<T>): T | undefined;
 }
 
 // @public

--- a/packages/test-utils/src/testUtils/TestApiProvider.test.tsx
+++ b/packages/test-utils/src/testUtils/TestApiProvider.test.tsx
@@ -98,7 +98,7 @@ describe('TestApiRegistry', () => {
   it('should be created with APIs', () => {
     const x = { a: 'a', b: 3 };
     const y = 'y';
-    const registry = TestApiRegistry.with([xApiRef, x], [yApiRef, y]);
+    const registry = TestApiRegistry.from([xApiRef, x], [yApiRef, y]);
 
     expect(registry.get(xApiRef)).toBe(x);
     expect(registry.get(yApiRef)).toBe(y);
@@ -106,7 +106,7 @@ describe('TestApiRegistry', () => {
 
   it('should allow partial implementations', () => {
     const x = { a: 'a' };
-    const registry = TestApiRegistry.with([xApiRef, x]);
+    const registry = TestApiRegistry.from([xApiRef, x]);
 
     expect(registry.get(xApiRef)).toBe(x);
     expect(registry.get(yApiRef)).toBeUndefined();
@@ -115,7 +115,7 @@ describe('TestApiRegistry', () => {
   it('should require partial implementations to match types', () => {
     const x = { a: 2 };
     // @ts-expect-error
-    const registry = TestApiRegistry.with([xApiRef, x]);
+    const registry = TestApiRegistry.from([xApiRef, x]);
 
     expect(registry.get(xApiRef)).toBe(x);
     expect(registry.get(yApiRef)).toBeUndefined();
@@ -125,7 +125,7 @@ describe('TestApiRegistry', () => {
     const x1 = { a: 'a' };
     const x2 = { a: 's' };
     const x3 = { a: 'd' };
-    const registry = TestApiRegistry.with(
+    const registry = TestApiRegistry.from(
       [xApiRef, x1],
       [xApiRef, x2],
       [xApiRef, x3],

--- a/packages/test-utils/src/testUtils/TestApiProvider.test.tsx
+++ b/packages/test-utils/src/testUtils/TestApiProvider.test.tsx
@@ -16,9 +16,8 @@
 
 import React from 'react';
 import { createApiRef, useApiHolder } from '@backstage/core-plugin-api';
-import { TestApiProvider } from './TestApiProvider';
+import { TestApiProvider, TestApiRegistry } from './TestApiProvider';
 import { render, screen } from '@testing-library/react';
-import { TestApiRegistry } from '.';
 
 const xApiRef = createApiRef<{ a: string; b: number }>({
   id: 'x',

--- a/packages/test-utils/src/testUtils/TestApiProvider.test.tsx
+++ b/packages/test-utils/src/testUtils/TestApiProvider.test.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { createApiRef, useApiHolder } from '@backstage/core-plugin-api';
+import { TestApiProvider } from './TestApiProvider';
+import { render, screen } from '@testing-library/react';
+import { TestApiRegistry } from '.';
+
+const xApiRef = createApiRef<{ a: string; b: number }>({
+  id: 'x',
+});
+const yApiRef = createApiRef<string>({
+  id: 'y',
+});
+
+function Verifier() {
+  const holder = useApiHolder();
+  const x = holder.get(xApiRef);
+  const y = holder.get(yApiRef);
+
+  return (
+    <div>
+      {x ? (
+        <span>
+          x={x.a},{x.b}
+        </span>
+      ) : (
+        <span>no x</span>
+      )}
+      {y ? <span>y={y}</span> : <span>no y</span>}
+    </div>
+  );
+}
+
+describe('TestApiProvider', () => {
+  it('should provide APIs', () => {
+    render(
+      <TestApiProvider
+        apis={[
+          [xApiRef, { a: 'a', b: 3 }],
+          [yApiRef, 'y'],
+        ]}
+      >
+        <Verifier />
+      </TestApiProvider>,
+    );
+    expect(screen.getByText('x=a,3')).toBeInTheDocument();
+    expect(screen.getByText('y=y')).toBeInTheDocument();
+  });
+
+  it('should provide partial APIs', () => {
+    render(
+      <TestApiProvider apis={[[xApiRef, { a: 'a' }]]}>
+        <Verifier />
+      </TestApiProvider>,
+    );
+    expect(screen.getByText('x=a,')).toBeInTheDocument();
+    expect(screen.getByText('no y')).toBeInTheDocument();
+  });
+
+  it('should require partial implementations to still match types', () => {
+    render(
+      // @ts-expect-error
+      <TestApiProvider apis={[[xApiRef, { a: 3 }]]}>
+        <Verifier />
+      </TestApiProvider>,
+    );
+    expect(screen.getByText('x=3,')).toBeInTheDocument();
+    expect(screen.getByText('no y')).toBeInTheDocument();
+  });
+
+  it('should allow empty APIs', () => {
+    render(
+      <TestApiProvider apis={[]}>
+        <Verifier />
+      </TestApiProvider>,
+    );
+    expect(screen.getByText('no x')).toBeInTheDocument();
+    expect(screen.getByText('no y')).toBeInTheDocument();
+  });
+});
+
+describe('TestApiRegistry', () => {
+  it('should be created with APIs', () => {
+    const x = { a: 'a', b: 3 };
+    const y = 'y';
+    const registry = TestApiRegistry.with([xApiRef, x], [yApiRef, y]);
+
+    expect(registry.get(xApiRef)).toBe(x);
+    expect(registry.get(yApiRef)).toBe(y);
+  });
+
+  it('should allow partial implementations', () => {
+    const x = { a: 'a' };
+    const registry = TestApiRegistry.with([xApiRef, x]);
+
+    expect(registry.get(xApiRef)).toBe(x);
+    expect(registry.get(yApiRef)).toBeUndefined();
+  });
+
+  it('should require partial implementations to match types', () => {
+    const x = { a: 2 };
+    // @ts-expect-error
+    const registry = TestApiRegistry.with([xApiRef, x]);
+
+    expect(registry.get(xApiRef)).toBe(x);
+    expect(registry.get(yApiRef)).toBeUndefined();
+  });
+
+  it('should prefer last duplicate API that was provided', () => {
+    const x1 = { a: 'a' };
+    const x2 = { a: 's' };
+    const x3 = { a: 'd' };
+    const registry = TestApiRegistry.with(
+      [xApiRef, x1],
+      [xApiRef, x2],
+      [xApiRef, x3],
+    );
+
+    expect(registry.get(xApiRef)).toBe(x3);
+  });
+});

--- a/packages/test-utils/src/testUtils/TestApiProvider.tsx
+++ b/packages/test-utils/src/testUtils/TestApiProvider.tsx
@@ -63,7 +63,7 @@ export class TestApiRegistry implements ApiHolder {
    * @public
    * @param apis - A list of pairs mapping an ApiRef to its respective implementation.
    */
-  static with<TApiPairs extends any[]>(
+  static from<TApiPairs extends any[]>(
     ...apis: readonly [...TestApiProviderPropsApiPairs<TApiPairs>]
   ) {
     return new TestApiRegistry(
@@ -121,6 +121,6 @@ export const TestApiProvider = <T extends any[]>({
   children,
 }: TestApiProviderProps<T>) => {
   return (
-    <ApiProvider apis={TestApiRegistry.with(...apis)} children={children} />
+    <ApiProvider apis={TestApiRegistry.from(...apis)} children={children} />
   );
 };

--- a/packages/test-utils/src/testUtils/TestApiProvider.tsx
+++ b/packages/test-utils/src/testUtils/TestApiProvider.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+import { ApiProvider } from '@backstage/core-app-api';
+import { ApiRef, ApiHolder } from '@backstage/core-plugin-api';
+
+type TestApiProviderPropsApiPair<TApi> = TApi extends infer TImpl
+  ? [ApiRef<TApi>, Partial<TImpl>]
+  : never;
+
+/** @ignore */
+type TestApiProviderPropsApiPairs<TApiPairs> = {
+  [TIndex in keyof TApiPairs]: TestApiProviderPropsApiPair<TApiPairs[TIndex]>;
+};
+
+/**
+ * Properties for the {@link TestApiProvider} component.
+ *
+ * @public
+ */
+export type TestApiProviderProps<TApiPairs extends any[]> = {
+  apis: [...TestApiProviderPropsApiPairs<TApiPairs>];
+  children: ReactNode;
+};
+
+/** @internal */
+class TestApiRegistry implements ApiHolder {
+  constructor(private readonly apis: Map<string, unknown>) {}
+
+  get<T>(api: ApiRef<T>): T | undefined {
+    return this.apis.get(api.id) as T | undefined;
+  }
+}
+
+/**
+ * An API provider that lets you provide any number of API implementations in
+ * a test, without necessarily having to implement the full APIs.
+ *
+ * A migration from `ApiRegistry` and `ApiProvider` might look like this, from:
+ *
+ * ```tsx
+ * renderInTestApp(
+ *   <ApiProvider
+ *     apis={ApiRegistry.from([
+ *       [identityApiRef, mockIdentityApi as unknown as IdentityApi]
+ *     ])}
+ *   >
+ *     {...}
+ *   </ApiProvider>
+ * )
+ * ```
+ *
+ * To the following:
+ *
+ * ```tsx
+ * renderInTestApp(
+ *   <TestApiProvider apis={[[identityApiRef, mockIdentityApi]]}>
+ *     {...}
+ *   </TestApiProvider>
+ * )
+ * ```
+ *
+ * Note that the cast to `IdentityApi` is no longer needed as long as the mock API
+ * implements a subset of the `IdentityApi`.
+ *
+ * @public
+ **/
+export const TestApiProvider = <T extends any[]>({
+  apis,
+  children,
+}: TestApiProviderProps<T>) => {
+  return (
+    <ApiProvider
+      apis={
+        new TestApiRegistry(new Map(apis.map(([api, impl]) => [api.id, impl])))
+      }
+      children={children}
+    />
+  );
+};

--- a/packages/test-utils/src/testUtils/TestApiProvider.tsx
+++ b/packages/test-utils/src/testUtils/TestApiProvider.tsx
@@ -54,7 +54,7 @@ export class TestApiRegistry implements ApiHolder {
    *
    * @example
    * ```ts
-   * const apis = TestApiRegistry.with(
+   * const apis = TestApiRegistry.from(
    *   [configApiRef, new ConfigReader({})],
    *   [identityApiRef, { getUserId: () => 'tester' }],
    * );

--- a/packages/test-utils/src/testUtils/TestApiProvider.tsx
+++ b/packages/test-utils/src/testUtils/TestApiProvider.tsx
@@ -73,7 +73,11 @@ export class TestApiRegistry implements ApiHolder {
 
   private constructor(private readonly apis: Map<string, unknown>) {}
 
-  /** {@inheritdoc @backstage/core-plugin-api#ApiHolder.get} */
+  /**
+   * Returns an implementation of the API.
+   *
+   * @public
+   */
   get<T>(api: ApiRef<T>): T | undefined {
     return this.apis.get(api.id) as T | undefined;
   }

--- a/packages/test-utils/src/testUtils/index.tsx
+++ b/packages/test-utils/src/testUtils/index.tsx
@@ -22,5 +22,5 @@ export * from './msw';
 export * from './Keyboard';
 export * from './logCollector';
 export * from './testingLibrary';
-export { TestApiProvider } from './TestApiProvider';
+export { TestApiProvider, TestApiRegistry } from './TestApiProvider';
 export type { TestApiProviderProps } from './TestApiProvider';

--- a/packages/test-utils/src/testUtils/index.tsx
+++ b/packages/test-utils/src/testUtils/index.tsx
@@ -22,3 +22,5 @@ export * from './msw';
 export * from './Keyboard';
 export * from './logCollector';
 export * from './testingLibrary';
+export { TestApiProvider } from './TestApiProvider';
+export type { TestApiProviderProps } from './TestApiProvider';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This deprecates the entire `ApiRegistry` class. To replace it, we introduce `TestApiProvider` and `TestApiRegistry` from `test-utils` instead. These are much better suited for writing tests, as they allow for a less verbose and more nicely formatted syntax, but more importantly have relaxed type checking allowing for partial API implementations to be used. No more `as unknown as *Api` needed or a long list of `jest.fn()` when you're only looking to mock a single method.

For example, code that currently looks like this:

```tsx
renderInTestApp(
  <ApiProvider
    apis={ApiRegistry.from([
      [identityApiRef, mockIdentityApi as unknown as IdentityApi]
    ])}
  >
    {...}
  </ApiProvider>
)
```

Can now be switched to this:

```tsx
renderInTestApp(
  <TestApiProvider apis={[[identityApiRef, mockIdentityApi]]}>
    {...}
  </TestApiProvider>
)
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
