### PR TITLE
[github-actions] Show empty state only when done loading

### DIFF
--- a/.changeset/beige-mangos-knock.md
+++ b/.changeset/beige-mangos-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-github-actions': patch
+---
+
+Show empty state only when workflow API call has completed

--- a/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
+++ b/plugins/github-actions/src/components/WorkflowRunsTable/WorkflowRunsTable.tsx
@@ -172,8 +172,9 @@ export const WorkflowRunsTable = ({
     });
 
   const githubHost = hostname || 'github.com';
+  const hasNoRuns = !loading && !tableProps.loading && !runs;
 
-  return !runs ? (
+  return hasNoRuns ? (
     <EmptyState
       missing="data"
       title="No Workflow Data"


### PR DESCRIPTION
Prevents a flash of empty state while github-actions workflow runs are still loading.

Before:
![workflow-loading-before](https://user-images.githubusercontent.com/556258/145468733-c5181256-f58b-4fb8-9d66-dd1149a9617d.gif)

After:
![workflow-loading-after](https://user-images.githubusercontent.com/556258/145468764-149e3ac7-75b3-4018-84ed-15cbb1ce82d0.gif)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
