### PR TITLE
Add .snyk ignore file for @techdocs/cli

### DIFF
--- a/packages/techdocs-cli/.snyk
+++ b/packages/techdocs-cli/.snyk
@@ -1,0 +1,17 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-BROWSERSLIST-1090194:
+    - '*':
+        reason: Developer tools are not a valid target for ReDoS attacks
+        expires: 2022-05-20T00:00:00.000Z
+        created: 2021-11-20T00:00:00.000Z
+
+  SNYK-JS-IMMER-1540542:
+    - '*':
+        reason: Prototype pollution is not an effective attack against a CLI as it already executes arbitrary code
+        expires: 2022-05-20T00:00:00.000Z
+        created: 2021-11-20T00:00:00.000Z
+
+patch: {}


### PR DESCRIPTION
This creates a `.snyk` ignore file for @techdocs/cli, ignoring two vulnerabilities that have also been ignored for @backstage/cli:

- SNYK-JS-BROWSERSLIST-1090194
- SNYK-JS-IMMER-1540542

Duration of ignores is 6 months.

Issues related to this pull request: https://github.com/backstage/backstage/issues/8112, https://github.com/backstage/backstage/issues/8092.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
