### PR TITLE
Add User entities displayName to default catalog collator to be able to search by user's full name

### DIFF
--- a/.changeset/smooth-vans-boil.md
+++ b/.changeset/smooth-vans-boil.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Index User entities by displayName to be able to search by full name. Added displayName (if present) to the 'text' field in the indexed document.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -32,7 +32,6 @@ import { Router } from 'express';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmIntegrations } from '@backstage/integration';
 import { UrlReader } from '@backstage/backend-common';
-import { UserEntity } from '@backstage/catalog-model';
 import { Validators } from '@backstage/catalog-model';
 
 // Warning: (ae-missing-release-tag) "AddLocationResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -764,10 +763,6 @@ export class DefaultCatalogCollator implements DocumentCollator {
       filter?: CatalogEntitiesRequest['filter'];
     },
   ): DefaultCatalogCollator;
-  // (undocumented)
-  protected getDocumentText(entity: Entity): string;
-  // (undocumented)
-  protected isUserEntity(entity: Entity): entity is UserEntity;
   // (undocumented)
   protected locationTemplate: string;
   // (undocumented)

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -32,6 +32,7 @@ import { Router } from 'express';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmIntegrations } from '@backstage/integration';
 import { UrlReader } from '@backstage/backend-common';
+import { UserEntity } from '@backstage/catalog-model';
 import { Validators } from '@backstage/catalog-model';
 
 // Warning: (ae-missing-release-tag) "AddLocationResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -763,6 +764,10 @@ export class DefaultCatalogCollator implements DocumentCollator {
       filter?: CatalogEntitiesRequest['filter'];
     },
   ): DefaultCatalogCollator;
+  // (undocumented)
+  protected getDocumentText(entity: Entity): string;
+  // (undocumented)
+  protected isUserEntity(entity: Entity): entity is UserEntity;
   // (undocumented)
   protected locationTemplate: string;
   // (undocumented)

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
@@ -82,7 +82,7 @@ export class DefaultCatalogCollator implements DocumentCollator {
   }
 
   private isUserEntity(entity: Entity): entity is UserEntity {
-    return entity.kind === 'User';
+    return entity.kind.toUpperCase() === 'USER';
   }
 
   private getDocumentText(entity: Entity): string {

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
@@ -82,7 +82,7 @@ export class DefaultCatalogCollator implements DocumentCollator {
   }
 
   private isUserEntity(entity: Entity): entity is UserEntity {
-    return entity.kind.toUpperCase() === 'USER';
+    return entity.kind.toLocaleUpperCase('en-US') === 'USER';
   }
 
   private getDocumentText(entity: Entity): string {

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
@@ -81,16 +81,17 @@ export class DefaultCatalogCollator implements DocumentCollator {
     return formatted.toLowerCase();
   }
 
-  protected isUserEntity(entity: Entity): entity is UserEntity {
+  private isUserEntity(entity: Entity): entity is UserEntity {
     return entity.kind === 'User';
   }
 
-  protected getDocumentText(entity: Entity): string {
+  private getDocumentText(entity: Entity): string {
     let documentText = entity.metadata.description || '';
     if (this.isUserEntity(entity)) {
-      if (entity.spec?.profile?.displayName && entity.metadata.description) {
+      if (entity.spec?.profile?.displayName && documentText) {
         // combine displayName and description
-        documentText = `${entity.spec?.profile?.displayName} : ${entity.metadata.description}`;
+        const displayName = entity.spec?.profile?.displayName;
+        documentText = displayName.concat(' : ', documentText);
       } else {
         documentText = entity.spec?.profile?.displayName || documentText;
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Right now, if a user’s entity name (`entity.metadata.name`) doesn’t include their first or last name, it is impossible to search for the user with that information. Users can be imported from a system where their usernames may differ from their given names, or don't include the full name. Also, even when we find the user in the search, their full name does not get displayed in the search results:

<img width="400" alt="Screenshot 2021-11-16 at 11 03 23" src="https://user-images.githubusercontent.com/7041022/142247590-4a24a93b-0402-47f7-b066-272a8d3e508c.png"> <img width="400" alt="Screenshot 2021-11-16 at 11 03 06" src="https://user-images.githubusercontent.com/7041022/142246479-74021fea-208c-44fa-a0c8-2bbf6018313d.png">

Since we expect the user's full name to be in `entity.spec.profile.displayName` I think we should include this field in the DefaultCatalogCollator so the user entities get indexed with this information.
Proposing to only apply these changes to User entities, and add `displayName` to the `text` field in the document to index so it shows automatically in the search results. When a user entity has both `displayName` and `entity.metadata.description`, combine them into the `text` field.

After these changes, searching for a user by full name is much easier:

<img width="500" alt="Screenshot 2021-11-16 at 11 03 49" src="https://user-images.githubusercontent.com/7041022/142247127-1addc0d0-b33e-4f60-8ca1-3e224776fc6d.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
