### PR TITLE
Handle empty values array in EntityFilter

### DIFF
--- a/.changeset/many-waves-visit.md
+++ b/.changeset/many-waves-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Providing an empty values array in an EntityFilter will now return no matches.

--- a/plugins/catalog-backend/src/service/NextEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/NextEntitiesCatalog.test.ts
@@ -435,5 +435,37 @@ describe('NextEntitiesCatalog', () => {
         expect(entities).toContainEqual(entity1);
       },
     );
+
+    it.each(databases.eachSupportedId())(
+      'should return no matches for an empty values array',
+      // NOTE: An empty values array is not a sensible input in a realistic scenario.
+      async databaseId => {
+        const { knex } = await createDatabase(databaseId);
+        const entity1: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'one' },
+          spec: {},
+        };
+        const entity2: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'two' },
+          spec: {},
+        };
+        await addEntityToSearch(knex, entity1);
+        await addEntityToSearch(knex, entity2);
+        const catalog = new NextEntitiesCatalog(knex);
+
+        const testFilter = {
+          key: 'kind',
+          values: [],
+        };
+        const request = { filter: testFilter };
+        const { entities } = await catalog.entities(request);
+
+        expect(entities.length).toBe(0);
+      },
+    );
   });
 });

--- a/plugins/catalog-backend/src/service/NextEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/NextEntitiesCatalog.ts
@@ -91,7 +91,7 @@ function addCondition(
       if (filter.values) {
         if (filter.values.length === 1) {
           this.where({ value: filter.values[0].toLowerCase() });
-        } else if (filter.values.length > 1) {
+        } else {
           this.andWhere(
             'value',
             'in',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While an empty values array is not really a sensible input, if an empty array is provided, technically nothing should be returned as a matching value, thus the existing behavior was technically a bug.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
