### PR TITLE
fix(circleci): Mapping vcs-type dynamically instead of hardcoding to git

### DIFF
--- a/.changeset/moody-pears-suffer.md
+++ b/.changeset/moody-pears-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-circleci': patch
+---
+
+Fixed bug in circleci plugin. The bug fix is with respect to restartBuild action in circleci.Changed the vcstype from Git to map the vcstype dynamically.

--- a/.changeset/moody-pears-suffer.md
+++ b/.changeset/moody-pears-suffer.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-circleci': patch
 ---
 
-Fixed bug in circleci plugin. The bug fix is with respect to restartBuild action in circleci.Changed the vcstype from Git to map the vcstype dynamically.
+Fixed a bug in the `CircleCI` plugin where restarting builds was hard-coded to GitHub rather than introspecting the entity source location.

--- a/plugins/circleci/src/state/useBuilds.ts
+++ b/plugins/circleci/src/state/useBuilds.ts
@@ -162,7 +162,7 @@ export function useBuilds() {
         vcs: {
           owner: owner,
           repo: repo,
-          type: GitType.GITHUB,
+          type: mapVcsType(vcs),
         },
       });
     } catch (e) {


### PR DESCRIPTION
Currently the retryBuild action in circleci plugin is taking git as vcs-type irrespective of the vcs-type the end user is using.
So, I changed the vcs-type to map dynamically for retrybuild action in circleci plugin.

This PR is a result of the discussion here https://github.com/backstage/backstage/discussions/8257

