### PR TITLE
[Search] export search api interface

### DIFF
--- a/.changeset/search-hip-schools-burn.md
+++ b/.changeset/search-hip-schools-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Export SearchApi interface from plugin

--- a/plugins/search/api-report.md
+++ b/plugins/search/api-report.md
@@ -74,7 +74,14 @@ export const HomePageSearchBar: ({
 // @public (undocumented)
 export const Router: () => JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "SearchApi" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "SearchApi" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface SearchApi {
+  // (undocumented)
+  query(query: SearchQuery): Promise<SearchResultSet>;
+}
+
 // Warning: (ae-missing-release-tag) "searchApiRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/plugins/search/src/index.ts
+++ b/plugins/search/src/index.ts
@@ -20,7 +20,8 @@
  * @packageDocumentation
  */
 
-export { searchApiRef, SearchApi } from './apis';
+export { searchApiRef } from './apis';
+export type { SearchApi } from './apis';
 export {
   Filters,
   FiltersButton,

--- a/plugins/search/src/index.ts
+++ b/plugins/search/src/index.ts
@@ -20,7 +20,7 @@
  * @packageDocumentation
  */
 
-export { searchApiRef } from './apis';
+export { searchApiRef, SearchApi } from './apis';
 export {
   Filters,
   FiltersButton,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The SearchAPI interface is not exported from the search plugin as described here https://backstage.io/docs/features/search/how-to-guides#how-to-implement-your-own-search-api. This PR export it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
