### PR TITLE
core-app-api: remedy wrong relative route reference resolution

### DIFF
--- a/.changeset/thick-poems-camp.md
+++ b/.changeset/thick-poems-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed a bug where `useRouteRef` would fail in situations where relative navigation was needed and the app was is mounted on a sub-path. This would typically show up as a failure to navigate to a tab on an entity page.

--- a/packages/core-app-api/src/routing/RouteResolver.ts
+++ b/packages/core-app-api/src/routing/RouteResolver.ts
@@ -207,6 +207,20 @@ export class RouteResolver {
       return undefined;
     }
 
+    // The location that we get passed in uses the full path, so start by trimming off
+    // the app base path prefix in case we're running the app on a sub-path.
+    let relativeSourceLocation: Parameters<typeof matchRoutes>[1];
+    if (typeof sourceLocation === 'string') {
+      relativeSourceLocation = this.trimPath(sourceLocation);
+    } else if (sourceLocation.pathname) {
+      relativeSourceLocation = {
+        ...sourceLocation,
+        pathname: this.trimPath(sourceLocation.pathname),
+      };
+    } else {
+      relativeSourceLocation = sourceLocation;
+    }
+
     // Next we figure out the base path, which is the combination of the common parent path
     // between our current location and our target location, as well as the additional path
     // that is the difference between the parent path and the base of our target location.
@@ -214,7 +228,7 @@ export class RouteResolver {
       this.appBasePath +
       resolveBasePath(
         targetRef,
-        sourceLocation,
+        relativeSourceLocation,
         this.routePaths,
         this.routeParents,
         this.routeObjects,
@@ -224,5 +238,16 @@ export class RouteResolver {
       return basePath + generatePath(targetPath, params);
     };
     return routeFunc;
+  }
+
+  private trimPath(targetPath: string) {
+    if (!targetPath) {
+      return targetPath;
+    }
+
+    if (targetPath.startsWith(this.appBasePath)) {
+      return targetPath.slice(this.appBasePath.length);
+    }
+    return targetPath;
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Thanks to @yousifalraheem for reporting this on Discord!

There was a bug in how we match the current route, where the structure we use to match the routes would not include the app's base path, but the location to pass in to the matcher would. This fixes that, along with some new tests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
