### PR TITLE
feat: expose catalog lib in `plugin-auth-backend`

### DIFF
--- a/.changeset/tasty-deers-play.md
+++ b/.changeset/tasty-deers-play.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Expose catalog lib in plugin-auth-backend, i.e `CatalogIdentityClient` class is exposed now.

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -175,6 +175,20 @@ export const bitbucketUserIdSignInResolver: SignInResolver<BitbucketOAuthResult>
 // @public (undocumented)
 export const bitbucketUsernameSignInResolver: SignInResolver<BitbucketOAuthResult>;
 
+// Warning: (ae-missing-release-tag) "CatalogIdentityClient" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export class CatalogIdentityClient {
+  constructor(options: { catalogApi: CatalogApi; tokenIssuer: TokenIssuer });
+  // Warning: (ae-forgotten-export) The symbol "UserQuery" needs to be exported by the entry point index.d.ts
+  findUser(query: UserQuery): Promise<UserEntity>;
+  // Warning: (ae-forgotten-export) The symbol "MemberClaimQuery" needs to be exported by the entry point index.d.ts
+  resolveCatalogMembership({
+    entityRefs,
+    logger,
+  }: MemberClaimQuery): Promise<string[]>;
+}
+
 // Warning: (ae-missing-release-tag) "createAtlassianProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -270,6 +284,12 @@ export const encodeState: (state: OAuthState) => string;
 //
 // @public (undocumented)
 export const ensuresXRequestedWith: (req: express.Request) => boolean;
+
+// Warning: (ae-forgotten-export) The symbol "TokenParams" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "getEntityClaims" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export function getEntityClaims(entity: UserEntity): TokenParams['claims'];
 
 // Warning: (ae-missing-release-tag) "GithubOAuthResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -578,7 +598,6 @@ export type WebMessageResponse =
 
 // Warnings were encountered during analysis:
 //
-// src/identity/types.d.ts:25:5 - (ae-forgotten-export) The symbol "TokenParams" needs to be exported by the entry point index.d.ts
 // src/identity/types.d.ts:31:9 - (ae-forgotten-export) The symbol "AnyJWK" needs to be exported by the entry point index.d.ts
 // src/providers/atlassian/provider.d.ts:37:5 - (ae-forgotten-export) The symbol "AuthHandler" needs to be exported by the entry point index.d.ts
 // src/providers/atlassian/provider.d.ts:42:9 - (ae-forgotten-export) The symbol "SignInResolver" needs to be exported by the entry point index.d.ts

--- a/plugins/auth-backend/src/index.ts
+++ b/plugins/auth-backend/src/index.ts
@@ -31,3 +31,5 @@ export * from './lib/flow';
 
 // OAuth wrapper over a passport or a custom `startegy`.
 export * from './lib/oauth';
+
+export * from './lib/catalog';


### PR DESCRIPTION
We are writing a custom OIDC provider plugin and need to use `CatalogIdentityClient` class in our provider. It is however not exported and we are not able to use it.

It is not a problem for providers that are committed to backstage repo as they use the local path, e.g https://github.com/backstage/backstage/blob/master/plugins/auth-backend/src/providers/aws-alb/provider.ts#L31 - but only for the ones that are developed locally.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~~Added or updated documentation~~
- [ ] ~~Tests for new functionality and regression tests for bug fixes~~
- [ ] ~~Screenshots attached (for UI changes)~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
