### PR TITLE
chore(actions): Update actions/checkout versions for FOSSA and Changeset

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create Changeset PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Install Dependencies
         run: yarn --frozen-lockfile
       - name: Create Release Pull Request

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v2
 
       - name: Install Fossa
         run: "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

GitHub's main checkout action is on major v2.x and does occasionally get updates. v2.x has been out since 2019.

https://github.com/actions/checkout/releases

This PR does two minor tweaks 🧹 ,

* bump `actions/checkout@v1` to `v2` for the changeset call out.  GitHub claims v2 is faster than v1, and the newer changeset docs uses v2 in the examples: https://github.com/changesets/action
* unpin the minor/patch version from the FOSSA workflow.  Note: FOSSA is currently manually disabled in the repo, and even their own examples generally use the generic `actions/checkout@v2`, but https://github.com/backstage/backstage/pull/4077 specifically pined it to the version that existed when that PR was fired. There's no discussion of needing to pin it, so this should hopefully reduce some maintenance longer term.



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
