### PR TITLE
slowing down the github refresh rate

### DIFF
--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -23,6 +23,7 @@ export default async function createPlugin(
   env: PluginEnvironment,
 ): Promise<Router> {
   const builder = await CatalogBuilder.create(env);
+  builder.setRefreshIntervalSeconds(350);
   builder.addProcessor(new ScaffolderEntitiesProcessor());
   const { processingEngine, router } = await builder.build();
   await processingEngine.start();


### PR DESCRIPTION
With our count of repositories in the siteimprove org (>300) I think we're running into the github api rate limiter of 5000 requests per hour. 
I think this is causing long wait times for backstage to recognize changes made to catalog-info.yaml files.
https://backstage.io/docs/integrations/github/discovery

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
Removed PR checklist -> assuming this part is a leftover from a template setup. Please correct me if I'm wrong.