### PR TITLE
[XCMetrics] Handle invalid build statuses

### DIFF
--- a/.changeset/four-fireants-whisper.md
+++ b/.changeset/four-fireants-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-xcmetrics': patch
+---
+
+Fix bug where invalid build statuses led to crashes

--- a/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.test.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { renderInTestApp } from '@backstage/test-utils';
 import { StatusIcon } from './StatusIcon';
+import { BuildStatus } from '../../api';
 
 describe('StatusIcon', () => {
   it('should render', async () => {
@@ -30,5 +31,12 @@ describe('StatusIcon', () => {
 
     rendered = await renderInTestApp(<StatusIcon buildStatus="stopped" />);
     expect(rendered.getByLabelText('Status warning')).toBeInTheDocument();
+  });
+
+  it('should render invalid statuses', async () => {
+    const rendered = await renderInTestApp(
+      <StatusIcon buildStatus={'invalid' as BuildStatus} />,
+    );
+    expect(rendered.getByLabelText('Status aborted')).toBeInTheDocument();
   });
 });

--- a/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
+++ b/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
@@ -15,6 +15,7 @@
  */
 import React from 'react';
 import {
+  StatusAborted,
   StatusError,
   StatusOK,
   StatusWarning,
@@ -32,4 +33,4 @@ interface StatusIconProps {
 }
 
 export const StatusIcon = ({ buildStatus }: StatusIconProps) =>
-  STATUS_ICONS[buildStatus];
+  STATUS_ICONS[buildStatus] ?? <StatusAborted />;


### PR DESCRIPTION
This is a fix for a bug in the XCMetrics plugin which resulted in a crash if an invalid build status was included in the results to be rendered.

The new behaviour is to display a default icon for all statuses not rekognized.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
