### PR TITLE
Letting GraphiQL use headers

### DIFF
--- a/.changeset/young-sheep-impress.md
+++ b/.changeset/young-sheep-impress.md
@@ -1,0 +1,5 @@
+---
+"@backstage/plugin-graphiql": patch
+---
+
+Letting GraphiQL use headers

--- a/.changeset/young-sheep-impress.md
+++ b/.changeset/young-sheep-impress.md
@@ -1,5 +1,5 @@
 ---
-"@backstage/plugin-graphiql": patch
+'@backstage/plugin-graphiql': patch
 ---
 
 Letting GraphiQL use headers

--- a/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.tsx
+++ b/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.tsx
@@ -73,7 +73,7 @@ export const GraphiQLBrowser = ({ endpoints }: GraphiQLBrowserProps) => {
         </Tabs>
         <Divider />
         <div className={classes.graphiQlWrapper}>
-          <GraphiQL key={tabIndex} fetcher={fetcher} storage={storage} />
+          <GraphiQL headerEditorEnabled={true} key={tabIndex} fetcher={fetcher} storage={storage} />
         </div>
       </Suspense>
     </div>

--- a/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.tsx
+++ b/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.tsx
@@ -73,7 +73,12 @@ export const GraphiQLBrowser = ({ endpoints }: GraphiQLBrowserProps) => {
         </Tabs>
         <Divider />
         <div className={classes.graphiQlWrapper}>
-          <GraphiQL headerEditorEnabled={true} key={tabIndex} fetcher={fetcher} storage={storage} />
+          <GraphiQL
+            headerEditorEnabled={true}
+            key={tabIndex}
+            fetcher={fetcher}
+            storage={storage}
+          />
         </div>
       </Suspense>
     </div>

--- a/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.tsx
+++ b/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.tsx
@@ -74,7 +74,7 @@ export const GraphiQLBrowser = ({ endpoints }: GraphiQLBrowserProps) => {
         <Divider />
         <div className={classes.graphiQlWrapper}>
           <GraphiQL
-            headerEditorEnabled={true}
+            headerEditorEnabled
             key={tabIndex}
             fetcher={fetcher}
             storage={storage}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The GraphiQL plugin uses the project found here: https://github.com/graphql/graphiql. This project allows for headers to be provided to the graph api call if a prop of headerEditorEnabled={true}  is provided to the component. Please see last comment on below thread: https://github.com/graphql/graphiql/issues/59

Example of the headers dialogue after being enabled:
![image](https://user-images.githubusercontent.com/9059196/142221973-d3e60296-6645-4276-89e0-7d282819619a.png)




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
