### PR TITLE
Overwrite sqlite filename per plugin

### DIFF
--- a/.changeset/pink-ladybugs-share.md
+++ b/.changeset/pink-ladybugs-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': minor
+---
+
+Each plugin now saves to a separate sqlite database file when `connection.filename` is provided in the sqlite config.

--- a/.changeset/pink-ladybugs-share.md
+++ b/.changeset/pink-ladybugs-share.md
@@ -1,5 +1,6 @@
 ---
-'@backstage/backend-common': minor
+'@backstage/backend-common': path
 ---
 
 Each plugin now saves to a separate sqlite database file when `connection.filename` is provided in the sqlite config.
+Any existing sqlite database files will be ignored.

--- a/.changeset/pink-ladybugs-share.md
+++ b/.changeset/pink-ladybugs-share.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-common': path
+'@backstage/backend-common': patch
 ---
 
 Each plugin now saves to a separate sqlite database file when `connection.filename` is provided in the sqlite config.

--- a/packages/backend-common/src/database/DatabaseManager.test.ts
+++ b/packages/backend-common/src/database/DatabaseManager.test.ts
@@ -15,6 +15,7 @@
  */
 import { ConfigReader } from '@backstage/config';
 import { omit } from 'lodash';
+import path from 'path';
 import {
   createDatabaseClient,
   ensureDatabaseExists,
@@ -284,7 +285,7 @@ describe('DatabaseManager', () => {
       // sqlite3 uses 'filename' instead of 'database'
       expect(overrides).toHaveProperty(
         'connection.filename',
-        `plugin_with_different_client/${pluginId}.sqlite`,
+        path.join('plugin_with_different_client', `${pluginId}.sqlite`),
       );
     });
 

--- a/packages/backend-common/src/database/DatabaseManager.test.ts
+++ b/packages/backend-common/src/database/DatabaseManager.test.ts
@@ -284,7 +284,7 @@ describe('DatabaseManager', () => {
       // sqlite3 uses 'filename' instead of 'database'
       expect(overrides).toHaveProperty(
         'connection.filename',
-        `plugin_with_different_client/${pluginId}`,
+        `plugin_with_different_client/${pluginId}.sqlite`,
       );
     });
 

--- a/packages/backend-common/src/database/DatabaseManager.test.ts
+++ b/packages/backend-common/src/database/DatabaseManager.test.ts
@@ -282,7 +282,10 @@ describe('DatabaseManager', () => {
       expect(baseConfig.get().client).toEqual('sqlite3');
 
       // sqlite3 uses 'filename' instead of 'database'
-      expect(overrides).toHaveProperty('connection.filename');
+      expect(overrides).toHaveProperty(
+        'connection.filename',
+        `plugin_with_different_client/${pluginId}`,
+      );
     });
 
     it('provides database client specific base from plugin connection string when client set under plugin', async () => {

--- a/packages/backend-common/src/database/DatabaseManager.ts
+++ b/packages/backend-common/src/database/DatabaseManager.ts
@@ -119,7 +119,7 @@ export class DatabaseManager {
         ?.filename;
 
       // if persisting to a file, create separate files per plugin to avoid db migration issues.
-      if (sqliteFilename !== ':memory:') {
+      if (sqliteFilename && sqliteFilename !== ':memory:') {
         return path.join(sqliteFilename, `${pluginId}.sqlite`);
       }
 

--- a/packages/backend-common/src/database/DatabaseManager.ts
+++ b/packages/backend-common/src/database/DatabaseManager.ts
@@ -28,6 +28,7 @@ import {
   normalizeConnection,
 } from './connection';
 import { PluginDatabaseManager } from './types';
+import path from 'path';
 
 /**
  * Provides a config lookup path for a plugin's config block.
@@ -119,7 +120,7 @@ export class DatabaseManager {
 
       // if persisting to a file, create separate files per plugin to avoid db migration issues.
       if (sqliteFilename !== ':memory:') {
-        return `${sqliteFilename}/${pluginId}.sqlite`;
+        return path.join(sqliteFilename, `${pluginId}.sqlite`);
       }
 
       // sqlite database name should fallback to ':memory:' as a special case

--- a/packages/backend-common/src/database/DatabaseManager.ts
+++ b/packages/backend-common/src/database/DatabaseManager.ts
@@ -119,7 +119,7 @@ export class DatabaseManager {
 
       // if persisting to a file, create separate files per plugin to avoid db migration issues.
       if (sqliteFilename !== ':memory:') {
-        return `${sqliteFilename}/${pluginId}`;
+        return `${sqliteFilename}/${pluginId}.sqlite`;
       }
 
       // sqlite database name should fallback to ':memory:' as a special case

--- a/packages/backend-common/src/database/DatabaseManager.ts
+++ b/packages/backend-common/src/database/DatabaseManager.ts
@@ -114,10 +114,16 @@ export class DatabaseManager {
     const connection = this.getConnectionConfig(pluginId);
 
     if (this.getClientType(pluginId).client === 'sqlite3') {
+      const sqliteFilename = (connection as Knex.Sqlite3ConnectionConfig)
+        ?.filename;
+
+      // if persisting to a file, create separate files per plugin to avoid db migration issues.
+      if (sqliteFilename !== ':memory:') {
+        return `${sqliteFilename}/${pluginId}`;
+      }
+
       // sqlite database name should fallback to ':memory:' as a special case
-      return (
-        (connection as Knex.Sqlite3ConnectionConfig)?.filename ?? ':memory:'
-      );
+      return ':memory:';
     }
 
     const databaseName = (connection as Knex.ConnectionConfig)?.database;

--- a/packages/backend-common/src/database/connectors/sqlite3.test.ts
+++ b/packages/backend-common/src/database/connectors/sqlite3.test.ts
@@ -73,28 +73,6 @@ describe('sqlite3', () => {
       });
     });
 
-    it('builds a persistent connection per database', () => {
-      expect(
-        buildSqliteDatabaseConfig(
-          createConfig({
-            filename: path.join('path', 'to', 'foo'),
-          }),
-          {
-            connection: {
-              database: 'my-database',
-            },
-          },
-        ),
-      ).toEqual({
-        client: 'sqlite3',
-        connection: {
-          filename: path.join('path', 'to', 'foo', 'my-database.sqlite'),
-          database: 'my-database',
-        },
-        useNullAsDefault: true,
-      });
-    });
-
     it('replaces the connection with an override', () => {
       expect(
         buildSqliteDatabaseConfig(createConfig(':memory:'), {

--- a/packages/backend-common/src/database/connectors/sqlite3.ts
+++ b/packages/backend-common/src/database/connectors/sqlite3.ts
@@ -86,19 +86,6 @@ export function buildSqliteDatabaseConfig(
     overrides,
   );
 
-  // If we don't create an in-memory database, interpret the connection string
-  // as a directory that contains multiple sqlite files based on the database
-  // name.
-  const database = (config.connection as Knex.ConnectionConfig).database;
-  const sqliteConnection = config.connection as Knex.Sqlite3ConnectionConfig;
-
-  if (database && sqliteConnection.filename !== ':memory:') {
-    sqliteConnection.filename = path.join(
-      sqliteConnection.filename,
-      `${database}.sqlite`,
-    );
-  }
-
   return config;
 }
 


### PR DESCRIPTION
Signed-off-by: Joe Porpeglia <josephp@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Closes #6811 

Seems like this use to be the expected behavior based on the existing sqlite connector. I tried making the original implementation work, but couldn't find an ideal way to pass the pluginID to the sqlite connector using the `connection.database` config. Instead, I moved this logic to the `DatabaseManager`, which is perhaps a better fit considering `connection.database` isn't documented or used by Knex's sqlite adapter. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
