### PR TITLE
Don't allow users to delete an entity in RO mode

### DIFF
--- a/plugins/catalog-backend/src/service/NextRouter.ts
+++ b/plugins/catalog-backend/src/service/NextRouter.ts
@@ -107,6 +107,9 @@ export async function createNextRouter(
       })
       .delete('/entities/by-uid/:uid', async (req, res) => {
         const { uid } = req.params;
+
+        disallowReadonlyMode(readonlyEnabled);
+
         await entitiesCatalog.removeEntityByUid(uid);
         res.status(204).end();
       })


### PR DESCRIPTION
When the catalog is in read-only mode, don't allow a user to delete an entity.
