### PR TITLE
Feat/custom error handler

### DIFF
--- a/.changeset/hot-toys-grab.md
+++ b/.changeset/hot-toys-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Add possibility to use custom error handler

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { applyCspDirectives } from './ServiceBuilderImpl';
+import { NextFunction, Request, Response } from 'express';
+import { applyCspDirectives, ServiceBuilderImpl } from './ServiceBuilderImpl';
 
 describe('ServiceBuilderImpl', () => {
   describe('applyCspDirectives', () => {
@@ -31,6 +32,24 @@ describe('ServiceBuilderImpl', () => {
     it('removes false value keys', () => {
       const result = applyCspDirectives({ 'upgrade-insecure-requests': false });
       expect(result!['upgrade-insecure-requests']).toBeUndefined();
+    });
+  });
+
+  describe('setCustomErrorHandler', () => {
+    it('adds custom error handler', () => {
+      const serviceBuilder = new ServiceBuilderImpl(module);
+      const customErrorHandler = (
+        error: Error,
+        req: Request,
+        res: Response,
+        next: NextFunction,
+      ) => {};
+      serviceBuilder.setErrorHandler(customErrorHandler);
+      expect(serviceBuilder.errorHandler).toEqual(customErrorHandler);
+    });
+    it('use default error handler', () => {
+      const serviceBuilder = new ServiceBuilderImpl(module);
+      expect(serviceBuilder.errorHandler).toBeUndefined();
     });
   });
 });

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -16,7 +16,7 @@
 
 import { Config } from '@backstage/config';
 import cors from 'cors';
-import { Router, RequestHandler } from 'express';
+import { Router, RequestHandler, ErrorRequestHandler } from 'express';
 import { Server } from 'http';
 import { Logger } from 'winston';
 
@@ -97,6 +97,15 @@ export type ServiceBuilder = {
   setRequestLoggingHandler(
     requestLoggingHandler: RequestLoggingHandlerFactory,
   ): ServiceBuilder;
+
+  /**
+   * Set the error handler
+   *
+   * If no handler is given the default one is used
+   *
+   * @param errorHandler - an error handler
+   */
+  setErrorHandler(errorHandler: ErrorRequestHandler): ServiceBuilder;
 
   /**
    * Starts the server using the given settings.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Reference: [Allow custom error handling in the express server on the Backend](https://github.com/backstage/backstage/issues/7609)

I've added possibility to use custom error handler.
In this PR I've decided to use either custom or default error handler, please let me know what do you think about it, maybe it's better to just add custom error handler before default one and always use default one at the end?

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
