### PR TITLE
backend-common: make sure readTree temp dirs are cleaned up

### DIFF
--- a/.changeset/friendly-seals-peel.md
+++ b/.changeset/friendly-seals-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Ensure temporary directories are cleaned up if an error is thrown in the `filter` callback of the `UrlReader.readTree` options.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Making sure we don't leave directories behind after `readTree`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
