### PR TITLE
fix(sidebar): use ellipsis styling for overflowed text

### DIFF
--- a/.changeset/olive-pens-poke.md
+++ b/.changeset/olive-pens-poke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Use ellipsis style for overflowed text in sidebar menu

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -235,7 +235,7 @@ const SidebarItemWithSubmenu = ({
         {itemIcon}
       </div>
       {text && (
-        <Typography variant="subtitle2" className={classes.text}>
+        <Typography variant="subtitle2" className={classes.label}>
           {text}
         </Typography>
       )}
@@ -402,7 +402,7 @@ export const SidebarItem = forwardRef<any, SidebarItemProps>((props, ref) => {
         {itemIcon}
       </div>
       {text && (
-        <Typography variant="subtitle2" className={classes.text}>
+        <Typography variant="subtitle2" className={classes.label}>
           {text}
         </Typography>
       )}


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

This reverts a recent [change](https://github.com/backstage/backstage/commit/303503ab9e5154f471b381afa8925cd88042534d#diff-228bdd0b6adf4855d9d3da007abd163ea5257be38fd779f9b9f884638fd887e1R400) that changed the styling of labels in the sidebar menu where it no longer applies ellipsis for overflowed texts. 

Before:
![Screen Shot 2021-12-02 at 4 38 30 PM](https://user-images.githubusercontent.com/6998196/144511935-23346dd0-075e-4012-a90f-7fbeb0644253.png)

After:
![Screen Shot 2021-12-02 at 4 36 58 PM](https://user-images.githubusercontent.com/6998196/144511950-7c6aa535-55a6-453e-baae-5fc04422405d.png)


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
