### PR TITLE
Adds support to customize the sanitizer

### DIFF
--- a/.changeset/neat-insects-ring.md
+++ b/.changeset/neat-insects-ring.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Add the techdocs.sanitizer.allowedIframeHosts config.
+This config allows all iframes which have the host of the attribute src in the 'allowedIframehosts' list to be displayed in the documentation.

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -421,3 +421,24 @@ folder (/docs) or replace the content in this file.
 > on how you have configured your `template.yaml`
 
 Done! You now have support for TechDocs in your own software template!
+
+## how to enable iframes in TechDocs
+
+Techdocs uses the [DOMPurify](https://github.com/cure53/DOMPurify) to sanitizes
+HTML and prevents XSS attacks
+
+It's possible to allow some iframes based on a list of allowed hosts. To do
+this, add the allowed hosts in the `techdocs.sanitizer.allowedIframeHosts`
+configuration of your `app-config.yaml`
+
+E.g.
+
+```yaml
+techdocs:
+  sanitizer:
+    allowedIframeHosts:
+      - drive.google.com
+```
+
+This way, all iframes where the host of src attribute is in the
+`sanitizer.allowedIframeHosts` list will be displayed

--- a/plugins/techdocs/config.d.ts
+++ b/plugins/techdocs/config.d.ts
@@ -39,5 +39,16 @@ export interface Config {
      * @deprecated
      */
     requestUrl?: string;
+
+    sanitizer?: {
+      /**
+       * Allows iframe tag only for listed hosts
+       * Example:
+       *  allowedIframeHosts: ["example.com"]
+       *  this will allow all iframes with the host `example.com` in the src attribute
+       * @visibility frontend
+       */
+      allowedIframeHosts?: string[];
+    };
   };
 }

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -28,7 +28,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Grid, makeStyles, useTheme } from '@material-ui/core';
 
 import { EntityName } from '@backstage/catalog-model';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 import { BackstageTheme } from '@backstage/theme';
 
@@ -137,6 +137,7 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
   const theme = useTheme<BackstageTheme>();
   const techdocsStorageApi = useApi(techdocsStorageApiRef);
   const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
+  const techdocsSanitizer = useApi(configApiRef);
   const { namespace = '', kind = '', name = '' } = entityRef;
   const { state, path, content: rawPage } = useTechDocsReader();
 
@@ -170,7 +171,7 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
   const preRender = useCallback(
     (rawContent: string, contentPath: string) =>
       transformer(rawContent, [
-        sanitizeDOM(),
+        sanitizeDOM(techdocsSanitizer.getOptionalConfig('techdocs.sanitizer')),
         addBaseUrl({
           techdocsStorageApi,
           entityId: {
@@ -319,6 +320,7 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
       namespace,
       scmIntegrationsApi,
       techdocsStorageApi,
+      techdocsSanitizer,
       theme.palette.action.disabledBackground,
       theme.palette.background.default,
       theme.palette.background.paper,


### PR DESCRIPTION
Hi, this PR aims to solve #7710, adding the possibility to overwrite the ADD_TAGS and FORBID_TAGS options in sanitizer.

to overwrite these options, you need to configure the app-config.yaml file
``` yaml
techdocs:
   ....
   sanitizer:
      addTags:
          - tag1
          - tag2
      forbidTags:          
          - tag1
          - tag2
```

P.S.: I made a change that i'm not sure i should xD. The schema data filter when dealing with an array it checked the visibility of each item in the array. Is it expected having to declare the visibility of every position in the array? I think it`s a little weird having to declare visibility for every position in a string array, for example, but I might be missing some context here.
