### PR TITLE
core-app-api: fix and release accidental createApp type breakage

### DIFF
--- a/packages/core-app-api/CHANGELOG.md
+++ b/packages/core-app-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/core-app-api
 
+## 0.1.22
+
+### Patch Changes
+
+- Reverted the `createApp` TypeScript type to match the one before version `0.1.21`, as it was an accidental breaking change.
+
 ## 0.1.21
 
 ### Patch Changes

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -27,6 +27,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { bitbucketAuthApiRef } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
 import { ConfigReader } from '@backstage/config';
+import { createApp as createApp_2 } from '@backstage/app-defaults';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { ErrorApi } from '@backstage/core-plugin-api';
 import { ErrorApiError } from '@backstage/core-plugin-api';
@@ -45,7 +46,6 @@ import { Observable } from '@backstage/types';
 import { oktaAuthApiRef } from '@backstage/core-plugin-api';
 import { oneloginAuthApiRef } from '@backstage/core-plugin-api';
 import { OpenIdConnectApi } from '@backstage/core-plugin-api';
-import { OptionalAppOptions } from '@backstage/app-defaults';
 import { PendingAuthRequest } from '@backstage/core-plugin-api';
 import { PluginOutput } from '@backstage/core-plugin-api';
 import { ProfileInfo } from '@backstage/core-plugin-api';
@@ -332,7 +332,9 @@ export type BootErrorPageProps = {
 export { ConfigReader };
 
 // @public @deprecated
-export function createApp(options?: OptionalAppOptions): BackstageApp;
+export function createApp(
+  options?: Parameters<typeof createApp_2>[0],
+): BackstageApp & AppContext;
 
 // @public
 export function createSpecializedApp(options: AppOptions): BackstageApp;

--- a/packages/core-app-api/package.json
+++ b/packages/core-app-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/core-app-api",
   "description": "Core app API used by Backstage apps",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/packages/core-app-api/src/app/createApp.tsx
+++ b/packages/core-app-api/src/app/createApp.tsx
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import {
-  createApp as createDefaultApp,
-  OptionalAppOptions,
-} from '@backstage/app-defaults';
+import { createApp as createDefaultApp } from '@backstage/app-defaults';
+import { AppContext, BackstageApp } from './types';
 
 /**
  * Creates a new Backstage App.
@@ -26,7 +24,9 @@ import {
  * @param options - A set of options for creating the app
  * @public
  */
-export function createApp(options?: OptionalAppOptions) {
+export function createApp(
+  options?: Parameters<typeof createDefaultApp>[0],
+): BackstageApp & AppContext {
   // eslint-disable-next-line no-console
   console.warn(
     'DEPRECATION WARNING: The createApp function from @backstage/core-app-api will soon be removed, ' +
@@ -34,5 +34,5 @@ export function createApp(options?: OptionalAppOptions) {
       'If you do not wish to use a standard app configuration but instead supply all options yourself ' +
       ' you can use createSpecializedApp from @backstage/core-app-api instead.',
   );
-  return createDefaultApp(options);
+  return createDefaultApp(options) as BackstageApp & AppContext;
 }

--- a/plugins/allure/package.json
+++ b/plugins/allure/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/analytics-module-ga/package.json
+++ b/plugins/analytics-module-ga/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/azure-devops/package.json
+++ b/plugins/azure-devops/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/badges/package.json
+++ b/plugins/badges/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/bitrise/package.json
+++ b/plugins/bitrise/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/catalog-graph/package.json
+++ b/plugins/catalog-graph/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/cloudbuild/package.json
+++ b/plugins/cloudbuild/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/code-coverage/package.json
+++ b/plugins/code-coverage/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/config-schema/package.json
+++ b/plugins/config-schema/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/firehydrant/package.json
+++ b/plugins/firehydrant/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/fossa/package.json
+++ b/plugins/fossa/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/gcp-projects/package.json
+++ b/plugins/gcp-projects/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/git-release-manager/package.json
+++ b/plugins/git-release-manager/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/github-actions/package.json
+++ b/plugins/github-actions/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/github-deployments/package.json
+++ b/plugins/github-deployments/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/gitops-profiles/package.json
+++ b/plugins/gitops-profiles/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/graphiql/package.json
+++ b/plugins/graphiql/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/ilert/package.json
+++ b/plugins/ilert/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/jenkins/package.json
+++ b/plugins/jenkins/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/kafka/package.json
+++ b/plugins/kafka/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/newrelic/package.json
+++ b/plugins/newrelic/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/pagerduty/package.json
+++ b/plugins/pagerduty/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/rollbar/package.json
+++ b/plugins/rollbar/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/shortcuts/package.json
+++ b/plugins/shortcuts/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/splunk-on-call/package.json
+++ b/plugins/splunk-on-call/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/todo/package.json
+++ b/plugins/todo/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/xcmetrics/package.json
+++ b/plugins/xcmetrics/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.9.0",
-    "@backstage/core-app-api": "^0.1.21",
+    "@backstage/core-app-api": "^0.1.22",
     "@backstage/dev-utils": "^0.2.13",
     "@backstage/test-utils": "^0.1.22",
     "@testing-library/jest-dom": "^5.10.1",


### PR DESCRIPTION
The only change in this release is a fix for the accidental breakage of the `createApp` from `@backstage/core-app-api`. The  previous release brought in the deprecation of `createApp` from `@backstage/core-app-api` in favor of the one from `@backstage/app-defaults`. The intention was to keep the existing deprecated function intact, but it mistakenly received changes to both the parameters and return type which have now been reverted.