### PR TITLE
catalog-backend: disallow duplicate entity search keys

### DIFF
--- a/.changeset/hot-dragons-kneel.md
+++ b/.changeset/hot-dragons-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Reject catalog entities that have duplicate fields that vary only in casing.

--- a/plugins/catalog-backend/src/stitching/Stitcher.ts
+++ b/plugins/catalog-backend/src/stitching/Stitcher.ts
@@ -209,6 +209,11 @@ export class Stitcher {
       entity.metadata.etag = hash;
     }
 
+    // This may throw if the entity is invalid, so we call it before
+    // the final_entites write, even though we may end up not needing
+    // to write the search index.
+    const searchEntries = buildEntitySearch(entityId, entity);
+
     const rowsChanged = await this.database<DbFinalEntitiesRow>(
       'final_entities',
     )
@@ -235,7 +240,6 @@ export class Stitcher {
     // B writes the entity ->
     // B writes search ->
     // A writes search
-    const searchEntries = buildEntitySearch(entityId, entity);
     await this.database<DbSearchRow>('search')
       .where({ entity_id: entityId })
       .delete();

--- a/plugins/catalog-backend/src/stitching/buildEntitySearch.test.ts
+++ b/plugins/catalog-backend/src/stitching/buildEntitySearch.test.ts
@@ -163,5 +163,51 @@ describe('buildEntitySearch', () => {
         { entity_id: 'eid', key: 'relations.t2', value: 'k:ns/b' },
       ]);
     });
+
+    it('rejects duplicate keys', () => {
+      expect(() =>
+        buildEntitySearch('eid', {
+          relations: [],
+          apiVersion: 'a',
+          kind: 'b',
+          metadata: {
+            name: 'n',
+            Namespace: 'ns',
+          },
+        }),
+      ).toThrow(
+        `Entity has duplicate keys that vary only in casing, 'metadata.namespace'`,
+      );
+
+      expect(() =>
+        buildEntitySearch('eid', {
+          relations: [
+            { type: 'dup', target: { kind: 'k', namespace: 'ns', name: 'a' } },
+            { type: 'DUP', target: { kind: 'k', namespace: 'ns', name: 'b' } },
+          ],
+          apiVersion: 'a',
+          kind: 'b',
+          metadata: { name: 'n' },
+        }),
+      ).toThrow(
+        `Entity has duplicate keys that vary only in casing, 'relations.dup'`,
+      );
+
+      expect(() =>
+        buildEntitySearch('eid', {
+          apiVersion: 'a',
+          kind: 'b',
+          metadata: { name: 'n' },
+          spec: {
+            owner: 'o',
+            OWNER: 'o',
+            lifecycle: 'production',
+            lifeCycle: 'production',
+          },
+        }),
+      ).toThrow(
+        `Entity has duplicate keys that vary only in casing, 'spec.owner', 'spec.lifecycle'`,
+      );
+    });
   });
 });

--- a/plugins/catalog-backend/src/stitching/buildEntitySearch.ts
+++ b/plugins/catalog-backend/src/stitching/buildEntitySearch.ts
@@ -19,6 +19,7 @@ import {
   ENTITY_DEFAULT_NAMESPACE,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
+import { InputError } from '@backstage/errors';
 import { DbSearchRow } from '../database/tables';
 
 // These are excluded in the generic loop, either because they do not make sense
@@ -182,6 +183,24 @@ export function buildEntitySearch(
       key: `relations.${relation.type}`,
       value: stringifyEntityRef(relation.target),
     });
+  }
+
+  // This validates that there are no keys that vary only in casing, such
+  // as `spec.foo` and `spec.Foo`.
+  const keys = new Set(raw.map(r => r.key));
+  const lowerKeys = new Set(raw.map(r => r.key.toLocaleLowerCase('en-US')));
+  if (keys.size !== lowerKeys.size) {
+    const difference = [];
+    for (const key of keys) {
+      const lower = key.toLocaleLowerCase('en-US');
+      if (!lowerKeys.delete(lower)) {
+        difference.push(lower);
+      }
+    }
+    const badKeys = `'${difference.join("', '")}'`;
+    throw new InputError(
+      `Entity has duplicate keys that vary only in casing, ${badKeys}`,
+    );
   }
 
   return mapToRows(raw, entityId);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Looking to add this check to the catalog to make the input a bit more strict, just in case.

This disallows entities that look for example like this:

```yaml
apiVersion: ...
kind: Component
metadata:
  name: foo
spec:
  foo: foo
  FOO: foo
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
