### PR TITLE
[Search] Add optional icon and secondaryAction properties 

### DIFF
--- a/.changeset/search-birds-leave.md
+++ b/.changeset/search-birds-leave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Add optional icon and secondaryAction properties for DefaultResultListItem component

--- a/plugins/search/api-report.md
+++ b/plugins/search/api-report.md
@@ -12,6 +12,7 @@ import { IndexableDocument } from '@backstage/search-common';
 import { JsonObject } from '@backstage/types';
 import { default as React_2 } from 'react';
 import { ReactElement } from 'react';
+import { ReactNode } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { SearchQuery } from '@backstage/search-common';
 import { SearchResult as SearchResult_2 } from '@backstage/search-common';
@@ -22,7 +23,11 @@ import { SearchResultSet } from '@backstage/search-common';
 // @public (undocumented)
 export const DefaultResultListItem: ({
   result,
+  icon,
+  secondaryAction,
 }: {
+  icon?: ReactNode;
+  secondaryAction?: ReactNode;
   result: IndexableDocument;
 }) => JSX.Element;
 

--- a/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.stories.tsx
+++ b/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.stories.tsx
@@ -16,6 +16,9 @@
 
 import React from 'react';
 import { Grid } from '@material-ui/core';
+import FindInPageIcon from '@material-ui/icons/FindInPage';
+import GroupIcon from '@material-ui/icons/Group';
+import { Button } from '@backstage/core-components';
 import { DefaultResultListItem } from '../index';
 import { MemoryRouter } from 'react-router';
 
@@ -24,17 +27,59 @@ export default {
   component: DefaultResultListItem,
 };
 
+const mockSearchResult = {
+  location: 'search/search-result',
+  title: 'Search Result 1',
+  text: 'some text from the search result',
+  owner: 'some-example-owner',
+};
+
 export const Default = () => {
   return (
     <MemoryRouter>
       <Grid container direction="row">
         <Grid item xs={12}>
+          <DefaultResultListItem result={mockSearchResult} />
+        </Grid>
+      </Grid>
+    </MemoryRouter>
+  );
+};
+
+export const WithIcon = () => {
+  return (
+    <MemoryRouter>
+      <Grid container direction="row">
+        <Grid item xs={12}>
           <DefaultResultListItem
-            result={{
-              location: 'search/search-result',
-              title: 'Search Result 1',
-              text: 'some text from the search result',
-            }}
+            result={mockSearchResult}
+            icon={<FindInPageIcon color="primary" />}
+          />
+        </Grid>
+      </Grid>
+    </MemoryRouter>
+  );
+};
+
+export const WithSecondaryAction = () => {
+  return (
+    <MemoryRouter>
+      <Grid container direction="row">
+        <Grid item xs={12}>
+          <DefaultResultListItem
+            result={mockSearchResult}
+            secondaryAction={
+              <Button
+                to="#"
+                size="small"
+                aria-label="owner"
+                variant="text"
+                startIcon={<GroupIcon />}
+                style={{ textTransform: 'lowercase' }}
+              >
+                {mockSearchResult.owner}
+              </Button>
+            }
           />
         </Grid>
       </Grid>

--- a/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.test.jsx
+++ b/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.test.jsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderInTestApp } from '@backstage/test-utils';
-
+import FindInPageIcon from '@material-ui/icons/FindInPage';
 import { DefaultResultListItem } from './DefaultResultListItem';
 
 describe('DefaultResultListItem', () => {
@@ -25,6 +25,7 @@ describe('DefaultResultListItem', () => {
     title: 'title',
     text: 'text',
     location: '/location',
+    owner: 'owner',
   };
 
   it('Links to result.location', async () => {
@@ -37,5 +38,22 @@ describe('DefaultResultListItem', () => {
     expect(screen.getByRole('listitem')).toHaveTextContent(
       result.title + result.text,
     );
+  });
+
+  it('should render icon if prop is specified', async () => {
+    await renderInTestApp(
+      <DefaultResultListItem
+        result={result}
+        icon={<FindInPageIcon title="icon" />}
+      />,
+    );
+    expect(screen.getByTitle('icon')).toBeInTheDocument();
+  });
+
+  it('should render secondary action if prop is specified', async () => {
+    await renderInTestApp(
+      <DefaultResultListItem result={result} secondaryAction={result.owner} />,
+    );
+    expect(screen.getByText('owner')).toBeInTheDocument();
   });
 });

--- a/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.tsx
+++ b/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.tsx
@@ -14,24 +14,38 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { IndexableDocument } from '@backstage/search-common';
-import { ListItem, ListItemText, Divider } from '@material-ui/core';
+import {
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Box,
+  Divider,
+} from '@material-ui/core';
 import { Link } from '@backstage/core-components';
 
 type Props = {
+  icon?: ReactNode;
+  secondaryAction?: ReactNode;
   result: IndexableDocument;
 };
 
-export const DefaultResultListItem = ({ result }: Props) => {
+export const DefaultResultListItem = ({
+  result,
+  icon,
+  secondaryAction,
+}: Props) => {
   return (
     <Link to={result.location}>
-      <ListItem alignItems="flex-start">
+      <ListItem alignItems="center">
+        {icon && <ListItemIcon>{icon}</ListItemIcon>}
         <ListItemText
           primaryTypographyProps={{ variant: 'h6' }}
           primary={result.title}
           secondary={result.text}
         />
+        {secondaryAction && <Box alignItems="flex-end">{secondaryAction}</Box>}
       </ListItem>
       <Divider />
     </Link>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add optional `icon` and `secondaryAction` properties for `<DefaultResultListItem/ >` component:

- With Icon:
```jsx
<DefaultResultListItem icon={<FindInPageIcon color="primary" />} />
```

![image](https://user-images.githubusercontent.com/6290749/144270730-f0d91e81-6495-4571-94f6-51e524efc499.png)

- With Secondary Action:
 ```jsx
<DefaultResultListItem secondaryAction={<Button href="#">Link</Button>}/>
```

![image](https://user-images.githubusercontent.com/6290749/144270836-4ed59bef-947c-44c1-9343-34514bc65e59.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
