### PR TITLE
Use `theme.title` instead of `theme.variant` in the theme switcher

### DIFF
--- a/.changeset/great-eagles-mate.md
+++ b/.changeset/great-eagles-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+The theme switcher now renders the title of themes instead of their variant

--- a/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
@@ -131,7 +131,7 @@ export const UserSettingsThemeToggle = () => {
                 value={theme.id}
               >
                 <>
-                  {theme.variant}&nbsp;
+                  {theme.title}&nbsp;
                   <ThemeIcon
                     id={theme.id}
                     icon={themeIcon}


### PR DESCRIPTION
Signed-off-by: Mike Cripps <mike.cripps@footballradar.com>

## Hey, I just made a Pull Request!

We (@footballradar) are implementing our own theme and adding it to the list of themes in the app (retaining the existing light and dark themes). However, when we view the User Settings page, we are unable to determine which 'light' theme is ours (without hovering over the button).

The [SidebarThemeSwitcher](https://github.com/backstage/backstage/blob/master/packages/dev-utils/src/devApp/SidebarThemeSwitcher.tsx#L118) renders the theme title in the theme switcher, but the existing User Settings card renders the theme variant. As theme variant can only be one of `light` or `dark` (by the TS types) this doesn't seem to the appropriate value.

After this PR, the toggle buttons now look like this:
![Screenshot 2021-12-01 at 13 34 26](https://user-images.githubusercontent.com/1618612/144243873-b1b6534d-4532-4859-8f4c-b52b735bd411.png)

There is, I guess, an argument that you should only have two styles in your app, but [this page](https://backstage.io/docs/getting-started/app-custom-theme#using-your-custom-theme) seems to suggest that you can have as many as you like, and we want a way of testing changes to the theme without impacting the existing, working, light theme. If this is the case I'm happy to drop this PR (although I think keeping the theme switchers in sync is probably worthwhile anyway).

It's also not particularly clear what 'Auto' theme will do in the case where you have two light themes?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
