### PR TITLE
Fixed bug in backend-common to allow passing of remote option in order to enable passing remote url in --config option.

### DIFF
--- a/.changeset/brave-impalas-switch.md
+++ b/.changeset/brave-impalas-switch.md
@@ -1,0 +1,24 @@
+---
+'example-backend': patch
+'@backstage/backend-common': patch
+'@backstage/config-loader': patch
+---
+
+Fixed bug in backend-common to allow passing of remote option in order to enable passing remote url in --config option. The remote option should be passed along with reloadIntervalSeconds from packages/backend/src/index.ts (Updated the file as well)
+
+These changes are needed in `packages/backend/src/index.ts` if remote urls are desired to be passed in --config option and read and watch remote files for config.
+
+```diff
+@@ -86,7 +86,11 @@ async function main() {
+   const config = await loadBackendConfig({
+     argv: process.argv,
+     logger,
++    remote: {
++      reloadIntervalSeconds: 60 * 60 * 12 // Check remote config changes every 12 hours. Change to your desired interval in seconds
++    }
+   });
++
+   const createEnv = makeCreateEnv(config);
+
+   const healthcheckEnv = useHotMemoize(module, () => createEnv('healthcheck'));
+```

--- a/docs/conf/writing.md
+++ b/docs/conf/writing.md
@@ -67,7 +67,7 @@ production build.
 
 ## Configuration Files
 
-It is possible to have multiple configuration files (bundled and/or remote),
+It is possible to have multiple configuration files (bundled and/or remote\*),
 both to support different environments, but also to define configuration that is
 local to specific packages. The configuration files to load are selected using a
 `--config <local-path|url>` flag, and it is possible to load any number of
@@ -75,7 +75,25 @@ files. Paths are relative to the working directory of the executed process, for
 example `package/backend`. This means that to select a config file in the repo
 root when running the backend, you would use `--config ../../my-config.yaml`,
 and for config file on a config server you would use
-`--config https://some.domain.io/app-config.yaml`
+`--config https://some.domain.io/app-config.yaml`<br/>
+
+**\*Note**: In order to use remote urls, ensure that the option 'remote' is
+passed in `loadBackendConfig(...)` call (See below) inside
+`packages/backend/src/index.ts`, with the option of
+reloadIntervalSeconds(required) as given below. This will allow the usage of
+remote configs and also, will ensure that this config is checked for any changes
+every 12 hours. (This can be any desired value in seconds, here 60 _ 60 _ 12 =
+12 hours!):
+
+```ts
+const config = await loadBackendConfig({
+  argv: process.argv,
+  logger,
+  remote: {
+    reloadIntervalSeconds: 60 * 60 * 12, // Check remote config changes every 12 hours. Change to your desired interval in seconds
+  },
+});
+```
 
 If no `config` flags are specified, the default behavior is to load
 `app-config.yaml` and, if it exists, `app-config.local.yaml` from the repo root.

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -23,6 +23,7 @@ import {
   loadConfig,
   ConfigSchema,
   ConfigTarget,
+  LoadConfigOptionsRemote,
 } from '@backstage/config-loader';
 import { AppConfig, Config, ConfigReader } from '@backstage/config';
 import { JsonValue } from '@backstage/types';
@@ -178,6 +179,7 @@ let currentCancelFunc: () => void;
 export async function loadBackendConfig(options: {
   logger: Logger;
   // process.argv or any other overrides
+  remote?: LoadConfigOptionsRemote;
   argv: string[];
 }): Promise<Config> {
   const args = parseArgs(options.argv);
@@ -204,6 +206,7 @@ export async function loadBackendConfig(options: {
     configRoot: paths.targetRoot,
     configPaths: [],
     configTargets: configTargets,
+    remote: options.remote,
     watch: {
       onChange(newConfigs) {
         options.logger.info(

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -86,7 +86,11 @@ async function main() {
   const config = await loadBackendConfig({
     argv: process.argv,
     logger,
+    remote: {
+      reloadIntervalSeconds: 60 * 60 * 12, // Check remote config changes every 12 hours. Change to your desired interval in seconds
+    },
   });
+
   const createEnv = makeCreateEnv(config);
 
   const healthcheckEnv = useHotMemoize(module, () => createEnv('healthcheck'));

--- a/packages/config-loader/src/loader.ts
+++ b/packages/config-loader/src/loader.ts
@@ -45,7 +45,7 @@ export type LoadConfigOptionsWatch = {
 
 export type LoadConfigOptionsRemote = {
   /**
-   * An optional remote config reloading period, in seconds
+   * A remote config reloading period, in seconds
    */
   reloadIntervalSeconds: number;
 };
@@ -126,8 +126,16 @@ export async function loadConfig(
     .filter((e): e is { url: string } => e.hasOwnProperty('url'))
     .map(configTarget => configTarget.url);
 
-  if (remote === undefined && configUrls.length > 0) {
-    throw new Error(`Remote config detected but this feature is turned off`);
+  if (remote === undefined) {
+    if (configUrls.length > 0) {
+      throw new Error(
+        `Remote config detected but this feature is turned off. Please enable by passing remote option in loadBackendConfig() call inside packages/backend/src/index.ts. See https://backstage.io/docs/conf/writing#configuration-files for detailed info.`,
+      );
+    }
+  } else if (remote.reloadIntervalSeconds === undefined) {
+    throw new Error(
+      `Remote config must be contain reloadIntervalSeconds: <seconds> value`,
+    );
   }
 
   // If no paths are provided, we default to reading


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Backend was giving error whenever any remote url config was passed while starting it.

Ex: `yarn start --config ../../app-config.yaml --config https://some.domain.io/app-config.yaml`

Error: 
```
Backend failed to start up Error: Remote config detected but this feature is turned off
    at loadConfig (webpack-internal:///../config-loader/src/loader.ts:156:11)
    at loadBackendConfig (webpack-internal:///../backend-common/src/config.ts:214:100)
    at async main (webpack-internal:///./src/index.ts:100:18)
```
#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes: Not present as there was no test written earlier as well. 
- [ ] Screenshots attached (for UI changes): No UI Change
- [x] All your commits have a `Signed-off-by` line in the message.
