### PR TITLE
core-plugin-api: refactor StorageApi to better cater to async storage implementations

### DIFF
--- a/.changeset/cyan-seahorses-film.md
+++ b/.changeset/cyan-seahorses-film.md
@@ -1,0 +1,11 @@
+---
+'@backstage/core-plugin-api': minor
+---
+
+**BREAKING CHANGE** The `StorageApi` has received several updates that fills in gaps for some use-cases and makes it easier to avoid mistakes:
+
+- The `StorageValueChange` type has been renamed to `StorageValueSnapshot`, the `newValue` property has been renamed to `value`, the stored value type has been narrowed to `JsonValue`, and it has received a new `presence` property that is `'unknown'`, `'absent'`, or `'present'`.
+- The `get` method has been deprecated in favor of a new `snapshot` method, which returns a `StorageValueSnapshot`.
+- The `observe$` method has had its contract changed. It should now emit values when the `presence` of a key changes, this may for example happen when remotely stored values are requested on page load and the presence switches from `'unknown'` to either `'absent'` or `'present'`.
+
+The above changes have been made with deprecations in place to maintain much of the backwards compatibility for consumers of the `StorageApi`. The only breaking change is the narrowing of the stored value type, which may in some cases require the addition of an explicit type parameter to the `get` and `observe$` methods.

--- a/.changeset/gorgeous-beers-teach.md
+++ b/.changeset/gorgeous-beers-teach.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': minor
+---
+
+Updated `WebStorageApi` to reflect the `StorageApi` changes in `@backstage/core-plugin-api`.

--- a/.changeset/green-timers-film.md
+++ b/.changeset/green-timers-film.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': minor
+---
+
+Updated `MockStorageApi` to reflect the `StorageApi` changes in `@backstage/core-plugin-api`.

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -39,6 +39,7 @@ import { gitlabAuthApiRef } from '@backstage/core-plugin-api';
 import { googleAuthApiRef } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { IdentityApi } from '@backstage/core-plugin-api';
+import { JsonValue } from '@backstage/types';
 import { microsoftAuthApiRef } from '@backstage/core-plugin-api';
 import { OAuthApi } from '@backstage/core-plugin-api';
 import { OAuthRequestApi } from '@backstage/core-plugin-api';
@@ -59,7 +60,7 @@ import { RouteRef } from '@backstage/core-plugin-api';
 import { SessionApi } from '@backstage/core-plugin-api';
 import { SessionState } from '@backstage/core-plugin-api';
 import { StorageApi } from '@backstage/core-plugin-api';
-import { StorageValueChange } from '@backstage/core-plugin-api';
+import { StorageValueSnapshot } from '@backstage/core-plugin-api';
 import { SubRouteRef } from '@backstage/core-plugin-api';
 
 // @public
