### PR TITLE
chore: lock `rc-progress` to a working version

### DIFF
--- a/.changeset/gorgeous-hats-fold.md
+++ b/.changeset/gorgeous-hats-fold.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-components': patch
+'@backstage/plugin-sonarqube': patch
+---
+
+Locking `rc-progress` to the working version of 3.1.4

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -51,7 +51,7 @@
     "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "qs": "^6.9.4",
-    "rc-progress": "^3.0.0",
+    "rc-progress": "3.1.4",
     "react-helmet": "6.1.0",
     "react-hook-form": "^7.12.2",
     "react-markdown": "^7.0.1",

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -43,7 +43,7 @@
     "@material-ui/lab": "4.0.0-alpha.57",
     "@material-ui/styles": "^4.10.0",
     "cross-fetch": "^3.0.6",
-    "rc-progress": "^3.0.0",
+    "rc-progress": "3.1.4",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24290,7 +24290,7 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-rc-progress@^3.0.0:
+rc-progress@3.1.4, rc-progress@^3.0.0:
   version "3.1.4"
   resolved "https://registry.npmjs.org/rc-progress/-/rc-progress-3.1.4.tgz#66040d0fae7d8ced2b38588378eccb2864bad615"
   integrity sha512-XBAif08eunHssGeIdxMXOmRQRULdHaDdIFENQ578CMb4dyewahmmfJRyab+hw4KH4XssEzzYOkAInTLS7JJG+Q==


### PR DESCRIPTION
Should fix the e2e tests.
