### PR TITLE
auth-backend: fix identity fallback to populate userEntityRef correctly

### DIFF
--- a/.changeset/rare-ladybugs-invite.md
+++ b/.changeset/rare-ladybugs-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed the fallback identity population to correctly generate an entity reference for `userEntityRef` if no token is provided.

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -18,6 +18,11 @@ import express from 'express';
 import crypto from 'crypto';
 import { URL } from 'url';
 import {
+  ENTITY_DEFAULT_NAMESPACE,
+  parseEntityRef,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
+import {
   AuthProviderRouteHandlers,
   AuthProviderConfig,
   BackstageIdentityResponse,
@@ -243,8 +248,14 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
       return prepareBackstageIdentityResponse(identity);
     }
 
+    const userEntityRef = stringifyEntityRef(
+      parseEntityRef(identity.id, {
+        defaultKind: 'user',
+        defaultNamespace: ENTITY_DEFAULT_NAMESPACE,
+      }),
+    );
     const token = await this.options.tokenIssuer.issueToken({
-      claims: { sub: identity.id },
+      claims: { sub: userEntityRef },
     });
 
     return prepareBackstageIdentityResponse({ ...identity, token });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The current fallback is currently converting for example `id: 'foo'` into `userEntityRef: 'foo'`. The intended conversion is to use the full entity ref, `'user:default/foo'`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
