### PR TITLE
Techdocs - Don't Copy docs/README.md -> index.md if it is provided

### DIFF
--- a/.changeset/twenty-balloons-cross.md
+++ b/.changeset/twenty-balloons-cross.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': minor
+---
+
+Prevent copying docs/README.md to docs/index.md. This allows the default MkDocs behavior of using a docs/README.md in place of an docs/index.md file.

--- a/.changeset/twenty-balloons-cross.md
+++ b/.changeset/twenty-balloons-cross.md
@@ -2,4 +2,4 @@
 '@backstage/techdocs-common': minor
 ---
 
-Prevent copying docs/README.md to docs/index.md. This allows the default MkDocs behavior of using a docs/README.md in place of an docs/index.md file.
+Prevent copying docs/README.md to docs/index.md. This allows the default MkDocs behavior of using a docs/README.md in place of a docs/index.md file.

--- a/packages/techdocs-common/src/stages/generate/helpers.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.ts
@@ -300,8 +300,8 @@ export const patchMkdocsYmlPreBuild = async (
 
 /**
  * Update docs/index.md file before TechDocs generator uses it to generate docs site,
- * falling back to docs/README.md or README.md in case a default docs/index.md
- * is not provided.
+ * falling back to README.md or readme.md or docs/readme.md in case a default docs/index.md
+ * or docs/README.md is not provided.
  */
 export const patchIndexPreBuild = async ({
   inputDir,

--- a/packages/techdocs-common/src/stages/generate/helpers.ts
+++ b/packages/techdocs-common/src/stages/generate/helpers.ts
@@ -314,13 +314,16 @@ export const patchIndexPreBuild = async ({
 }) => {
   const docsPath = path.join(inputDir, docsDir);
   const indexMdPath = path.join(docsPath, 'index.md');
+  const readmeMdPath = path.join(docsPath, 'README.md');
 
-  if (await fs.pathExists(indexMdPath)) {
+  if (
+    (await fs.pathExists(indexMdPath)) ||
+    (await fs.pathExists(readmeMdPath))
+  ) {
     return;
   }
-  logger.warn(`${path.join(docsDir, 'index.md')} not found.`);
+  logger.warn(`No index.md or README.md found in ${docsPath}.`);
   const fallbacks = [
-    path.join(docsPath, 'README.md'),
     path.join(docsPath, 'readme.md'),
     path.join(inputDir, 'README.md'),
     path.join(inputDir, 'readme.md'),
@@ -339,6 +342,7 @@ export const patchIndexPreBuild = async ({
   logger.warn(
     `Could not find any techdocs' index file. Please make sure at least one of ${[
       indexMdPath,
+      readmeMdPath,
       ...fallbacks,
     ].join(' ')} exists.`,
   );


### PR DESCRIPTION
MkDocs allows you to use a `README.md` in place of an `index.md`:

> Many repository hosting sites provide special treatment for README files by displaying the contents of the README file when browsing the contents of a directory. Therefore, MkDocs will allow you to name your index pages as README.md instead of index.md. In that way, when users are browsing your source code, the repository host can display the index page of that directory as it is a README file. However, when MkDocs renders your site, the file will be renamed to index.html so that the server will serve it as a proper index file.

> If both an index.md file and a README.md file are found in the same directory, then the index.md file is used and the README.md file is ignored.
- https://www.mkdocs.org/user-guide/writing-your-docs/

As the above mentions, if an `index.md` is detected, the `README.md` is ignored. https://github.com/mkdocs/mkdocs/pull/1582

If a `docs/README.md` is provided, TechDocs should not copy this file over to an `index.md` file, as this breaks rendering of the docs. (Using `README.md` as a reference in `mkdocs.yaml`)

Since all of the fallbacks are variants of `README.md(docs/readme.md, README.md, readme.md)`, I was considering copying this file over to `docs/README.md` instead of `docs/index.md`. However, this would further break the implementations of user's who are referencing `index.md` in their `mkdocs.yaml` files, and relying on the patch/copy. To be clear, this will break any implementations that supply a `docs/README.md`, expect the patch/copy to happen, and use a reference to `index.md` in their `mkdocs.yaml` file. For example:

`ls docs/ -> README.md` (No `index.md` file provided)

mkdocs.yaml
```
site_name: Hello
site_description: Hello World 
nav:
  - Home: index.md
  - User Guide': user-guide.md
plugins:
  - techdocs-core
```

^ That would break with this change. But I think it makes sense to enforce the reference of `README.md` for these cases, as that is what is expected in the MkDocs documentation.

mkdocs.yaml
```
site_name: Hello
site_description: Hello World 
nav:
  - Home: README.md
  - User Guide': user-guide.md
plugins:
  - techdocs-core
```
^ Works

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
