### PR TITLE
Add options to spawn in runCommand

### DIFF
--- a/.changeset/twenty-worms-provide.md
+++ b/.changeset/twenty-worms-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Add options to spawn in runCommand helper

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -24,6 +24,7 @@ import { PluginDatabaseManager } from '@backstage/backend-common';
 import { Schema } from 'jsonschema';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { ScmIntegrations } from '@backstage/integration';
+import { SpawnOptionsWithoutStdio } from 'child_process';
 import { TemplateEntityV1beta2 } from '@backstage/catalog-model';
 import { UrlReader } from '@backstage/backend-common';
 import { Writable } from 'stream';
@@ -304,11 +305,12 @@ export interface RouterOptions {
 // Warning: (ae-forgotten-export) The symbol "RunCommandOptions" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "runCommand" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public
 export const runCommand: ({
   command,
   args,
   logStream,
+  options,
 }: RunCommandOptions) => Promise<void>;
 
 // @public (undocumented)

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { spawn } from 'child_process';
+import { SpawnOptionsWithoutStdio, spawn } from 'child_process';
 import { PassThrough, Writable } from 'stream';
 import { Logger } from 'winston';
 import { Git } from '@backstage/backend-common';
@@ -22,18 +22,27 @@ import { Octokit } from '@octokit/rest';
 import { assertError } from '@backstage/errors';
 
 export type RunCommandOptions = {
+  /** command to run */
   command: string;
+  /** arguments to pass the command */
   args: string[];
+  /** options to pass to spawn */
+  options?: SpawnOptionsWithoutStdio;
+  /** stream to capture stdout and stderr output */
   logStream?: Writable;
 };
 
+/**
+ * Run a command in a sub-process, normally a shell command.
+ */
 export const runCommand = async ({
   command,
   args,
   logStream = new PassThrough(),
+  options,
 }: RunCommandOptions) => {
   await new Promise<void>((resolve, reject) => {
-    const process = spawn(command, args);
+    const process = spawn(command, args, options);
 
     process.stdout.on('data', stream => {
       logStream.write(stream);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I would like to use the options in runCommand in my custom action built on top of scaffolder.

techdocs common already has the options added: https://github.com/backstage/backstage/blob/master/packages/techdocs-common/src/stages/generate/helpers.ts#L58

Are we able to add this here please?

I can copy code / work around it for now but I think this would be a good enhancement

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
