### PR TITLE
adds the ability to configure the gh creds provider

### DIFF
--- a/.changeset/shaggy-planes-add.md
+++ b/.changeset/shaggy-planes-add.md
@@ -1,0 +1,8 @@
+---
+'@backstage/backend-common': patch
+'@backstage/integration': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Allow the ability to implement customer GitHub credentials provider.

--- a/packages/backend-common/CHANGELOG.md
+++ b/packages/backend-common/CHANGELOG.md
@@ -769,7 +769,7 @@
   Usage:
 
   ```javascript
-  const credentialsProvider = new GithubCredentialsProvider(config);
+  const credentialsProvider = new DefaultGithubCredentialsProvider(config);
   const { token, headers } = await credentialsProvider.getCredentials({
     url: 'https://github.com/',
   });

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -15,9 +15,9 @@ import cors from 'cors';
 import Docker from 'dockerode';
 import { ErrorRequestHandler } from 'express';
 import express from 'express';
+import { GithubCredentialsProvider } from '@backstage/integration';
 import { GitHubIntegration } from '@backstage/integration';
 import { GitLabIntegration } from '@backstage/integration';
-import { IGithubCredentialsProvider } from '@backstage/integration';
 import { isChildPath } from '@backstage/cli-common';
 import { JsonValue } from '@backstage/types';
 import { Knex } from 'knex';
@@ -342,7 +342,7 @@ export class GithubUrlReader implements UrlReader {
     integration: GitHubIntegration,
     deps: {
       treeResponseFactory: ReadTreeResponseFactory;
-      credentialsProvider: IGithubCredentialsProvider;
+      credentialsProvider: GithubCredentialsProvider;
     },
   );
   // (undocumented)

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -15,9 +15,9 @@ import cors from 'cors';
 import Docker from 'dockerode';
 import { ErrorRequestHandler } from 'express';
 import express from 'express';
-import { GithubCredentialsProvider } from '@backstage/integration';
 import { GitHubIntegration } from '@backstage/integration';
 import { GitLabIntegration } from '@backstage/integration';
+import { IGithubCredentialsProvider } from '@backstage/integration';
 import { isChildPath } from '@backstage/cli-common';
 import { JsonValue } from '@backstage/types';
 import { Knex } from 'knex';
@@ -342,7 +342,7 @@ export class GithubUrlReader implements UrlReader {
     integration: GitHubIntegration,
     deps: {
       treeResponseFactory: ReadTreeResponseFactory;
-      credentialsProvider: GithubCredentialsProvider;
+      credentialsProvider: IGithubCredentialsProvider;
     },
   );
   // (undocumented)

--- a/packages/backend-common/src/reading/GithubUrlReader.test.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.test.ts
@@ -16,7 +16,7 @@
 
 import { ConfigReader } from '@backstage/config';
 import {
-  GithubCredentialsProvider,
+  DefaultGithubCredentialsProvider,
   GitHubIntegration,
   readGitHubIntegrationConfig,
 } from '@backstage/integration';
@@ -43,7 +43,7 @@ const treeResponseFactory = DefaultReadTreeResponseFactory.create({
 
 const mockCredentialsProvider = {
   getCredentials: jest.fn().mockResolvedValue({ headers: {} }),
-} as unknown as GithubCredentialsProvider;
+} as unknown as DefaultGithubCredentialsProvider;
 
 const githubProcessor = new GithubUrlReader(
   new GitHubIntegration(

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -16,7 +16,8 @@
 
 import {
   getGitHubFileFetchUrl,
-  GithubCredentialsProvider,
+  IGithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
   GitHubIntegration,
   ScmIntegrations,
 } from '@backstage/integration';
@@ -58,7 +59,7 @@ export class GithubUrlReader implements UrlReader {
   static factory: ReaderFactory = ({ config, treeResponseFactory }) => {
     const integrations = ScmIntegrations.fromConfig(config);
     return integrations.github.list().map(integration => {
-      const credentialsProvider = GithubCredentialsProvider.create(
+      const credentialsProvider = GithubCredentialsProviderFactory.create(
         integration.config,
       );
       const reader = new GithubUrlReader(integration, {
@@ -74,7 +75,7 @@ export class GithubUrlReader implements UrlReader {
     private readonly integration: GitHubIntegration,
     private readonly deps: {
       treeResponseFactory: ReadTreeResponseFactory;
-      credentialsProvider: GithubCredentialsProvider;
+      credentialsProvider: IGithubCredentialsProvider;
     },
   ) {
     if (!integration.config.apiBaseUrl && !integration.config.rawBaseUrl) {

--- a/packages/backend-common/src/reading/GithubUrlReader.ts
+++ b/packages/backend-common/src/reading/GithubUrlReader.ts
@@ -16,11 +16,11 @@
 
 import {
   getGitHubFileFetchUrl,
-  IGithubCredentialsProvider,
+  GithubCredentialsProvider,
   GitHubIntegration,
   ScmIntegrations,
-  GithubCredentialsProvider,
-  IGithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
 } from '@backstage/integration';
 import { RestEndpointMethodTypes } from '@octokit/rest';
 import fetch, { RequestInit, Response } from 'node-fetch';
@@ -60,7 +60,7 @@ export class GithubUrlReader implements UrlReader {
   static factory: ReaderFactory = ({ config, treeResponseFactory }) => {
     const integrations = ScmIntegrations.fromConfig(config);
     return integrations.github.list().map(integration => {
-      const credentialsProvider = GithubCredentialsProvider.create(
+      const credentialsProvider = DefaultGithubCredentialsProvider.create(
         integration.config,
       );
 
@@ -77,7 +77,7 @@ export class GithubUrlReader implements UrlReader {
     private readonly integration: GitHubIntegration,
     private readonly deps: {
       treeResponseFactory: ReadTreeResponseFactory;
-      credentialsProvider: IGithubCredentialsProvider;
+      credentialsProvider: GithubCredentialsProvider;
     },
   ) {
     if (!integration.config.apiBaseUrl && !integration.config.rawBaseUrl) {
@@ -351,8 +351,8 @@ export class GithubUrlReader implements UrlReader {
 }
 
 export class GithubUrlReaderFactory {
-  private credsProviderFactory: IGithubCredentialsProviderFactory;
-  constructor(credsProviderFactory: IGithubCredentialsProviderFactory) {
+  private credsProviderFactory: GithubCredentialsProviderFactory;
+  constructor(credsProviderFactory: GithubCredentialsProviderFactory) {
     this.credsProviderFactory = credsProviderFactory;
   }
 

--- a/packages/backend-common/src/reading/UrlReaders.ts
+++ b/packages/backend-common/src/reading/UrlReaders.ts
@@ -20,12 +20,13 @@ import { ReaderFactory, UrlReader } from './types';
 import { UrlReaderPredicateMux } from './UrlReaderPredicateMux';
 import { AzureUrlReader } from './AzureUrlReader';
 import { BitbucketUrlReader } from './BitbucketUrlReader';
-import { GithubUrlReader } from './GithubUrlReader';
+import { GithubUrlReaderFactory } from './GithubUrlReader';
 import { GitlabUrlReader } from './GitlabUrlReader';
 import { DefaultReadTreeResponseFactory } from './tree';
 import { FetchUrlReader } from './FetchUrlReader';
 import { GoogleGcsUrlReader } from './GoogleGcsUrlReader';
 import { AwsS3UrlReader } from './AwsS3UrlReader';
+import { GithubCredentialsProviderFactory } from '@backstage/integration';
 
 /** @public */
 export type UrlReadersOptions = {
@@ -75,7 +76,8 @@ export class UrlReaders {
       factories: factories.concat([
         AzureUrlReader.factory,
         BitbucketUrlReader.factory,
-        GithubUrlReader.factory,
+        new GithubUrlReaderFactory(new GithubCredentialsProviderFactory())
+          .factory,
         GitlabUrlReader.factory,
         GoogleGcsUrlReader.factory,
         AwsS3UrlReader.factory,

--- a/packages/backend-common/src/reading/UrlReaders.ts
+++ b/packages/backend-common/src/reading/UrlReaders.ts
@@ -26,7 +26,7 @@ import { DefaultReadTreeResponseFactory } from './tree';
 import { FetchUrlReader } from './FetchUrlReader';
 import { GoogleGcsUrlReader } from './GoogleGcsUrlReader';
 import { AwsS3UrlReader } from './AwsS3UrlReader';
-import { GithubCredentialsProviderFactory } from '@backstage/integration';
+import { DefaultGithubCredentialsProviderFactory } from '@backstage/integration';
 
 /** @public */
 export type UrlReadersOptions = {
@@ -76,8 +76,9 @@ export class UrlReaders {
       factories: factories.concat([
         AzureUrlReader.factory,
         BitbucketUrlReader.factory,
-        new GithubUrlReaderFactory(new GithubCredentialsProviderFactory())
-          .factory,
+        new GithubUrlReaderFactory(
+          new DefaultGithubCredentialsProviderFactory(),
+        ).factory,
         GitlabUrlReader.factory,
         GoogleGcsUrlReader.factory,
         AwsS3UrlReader.factory,

--- a/packages/integration/CHANGELOG.md
+++ b/packages/integration/CHANGELOG.md
@@ -322,7 +322,7 @@
   Usage:
 
   ```javascript
-  const credentialsProvider = new GithubCredentialsProvider(config);
+  const credentialsProvider = new DefaultGithubCredentialsProvider(config);
   const { token, headers } = await credentialsProvider.getCredentials({
     url: 'https://github.com/',
   });

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -93,6 +93,27 @@ export type BitbucketIntegrationConfig = {
 };
 
 // @public