@@ -606,10 +607,12 @@ export class WebStorage implements StorageApi {
   // (undocumented)
   get<T>(key: string): T | undefined;
   // (undocumented)
-  observe$<T>(key: string): Observable<StorageValueChange<T>>;
+  observe$<T>(key: string): Observable<StorageValueSnapshot<T>>;
   // (undocumented)
   remove(key: string): Promise<void>;
   // (undocumented)
   set<T>(key: string, data: T): Promise<void>;
+  // (undocumented)
+  snapshot<T extends JsonValue>(key: string): StorageValueSnapshot<T>;
 }
 ```

--- a/packages/core-plugin-api/api-report.md
+++ b/packages/core-plugin-api/api-report.md
@@ -10,6 +10,7 @@ import { ComponentType } from 'react';
 import { Config } from '@backstage/config';
 import { IconComponent as IconComponent_2 } from '@backstage/core-plugin-api';
 import { IdentityApi as IdentityApi_2 } from '@backstage/core-plugin-api';
+import { JsonValue } from '@backstage/types';
 import { Observable } from '@backstage/types';
 import { ProfileInfo as ProfileInfo_2 } from '@backstage/core-plugin-api';
 import { default as React_2 } from 'react';
@@ -762,20 +763,37 @@ export type SignInResult = {
 // @public
 export interface StorageApi {
   forBucket(name: string): StorageApi;
-  get<T>(key: string): T | undefined;
-  observe$<T>(key: string): Observable<StorageValueChange<T>>;
+  // @deprecated
+  get<T extends JsonValue>(key: string): T | undefined;
+  observe$<T extends JsonValue>(
+    key: string,
+  ): Observable<StorageValueSnapshot<T>>;
   remove(key: string): Promise<void>;
-  set(key: string, data: any): Promise<void>;
+  set<T extends JsonValue>(key: string, data: T): Promise<void>;
+  snapshot<T extends JsonValue>(key: string): StorageValueSnapshot<T>;
 }
 
 // @public
 export const storageApiRef: ApiRef<StorageApi>;
 
+// @public @deprecated (undocumented)
+export type StorageValueChange<TValue extends JsonValue> =
+  StorageValueSnapshot<TValue>;
+
 // @public
-export type StorageValueChange<T = any> = {
-  key: string;
-  newValue?: T;
-};
+export type StorageValueSnapshot<TValue extends JsonValue> =
+  | {
+      key: string;
+      presence: 'unknown' | 'absent';
+      value?: undefined;
+      newValue?: undefined;
+    }
+  | {
+      key: string;
+      presence: 'present';
+      value: TValue;
+      newValue?: TValue;
+    };
 
 // @public
 export type SubRouteRef<Params extends AnyParams = any> = {

--- a/packages/core-plugin-api/src/apis/definitions/StorageApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/StorageApi.ts
@@ -38,7 +38,10 @@ export type StorageValueSnapshot<TValue extends JsonValue> =
       newValue?: TValue;
     };
 
-/** @deprecated Use StorageValueSnapshot instead */
+/**
+ * @public
+ * @deprecated Use StorageValueSnapshot instead
+ */
 export type StorageValueChange<TValue extends JsonValue> =
   StorageValueSnapshot<TValue>;
 

--- a/packages/core-plugin-api/src/apis/definitions/StorageApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/StorageApi.ts
@@ -15,55 +15,102 @@
  */
 
 import { ApiRef, createApiRef } from '../system';
-import { Observable } from '@backstage/types';
+import { JsonValue, Observable } from '@backstage/types';
 
 /**
- * Describes a value change event.
+ * A snapshot in time of the current known value of a storage key.
  *
  * @public
  */
-export type StorageValueChange<T = any> = {
-  key: string;
-  newValue?: T;
-};
+export type StorageValueSnapshot<TValue extends JsonValue> =
+  | {
+      key: string;
+      presence: 'unknown' | 'absent';
+      value?: undefined;
+      /** @deprecated Use `value` instead */
+      newValue?: undefined;
+    }
+  | {
+      key: string;
+      presence: 'present';
+      value: TValue;
+      /** @deprecated Use `value` instead */
+      newValue?: TValue;
+    };
+
+/** @deprecated Use StorageValueSnapshot instead */
+export type StorageValueChange<TValue extends JsonValue> =
+  StorageValueSnapshot<TValue>;
 
 /**
- * Provides key-value persistence API.
+ * Provides a key-value persistence API.
  *
  * @public
  */
 export interface StorageApi {
   /**
    * Create a bucket to store data in.
+   *
    * @param name - Namespace for the storage to be stored under,
-   *                      will inherit previous namespaces too
+   *               will inherit previous namespaces too
    */
   forBucket(name: string): StorageApi;
 
   /**
    * Get the current value for persistent data, use observe$ to be notified of updates.
+   *
+   * @deprecated Use `snapshot` instead.
    * @param key - Unique key associated with the data.
    */
-  get<T>(key: string): T | undefined;
+  get<T extends JsonValue>(key: string): T | undefined;
 
   /**
    * Remove persistent data.
+   *
    * @param key - Unique key associated with the data.
    */
   remove(key: string): Promise<void>;
 
   /**
-   * Save persistent data, and emit messages to anyone that is using observe$ for this key
+   * Save persistent data, and emit messages to anyone that is using
+   * {@link StorageApi.observe$} for this key.
+   *
    * @param key - Unique key associated with the data.
    * @param data - The data to be stored under the key.
    */
-  set(key: string, data: any): Promise<void>;
+  set<T extends JsonValue>(key: string, data: T): Promise<void>;
 
   /**
-   * Observe changes on a particular key in the bucket
+   * Observe the value over time for a particular key in the current bucket.
+   *
+   * @remarks
+   *
+   * The returned observable will immediately emit a value snapshot when
+   * subscribed to, even if the presence of the value is unknown at that time.
+   *
+   * The values emitted by the observe method aim to keep reference equality
+   * across snapshots if the value is unchanged. This means that it is important
+   * not to mutate the returned values, and they may be frozen as a precaution.
+   *
    * @param key - Unique key associated with the data
    */
-  observe$<T>(key: string): Observable<StorageValueChange<T>>;
+  observe$<T extends JsonValue>(
+    key: string,
+  ): Observable<StorageValueSnapshot<T>>;
+
+  /**
+   * Returns an immediate snapshot value for the given key, if possible.
+   *
+   * @remarks
+   *
+   * Combine with {@link StorageApi.observe$} to get notified of value changes.
+   *
+   * Note that this method is synchronous, and some underlying storages may be
+   * unable to retrieve a value using this method - the result may or may not
+   * consistently have a presence of 'unknown'. Use {@link StorageApi.observe$}
+   * to be sure to receive an actual value eventually.
+   */
+  snapshot<T extends JsonValue>(key: string): StorageValueSnapshot<T>;
 }
 
 /**

--- a/packages/core-plugin-api/src/apis/definitions/StorageApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/StorageApi.ts
@@ -85,12 +85,15 @@ export interface StorageApi {
    *
    * @remarks
    *
-   * The returned observable will immediately emit a value snapshot when
-   * subscribed to, even if the presence of the value is unknown at that time.
+   * The observable will only emit values when the value changes in the underlying
+   * storage, although multiple values with the same shape may be emitted in a row.
    *
-   * The values emitted by the observe method aim to keep reference equality
-   * across snapshots if the value is unchanged. This means that it is important
-   * not to mutate the returned values, and they may be frozen as a precaution.
+   * If a {@link StorageApi.snapshot} of a key is retrieved and the presence is
+   * `'unknown'`, then you are guaranteed to receive a snapshot with a known
+   * presence, as long as you observe the key within the same tick.
+   *
+   * Since the emitted values are shared across all subscribers, it is important
+   * not to mutate the returned values. The values may be frozen as a precaution.
    *
    * @param key - Unique key associated with the data
    */

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -12,13 +12,14 @@ import { ErrorApi } from '@backstage/core-plugin-api';
 import { ErrorApiError } from '@backstage/core-plugin-api';
 import { ErrorApiErrorContext } from '@backstage/core-plugin-api';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
+import { JsonValue } from '@backstage/types';
 import { Observable } from '@backstage/types';
 import { ReactElement } from 'react';
 import { ReactNode } from 'react';
 import { RenderResult } from '@testing-library/react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { StorageApi } from '@backstage/core-plugin-api';
-import { StorageValueChange } from '@backstage/core-plugin-api';
+import { StorageValueSnapshot } from '@backstage/core-plugin-api';
 
 // @public
 export type AsyncLogCollector = () => Promise<void>;
@@ -81,11 +82,13 @@ export class MockStorageApi implements StorageApi {
   // (undocumented)
   get<T>(key: string): T | undefined;
   // (undocumented)
-  observe$<T>(key: string): Observable<StorageValueChange<T>>;
+  observe$<T>(key: string): Observable<StorageValueSnapshot<T>>;
   // (undocumented)
   remove(key: string): Promise<void>;
   // (undocumented)
   set<T>(key: string, data: T): Promise<void>;
+  // (undocumented)
+  snapshot<T extends JsonValue>(key: string): StorageValueSnapshot<T>;
 }
 
 // @public

--- a/plugins/catalog-react/src/apis/StarredEntitiesApi/migration.ts
+++ b/plugins/catalog-react/src/apis/StarredEntitiesApi/migration.ts
@@ -41,8 +41,7 @@ export async function performMigrationToTheNewBucket({
     // nothing to do
     return;
   }
-
-  const targetEntities = new Set(target.get('entityRefs') ?? []);
+  const targetEntities = new Set(target.get<string[]>('entityRefs') ?? []);
 
   oldStarredEntities
     .filter(isString)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #8412 as this is the final piece.

This change picks up the thread in #7336, where we realized that the StorageApi was lacking a way to wait for an up-to-date value. That can now be done by getting a snapshot for a key and check the `presence`. If the presence is `'unknown'` it is safe to observe the same key within the same tick, as the observable is now guaranteed to emit a value when the presence changes, which for example would happen after loading a remote value.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
