### PR TITLE
Tweak release process to require changesets for new packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,9 @@ We use [changesets](https://github.com/atlassian/changesets) to help us prepare 
 
 Any time a patch, minor, or major change aligning to [Semantic Versioning](https://semver.org) is made to any published package in `packages/` or `plugins/`, a changeset should be used. It helps to align your change to the [Backstage stability index](https://backstage.io/docs/overview/stability-index) for the package you are changing, for example, when to provide additional clarity on deprecation or impacting changes which will then be included into CHANGELOGs.
 
-In general, changesets are not needed for the documentation, build utilities, contributed samples in `contrib/`, or the [example `packages/app`](packages/app).
+In general, changesets are only needed for changes to packages within `packages/` or `plugins/` directories, and only for the packages that are not marked as `private`. Changesets are also not needed for changes that do not affect the published version of each package, for example changes to tests or in-line source code comments.
+
+Changesets **are** needed for new packages, as that is what triggers the package to be part of the next release.
 
 ### How to create a changeset
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*", "plugins/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.0"
+  "version": "0.0.0"
 }

--- a/scripts/check-if-release.js
+++ b/scripts/check-if-release.js
@@ -96,7 +96,9 @@ async function main() {
 
   const newVersions = packageVersions.filter(
     ({ oldVersion, newVersion }) =>
-      oldVersion !== newVersion && newVersion !== '<none>',
+      oldVersion !== newVersion &&
+      oldVersion !== '<none>' &&
+      newVersion !== '<none>',
   );
 
   if (newVersions.length === 0) {


### PR DESCRIPTION
The separate releases for new packages has been a bit of a funky part of our release process. It's sometimes nice that packages go out early, but it can also cause trouble because the new packages in turn depend on unreleased features and might be published in a broken state.

This tweaks the release process so that new packages now require an initial changeset for them to be released, and with that delays the release of new packages until the next release.

This also sets the initial version of packages to `0.0.0`, so that the first published version receives a version that makes more sense :grin:
