### PR TITLE
auth-backend: use more standardized error responses

### DIFF
--- a/.changeset/forty-teachers-argue.md
+++ b/.changeset/forty-teachers-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Switched to using the standardized JSON error responses for all provider endpoints.

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
@@ -176,7 +176,7 @@ describe('OAuthAdapter', () => {
 
     const mockResponse = {
       cookie: jest.fn().mockReturnThis(),
-      send: jest.fn().mockReturnThis(),
+      end: jest.fn().mockReturnThis(),
       status: jest.fn().mockReturnThis(),
     } as unknown as express.Response;
 
@@ -187,6 +187,7 @@ describe('OAuthAdapter', () => {
       '',
       expect.objectContaining({ path: '/auth/test-provider' }),
     );
+    expect(mockResponse.end).toHaveBeenCalledTimes(1);
   });
 
   it('gets new access-token when refreshing', async () => {
@@ -230,21 +231,14 @@ describe('OAuthAdapter', () => {
 
     const mockRequest = {
       header: () => 'XMLHttpRequest',
-      cookies: {
-        'test-provider-refresh-token': 'token',
-      },
-      query: {},
     } as unknown as express.Request;
 
-    const mockResponse = {
-      send: jest.fn().mockReturnThis(),
-      status: jest.fn().mockReturnThis(),
-    } as unknown as express.Response;
+    const mockResponse = {} as unknown as express.Response;
 
-    await oauthProvider.refresh(mockRequest, mockResponse);
-    expect(mockResponse.send).toHaveBeenCalledTimes(1);
-    expect(mockResponse.send).toHaveBeenCalledWith(
-      'Refresh token not supported for provider: test-provider',
+    await expect(
+      oauthProvider.refresh(mockRequest, mockResponse),
+    ).rejects.toThrow(
+      'Refresh token is not supported for provider test-provider',
     );
   });
 });

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -22,7 +22,12 @@ import {
   BackstageIdentity,
   AuthProviderConfig,
 } from '../../providers/types';
-import { InputError, isError, NotAllowedError } from '@backstage/errors';
+import {
+  AuthenticationError,
+  InputError,
+  isError,
+  NotAllowedError,
+} from '@backstage/errors';
 import { TokenIssuer } from '../../identity/types';
 import { readState, verifyNonce } from './helpers';
 import { postMessageResponse, ensuresXRequestedWith } from '../flow';
@@ -166,29 +171,24 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
 
   async logout(req: express.Request, res: express.Response): Promise<void> {
     if (!ensuresXRequestedWith(req)) {
-      res.status(401).send('Invalid X-Requested-With header');
-      return;
+      throw new AuthenticationError('Invalid X-Requested-With header');
     }
 
     // remove refresh token cookie if it is set
     this.removeRefreshTokenCookie(res);
 
-    res.status(200).send('logout!');
+    res.status(200).end();
   }
 
   async refresh(req: express.Request, res: express.Response): Promise<void> {
     if (!ensuresXRequestedWith(req)) {
-      res.status(401).send('Invalid X-Requested-With header');
-      return;
+      throw new AuthenticationError('Invalid X-Requested-With header');
     }
 
     if (!this.handlers.refresh || this.options.disableRefresh) {
-      res
-        .status(400)
-        .send(
-          `Refresh token not supported for provider: ${this.options.providerId}`,
-        );
-      return;
+      throw new InputError(
+        `Refresh token is not supported for provider ${this.options.providerId}`,
+      );
     }
 
     try {
@@ -197,7 +197,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
 
       // throw error if refresh token is missing in the request
       if (!refreshToken) {
-        throw new Error('Missing session cookie');
+        throw new InputError('Missing session cookie');
       }
 
       const scope = req.query.scope?.toString() ?? '';
@@ -220,7 +220,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
 
       res.status(200).json(response);
     } catch (error) {
-      res.status(401).send(String(error));
+      throw new AuthenticationError('Refresh failed', error);
     }
   }
 


### PR DESCRIPTION
Co-authored-by: Johan Haals <johan.haals@gmail.com>

## Hey, I just made a Pull Request!

Bit of 🧹 by switching over error responses in the auth-backend to use our standardized formatting

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
