### PR TITLE
Select and Autocomplete select readonly when one option available 

### DIFF
--- a/.changeset/beige-balloons-grin.md
+++ b/.changeset/beige-balloons-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+When user will have one option available in hostUrl or owner - autoselect and select component should be readonly

--- a/.changeset/curvy-walls-itch.md
+++ b/.changeset/curvy-walls-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Select component has extended API with few more props

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -161,9 +161,10 @@ export function SelectComponent(props: SelectProps) {
   };
 
   const handleClick = (event: React.ChangeEvent<any>) => {
-    // if (disabled) {
-    //   return event.preventDefault();
-    // }
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
     setOpen(previous => {
       if (multiple && !(event.target instanceof HTMLElement)) {
         return true;

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -21,13 +21,13 @@ import FormControl from '@material-ui/core/FormControl';
 import InputBase from '@material-ui/core/InputBase';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
-import Typography from '@material-ui/core/Typography';
 import {
   createStyles,
   makeStyles,
   Theme,
   withStyles,
 } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
 import React, { useEffect, useState } from 'react';
 import ClosedDropdown from './static/ClosedDropdown';
 import OpenedDropdown from './static/OpenedDropdown';
@@ -92,7 +92,14 @@ const useStyles = makeStyles(
       chip: {
         margin: 2,
       },
+
       checkbox: {},
+      select: {
+        '&:hover': {
+          cursor: 'not-allowed',
+        },
+      },
+
       root: {
         display: 'flex',
         flexDirection: 'column',
@@ -101,12 +108,12 @@ const useStyles = makeStyles(
   { name: 'BackstageSelect' },
 );
 
-type Item = {
+export type Item = {
   label: string;
   value: string | number;
 };
 
-type Selection = string | string[] | number | number[];
+export type Selection = string | string[] | number | number[];
 
 export type SelectProps = {
   multiple?: boolean;
@@ -116,6 +123,8 @@ export type SelectProps = {
   selected?: Selection;
   onChange: (arg: Selection) => void;
   triggerReset?: boolean;
+  native?: boolean;
+  disabled?: boolean;
 };
 
 export function SelectComponent(props: SelectProps) {
@@ -127,6 +136,8 @@ export function SelectComponent(props: SelectProps) {
     selected,
     onChange,
     triggerReset,
+    native = false,
+    disabled = false,
   } = props;
   const classes = useStyles();
   const [value, setValue] = useState<Selection>(
@@ -150,6 +161,9 @@ export function SelectComponent(props: SelectProps) {
   };
 
   const handleClick = (event: React.ChangeEvent<any>) => {
+    // if (disabled) {
+    //   return event.preventDefault();
+    // }
     setOpen(previous => {
       if (multiple && !(event.target instanceof HTMLElement)) {
         return true;
@@ -175,6 +189,8 @@ export function SelectComponent(props: SelectProps) {
         <FormControl className={classes.formControl}>
           <Select
             value={value}
+            native={native}
+            disabled={disabled}
             data-testid="select"
             displayEmpty
             multiple={multiple}
@@ -223,19 +239,26 @@ export function SelectComponent(props: SelectProps) {
             {placeholder && !multiple && (
               <MenuItem value={[]}>{placeholder}</MenuItem>
             )}
-            {items &&
-              items.map(item => (
-                <MenuItem key={item.value} value={item.value}>
-                  {multiple && (
-                    <Checkbox
-                      color="primary"
-                      checked={(value as any[]).includes(item.value) || false}
-                      className={classes.checkbox}
-                    />
-                  )}
-                  {item.label}
-                </MenuItem>
-              ))}
+            {native
+              ? items &&
+                items.map(item => (
+                  <option value={item.value} key={item.value}>
+                    {item.label}
+                  </option>
+                ))
+              : items &&
+                items.map(item => (
+                  <MenuItem key={item.value} value={item.value}>
+                    {multiple && (
+                      <Checkbox
+                        color="primary"
+                        checked={(value as any[]).includes(item.value) || false}
+                        className={classes.checkbox}
+                      />
+                    )}
+                    {item.label}
+                  </MenuItem>
+                ))}
           </Select>
         </FormControl>
       </ClickAwayListener>

--- a/packages/core-components/src/components/Select/index.tsx
+++ b/packages/core-components/src/components/Select/index.tsx
@@ -15,6 +15,11 @@
  */
 
 export { SelectComponent as Select } from './Select';
-export type { SelectClassKey, SelectInputBaseClassKey } from './Select';
+export type {
+  Item,
+  SelectClassKey,
+  SelectInputBaseClassKey,
+  Selection,
+} from './Select';
 export type { ClosedDropdownClassKey } from './static/ClosedDropdown';
 export type { OpenedDropdownClassKey } from './static/OpenedDropdown';

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -22,7 +22,7 @@ import { TextField } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import { FieldProps } from '@rjsf/core';
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useAsync } from 'react-use';
 
 export const EntityPicker = ({
@@ -48,9 +48,18 @@ export const EntityPicker = ({
     formatEntityRefTitle(e, { defaultKind }),
   );
 
-  const onSelect = (_: any, value: string | null) => {
-    onChange(value || '');
-  };
+  const onSelect = useCallback(
+    (_: any, value: string | null) => {
+      onChange(value || '');
+    },
+    [onChange],
+  );
+
+  useEffect(() => {
+    if (entityRefs?.length === 1) {
+      onSelect('', entityRefs[0]);
+    }
+  }, [entityRefs, onSelect]);
 
   return (
     <FormControl
@@ -59,6 +68,7 @@ export const EntityPicker = ({
       error={rawErrors?.length > 0 && !formData}
     >
       <Autocomplete
+        disabled={entityRefs?.length === 1}
         id={idSchema?.$id}
         value={(formData as string) || ''}
         loading={loading}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -13,19 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useCallback, useEffect } from 'react';
-import { FieldProps } from '@rjsf/core';
-import { scaffolderApiRef } from '../../../api';
+import { Item, Progress, Select, Selection } from '@backstage/core-components';
+import { useApi } from '@backstage/core-plugin-api';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
-import { useAsync } from 'react-use';
-import Select from '@material-ui/core/Select';
-import InputLabel from '@material-ui/core/InputLabel';
-import Input from '@material-ui/core/Input';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
-
-import { useApi } from '@backstage/core-plugin-api';
-import { Progress } from '@backstage/core-components';
+import Input from '@material-ui/core/Input';
+import InputLabel from '@material-ui/core/InputLabel';
+import { FieldProps } from '@rjsf/core';
+import React, { useCallback, useEffect } from 'react';
+import { useAsync } from 'react-use';
+import { scaffolderApiRef } from '../../../api';
 
 function splitFormData(url: string | undefined, allowedOwners?: string[]) {
   let host = undefined;
@@ -106,10 +104,10 @@ export const RepoUrlPicker = ({
     allowedOwners,
   );
   const updateHost = useCallback(
-    (evt: React.ChangeEvent<{ name?: string; value: unknown }>) => {
+    (value: Selection) => {
       onChange(
         serializeFormData({
-          host: evt.target.value as string,
+          host: value as string,
           owner,
           repo,
           organization,
@@ -119,6 +117,21 @@ export const RepoUrlPicker = ({
       );
     },
     [onChange, owner, repo, organization, workspace, project],
+  );
+
+  const updateOwnerSelect = useCallback(
+    (value: Selection) =>
+      onChange(
+        serializeFormData({
+          host,
+          owner: value as string,
+          repo,
+          organization,
+          workspace,
+          project,
+        }),
+      ),
+    [onChange, host, repo, organization, workspace, project],
   );
 
   const updateOwner = useCallback(
@@ -224,6 +237,16 @@ export const RepoUrlPicker = ({
     return <Progress />;
   }
 
+  const hostsOptions: Item[] = integrations
+    ? integrations
+        .filter(i => allowedHosts?.includes(i.host))
+        .map(i => ({ label: i.title, value: i.host }))
+    : [{ label: 'Loading...', value: 'loading' }];
+
+  const ownersOptions: Item[] = allowedOwners
+    ? allowedOwners.map(i => ({ label: i, value: i }))
+    : [{ label: 'Loading...', value: 'loading' }];
+
   return (
     <>
       <FormControl
@@ -231,20 +254,15 @@ export const RepoUrlPicker = ({
         required
         error={rawErrors?.length > 0 && !host}
       >
-        <InputLabel htmlFor="hostInput">Host</InputLabel>
-        <Select native id="hostInput" onChange={updateHost} value={host}>
-          {integrations ? (
-            integrations
-              .filter(i => allowedHosts?.includes(i.host))
-              .map(i => (
-                <option key={i.host} value={i.host}>
-                  {i.title}
-                </option>
-              ))
-          ) : (
-            <p>loading</p>
-          )}
-        </Select>
+        <Select
+          native
+          disabled={hostsOptions.length === 1}
+          label="Host"
+          onChange={updateHost}
+          selected={host}
+          items={hostsOptions}
+        />
+
         <FormHelperText>
           The host where the repository will be created
         </FormHelperText>
@@ -330,24 +348,15 @@ export const RepoUrlPicker = ({
               required
               error={rawErrors?.length > 0 && !owner}
             >
-              <InputLabel htmlFor="ownerInput">Owner Available</InputLabel>
               <Select
                 native
-                id="ownerInput"
-                onChange={updateOwner}
-                value={owner}
-              >
-                {allowedOwners ? (
-                  allowedOwners.map(i => (
-                    <option key={i} value={i}>
-                      {i}
-                    </option>
-                  ))
-                ) : (
-                  <p>loading</p>
-                )}
-                ;
-              </Select>
+                label="Owner Available"
+                onChange={updateOwnerSelect}
+                disabled={ownersOptions.length === 1}
+                selected={owner}
+                items={ownersOptions}
+              />
+
               <FormHelperText>
                 The organization, user or project that this repo will belong to
               </FormHelperText>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

1. Repo Owner Autocomplete Select is now disabled when 1 option is available (and this option is selected)
2. Host Url Select is disabled when 1 option is available  (and this option is selected)
3. Select was replaced - instead `@material-ui/core` i used our `@backstage/core-components` - extended our select API as well with some additional props. 

<img width="942" alt="Zrzut ekranu 2021-12-11 o 01 36 56" src="https://user-images.githubusercontent.com/55348672/145657144-29dfbdff-dd7d-4b5b-9864-17a1f3650590.png">
<img width="722" alt="Zrzut ekranu 2021-12-11 o 01 37 46" src="https://user-images.githubusercontent.com/55348672/145657152-6fe16cb7-22c1-4b77-88b3-b7718bb07fb6.png">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
