### PR TITLE
Catalog: cursor based pagination

### DIFF
--- a/.changeset/stale-pumas-flash.md
+++ b/.changeset/stale-pumas-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Implement cursor based pagination including server side sorting

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -29,15 +29,6 @@ export type EntityFilter =
   | EntitiesSearchFilter;
 
 /**
- * A pagination rule for entities.
- */
-export type EntityPagination = {
-  limit?: number;
-  offset?: number;
-  after?: string;
-};
-
-/**
  * Matches rows in the entities_search table.
  */
 export type EntitiesSearchFilter = {
@@ -57,19 +48,36 @@ export type EntitiesSearchFilter = {
   values?: string[];
 };
 
-export type PageInfo =
-  | {
-      hasNextPage: false;
-    }
-  | {
-      hasNextPage: true;
-      endCursor: string;
-    };
+export type PageInfo = { nextCursor?: string; prevCursor?: string };
 
-export type EntitiesRequest = {
-  filter?: EntityFilter;
+export type EntitiesRequest = EntitiesBaseRequest | EntitiesCursorRequest;
+
+export type EntitiesBaseRequest = {
   fields?: (entity: Entity) => Entity;
-  pagination?: EntityPagination;
+  filter?: EntityFilter;
+  limit?: number;
+  sortField?: string;
+  sortFieldOrder?: 'asc' | 'desc';
+};
+
+export type EntitiesCursorRequest = {
+  fields?: (entity: Entity) => Entity;
+  limit?: number;
+  cursor: string;
+};
+
+export type Cursor = {
+  sortField: string;
+  sortFieldId: string;
+  sortFieldOrder: 'asc' | 'desc';
+  filter?: EntityFilter;
+  isPrevious: boolean;
+  /**
+   * used only for efficiently
+   * finding the initial batch of items
+   * when navigating backwards
+   */
+  previousPage: number;
 };
 
 export type EntitiesResponse = {

--- a/plugins/catalog-backend/src/service/NextRouter.ts
+++ b/plugins/catalog-backend/src/service/NextRouter.ts
@@ -78,14 +78,16 @@ export async function createNextRouter(
   if (entitiesCatalog) {
     router
       .get('/entities', async (req, res) => {
+        const pagination = parseEntityPaginationParams(req.query);
+
         const { entities, pageInfo } = await entitiesCatalog.entities({
           filter: parseEntityFilterParams(req.query),
           fields: parseEntityTransformParams(req.query),
-          pagination: parseEntityPaginationParams(req.query),
+          pagination,
         });
 
         // Add a Link header to the next page
-        if (pageInfo.hasNextPage) {
+        if (pageInfo.nextCursor) {
           const url = new URL(`http://ignored${req.url}`);
           url.searchParams.delete('offset');
           url.searchParams.set('after', pageInfo.endCursor);


### PR DESCRIPTION
Signed-off-by: Vincenzo Scamporlino <me@vinzscam.dev>

## Hey, I just made a Pull Request!

This is a starting point for improving the `CatalogPage` frontend.
Right now the current `/entities` endpoint is very unefficient, since it returns all the entities stored on the database to the frontend. So, if the database contains 20k+ elements, all 20k+ entities are sent to the frontend in one shot. Depending on the amount of data, this might be a big problem.

Solution: **make catalog return paginated data**.
I've seen that pagination is already implemented in catalog. However, the current implementation is lacking a few things (server side sorting and backwards navigation amoung them), which make it useless.
For an efficient and **reliable** pagination, all the filter operations and sorting operations need to be moved server side. Also, the current pagination is based on offset/limits, which affect performance a lot while navigating forward.

This PR introduce a more efficient cursor based pagination, with filters and sorting capabilities.
The filters and sorting properties are set at the beginning, during the first `entities()` invocation and are embedded in the cursors, which make them immutable during the entire navigation process.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
