### PR TITLE
Feat/add custom error handler

### DIFF
--- a/.changeset/hot-toys-grab.md
+++ b/.changeset/hot-toys-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Add possibility to use custom error handler

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -561,6 +561,8 @@ export type ServiceBuilder = {
   setRequestLoggingHandler(
     requestLoggingHandler: RequestLoggingHandlerFactory,
   ): ServiceBuilder;
+  setErrorHandler(errorHandler: ErrorRequestHandler): ServiceBuilder;
+  disableDefaultErrorHandler(): ServiceBuilder;
   start(): Promise<Server>;
 };
 

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
@@ -40,11 +40,12 @@ describe('ServiceBuilderImpl', () => {
       const serviceBuilder = new ServiceBuilderImpl(module);
       const customErrorHandler = (
         error: Error,
+        // @ts-ignore
         req: Request,
+        // @ts-ignore
         res: Response,
         next: NextFunction,
       ) => {
-        console.log(req, res);
         next(error);
       };
       serviceBuilder.setErrorHandler(customErrorHandler);

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { applyCspDirectives } from './ServiceBuilderImpl';
+import { NextFunction, Request, Response } from 'express';
+import { applyCspDirectives, ServiceBuilderImpl } from './ServiceBuilderImpl';
 
 describe('ServiceBuilderImpl', () => {
   describe('applyCspDirectives', () => {
@@ -31,6 +32,24 @@ describe('ServiceBuilderImpl', () => {
     it('removes false value keys', () => {
       const result = applyCspDirectives({ 'upgrade-insecure-requests': false });
       expect(result!['upgrade-insecure-requests']).toBeUndefined();
+    });
+  });
+
+  describe('setCustomErrorHandler', () => {
+    it('adds custom error handler', () => {
+      const serviceBuilder = new ServiceBuilderImpl(module);
+      const customErrorHandler = (
+        error: Error,
+        req: Request,
+        res: Response,
+        next: NextFunction,
+      ) => {};
+      serviceBuilder.setErrorHandler(customErrorHandler);
+      expect(serviceBuilder.errorHandler).toEqual(customErrorHandler);
+    });
+    it('use default error handler', () => {
+      const serviceBuilder = new ServiceBuilderImpl(module);
+      expect(serviceBuilder.errorHandler).toBeUndefined();
     });
   });
 });

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
@@ -36,8 +36,15 @@ describe('ServiceBuilderImpl', () => {
   });
 
   describe('setCustomErrorHandler', () => {
+    it('check if custom error handler is undefined', () => {
+      const serviceBuilder = new ServiceBuilderImpl(module);
+      const serviceBuilderProto = Object.getPrototypeOf(serviceBuilder);
+      expect(serviceBuilderProto.errorHandler).toBeUndefined();
+    });
+
     it('adds custom error handler', () => {
       const serviceBuilder = new ServiceBuilderImpl(module);
+      const serviceBuilderProto = Object.getPrototypeOf(serviceBuilder);
       const customErrorHandler = (
         error: Error,
         _req: Request,
@@ -46,12 +53,8 @@ describe('ServiceBuilderImpl', () => {
       ) => {
         next(error);
       };
-      serviceBuilder.setErrorHandler(customErrorHandler);
-      expect(serviceBuilder.errorHandler).toEqual(customErrorHandler);
-    });
-    it('use default error handler', () => {
-      const serviceBuilder = new ServiceBuilderImpl(module);
-      expect(serviceBuilder.errorHandler).toBeUndefined();
+      serviceBuilderProto.setErrorHandler(customErrorHandler);
+      expect(serviceBuilderProto.errorHandler).toEqual(customErrorHandler);
     });
   });
 });

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
@@ -43,12 +43,17 @@ describe('ServiceBuilderImpl', () => {
         req: Request,
         res: Response,
         next: NextFunction,
-      ) => {};
+      ) => {
+        console.log(req, res);
+        next(error);
+      };
       serviceBuilder.setErrorHandler(customErrorHandler);
+      // @ts-ignore check private attribute
       expect(serviceBuilder.errorHandler).toEqual(customErrorHandler);
     });
     it('use default error handler', () => {
       const serviceBuilder = new ServiceBuilderImpl(module);
+      // @ts-ignore check private attribute
       expect(serviceBuilder.errorHandler).toBeUndefined();
     });
   });

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.test.ts
@@ -40,21 +40,17 @@ describe('ServiceBuilderImpl', () => {
       const serviceBuilder = new ServiceBuilderImpl(module);
       const customErrorHandler = (
         error: Error,
-        // @ts-ignore
-        req: Request,
-        // @ts-ignore
-        res: Response,
+        _req: Request,
+        _res: Response,
         next: NextFunction,
       ) => {
         next(error);
       };
       serviceBuilder.setErrorHandler(customErrorHandler);
-      // @ts-ignore check private attribute
       expect(serviceBuilder.errorHandler).toEqual(customErrorHandler);
     });
     it('use default error handler', () => {
       const serviceBuilder = new ServiceBuilderImpl(module);
-      // @ts-ignore check private attribute
       expect(serviceBuilder.errorHandler).toBeUndefined();
     });
   });

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -111,7 +111,6 @@ export type ServiceBuilder = {
   /**
    * Disable default error handler
    *
-   * If it's not called, default error handler is used
    */
   disableDefaultErrorHandler(): ServiceBuilder;
 

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -109,8 +109,7 @@ export type ServiceBuilder = {
   setErrorHandler(errorHandler: ErrorRequestHandler): ServiceBuilder;
 
   /**
-   * Disable default error handler
-   *
+   * Disables the default error handler
    */
   disableDefaultErrorHandler(): ServiceBuilder;
 

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -16,7 +16,7 @@
 
 import { Config } from '@backstage/config';
 import cors from 'cors';
-import { Router, RequestHandler } from 'express';
+import { Router, RequestHandler, ErrorRequestHandler } from 'express';
 import { Server } from 'http';
 import { Logger } from 'winston';
 
@@ -97,6 +97,15 @@ export type ServiceBuilder = {
   setRequestLoggingHandler(
     requestLoggingHandler: RequestLoggingHandlerFactory,
   ): ServiceBuilder;
+
+  /**
+   * Set the error handler
+   *
+   * If no handler is given the default one is used
+   *
+   * @param errorHandler - an error handler
+   */
+  setErrorHandler(errorHandler: ErrorRequestHandler): ServiceBuilder;
 
   /**
    * Starts the server using the given settings.

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -101,8 +101,8 @@ export type ServiceBuilder = {
   /**
    * Sets an additional errorHandler to run before the defaultErrorHandler.
    *
-   * If we want to use only custom errorHandler without defaultErrorHandler we need to
-   * disable the defaultErrorHandler by invoking disableDefaultErrorHandler()
+   * For execution of only the custom error handler make sure to also invoke disableDefaultErrorHandler()
+   * otherwise the defaultErrorHandler is executed at the end of the error middleware chain.
    *
    * @param errorHandler - an error handler
    */

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -108,6 +108,13 @@ export type ServiceBuilder = {
   setErrorHandler(errorHandler: ErrorRequestHandler): ServiceBuilder;
 
   /**
+   * Disable default error handler
+   *
+   * If it's not called, default error handler is used
+   */
+  disableDefaultErrorHandler(): ServiceBuilder;
+
+  /**
    * Starts the server using the given settings.
    */
   start(): Promise<Server>;

--- a/packages/backend-common/src/service/types.ts
+++ b/packages/backend-common/src/service/types.ts
@@ -99,9 +99,10 @@ export type ServiceBuilder = {
   ): ServiceBuilder;
 
   /**
-   * Set the error handler
+   * Sets an additional errorHandler to run before the defaultErrorHandler.
    *
-   * If no handler is given the default one is used
+   * If we want to use only custom errorHandler without defaultErrorHandler we need to
+   * disable the defaultErrorHandler by invoking disableDefaultErrorHandler()
    *
    * @param errorHandler - an error handler
    */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Reference: [Allow custom error handling in the express server on the Backend](https://github.com/backstage/backstage/issues/7609)

I've added possibility to use custom error handler.
In this PR I've decided to use either custom or default error handler, please let me know what do you think about it, maybe it's better to just add custom error handler before default one and always use default one at the end?

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))