### PR TITLE
backstage-cli install: add plugin dependencies to experimentalInstallationRecipe

### DIFF
--- a/.changeset/fluffy-grapes-decide.md
+++ b/.changeset/fluffy-grapes-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added peerPluginDependencies option to experimentalInstallationRecipe for install command to install plugins it depends on.

--- a/packages/cli/src/commands/install/install.ts
+++ b/packages/cli/src/commands/install/install.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Step, PackageWithInstallRecipe } from './types';
+import {
+  Step,
+  PackageWithInstallRecipe,
+  PeerPluginDependencies,
+} from './types';
 import { fetchPackageInfo } from '../../lib/versioning';
 import { NotFoundError } from '../../lib/errors';
 import * as stepDefinitionMap from './steps';
@@ -52,7 +56,10 @@ type Steps = Array<{
 }>;
 
 class PluginInstaller {
-  static async resolveSteps(pkg: PackageWithInstallRecipe) {
+  static async resolveSteps(
+    pkg: PackageWithInstallRecipe,
+    versionToInstall?: string,
+  ) {
     const steps: Steps = [];
 
     // collectDependencies
@@ -62,7 +69,7 @@ class PluginInstaller {
       target: 'packages/app',
       type: 'dependencies' as const,
       name: pkg.name,
-      query: `^${pkg.version}`,
+      query: versionToInstall || `^${pkg.version}`,
     });
     steps.push({
       type: 'dependencies',
@@ -97,22 +104,63 @@ class PluginInstaller {
   }
 }
 
+async function installPluginAndPeerPlugins(pkg: PackageWithInstallRecipe) {
+  const pluginDeps: PeerPluginDependencies = new Map();
+  pluginDeps.set(pkg.name, { pkg });
+  await loadPeerPluginDeps(pkg, pluginDeps);
+
+  console.log(`Installing ${pkg.name} AND any peer plugin dependencies.`);
+  for (const [_pluginDepName, pluginDep] of pluginDeps.entries()) {
+    const { pkg: pluginDepPkg, versionToInstall } = pluginDep;
+    console.log(
+      `Installing plugin: ${pluginDepPkg.name}: ${
+        versionToInstall || pluginDepPkg.version
+      }`,
+    );
+    const steps = await PluginInstaller.resolveSteps(
+      pluginDepPkg,
+      versionToInstall,
+    );
+    const installer = new PluginInstaller(steps);
+    await installer.run();
+  }
+}
+
+async function loadPackageJson(
+  plugin: string,
+): Promise<PackageWithInstallRecipe> {
+  if (plugin.endsWith('package.json')) {
+    // Install from local package if pluginId is a package.json file - needs to be absolute path
+    return await fs.readJson(plugin);
+  }
+  return await fetchPluginPackage(plugin);
+}
+
+async function loadPeerPluginDeps(
+  pkg: PackageWithInstallRecipe,
+  pluginMap: PeerPluginDependencies,
+) {
+  for (const [pluginId, pluginVersion] of Object.entries(
+    pkg.experimentalInstallationRecipe?.peerPluginDependencies ?? {},
+  )) {
+    const depPkg = await loadPackageJson(pluginId);
+    if (!pluginMap.get(depPkg.name)) {
+      pluginMap.set(depPkg.name, {
+        pkg: depPkg,
+        versionToInstall: pluginVersion,
+      });
+      await loadPeerPluginDeps(depPkg, pluginMap);
+    }
+  }
+}
+
 export default async (pluginId?: string, cmd?: Command) => {
   // TODO(himanshu): If no plugin id is provided, it should list all plugins available. Maybe in some other command?
-
-  let pkg: PackageWithInstallRecipe;
-  if (pluginId) {
-    pkg = await fetchPluginPackage(pluginId);
-  } else if (cmd?.from) {
-    // TODO(himanshu): Also support reading directly from url
-    pkg = await fs.readJson(cmd.from);
-  } else {
+  if (!pluginId && !cmd?.from) {
     throw new Error(
       'Missing both <plugin-id> or a package.json file path in the --from flag.',
     );
   }
-
-  const steps = await PluginInstaller.resolveSteps(pkg);
-  const installer = new PluginInstaller(steps);
-  await installer.run();
+  const pkg = await loadPackageJson(pluginId || cmd?.from);
+  await installPluginAndPeerPlugins(pkg);
 };

--- a/packages/cli/src/commands/install/install.ts
+++ b/packages/cli/src/commands/install/install.ts
@@ -155,12 +155,13 @@ async function loadPeerPluginDeps(
 }
 
 export default async (pluginId?: string, cmd?: Command) => {
+  const from = pluginId || cmd?.from;
   // TODO(himanshu): If no plugin id is provided, it should list all plugins available. Maybe in some other command?
-  if (!pluginId && !cmd?.from) {
+  if (!from) {
     throw new Error(
       'Missing both <plugin-id> or a package.json file path in the --from flag.',
     );
   }
-  const pkg = await loadPackageJson(pluginId || cmd?.from);
+  const pkg = await loadPackageJson(from);
   await installPluginAndPeerPlugins(pkg);
 };

--- a/packages/cli/src/commands/install/types.ts
+++ b/packages/cli/src/commands/install/types.ts
@@ -38,6 +38,7 @@ export type SerializedStep = {
 export type InstallationRecipe = {
   type?: 'frontend' | 'backend';
   steps: SerializedStep[];
+  peerPluginDependencies: { [pluginId: string]: string };
 };
 
 /** package.json data */
@@ -45,6 +46,14 @@ export type PackageWithInstallRecipe = YarnInfoInspectData & {
   version: string;
   experimentalInstallationRecipe?: InstallationRecipe;
 };
+
+export type PeerPluginDependencies = Map<
+  string,
+  {
+    pkg: PackageWithInstallRecipe;
+    versionToInstall?: string;
+  }
+>;
 
 export interface Step {
   run(): Promise<void>;


### PR DESCRIPTION
Signed-off-by: Ainhoa Larumbe <ainhoaL@users.noreply.github.com>

## Hey, I just made a Pull Request!

Part of: https://github.com/backstage/backstage/issues/7422

Some plugins have both a frontend and backend side, and both need to be installed to get the functionality. Some plugins might depend on more than one plugin too. This PR brings that dependency functionality to the `backstage-cli install` `experimentalInstallationRecipe` mode.

Added a new feature to `backstage-cli install <plugin>` to give it the plugins that are needed for the current plugin to run successfully.
List any plugins the plugin to install depends on (and their versions, or "latest") using the new option in package.json's `experimentalInstallationRecipe`: `peerPluginDependencies`, like this:
```
"experimentalInstallationRecipe": {
    "type": "frontend-plugin",
    "peerPluginDependencies": {
      "other-plugin": "^0.2.20"
    },
    ...
  }
```
When running `bakstage-cli install <plugin>` it will install the plugin plus any peerPluginDependencies it finds (and install their listed versions) and run their installation steps too.

This code also takes care of circular dependencies, so a frontend plugin can list its backend plugin and the backend plugin can list as dependency the frontend plugin and the command will only install each once.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
