### PR TITLE
backend-common: clarify responsiblity of readTree directory deletion

### DIFF
--- a/.changeset/hip-doors-joke.md
+++ b/.changeset/hip-doors-joke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Updated the `ReadTreeResponse` documentation to clarify that the caller of `dir()` is responsible for removing the directory after use.

--- a/packages/backend-common/src/reading/types.ts
+++ b/packages/backend-common/src/reading/types.ts
@@ -222,6 +222,8 @@ export type ReadTreeResponse = {
   /**
    * Extracts the tree response into a directory and returns the path of the
    * directory.
+   *
+   * **NOTE**: It is the responsibility of the caller to remove the directory after use.
    */
   dir(options?: ReadTreeResponseDirOptions): Promise<string>;
 


### PR DESCRIPTION
A missing clarification 🧹 