### PR TITLE
auth-backend: migrate saml provider to sign-in resolver

### DIFF
--- a/.changeset/dry-schools-hear.md
+++ b/.changeset/dry-schools-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Migrated the SAML provider to implement the `authHandler` and `signIn.resolver` options.

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -268,6 +268,11 @@ export function createRouter({
   providerFactories,
 }: RouterOptions): Promise<express.Router>;
 
+// @public (undocumented)
+export const createSamlProvider: (
+  options?: SamlProviderOptions | undefined,
+) => AuthProviderFactory;
+
 // Warning: (ae-missing-release-tag) "factories" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -567,6 +572,19 @@ export interface RouterOptions {
   // (undocumented)
   providerFactories?: ProviderFactories;
 }
+
+// @public (undocumented)
+export type SamlAuthResult = {
+  fullProfile: any;
+};
+
+// @public (undocumented)
+export type SamlProviderOptions = {
+  authHandler?: AuthHandler<SamlAuthResult>;
+  signIn?: {
+    resolver?: SignInResolver<SamlAuthResult>;
+  };
+};
 
 // Warning: (ae-missing-release-tag) "TokenIssuer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/auth-backend/src/providers/index.ts
+++ b/plugins/auth-backend/src/providers/index.ts
@@ -23,6 +23,7 @@ export * from './okta';
 export * from './bitbucket';
 export * from './atlassian';
 export * from './aws-alb';
+export * from './saml';
 
 export { factories as defaultAuthProviderFactories } from './factories';
 

--- a/plugins/auth-backend/src/providers/saml/index.ts
+++ b/plugins/auth-backend/src/providers/saml/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { createSamlProvider } from './provider';
-export type { SamlProviderOptions } from './provider';
+export type { SamlProviderOptions, SamlAuthResult } from './provider';

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -128,7 +128,7 @@ export const createSamlProvider = (
       audience: config.getOptionalString('audience'),
       issuer: config.getString('issuer'),
       cert: config.getString('cert'),
-      privateCert: config.getOptionalString('privateKey'),
+      privateKey: config.getOptionalString('privateKey'),
       authnContext: config.getOptionalStringArray('authnContext'),
       identifierFormat: config.getOptionalString('identifierFormat'),
       decryptionPvk: config.getOptionalString('decryptionPvk'),


### PR DESCRIPTION
Some more work towards #6245