### PR TITLE
permissions: change permission integration route to use /.well-known prefix

### DIFF
--- a/.changeset/long-suits-retire.md
+++ b/.changeset/long-suits-retire.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-permission-backend': minor
+'@backstage/plugin-permission-node': minor
+---
+
+Change route used for integration between the authorization framework and other plugin backends to use the /.well-known prefix.

--- a/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
+++ b/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
@@ -64,7 +64,7 @@ describe('PermissionIntegrationClient', () => {
       server.listen({ onUnhandledRequest: 'error' });
       server.use(
         rest.post(
-          `${mockBaseUrl}/permissions/apply-conditions`,
+          `${mockBaseUrl}/.well-known/backstage/permissions/apply-conditions`,
           mockApplyConditionsHandler,
         ),
       );

--- a/plugins/permission-backend/src/service/PermissionIntegrationClient.ts
+++ b/plugins/permission-backend/src/service/PermissionIntegrationClient.ts
@@ -54,7 +54,7 @@ export class PermissionIntegrationClient {
   ): Promise<ApplyConditionsResponse> {
     const endpoint = `${await this.discovery.getBaseUrl(
       pluginId,
-    )}/permissions/apply-conditions`;
+    )}/.well-known/backstage/permissions/apply-conditions`;
 
     const request: ApplyConditionsRequest = {
       resourceRef,

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -61,7 +61,7 @@ describe('createPermissionIntegrationRouter', () => {
     expect(router).toBeDefined();
   });
 
-  describe('POST /permissions/apply-conditions', () => {
+  describe('POST /.well-known/backstage/permissions/apply-conditions', () => {
     it.each([
       { rule: 'test-rule-1', params: ['abc', 123] },
       {
@@ -94,7 +94,7 @@ describe('createPermissionIntegrationRouter', () => {
       },
     ])('returns 200/ALLOW when criteria match (case %#)', async conditions => {
       const response = await request(app)
-        .post('/permissions/apply-conditions')
+        .post('/.well-known/backstage/permissions/apply-conditions')
         .send({
           resourceRef: 'default:test/resource',
           resourceType: 'test-resource',
@@ -135,7 +135,7 @@ describe('createPermissionIntegrationRouter', () => {
       'returns 200/DENY when criteria do not match (case %#)',
       async conditions => {
         const response = await request(app)
-          .post('/permissions/apply-conditions')
+          .post('/.well-known/backstage/permissions/apply-conditions')
           .send({
             resourceRef: 'default:test/resource',
             resourceType: 'test-resource',
@@ -149,7 +149,7 @@ describe('createPermissionIntegrationRouter', () => {
 
     it('returns 400 when called with incorrect resource type', async () => {
       const response = await request(app)
-        .post('/permissions/apply-conditions')
+        .post('/.well-known/backstage/permissions/apply-conditions')
         .send({
           resourceRef: 'default:test/resource',
           resourceType: 'test-incorrect-resource',
@@ -168,7 +168,7 @@ describe('createPermissionIntegrationRouter', () => {
       mockGetResource.mockReturnValueOnce(Promise.resolve(undefined));
 
       const response = await request(app)
-        .post('/permissions/apply-conditions')
+        .post('/.well-known/backstage/permissions/apply-conditions')
         .send({
           resourceRef: 'default:test/resource',
           resourceType: 'test-resource',
@@ -198,7 +198,7 @@ describe('createPermissionIntegrationRouter', () => {
       { conditions: { anyOf: [] } },
     ])(`returns 400 for invalid input %#`, async input => {
       const response = await request(app)
-        .post('/permissions/apply-conditions')
+        .post('/.well-known/backstage/permissions/apply-conditions')
         .send(input);
 
       expect(response.status).toEqual(400);

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -132,7 +132,7 @@ export const createPermissionIntegrationRouter = <TResource>({
   const getRule = createGetRule(rules);
 
   router.post(
-    '/permissions/apply-conditions',
+    '/.well-known/backstage/permissions/apply-conditions',
     express.json(),
     async (
       req,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adjusts the route used by the permission integration system to use a [`/.well-known` prefix](https://www.keycdn.com/support/well-known#what-is-the-well-known-path-prefix), in the hope that this reduces the chance that the route conflicts with other routes in plugin backends.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
