### PR TITLE
add optional subRoutePath property EntityRefLink

### DIFF
--- a/.changeset/twelve-chicken-tan.md
+++ b/.changeset/twelve-chicken-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Add optional subRoutePath property to EntityRefLink

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -536,6 +536,7 @@ export const EntityRefLink: React_2.ForwardRefExoticComponent<
     | 'TypographyClasses'
     | 'entityRef'
     | 'defaultKind'
+    | 'subRoutePath'
   > &
     React_2.RefAttributes<any>
 >;

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.test.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.test.tsx
@@ -185,4 +185,32 @@ describe('<EntityRefLink />', () => {
       '/catalog/test/component/software',
     );
   });
+
+  it('renders link for entity with defined subRoutePath', async () => {
+    const entity = {
+      apiVersion: 'v1',
+      kind: 'Component',
+      metadata: {
+        name: 'software',
+      },
+      spec: {
+        owner: 'guest',
+        type: 'service',
+        lifecycle: 'production',
+      },
+    };
+    const subRoute = '/sub-route';
+    const { getByText } = await renderInTestApp(
+      <EntityRefLink entityRef={entity} subRoutePath={subRoute} />,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+        },
+      },
+    );
+    expect(getByText('component:software')).toHaveAttribute(
+      'href',
+      '/catalog/default/component/software/sub-route',
+    );
+  });
 });

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
@@ -25,16 +25,26 @@ import { Link, LinkProps } from '@backstage/core-components';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { Tooltip } from '@material-ui/core';
 
+type SubRoutePath = `${'#' | '/'}${string}`;
+
 export type EntityRefLinkProps = {
   entityRef: Entity | EntityName;
   defaultKind?: string;
   title?: string;
   children?: React.ReactNode;
+  subRoutePath?: SubRoutePath;
 } & Omit<LinkProps, 'to'>;
 
 export const EntityRefLink = forwardRef<any, EntityRefLinkProps>(
   (props, ref) => {
-    const { entityRef, defaultKind, title, children, ...linkProps } = props;
+    const {
+      entityRef,
+      defaultKind,
+      title,
+      children,
+      subRoutePath,
+      ...linkProps
+    } = props;
     const entityRoute = useRouteRef(entityRouteRef);
 
     let kind;
@@ -59,12 +69,13 @@ export const EntityRefLink = forwardRef<any, EntityRefLinkProps>(
         namespace?.toLocaleLowerCase('en-US') ?? ENTITY_DEFAULT_NAMESPACE,
       name,
     };
+    const linkUrl = `${entityRoute(routeParams)}${subRoutePath ?? ''}`;
     const formattedEntityRefTitle = formatEntityRefTitle(entityRef, {
       defaultKind,
     });
 
     const link = (
-      <Link {...linkProps} ref={ref} to={entityRoute(routeParams)}>
+      <Link {...linkProps} ref={ref} to={linkUrl}>
         {children}
         {!children && (title ?? formattedEntityRefTitle)}
       </Link>


### PR DESCRIPTION
Signed-off-by: david.collins <david.collins@cvent.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Allows users of EntityRefLink component to specify an optional `subRoutePath` property which will be appended to the entityRoute link returned by the component. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
