### PR TITLE
Ability to use the signed in OAuth token in Software Templates

### DIFF
--- a/packages/integration-react/src/api/ScmAuthApi.ts
+++ b/packages/integration-react/src/api/ScmAuthApi.ts
@@ -38,7 +38,18 @@ export interface ScmAuthTokenOptions extends AuthRequestOptions {
    *
    * Read access to user, organization, and repositories is always included.
    */
+
   additionalScope?: {
+    /**
+     * Allow an arbitrary list of scopes provided from the user
+     * to request from the provider.
+     */
+    customScopes?: {
+      github?: string[];
+      azure?: string[];
+      bitbucket?: string[];
+      gitlab?: string[];
+    };
     /**
      * Requests access to be able to write repository content, including
      * the ability to create things like issues and pull requests.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
@@ -51,7 +51,10 @@ export class OctokitProvider {
    *
    * @param repoUrl Repository URL
    */
-  async getOctokit(repoUrl: string): Promise<OctokitIntegration> {
+  async getOctokit(
+    repoUrl: string,
+    tokenOverride?: string,
+  ): Promise<OctokitIntegration> {
     const { owner, repo, host } = parseRepoUrl(repoUrl, this.integrations);
 
     if (!owner) {
@@ -74,11 +77,13 @@ export class OctokitProvider {
 
     // TODO(blam): Consider changing this API to have owner, repo interface instead of URL as the it's
     // needless to create URL and then parse again the other side.
-    const { token } = await credentialsProvider.getCredentials({
-      url: `https://${host}/${encodeURIComponent(owner)}/${encodeURIComponent(
-        repo,
-      )}`,
-    });
+    const { token } = tokenOverride
+      ? { token: tokenOverride }
+      : await credentialsProvider.getCredentials({
+          url: `https://${host}/${encodeURIComponent(
+            owner,
+          )}/${encodeURIComponent(repo)}`,
+        });
 
     if (!token) {
       throw new InputError(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -44,7 +44,7 @@ export function createPublishGithubAction(options: {
     repoVisibility: 'private' | 'internal' | 'public';
     collaborators: Collaborator[];
     topics?: string[];
-    GIT_TOKEN?: string;
+    userToken?: string;
   }>({
     id: 'publish:github',
     description:
@@ -54,7 +54,7 @@ export function createPublishGithubAction(options: {
         type: 'object',
         required: ['repoUrl'],
         properties: {
-          GIT_TOKEN: {
+          userToken: {
             title: 'Github token to use',
             type: 'string',
           },
@@ -145,13 +145,12 @@ export function createPublishGithubAction(options: {
         defaultBranch = 'master',
         collaborators,
         topics,
-        GIT_TOKEN,
+        userToken,
       } = ctx.input;
 
-      console.log('gitToken', GIT_TOKEN);
       const { client, token, owner, repo } = await octokitProvider.getOctokit(
         repoUrl,
-        GIT_TOKEN,
+        userToken,
       );
 
       const user = await client.users.getByUsername({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -44,6 +44,7 @@ export function createPublishGithubAction(options: {
     repoVisibility: 'private' | 'internal' | 'public';
     collaborators: Collaborator[];
     topics?: string[];
+    GIT_TOKEN?: string;
   }>({
     id: 'publish:github',
     description:
@@ -53,6 +54,10 @@ export function createPublishGithubAction(options: {
         type: 'object',
         required: ['repoUrl'],
         properties: {
+          GIT_TOKEN: {
+            title: 'Github token to use',
+            type: 'string',
+          },
           repoUrl: {
             title: 'Repository Location',
             description: `Accepts the format 'github.com?repo=reponame&owner=owner' where 'reponame' is the new repository name and 'owner' is an organization or username`,
@@ -140,10 +145,13 @@ export function createPublishGithubAction(options: {
         defaultBranch = 'master',
         collaborators,
         topics,
+        GIT_TOKEN,
       } = ctx.input;
 
+      console.log('gitToken', GIT_TOKEN);
       const { client, token, owner, repo } = await octokitProvider.getOctokit(
         repoUrl,
+        GIT_TOKEN,
       );
 
       const user = await client.users.getByUsername({

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -17,6 +17,7 @@
 import { ScmIntegrations } from '@backstage/integration';
 import {
   TaskContext,
+  TaskSecrets,
   TaskSpec,
   TaskSpecV1beta3,
   TaskStep,
@@ -51,6 +52,7 @@ type TemplateContext = {
   steps: {
     [stepName: string]: { output: { [outputName: string]: JsonValue } };
   };
+  secrets: TaskSecrets;
 };
 
 const isValidTaskSpec = (taskSpec: TaskSpec): taskSpec is TaskSpecV1beta3 => {
@@ -200,9 +202,11 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
 
       const context: TemplateContext = {
         parameters: task.spec.parameters,
+        secrets: task.secrets?.uiSecrets,
         steps: {},
       };
 
+      console.log('context', context);
       for (const step of task.spec.steps) {
         try {
           if (step.if) {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
@@ -134,6 +134,7 @@ export type TaskSpec = TaskSpecV1beta2 | TaskSpecV1beta3;
  */
 export type TaskSecrets = {
   token: string | undefined;
+  uiSecrets: JsonObject;
 };
 
 /**

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -231,8 +231,11 @@ export async function createRouter(
         );
       }
 
+      console.log('secrets', req.body.secrets);
+
       const result = await taskBroker.dispatch(taskSpec, {
         token: token,
+        uiSecrets: req.body.secrets ?? {},
       });
 
       res.status(201).json({ id: result.taskId });

--- a/plugins/scaffolder/src/api.ts
+++ b/plugins/scaffolder/src/api.ts
@@ -71,7 +71,11 @@ export interface ScaffolderApi {
    * @param templateName Name of the Template entity for the scaffolder to use. New project is going to be created out of this template.
    * @param values Parameters for the template, e.g. name, description
    */
-  scaffold(templateName: string, values: Record<string, any>): Promise<string>;
+  scaffold(
+    templateName: string,
+    values: Record<string, any>,
+    secrets?: Record<string, any>,
+  ): Promise<string>;
 
   getTask(taskId: string): Promise<ScaffolderTask>;
 
@@ -156,6 +160,7 @@ export class ScaffolderClient implements ScaffolderApi {
   async scaffold(
     templateName: string,
     values: Record<string, any>,
+    secrets?: Record<string, any>,
   ): Promise<string> {
     const token = await this.identityApi.getIdToken();
     const url = `${await this.discoveryApi.getBaseUrl('scaffolder')}/v2/tasks`;
@@ -165,7 +170,7 @@ export class ScaffolderClient implements ScaffolderApi {
         'Content-Type': 'application/json',
         ...(token && { Authorization: `Bearer ${token}` }),
       },
-      body: JSON.stringify({ templateName, values: { ...values } }),
+      body: JSON.stringify({ templateName, values: { ...values }, secrets }),
     });
 
     if (response.status !== 201) {

--- a/plugins/scaffolder/src/components/Router.tsx
+++ b/plugins/scaffolder/src/components/Router.tsx
@@ -29,6 +29,7 @@ import {
   DEFAULT_SCAFFOLDER_FIELD_EXTENSIONS,
 } from '../extensions';
 import { useElementFilter } from '@backstage/core-plugin-api';
+import { SecretsContextProvider } from './secrets/Context';
 
 type RouterProps = {
   TemplateCardComponent?:
@@ -77,7 +78,11 @@ export const Router = ({ TemplateCardComponent, groups }: RouterProps) => {
       />
       <Route
         path="/templates/:templateName"
-        element={<TemplatePage customFieldExtensions={fieldExtensions} />}
+        element={
+          <SecretsContextProvider>
+            <TemplatePage customFieldExtensions={fieldExtensions} />
+          </SecretsContextProvider>
+        }
       />
       <Route path="/tasks/:taskId" element={<TaskPage />} />
       <Route path="/actions" element={<ActionsPage />} />

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -16,7 +16,7 @@
 import { JsonObject, JsonValue } from '@backstage/types';
 import { LinearProgress } from '@material-ui/core';
 import { FormValidation, IChangeEvent } from '@rjsf/core';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { generatePath, Navigate, useNavigate } from 'react-router';
 import { useParams } from 'react-router-dom';
 import { useAsync } from 'react-use';
@@ -39,6 +39,7 @@ import {
   useApiHolder,
   useRouteRef,
 } from '@backstage/core-plugin-api';
+import { SecretsContextProvider, SecretsContext } from '../secrets/Context';
 
 const useTemplateParameterSchema = (templateName: string) => {
   const scaffolderApi = useApi(scaffolderApiRef);
@@ -122,6 +123,8 @@ export const TemplatePage = ({
   const { schema, loading, error } = useTemplateParameterSchema(templateName);
   const [formState, setFormState] = useState({});
   const handleFormReset = () => setFormState({});
+  const secretsContext = useContext(SecretsContext);
+
   const handleChange = useCallback(
     (e: IChangeEvent) => setFormState(e.formData),
     [setFormState],

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -39,7 +39,7 @@ import {
   useApiHolder,
   useRouteRef,
 } from '@backstage/core-plugin-api';
-import { SecretsContextProvider, SecretsContext } from '../secrets/Context';
+import { SecretsContext } from '../secrets/Context';
 
 const useTemplateParameterSchema = (templateName: string) => {
   const scaffolderApi = useApi(scaffolderApiRef);
@@ -131,7 +131,11 @@ export const TemplatePage = ({
   );
 
   const handleCreate = async () => {
-    const id = await scaffolderApi.scaffold(templateName, formState);
+    const id = await scaffolderApi.scaffold(
+      templateName,
+      formState,
+      secretsContext?.secrets ?? {},
+    );
     navigate(generatePath(`${rootLink()}/tasks/:taskId`, { taskId: id }));
   };
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -115,6 +115,26 @@ export const RepoUrlPicker = ({
     formData,
     allowedOwners,
   );
+
+  const onBlur = useCallback(() => {
+    const withCredentials = uiSchema['ui:options']?.withCredentials as {
+      key: string;
+    };
+
+    const check = async () => {
+      if (withCredentials) {
+        if (host && owner && repo) {
+          const token = await scmAuthApi.getCredentials({
+            url: `https://${host}/${owner}/${repo}`,
+          });
+
+          setSecret({ [withCredentials.key]: token.token });
+        }
+      }
+    };
+    check();
+  }, [host, owner, repo, scmAuthApi, setSecret, uiSchema]);
+
   const updateHost = useCallback(
     (value: SelectedItems) => {
       onChange(
@@ -127,8 +147,10 @@ export const RepoUrlPicker = ({
           project,
         }),
       );
+
+      onBlur();
     },
-    [onChange, owner, repo, organization, workspace, project],
+    [onChange, owner, repo, organization, workspace, project, onBlur],
   );
 
   const updateOwnerSelect = useCallback(
@@ -244,19 +266,6 @@ export const RepoUrlPicker = ({
     workspace,
     project,
   ]);
-
-  const onBlur = useCallback(() => {
-    const check = async () => {
-      if (host && owner && repo) {
-        const token = await scmAuthApi.getCredentials({
-          url: `https://${host}/${owner}/${repo}`,
-        });
-
-        setSecret({ scmToken: token.token });
-      }
-    };
-    check();
-  }, [host, owner, repo, scmAuthApi, setSecret]);
 
   if (loading) {
     return <Progress />;

--- a/plugins/scaffolder/src/components/secrets/Context.tsx
+++ b/plugins/scaffolder/src/components/secrets/Context.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, {
+  useState,
+  useCallback,
+  useContext,
+  createContext,
+  PropsWithChildren,
+} from 'react';
+import { JsonObject } from '@backstage/types';
+
+type SecretsContextContents = {
+  secrets: JsonObject;
+  setSecrets: React.Dispatch<React.SetStateAction<JsonObject>>;
+};
+
+export const SecretsContext = createContext<SecretsContextContents | undefined>(
+  undefined,
+);
+
+export const SecretsContextProvider = ({ children }: PropsWithChildren<{}>) => {
+  const [secrets, setSecrets] = useState<JsonObject>({});
+
+  return (
+    <SecretsContext.Provider value={{ secrets, setSecrets }}>
+      {children}
+    </SecretsContext.Provider>
+  );
+};
+
+export const useSecretsContext = () => {
+  const value = useContext(SecretsContext);
+  if (!value) {
+    throw new Error('SecretsContext has not been initialized');
+  }
+  const { secrets, setSecrets } = value;
+
+  const setSecret = useCallback(
+    (input: JsonObject) => {
+      setSecrets({ ...secrets, ...input });
+    },
+    [secrets, setSecrets],
+  );
+
+  return { setSecret };
+};

--- a/plugins/scaffolder/src/components/secrets/index.ts
+++ b/plugins/scaffolder/src/components/secrets/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { useSecretsContext } from './Context';

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -49,3 +49,4 @@ export { FavouriteTemplate } from './components/FavouriteTemplate';
 export { TemplateList } from './components/TemplateList';
 export type { TemplateListProps } from './components/TemplateList';
 export { TemplateTypePicker } from './components/TemplateTypePicker';
+export * from './components/secrets';


### PR DESCRIPTION
Here's a draft start of how we can solve `secrets` in Software Templates and the `scaffolder-backend`.

This just solves the secret context in the frontend, and it's still not finished yet.
Also the backend work is not started yet.

Closes #7684 
