### PR TITLE
Added kind change event

### DIFF
--- a/.changeset/spotty-dancers-hear.md
+++ b/.changeset/spotty-dancers-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Added ability to listen to the catalog kind filter changes

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -17,6 +17,7 @@ import { CatalogEntityAncestorsResponse } from '@backstage/catalog-client';
 import { CatalogListResponse } from '@backstage/catalog-client';
 import { CatalogRequestOptions } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
+import { EntityKindFilter } from '@backstage/plugin-catalog-react';
 import { EntityName } from '@backstage/catalog-model';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
@@ -134,6 +135,7 @@ export const CatalogIndexPage: ({
   columns,
   actions,
   initiallySelectedFilter,
+  onKindChange,
 }: CatalogPageProps) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "CatalogKindHeaderProps" needs to be exported by the entry point index.d.ts
@@ -142,6 +144,7 @@ export const CatalogIndexPage: ({
 // @public (undocumented)
 export const CatalogKindHeader: ({
   initialFilter,
+  onChange,
 }: CatalogKindHeaderProps) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "catalogPlugin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.test.tsx
+++ b/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.test.tsx
@@ -118,4 +118,24 @@ describe('<CatalogKindHeader />', () => {
       kind: new EntityKindFilter('template'),
     });
   });
+
+  it('triggers the kind change event', async () => {
+    const onChange = jest.fn();
+    const rendered = await renderWithEffects(
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider>
+          <CatalogKindHeader onChange={onChange} />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+    expect(onChange).toHaveBeenCalledWith(new EntityKindFilter('component'));
+
+    const input = rendered.getByText('Components');
+    fireEvent.mouseDown(input);
+
+    const option = rendered.getByRole('option', { name: 'Systems' });
+    fireEvent.click(option);
+
+    expect(onChange).toHaveBeenCalledWith(new EntityKindFilter('system'));
+  });
 });

--- a/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.tsx
+++ b/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.tsx
@@ -40,26 +40,38 @@ const useStyles = makeStyles((theme: Theme) =>
 
 type CatalogKindHeaderProps = {
   initialFilter?: string;
+  onChange?: (kind: EntityKindFilter) => void;
 };
 
 export const CatalogKindHeader = ({
   initialFilter = 'component',
+  onChange,
 }: CatalogKindHeaderProps) => {
   const classes = useStyles();
   const { kinds: allKinds = [] } = useEntityKinds();
-  const { updateFilters, queryParameters } = useEntityListProvider();
+  const { updateFilters, queryParameters, filters } = useEntityListProvider();
 
   const [selectedKind, setSelectedKind] = useState(
     ([queryParameters.kind].flat()[0] ?? initialFilter).toLocaleLowerCase(
       'en-US',
     ),
   );
+  const { kind: filteredKind } = filters;
 
   useEffect(() => {
     updateFilters({
       kind: selectedKind ? new EntityKindFilter(selectedKind) : undefined,
     });
   }, [selectedKind, updateFilters]);
+
+  // Use kind from filters as a dependency instead of the selectedKind because we want to wait with triggering this until the data has been loaded
+  useEffect(() => {
+    if (!filteredKind?.value || !onChange) {
+      return;
+    }
+
+    onChange(filteredKind);
+  }, [filteredKind, onChange]);
 
   // Before allKinds is loaded, or when a kind is entered manually in the URL, selectedKind may not
   // be present in allKinds. It should still be shown in the dropdown, but may not have the nice

--- a/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/CatalogPage.tsx
@@ -25,6 +25,7 @@ import {
 } from '@backstage/core-components';
 import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import {
+  EntityKindFilter,
   EntityLifecyclePicker,
   EntityListProvider,
   EntityOwnerPicker,
@@ -48,12 +49,14 @@ export type CatalogPageProps = {
   initiallySelectedFilter?: UserListFilterKind;
   columns?: TableColumn<EntityRow>[];
   actions?: TableProps<EntityRow>['actions'];
+  onKindChange?: (kind: EntityKindFilter) => void;
 };
 
 export const CatalogPage = ({
   columns,
   actions,
   initiallySelectedFilter = 'owned',
+  onKindChange,
 }: CatalogPageProps) => {
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
@@ -63,7 +66,9 @@ export const CatalogPage = ({
     <PageWithHeader title={`${orgName} Catalog`} themeId="home">
       <EntityListProvider>
         <Content>
-          <ContentHeader titleComponent={<CatalogKindHeader />}>
+          <ContentHeader
+            titleComponent={<CatalogKindHeader onChange={onKindChange} />}
+          >
             <CreateButton
               title="Create Component"
               to={createComponentLink && createComponentLink()}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've added a small update giving us the option to update the catalog index columns after changing the kind in the filter. See the issue here https://github.com/backstage/backstage/issues/8336

With this update, after the kind is changed in the filter, we can detect it at the app level and update the columns based on it. This way for each kind we can render a different set of columns if so desirable

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
