### PR TITLE
Disable pagination in search plugin when permissions are enabled

### DIFF
--- a/.changeset/lazy-badgers-pretend.md
+++ b/.changeset/lazy-badgers-pretend.md
@@ -1,0 +1,43 @@
+---
+'@backstage/plugin-search': minor
+---
+
+Pagination is not supported in the search backend when permissions are enabled. To match this, the SearchModal component now hides the pagination buttons when permissions are enabled. There is also a new component, SearchResultFooter, which includes the logic to switch between a "no more results" message and the pagination buttons depending on the enabled state of the permissions system. If you're using the permissions system, you should switch to this component in your search page:
+
+```diff
+import {
+  DefaultResultListItem,
+  SearchBar,
+  SearchFilter,
+  SearchResult,
+-  SearchResultPager,
++  SearchResultFooter,
+  SearchType,
+} from '@backstage/plugin-search';
+
+// ...
+
+const SearchPage = () => {
+  const classes = useStyles();
+
+  return (
+    <Page themeId="home">
+      <Header title="Search" subtitle={<Lifecycle alpha />} />
+      <Content>
+        <Grid container direction="row">
+          {/* ... */}
+          <Grid item xs={9}>
+            <SearchResult>
+              {({ results }) => (
+                {/* ... */}
+              )}
+            </SearchResult>
+-            <SearchResultPager />
++            <SearchResultFooter />
+          </Grid>
+        </Grid>
+      </Content>
+    </Page>
+  );
+};
+```

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -21,7 +21,7 @@ import {
   SearchBar,
   SearchFilter,
   SearchResult,
-  SearchResultPager,
+  SearchResultFooter,
   SearchType,
 } from '@backstage/plugin-search';
 import { DocsResultListItem } from '@backstage/plugin-techdocs';
@@ -105,7 +105,7 @@ const SearchPage = () => {
                 </List>
               )}
             </SearchResult>
-            <SearchResultPager />
+            <SearchResultFooter />
           </Grid>
         </Grid>
       </Content>

--- a/plugins/search/api-report.md
+++ b/plugins/search/api-report.md
@@ -194,6 +194,11 @@ export const SearchResult: ({
   children: (results: { results: SearchResult_2[] }) => JSX.Element;
 }) => JSX.Element;
 
+// Warning: (ae-missing-release-tag) "SearchResultFooter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const SearchResultFooter: () => JSX.Element;
+
 // Warning: (ae-missing-release-tag) "SearchResultPager" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -30,8 +30,9 @@ import { SearchBarBase } from '../SearchBar';
 import { DefaultResultListItem } from '../DefaultResultListItem';
 import { SearchResult } from '../SearchResult';
 import { SearchContextProvider, useSearch } from '../SearchContext';
+import { SearchRefineResultsPrompt } from '../SearchRefineResultsPrompt';
 import { SearchResultPager } from '../SearchResultPager';
-import { useRouteRef } from '@backstage/core-plugin-api';
+import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { Link } from '@backstage/core-components';
 import { rootRouteRef } from '../../plugin';
 
@@ -63,6 +64,7 @@ export const Modal = ({ open = true, toggleModal }: SearchModalProps) => {
 
   const { term, setTerm } = useSearch();
   const [value, setValue] = useState<string>(term);
+  const config = useApi(configApiRef);
 
   useEffect(() => {
     setValue(prevValue => (prevValue !== term ? term : prevValue));
@@ -144,14 +146,20 @@ export const Modal = ({ open = true, toggleModal }: SearchModalProps) => {
             </List>
           )}
         </SearchResult>
+        {config.getOptionalBoolean('permission.enabled') ? (
+          <SearchRefineResultsPrompt />
+        ) : null}
       </DialogContent>
-      <DialogActions className={classes.dialogActionsContainer}>
-        <Grid container direction="row">
-          <Grid item xs={12}>
-            <SearchResultPager />
+
+      {!config.getOptionalBoolean('permission.enabled') ? (
+        <DialogActions className={classes.dialogActionsContainer}>
+          <Grid container direction="row">
+            <Grid item xs={12}>
+              <SearchResultPager />
+            </Grid>
           </Grid>
-        </Grid>
-      </DialogActions>
+        </DialogActions>
+      ) : null}
     </Dialog>
   );
 };

--- a/plugins/search/src/components/SearchRefineResultsPrompt/SearchRefineResultsPrompt.tsx
+++ b/plugins/search/src/components/SearchRefineResultsPrompt/SearchRefineResultsPrompt.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { makeStyles, Typography } from '@material-ui/core';
+import React from 'react';
+
+const useStyles = makeStyles({
+  root: {
+    margin: '1rem 0',
+  },
+});
+
+export const SearchRefineResultsPrompt = () => {
+  const classes = useStyles();
+
+  return (
+    <Typography
+      className={classes.root}
+      variant="body2"
+      color="textSecondary"
+      display="block"
+      align="center"
+    >
+      Search is limited to a fixed number of results. You can try refining your
+      search query if you're not finding what you're looking for.
+    </Typography>
+  );
+};

--- a/plugins/search/src/components/SearchRefineResultsPrompt/index.tsx
+++ b/plugins/search/src/components/SearchRefineResultsPrompt/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,4 @@
  * limitations under the License.
  */
 
