### PR TITLE
cli: test coverage and speed improvements

### DIFF
--- a/.changeset/giant-bees-applaud.md
+++ b/.changeset/giant-bees-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switch the default test coverage provider from the jest default one to `'v8'`, which provides much better coverage information when using the default Backstage test setup. This is considered a bug fix as the current coverage information is often very inaccurate.

--- a/.changeset/large-mugs-repair.md
+++ b/.changeset/large-mugs-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Disable ES transforms in tests transformed by the `jestSucraseTransform.js`. This is not considered a breaking change since all code is already transpiled this way in the development setup.

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -95,6 +95,7 @@ async function getProjectConfig(targetPath, displayName) {
     ...(displayName && { displayName }),
     rootDir: path.resolve(targetPath, 'src'),
     coverageDirectory: path.resolve(targetPath, 'coverage'),
+    coverageProvider: 'v8',
     collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}', '!**/*.d.ts'],
     moduleNameMapper: {
       '\\.(css|less|scss|sss|styl)$': require.resolve('jest-css-modules'),

--- a/packages/cli/config/jestSucraseTransform.js
+++ b/packages/cli/config/jestSucraseTransform.js
@@ -46,7 +46,11 @@ function process(source, filePath) {
   }
 
   if (transforms) {
-    return transform(source, { transforms, filePath }).code;
+    return transform(source, {
+      transforms,
+      filePath,
+      disableESTransforms: true,
+    }).code;
   }
 
   return source;


### PR DESCRIPTION
Turns out the `v8` coverage provider is great for our test setup :grin: switching to it properly fixes #6836. 

For example, our coverage of `core-components` goes from the following before this change:

| % Stmts | % Branch | % Funcs | % Lines |
|---------|----------|---------|---------|
|   62.41 |    58.95 |   50.14 |   60.27 |

To this after the change:

| % Stmts | % Branch | % Funcs | % Lines |
|---------|----------|---------|---------|
|   65.45 |    86.76 |   76.56 |   65.45 |

This also switches off ES transform for tests, because that was unintentionally enabled 😅 
