### PR TITLE
More scaffolder config cleanup

### DIFF
--- a/.changeset/tiny-trains-notice.md
+++ b/.changeset/tiny-trains-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Removed the `scaffolder.github.visibility` configuration that is no longer used from the default app template.

--- a/docs/features/software-templates/configuration.md
+++ b/docs/features/software-templates/configuration.md
@@ -18,17 +18,31 @@ The next step is to add
 [add templates](http://backstage.io/docs/features/software-templates/adding-templates)
 to your Backstage app.
 
-### GitHub
+### Publishing defaults
 
-For GitHub, you can configure who can see the new repositories that are created
-by specifying `visibility` option. Valid options are `public`, `private` and
-`internal`. The `internal` option is for GitHub Enterprise clients, which means
-public within the enterprise.
+Software templates can define _publish_ actions, such as `publish:github`, to
+create new repositories or submit pull / merge requests to existing
+repositories. You can configure the author and commit message through the
+`scaffolder` configuration in `app-config.yaml`:
 
 ```yaml
 scaffolder:
-  github:
-    visibility: public # or 'internal' or 'private'
+  defaultAuthor:
+    name: M.C. Hammer # Defaults to `Scaffolder`
+    email: hammer@donthurtem.com # Defaults to `scaffolder@backstage.io`
+  defaultCommitMessage: "U can't touch this" # Defaults to 'Initial commit'
+```
+
+To configure who can see the new repositories created from software templates,
+add the `repoVisibility` key within a software template:
+
+```yaml
+- id: publish
+  name: Publish
+  action: publish:github
+  input:
+    repoUrl: '{{ parameters.repoUrl }}'
+    repoVisibility: public # or 'internal' or 'private'
 ```
 
 ### Disabling Docker in Docker situation (Optional)

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -77,9 +77,7 @@ auth:
   providers: {}
 
 scaffolder:
-  github:
-    token: ${GITHUB_TOKEN}
-    visibility: public # or 'internal' or 'private'
+  # see https://backstage.io/docs/features/software-templates/configuration for software template options
 
 catalog:
   rules:


### PR DESCRIPTION
🧹 

Follow-on to #8309, the old scaffolder config was still included in the create-app template and docs. Now updated.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
