### PR TITLE
fix(techdocsStorageClient): properly construct baseUrls

### DIFF
--- a/.changeset/techdocs-forty-pumas-compete.md
+++ b/.changeset/techdocs-forty-pumas-compete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix issue where assets weren't being fetched from the correct URL path for doc URLs without trailing slashes

--- a/plugins/techdocs/src/client.test.ts
+++ b/plugins/techdocs/src/client.test.ts
@@ -59,6 +59,12 @@ describe('TechDocsStorageClient', () => {
     ).resolves.toEqual(
       `${mockBaseUrl}/static/docs/${mockEntity.namespace}/${mockEntity.kind}/${mockEntity.name}/test.js`,
     );
+
+    await expect(
+      storageApi.getBaseUrl('../test.js', mockEntity, 'some-docs-path'),
+    ).resolves.toEqual(
+      `${mockBaseUrl}/static/docs/${mockEntity.namespace}/${mockEntity.kind}/${mockEntity.name}/test.js`,
+    );
   });
 
   it('should return base url with correct entity structure', async () => {

--- a/plugins/techdocs/src/client.ts
+++ b/plugins/techdocs/src/client.ts
@@ -263,9 +263,11 @@ export class TechDocsStorageClient implements TechDocsStorageApi {
     const { kind, namespace, name } = entityId;
 
     const apiOrigin = await this.getApiOrigin();
+    const newBaseUrl = `${apiOrigin}/static/docs/${namespace}/${kind}/${name}/${path}`;
+
     return new URL(
       oldBaseUrl,
-      `${apiOrigin}/static/docs/${namespace}/${kind}/${name}/${path}`,
+      newBaseUrl.endsWith('/') ? newBaseUrl : `${newBaseUrl}/`,
     ).toString();
   }
 }


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Context: https://github.com/mkdocs/mkdocs/issues/2456

We have some docs with the older style of relative links as shown in the linked issue above. 
eg. `[linking to other page](../foo-bar)` which loads `/docs/default/Component/my-component/foo-bar` (note the missing trailing slash)

Looking into the TechDocs reader, this is inherently supported when attempting to load the raw docs html and inspecting the network requests, it is being fetched correctly since the trailing slash is added appropriately:
https://github.com/backstage/backstage/blob/a173851193de1c0db510bcaf3784dcd279c3f0a5/plugins/techdocs/src/client.ts#L162-L174

The issue arises when updating links that load additional assets: 
https://github.com/backstage/backstage/blob/a173851193de1c0db510bcaf3784dcd279c3f0a5/plugins/techdocs/src/reader/transformers/addBaseUrl.ts#L60-L64

eg. a `<link href="../extra.css">` is incorrectly transformed to `<link href="<app-origin>/static/docs/default/Component/extra.css" />` 

This change fixes the URL transformation to ensure a trailing slash so that the asset path is resolved correctly eg. `<link href="<app-origin>/static/docs/default/Component/my-component/extra.css" />` 



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
