### PR TITLE
core-plugin-api: Deprecate Plugin register and output

### DIFF
--- a/.changeset/slow-olives-confess.md
+++ b/.changeset/slow-olives-confess.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Deprecated `register` option of `createPlugin` and the `outputs` methods of the plugin instance.
+
+Introduces the `featureFlags` property to define your feature flags instead.

--- a/.changeset/young-hats-shop.md
+++ b/.changeset/young-hats-shop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Supply featureFlags using featureFlag config option.

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -272,17 +272,26 @@ export class AppManager implements BackstageApp {
           const featureFlagsApi = this.getApiHolder().get(featureFlagsApiRef)!;
 
           for (const plugin of this.plugins.values()) {
-            for (const output of plugin.output()) {
-              switch (output.type) {
-                case 'feature-flag': {
-                  featureFlagsApi.registerFlag({
-                    name: output.name,
-                    pluginId: plugin.getId(),
-                  });
-                  break;
+            if ('getFeatureFlags' in plugin) {
+              for (const flag of plugin.getFeatureFlags()) {
+                featureFlagsApi.registerFlag({
+                  name: flag.name,
+                  pluginId: plugin.getId(),
+                });
+              }
+            } else {
+              for (const output of plugin.output()) {
+                switch (output.type) {
+                  case 'feature-flag': {
+                    featureFlagsApi.registerFlag({
+                      name: output.name,
+                      pluginId: plugin.getId(),
+                    });
+                    break;
+                  }
+                  default:
+                    break;
                 }
-                default:
-                  break;
               }
             }
           }

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -258,6 +258,7 @@ export type BackstagePlugin<
   getId(): string;
   output(): PluginOutput[];
   getApis(): Iterable<AnyApiFactory>;
+  getFeatureFlags(): Iterable<PluginFeatureFlagConfig>;
   provide<T>(extension: Extension<T>): T;
   routes: Routes;
   externalRoutes: ExternalRoutes;
@@ -463,7 +464,7 @@ export type FeatureFlag = {
   pluginId: string;
 };
 
-// @public
+// @public @deprecated
 export type FeatureFlagOutput = {
   type: 'feature-flag';
   name: string;
@@ -682,14 +683,20 @@ export type PluginConfig<
   register?(hooks: PluginHooks): void;
   routes?: Routes;
   externalRoutes?: ExternalRoutes;
+  featureFlags?: PluginFeatureFlagConfig[];
 };
 
 // @public
+export type PluginFeatureFlagConfig = {
+  name: string;
+};
+
+// @public @deprecated
 export type PluginHooks = {
   featureFlags: FeatureFlagsHooks;
 };
 
-// @public
+// @public @deprecated
 export type PluginOutput = FeatureFlagOutput;
 
 // @public

--- a/packages/core-plugin-api/src/plugin/Plugin.test.tsx
+++ b/packages/core-plugin-api/src/plugin/Plugin.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createPlugin } from './Plugin';
+
+describe('Plugin Feature Flag', () => {
+  it('should be able to register and receive feature flags', () => {
+    expect(
+      createPlugin({
+        id: 'test',
+        featureFlags: [{ name: 'test' }],
+      }).getFeatureFlags(),
+    ).toEqual([{ name: 'test' }]);
+
+    expect(
+      createPlugin({
+        id: 'test',
+        register({ featureFlags }) {
+          featureFlags.register('blob');
+        },
+      }).getFeatureFlags(),
+    ).toEqual([{ name: 'blob' }]);
+
+    expect(
+      createPlugin({
+        id: 'test',
+        register({ featureFlags }) {
+          featureFlags.register('blob');
+        },
+        featureFlags: [{ name: 'test' }],
+      }).getFeatureFlags(),
+    ).toEqual([{ name: 'test' }, { name: 'blob' }]);
+
+    expect(
+      createPlugin({
+        id: 'test',
+      }).getFeatureFlags(),
+    ).toEqual([]);
+
+    /* deprecated tests */
+
+    expect(
+      createPlugin({
+        id: 'test',
+        featureFlags: [{ name: 'test' }],
+      }).output(),
+    ).toEqual([{ name: 'test', type: 'feature-flag' }]);
+
+    expect(
+      createPlugin({
+        id: 'test',
+        register({ featureFlags }) {
+          featureFlags.register('blob');
+        },
+      }).output(),
+    ).toEqual([{ name: 'blob', type: 'feature-flag' }]);
+    expect(
+      createPlugin({
+        id: 'test',
+        register({ featureFlags }) {
+          featureFlags.register('blob');
+        },
+        featureFlags: [{ name: 'test' }],
+      }).output(),
+    ).toEqual([
+      { name: 'test', type: 'feature-flag' },
+      { name: 'blob', type: 'feature-flag' },
+    ]);
+
+    expect(
+      createPlugin({
+        id: 'test',
+      }).output(),
+    ).toEqual([]);
+  });
+});

--- a/packages/core-plugin-api/src/plugin/index.ts
+++ b/packages/core-plugin-api/src/plugin/index.ts
@@ -25,4 +25,5 @@ export type {
   PluginConfig,
   PluginHooks,
   PluginOutput,
+  PluginFeatureFlagConfig,
 } from './types';

--- a/packages/core-plugin-api/src/plugin/types.ts
+++ b/packages/core-plugin-api/src/plugin/types.ts
@@ -19,7 +19,7 @@ import { AnyApiFactory } from '../apis/system';
 
 /**
  * Replace with using {@link RouteRef}s.
- *
+ * @deprecated
  * @public
  */
 export type FeatureFlagOutput = {
@@ -31,6 +31,7 @@ export type FeatureFlagOutput = {
  * {@link FeatureFlagOutput} type.
  *
  * @public
+ * @deprecated Use {@link BackstagePlugin.getFeatureFlags} instead.
  */
 export type PluginOutput = FeatureFlagOutput;
 
@@ -71,11 +72,28 @@ export type BackstagePlugin<
   ExternalRoutes extends AnyExternalRoutes = {},
 > = {
   getId(): string;
+  /**
+   * @deprecated use getFeatureFlags instead.
+   * */
   output(): PluginOutput[];
   getApis(): Iterable<AnyApiFactory>;
+  /**
+   * Returns all registered feature flags for this plugin.
+   */
+  getFeatureFlags(): Iterable<PluginFeatureFlagConfig>;
   provide<T>(extension: Extension<T>): T;
   routes: Routes;
   externalRoutes: ExternalRoutes;
+};
+
+/**
+ * Plugin feature flag configuration.
+ *
+ * @public
+ */
+export type PluginFeatureFlagConfig = {
+  /** Feature flag name */
+  name: string;
 };
 
 /**
@@ -89,14 +107,17 @@ export type PluginConfig<
 > = {
   id: string;
   apis?: Iterable<AnyApiFactory>;
+  /** @deprecated use featureFlags property instead for defining feature flags */
   register?(hooks: PluginHooks): void;
   routes?: Routes;
   externalRoutes?: ExternalRoutes;
+  featureFlags?: PluginFeatureFlagConfig[];
 };
 
 /**
  * Holds hooks registered by the plugin.
  *
+ * @deprecated - feature flags are now registered in plugin config under featureFlags
  * @public
  */
 export type PluginHooks = {

--- a/packages/core-plugin-api/src/plugin/types.ts
+++ b/packages/core-plugin-api/src/plugin/types.ts
@@ -19,7 +19,7 @@ import { AnyApiFactory } from '../apis/system';
 
 /**
  * Replace with using {@link RouteRef}s.
- * @deprecated
+ * @deprecated will be removed
  * @public
  */
 export type FeatureFlagOutput = {

--- a/plugins/cost-insights/src/plugin.ts
+++ b/plugins/cost-insights/src/plugin.ts
@@ -34,9 +34,7 @@ export const unlabeledDataflowAlertRef = createRouteRef({
 
 export const costInsightsPlugin = createPlugin({
   id: 'cost-insights',
-  register({ featureFlags }) {
-    featureFlags.register('cost-insights-currencies');
-  },
+  featureFlags: [{ name: 'cost-insights-currencies' }],
   routes: {
     root: rootRouteRef,
     growthAlerts: projectGrowthAlertRef,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Deprecated `register` option of `createPlugin` and the `outputs` methods of the plugin instance.

Introduces the `featureFlags` property to define your feature flags instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
