### PR TITLE
Fail when adding duplicate locations using the dry run flag

### DIFF
--- a/plugins/catalog-backend/src/service/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.ts
@@ -98,6 +98,14 @@ export class DefaultLocationService implements LocationService {
       });
 
       if (processed.ok) {
+        const { metadata, kind } = processed.completedEntity;
+        if (
+          entities.some(
+            e => e.metadata.name === metadata.name && e.kind === kind,
+          )
+        ) {
+          throw new Error(`Duplicate nested entity: ${metadata.name}`);
+        }
         unprocessedEntities.push(...processed.deferredEntities);
         entities.push(processed.completedEntity);
       } else {


### PR DESCRIPTION
This change here adds in logic to the DefaultLocationService that will prematurely terminate the dry run addition of locations if there is a duplicate entity in the unprocessed entities.
Adding this logic here will avoid an infinite loop if a monorepo arch is used (for example if a target references itself). It will also enforce some best practices.
I have also added tests.

Signed-off-by: Nicolas Arnold <nic@roadie.io>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
