### PR TITLE
catalog-backend: refactor entityProviders connect

### DIFF
--- a/.changeset/metal-donuts-cross.md
+++ b/.changeset/metal-donuts-cross.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+This fixes a bug where locations couldn't be added unless the processing engine is started.
+It's now possible to run the catalog backend without starting the processing engine and still allowing locations registrations.
+
+This is done by refactor the `EntityProvider.connect` to happen outside the engine.

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.test.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.test.ts
@@ -61,7 +61,6 @@ describe('DefaultCatalogProcessingEngine', () => {
     });
     const engine = new DefaultCatalogProcessingEngine(
       getVoidLogger(),
-      [],
       db,
       orchestrator,
       stitcher,
@@ -123,7 +122,6 @@ describe('DefaultCatalogProcessingEngine', () => {
     });
     const engine = new DefaultCatalogProcessingEngine(
       getVoidLogger(),
-      [],
       db,
       orchestrator,
       stitcher,
@@ -201,7 +199,6 @@ describe('DefaultCatalogProcessingEngine', () => {
 
     const engine = new DefaultCatalogProcessingEngine(
       getVoidLogger(),
-      [],
       db,
       orchestrator,
       stitcher,
@@ -273,7 +270,6 @@ describe('DefaultCatalogProcessingEngine', () => {
 
     const engine = new DefaultCatalogProcessingEngine(
       getVoidLogger(),
-      [],
       db,
       orchestrator,
       stitcher,

--- a/plugins/catalog-backend/src/processing/connectEntityProviders.ts
+++ b/plugins/catalog-backend/src/processing/connectEntityProviders.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  entityEnvelopeSchemaValidator,
+} from '@backstage/catalog-model';
+import { ProcessingDatabase } from '../database/types';
+import {
+  EntityProvider,
+  EntityProviderConnection,
+  EntityProviderMutation,
+} from '../providers/types';
+
+class Connection implements EntityProviderConnection {
+  readonly validateEntityEnvelope = entityEnvelopeSchemaValidator();
+
+  constructor(
+    private readonly config: {
+      id: string;
+      processingDatabase: ProcessingDatabase;
+    },
+  ) {}
+
+  async applyMutation(mutation: EntityProviderMutation): Promise<void> {
+    const db = this.config.processingDatabase;
+
+    if (mutation.type === 'full') {
+      this.check(mutation.entities.map(e => e.entity));
+      await db.transaction(async tx => {
+        await db.replaceUnprocessedEntities(tx, {
+          sourceKey: this.config.id,
+          type: 'full',
+          items: mutation.entities,
+        });
+      });
+    } else if (mutation.type === 'delta') {
+      this.check(mutation.added.map(e => e.entity));
+      this.check(mutation.removed.map(e => e.entity));
+      await db.transaction(async tx => {
+        await db.replaceUnprocessedEntities(tx, {
+          sourceKey: this.config.id,
+          type: 'delta',
+          added: mutation.added,
+          removed: mutation.removed,
+        });
+      });
+    }
+  }
+
+  private check(entities: Entity[]) {
+    for (const entity of entities) {
+      try {
+        this.validateEntityEnvelope(entity);
+      } catch (e) {
+        throw new TypeError(`Malformed entity envelope, ${e}`);
+      }
+    }
+  }
+}
+
+export async function connectEntityProviders(
+  db: ProcessingDatabase,
+  providers: EntityProvider[],
+) {
+  await Promise.all(
+    providers.map(async provider => {
+      const connection = new Connection({
+        id: provider.getProviderName(),
+        processingDatabase: db,
+      });
+      return provider.connect(connection);
+    }),
+  );
+}

--- a/plugins/catalog-backend/src/service/DefaultRefreshService.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultRefreshService.test.ts
@@ -103,7 +103,6 @@ describe('Refresh integration', () => {
 
     const engine = new DefaultCatalogProcessingEngine(
       defaultLogger,
-      [],
       db,
       {
         async process(request: EntityProcessingRequest) {

--- a/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
@@ -80,6 +80,7 @@ import { DefaultCatalogRulesEnforcer } from '../ingestion/CatalogRules';
 import { Config } from '@backstage/config';
 import { Logger } from 'winston';
 import { LocationService } from './types';
+import { connectEntityProviders } from '../processing/connectEntityProviders';
 
 export type CatalogEnvironment = {
   logger: Logger;
@@ -364,7 +365,6 @@ export class NextCatalogBuilder {
 
     const processingEngine = new DefaultCatalogProcessingEngine(
       logger,
-      entityProviders,
       processingDatabase,
       orchestrator,
       stitcher,
@@ -389,6 +389,8 @@ export class NextCatalogBuilder {
       logger,
       config,
     });
+
+    await connectEntityProviders(processingDatabase, entityProviders);
 
     return {
       entitiesCatalog,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a bug where locations couldn't be added unless the processing engine is started.
It's now possible to run the catalog backend without starting the processing engine and still allowing locations registrations.

This is done by refactor the `EntityProvider.connect` to happen outside the engine.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
