### PR TITLE
Remove unnecessary useMemo call in useEntityListProvider

### DIFF
--- a/.changeset/lazy-rules-reply.md
+++ b/.changeset/lazy-rules-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+`useEntityListProvider`: Remove unnecessary `useMemo` call on provider value.

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -22,7 +22,6 @@ import React, {
   PropsWithChildren,
   useCallback,
   useContext,
-  useMemo,
   useState,
 } from 'react';
 import { useAsyncFn, useDebounce, useMountedState } from 'react-use';
@@ -212,18 +211,15 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>({
     [],
   );
 
-  const value = useMemo(
-    () => ({
-      filters: outputState.appliedFilters,
-      entities: outputState.entities,
-      backendEntities: outputState.backendEntities,
-      updateFilters,
-      queryParameters: outputState.queryParameters,
-      loading,
-      error,
-    }),
-    [outputState, updateFilters, loading, error],
-  );
+  const value = {
+    filters: outputState.appliedFilters,
+    entities: outputState.entities,
+    backendEntities: outputState.backendEntities,
+    updateFilters,
+    queryParameters: outputState.queryParameters,
+    loading,
+    error,
+  };
 
   return (
     <EntityListContext.Provider value={value}>


### PR DESCRIPTION
The values in the provider context are already memoized via `useState`, `useCallback` and `useAsyncFn`; the extra `useMemo` call was causing unnecessary effect flushing.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
