### PR TITLE
Add tests for the GitLab client in catalog-backend and refactor

### DIFF
--- a/.changeset/hip-bananas-laugh.md
+++ b/.changeset/hip-bananas-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+The `pagedRequest` method in the GitLab ingestion client is now public for re-use and may be used to make other calls to the GitLab API. Developers can now pass in a type into the GitLab `paginated` and `pagedRequest` functions as generics instead of forcing `any` (defaults to `any` to maintain compatibility). The `GitLabClient` now provides a `isSelfManaged` convenience method.

--- a/plugins/catalog-backend/src/ingestion/processors/gitlab/client.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/gitlab/client.test.ts
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ConfigReader } from '@backstage/config';
+import { setupRequestMockHandlers } from '@backstage/test-utils';
+import { readGitLabIntegrationConfig } from '@backstage/integration';
+import { getVoidLogger } from '@backstage/backend-common';
+import { rest } from 'msw';
+import { setupServer, SetupServerApi } from 'msw/node';
+
+import { GitLabClient, paginated } from './client';
+
+const server = setupServer();
+setupRequestMockHandlers(server);
+
+const MOCK_CONFIG = readGitLabIntegrationConfig(
+  new ConfigReader({
+    host: 'example.com',
+    token: 'test-token',
+    apiBaseUrl: 'https://example.com/api/v4',
+  }),
+);
+
+const FAKE_PAGED_ENDPOINT = `${MOCK_CONFIG.apiBaseUrl}/some-endpoint`;
+
+function setupFakeFourPageEndpoint(srv: SetupServerApi, endpoint: string) {
+  srv.use(
+    rest.get(endpoint, (req, res, ctx) => {
+      const page = req.url.searchParams.get('page');
+      const currentPage = page ? Number(page) : 1;
+      const fakePageCount = 4;
+
+      return res(
+        ctx.set({
+          'x-next-page':
+            currentPage < fakePageCount ? String(currentPage + 1) : '',
+        }),
+        ctx.json([{ someContentOfPage: currentPage }]),
+      );
+    }),
+  );
+}
+
+function setupFakeGroupProjectsEndpoint(
+  srv: SetupServerApi,
+  apiBaseUrl: string,
+  groupID: string,
+) {
+  srv.use(
+    rest.get(`${apiBaseUrl}/groups/${groupID}/projects`, (_, res, ctx) => {
+      return res(
+        ctx.set('x-next-page', ''),
+        ctx.json([
+          {
+            id: 1,
+            description: 'Project One Description',
+            name: 'Project One',
+            path: 'project-one',
+          },
+        ]),
+      );
+    }),
+  );
+}
+
+function setupFakeInstanceProjectsEndpoint(
+  srv: SetupServerApi,
+  apiBaseUrl: string,
+) {
+  srv.use(
+    rest.get(`${apiBaseUrl}/projects`, (_, res, ctx) => {
+      return res(
+        ctx.set('x-next-page', ''),
+        ctx.json([
+          {
+            id: 1,
+            description: 'Project One Description',
+            name: 'Project One',
+            path: 'project-one',
+          },
+          {
+            id: 2,
+            description: 'Project Two Description',
+            name: 'Project Two',
+            path: 'project-two',
+          },
+        ]),
+      );
+    }),
+  );
+}
+
+describe('GitLabClient', () => {
+  describe('pagedRequest', () => {
+    beforeEach(() => {
+      // setup fake paginated endpoint with 4 pages each returning one item
+      setupFakeFourPageEndpoint(server, FAKE_PAGED_ENDPOINT);
+    });
+
+    it('should provide immediate items within the page', async () => {
+      const client = new GitLabClient({
+        config: MOCK_CONFIG,
+        logger: getVoidLogger(),
+      });
+
+      const { items } = await client.pagedRequest(FAKE_PAGED_ENDPOINT);
+      // fake page contains exactly one item
+      expect(items).toHaveLength(1);
+    });
+
+    it('should request items for a given page number', async () => {
+      const client = new GitLabClient({
+        config: MOCK_CONFIG,
+        logger: getVoidLogger(),
+      });
+
+      const requestedPage = 2;
+      const { items, nextPage } = await client.pagedRequest(
+        FAKE_PAGED_ENDPOINT,
+        {
+          page: requestedPage,
+        },
+      );
+      // should contain an item from a given page
+      expect(items[0].someContentOfPage).toEqual(requestedPage);
+      // should set the nextPage property to the next page
+      expect(nextPage).toEqual(3);
+    });
+
+    it('should not have a next page if at the end', async () => {
+      const client = new GitLabClient({
+        config: MOCK_CONFIG,
+        logger: getVoidLogger(),
+      });
+
+      const { items, nextPage } = await client.pagedRequest(
+        FAKE_PAGED_ENDPOINT,
+        {
+          page: 4,
+        },
+      );
+      // should contain item of last page
+      expect(items).toHaveLength(1);
+      expect(nextPage).toBeNull();
+    });
+
+    it('should throw if response is not okay', async () => {
+      const endpoint = `${MOCK_CONFIG.apiBaseUrl}/unhealthy-endpoint`;
+      server.use(
+        rest.get(endpoint, (_, res, ctx) => {
+          return res(ctx.status(400), ctx.json({ error: 'some error' }));
+        }),
+      );
+
+      const client = new GitLabClient({
+        config: MOCK_CONFIG,
+        logger: getVoidLogger(),
+      });
+      // non-200 status code should throw
+      await expect(() => client.pagedRequest(endpoint)).rejects.toThrowError();
+    });
+  });
+
+  describe('listProjects', () => {
+    it('should get projects for a given group', async () => {
+      setupFakeGroupProjectsEndpoint(
+        server,
+        MOCK_CONFIG.apiBaseUrl,
+        'test-group',
+      );
+      const client = new GitLabClient({
+        config: MOCK_CONFIG,
+        logger: getVoidLogger(),
+      });
+
+      const groupProjectsGen = paginated(
+        options => client.listProjects(options),
+        { group: 'test-group' },
+      );
+      const allItems = [];
+      for await (const item of groupProjectsGen) {
+        allItems.push(item);
+      }
+      expect(allItems).toHaveLength(1);
+    });
+
+    it('should get all projects for an instance', async () => {
+      setupFakeInstanceProjectsEndpoint(server, MOCK_CONFIG.apiBaseUrl);
+      const client = new GitLabClient({
+        config: MOCK_CONFIG,
+        logger: getVoidLogger(),
+      });
+
+      const instanceProjectsGen = paginated(
+        options => client.listProjects(options),
+        {},
+      );
+      const allItems = [];
+      for await (const item of instanceProjectsGen) {
+        allItems.push(item);
+      }
+      expect(allItems).toHaveLength(2);
+    });
+  });
+});
+
+describe('paginated', () => {
+  it('should iterate through the pages until exhausted', async () => {
+    setupFakeFourPageEndpoint(server, FAKE_PAGED_ENDPOINT);
+    const client = new GitLabClient({
+      config: MOCK_CONFIG,
+      logger: getVoidLogger(),
+    });
+
+    const paginatedAsyncGenerator = paginated(
+      options => client.pagedRequest(FAKE_PAGED_ENDPOINT, options),
+      {},
+    );
+    const allItems = [];
+    for await (const item of paginatedAsyncGenerator) {
+      allItems.push(item);
+    }
+
+    expect(allItems).toHaveLength(4);
+  });
+});

