### PR TITLE
Clean up scaffolder config

### DIFF
--- a/.changeset/cool-rules-smash.md
+++ b/.changeset/cool-rules-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Removed unused scaffolder visibility configuration; this has been moved to publish actions. Deprecated scaffolder provider configuration keys; these should use the integrations configuration instead.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -277,24 +277,6 @@ scaffolder:
   #   email: scaffolder@backstage.io
   # Use to customize the default commit message when new components are created
   # defaultCommitMessage: 'Initial commit'
-  github:
-    token: ${GITHUB_TOKEN}
-    visibility: public # or 'internal' or 'private'
-  gitlab:
-    api:
-      baseUrl: https://gitlab.com
-      token: ${GITLAB_TOKEN}
-    visibility: public # or 'internal' or 'private'
-  azure:
-    baseUrl: https://dev.azure.com/{your-organization}
-    api:
-      token: ${AZURE_TOKEN}
-  bitbucket:
-    api:
-      host: https://bitbucket.org
-      username: ${BITBUCKET_USERNAME}
-      token: ${BITBUCKET_TOKEN}
-    visibility: public # or or 'private'
 
 auth:
   ### Add auth.keyStore.provider to more granularly control how to store JWK data when running

--- a/plugins/scaffolder-backend/config.d.ts
+++ b/plugins/scaffolder-backend/config.d.ts
@@ -28,30 +28,30 @@ export interface Config {
      * The commit message used when new components are created.
      */
     defaultCommitMessage?: string;
+    /**
+     * @deprecated Replaced by parameters for the publish:github action
+     */
     github?: {
       [key: string]: string;
-      /**
-       * The visibility to set on created repositories.
-       */
-      visibility?: 'public' | 'internal' | 'private';
     };
+    /**
+     * @deprecated Use the Gitlab integration instead
+     */
     gitlab?: {
       api: { [key: string]: string };
-      /**
-       * The visibility to set on created repositories.
-       */
-      visibility?: 'public' | 'internal' | 'private';
     };
+    /**
+     * @deprecated Use the Azure integration instead
+     */
     azure?: {
       baseUrl: string;
       api: { [key: string]: string };
     };
+    /**
+     * @deprecated Use the Bitbucket integration instead
+     */
     bitbucket?: {
       api: { [key: string]: string };
-      /**
-       * The visibility to set on created repositories.
-       */
-      visibility?: 'public' | 'private';
     };
   };
 }


### PR DESCRIPTION
🧹 

Removes the scaffolder `visibility` configurations entirely, these were moved to `repoVisibility` for each publish action. Deprecates the provider-specific configuration; tokens and such are read from the `integrations` config universally now, but there are some flexible fields that may be in use like:

```ts
github?: {
  [key: string]: string;
}
```

I started to add a warning log when these configuration keys are detected, but I wonder — can we more generically in config-loader detect `@deprecated` and warn about any such config in use?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
