### PR TITLE
Fix bug in OwnershipCard component where text wasn't correctly plur…

### DIFF
--- a/.changeset/funny-chefs-guess.md
+++ b/.changeset/funny-chefs-guess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fixed bug in OwnershipCard component where text wasn't correctly pluralized

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -29,6 +29,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
+    "pluralize": "^8.0.0",
     "qs": "^6.10.1",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -40,6 +40,7 @@ import {
 } from '@material-ui/core';
 import qs from 'qs';
 import React from 'react';
+import pluralize from 'pluralize';
 import { useAsync } from 'react-use';
 
 type EntityTypeProps = {
@@ -96,7 +97,7 @@ const EntityCountTile = ({
           {counter}
         </Typography>
         <Typography className={classes.bold} variant="h6">
-          {name}
+          {pluralize(name, counter)}
         </Typography>
       </Box>
     </Link>


### PR DESCRIPTION
…alized

Signed-off-by: Austina Lin <austinal@vmware.com>

## Hey, I just made a Pull Request!


At VMware we noticed that the Ownership section on Team pages does not correctly pluralize the entity types. We would like to fix this with the pluralize dependency already used throughout backstage.

Before:
<img width="1915" alt="Screen Shot 2021-12-13 at 2 44 38 AM" src="https://user-images.githubusercontent.com/44930921/145866251-659d510c-1cb6-4635-9008-49ff9e9987ae.png">
After:
<img width="1913" alt="Screen Shot 2021-12-13 at 2 34 59 AM" src="https://user-images.githubusercontent.com/44930921/145866250-285ebccb-bbaa-4865-9194-e1f19e285ec2.png">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
