### PR TITLE
Request CronJobs with older apiGroup

### DIFF
--- a/.changeset/light-cooks-train.md
+++ b/.changeset/light-cooks-train.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Query CronJobs from Kubernetes with apiGroup BatchV1beta1

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -16,7 +16,7 @@
 
 import {
   AppsV1Api,
-  BatchV1Api,
+  BatchV1beta1Api,
   AutoscalingV1Api,
   CoreV1Api,
   KubeConfig,
@@ -78,7 +78,7 @@ export class KubernetesClientProvider {
   getBatchClientByClusterDetails(clusterDetails: ClusterDetails) {
     const kc = this.getKubeConfig(clusterDetails);
 
-    return kc.makeApiClient(BatchV1Api);
+    return kc.makeApiClient(BatchV1beta1Api);
   }
 
   getNetworkingBeta1Client(clusterDetails: ClusterDetails) {

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.ts
@@ -17,7 +17,7 @@
 import {
   AppsV1Api,
   AutoscalingV1Api,
-  BatchV1Api,
+  BatchV1beta1Api,
   CoreV1Api,
   NetworkingV1beta1Api,
 } from '@kubernetes/client-node';
@@ -42,7 +42,7 @@ export interface Clients {
   core: CoreV1Api;
   apps: AppsV1Api;
   autoscaling: AutoscalingV1Api;
-  batch: BatchV1Api;
+  batch: BatchV1beta1Api;
   networkingBeta1: NetworkingV1beta1Api;
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This will query CronJobs from Kubernetes with apiGroup BatchV1beta1 which is supported in Kubernetes < 1.21. Currently, getting the CronJobs requires running at least Kubernetes 1.21.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
