### PR TITLE
auth-backend(fix): Add basicAuth option to OAuth provider

### DIFF
--- a/.changeset/clean-apples-breathe.md
+++ b/.changeset/clean-apples-breathe.md
@@ -3,4 +3,4 @@
 ---
 
 Fixes potential bug introduced in `0.4.10` which causes `OAuth2AuthProvider` to authenticate using credentials in both POST payload and headers.
-This might break some stricter OAuth2 implementations so there is now a `basicAuth` config option that can manually be set to `true` to enable this behavior.
+This might break some stricter OAuth2 implementations so there is now a `includeBasicAuth` config option that can manually be set to `true` to enable this behavior.

--- a/.changeset/clean-apples-breathe.md
+++ b/.changeset/clean-apples-breathe.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixes potential bug introduced in `0.4.10` which causes `OAuth2AuthProvider` to authenticate using credentials in both POST payload and headers.
+This might break some stricter OAuth2 implementations so there is now a `basicAuth` config option that can manually be set to `true` to enable this behavior.

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -59,6 +59,7 @@ export type OAuth2AuthProviderOptions = OAuthProviderOptions & {
   tokenUrl: string;
   scope?: string;
   logger: Logger;
+  basicAuth?: boolean;
 };
 
 export class OAuth2AuthProvider implements OAuthHandlers {
@@ -85,12 +86,14 @@ export class OAuth2AuthProvider implements OAuthHandlers {
         tokenURL: options.tokenUrl,
         passReqToCallback: false as true,
         scope: options.scope,
-        customHeaders: {
-          Authorization: `Basic ${this.encodeClientCredentials(
-            options.clientId,
-            options.clientSecret,
-          )}`,
-        },
+        customHeaders: options.basicAuth
+          ? {
+              Authorization: `Basic ${this.encodeClientCredentials(
+                options.clientId,
+                options.clientSecret,
+              )}`,
+            }
+          : undefined,
       },
       (
         accessToken: any,
@@ -244,6 +247,7 @@ export const createOAuth2Provider = (
       const authorizationUrl = envConfig.getString('authorizationUrl');
       const tokenUrl = envConfig.getString('tokenUrl');
       const scope = envConfig.getOptionalString('scope');
+      const basicAuth = envConfig.getOptionalBoolean('basicAuth');
       const disableRefresh =
         envConfig.getOptionalBoolean('disableRefresh') ?? false;
 
@@ -280,6 +284,7 @@ export const createOAuth2Provider = (
         tokenUrl,
         scope,
         logger,
+        basicAuth,
       });
 
       return OAuthAdapter.fromConfig(globalConfig, provider, {

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -59,7 +59,7 @@ export type OAuth2AuthProviderOptions = OAuthProviderOptions & {
   tokenUrl: string;
   scope?: string;
   logger: Logger;
-  basicAuth?: boolean;
+  includeBasicAuth?: boolean;
 };
 
 export class OAuth2AuthProvider implements OAuthHandlers {
@@ -86,7 +86,7 @@ export class OAuth2AuthProvider implements OAuthHandlers {
         tokenURL: options.tokenUrl,
         passReqToCallback: false as true,
         scope: options.scope,
-        customHeaders: options.basicAuth
+        customHeaders: options.includeBasicAuth
           ? {
               Authorization: `Basic ${this.encodeClientCredentials(
                 options.clientId,
@@ -247,7 +247,7 @@ export const createOAuth2Provider = (
       const authorizationUrl = envConfig.getString('authorizationUrl');
       const tokenUrl = envConfig.getString('tokenUrl');
       const scope = envConfig.getOptionalString('scope');
-      const basicAuth = envConfig.getOptionalBoolean('basicAuth');
+      const includeBasicAuth = envConfig.getOptionalBoolean('includeBasicAuth');
       const disableRefresh =
         envConfig.getOptionalBoolean('disableRefresh') ?? false;
 
@@ -284,7 +284,7 @@ export const createOAuth2Provider = (
         tokenUrl,
         scope,
         logger,
-        basicAuth,
+        includeBasicAuth,
       });
 
       return OAuthAdapter.fromConfig(globalConfig, provider, {


### PR DESCRIPTION
Signed-off-by: Johan Haals <johan.haals@gmail.com>

## Hey, I just made a Pull Request!

Fixes potential bug introduced in `0.4.10` which causes `OAuth2AuthProvider` to authenticate using credentials in both POST payload and headers.
This might break some stricter OAuth2 implementations so there is now a `basicAuth` config option that can manually be set to `true` to enable this behavior.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
