### PR TITLE
Correct keyword for microsoftAuthApiRef

### DIFF
--- a/docs/auth/microsoft/provider.md
+++ b/docs/auth/microsoft/provider.md
@@ -48,6 +48,6 @@ The Microsoft provider is a structure with three configuration keys:
 
 ## Adding the provider to the Backstage frontend
 
-To add the provider to the frontend, add the `microsoftAuthApi` reference and
+To add the provider to the frontend, add the `microsoftAuthApiRef` reference and
 `SignInPage` component as shown in
 [Adding the provider to the sign-in page](../index.md#adding-the-provider-to-the-sign-in-page).


### PR DESCRIPTION
Makes for a little less guesswork in the middle of things.

## Hey, I just made a Pull Request!

Changes a keyword in the docs for the Azure Auth provider, so one can follow the guides a little easier. Didn't work with the old "microsoftAuthApi", but did by adding `Ref` to the end.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
