### PR TITLE
workflows/stale: bump PR close days to 5

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,7 @@ jobs:
             recent activity from the author. It will be closed if no further activity occurs.
             If you are the author and the PR has been closed, feel free to re-open the PR and continue the contribution!
           days-before-pr-stale: 7
-          days-before-pr-close: 3
+          days-before-pr-close: 5
           exempt-pr-labels: reviewer-approved,awaiting-review
           stale-pr-label: stale
           operations-per-run: 100


### PR DESCRIPTION
3 is a bit too short for our current workflow, with the risk of PRs being marked as stale and closed without the maintainers getting a proper look at them