--- a/plugins/catalog-backend/src/ingestion/processors/gitlab/client.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/gitlab/client.test.ts
@@ -104,6 +104,34 @@ function setupFakeInstanceProjectsEndpoint(
 }
 
 describe('GitLabClient', () => {
+  describe('isSelfManaged', () => {
+    it('returns true if self managed instance', () => {
+      const client = new GitLabClient({
+        config: readGitLabIntegrationConfig(
+          new ConfigReader({
+            host: 'example.com',
+            token: 'test-token',
+            apiBaseUrl: 'https://example.com/api/v4',
+          }),
+        ),
+        logger: getVoidLogger(),
+      });
+      expect(client.isSelfManaged()).toBeTruthy();
+    });
+    it('returns false if gitlab.com', () => {
+      const client = new GitLabClient({
+        config: readGitLabIntegrationConfig(
+          new ConfigReader({
+            host: 'gitlab.com',
+            token: 'test-token',
+          }),
+        ),
+        logger: getVoidLogger(),
+      });
+      expect(client.isSelfManaged()).toBeFalsy();
+    });
+  });
+
   describe('pagedRequest', () => {
     beforeEach(() => {
       // setup fake paginated endpoint with 4 pages each returning one item

--- a/plugins/catalog-backend/src/ingestion/processors/gitlab/client.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/gitlab/client.ts
@@ -58,10 +58,10 @@ export class GitLabClient {
    * @param endpoint - The complete request URL for the endpoint.
    * @param options - Request queryString options which may also include page variables.
    */
-  async pagedRequest(
+  async pagedRequest<T = any>(
     endpoint: string,
     options?: ListOptions,
-  ): Promise<PagedResponse<any>> {
+  ): Promise<PagedResponse<T>> {
     const request = new URL(endpoint);
     for (const key in options) {
       if (options[key]) {
@@ -116,8 +116,8 @@ export type PagedResponse<T> = {
  * @param request - Function which returns a PagedResponse to walk through.
  * @param options - Initial ListOptions for the request function.
  */
-export async function* paginated(
-  request: (options: ListOptions) => Promise<PagedResponse<any>>,
+export async function* paginated<T = any>(
+  request: (options: ListOptions) => Promise<PagedResponse<T>>,
   options: ListOptions,
 ) {
   let res;

--- a/plugins/catalog-backend/src/ingestion/processors/gitlab/client.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/gitlab/client.ts
@@ -42,6 +42,13 @@ export class GitLabClient {
     this.logger = options.logger;
   }
 
+  /**
+   * Indicates whether the client is for a SaaS or self managed GitLab instance.
+   */
+  isSelfManaged(): boolean {
+    return this.config.host !== 'gitlab.com';
+  }
+
   async listProjects(options?: ListOptions): Promise<PagedResponse<any>> {
     if (options?.group) {
       return this.pagedRequest(

--- a/plugins/catalog-backend/src/ingestion/processors/gitlab/client.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/gitlab/client.ts
@@ -46,7 +46,19 @@ export class GitLabClient {
     return this.pagedRequest(`${this.config.apiBaseUrl}/projects`, options);
   }
 
-  private async pagedRequest(
+  /**
+   * Performs a request against a given paginated GitLab endpoint.
+   *
+   * This method may be used to perform authenticated REST calls against any
+   * paginated GitLab endpoint which uses X-NEXT-PAGE headers. The return value
+   * can be be used with the {@link paginated} async-generator function to yield
+   * each item from the paged request.
+   *
+   * @see {@link paginated}
+   * @param endpoint - The complete request URL for the endpoint.
+   * @param options - Request queryString options which may also include page variables.
+   */
+  async pagedRequest(
     endpoint: string,
     options?: ListOptions,
   ): Promise<PagedResponse<any>> {
@@ -92,6 +104,18 @@ export type PagedResponse<T> = {
   nextPage?: number;
 };
 
+/**
+ * Advances through each page and provides each item from a paginated request.
+ *
+ * The async generator function yields each item from repeated calls to the
+ * provided request function. The generator walks through each available page by
+ * setting the page key in the options passed into the request function and
+ * making repeated calls until there are no more pages.
+ *
+ * @see {@link pagedRequest}
+ * @param request - Function which returns a PagedResponse to walk through.
+ * @param options - Initial ListOptions for the request function.
+ */
 export async function* paginated(
   request: (options: ListOptions) => Promise<PagedResponse<any>>,
   options: ListOptions,


### PR DESCRIPTION
## Add Tests and Refactor GitLab Client

This PR adds tests for the GitLab ingestion client under `plugin/catalog-backend` in order to add coverage and increase confidence. The primary purpose is to increase confidence in its implementation and prepare it for reuse when ingesting groups and users (increase utility of client). The PR makes the following changes:

- Add test coverage for `GitLabClient` and `paginated` to capture externally facing behaviour.
- Improve TypeScript inference by allowing developers to pass in a type into `paginated` and `pagedRequest` as generics instead of forcing `any` (but defaulting to `any` to maintain compatibility).
- Refactor and open up `pagedRequest` so that it can be used to make other calls to the GitLab API with a given client instance. This is preparation for a contribution which will bring org and user parity for `gitlab` to match `github`.
- Add convenience method to determine whether the client is configured against a SaaS or Self Managed instance.
- Add documentation.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
