### PR TITLE
package.json: add script for running snyk tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "prettier:check": "prettier --check .",
     "lerna": "lerna",
     "storybook": "yarn workspace storybook start",
+    "snyk:test": "npx snyk test --yarn-workspaces --strict-out-of-sync=false",
+    "snyk:test:package": "yarn snyk:test --include",
     "build-storybook": "yarn workspace storybook build-storybook",
     "techdocs-cli": "node scripts/techdocs-cli.js",
     "techdocs-cli:dev": "cross-env TECHDOCS_CLI_DEV_MODE=true node scripts/techdocs-cli.js",


### PR DESCRIPTION
Because running snyk in the repo requires a couple of specific flags, I figured we'd add some scripts to the root `package.json`. I'm looking to avoid adding the snyk CLI as a dep because it's quite large and most people won't end up using it, so executing it via `npx` instead.

Usage:

```bash
yarn snyk:test
```

and

```bash
yarn snyk:test:package @backstage/cli
```