### PR TITLE
Fix scaffolder repo owner bug

### DIFF
--- a/.changeset/light-pigs-protect.md
+++ b/.changeset/light-pigs-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fix bug with setting owner in RepoUrlPicker causing validation failure

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -27,7 +27,7 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 import { useApi } from '@backstage/core-plugin-api';
 import { Progress } from '@backstage/core-components';
 
-function splitFormData(url: string | undefined, allowedOwners: string[]) {
+function splitFormData(url: string | undefined, allowedOwners?: string[]) {
   let host = undefined;
   let owner = undefined;
   let repo = undefined;
@@ -39,10 +39,7 @@ function splitFormData(url: string | undefined, allowedOwners: string[]) {
     if (url) {
       const parsed = new URL(`https://${url}`);
       host = parsed.host;
-      owner =
-        parsed.searchParams.get('owner') || allowedOwners
-          ? allowedOwners[0]
-          : undefined;
+      owner = parsed.searchParams.get('owner') || allowedOwners?.[0];
       repo = parsed.searchParams.get('repo') || undefined;
       // This is azure dev ops specific. not used for any other provider.
       organization = parsed.searchParams.get('organization') || undefined;


### PR DESCRIPTION
Signed-off-by: Nataliya Issayeva <nissayeva@users.noreply.github.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixing a bug introduced in #8207 

The combined logical OR and ternary is evaluated not in the way it was intended, causing scaffolder form validation to always fail because of an empty owner when no `allowedOwners` are defined.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
