### PR TITLE
catalog-react: remove core-app-api dependency

### DIFF
--- a/.changeset/witty-singers-occur.md
+++ b/.changeset/witty-singers-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Removed dependency on `@backstage/core-app-api`.

--- a/.changeset/witty-singers-occur.md
+++ b/.changeset/witty-singers-occur.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-catalog-react': patch
----
-
-Removed dependency on `@backstage/core-app-api`.

--- a/plugins/catalog-react/CHANGELOG.md
+++ b/plugins/catalog-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-catalog-react
 
+## 0.6.6
+
+### Patch Changes
+
+- 4c0f0b2003: Removed dependency on `@backstage/core-app-api`.
+
 ## 0.6.5
 
 ### Patch Changes

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@backstage/catalog-client": "^0.5.2",
     "@backstage/catalog-model": "^0.9.7",
-    "@backstage/core-app-api": "^0.2.0",
     "@backstage/core-components": "^0.8.0",
     "@backstage/core-plugin-api": "^0.3.0",
     "@backstage/errors": "^0.1.4",
@@ -54,6 +53,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",
+    "@backstage/core-app-api": "^0.2.0",
     "@backstage/test-utils": "^0.1.24",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^11.2.5",

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-react",
   "description": "A frontend library that helps other Backstage plugins interact with the catalog",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Removed the dependency that `@backstage/plugin-catalog-react` had on `@backstage/core-app-api`. This fixes numerous issues that might show up when trying to bump a Backstage app to the most recent release.