### PR TITLE
scaffolder: add Markdown default field

### DIFF
--- a/.changeset/unlucky-wolves-reply.md
+++ b/.changeset/unlucky-wolves-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Add DescriptionField override to support Markdown

--- a/plugins/scaffolder/src/components/MultistepJsonForm/FieldOverrides/DescriptionField.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/FieldOverrides/DescriptionField.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { MarkdownContent } from '@backstage/core-components';
+import { FieldProps } from '@rjsf/core';
+
+export const DescriptionField = ({ description }: FieldProps) =>
+  description && <MarkdownContent content={description} />;

--- a/plugins/scaffolder/src/components/MultistepJsonForm/FieldOverrides/index.ts
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/FieldOverrides/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { DescriptionField } from './DescriptionField';

--- a/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
+++ b/plugins/scaffolder/src/components/MultistepJsonForm/MultistepJsonForm.tsx
@@ -30,6 +30,7 @@ import { Theme as MuiTheme } from '@rjsf/material-ui';
 import React, { useState } from 'react';
 import { transformSchemaToProps } from './schema';
 import { Content, StructuredMetadataTable } from '@backstage/core-components';
+import * as fieldOverrides from './FieldOverrides';
 
 const Form = withTheme(MuiTheme);
 type Step = {
@@ -152,7 +153,7 @@ export const MultistepJsonForm = ({
               <StepContent key={title}>
                 <Form
                   showErrorList={false}
-                  fields={fields}
+                  fields={{ ...fieldOverrides, ...fields }}
                   widgets={widgets}
                   noHtml5Validate
                   formData={formData}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This adds a Markdown default field for the scaffolder. Fixes #8433  

You can use the Markdown component like this
```yaml
# ...
      properties:
        helpText:
          type: "null"
          description: |
            # Important

            This will open a PR against a repo of your choice. You can learn more about Pull Requests [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).

            `Here is a code block`
          ui:field: Markdown
          ui:backstage:
            review:
              show: false
# ...
```

![image](https://user-images.githubusercontent.com/10840090/145475693-216e6888-b138-42cd-9fae-82cea2d81a67.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
