### PR TITLE
Skip updating selected types if they didn't change

### DIFF
--- a/.changeset/thirty-ways-attend.md
+++ b/.changeset/thirty-ways-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+`useEntityTypeFilter`: Skip updating selected types if a kind filter change did not change them.

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAsync } from 'react-use';
+import isEqual from 'lodash/isEqual';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '../api';
 import { useEntityListProvider } from './useEntityListProvider';
@@ -107,7 +108,9 @@ export function useEntityTypeFilter(): EntityTypeReturn {
     const stillValidTypes = selectedTypes.filter(value =>
       newTypes.includes(value),
     );
-    setSelectedTypes(stillValidTypes);
+    if (!isEqual(selectedTypes, stillValidTypes)) {
+      setSelectedTypes(stillValidTypes);
+    }
   }, [loading, kind, selectedTypes, setSelectedTypes, entities]);
 
   useEffect(() => {


### PR DESCRIPTION
The `type` filter in `EntityListProvider` context would always get updated when `kind` changed, since the `selectedTypes` value was re-created. This skips updating `selectedTypes` if the values are equivalent (most commonly as an empty array).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