+export class DefaultGithubCredentialsProvider
+  implements GithubCredentialsProvider
+{
+  constructor(
+    githubAppCredentialsMux: GithubAppCredentialsMux,
+    token?: string | undefined,
+  );
+  // (undocumented)
+  static create(config: GitHubIntegrationConfig): GithubCredentialsProvider;
+  getCredentials(opts: { url: string }): Promise<GithubCredentials>;
+}
+
+// @public
+export class DefaultGithubCredentialsProviderFactory
+  implements GithubCredentialsProviderFactory
+{
+  // (undocumented)
+  create(config: GitHubIntegrationConfig): GithubCredentialsProvider;
+}
+
+// @public
 export function defaultScmResolveUrl(options: {
   url: string;
   base: string;
@@ -198,22 +219,15 @@ export type GithubCredentials = {
 };
 
 // @public
-export class GithubCredentialsProvider implements IGithubCredentialsProvider {
-  constructor(
-    githubAppCredentialsMux: GithubAppCredentialsMux,
-    token?: string | undefined,
-  );
+export interface GithubCredentialsProvider {
   // (undocumented)
-  static create(config: GitHubIntegrationConfig): IGithubCredentialsProvider;
   getCredentials(opts: { url: string }): Promise<GithubCredentials>;
 }
 
 // @public
-export class GithubCredentialsProviderFactory
-  implements IGithubCredentialsProviderFactory
-{
+export interface GithubCredentialsProviderFactory {
   // (undocumented)
-  create(config: GitHubIntegrationConfig): IGithubCredentialsProvider;
+  create(opts: any): GithubCredentialsProvider;
 }
 
 // @public
@@ -283,18 +297,6 @@ export type GoogleGcsIntegrationConfig = {
   clientEmail?: string;
   privateKey?: string;
 };
-
-// @public
-export interface IGithubCredentialsProvider {
-  // (undocumented)
-  getCredentials(opts: { url: string }): Promise<GithubCredentials>;
-}
-
-// @public
-export interface IGithubCredentialsProviderFactory {
-  // (undocumented)
-  create(opts: any): IGithubCredentialsProvider;
-}
 
 // @public
 export interface IntegrationsByType {

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -208,9 +208,7 @@ export class GithubCredentialsProvider implements IGithubCredentialsProvider {
   getCredentials(opts: { url: string }): Promise<GithubCredentials>;
 }
 
-// Warning: (ae-missing-release-tag) "GithubCredentialsProviderFactory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export class GithubCredentialsProviderFactory
   implements IGithubCredentialsProviderFactory
 {

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -199,19 +199,23 @@ export type GithubCredentials = {
 
 // @public
 export class GithubCredentialsProvider implements IGithubCredentialsProvider {
+  constructor(
+    githubAppCredentialsMux: GithubAppCredentialsMux,
+    token?: string | undefined,
+  );
   // (undocumented)
   static create(config: GitHubIntegrationConfig): IGithubCredentialsProvider;
   getCredentials(opts: { url: string }): Promise<GithubCredentials>;
 }
 
-// @public
-export class GithubCredentialsProviderFactory {
+// Warning: (ae-missing-release-tag) "GithubCredentialsProviderFactory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class GithubCredentialsProviderFactory
+  implements IGithubCredentialsProviderFactory
+{
   // (undocumented)
-  static create(config: GitHubIntegrationConfig): IGithubCredentialsProvider;
-  // (undocumented)
-  static provider: typeof GithubCredentialsProvider;
-  // (undocumented)
-  static setProvider(provider: any): void;
+  create(config: GitHubIntegrationConfig): IGithubCredentialsProvider;
 }
 
 // @public
@@ -286,6 +290,12 @@ export type GoogleGcsIntegrationConfig = {
 export interface IGithubCredentialsProvider {
   // (undocumented)
   getCredentials(opts: { url: string }): Promise<GithubCredentials>;
+}
+
+// @public
+export interface IGithubCredentialsProviderFactory {
+  // (undocumented)
+  create(opts: any): IGithubCredentialsProvider;
 }
 
 // @public

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -198,10 +198,20 @@ export type GithubCredentials = {
 };
 
 // @public
-export class GithubCredentialsProvider {
+export class GithubCredentialsProvider implements IGithubCredentialsProvider {
   // (undocumented)
-  static create(config: GitHubIntegrationConfig): GithubCredentialsProvider;
+  static create(config: GitHubIntegrationConfig): IGithubCredentialsProvider;
   getCredentials(opts: { url: string }): Promise<GithubCredentials>;
+}
+
+// @public
+export class GithubCredentialsProviderFactory {
+  // (undocumented)
+  static create(config: GitHubIntegrationConfig): IGithubCredentialsProvider;
+  // (undocumented)
+  static provider: typeof GithubCredentialsProvider;
+  // (undocumented)
+  static setProvider(provider: any): void;
 }
 
 // @public
@@ -271,6 +281,12 @@ export type GoogleGcsIntegrationConfig = {
   clientEmail?: string;
   privateKey?: string;
 };
+
+// @public
+export interface IGithubCredentialsProvider {
+  // (undocumented)
+  getCredentials(opts: { url: string }): Promise<GithubCredentials>;
+}
 
 // @public
 export interface IntegrationsByType {

--- a/packages/integration/src/github/DefaultGithubCredentialsProvider.test.ts
+++ b/packages/integration/src/github/DefaultGithubCredentialsProvider.test.ts
@@ -31,11 +31,11 @@ jest.doMock('@octokit/rest', () => {
   return { Octokit };
 });
 
-import { GithubCredentialsProvider } from './GithubCredentialsProvider';
+import { DefaultGithubCredentialsProvider } from './DefaultGithubCredentialsProvider';
 import { RestEndpointMethodTypes } from '@octokit/rest';
 import { DateTime } from 'luxon';
 
-const github = GithubCredentialsProvider.create({
+const github = DefaultGithubCredentialsProvider.create({
   host: 'github.com',
   apps: [
     {
@@ -204,7 +204,7 @@ describe('GithubCredentialsProvider tests', () => {
   });
 
   it('should return the default token if no app is configured', async () => {
-    const githubProvider = GithubCredentialsProvider.create({
+    const githubProvider = DefaultGithubCredentialsProvider.create({
       host: 'github.com',
       apps: [],
       token: 'fallback_token',
@@ -218,7 +218,7 @@ describe('GithubCredentialsProvider tests', () => {
   });
 
   it('should return the configured token if there are no installations', async () => {
-    const githubProvider = GithubCredentialsProvider.create({
+    const githubProvider = DefaultGithubCredentialsProvider.create({
       host: 'github.com',
       apps: [
         {
@@ -243,7 +243,7 @@ describe('GithubCredentialsProvider tests', () => {
   });
 
   it('should return undefined if no token or apps are configured', async () => {
-    const githubProvider = GithubCredentialsProvider.create({
+    const githubProvider = DefaultGithubCredentialsProvider.create({
       host: 'github.com',
     });
 

--- a/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
@@ -239,7 +239,7 @@ export type GithubCredentials = {
  * @public
  *
  */
-export interface IGithubCredentialsProvider {
+export interface GithubCredentialsProvider {
   getCredentials(opts: { url: string }): Promise<GithubCredentials>;
 }
 
@@ -251,9 +251,11 @@ export interface IGithubCredentialsProvider {
  *
  * TODO: Possibly move this to a backend only package so that it's not used in the frontend by mistake
  */
-export class GithubCredentialsProvider implements IGithubCredentialsProvider {
-  static create(config: GitHubIntegrationConfig): IGithubCredentialsProvider {
-    return new GithubCredentialsProvider(
+export class DefaultGithubCredentialsProvider
+  implements GithubCredentialsProvider
+{
+  static create(config: GitHubIntegrationConfig): GithubCredentialsProvider {
+    return new DefaultGithubCredentialsProvider(
       new GithubAppCredentialsMux(config),
       config.token,
     );

--- a/packages/integration/src/github/DefaultGithubCredentialsProviderFactory.ts
+++ b/packages/integration/src/github/DefaultGithubCredentialsProviderFactory.ts
@@ -16,9 +16,9 @@
 import { GitHubIntegrationConfig } from './config';
 import {
   GithubAppCredentialsMux,
+  DefaultGithubCredentialsProvider,
   GithubCredentialsProvider,
-  IGithubCredentialsProvider,
-} from './GithubCredentialsProvider';
+} from './DefaultGithubCredentialsProvider';
 
 /**
  * This allows implementations to be provided to retrieve GitHub credentials.
@@ -26,8 +26,8 @@ import {
  * @public
  *
  */
-export interface IGithubCredentialsProviderFactory {
-  create(opts: any): IGithubCredentialsProvider;
+export interface GithubCredentialsProviderFactory {
+  create(opts: any): GithubCredentialsProvider;
 }
 
 /**
@@ -36,11 +36,11 @@ export interface IGithubCredentialsProviderFactory {
  * @public
  *
  */
-export class GithubCredentialsProviderFactory
-  implements IGithubCredentialsProviderFactory
+export class DefaultGithubCredentialsProviderFactory
+  implements GithubCredentialsProviderFactory
 {
-  create(config: GitHubIntegrationConfig): IGithubCredentialsProvider {
-    return new GithubCredentialsProvider(
+  create(config: GitHubIntegrationConfig): GithubCredentialsProvider {
+    return new DefaultGithubCredentialsProvider(
       new GithubAppCredentialsMux(config),
       config.token,
     );

--- a/packages/integration/src/github/GithubCredentialsProvider.ts
+++ b/packages/integration/src/github/GithubCredentialsProvider.ts
@@ -233,6 +233,10 @@ export type GithubCredentials = {
   type: GithubCredentialType;
 };
 
+export interface IGithubCredentialsProvider {
+  getCredentials(opts: { url: string }): Promise<GithubCredentials>;
+}
+
 /**
  * Handles the creation and caching of credentials for GitHub integrations.
  *
@@ -241,8 +245,8 @@ export type GithubCredentials = {
  *
  * TODO: Possibly move this to a backend only package so that it's not used in the frontend by mistake
  */
-export class GithubCredentialsProvider {
-  static create(config: GitHubIntegrationConfig): GithubCredentialsProvider {
+export class GithubCredentialsProvider implements IGithubCredentialsProvider {
+  static create(config: GitHubIntegrationConfig): IGithubCredentialsProvider {
     return new GithubCredentialsProvider(
       new GithubAppCredentialsMux(config),
       config.token,
@@ -292,5 +296,17 @@ export class GithubCredentialsProvider {
       token,
       type,
     };
+  }
+}
+
+export class GithubCredentialsProviderFactory {
+  static provider = GithubCredentialsProvider;
+
+  static setProvider(provider: any) {
+    this.provider = provider;
+  }
+
+  static create(config: GitHubIntegrationConfig): IGithubCredentialsProvider {
+    return this.provider.create(config);
   }
 }

--- a/packages/integration/src/github/GithubCredentialsProvider.ts
+++ b/packages/integration/src/github/GithubCredentialsProvider.ts
@@ -259,7 +259,7 @@ export class GithubCredentialsProvider implements IGithubCredentialsProvider {
     );
   }
 
-  private constructor(
+  public constructor(
     private readonly githubAppCredentialsMux: GithubAppCredentialsMux,
     private readonly token?: string,
   ) {}
@@ -302,23 +302,5 @@ export class GithubCredentialsProvider implements IGithubCredentialsProvider {
       token,
       type,
     };
-  }
-}
-
-/**
- * Handles the creation and of GitHub credentials providers.
- *
- * @public
- *
- */
-export class GithubCredentialsProviderFactory {
-  static provider = GithubCredentialsProvider;
-
-  static setProvider(provider: any) {
-    this.provider = provider;
-  }
-
-  static create(config: GitHubIntegrationConfig): IGithubCredentialsProvider {
-    return this.provider.create(config);
   }
 }

--- a/packages/integration/src/github/GithubCredentialsProvider.ts
+++ b/packages/integration/src/github/GithubCredentialsProvider.ts
@@ -233,6 +233,12 @@ export type GithubCredentials = {
   type: GithubCredentialType;
 };
 
+/**
+ * This allows implementations to be provided to retrieve GitHub credentials.
+ *
+ * @public
+ *
+ */
 export interface IGithubCredentialsProvider {
   getCredentials(opts: { url: string }): Promise<GithubCredentials>;
 }
@@ -299,6 +305,12 @@ export class GithubCredentialsProvider implements IGithubCredentialsProvider {
   }
 }
 
+/**
+ * Handles the creation and of GitHub credentials providers.
+ *
+ * @public
+ *
+ */
 export class GithubCredentialsProviderFactory {
   static provider = GithubCredentialsProvider;
 

--- a/packages/integration/src/github/GithubCredentialsProviderFactory.ts
+++ b/packages/integration/src/github/GithubCredentialsProviderFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export {
-  readGitHubIntegrationConfig,
-  readGitHubIntegrationConfigs,
-} from './config';
-export type { GithubAppConfig, GitHubIntegrationConfig } from './config';
-export { getGitHubFileFetchUrl, getGitHubRequestOptions } from './core';
-export {
+import { GitHubIntegrationConfig } from './config';
+import {
   GithubAppCredentialsMux,
   GithubCredentialsProvider,
-} from './GithubCredentialsProvider';
-export { GithubCredentialsProviderFactory } from './GithubCredentialsProviderFactory';
-export type { IGithubCredentialsProviderFactory } from './GithubCredentialsProviderFactory';
-export type {
-  GithubCredentials,
-  GithubCredentialType,
   IGithubCredentialsProvider,
 } from './GithubCredentialsProvider';
-export { GitHubIntegration, replaceGitHubUrlType } from './GitHubIntegration';
+
+/**
+ * This allows implementations to be provided to retrieve GitHub credentials.
+ *
+ * @public
+ *
+ */
+export interface IGithubCredentialsProviderFactory {
+  create(opts: any): IGithubCredentialsProvider;
+}
+
+export class GithubCredentialsProviderFactory
+  implements IGithubCredentialsProviderFactory
+{
+  create(config: GitHubIntegrationConfig): IGithubCredentialsProvider {
+    return new GithubCredentialsProvider(
+      new GithubAppCredentialsMux(config),
+      config.token,
+    );
+  }
+}

--- a/packages/integration/src/github/GithubCredentialsProviderFactory.ts
+++ b/packages/integration/src/github/GithubCredentialsProviderFactory.ts
@@ -30,6 +30,12 @@ export interface IGithubCredentialsProviderFactory {
   create(opts: any): IGithubCredentialsProvider;
 }
 
+/**
+ * Default factory implementation to retrieve credentials using the app or token config.
+ *
+ * @public
+ *
+ */
 export class GithubCredentialsProviderFactory
   implements IGithubCredentialsProviderFactory
 {

--- a/packages/integration/src/github/core.test.ts
+++ b/packages/integration/src/github/core.test.ts
@@ -16,7 +16,7 @@
 
 import { GitHubIntegrationConfig } from './config';
 import { getGitHubFileFetchUrl, getGitHubRequestOptions } from './core';
-import { GithubCredentials } from './GithubCredentialsProvider';
+import { GithubCredentials } from './DefaultGithubCredentialsProvider';
 
 describe('github core', () => {
   const appCredentials: GithubCredentials = {

--- a/packages/integration/src/github/core.ts
+++ b/packages/integration/src/github/core.ts
@@ -16,7 +16,7 @@
 
 import parseGitUrl from 'git-url-parse';
 import { GitHubIntegrationConfig } from './config';
-import { GithubCredentials } from './GithubCredentialsProvider';
+import { GithubCredentials } from './DefaultGithubCredentialsProvider';
 
 /**
  * Given a URL pointing to a file on a provider, returns a URL that is suitable

--- a/packages/integration/src/github/index.ts
+++ b/packages/integration/src/github/index.ts
@@ -22,13 +22,13 @@ export type { GithubAppConfig, GitHubIntegrationConfig } from './config';
 export { getGitHubFileFetchUrl, getGitHubRequestOptions } from './core';
 export {
   GithubAppCredentialsMux,
-  GithubCredentialsProvider,
-} from './GithubCredentialsProvider';
-export { GithubCredentialsProviderFactory } from './GithubCredentialsProviderFactory';
-export type { IGithubCredentialsProviderFactory } from './GithubCredentialsProviderFactory';
+  DefaultGithubCredentialsProvider,
+} from './DefaultGithubCredentialsProvider';
+export { DefaultGithubCredentialsProviderFactory } from './DefaultGithubCredentialsProviderFactory';
+export type { GithubCredentialsProviderFactory } from './DefaultGithubCredentialsProviderFactory';
 export type {
   GithubCredentials,
   GithubCredentialType,
-  IGithubCredentialsProvider,
-} from './GithubCredentialsProvider';
+  GithubCredentialsProvider,
+} from './DefaultGithubCredentialsProvider';
 export { GitHubIntegration, replaceGitHubUrlType } from './GitHubIntegration';

--- a/packages/integration/src/github/index.ts
+++ b/packages/integration/src/github/index.ts
@@ -23,9 +23,11 @@ export { getGitHubFileFetchUrl, getGitHubRequestOptions } from './core';
 export {
   GithubAppCredentialsMux,
   GithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
 } from './GithubCredentialsProvider';
 export type {
   GithubCredentials,
   GithubCredentialType,
+  IGithubCredentialsProvider,
 } from './GithubCredentialsProvider';
 export { GitHubIntegration, replaceGitHubUrlType } from './GitHubIntegration';

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -1047,9 +1047,7 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
   ): Promise<boolean>;
 }
 
-// Warning: (ae-missing-release-tag) "GithubDiscoveryProcessorBuilder" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export class GithubDiscoveryProcessorBuilder
   implements CatalogProcessorBuilder
 {
@@ -1160,9 +1158,7 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
   ): Promise<boolean>;
 }
 
-// Warning: (ae-missing-release-tag) "GithubOrgReaderProcessorBuilder" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export class GithubOrgReaderProcessorBuilder
   implements CatalogProcessorBuilder
 {

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -16,8 +16,8 @@ import { EntityName } from '@backstage/catalog-model';
 import { EntityPolicy } from '@backstage/catalog-model';
 import { EntityRelationSpec } from '@backstage/catalog-model';
 import express from 'express';
+import { GithubCredentialsProviderFactory } from '@backstage/integration';
 import { GitHubIntegrationConfig } from '@backstage/integration';
-import { IGithubCredentialsProviderFactory } from '@backstage/integration';
 import { IndexableDocument } from '@backstage/search-common';
 import { JsonObject } from '@backstage/types';
 import { JsonValue } from '@backstage/types';
@@ -1030,7 +1030,7 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrations;
     logger: Logger_2;
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
   });
   // (undocumented)
   static fromConfig(
@@ -1052,7 +1052,7 @@ export class GithubDiscoveryProcessorBuilder
   implements CatalogProcessorBuilder
 {
   constructor(
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory,
   );
   // (undocumented)
   fromConfig(
@@ -1069,7 +1069,7 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
     integrations: ScmIntegrations;
     logger: Logger_2;
     orgs: GithubMultiOrgConfig;
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
   });
   // (undocumented)
   static fromConfig(
@@ -1093,7 +1093,7 @@ export class GithubMultiOrgReaderProcessorBuilder
   implements CatalogProcessorBuilder
 {
   constructor(
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory,
   );
   // Warning: (ae-incompatible-release-tags) The symbol "fromConfig" is marked as @public, but its signature references "GithubMultiOrgReaderProcessor" which is marked as @alpha
   //
@@ -1115,7 +1115,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
     orgUrl: string;
     gitHubConfig: GitHubIntegrationConfig;
     logger: Logger_2;
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
   });
   // (undocumented)
   connect(connection: EntityProviderConnection): Promise<void>;
@@ -1139,7 +1139,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
 // @public
 export class GithubOrgReaderProcessor implements CatalogProcessor {
   constructor(options: {
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
     integrations: ScmIntegrations;
     logger: Logger_2;
   });
@@ -1163,7 +1163,7 @@ export class GithubOrgReaderProcessorBuilder
   implements CatalogProcessorBuilder
 {
   constructor(
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory,
   );
   // (undocumented)
   fromConfig(

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -17,6 +17,7 @@ import { EntityPolicy } from '@backstage/catalog-model';
 import { EntityRelationSpec } from '@backstage/catalog-model';
 import express from 'express';
 import { GitHubIntegrationConfig } from '@backstage/integration';
+import { IGithubCredentialsProviderFactory } from '@backstage/integration';
 import { IndexableDocument } from '@backstage/search-common';
 import { JsonObject } from '@backstage/types';
 import { JsonValue } from '@backstage/types';
@@ -352,6 +353,18 @@ export type CatalogProcessor = {
     location: LocationSpec,
     emit: CatalogProcessorEmit,
   ): Promise<void>;
+};
+
+// Warning: (ae-missing-release-tag) "CatalogProcessorBuilder" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CatalogProcessorBuilder = {
+  fromConfig(
+    config: Config,
+    options: {
+      logger: Logger_2;
+    },
+  ): CatalogProcessor;
 };
 
 // @public
@@ -1014,7 +1027,11 @@ function generalError(
 //
 // @public
 export class GithubDiscoveryProcessor implements CatalogProcessor {
-  constructor(options: { integrations: ScmIntegrations; logger: Logger_2 });
+  constructor(options: {
+    integrations: ScmIntegrations;
+    logger: Logger_2;
+    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  });
   // (undocumented)
   static fromConfig(
     config: Config,
@@ -1030,12 +1047,31 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
   ): Promise<boolean>;
 }
 
+// Warning: (ae-missing-release-tag) "GithubDiscoveryProcessorBuilder" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class GithubDiscoveryProcessorBuilder
+  implements CatalogProcessorBuilder
+{
+  constructor(
+    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+  );
+  // (undocumented)
+  fromConfig(
+    config: Config,
+    options: {
+      logger: Logger_2;
+    },
+  ): GithubDiscoveryProcessor;
+}
+
 // @alpha
 export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrations;
     logger: Logger_2;
     orgs: GithubMultiOrgConfig;
+    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
   });
   // (undocumented)
   static fromConfig(
@@ -1052,6 +1088,26 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
   ): Promise<boolean>;
 }
 
+// Warning: (ae-missing-release-tag) "GithubMultiOrgReaderProcessorBuilder" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class GithubMultiOrgReaderProcessorBuilder
+  implements CatalogProcessorBuilder
+{
+  constructor(
+    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+  );
+  // Warning: (ae-incompatible-release-tags) The symbol "fromConfig" is marked as @public, but its signature references "GithubMultiOrgReaderProcessor" which is marked as @alpha
+  //
+  // (undocumented)
+  fromConfig(
+    config: Config,
+    options: {
+      logger: Logger_2;
+    },
+  ): GithubMultiOrgReaderProcessor;
+}
+
 // Warning: (ae-missing-release-tag) "GitHubOrgEntityProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -1061,6 +1117,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
     orgUrl: string;
     gitHubConfig: GitHubIntegrationConfig;
     logger: Logger_2;
+    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
   });
   // (undocumented)
   connect(connection: EntityProviderConnection): Promise<void>;
@@ -1083,7 +1140,11 @@ export class GitHubOrgEntityProvider implements EntityProvider {
 //
 // @public
 export class GithubOrgReaderProcessor implements CatalogProcessor {
-  constructor(options: { integrations: ScmIntegrations; logger: Logger_2 });
+  constructor(options: {
+    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+    integrations: ScmIntegrations;
+    logger: Logger_2;
+  });
   // (undocumented)
   static fromConfig(
     config: Config,
@@ -1097,6 +1158,24 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     _optional: boolean,
     emit: CatalogProcessorEmit,
   ): Promise<boolean>;
+}
+
+// Warning: (ae-missing-release-tag) "GithubOrgReaderProcessorBuilder" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export class GithubOrgReaderProcessorBuilder
+  implements CatalogProcessorBuilder
+{
+  constructor(
+    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+  );
+  // (undocumented)
+  fromConfig(
+    config: Config,
+    options: {
+      logger: Logger_2;
+    },
+  ): GithubOrgReaderProcessor;
 }
 
 // Warning: (ae-missing-release-tag) "GitLabDiscoveryProcessor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -1577,7 +1656,7 @@ export class UrlReaderProcessor implements CatalogProcessor {
 // src/catalog/types.d.ts:94:8 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
 // src/catalog/types.d.ts:95:8 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
 // src/catalog/types.d.ts:96:8 - (tsdoc-param-tag-with-invalid-name) The @param block should be followed by a valid parameter name: The identifier cannot non-word characters
-// src/ingestion/processors/GithubMultiOrgReaderProcessor.d.ts:23:9 - (ae-forgotten-export) The symbol "GithubMultiOrgConfig" needs to be exported by the entry point index.d.ts
+// src/ingestion/processors/GithubMultiOrgReaderProcessor.d.ts:24:9 - (ae-forgotten-export) The symbol "GithubMultiOrgConfig" needs to be exported by the entry point index.d.ts
 // src/ingestion/types.d.ts:8:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/legacy/database/types.d.ts:98:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
 // src/legacy/database/types.d.ts:104:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
@@ -16,9 +16,13 @@
 
 import { getVoidLogger } from '@backstage/backend-common';
 import { LocationSpec } from '@backstage/catalog-model';
-import { GithubDiscoveryProcessor, parseUrl } from './GithubDiscoveryProcessor';
+import {
+  GithubDiscoveryProcessorBuilder,
+  parseUrl,
+} from './GithubDiscoveryProcessor';
 import { getOrganizationRepositories } from './github';
 import { ConfigReader } from '@backstage/config';
+import { GithubCredentialsProviderFactory } from '@backstage/integration';
 
 jest.mock('./github');
 const mockGetOrganizationRepositories =
@@ -67,7 +71,9 @@ describe('GithubDiscoveryProcessor', () => {
 
   describe('reject unrelated entries', () => {
     it('rejects unknown types', async () => {
-      const processor = GithubDiscoveryProcessor.fromConfig(
+      const processor = new GithubDiscoveryProcessorBuilder(
+        new GithubCredentialsProviderFactory(),
+      ).fromConfig(
         new ConfigReader({
           integrations: {
             github: [{ host: 'github.com', token: 'blob' }],
@@ -85,7 +91,9 @@ describe('GithubDiscoveryProcessor', () => {
     });
 
     it('rejects unknown targets', async () => {
-      const processor = GithubDiscoveryProcessor.fromConfig(
+      const processor = new GithubDiscoveryProcessorBuilder(
+        new GithubCredentialsProviderFactory(),
+      ).fromConfig(
         new ConfigReader({
           integrations: {
             github: [
@@ -109,7 +117,9 @@ describe('GithubDiscoveryProcessor', () => {
   });
 
   describe('handles repositories', () => {
-    const processor = GithubDiscoveryProcessor.fromConfig(
+    const processor = new GithubDiscoveryProcessorBuilder(
+      new GithubCredentialsProviderFactory(),
+    ).fromConfig(
       new ConfigReader({
         integrations: {
           github: [{ host: 'github.com', token: 'blob' }],

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.test.ts
@@ -22,7 +22,7 @@ import {
 } from './GithubDiscoveryProcessor';
 import { getOrganizationRepositories } from './github';
 import { ConfigReader } from '@backstage/config';
-import { GithubCredentialsProviderFactory } from '@backstage/integration';
+import { DefaultGithubCredentialsProviderFactory } from '@backstage/integration';
 
 jest.mock('./github');
 const mockGetOrganizationRepositories =
@@ -72,7 +72,7 @@ describe('GithubDiscoveryProcessor', () => {
   describe('reject unrelated entries', () => {
     it('rejects unknown types', async () => {
       const processor = new GithubDiscoveryProcessorBuilder(
-        new GithubCredentialsProviderFactory(),
+        new DefaultGithubCredentialsProviderFactory(),
       ).fromConfig(
         new ConfigReader({
           integrations: {
@@ -92,7 +92,7 @@ describe('GithubDiscoveryProcessor', () => {
 
     it('rejects unknown targets', async () => {
       const processor = new GithubDiscoveryProcessorBuilder(
-        new GithubCredentialsProviderFactory(),
+        new DefaultGithubCredentialsProviderFactory(),
       ).fromConfig(
         new ConfigReader({
           integrations: {
@@ -118,7 +118,7 @@ describe('GithubDiscoveryProcessor', () => {
 
   describe('handles repositories', () => {
     const processor = new GithubDiscoveryProcessorBuilder(
-      new GithubCredentialsProviderFactory(),
+      new DefaultGithubCredentialsProviderFactory(),
     ).fromConfig(
       new ConfigReader({
         integrations: {

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
@@ -193,6 +193,11 @@ export function escapeRegExp(str: string): RegExp {
   return new RegExp(`^${str.replace(/\*/g, '.*')}$`);
 }
 
+/**
+ * Builder class to create GitHub discovery processors
+ *
+ * @public
+ **/
 export class GithubDiscoveryProcessorBuilder
   implements CatalogProcessorBuilder
 {

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
@@ -17,7 +17,7 @@
 import { LocationSpec } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
-  GithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { graphql } from '@octokit/graphql';
@@ -84,7 +84,7 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
     // about how to handle the wild card which is special for this processor.
     const orgUrl = `https://${host}/${org}`;
 
-    const { headers } = await GithubCredentialsProvider.create(
+    const { headers } = await GithubCredentialsProviderFactory.create(
       gitHubConfig,
     ).getCredentials({ url: orgUrl });
 

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
@@ -17,9 +17,9 @@
 import { LocationSpec } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
-  IGithubCredentialsProviderFactory,
-  ScmIntegrations,
   GithubCredentialsProviderFactory,
+  ScmIntegrations,
+  DefaultGithubCredentialsProviderFactory,
 } from '@backstage/integration';
 import { graphql } from '@octokit/graphql';
 import { Logger } from 'winston';
@@ -48,7 +48,7 @@ import {
 export class GithubDiscoveryProcessor implements CatalogProcessor {
   private readonly integrations: ScmIntegrations;
   private readonly logger: Logger;
-  private readonly githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  private readonly githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 
   static fromConfig(config: Config, options: { logger: Logger }) {
     const integrations = ScmIntegrations.fromConfig(config);
@@ -56,14 +56,15 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
     return new GithubDiscoveryProcessor({
       ...options,
       integrations,
-      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+      githubCredentialsProviderFactory:
+        new DefaultGithubCredentialsProviderFactory(),
     });
   }
 
   constructor(options: {
     integrations: ScmIntegrations;
     logger: Logger;
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
   }) {
     this.integrations = options.integrations;
     this.logger = options.logger;
@@ -201,9 +202,9 @@ export function escapeRegExp(str: string): RegExp {
 export class GithubDiscoveryProcessorBuilder
   implements CatalogProcessorBuilder
 {
-  private githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  private githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
   constructor(
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory,
   ) {
     this.githubCredentialsProviderFactory = githubCredentialsProviderFactory;
   }

--- a/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
@@ -18,9 +18,9 @@ import { LocationSpec } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
   GithubAppCredentialsMux,
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProviderFactory,
   GitHubIntegrationConfig,
-  IGithubCredentialsProviderFactory,
+  GithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { graphql } from '@octokit/graphql';
@@ -49,7 +49,7 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
   private readonly integrations: ScmIntegrations;
   private readonly orgs: GithubMultiOrgConfig;
   private readonly logger: Logger;
-  private readonly githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  private readonly githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 
   // deprecated
   static fromConfig(config: Config, options: { logger: Logger }) {
@@ -60,7 +60,8 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
       ...options,
       integrations,
       orgs: c ? readGithubMultiOrgConfig(c) : [],
-      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+      githubCredentialsProviderFactory:
+        new DefaultGithubCredentialsProviderFactory(),
     });
   }
 
@@ -68,7 +69,7 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
     integrations: ScmIntegrations;
     logger: Logger;
     orgs: GithubMultiOrgConfig;
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
   }) {
     this.integrations = options.integrations;
     this.logger = options.logger;
@@ -198,10 +199,10 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
 export class GithubMultiOrgReaderProcessorBuilder
   implements CatalogProcessorBuilder
 {
-  private githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  private githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 
   constructor(
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory,
   ) {
     this.githubCredentialsProviderFactory = githubCredentialsProviderFactory;
   }

--- a/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
@@ -18,7 +18,7 @@ import { LocationSpec } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
   GithubAppCredentialsMux,
-  GithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
   GitHubIntegrationConfig,
   ScmIntegrations,
 } from '@backstage/integration';
@@ -86,7 +86,8 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
 
     const allUsersMap = new Map();
     const baseUrl = new URL(location.target).origin;
-    const credentialsProvider = GithubCredentialsProvider.create(gitHubConfig);
+    const credentialsProvider =
+      GithubCredentialsProviderFactory.create(gitHubConfig);
 
     const orgsToProcess = this.orgs.length
       ? this.orgs

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
@@ -18,6 +18,7 @@ import { LocationSpec } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import {
   GithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { graphql } from '@octokit/graphql';
@@ -48,6 +49,8 @@ describe('GithubOrgReaderProcessor', () => {
       const processor = new GithubOrgReaderProcessor({
         integrations,
         logger,
+        githubCredentialsProviderFactory:
+          new GithubCredentialsProviderFactory(),
       });
       const location: LocationSpec = {
         type: 'github-org',
@@ -94,6 +97,8 @@ describe('GithubOrgReaderProcessor', () => {
       const processor = new GithubOrgReaderProcessor({
         integrations,
         logger,
+        githubCredentialsProviderFactory:
+          new GithubCredentialsProviderFactory(),
       });
       const location: LocationSpec = {
         type: 'github-org',
@@ -142,6 +147,8 @@ describe('GithubOrgReaderProcessor', () => {
       const processor = new GithubOrgReaderProcessor({
         integrations,
         logger,
+        githubCredentialsProviderFactory:
+          new GithubCredentialsProviderFactory(),
       });
       const location: LocationSpec = {
         type: 'github-org',

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
@@ -17,8 +17,8 @@ import { getVoidLogger } from '@backstage/backend-common';
 import { LocationSpec } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import {
-  GithubCredentialsProvider,
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProvider,
+  DefaultGithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { graphql } from '@octokit/graphql';
@@ -50,7 +50,7 @@ describe('GithubOrgReaderProcessor', () => {
         integrations,
         logger,
         githubCredentialsProviderFactory:
-          new GithubCredentialsProviderFactory(),
+          new DefaultGithubCredentialsProviderFactory(),
       });
       const location: LocationSpec = {
         type: 'github-org',
@@ -65,7 +65,7 @@ describe('GithubOrgReaderProcessor', () => {
 
     it('should not query for email addresses when GitHub Apps is used for authentication', async () => {
       const githubCredentialsProviderFactory =
-        new GithubCredentialsProviderFactory();
+        new DefaultGithubCredentialsProviderFactory();
 
       const mockGetCredentials = jest.fn().mockReturnValue({
         headers: { token: 'blah' },
@@ -142,7 +142,7 @@ describe('GithubOrgReaderProcessor', () => {
 
       (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
 
-      jest.spyOn(GithubCredentialsProvider, 'create').mockReturnValue({
+      jest.spyOn(DefaultGithubCredentialsProvider, 'create').mockReturnValue({
         getCredentials: mockGetCredentials,
       } as any);
 
@@ -150,7 +150,7 @@ describe('GithubOrgReaderProcessor', () => {
         integrations,
         logger,
         githubCredentialsProviderFactory:
-          new GithubCredentialsProviderFactory(),
+          new DefaultGithubCredentialsProviderFactory(),
       });
       const location: LocationSpec = {
         type: 'github-org',

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.test.ts
@@ -64,6 +64,9 @@ describe('GithubOrgReaderProcessor', () => {
     });
 
     it('should not query for email addresses when GitHub Apps is used for authentication', async () => {
+      const githubCredentialsProviderFactory =
+        new GithubCredentialsProviderFactory();
+
       const mockGetCredentials = jest.fn().mockReturnValue({
         headers: { token: 'blah' },
         type: 'app',
@@ -90,15 +93,14 @@ describe('GithubOrgReaderProcessor', () => {
 
       (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
 
-      jest.spyOn(GithubCredentialsProvider, 'create').mockReturnValue({
+      jest.spyOn(githubCredentialsProviderFactory, 'create').mockReturnValue({
         getCredentials: mockGetCredentials,
       } as any);
 
       const processor = new GithubOrgReaderProcessor({
         integrations,
         logger,
-        githubCredentialsProviderFactory:
-          new GithubCredentialsProviderFactory(),
+        githubCredentialsProviderFactory,
       });
       const location: LocationSpec = {
         type: 'github-org',

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
@@ -136,6 +136,11 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
   }
 }
 
+/**
+ * Builds GitHub org reader processors
+ *
+ * @public
+ */
 export class GithubOrgReaderProcessorBuilder
   implements CatalogProcessorBuilder
 {

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
@@ -17,9 +17,9 @@
 import { LocationSpec } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProviderFactory,
   GithubCredentialType,
-  IGithubCredentialsProviderFactory,
+  GithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { graphql } from '@octokit/graphql';
@@ -45,7 +45,7 @@ type GraphQL = typeof graphql;
 export class GithubOrgReaderProcessor implements CatalogProcessor {
   private readonly integrations: ScmIntegrations;
   private readonly logger: Logger;
-  private readonly githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  private readonly githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 
   static fromConfig(config: Config, options: { logger: Logger }) {
     const integrations = ScmIntegrations.fromConfig(config);
@@ -53,12 +53,13 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     return new GithubOrgReaderProcessor({
       ...options,
       integrations,
-      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+      githubCredentialsProviderFactory:
+        new DefaultGithubCredentialsProviderFactory(),
     });
   }
 
   constructor(options: {
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
     integrations: ScmIntegrations;
     logger: Logger;
   }) {
@@ -144,10 +145,10 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
 export class GithubOrgReaderProcessorBuilder
   implements CatalogProcessorBuilder
 {
-  private githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  private githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 
   constructor(
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory,
   ) {
     this.githubCredentialsProviderFactory = githubCredentialsProviderFactory;
   }

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
@@ -17,7 +17,7 @@
 import { LocationSpec } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
-  GithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
   GithubCredentialType,
   ScmIntegrations,
 } from '@backstage/integration';
@@ -107,7 +107,8 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
       );
     }
 
-    const credentialsProvider = GithubCredentialsProvider.create(gitHubConfig);
+    const credentialsProvider =
+      GithubCredentialsProviderFactory.create(gitHubConfig);
     const { headers, type: tokenType } =
       await credentialsProvider.getCredentials({
         url: orgUrl,

--- a/plugins/catalog-backend/src/ingestion/processors/index.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/index.ts
@@ -25,10 +25,19 @@ export { BitbucketDiscoveryProcessor } from './BitbucketDiscoveryProcessor';
 export { BuiltinKindsEntityProcessor } from './BuiltinKindsEntityProcessor';
 export { CodeOwnersProcessor } from './CodeOwnersProcessor';
 export { FileReaderProcessor } from './FileReaderProcessor';
-export { GithubDiscoveryProcessor } from './GithubDiscoveryProcessor';
+export {
+  GithubDiscoveryProcessor,
+  GithubDiscoveryProcessorBuilder,
+} from './GithubDiscoveryProcessor';
 export { AzureDevOpsDiscoveryProcessor } from './AzureDevOpsDiscoveryProcessor';
-export { GithubOrgReaderProcessor } from './GithubOrgReaderProcessor';
-export { GithubMultiOrgReaderProcessor } from './GithubMultiOrgReaderProcessor';
+export {
+  GithubOrgReaderProcessor,
+  GithubOrgReaderProcessorBuilder,
+} from './GithubOrgReaderProcessor';
+export {
+  GithubMultiOrgReaderProcessor,
+  GithubMultiOrgReaderProcessorBuilder,
+} from './GithubMultiOrgReaderProcessor';
 export { GitLabDiscoveryProcessor } from './GitLabDiscoveryProcessor';
 export { LocationEntityProcessor } from './LocationEntityProcessor';
 export type { LocationEntityProcessorOptions } from './LocationEntityProcessor';

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -20,6 +20,12 @@ import {
   LocationSpec,
 } from '@backstage/catalog-model';
 import { JsonValue } from '@backstage/types';
+import { Config } from '@backstage/config';
+import { Logger } from 'winston';
+
+export type CatalogProcessorBuilder = {
+  fromConfig(config: Config, options: { logger: Logger }): CatalogProcessor;
+};
 
 export type CatalogProcessor = {
   /**

--- a/plugins/catalog-backend/src/ingestion/providers/GitHubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend/src/ingestion/providers/GitHubOrgEntityProvider.test.ts
@@ -17,8 +17,8 @@
 import { getVoidLogger } from '@backstage/backend-common';
 import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 import {
-  GithubCredentialsProvider,
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProvider,
+  DefaultGithubCredentialsProviderFactory,
   GitHubIntegrationConfig,
 } from '@backstage/integration';
 import { GitHubOrgEntityProvider } from '.';
@@ -94,7 +94,7 @@ describe('GitHubOrgEntityProvider', () => {
         type: 'app',
       });
 
-      jest.spyOn(GithubCredentialsProvider, 'create').mockReturnValue({
+      jest.spyOn(DefaultGithubCredentialsProvider, 'create').mockReturnValue({
         getCredentials: mockGetCredentials,
       } as any);
 
@@ -104,7 +104,7 @@ describe('GitHubOrgEntityProvider', () => {
         gitHubConfig,
         logger,
         githubCredentialsProviderFactory:
-          new GithubCredentialsProviderFactory(),
+          new DefaultGithubCredentialsProviderFactory(),
       });
 
       entityProvider.connect(entityProviderConnection);

--- a/plugins/catalog-backend/src/ingestion/providers/GitHubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend/src/ingestion/providers/GitHubOrgEntityProvider.test.ts
@@ -18,6 +18,7 @@ import { getVoidLogger } from '@backstage/backend-common';
 import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 import {
   GithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
   GitHubIntegrationConfig,
 } from '@backstage/integration';
 import { GitHubOrgEntityProvider } from '.';
@@ -102,6 +103,8 @@ describe('GitHubOrgEntityProvider', () => {
         orgUrl: 'https://github.com/backstage',
         gitHubConfig,
         logger,
+        githubCredentialsProviderFactory:
+          new GithubCredentialsProviderFactory(),
       });
 
       entityProvider.connect(entityProviderConnection);

--- a/plugins/catalog-backend/src/ingestion/providers/GitHubOrgEntityProvider.ts
+++ b/plugins/catalog-backend/src/ingestion/providers/GitHubOrgEntityProvider.ts
@@ -20,11 +20,11 @@ import {
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
-  IGithubCredentialsProvider,
-  GithubCredentialsProviderFactory,
+  GithubCredentialsProvider,
+  DefaultGithubCredentialsProviderFactory,
   GitHubIntegrationConfig,
   ScmIntegrations,
-  IGithubCredentialsProviderFactory,
+  GithubCredentialsProviderFactory,
 } from '@backstage/integration';
 import { graphql } from '@octokit/graphql';
 import { merge } from 'lodash';
@@ -45,7 +45,7 @@ import { assignGroupsToUsers, buildOrgHierarchy } from '../processors/util/org';
 
 export class GitHubOrgEntityProvider implements EntityProvider {
   private connection?: EntityProviderConnection;
-  private readonly credentialsProvider: IGithubCredentialsProvider;
+  private readonly credentialsProvider: GithubCredentialsProvider;
 
   static fromConfig(
     config: Config,
@@ -69,7 +69,8 @@ export class GitHubOrgEntityProvider implements EntityProvider {
       orgUrl: options.orgUrl,
       logger,
       gitHubConfig,
-      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+      githubCredentialsProviderFactory:
+        new DefaultGithubCredentialsProviderFactory(),
     });
   }
 
@@ -79,7 +80,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
       orgUrl: string;
       gitHubConfig: GitHubIntegrationConfig;
       logger: Logger;
-      githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+      githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
     },
   ) {
     this.credentialsProvider = options.githubCredentialsProviderFactory.create(
@@ -185,10 +186,10 @@ export function withLocations(
 }
 
 export class GitHubOrgEntityProviderBuilder implements EntityProviderBuilder {
-  private githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  private githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 
   constructor(
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory,
   ) {
     this.githubCredentialsProviderFactory = githubCredentialsProviderFactory;
   }

--- a/plugins/catalog-backend/src/ingestion/providers/GitHubOrgEntityProvider.ts
+++ b/plugins/catalog-backend/src/ingestion/providers/GitHubOrgEntityProvider.ts
@@ -20,7 +20,8 @@ import {
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
-  GithubCredentialsProvider,
+  IGithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
   GitHubIntegrationConfig,
   ScmIntegrations,
 } from '@backstage/integration';
@@ -42,7 +43,7 @@ import { assignGroupsToUsers, buildOrgHierarchy } from '../processors/util/org';
 
 export class GitHubOrgEntityProvider implements EntityProvider {
   private connection?: EntityProviderConnection;
-  private readonly credentialsProvider: GithubCredentialsProvider;
+  private readonly credentialsProvider: IGithubCredentialsProvider;
 
   static fromConfig(
     config: Config,
@@ -77,7 +78,7 @@ export class GitHubOrgEntityProvider implements EntityProvider {
       logger: Logger;
     },
   ) {
-    this.credentialsProvider = GithubCredentialsProvider.create(
+    this.credentialsProvider = GithubCredentialsProviderFactory.create(
       options.gitHubConfig,
     );
   }

--- a/plugins/catalog-backend/src/legacy/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/legacy/service/CatalogBuilder.ts
@@ -25,7 +25,7 @@ import {
   Validators,
 } from '@backstage/catalog-model';
 import {
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import lodash from 'lodash';
@@ -318,7 +318,7 @@ export class CatalogBuilder {
     // These are only added unless the user replaced them all
     if (!this.processorsReplace) {
       const githubCredentialsProviderFactory =
-        new GithubCredentialsProviderFactory();
+        new DefaultGithubCredentialsProviderFactory();
       processors.push(
         new FileReaderProcessor(),
         BitbucketDiscoveryProcessor.fromConfig(config, { logger }),

--- a/plugins/catalog-backend/src/providers/types.ts
+++ b/plugins/catalog-backend/src/providers/types.ts
@@ -15,6 +15,8 @@
  */
 
 import { DeferredEntity } from '../processing';
+import { Config } from '@backstage/config';
+import { Logger } from 'winston';
 
 export type EntityProviderMutation =
   | { type: 'full'; entities: DeferredEntity[] }
@@ -27,4 +29,11 @@ export interface EntityProviderConnection {
 export interface EntityProvider {
   getProviderName(): string;
   connect(connection: EntityProviderConnection): Promise<void>;
+}
+
+export interface EntityProviderBuilder {
+  fromConfig(
+    config: Config,
+    options: { id: string; orgUrl: string; logger: Logger },
+  ): EntityProvider;
 }

--- a/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
@@ -26,7 +26,7 @@ import {
   Validators,
 } from '@backstage/catalog-model';
 import {
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { createHash } from 'crypto';
@@ -293,7 +293,7 @@ export class NextCatalogBuilder {
     const { config, logger, reader } = this.env;
     const integrations = ScmIntegrations.fromConfig(config);
     const githubCredentialsProviderFactory =
-      new GithubCredentialsProviderFactory();
+      new DefaultGithubCredentialsProviderFactory();
 
     return [
       new FileReaderProcessor(),

--- a/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
@@ -25,7 +25,10 @@ import {
   SchemaValidEntityPolicy,
   Validators,
 } from '@backstage/catalog-model';
-import { ScmIntegrations } from '@backstage/integration';
+import {
+  GithubCredentialsProviderFactory,
+  ScmIntegrations,
+} from '@backstage/integration';
 import { createHash } from 'crypto';
 import { Router } from 'express';
 import lodash from 'lodash';
@@ -45,8 +48,8 @@ import {
   CodeOwnersProcessor,
   FileReaderProcessor,
   AzureDevOpsDiscoveryProcessor,
-  GithubDiscoveryProcessor,
-  GithubOrgReaderProcessor,
+  GithubDiscoveryProcessorBuilder,
+  GithubOrgReaderProcessorBuilder,
   GitLabDiscoveryProcessor,
   PlaceholderProcessor,
   PlaceholderResolver,
@@ -289,13 +292,19 @@ export class NextCatalogBuilder {
   getDefaultProcessors(): CatalogProcessor[] {
     const { config, logger, reader } = this.env;
     const integrations = ScmIntegrations.fromConfig(config);
+    const githubCredentialsProviderFactory =
+      new GithubCredentialsProviderFactory();
 
     return [
       new FileReaderProcessor(),
       BitbucketDiscoveryProcessor.fromConfig(config, { logger }),
       AzureDevOpsDiscoveryProcessor.fromConfig(config, { logger }),
-      GithubDiscoveryProcessor.fromConfig(config, { logger }),
-      GithubOrgReaderProcessor.fromConfig(config, { logger }),
+      new GithubDiscoveryProcessorBuilder(
+        githubCredentialsProviderFactory,
+      ).fromConfig(config, { logger }),
+      new GithubOrgReaderProcessorBuilder(
+        githubCredentialsProviderFactory,
+      ).fromConfig(config, { logger }),
       GitLabDiscoveryProcessor.fromConfig(config, { logger }),
       new UrlReaderProcessor({ reader, logger }),
       CodeOwnersProcessor.fromConfig(config, { logger, reader }),

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -14,6 +14,7 @@ import { createFetchCookiecutterAction } from '@backstage/plugin-scaffolder-back
 import { createPullRequest } from 'octokit-plugin-create-pull-request';
 import { Entity } from '@backstage/catalog-model';
 import express from 'express';
+import { IGithubCredentialsProviderFactory } from '@backstage/integration';
 import { JsonObject } from '@backstage/types';
 import { JsonValue } from '@backstage/types';
 import { Knex } from 'knex';
@@ -70,6 +71,7 @@ export const createBuiltinActions: (options: {
   catalogClient: CatalogApi;
   containerRunner: ContainerRunner;
   config: Config;
+  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
 }) => TemplateAction<any>[];
 
 // Warning: (ae-missing-release-tag) "createCatalogRegisterAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -123,6 +125,7 @@ export const createFilesystemRenameAction: () => TemplateAction<any>;
 // @public (undocumented)
 export function createGithubActionsDispatchAction(options: {
   integrations: ScmIntegrationRegistry;
+  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
 }): TemplateAction<any>;
 
 // Warning: (ae-missing-release-tag) "createGithubWebhookAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -131,6 +134,7 @@ export function createGithubActionsDispatchAction(options: {
 export function createGithubWebhookAction(options: {
   integrations: ScmIntegrationRegistry;
   defaultWebhookSecret?: string;
+  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
 }): TemplateAction<any>;
 
 // Warning: (ae-missing-release-tag) "createPublishAzureAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -160,6 +164,7 @@ export function createPublishFileAction(): TemplateAction<any>;
 export function createPublishGithubAction(options: {
   integrations: ScmIntegrationRegistry;
   config: Config;
+  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
 }): TemplateAction<any>;
 
 // Warning: (ae-forgotten-export) The symbol "CreateGithubPullRequestActionOptions" needs to be exported by the entry point index.d.ts
@@ -169,6 +174,7 @@ export function createPublishGithubAction(options: {
 export const createPublishGithubPullRequestAction: ({
   integrations,
   clientFactory,
+  githubCredentialsProviderFactory,
 }: CreateGithubPullRequestActionOptions) => TemplateAction<any>;
 
 // Warning: (ae-missing-release-tag) "createPublishGitlabAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -274,7 +280,10 @@ export function fetchContents({
 //
 // @public
 export class OctokitProvider {
-  constructor(integrations: ScmIntegrationRegistry);
+  constructor(
+    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    integrations: ScmIntegrationRegistry,
+  );
   // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
   // Warning: (ae-forgotten-export) The symbol "OctokitIntegration" needs to be exported by the entry point index.d.ts
   getOctokit(repoUrl: string): Promise<OctokitIntegration>;
@@ -292,6 +301,8 @@ export interface RouterOptions {
   containerRunner: ContainerRunner;
   // (undocumented)
   database: PluginDatabaseManager;
+  // (undocumented)
+  githubCredentialsProviderFactory?: IGithubCredentialsProviderFactory;
   // (undocumented)
   logger: Logger_2;
   // (undocumented)

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -14,7 +14,7 @@ import { createFetchCookiecutterAction } from '@backstage/plugin-scaffolder-back
 import { createPullRequest } from 'octokit-plugin-create-pull-request';
 import { Entity } from '@backstage/catalog-model';
 import express from 'express';
-import { IGithubCredentialsProviderFactory } from '@backstage/integration';
+import { GithubCredentialsProviderFactory } from '@backstage/integration';
 import { JsonObject } from '@backstage/types';
 import { JsonValue } from '@backstage/types';
 import { Knex } from 'knex';
@@ -71,7 +71,7 @@ export const createBuiltinActions: (options: {
   catalogClient: CatalogApi;
   containerRunner: ContainerRunner;
   config: Config;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 }) => TemplateAction<any>[];
 
 // Warning: (ae-missing-release-tag) "createCatalogRegisterAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -125,7 +125,7 @@ export const createFilesystemRenameAction: () => TemplateAction<any>;
 // @public (undocumented)
 export function createGithubActionsDispatchAction(options: {
   integrations: ScmIntegrationRegistry;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 }): TemplateAction<any>;
 
 // Warning: (ae-missing-release-tag) "createGithubWebhookAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -134,7 +134,7 @@ export function createGithubActionsDispatchAction(options: {
 export function createGithubWebhookAction(options: {
   integrations: ScmIntegrationRegistry;
   defaultWebhookSecret?: string;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 }): TemplateAction<any>;
 
 // Warning: (ae-missing-release-tag) "createPublishAzureAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -164,7 +164,7 @@ export function createPublishFileAction(): TemplateAction<any>;
 export function createPublishGithubAction(options: {
   integrations: ScmIntegrationRegistry;
   config: Config;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 }): TemplateAction<any>;
 
 // Warning: (ae-forgotten-export) The symbol "CreateGithubPullRequestActionOptions" needs to be exported by the entry point index.d.ts
@@ -281,7 +281,7 @@ export function fetchContents({
 // @public
 export class OctokitProvider {
   constructor(
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory,
     integrations: ScmIntegrationRegistry,
   );
   // Warning: (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
@@ -302,7 +302,7 @@ export interface RouterOptions {
   // (undocumented)
   database: PluginDatabaseManager;
   // (undocumented)
-  githubCredentialsProviderFactory?: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory?: GithubCredentialsProviderFactory;
   // (undocumented)
   logger: Logger_2;
   // (undocumented)

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -17,7 +17,7 @@
 import { ContainerRunner, UrlReader } from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
 import {
-  IGithubCredentialsProviderFactory,
+  GithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { Config } from '@backstage/config';
@@ -51,7 +51,7 @@ export const createBuiltinActions = (options: {
   catalogClient: CatalogApi;
   containerRunner: ContainerRunner;
   config: Config;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 }) => {
   const {
     githubCredentialsProviderFactory,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -16,7 +16,10 @@
 
 import { ContainerRunner, UrlReader } from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
-import { ScmIntegrations } from '@backstage/integration';
+import {
+  IGithubCredentialsProviderFactory,
+  ScmIntegrations,
+} from '@backstage/integration';
 import { Config } from '@backstage/config';
 import {
   createCatalogWriteAction,
@@ -48,9 +51,16 @@ export const createBuiltinActions = (options: {
   catalogClient: CatalogApi;
   containerRunner: ContainerRunner;
   config: Config;
+  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
 }) => {
-  const { reader, integrations, containerRunner, catalogClient, config } =
-    options;
+  const {
+    githubCredentialsProviderFactory,
+    reader,
+    integrations,
+    containerRunner,
+    catalogClient,
+    config,
+  } = options;
 
   return [
     createFetchPlainAction({
@@ -69,9 +79,11 @@ export const createBuiltinActions = (options: {
     createPublishGithubAction({
       integrations,
       config,
+      githubCredentialsProviderFactory,
     }),
     createPublishGithubPullRequestAction({
       integrations,
+      githubCredentialsProviderFactory,
     }),
     createPublishGitlabAction({
       integrations,
@@ -92,9 +104,11 @@ export const createBuiltinActions = (options: {
     createFilesystemRenameAction(),
     createGithubActionsDispatchAction({
       integrations,
+      githubCredentialsProviderFactory,
     }),
     createGithubWebhookAction({
       integrations,
+      githubCredentialsProviderFactory,
     }),
   ];
 };

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.test.ts
@@ -16,7 +16,7 @@
 
 import { OctokitProvider } from './OctokitProvider';
 import {
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
@@ -33,7 +33,7 @@ describe('getOctokit', () => {
 
   const integrations = ScmIntegrations.fromConfig(config);
   const octokitProvider = new OctokitProvider(
-    new GithubCredentialsProviderFactory(),
+    new DefaultGithubCredentialsProviderFactory(),
     integrations,
   );
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { OctokitProvider } from './OctokitProvider';
-import { ScmIntegrations } from '@backstage/integration';
+import {
+  GithubCredentialsProviderFactory,
+  ScmIntegrations,
+} from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
 
 describe('getOctokit', () => {
@@ -29,7 +32,10 @@ describe('getOctokit', () => {
   });
 
   const integrations = ScmIntegrations.fromConfig(config);
-  const octokitProvider = new OctokitProvider(integrations);
+  const octokitProvider = new OctokitProvider(
+    new GithubCredentialsProviderFactory(),
+    integrations,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
@@ -16,7 +16,8 @@
 
 import { InputError } from '@backstage/errors';
 import {
-  GithubCredentialsProvider,
+  IGithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
 import { Octokit } from '@octokit/rest';
@@ -34,13 +35,18 @@ export type OctokitIntegration = {
  */
 export class OctokitProvider {
   private readonly integrations: ScmIntegrationRegistry;
-  private readonly credentialsProviders: Map<string, GithubCredentialsProvider>;
+  private readonly credentialsProviders: Map<
+    string,
+    IGithubCredentialsProvider
+  >;
 
   constructor(integrations: ScmIntegrationRegistry) {
     this.integrations = integrations;
     this.credentialsProviders = new Map(
       integrations.github.list().map(integration => {
-        const provider = GithubCredentialsProvider.create(integration.config);
+        const provider = GithubCredentialsProviderFactory.create(
+          integration.config,
+        );
         return [integration.config.host, provider];
       }),
     );

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
@@ -17,8 +17,8 @@
 import { InputError } from '@backstage/errors';
 import {
   IGithubCredentialsProvider,
-  GithubCredentialsProviderFactory,
   ScmIntegrationRegistry,
+  IGithubCredentialsProviderFactory,
 } from '@backstage/integration';
 import { Octokit } from '@octokit/rest';
 import { parseRepoUrl } from '../publish/util';
@@ -40,11 +40,14 @@ export class OctokitProvider {
     IGithubCredentialsProvider
   >;
 
-  constructor(integrations: ScmIntegrationRegistry) {
+  constructor(
+    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    integrations: ScmIntegrationRegistry,
+  ) {
     this.integrations = integrations;
     this.credentialsProviders = new Map(
       integrations.github.list().map(integration => {
-        const provider = GithubCredentialsProviderFactory.create(
+        const provider = githubCredentialsProviderFactory.create(
           integration.config,
         );
         return [integration.config.host, provider];

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
@@ -16,9 +16,9 @@
 
 import { InputError } from '@backstage/errors';
 import {
-  IGithubCredentialsProvider,
+  GithubCredentialsProvider,
   ScmIntegrationRegistry,
-  IGithubCredentialsProviderFactory,
+  GithubCredentialsProviderFactory,
 } from '@backstage/integration';
 import { Octokit } from '@octokit/rest';
 import { parseRepoUrl } from '../publish/util';
@@ -35,13 +35,10 @@ export type OctokitIntegration = {
  */
 export class OctokitProvider {
   private readonly integrations: ScmIntegrationRegistry;
-  private readonly credentialsProviders: Map<
-    string,
-    IGithubCredentialsProvider
-  >;
+  private readonly credentialsProviders: Map<string, GithubCredentialsProvider>;
 
   constructor(
-    githubCredentialsProviderFactory: IGithubCredentialsProviderFactory,
+    githubCredentialsProviderFactory: GithubCredentialsProviderFactory,
     integrations: ScmIntegrationRegistry,
   ) {
     this.integrations = integrations;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.test.ts
@@ -18,7 +18,7 @@ jest.mock('@octokit/rest');
 
 import { createGithubActionsDispatchAction } from './githubActionsDispatch';
 import {
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
@@ -38,7 +38,8 @@ describe('github:actions:dispatch', () => {
   const integrations = ScmIntegrations.fromConfig(config);
   const action = createGithubActionsDispatchAction({
     integrations,
-    githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+    githubCredentialsProviderFactory:
+      new DefaultGithubCredentialsProviderFactory(),
   });
 
   const mockContext = {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.test.ts
@@ -17,7 +17,10 @@
 jest.mock('@octokit/rest');
 
 import { createGithubActionsDispatchAction } from './githubActionsDispatch';
-import { ScmIntegrations } from '@backstage/integration';
+import {
+  GithubCredentialsProviderFactory,
+  ScmIntegrations,
+} from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
 import { getVoidLogger } from '@backstage/backend-common';
 import { PassThrough } from 'stream';
@@ -33,7 +36,10 @@ describe('github:actions:dispatch', () => {
   });
 
   const integrations = ScmIntegrations.fromConfig(config);
-  const action = createGithubActionsDispatchAction({ integrations });
+  const action = createGithubActionsDispatchAction({
+    integrations,
+    githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+  });
 
   const mockContext = {
     input: {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {
-  IGithubCredentialsProviderFactory,
+  GithubCredentialsProviderFactory,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
 import { createTemplateAction } from '../../createTemplateAction';
@@ -22,7 +22,7 @@ import { OctokitProvider } from './OctokitProvider';
 
 export function createGithubActionsDispatchAction(options: {
   integrations: ScmIntegrationRegistry;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 }) {
   const { githubCredentialsProviderFactory, integrations } = options;
   const octokitProvider = new OctokitProvider(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
@@ -13,15 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ScmIntegrationRegistry } from '@backstage/integration';
+import {
+  IGithubCredentialsProviderFactory,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
 import { createTemplateAction } from '../../createTemplateAction';
 import { OctokitProvider } from './OctokitProvider';
 
 export function createGithubActionsDispatchAction(options: {
   integrations: ScmIntegrationRegistry;
+  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
 }) {
-  const { integrations } = options;
-  const octokitProvider = new OctokitProvider(integrations);
+  const { githubCredentialsProviderFactory, integrations } = options;
+  const octokitProvider = new OctokitProvider(
+    githubCredentialsProviderFactory,
+    integrations,
+  );
 
   return createTemplateAction<{
     repoUrl: string;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
@@ -17,7 +17,10 @@
 jest.mock('@octokit/rest');
 
 import { createGithubWebhookAction } from './githubWebhook';
-import { ScmIntegrations } from '@backstage/integration';
+import {
+  GithubCredentialsProviderFactory,
+  ScmIntegrations,
+} from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
 import { getVoidLogger } from '@backstage/backend-common';
 import { PassThrough } from 'stream';
@@ -37,6 +40,7 @@ describe('github:repository:webhook:create', () => {
   const action = createGithubWebhookAction({
     integrations,
     defaultWebhookSecret,
+    githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
   });
 
   const mockContext = {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.test.ts
@@ -18,7 +18,7 @@ jest.mock('@octokit/rest');
 
 import { createGithubWebhookAction } from './githubWebhook';
 import {
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
@@ -40,7 +40,8 @@ describe('github:repository:webhook:create', () => {
   const action = createGithubWebhookAction({
     integrations,
     defaultWebhookSecret,
-    githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+    githubCredentialsProviderFactory:
+      new DefaultGithubCredentialsProviderFactory(),
   });
 
   const mockContext = {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {
-  IGithubCredentialsProviderFactory,
+  GithubCredentialsProviderFactory,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
 import { createTemplateAction } from '../../createTemplateAction';
@@ -27,7 +27,7 @@ type ContentType = 'form' | 'json';
 export function createGithubWebhookAction(options: {
   integrations: ScmIntegrationRegistry;
   defaultWebhookSecret?: string;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 }) {
   const {
     githubCredentialsProviderFactory,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ScmIntegrationRegistry } from '@backstage/integration';
+import {
+  IGithubCredentialsProviderFactory,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
 import { createTemplateAction } from '../../createTemplateAction';
 import { OctokitProvider } from './OctokitProvider';
 import { emitterEventNames } from '@octokit/webhooks';
@@ -24,9 +27,17 @@ type ContentType = 'form' | 'json';
 export function createGithubWebhookAction(options: {
   integrations: ScmIntegrationRegistry;
   defaultWebhookSecret?: string;
+  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
 }) {
-  const { integrations, defaultWebhookSecret } = options;
-  const octokitProvider = new OctokitProvider(integrations);
+  const {
+    githubCredentialsProviderFactory,
+    integrations,
+    defaultWebhookSecret,
+  } = options;
+  const octokitProvider = new OctokitProvider(
+    githubCredentialsProviderFactory,
+    integrations,
+  );
   const eventNames = emitterEventNames.filter(event => !event.includes('.'));
 
   return createTemplateAction<{

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -18,7 +18,10 @@ jest.mock('../helpers');
 jest.mock('@octokit/rest');
 
 import { createPublishGithubAction } from './github';
-import { ScmIntegrations } from '@backstage/integration';
+import {
+  GithubCredentialsProviderFactory,
+  ScmIntegrations,
+} from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
 import { getVoidLogger } from '@backstage/backend-common';
 import { PassThrough } from 'stream';
@@ -39,7 +42,11 @@ describe('publish:github', () => {
   });
 
   const integrations = ScmIntegrations.fromConfig(config);
-  const action = createPublishGithubAction({ integrations, config });
+  const action = createPublishGithubAction({
+    integrations,
+    config,
+    githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+  });
   const mockContext = {
     input: {
       repoUrl: 'github.com?repo=repo&owner=owner',
@@ -201,6 +208,7 @@ describe('publish:github', () => {
     const customAuthorAction = createPublishGithubAction({
       integrations: customAuthorIntegrations,
       config: customAuthorConfig,
+      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
     });
 
     mockGithubClient.users.getByUsername.mockResolvedValue({
@@ -244,6 +252,7 @@ describe('publish:github', () => {
     const customAuthorAction = createPublishGithubAction({
       integrations: customAuthorIntegrations,
       config: customAuthorConfig,
+      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
     });
 
     mockGithubClient.users.getByUsername.mockResolvedValue({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -19,7 +19,7 @@ jest.mock('@octokit/rest');
 
 import { createPublishGithubAction } from './github';
 import {
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
@@ -45,7 +45,8 @@ describe('publish:github', () => {
   const action = createPublishGithubAction({
     integrations,
     config,
-    githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+    githubCredentialsProviderFactory:
+      new DefaultGithubCredentialsProviderFactory(),
   });
   const mockContext = {
     input: {
@@ -208,7 +209,8 @@ describe('publish:github', () => {
     const customAuthorAction = createPublishGithubAction({
       integrations: customAuthorIntegrations,
       config: customAuthorConfig,
-      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+      githubCredentialsProviderFactory:
+        new DefaultGithubCredentialsProviderFactory(),
     });
 
     mockGithubClient.users.getByUsername.mockResolvedValue({
@@ -252,7 +254,8 @@ describe('publish:github', () => {
     const customAuthorAction = createPublishGithubAction({
       integrations: customAuthorIntegrations,
       config: customAuthorConfig,
-      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+      githubCredentialsProviderFactory:
+        new DefaultGithubCredentialsProviderFactory(),
     });
 
     mockGithubClient.users.getByUsername.mockResolvedValue({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ScmIntegrationRegistry } from '@backstage/integration';
+import {
+  IGithubCredentialsProviderFactory,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
 import {
   enableBranchProtectionOnDefaultRepoBranch,
   initRepoAndPush,
@@ -30,9 +33,13 @@ type Collaborator = { access: Permission; username: string };
 export function createPublishGithubAction(options: {
   integrations: ScmIntegrationRegistry;
   config: Config;
+  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
 }) {
-  const { integrations, config } = options;
-  const octokitProvider = new OctokitProvider(integrations);
+  const { githubCredentialsProviderFactory, integrations, config } = options;
+  const octokitProvider = new OctokitProvider(
+    githubCredentialsProviderFactory,
+    integrations,
+  );
 
   return createTemplateAction<{
     repoUrl: string;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {
-  IGithubCredentialsProviderFactory,
+  GithubCredentialsProviderFactory,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
 import {
@@ -33,7 +33,7 @@ type Collaborator = { access: Permission; username: string };
 export function createPublishGithubAction(options: {
   integrations: ScmIntegrationRegistry;
   config: Config;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 }) {
   const { githubCredentialsProviderFactory, integrations, config } = options;
   const octokitProvider = new OctokitProvider(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
@@ -17,7 +17,7 @@
 import { getRootLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import {
-  GithubCredentialsProviderFactory,
+  DefaultGithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import mockFs from 'mock-fs';
@@ -60,7 +60,8 @@ describe('createPublishGithubPullRequestAction', () => {
     instance = createPublishGithubPullRequestAction({
       integrations,
       clientFactory,
-      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
+      githubCredentialsProviderFactory:
+        new DefaultGithubCredentialsProviderFactory(),
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
@@ -16,7 +16,10 @@
 
 import { getRootLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
-import { ScmIntegrations } from '@backstage/integration';
+import {
+  GithubCredentialsProviderFactory,
+  ScmIntegrations,
+} from '@backstage/integration';
 import mockFs from 'mock-fs';
 import os from 'os';
 import { resolve as resolvePath } from 'path';
@@ -57,6 +60,7 @@ describe('createPublishGithubPullRequestAction', () => {
     instance = createPublishGithubPullRequestAction({
       integrations,
       clientFactory,
+      githubCredentialsProviderFactory: new GithubCredentialsProviderFactory(),
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -18,7 +18,7 @@ import fs from 'fs-extra';
 import { parseRepoUrl, isExecutable } from './util';
 
 import {
-  IGithubCredentialsProviderFactory,
+  GithubCredentialsProviderFactory,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
 import { zipObject } from 'lodash';
@@ -61,7 +61,7 @@ export type ClientFactoryInput = {
   host: string;
   owner: string;
   repo: string;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 };
 
 export const defaultClientFactory = async ({
@@ -109,7 +109,7 @@ export const defaultClientFactory = async ({
 interface CreateGithubPullRequestActionOptions {
   integrations: ScmIntegrationRegistry;
   clientFactory?: (input: ClientFactoryInput) => Promise<PullRequestCreator>;
-  githubCredentialsProviderFactory: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory: GithubCredentialsProviderFactory;
 }
 
 export const createPublishGithubPullRequestAction = ({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -18,7 +18,7 @@ import fs from 'fs-extra';
 import { parseRepoUrl, isExecutable } from './util';
 
 import {
-  GithubCredentialsProvider,
+  GithubCredentialsProviderFactory,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
 import { zipObject } from 'lodash';
@@ -76,7 +76,7 @@ export const defaultClientFactory = async ({
   }
 
   const credentialsProvider =
-    GithubCredentialsProvider.create(integrationConfig);
+    GithubCredentialsProviderFactory.create(integrationConfig);
 
   if (!credentialsProvider) {
     throw new InputError(

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -24,8 +24,8 @@ import { Entity, TemplateEntityV1beta2 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { InputError, NotFoundError } from '@backstage/errors';
 import {
+  DefaultGithubCredentialsProviderFactory,
   GithubCredentialsProviderFactory,
-  IGithubCredentialsProviderFactory,
   ScmIntegrations,
 } from '@backstage/integration';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
@@ -61,7 +61,7 @@ export interface RouterOptions {
   taskWorkers?: number;
   containerRunner: ContainerRunner;
   taskBroker?: TaskBroker;
-  githubCredentialsProviderFactory?: IGithubCredentialsProviderFactory;
+  githubCredentialsProviderFactory?: GithubCredentialsProviderFactory;
 }
 
 function isSupportedTemplate(
@@ -130,7 +130,7 @@ export async function createRouter(
         config,
         githubCredentialsProviderFactory:
           githubCredentialsProviderFactory ||
-          new GithubCredentialsProviderFactory(),
+          new DefaultGithubCredentialsProviderFactory(),
       });
 
   actionsToRegister.forEach(action => actionRegistry.register(action));

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -23,7 +23,11 @@ import { CatalogApi } from '@backstage/catalog-client';
 import { Entity, TemplateEntityV1beta2 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { InputError, NotFoundError } from '@backstage/errors';
-import { ScmIntegrations } from '@backstage/integration';
+import {
+  GithubCredentialsProviderFactory,
+  IGithubCredentialsProviderFactory,
+  ScmIntegrations,
+} from '@backstage/integration';
 import { TemplateEntityV1beta3 } from '@backstage/plugin-scaffolder-common';
 import express from 'express';
 import Router from 'express-promise-router';
@@ -57,6 +61,7 @@ export interface RouterOptions {
   taskWorkers?: number;
   containerRunner: ContainerRunner;
   taskBroker?: TaskBroker;
+  githubCredentialsProviderFactory?: IGithubCredentialsProviderFactory;
 }
 
 function isSupportedTemplate(
@@ -83,6 +88,7 @@ export async function createRouter(
     actions,
     containerRunner,
     taskWorkers,
+    githubCredentialsProviderFactory,
   } = options;
 
   const logger = parentLogger.child({ plugin: 'scaffolder' });
@@ -122,6 +128,9 @@ export async function createRouter(
         containerRunner,
         reader,
         config,
+        githubCredentialsProviderFactory:
+          githubCredentialsProviderFactory ||
+          new GithubCredentialsProviderFactory(),
       });
 
   actionsToRegister.forEach(action => actionRegistry.register(action));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change provides an ability to pass a custom implementation of
the credentials provider via the backend package.

The motivation for this change is to make the private key of the
GitHub app more secure by allowing the backstage deployer to make
decisions about how the GitHub credentials are protected.

The GitHub app key gives great power to the holder and as such is
very sensitive. e.g. if you are using the scaffolder, you probably
have requested administration write permissions on your installations
organizations. The key needs to be protected well.

This change creates a new interface called IGitHubCredenialsProvider
and an IGitHubCredentialsProviderFactory. Processors, URL readers etc
have been switched to use theses factories.

Another proposal has been made to implement a dependency injection container.
The DI container approach would be better approach, however it requires more
discussion and design. This change brings us a step closer, because the DI
solution will require the new interface in any case.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
