### PR TITLE
Export Icon Props for SidebarSearch and SidebarSearchModal Component

### DIFF
--- a/.changeset/afraid-carpets-know.md
+++ b/.changeset/afraid-carpets-know.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search': patch
 ---
 
-Added Overridable Icon for SidebarSearch Component
+Add Optional Props to Override Icon for SidebarSearch Component

--- a/.changeset/afraid-carpets-know.md
+++ b/.changeset/afraid-carpets-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Added Overridable Icon for SidebarSearch Component

--- a/.changeset/afraid-carpets-know.md
+++ b/.changeset/afraid-carpets-know.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search': patch
 ---
 
-Add Optional Props to Override Icon for SidebarSearch Component
+Add Optional Props to Override Icon for SidebarSearch and SidebarSearchModal Component

--- a/plugins/search/api-report.md
+++ b/plugins/search/api-report.md
@@ -211,19 +211,31 @@ export const SearchType: ({
   defaultValue,
 }: SearchTypeProps) => JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "SidebarSearchProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "SidebarSearch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const SidebarSearch: (props: SidebarSearchProps) => JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "SidebarSearchModalProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "SidebarSearchModal" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const SidebarSearchModal: (
   props: SidebarSearchModalProps,
 ) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "SidebarSearchModalProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarSearchModalProps = {
+  icon?: IconComponent;
+};
+
+// Warning: (ae-missing-release-tag) "SidebarSearchProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarSearchProps = {
+  icon?: IconComponent;
+};
 
 // Warning: (ae-forgotten-export) The symbol "SearchContextValue" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "useSearch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/search/api-report.md
+++ b/plugins/search/api-report.md
@@ -217,10 +217,13 @@ export const SearchType: ({
 // @public (undocumented)
 export const SidebarSearch: (props: SidebarSearchProps) => JSX.Element;
 
+// Warning: (ae-forgotten-export) The symbol "SidebarSearchModalProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "SidebarSearchModal" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const SidebarSearchModal: () => JSX.Element;
+export const SidebarSearchModal: (
+  props: SidebarSearchModalProps,
+) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "SearchContextValue" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "useSearch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/search/api-report.md
+++ b/plugins/search/api-report.md
@@ -8,6 +8,7 @@
 import { ApiRef } from '@backstage/core-plugin-api';
 import { AsyncState } from 'react-use/lib/useAsync';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { IconComponent } from '@backstage/core-plugin-api';
 import { IndexableDocument } from '@backstage/search-common';
 import { JsonObject } from '@backstage/types';
 import { default as React_2 } from 'react';
@@ -210,10 +211,11 @@ export const SearchType: ({
   defaultValue,
 }: SearchTypeProps) => JSX.Element;
 
+// Warning: (ae-forgotten-export) The symbol "SidebarSearchProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "SidebarSearch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const SidebarSearch: () => JSX.Element;
+export const SidebarSearch: (props: SidebarSearchProps) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "SidebarSearchModal" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
+++ b/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
@@ -21,7 +21,7 @@ import { rootRouteRef } from '../../plugin';
 import { SidebarSearchField } from '@backstage/core-components';
 import { useRouteRef, IconComponent } from '@backstage/core-plugin-api';
 
-type SidebarSearchProps = {
+export type SidebarSearchProps = {
   icon?: IconComponent;
 };
 

--- a/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
+++ b/plugins/search/src/components/SidebarSearch/SidebarSearch.tsx
@@ -19,9 +19,13 @@ import { useNavigate } from 'react-router-dom';
 import { rootRouteRef } from '../../plugin';
 
 import { SidebarSearchField } from '@backstage/core-components';
-import { useRouteRef } from '@backstage/core-plugin-api';
+import { useRouteRef, IconComponent } from '@backstage/core-plugin-api';
 
-export const SidebarSearch = () => {
+type SidebarSearchProps = {
+  icon?: IconComponent;
+};
+
+export const SidebarSearch = (props: SidebarSearchProps) => {
   const searchRoute = useRouteRef(rootRouteRef);
   const navigate = useNavigate();
   const handleSearch = useCallback(
@@ -33,5 +37,11 @@ export const SidebarSearch = () => {
     [navigate, searchRoute],
   );
 
-  return <SidebarSearchField onSearch={handleSearch} to="/search" />;
+  return (
+    <SidebarSearchField
+      icon={props.icon}
+      onSearch={handleSearch}
+      to="/search"
+    />
+  );
 };

--- a/plugins/search/src/components/SidebarSearch/index.ts
+++ b/plugins/search/src/components/SidebarSearch/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { SidebarSearch } from './SidebarSearch';
+export type { SidebarSearchProps } from './SidebarSearch';

--- a/plugins/search/src/components/SidebarSearchModal/SidebarSearchModal.tsx
+++ b/plugins/search/src/components/SidebarSearchModal/SidebarSearchModal.tsx
@@ -16,17 +16,23 @@
 import React from 'react';
 import SearchIcon from '@material-ui/icons/Search';
 import { SidebarItem } from '@backstage/core-components';
+import { IconComponent } from '@backstage/core-plugin-api';
 import { SearchModal } from '../SearchModal';
 import { useSearch } from '../SearchContext';
 
-export const SidebarSearchModal = () => {
+export type SidebarSearchModalProps = {
+  icon?: IconComponent;
+};
+
+export const SidebarSearchModal = (props: SidebarSearchModalProps) => {
   const { open, toggleModal } = useSearch();
+  const Icon = props.icon ? props.icon : SearchIcon;
 
   return (
     <>
       <SidebarItem
         className="search-icon"
-        icon={SearchIcon}
+        icon={Icon}
         text="Search"
         onClick={toggleModal}
       />

--- a/plugins/search/src/components/SidebarSearchModal/index.ts
+++ b/plugins/search/src/components/SidebarSearchModal/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { SidebarSearchModal } from './SidebarSearchModal';
+export type { SidebarSearchModalProps } from './SidebarSearchModal';

--- a/plugins/search/src/index.ts
+++ b/plugins/search/src/index.ts
@@ -36,7 +36,11 @@ export {
   SidebarSearch,
   useSearch,
 } from './components';
-export type { SearchModalProps } from './components';
+export type {
+  SearchModalProps,
+  SidebarSearchModalProps,
+  SidebarSearchProps,
+} from './components';
 export type { FiltersState } from './components';
 export {
   DefaultResultListItem,


### PR DESCRIPTION
Signed-off-by: Dede Hamzah <dehamzah@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This changes was missing in PR https://github.com/backstage/backstage/pull/7874, because the backstage app in Root.tsx is using SidebarSearch and SidebarSearchModal Component instead of SidebarSearchField Component directly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
~~- [ ] Added or updated documentation~~
~~- [ ] Tests for new functionality and regression tests for bug fixes~~
~~- [ ] Screenshots attached (for UI changes)~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
