### PR TITLE
[Shortcuts] Show tooltips on hover

### DIFF
--- a/.changeset/sweet-suits-sit.md
+++ b/.changeset/sweet-suits-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-shortcuts': patch
+---
+
+Add tooltip to display shortcut title on hover. This should improve the readability of shortcuts with long names, which are cutoff by ellipsis.

--- a/plugins/shortcuts/src/ShortcutItem.tsx
+++ b/plugins/shortcuts/src/ShortcutItem.tsx
@@ -15,7 +15,9 @@
  */
 
 import React from 'react';
-import { IconButton, makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
 import EditIcon from '@material-ui/icons/Edit';
 import { ShortcutIcon } from './ShortcutIcon';
 import { EditShortcut } from './EditShortcut';
@@ -76,21 +78,23 @@ export const ShortcutItem = ({ shortcut, api }: Props) => {
 
   return (
     <>
-      <SidebarItem
-        className={classes.root}
-        to={shortcut.url}
-        text={shortcut.title}
-        icon={() => <ShortcutIcon text={text} color={color} />}
-      >
-        <IconButton
-          id="edit"
-          data-testid="edit"
-          onClick={handleClick}
-          className={classes.button}
+      <Tooltip title={shortcut.title} enterDelay={500}>
+        <SidebarItem
+          className={classes.root}
+          to={shortcut.url}
+          text={shortcut.title}
+          icon={() => <ShortcutIcon text={text} color={color} />}
         >
-          <EditIcon className={classes.icon} />
-        </IconButton>
-      </SidebarItem>
+          <IconButton
+            id="edit"
+            data-testid="edit"
+            onClick={handleClick}
+            className={classes.button}
+          >
+            <EditIcon className={classes.icon} />
+          </IconButton>
+        </SidebarItem>
+      </Tooltip>
       <EditShortcut
         onClose={handleClose}
         anchorEl={anchorEl}


### PR DESCRIPTION
https://user-images.githubusercontent.com/8904624/142226970-3d6be225-3d65-40a2-9fd5-8169fd67a310.mp4

Add tooltip to display shortcut title on hover. This should improve the readability of shortcuts with long names, which are cutoff by ellipsis.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