-export * from './DefaultResultListItem';
-export * from './Filters';
-export * from './SearchBar';
-export * from './SearchContext';
-export * from './SearchFilter';
-export * from './SearchModal';
-export * from './SearchPage';
-export * from './SearchRefineResultsPrompt';
-export * from './SearchResult';
-export * from './SearchResultFooter';
-export * from './SearchResultPager';
-export * from './SearchType';
-export * from './SidebarSearch';
-export * from './SidebarSearchModal';
+export { SearchRefineResultsPrompt } from './SearchRefineResultsPrompt';

--- a/plugins/search/src/components/SearchResultFooter/SearchResultFooter.test.tsx
+++ b/plugins/search/src/components/SearchResultFooter/SearchResultFooter.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { configApiRef } from '@backstage/core-plugin-api';
+import { ConfigReader } from '@backstage/config';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { SearchResultFooter } from './SearchResultFooter';
+
+jest.mock('../SearchContext', () => ({
+  ...jest.requireActual('../SearchContext'),
+  useSearch: jest.fn().mockReturnValue({
+    result: { loading: false, value: [] },
+    fetchNextPage: jest.fn(),
+    fetchPreviousPage: jest.fn(),
+  }),
+}));
+
+describe('SearchResultFooter', () => {
+  it('includes a prompt to refine search results when permissions are enabled', async () => {
+    const { getByText, queryByLabelText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [configApiRef, new ConfigReader({ permission: { enabled: true } })],
+        ]}
+      >
+        <SearchResultFooter />
+      </TestApiProvider>,
+    );
+
+    expect(getByText(/try refining your search query/i)).toBeInTheDocument();
+
+    expect(queryByLabelText('previous page')).not.toBeInTheDocument();
+    expect(queryByLabelText('next page')).not.toBeInTheDocument();
+  });
+
+  it('includes pagination controls when permissions are disabled', async () => {
+    const { getByLabelText, queryByText } = await renderInTestApp(
+      <SearchResultFooter />,
+    );
+
+    expect(getByLabelText('previous page')).toBeInTheDocument();
+    expect(getByLabelText('next page')).toBeInTheDocument();
+
+    expect(
+      queryByText(/try refining your search query/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/plugins/search/src/components/SearchResultFooter/SearchResultFooter.tsx
+++ b/plugins/search/src/components/SearchResultFooter/SearchResultFooter.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-export * from './DefaultResultListItem';
-export * from './Filters';
-export * from './SearchBar';
-export * from './SearchContext';
-export * from './SearchFilter';
-export * from './SearchModal';
-export * from './SearchPage';
-export * from './SearchRefineResultsPrompt';
-export * from './SearchResult';
-export * from './SearchResultFooter';
-export * from './SearchResultPager';
-export * from './SearchType';
-export * from './SidebarSearch';
-export * from './SidebarSearchModal';
+import React from 'react';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { SearchRefineResultsPrompt } from '../SearchRefineResultsPrompt';
+import { SearchResultPager } from '../SearchResultPager';
+
+export const SearchResultFooter = () => {
+  const config = useApi(configApiRef);
+
+  if (config.getOptionalBoolean('permission.enabled')) {
+    return <SearchRefineResultsPrompt />;
+  }
+
+  return <SearchResultPager />;
+};

--- a/plugins/search/src/components/SearchResultFooter/index.tsx
+++ b/plugins/search/src/components/SearchResultFooter/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,4 @@
  * limitations under the License.
  */
 
-export * from './DefaultResultListItem';
-export * from './Filters';
-export * from './SearchBar';
-export * from './SearchContext';
-export * from './SearchFilter';
-export * from './SearchModal';
-export * from './SearchPage';
-export * from './SearchRefineResultsPrompt';
-export * from './SearchResult';
-export * from './SearchResultFooter';
-export * from './SearchResultPager';
-export * from './SearchType';
-export * from './SidebarSearch';
-export * from './SidebarSearchModal';
+export { SearchResultFooter } from './SearchResultFooter';

--- a/plugins/search/src/index.ts
+++ b/plugins/search/src/index.ts
@@ -31,6 +31,7 @@ export {
   SearchFilterNext,
   SearchModal,
   SearchPage as Router,
+  SearchResultFooter,
   SearchResultPager,
   SearchType,
   SidebarSearch,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Our current plan to integrate authorization into the search system includes disabling pagination when the permissions system is enabled. This is necessary because search results must be authorized result-by-result, which makes loading high page offsets expensive.

To match this backend behavior, this PR hides the pagination buttons when the permissions system is enabled, replacing them with a message encouraging the user to refine their search query if they haven't yet found what they're looking for.

#### Before

![Screenshot 2021-12-15 at 20 00 36](https://user-images.githubusercontent.com/542836/146256724-2548d612-30d2-42d9-a115-ece5a2aabf6f.png)

![Screenshot 2021-12-15 at 20 02 00](https://user-images.githubusercontent.com/542836/146256887-dee63119-31d6-490d-a171-32db9942ccc7.png)

#### After

![Screenshot 2021-12-15 at 19 59 23](https://user-images.githubusercontent.com/542836/146256737-95aa4e0d-b44e-4b3a-a733-f1c2ba730a19.png)

![Screenshot 2021-12-15 at 20 03 48](https://user-images.githubusercontent.com/542836/146257052-d2ad5c7c-8c3d-4d9d-93cf-ab540e60ea2b.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
