### PR TITLE
snyk: ignore MPL and LGPL license warnings

### DIFF
--- a/packages/cli/.snyk
+++ b/packages/cli/.snyk
@@ -67,4 +67,16 @@ ignore:
         reason: Prototype pollution is not an effective attack against a CLI as it already executes arbitrary code
         expires: 2022-03-06T17:18:55.019Z
         created: 2021-09-06T17:18:55.027Z
+
+  'snyk:lic:npm:rollup-plugin-dts:LGPL-3.0':
+    - '*':
+        reason: Backstage itself does not redistribute this dependency in minified form
+        expires: 2031-09-06T17:18:55.027Z
+        created: 2021-09-06T17:18:55.027Z
+
+  'snyk:lic:npm:axe-core:MPL-2.0':
+    - '*':
+        reason: Backstage itself does not redistribute this dependency in minified form
+        expires: 2031-09-06T17:18:55.027Z
+        created: 2021-09-06T17:18:55.027Z
 patch: {}


### PR DESCRIPTION
Fixes #7969
Fixes #7970

Our judgement here is that the Backstage project itself does not redistribute these dependencies in binary/object/minified form, and so we should not add a license notice. It may however be the case that organizations that build and publish public web pages using Backstage would need these notifications, but it is no different than how most of our other dependencies need to be treated that for example are MIT and BSD.