### PR TITLE
Pin Sidebar by default

### DIFF
--- a/.changeset/yellow-pandas-draw.md
+++ b/.changeset/yellow-pandas-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Pin sidebar by default for easier navigation

--- a/packages/core-components/src/layout/Sidebar/Page.tsx
+++ b/packages/core-components/src/layout/Sidebar/Page.tsx
@@ -49,7 +49,7 @@ export type SidebarPinStateContextType = {
 
 export const SidebarPinStateContext = createContext<SidebarPinStateContextType>(
   {
-    isPinned: false,
+    isPinned: true,
     toggleSidebarPinState: () => {},
   },
 );

--- a/packages/core-components/src/layout/Sidebar/localStorage.ts
+++ b/packages/core-components/src/layout/Sidebar/localStorage.ts
@@ -24,10 +24,10 @@ export const LocalStorage = {
     try {
       value = JSON.parse(
         window.localStorage.getItem(LocalStorageKeys.SIDEBAR_PIN_STATE) ||
-          'false',
+          'true',
       );
     } catch {
-      return false;
+      return true;
     }
     return !!value;
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR changes the default state of the sidebar for new users to be pinned so that each sidebar link always has text visible.

The assumption behind this change is that the UI should be as obvious and easy to navigate as possible for new users and that a sidebar that only shows you what is there when you hover over it is not as easy to use as a sidebar that has clear text links visible at all times. 

The compact "unpinned" view relies on icons to indicate what sidebar options are available at a glance but allows more horizontal space in the main page which can be useful on narrow screens or when browsing tabular layouts like the catalog. It feels more like a power-user feature and in our experience can leave first time users feeling a bit lost when looking at the interface. It would still be available for individual users via the Settings page but not enabled as the default view for all users. 

An alternative implementation would be to add a config value for this which would make it easier to set the default as you feel fits your organisation. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
