### PR TITLE
fix: draw only what is in the system

### DIFF
--- a/.changeset/eighty-dolls-tie.md
+++ b/.changeset/eighty-dolls-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+draw only the system's parts

--- a/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.test.tsx
+++ b/plugins/catalog/src/components/SystemDiagramCard/SystemDiagramCard.test.tsx
@@ -15,12 +15,17 @@
  */
 
 import {
-  catalogApiRef,
   CatalogApi,
+  catalogApiRef,
   EntityProvider,
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
-import { Entity, RELATION_PART_OF } from '@backstage/catalog-model';
+import {
+  Entity,
+  RELATION_DEPENDS_ON,
+  RELATION_PART_OF,
+  RELATION_PROVIDES_API,
+} from '@backstage/catalog-model';
 import { renderInTestApp } from '@backstage/test-utils';
 import React from 'react';
 import { SystemDiagramCard } from './SystemDiagramCard';
@@ -89,6 +94,36 @@ describe('<SystemDiagramCard />', () => {
                 type: 'service',
                 system: 'system',
               },
+              relations: [
+                {
+                  target: {
+                    kind: 'API',
+                    namespace: 'namespace',
+                    name: 'api',
+                  },
+                  type: RELATION_PROVIDES_API,
+                },
+                {
+                  target: {
+                    kind: 'Resource',
+                    namespace: 'namespace',
+                    name: 'resource',
+                  },
+                  type: RELATION_DEPENDS_ON,
+                },
+              ],
+            },
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Resource',
+              metadata: {
+                name: 'resource',
+                namespace: 'namespace',
+              },
+              spec: {
+                owner: 'not-tools@example.com',
+                system: 'system',
+              },
             },
           ] as Entity[],
         }),
@@ -113,7 +148,7 @@ describe('<SystemDiagramCard />', () => {
       ],
     };
 
-    const { getByText } = await renderInTestApp(
+    const { queryByText } = await renderInTestApp(
       <ApiProvider apis={ApiRegistry.from([[catalogApiRef, catalogApi]])}>
         <EntityProvider entity={entity}>
           <SystemDiagramCard />
@@ -126,9 +161,11 @@ describe('<SystemDiagramCard />', () => {
       },
     );
 
-    expect(getByText('System Diagram')).toBeInTheDocument();
-    expect(getByText('namespace/system')).toBeInTheDocument();
-    expect(getByText('namespace/entity')).toBeInTheDocument();
+    expect(queryByText(/System Diagram/)).toBeInTheDocument();
+    expect(queryByText(/namespace\/system/)).toBeInTheDocument();
+    expect(queryByText(/namespace\/entity/)).toBeInTheDocument();
+    expect(queryByText(/namespace\/resource/)).toBeInTheDocument();
+    expect(queryByText(/namespace\/api/)).not.toBeInTheDocument();
   });
 
   it('should truncate long domains, systems or entities', async () => {


### PR DESCRIPTION
Signed-off-by: Erkan Zileli <erkan.zileli@trendyol.com>

## Hey, I just made a Pull Request!

System diagrams are not working right IMO. There are nodeless arrows. It is drawing an arrow for each relation of the system's parts but not drawing any node because the parts are not actually part of the system. Nodeless arrows are just related to a specific part of the system.

For example, when you have multiple APIs but they are not part of the system, the diagram is like below.

![image](https://user-images.githubusercontent.com/26749979/142757448-16b6f9bd-b26b-43bc-9b1b-25c2eb1f740c.png)

What the diagram should be is below

![image](https://user-images.githubusercontent.com/26749979/142757477-a2fccd9b-89d8-46ab-8247-094f8a3d356c.png)

Waiting for your responses.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
