### PR TITLE
Add Missing Overridable Components Type for SidebarSpace, SidebarSpacer, and SidebarDivider

### DIFF
--- a/.changeset/stupid-mice-dream.md
+++ b/.changeset/stupid-mice-dream.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Add Missing Overridable Components Type for SidebarSpace, SidebarSpacer, and SidebarDivider Components.
+Add Missing Override Components Type for SidebarSpace, SidebarSpacer, and SidebarDivider Components.

--- a/.changeset/stupid-mice-dream.md
+++ b/.changeset/stupid-mice-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add Missing Overridable Components Type for SidebarSpace, SidebarSpacer, and SidebarDivider Components.

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1152,6 +1152,11 @@ export const SidebarDivider: React_2.ComponentType<
     }
 >;
 
+// Warning: (ae-missing-release-tag) "SidebarDividerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarDividerClassKey = 'root';
+
 // @public
 export const SidebarExpandButton: () => JSX.Element | null;
 
@@ -1760,6 +1765,11 @@ export const SidebarSpace: React_2.ComponentType<
     }
 >;
 
+// Warning: (ae-missing-release-tag) "SidebarSpaceClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarSpaceClassKey = 'root';
+
 // Warning: (ae-missing-release-tag) "SidebarSpacer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -2028,6 +2038,11 @@ export const SidebarSpacer: React_2.ComponentType<
       className?: string | undefined;
     }
 >;
+
+// Warning: (ae-missing-release-tag) "SidebarSpacerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type SidebarSpacerClassKey = 'root';
 
 // @public
 export const SidebarSubmenu: (props: SidebarSubmenuProps) => JSX.Element;

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -548,6 +548,8 @@ export function SidebarSearchField(props: SidebarSearchFieldProps) {
   );
 }
 
+export type SidebarSpaceClassKey = 'root';
+
 export const SidebarSpace = styled('div')(
   {
     flex: 1,
@@ -555,12 +557,16 @@ export const SidebarSpace = styled('div')(
   { name: 'BackstageSidebarSpace' },
 );
 
+export type SidebarSpacerClassKey = 'root';
+
 export const SidebarSpacer = styled('div')(
   {
     height: 8,
   },
   { name: 'BackstageSidebarSpacer' },
 );
+
+export type SidebarDividerClassKey = 'root';
 
 export const SidebarDivider = styled('hr')(
   {

--- a/packages/core-components/src/layout/Sidebar/index.ts
+++ b/packages/core-components/src/layout/Sidebar/index.ts
@@ -33,7 +33,12 @@ export {
   SidebarSpacer,
   SidebarScrollWrapper,
 } from './Items';
-export type { SidebarItemClassKey } from './Items';
+export type {
+  SidebarItemClassKey,
+  SidebarSpaceClassKey,
+  SidebarSpacerClassKey,
+  SidebarDividerClassKey,
+} from './Items';
 export { IntroCard, SidebarIntro } from './Intro';
 export type { SidebarIntroClassKey } from './Intro';
 export {

--- a/packages/core-components/src/overridableComponents.ts
+++ b/packages/core-components/src/overridableComponents.ts
@@ -83,6 +83,9 @@ import {
   ItemCardHeaderClassKey,
   PageClassKey,
   SidebarClassKey,
+  SidebarSpaceClassKey,
+  SidebarSpacerClassKey,
+  SidebarDividerClassKey,
   SidebarIntroClassKey,
   SidebarItemClassKey,
   SidebarPageClassKey,
@@ -157,6 +160,9 @@ type BackstageComponentsNameToClassKey = {
   BackstageItemCardHeader: ItemCardHeaderClassKey;
   BackstagePage: PageClassKey;
   BackstageSidebar: SidebarClassKey;
+  BackstageSidebarSpace: SidebarSpaceClassKey;
+  BackstageSidebarSpacer: SidebarSpacerClassKey;
+  BackstageSidebarDivider: SidebarDividerClassKey;
   BackstageSidebarIntro: SidebarIntroClassKey;
   BackstageSidebarItem: SidebarItemClassKey;
   BackstageSidebarPage: SidebarPageClassKey;


### PR DESCRIPTION

Signed-off-by: Dede Hamzah <dehamzah@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Just realized that this PR (https://github.com/backstage/backstage/pull/7873) is not working yet, because I didn't export any type in the `overrideableComponents.ts`. The `root` key was identified when I inspect the element:

<img width="1619" alt="Screen Shot 2021-12-14 at 14 35 33" src="https://user-images.githubusercontent.com/6959476/145959399-662050de-384e-479e-aa00-ec29074ac29f.png">



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
~- [ ] Added or updated documentation~
~- [ ] Tests for new functionality and regression tests for bug fixes~
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
