### PR TITLE
feat(analytics-module-ga): support self hosted analytics.js

### DIFF
--- a/.changeset/sixty-files-talk.md
+++ b/.changeset/sixty-files-talk.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-analytics-module-ga': patch
 ---
 
-Support self hosted analytics.js script via `gaAddress` config option
+Support self hosted analytics.js script via `scriptSrc` config option

--- a/.changeset/sixty-files-talk.md
+++ b/.changeset/sixty-files-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-analytics-module-ga': patch
+---
+
+Support self hosted analytics.js script via `gaAddress` config option

--- a/plugins/analytics-module-ga/config.d.ts
+++ b/plugins/analytics-module-ga/config.d.ts
@@ -29,10 +29,10 @@ export interface Config {
 
         /**
          * URL to Google Analytics analytics.js script
-         * Defaults to https://www.google-analytics.com/analytics.js
+         * Defaults to fetching from GA source (eg. https://www.google-analytics.com/analytics.js)
          * @visibility frontend
          */
-        gaAddress?: string;
+        scriptSrc?: string;
 
         /**
          * Whether or not to log analytics debug statements to the console.

--- a/plugins/analytics-module-ga/config.d.ts
+++ b/plugins/analytics-module-ga/config.d.ts
@@ -28,6 +28,13 @@ export interface Config {
         trackingId: string;
 
         /**
+         * URL to Google Analytics analytics.js script
+         * Defaults to https://www.google-analytics.com/analytics.js
+         * @visibility frontend
+         */
+        gaAddress?: string;
+
+        /**
          * Whether or not to log analytics debug statements to the console.
          * Defaults to false.
          *

--- a/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.ts
+++ b/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.ts
@@ -42,18 +42,25 @@ export class GoogleAnalytics implements AnalyticsApi {
   private constructor({
     cdmConfig,
     trackingId,
+    gaAddress,
     testMode,
     debug,
   }: {
     cdmConfig: CustomDimensionOrMetricConfig[];
     trackingId: string;
+    gaAddress: string;
     testMode: boolean;
     debug: boolean;
   }) {
     this.cdmConfig = cdmConfig;
 
     // Initialize Google Analytics.
-    ReactGA.initialize(trackingId, { testMode, debug, titleCase: false });
+    ReactGA.initialize(trackingId, {
+      gaAddress,
+      testMode,
+      debug,
+      titleCase: false,
+    });
   }
 
   /**
@@ -62,6 +69,9 @@ export class GoogleAnalytics implements AnalyticsApi {
   static fromConfig(config: Config) {
     // Get all necessary configuration.
     const trackingId = config.getString('app.analytics.ga.trackingId');
+    const gaAddress =
+      config.getOptionalString('app.analytics.ga.gaAddress') ??
+      'https://www.google-analytics.com/analytics.js';
     const debug = config.getOptionalBoolean('app.analytics.ga.debug') ?? false;
     const testMode =
       config.getOptionalBoolean('app.analytics.ga.testMode') ?? false;
@@ -82,6 +92,7 @@ export class GoogleAnalytics implements AnalyticsApi {
     // Return an implementation instance.
     return new GoogleAnalytics({
       trackingId,
+      gaAddress,
       cdmConfig,
       testMode,
       debug,

--- a/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.ts
+++ b/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.ts
@@ -42,13 +42,13 @@ export class GoogleAnalytics implements AnalyticsApi {
   private constructor({
     cdmConfig,
     trackingId,
-    gaAddress,
+    scriptSrc,
     testMode,
     debug,
   }: {
     cdmConfig: CustomDimensionOrMetricConfig[];
     trackingId: string;
-    gaAddress: string;
+    scriptSrc?: string;
     testMode: boolean;
     debug: boolean;
   }) {
@@ -56,9 +56,9 @@ export class GoogleAnalytics implements AnalyticsApi {
 
     // Initialize Google Analytics.
     ReactGA.initialize(trackingId, {
-      gaAddress,
       testMode,
       debug,
+      gaAddress: scriptSrc,
       titleCase: false,
     });
   }
@@ -69,9 +69,7 @@ export class GoogleAnalytics implements AnalyticsApi {
   static fromConfig(config: Config) {
     // Get all necessary configuration.
     const trackingId = config.getString('app.analytics.ga.trackingId');
-    const gaAddress =
-      config.getOptionalString('app.analytics.ga.gaAddress') ??
-      'https://www.google-analytics.com/analytics.js';
+    const scriptSrc = config.getOptionalString('app.analytics.ga.scriptSrc');
     const debug = config.getOptionalBoolean('app.analytics.ga.debug') ?? false;
     const testMode =
       config.getOptionalBoolean('app.analytics.ga.testMode') ?? false;
@@ -92,7 +90,7 @@ export class GoogleAnalytics implements AnalyticsApi {
     // Return an implementation instance.
     return new GoogleAnalytics({
       trackingId,
-      gaAddress,
+      scriptSrc,
       cdmConfig,
       testMode,
       debug,


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Add support for specifying location of self hosted `analytics.js` script to load from

For reference: 
- https://github.com/react-ga/react-ga/tree/master#api
- https://github.com/react-ga/react-ga/blob/984a29c61d393eda13058a9e62e0e42ed170fb6e/src/utils/loadGA.js#L5

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
