### PR TITLE
Add new auth providers to the doc index

### DIFF
--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -16,8 +16,10 @@ Backstage identity information in your app or plugins.
 
 Backstage comes with many common authentication providers in the core library:
 
+- [Atlassian](atlassian/provider.md)
 - [Auth0](auth0/provider.md)
 - [Azure](microsoft/provider.md)
+- [Bitbucket](bitbucket/provider.md)
 - [GitHub](github/provider.md)
 - [GitLab](gitlab/provider.md)
 - [Google](google/provider.md)


### PR DESCRIPTION
Adds the auth providers from #7570 and #7308 to the auth index doc.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
