### PR TITLE
fix(user-settings): use non-deprecated IdentityApi methods

### DIFF
--- a/.changeset/cuddly-suns-sit.md
+++ b/.changeset/cuddly-suns-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Fix undefined identity bug in UserSettingsProfileCard caused by using deprecated methods of the IdentityApi

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -119,5 +119,6 @@ export const UserSettingsThemeToggle: () => JSX.Element;
 export const useUserProfile: () => {
   profile: ProfileInfo;
   displayName: string;
+  loading: boolean;
 };
 ```

--- a/plugins/user-settings/src/components/useUserProfileInfo.ts
+++ b/plugins/user-settings/src/components/useUserProfileInfo.ts
@@ -17,6 +17,7 @@
 import {
   alertApiRef,
   identityApiRef,
+  ProfileInfo,
   useApi,
 } from '@backstage/core-plugin-api';
 import { useEffect } from 'react';
@@ -37,16 +38,22 @@ export const useUserProfile = () => {
     if (error) {
       alertApi.post({
         message: `Failed to load user identity: ${error}`,
-        severity: "error",
+        severity: 'error',
       });
     }
   }, [error, alertApi]);
 
+  if (loading || error) {
+    return {
+      profile: {} as ProfileInfo,
+      displayName: '',
+      loading,
+    };
+  }
+
   return {
-    profile: loading ? {} : value!.profile,
-    displayName: loading
-      ? ''
-      : value!.profile.displayName ?? value!.identity.userEntityRef,
+    profile: value!.profile,
+    displayName: value!.profile.displayName ?? value!.identity.userEntityRef,
     loading,
   };
 };

--- a/plugins/user-settings/src/components/useUserProfileInfo.ts
+++ b/plugins/user-settings/src/components/useUserProfileInfo.ts
@@ -14,13 +14,36 @@
  * limitations under the License.
  */
 
-import { useApi, identityApiRef } from '@backstage/core-plugin-api';
+import {
+  useApi,
+  identityApiRef,
+  BackstageUserIdentity,
+  ProfileInfo,
+} from '@backstage/core-plugin-api';
+import { useEffect, useState } from 'react';
 
 export const useUserProfile = () => {
   const identityApi = useApi(identityApiRef);
-  const userId = identityApi.getUserId();
-  const profile = identityApi.getProfile();
-  const displayName = profile.displayName ?? userId;
+
+  const [displayName, setDisplayName] = useState<
+    string | BackstageUserIdentity
+  >('');
+  const [profile, setProfile] = useState<ProfileInfo>({});
+
+  const getUserProfile = async () => {
+    const backstageIdentity = await identityApi.getBackstageIdentity();
+    const profileInfo = await identityApi.getProfileInfo();
+    const name = profileInfo.displayName ?? backstageIdentity;
+
+    setDisplayName(name);
+    setProfile(profileInfo);
+  };
+
+  useEffect(() => {
+    if (!displayName) {
+      getUserProfile();
+    }
+  });
 
   return { profile, displayName };
 };


### PR DESCRIPTION
This fixes the undefined identity error that is being thrown on the user-settings page.

Signed-off-by: Reinoud Kruithof <2184455+reinoudk@users.noreply.github.com>

## Hey, I just made a Pull Request!

I've updated the `useUserProfile` hook in `plugin-user-settings` so it uses the recommended API methods of `IdentityApi`.
These new methods are asynchronous, so I added the `useState` and `useEffect` hooks. I'm not a React developer at heart, so I'm not a 100% sure this is the way to go. It **does** fix #8520, but I don't know if I can write a regression test for it.

Sidenote: I'm not really sure the linter made the code in line 28 more readable...

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
