### PR TITLE
fixes api auth bug in techdocs backend

### DIFF
--- a/.changeset/seven-tomatoes-smash.md
+++ b/.changeset/seven-tomatoes-smash.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-techdocs-backend': minor
+'@backstage/plugin-techdocs-backend': patch
 ---
 
-fixes api auth bug in techdocs backend
+Add support for API auth in DefaultTechDocsCollator

--- a/.changeset/seven-tomatoes-smash.md
+++ b/.changeset/seven-tomatoes-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+---
+
+fixes api auth bug in techdocs backend

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
@@ -123,6 +123,11 @@ export class DefaultTechDocsCollator implements DocumentCollator {
                 techDocsBaseUrl,
                 entityInfo,
               ),
+              {
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                },
+              },
             );
             const searchIndex = await searchIndexResponse.json();
 


### PR DESCRIPTION
Signed-off-by: Erik Larsson <erik.larsson@schibsted.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

DefaultTechDocsCollator does not supply an api token when fetching search indices for tech docs, resulting in 401 responses for backends requiring api tokens and thus failed search indexing. This PR adds the api token to the requests to fix that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
