### PR TITLE
permission-node: switch initial release changeset to minor

### DIFF
--- a/.changeset/heavy-tools-hang.md
+++ b/.changeset/heavy-tools-hang.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-permission-node': patch
+'@backstage/plugin-permission-node': minor
 ---
 
 New package containing common permission and authorization utilities for backend plugins. For more information, see the [authorization PRFC](https://github.com/backstage/backstage/pull/7761).


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Saw [this discussion](https://github.com/backstage/backstage/pull/8215#discussion_r756279216) and figured it made sense for permission-node too! Hoping it's safe to update changesets that are already in master.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
