### PR TITLE
[XCMetrics] Bugfix: Handle missing Xcode data

### DIFF
--- a/.changeset/three-coins-kiss.md
+++ b/.changeset/three-coins-kiss.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-xcmetrics': patch
 ---
 
-Handle a case where Xcode data from XCMetrics version < 0.0.8 could be missing
+Handle a case where XCode data from backend (before 0.0.8) could be missing

--- a/.changeset/three-coins-kiss.md
+++ b/.changeset/three-coins-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-xcmetrics': patch
+---
+
+Handle a case where Xcode data from XCMetrics version < 0.0.8 could be missing

--- a/plugins/xcmetrics/src/api/types.ts
+++ b/plugins/xcmetrics/src/api/types.ts
@@ -163,7 +163,7 @@ export type Xcode = {
 export type BuildResponse = {
   build: Build;
   targets: Target[];
-  xcode: Xcode;
+  xcode?: Xcode; // Can be undefined if XCMetrics version < v0.0.8
 };
 
 export type BuildFilters = {

--- a/plugins/xcmetrics/src/components/BuildDetails/BuildDetails.test.tsx
+++ b/plugins/xcmetrics/src/components/BuildDetails/BuildDetails.test.tsx
@@ -51,6 +51,20 @@ describe('BuildDetails', () => {
     ).toBeInTheDocument();
     expect(rendered.getByText(client.mockBuild.schema)).toBeInTheDocument();
   });
+
+  it('should render if xcode data is not present', async () => {
+    const rendered = await renderInTestApp(
+      <TestApiProvider apis={[[xcmetricsApiRef, client.XcmetricsClient]]}>
+        <BuildDetails
+          buildData={{ ...client.mockBuildResponse, xcode: undefined }}
+        />
+      </TestApiProvider>,
+    );
+
+    expect(
+      rendered.getByText('Xcode').parentNode?.childNodes[1].textContent,
+    ).toEqual('Unknown');
+  });
 });
 
 describe('BuildDetails with request', () => {

--- a/plugins/xcmetrics/src/components/BuildDetails/BuildDetails.tsx
+++ b/plugins/xcmetrics/src/components/BuildDetails/BuildDetails.tsx
@@ -78,7 +78,7 @@ export const BuildDetails = ({
         {formatStatus(build.buildStatus)}
       </>
     ),
-    xcode: `${xcode.version} (${xcode.buildNumber})`,
+    xcode: xcode ? `${xcode.version} (${xcode.buildNumber})` : 'Unknown',
     CI: build.isCi,
   };
 


### PR DESCRIPTION
## Bugfix for XCMetrics plugin
Fixes a bug where missing data about Xcode in the result of some XCMetrics versions resulted in crashes.
This is now reflected in the type as well as in the UI (where "Unknown" is rendered instead of crashing)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

<img width="409" alt="Screen Shot 2021-12-03 at 16 31 32" src="https://user-images.githubusercontent.com/86348051/144628891-942ab902-338d-45c5-a51f-c4381229776e.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
