### PR TITLE
Ownershipcard filter configurable

### DIFF
--- a/.changeset/org-ownershipcard-filteradded.md
+++ b/.changeset/org-ownershipcard-filteradded.md
@@ -1,5 +1,4 @@
 ---
-'example-app': patch
 '@backstage/plugin-org': patch
 ---
 

--- a/.changeset/org-ownershipcard-filteradded.md
+++ b/.changeset/org-ownershipcard-filteradded.md
@@ -1,0 +1,6 @@
+---
+"example-app": patch
+"@backstage/plugin-org": patch
+---
+
+Added `entityFilterKind` property for `EntityOwnershipCard`

--- a/.changeset/org-ownershipcard-filteradded.md
+++ b/.changeset/org-ownershipcard-filteradded.md
@@ -1,6 +1,6 @@
 ---
-"example-app": patch
-"@backstage/plugin-org": patch
+'example-app': patch
+'@backstage/plugin-org': patch
 ---
 
 Added `entityFilterKind` property for `EntityOwnershipCard`

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -525,7 +525,10 @@ const userPage = (
           <EntityUserProfileCard variant="gridItem" />
         </Grid>
         <Grid item xs={12} md={6}>
-          <EntityOwnershipCard variant="gridItem" entityFilterKind={customEntityFilterKind} />
+          <EntityOwnershipCard
+            variant="gridItem"
+            entityFilterKind={customEntityFilterKind}
+          />
         </Grid>
       </Grid>
     </EntityLayout.Route>
@@ -541,7 +544,10 @@ const groupPage = (
           <EntityGroupProfileCard variant="gridItem" />
         </Grid>
         <Grid item xs={12} md={6}>
-          <EntityOwnershipCard variant="gridItem" entityFilterKind={customEntityFilterKind} />
+          <EntityOwnershipCard
+            variant="gridItem"
+            entityFilterKind={customEntityFilterKind}
+          />
         </Grid>
         <Grid item xs={12}>
           <EntityMembersListCard />

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -126,6 +126,8 @@ import {
 } from '@roadiehq/backstage-plugin-travis-ci';
 import React, { ReactNode, useMemo, useState } from 'react';
 
+const customEntityFilterKind = ['Component', 'API', 'System'];
+
 const EntityLayoutWrapper = (props: { children?: ReactNode }) => {
   const [badgesDialogOpen, setBadgesDialogOpen] = useState(false);
 
@@ -523,7 +525,7 @@ const userPage = (
           <EntityUserProfileCard variant="gridItem" />
         </Grid>
         <Grid item xs={12} md={6}>
-          <EntityOwnershipCard variant="gridItem" />
+          <EntityOwnershipCard variant="gridItem" entityFilterKind={customEntityFilterKind} />
         </Grid>
       </Grid>
     </EntityLayout.Route>
@@ -539,7 +541,7 @@ const groupPage = (
           <EntityGroupProfileCard variant="gridItem" />
         </Grid>
         <Grid item xs={12} md={6}>
-          <EntityOwnershipCard variant="gridItem" />
+          <EntityOwnershipCard variant="gridItem" entityFilterKind={customEntityFilterKind} />
         </Grid>
         <Grid item xs={12}>
           <EntityMembersListCard />

--- a/plugins/org/CHANGELOG.md
+++ b/plugins/org/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-org
 
+## 0.3.31
+
+### Patch Changes
+
+- added `entityFilterKind` property for `EntityOwnershipCard` 
+
 ## 0.3.30
 
 ### Patch Changes

--- a/plugins/org/CHANGELOG.md
+++ b/plugins/org/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @backstage/plugin-org
 
-## 0.3.31
-
-### Patch Changes
-
-- added `entityFilterKind` property for `EntityOwnershipCard` 
-
 ## 0.3.30
 
 ### Patch Changes

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -33,9 +33,11 @@ export const EntityMembersListCard: (_props: {
 // @public (undocumented)
 export const EntityOwnershipCard: ({
   variant,
+  entityFilterKind,
 }: {
   entity?: Entity | undefined;
   variant?: InfoCardVariants | undefined;
+  entityFilterKind?: string[] | undefined;
 }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "EntityUserProfileCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -75,9 +77,11 @@ export { orgPlugin as plugin };
 // @public (undocumented)
 export const OwnershipCard: ({
   variant,
+  entityFilterKind,
 }: {
   entity?: Entity | undefined;
   variant?: InfoCardVariants | undefined;
+  entityFilterKind?: string[] | undefined;
 }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "UserProfileCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.10.1",
     "@backstage/core-app-api": "^0.2.0",
+    "@backstage/catalog-client": "^0.5.2",
     "@backstage/dev-utils": "^0.2.14",
     "@backstage/test-utils": "^0.1.24",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-org",
   "description": "A Backstage plugin that helps you create entity pages for your organization",
-  "version": "0.3.31",
+  "version": "0.3.30",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-org",
   "description": "A Backstage plugin that helps you create entity pages for your organization",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -108,6 +108,22 @@ describe('OwnershipCard', () => {
         },
       ],
     },
+    {
+      kind: 'system',
+      metadata: {
+        name: 'my-systen',
+      },
+      relations: [
+        {
+          type: 'ownedBy',
+          target: {
+            name: 'my-team',
+            namespace: 'default',
+            kind: 'Group',
+          },
+        },
+      ],
+    },
   ] as any;
 
   it('displays entity counts', async () => {
@@ -144,6 +160,7 @@ describe('OwnershipCard', () => {
     expect(
       queryByText(getByText('LIBRARY').parentElement!, '1'),
     ).toBeInTheDocument();
+    expect(getByText('SYSTEM')).not.toBeInTheDocument();
   });
 
   it('links to the catalog with the group filter', async () => {
@@ -220,5 +237,140 @@ describe('OwnershipCard', () => {
       'href',
       '/create/?filters%5Bkind%5D=API&filters%5Btype%5D=openapi&filters%5Bowners%5D%5B0%5D=user%3Athe-user&filters%5Bowners%5D%5B1%5D=my-team&filters%5Buser%5D=all',
     );
+  });
+});
+
+describe('OwnershipCardWithCustomFilterDefinition', () => {
+  const groupEntity: GroupEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Group',
+    metadata: {
+      name: 'my-team',
+    },
+    spec: {
+      type: 'team',
+      children: [],
+    },
+    relations: [
+      {
+        type: 'memberOf',
+        target: {
+          kind: 'group',
+          name: 'ExampleGroup',
+          namespace: 'default',
+        },
+      },
+    ],
+  };
+
+  const items = [
+    {
+      kind: 'API',
+      metadata: {
+        name: 'my-api',
+      },
+      spec: {
+        type: 'openapi',
+      },
+      relations: [
+        {
+          type: 'ownedBy',
+          target: {
+            name: 'my-team',
+            namespace: 'default',
+            kind: 'Group',
+          },
+        },
+      ],
+    },
+    {
+      kind: 'Component',
+      metadata: {
+        name: 'my-service',
+      },
+      spec: {
+        type: 'service',
+      },
+      relations: [
+        {
+          type: 'ownedBy',
+          target: {
+            name: 'my-team',
+            namespace: 'default',
+            kind: 'Group',
+          },
+        },
+      ],
+    },
+    {
+      kind: 'Component',
+      metadata: {
+        name: 'my-library',
+        namespace: 'other-namespace',
+      },
+      spec: {
+        type: 'library',
+      },
+      relations: [
+        {
+          type: 'ownedBy',
+          target: {
+            name: 'my-team',
+            namespace: 'default',
+            kind: 'Group',
+          },
+        },
+      ],
+    },
+    {
+      kind: 'system',
+      metadata: {
+        name: 'my-systen',
+      },
+      relations: [
+        {
+          type: 'ownedBy',
+          target: {
+            name: 'my-team',
+            namespace: 'default',
+            kind: 'Group',
+          },
+        },
+      ],
+    },
+  ] as any;
+
+  it('displays entity counts', async () => {
+    const catalogApi: jest.Mocked<CatalogApi> = {
+      getEntities: jest.fn(),
+    } as any;
+
+    catalogApi.getEntities.mockResolvedValue({
+      items,
+    });
+
+    const { getByText } = await renderInTestApp(
+      <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+        <EntityProvider entity={groupEntity}>
+          <OwnershipCard entityFilterKind={['API','system']} />
+        </EntityProvider>
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/create': catalogRouteRef,
+        },
+      },
+    );
+
+    expect(getByText('OPENAPI')).toBeInTheDocument();
+    expect(
+      queryByText(getByText('OPENAPI').parentElement!, '1'),
+    ).toBeInTheDocument();
+    expect(getByText('SERVICE')).not.toBeInTheDocument();
+    expect(getByText('LIBRARY')).not.toBeInTheDocument();
+    expect(getByText('SYSTEM')).toBeInTheDocument();
+    expect(
+      queryByText(getByText('SYSTEM').parentElement!, '1'),
+    ).toBeInTheDocument();
   });
 });

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -115,7 +115,7 @@ const getEntitiesMock = (
   const filterKinds =
     !Array.isArray(request?.filter) && Array.isArray(request?.filter?.kind)
       ? request?.filter?.kind ?? []
-      : []; // we expect the request to be like { filter: { kind: ['API','System'], .... }
+      : []; // we expect the request to be like { filter: { kind: ['API','System'], .... }. If changed in OwnerShipCard, let's change in also here
   return Promise.resolve({
     items: items.filter(item => filterKinds.find(k => k === item.kind)),
   } as CatalogListResponse<Entity>);

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -352,7 +352,7 @@ describe('OwnershipCardWithCustomFilterDefinition', () => {
     const { getByText } = await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
         <EntityProvider entity={groupEntity}>
-          <OwnershipCard entityFilterKind={['API','system']} />
+          <OwnershipCard entityFilterKind={['API', 'system']} />
         </EntityProvider>
       </TestApiProvider>,
       {

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -128,10 +128,12 @@ const getQueryParams = (
 
 export const OwnershipCard = ({
   variant,
+  entityFilterKind
 }: {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: Entity;
   variant?: InfoCardVariants;
+  entityFilterKind?: string[];
 }) => {
   const { entity } = useEntity();
   const catalogApi = useApi(catalogApiRef);
@@ -142,7 +144,7 @@ export const OwnershipCard = ({
     error,
     value: componentsWithCounters,
   } = useAsync(async () => {
-    const kinds = ['Component', 'API'];
+    const kinds = entityFilterKind ?? ['Component', 'API'];
     const entitiesList = await catalogApi.getEntities({
       filter: {
         kind: kinds,

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -162,17 +162,15 @@ export const OwnershipCard = ({
 
     const counts = ownedEntitiesList.reduce(
       (acc: EntityTypeProps[], ownedEntity) => {
-        if (typeof ownedEntity.spec?.type !== 'string') return acc;
-
         const match = acc.find(
-          x => x.kind === ownedEntity.kind && x.type === ownedEntity.spec?.type,
+          x => x.kind === ownedEntity.kind && x.type === (ownedEntity.spec?.type ?? ownedEntity.kind),
         );
         if (match) {
           match.count += 1;
         } else {
           acc.push({
             kind: ownedEntity.kind,
-            type: ownedEntity.spec?.type,
+            type: ownedEntity.spec?.type?.toString() ?? ownedEntity.kind,
             count: 1,
           });
         }

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -128,7 +128,7 @@ const getQueryParams = (
 
 export const OwnershipCard = ({
   variant,
-  entityFilterKind
+  entityFilterKind,
 }: {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: Entity;
@@ -165,7 +165,9 @@ export const OwnershipCard = ({
     const counts = ownedEntitiesList.reduce(
       (acc: EntityTypeProps[], ownedEntity) => {
         const match = acc.find(
-          x => x.kind === ownedEntity.kind && x.type === (ownedEntity.spec?.type ?? ownedEntity.kind),
+          x =>
+            x.kind === ownedEntity.kind &&
+            x.type === (ownedEntity.spec?.type ?? ownedEntity.kind),
         );
         if (match) {
           match.count += 1;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `entityFilterKind` property for `EntityOwnershipCard`: Should allow change of filter for OwnershipCard. Default is Component, API. See issue #7806 

Where it affects UI:
![image](https://user-images.githubusercontent.com/16001792/145675734-e023d245-c51a-40b1-84a1-5fee9eb56efc.png)

Upated also example-app.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
