### PR TITLE
K8s Cronjob Style Change and UI Fix

### DIFF
--- a/.changeset/cold-dolls-beam.md
+++ b/.changeset/cold-dolls-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Fixed styling bug for the CronJobsAccordions and updated Completed pods to display a green dot.

--- a/plugins/kubernetes/src/components/Cluster/Cluster.tsx
+++ b/plugins/kubernetes/src/components/Cluster/Cluster.tsx
@@ -148,9 +148,9 @@ export const Cluster = ({ clusterObjects, podsWithErrors }: ClusterProps) => {
                   <Grid item>
                     <ServicesAccordions />
                   </Grid>
-                </Grid>
-                <Grid item>
-                  <CronJobsAccordions />
+                  <Grid item>
+                    <CronJobsAccordions />
+                  </Grid>
                 </Grid>
               </AccordionDetails>
             </Accordion>

--- a/plugins/kubernetes/src/utils/pod.tsx
+++ b/plugins/kubernetes/src/utils/pod.tsx
@@ -63,7 +63,13 @@ export const containerStatuses = (pod: V1Pod): ReactNode => {
     const renderCell = (reason: string | undefined) => (
       <Fragment key={`${pod.metadata?.name}-${next.name}`}>
         <SubvalueCell
-          value={<StatusError>Container: {next.name}</StatusError>}
+          value={
+            reason === 'Completed' ? (
+              <StatusOK>Container: {next.name}</StatusOK>
+            ) : (
+              <StatusError>Container: {next.name}</StatusError>
+            )
+          }
           subvalue={reason}
         />
         <br />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Updated the component for Completed pods from `StatusError` to `StatusOK` (example attached). Fixed a bug where the CronjobsAccordions Grid item had been moved out of the corresponding Grid container. 

<img width="1792" alt="Screen Shot 2021-12-13 at 10 13 12 AM" src="https://user-images.githubusercontent.com/92325617/145849312-55240940-612f-4337-af21-94b2dc966223.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
