### PR TITLE
fix: inconsistent time units

### DIFF
--- a/docs/overview/stability-index.md
+++ b/docs/overview/stability-index.md
@@ -27,7 +27,7 @@ point building on top of the previous one:
   and the new APIs can be used in parallel. This deprecation must have been
   released for at least two weeks before the deprecated API is removed in a
   minor version bump.
-- **3** - The time limit for the deprecation is 3 months instead of two days.
+- **3** - The time limit for the deprecation is 3 months instead of two weeks.
 
 TL;DR:
 


### PR DESCRIPTION
The stability document had mixed use of "two days" and "two weeks" ... with "two weeks" seeming to be the intended value.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Changed a time description from "two days" to "two weeks" to align with other references in the document.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ X ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
