### PR TITLE
create-app: add pack scripts that excludes peer depdencies during publish

### DIFF
--- a/.changeset/chilly-sloths-sniff.md
+++ b/.changeset/chilly-sloths-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Cleaned out the `peerDependencies` in the published version of the package, making it much quicker to run `npx @backstage/create-app` as it no longer needs to install a long list of unnecessary.

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -25,6 +25,8 @@
     "lint": "backstage-cli lint",
     "test": "backstage-cli test",
     "clean": "backstage-cli clean",
+    "prepack": "node scripts/prepack.js",
+    "postpack": "node scripts/postpack.js",
     "start": "nodemon --"
   },
   "dependencies": {

--- a/packages/create-app/scripts/postpack.js
+++ b/packages/create-app/scripts/postpack.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-restricted-syntax */
+
+const fs = require('fs-extra');
+const path = require('path');
+
+async function main() {
+  const pkgPath = path.resolve(__dirname, '../package.json');
+  const pkgBackupPath = path.resolve(__dirname, '../package.json-prepack');
+
+  try {
+    await fs.move(pkgBackupPath, pkgPath, { overwrite: true });
+  } catch (err) {
+    console.error(`Failed to restore package.json during postpack, ${err}`);
+  }
+}
+
+main().catch(err => {
+  console.error(err.stack);
+  process.exit(1);
+});

--- a/packages/create-app/scripts/prepack.js
+++ b/packages/create-app/scripts/prepack.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-restricted-syntax */
+
+const fs = require('fs-extra');
+const path = require('path');
+
+async function main() {
+  const pkgPath = path.resolve(__dirname, '../package.json');
+  const pkgBackupPath = path.resolve(__dirname, '../package.json-prepack');
+
+  const pkg = await fs.readJson(pkgPath);
+  await fs.writeJson(pkgBackupPath, pkg, { encoding: 'utf8', spaces: 2 });
+  delete pkg.peerDependencies;
+  await fs.writeJson(pkgPath, pkg, { encoding: 'utf8', spaces: 2 });
+}
+
+main().catch(err => {
+  console.error(err.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
Trying this out as a fix for #8225, expecting e2e test issues 😅 