### PR TITLE
 containerRunner optional for createRouter

### DIFF
--- a/.changeset/mighty-llamas-hope.md
+++ b/.changeset/mighty-llamas-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Makes cookiecutter a default, but optional action based on if a containerRunner argument is passed in to createRouter or createBuiltinActions

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -68,7 +68,7 @@ export const createBuiltinActions: (options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
   catalogClient: CatalogApi;
-  containerRunner: ContainerRunner;
+  containerRunner?: ContainerRunner;
   config: Config;
 }) => TemplateAction<any>[];
 
@@ -289,7 +289,7 @@ export interface RouterOptions {
   // (undocumented)
   config: Config;
   // (undocumented)
-  containerRunner: ContainerRunner;
+  containerRunner?: ContainerRunner;
   // (undocumented)
   database: PluginDatabaseManager;
   // (undocumented)

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -46,21 +46,16 @@ export const createBuiltinActions = (options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
   catalogClient: CatalogApi;
-  containerRunner: ContainerRunner;
+  containerRunner?: ContainerRunner;
   config: Config;
 }) => {
   const { reader, integrations, containerRunner, catalogClient, config } =
     options;
 
-  return [
+  const actions = [
     createFetchPlainAction({
       reader,
       integrations,
-    }),
-    createFetchCookiecutterAction({
-      reader,
-      integrations,
-      containerRunner,
     }),
     createFetchTemplateAction({
       integrations,
@@ -97,4 +92,16 @@ export const createBuiltinActions = (options: {
       integrations,
     }),
   ];
+
+  if (containerRunner) {
+    actions.push(
+      createFetchCookiecutterAction({
+        reader,
+        integrations,
+        containerRunner,
+      }),
+    );
+  }
+
+  return actions;
 };

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -55,7 +55,7 @@ export interface RouterOptions {
   catalogClient: CatalogApi;
   actions?: TemplateAction<any>[];
   taskWorkers?: number;
-  containerRunner: ContainerRunner;
+  containerRunner?: ContainerRunner;
   taskBroker?: TaskBroker;
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This Smol MR is just to make cookiecutter an optional action, it's added if containerRunner is passed into the scaffolder so this should have no affect on existing builds, but sets us up to remove it down the line.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
