### PR TITLE
Kubernetes Plugin: Export CustomisationProps

### DIFF
--- a/.changeset/friendly-baboons-sparkle.md
+++ b/.changeset/friendly-baboons-sparkle.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes': patch
 ---
 
-Export a CustomisationProps object from the kubernetes plugin, which includes a customPodTableColumns argument, to allow users to add additional custom columns to the Pod Table in the Deployments Accordion
+Export a CustomisationProps object from the kubernetes plugin, which includes a customPodTableColumns argument, to allow users to specify the columns they'd like on the Pod Table in the Deployments Accordion

--- a/.changeset/friendly-baboons-sparkle.md
+++ b/.changeset/friendly-baboons-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Export a CustomisationProps object from the kubernetes plugin, which includes a customPodTableColumns argument, to allow users to add additional custom columns to the Pod Table in the Deployments Accordion

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -14,6 +14,8 @@ import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { OAuthApi } from '@backstage/core-plugin-api';
 import { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';
 import { RouteRef } from '@backstage/core-plugin-api';
+import { TableColumn } from '@backstage/core-components';
+import { V1Pod } from '@kubernetes/client-node';
 
 // Warning: (ae-forgotten-export) The symbol "ClusterLinksFormatter" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "clusterLinksFormatters" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -21,11 +23,22 @@ import { RouteRef } from '@backstage/core-plugin-api';
 // @public (undocumented)
 export const clusterLinksFormatters: Record<string, ClusterLinksFormatter>;
 
+// Warning: (ae-missing-release-tag) "CustomisationProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface CustomisationProps {
+  // (undocumented)
+  customPodTableColumns: TableColumn<V1Pod>[];
+}
+
 // Warning: (ae-missing-release-tag) "EntityKubernetesContent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const EntityKubernetesContent: (_props: {
+export const EntityKubernetesContent: ({
+  customisationProps,
+}: {
   entity?: Entity | undefined;
+  customisationProps?: CustomisationProps | undefined;
 }) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "FormatClusterLinkOptions" needs to be exported by the entry point index.d.ts
@@ -128,5 +141,5 @@ export { kubernetesPlugin as plugin };
 // Warning: (ae-missing-release-tag) "Router" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const Router: (_props: Props) => JSX.Element;
+export const Router: ({ customisationProps }: Props) => JSX.Element;
 ```

--- a/plugins/kubernetes/src/Router.tsx
+++ b/plugins/kubernetes/src/Router.tsx
@@ -21,6 +21,7 @@ import { Route, Routes } from 'react-router-dom';
 import { KubernetesContent } from './components/KubernetesContent';
 import { Button } from '@material-ui/core';
 import { MissingAnnotationEmptyState } from '@backstage/core-components';
+import { CustomisationProps } from './api/types';
 
 const KUBERNETES_ANNOTATION = 'backstage.io/kubernetes-id';
 const KUBERNETES_LABEL_SELECTOR_QUERY_ANNOTATION =
@@ -35,9 +36,10 @@ export const isKubernetesAvailable = (entity: Entity) =>
 type Props = {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: Entity;
+  customisationProps?: typeof CustomisationProps;
 };
 
-export const Router = (_props: Props) => {
+export const Router = ({ customisationProps }: Props) => {
   const { entity } = useEntity();
 
   const kubernetesAnnotationValue =
@@ -52,7 +54,15 @@ export const Router = (_props: Props) => {
   ) {
     return (
       <Routes>
-        <Route path="/" element={<KubernetesContent entity={entity} />} />
+        <Route
+          path="/"
+          element={
+            <KubernetesContent
+              entity={entity}
+              customisationProps={customisationProps}
+            />
+          }
+        />
       </Routes>
     );
   }

--- a/plugins/kubernetes/src/Router.tsx
+++ b/plugins/kubernetes/src/Router.tsx
@@ -36,7 +36,7 @@ export const isKubernetesAvailable = (entity: Entity) =>
 type Props = {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: Entity;
-  customisationProps?: typeof CustomisationProps;
+  customisationProps?: CustomisationProps;
 };
 
 export const Router = ({ customisationProps }: Props) => {

--- a/plugins/kubernetes/src/api/index.ts
+++ b/plugins/kubernetes/src/api/index.ts
@@ -17,4 +17,4 @@
 export { kubernetesApiRef } from './types';
 export type { KubernetesApi } from './types';
 export { KubernetesBackendClient } from './KubernetesBackendClient';
-export { CustomisationProps } from './types';
+export type { CustomisationProps } from './types';

--- a/plugins/kubernetes/src/api/index.ts
+++ b/plugins/kubernetes/src/api/index.ts
@@ -17,3 +17,4 @@
 export { kubernetesApiRef } from './types';
 export type { KubernetesApi } from './types';
 export { KubernetesBackendClient } from './KubernetesBackendClient';
+export { CustomisationProps } from './types';

--- a/plugins/kubernetes/src/api/types.ts
+++ b/plugins/kubernetes/src/api/types.ts
@@ -33,8 +33,6 @@ export interface KubernetesApi {
   getClusters(): Promise<{ name: string; authProvider: string }[]>;
 }
 
-export class CustomisationProps {
-  constructor(customPodTableColumns: TableColumn<V1Pod>[]) {
-    this.customPodTableColumns = customPodTableColumns;
-  }
+export interface CustomisationProps {
+  customPodTableColumns: TableColumn<V1Pod>[];
 }

--- a/plugins/kubernetes/src/api/types.ts
+++ b/plugins/kubernetes/src/api/types.ts
@@ -19,6 +19,8 @@ import {
   ObjectsByEntityResponse,
 } from '@backstage/plugin-kubernetes-common';
 import { createApiRef } from '@backstage/core-plugin-api';
+import { V1Pod } from '@kubernetes/client-node';
+import { TableColumn } from '@backstage/core-components';
 
 export const kubernetesApiRef = createApiRef<KubernetesApi>({
   id: 'plugin.kubernetes.service',
@@ -29,4 +31,10 @@ export interface KubernetesApi {
     requestBody: KubernetesRequestBody,
   ): Promise<ObjectsByEntityResponse>;
   getClusters(): Promise<{ name: string; authProvider: string }[]>;
+}
+
+export class CustomisationProps {
+  constructor(customPodTableColumns: TableColumn<V1Pod>[]) {
+    this.customPodTableColumns = customPodTableColumns;
+  }
 }

--- a/plugins/kubernetes/src/components/Cluster/Cluster.tsx
+++ b/plugins/kubernetes/src/components/Cluster/Cluster.tsx
@@ -42,6 +42,7 @@ import {
 
 import { StatusError, StatusOK } from '@backstage/core-components';
 import { PodNamesWithMetricsContext } from '../../hooks/PodNamesWithMetrics';
+import { CustomisationProps } from '../../api/types';
 
 type ClusterSummaryProps = {
   clusterName: string;
@@ -107,10 +108,15 @@ const ClusterSummary = ({
 type ClusterProps = {
   clusterObjects: ClusterObjects;
   podsWithErrors: Set<string>;
+  customisationProps?: typeof CustomisationProps;
   children?: React.ReactNode;
 };
 
-export const Cluster = ({ clusterObjects, podsWithErrors }: ClusterProps) => {
+export const Cluster = ({
+  clusterObjects,
+  podsWithErrors,
+  customisationProps,
+}: ClusterProps) => {
   const groupedResponses = groupResponses(clusterObjects.resources);
   const podNameToMetrics = clusterObjects.podMetrics
     .flat()
@@ -140,7 +146,9 @@ export const Cluster = ({ clusterObjects, podsWithErrors }: ClusterProps) => {
                     <CustomResources />
                   </Grid>
                   <Grid item>
-                    <DeploymentsAccordions />
+                    <DeploymentsAccordions
+                      customisationProps={customisationProps}
+                    />
                   </Grid>
                   <Grid item>
                     <IngressesAccordions />

--- a/plugins/kubernetes/src/components/Cluster/Cluster.tsx
+++ b/plugins/kubernetes/src/components/Cluster/Cluster.tsx
@@ -108,7 +108,7 @@ const ClusterSummary = ({
 type ClusterProps = {
   clusterObjects: ClusterObjects;
   podsWithErrors: Set<string>;
-  customisationProps?: typeof CustomisationProps;
+  customisationProps?: CustomisationProps;
   children?: React.ReactNode;
 };
 

--- a/plugins/kubernetes/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
+++ b/plugins/kubernetes/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
@@ -45,7 +45,7 @@ import { READY_COLUMNS, RESOURCE_COLUMNS } from '../Pods/PodsTable';
 import { CustomisationProps } from '../../api/types';
 
 type DeploymentsAccordionsProps = {
-  customisationProps?: typeof CustomisationProps;
+  customisationProps?: CustomisationProps;
   children?: React.ReactNode;
 };
 
@@ -53,7 +53,7 @@ type DeploymentAccordionProps = {
   deployment: V1Deployment;
   ownedPods: V1Pod[];
   matchingHpa?: V1HorizontalPodAutoscaler;
-  customisationProps?: typeof CustomisationProps;
+  customisationProps?: CustomisationProps;
   children?: React.ReactNode;
 };
 

--- a/plugins/kubernetes/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
+++ b/plugins/kubernetes/src/components/DeploymentsAccordions/DeploymentsAccordions.tsx
@@ -42,8 +42,10 @@ import {
 } from '../../hooks';
 import { StatusError, StatusOK } from '@backstage/core-components';
 import { READY_COLUMNS, RESOURCE_COLUMNS } from '../Pods/PodsTable';
+import { CustomisationProps } from '../../api/types';
 
 type DeploymentsAccordionsProps = {
+  customisationProps?: typeof CustomisationProps;
   children?: React.ReactNode;
 };
 
@@ -51,6 +53,7 @@ type DeploymentAccordionProps = {
   deployment: V1Deployment;
   ownedPods: V1Pod[];
   matchingHpa?: V1HorizontalPodAutoscaler;
+  customisationProps?: typeof CustomisationProps;
   children?: React.ReactNode;
 };
 
@@ -144,12 +147,15 @@ const DeploymentAccordion = ({
   deployment,
   ownedPods,
   matchingHpa,
+  customisationProps,
 }: DeploymentAccordionProps) => {
   const podNamesWithErrors = useContext(PodNamesWithErrorsContext);
 
   const podsWithErrors = ownedPods.filter(p =>
     podNamesWithErrors.has(p.metadata?.name ?? ''),
   );
+
+  const customColumns = customisationProps?.customPodTableColumns || [];
 
   return (
     <Accordion TransitionProps={{ unmountOnExit: true }}>
@@ -165,13 +171,16 @@ const DeploymentAccordion = ({
         <PodsTable
           pods={ownedPods}
           extraColumns={[READY_COLUMNS, RESOURCE_COLUMNS]}
+          customColumns={customColumns}
         />
       </AccordionDetails>
     </Accordion>
   );
 };
 
-export const DeploymentsAccordions = ({}: DeploymentsAccordionsProps) => {
+export const DeploymentsAccordions = ({
+  customisationProps,
+}: DeploymentsAccordionsProps) => {
   const groupedResponses = useContext(GroupedResponsesContext);
 
   return (
@@ -196,6 +205,7 @@ export const DeploymentsAccordions = ({}: DeploymentsAccordionsProps) => {
                 groupedResponses.pods,
               )}
               deployment={deployment}
+              customisationProps={customisationProps}
             />
           </Grid>
         </Grid>

--- a/plugins/kubernetes/src/components/KubernetesContent.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent.tsx
@@ -24,10 +24,18 @@ import { Cluster } from './Cluster';
 import EmptyStateImage from '../assets/emptystate.svg';
 import { useKubernetesObjects } from '../hooks';
 import { Content, Page, Progress } from '@backstage/core-components';
+import { CustomisationProps } from '../api/types';
 
-type KubernetesContentProps = { entity: Entity; children?: React.ReactNode };
+type KubernetesContentProps = {
+  entity: Entity;
+  customisationProps?: typeof CustomisationProps;
+  children?: React.ReactNode;
+};
 
-export const KubernetesContent = ({ entity }: KubernetesContentProps) => {
+export const KubernetesContent = ({
+  entity,
+  customisationProps,
+}: KubernetesContentProps) => {
   const { kubernetesObjects, error } = useKubernetesObjects(entity);
 
   const clustersWithErrors =
@@ -117,6 +125,7 @@ export const KubernetesContent = ({ entity }: KubernetesContentProps) => {
                       <Cluster
                         clusterObjects={item}
                         podsWithErrors={podsWithErrors}
+                        customisationProps={customisationProps}
                       />
                     </Grid>
                   );

--- a/plugins/kubernetes/src/components/KubernetesContent.tsx
+++ b/plugins/kubernetes/src/components/KubernetesContent.tsx
@@ -28,7 +28,7 @@ import { CustomisationProps } from '../api/types';
 
 type KubernetesContentProps = {
   entity: Entity;
-  customisationProps?: typeof CustomisationProps;
+  customisationProps?: CustomisationProps;
   children?: React.ReactNode;
 };
 

--- a/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
@@ -22,6 +22,15 @@ import { wrapInTestApp } from '@backstage/test-utils';
 import { PodsTable, READY_COLUMNS, RESOURCE_COLUMNS } from './PodsTable';
 import { kubernetesProviders } from '../../hooks/test-utils';
 import { ClientPodStatus } from '@backstage/plugin-kubernetes-common';
+import { V1Pod } from '@kubernetes/client-node';
+import { TableColumn } from '@backstage/core-components';
+
+const customColumns: TableColumn<V1Pod>[] = [
+  {
+    title: 'Custom Column',
+    align: 'center',
+  },
+];
 
 describe('PodsTable', () => {
   it('should render pod', async () => {
@@ -176,5 +185,34 @@ describe('PodsTable', () => {
     expect(getByText('Container: side-car')).toBeInTheDocument();
     expect(getByText('Container: other-side-car')).toBeInTheDocument();
     expect(getAllByText('CrashLoopBackOff')).toHaveLength(2);
+  });
+  it('should render additional custom columns', async () => {
+    const { getByText, getAllByText } = render(
+      wrapInTestApp(
+        <PodsTable
+          pods={[pod as any]}
+          extraColumns={[READY_COLUMNS, RESOURCE_COLUMNS]}
+          customColumns={customColumns}
+        />,
+      ),
+    );
+
+    // titles
+    expect(getByText('name')).toBeInTheDocument();
+    expect(getByText('phase')).toBeInTheDocument();
+    expect(getByText('containers ready')).toBeInTheDocument();
+    expect(getByText('total restarts')).toBeInTheDocument();
+    expect(getByText('status')).toBeInTheDocument();
+    expect(getByText('CPU usage %')).toBeInTheDocument();
+    expect(getByText('Memory usage %')).toBeInTheDocument();
+    expect(getByText('Custom Column')).toBeInTheDocument();
+
+    // values
+    expect(getByText('dice-roller-6c8646bfd-2m5hv')).toBeInTheDocument();
+    expect(getByText('Running')).toBeInTheDocument();
+    expect(getByText('1/1')).toBeInTheDocument();
+    expect(getByText('0')).toBeInTheDocument();
+    expect(getByText('OK')).toBeInTheDocument();
+    expect(getAllByText('unknown')).toHaveLength(2);
   });
 });

--- a/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
@@ -19,7 +19,13 @@ import { render } from '@testing-library/react';
 import * as pod from './__fixtures__/pod.json';
 import * as crashingPod from './__fixtures__/crashing-pod.json';
 import { wrapInTestApp } from '@backstage/test-utils';
-import { PodsTable, READY_COLUMNS, RESOURCE_COLUMNS } from './PodsTable';
+import {
+  PodsTable,
+  DEFAULT_COLUMNS,
+  READY_COLUMNS,
+  RESOURCE_COLUMNS,
+  READY,
+} from './PodsTable';
 import { kubernetesProviders } from '../../hooks/test-utils';
 import { ClientPodStatus } from '@backstage/plugin-kubernetes-common';
 import { V1Pod } from '@kubernetes/client-node';
@@ -187,12 +193,16 @@ describe('PodsTable', () => {
     expect(getAllByText('CrashLoopBackOff')).toHaveLength(2);
   });
   it('should render additional custom columns', async () => {
+    const columns: TableColumn<V1Pod>[] = [];
+    columns.push(...DEFAULT_COLUMNS);
+    columns.push(...READY);
+    columns.push(...customColumns);
     const { getByText, getAllByText } = render(
       wrapInTestApp(
         <PodsTable
           pods={[pod as any]}
-          extraColumns={[READY_COLUMNS, RESOURCE_COLUMNS]}
-          customColumns={customColumns}
+          extraColumns={[]}
+          customColumns={columns}
         />,
       ),
     );
@@ -203,8 +213,6 @@ describe('PodsTable', () => {
     expect(getByText('containers ready')).toBeInTheDocument();
     expect(getByText('total restarts')).toBeInTheDocument();
     expect(getByText('status')).toBeInTheDocument();
-    expect(getByText('CPU usage %')).toBeInTheDocument();
-    expect(getByText('Memory usage %')).toBeInTheDocument();
     expect(getByText('Custom Column')).toBeInTheDocument();
 
     // values
@@ -213,6 +221,5 @@ describe('PodsTable', () => {
     expect(getByText('1/1')).toBeInTheDocument();
     expect(getByText('0')).toBeInTheDocument();
     expect(getByText('OK')).toBeInTheDocument();
-    expect(getAllByText('unknown')).toHaveLength(2);
   });
 });

--- a/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodsTable.test.tsx
@@ -197,7 +197,7 @@ describe('PodsTable', () => {
     columns.push(...DEFAULT_COLUMNS);
     columns.push(...READY);
     columns.push(...customColumns);
-    const { getByText, getAllByText } = render(
+    const { getByText } = render(
       wrapInTestApp(
         <PodsTable
           pods={[pod as any]}

--- a/plugins/kubernetes/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodsTable.tsx
@@ -34,6 +34,7 @@ export type PodColumns = 'READY' | 'RESOURCE';
 type PodsTablesProps = {
   pods: V1Pod[];
   extraColumns?: PodColumns[];
+  customColumns?: TableColumn<V1Pod>[];
   children?: React.ReactNode;
 };
 
@@ -67,7 +68,11 @@ const READY: TableColumn<V1Pod>[] = [
   },
 ];
 
-export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
+export const PodsTable = ({
+  pods,
+  extraColumns = [],
+  customColumns = [],
+}: PodsTablesProps) => {
   const podNamesWithMetrics = useContext(PodNamesWithMetricsContext);
   const columns: TableColumn<V1Pod>[] = [...DEFAULT_COLUMNS];
 
@@ -102,6 +107,9 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
       },
     ];
     columns.push(...resourceColumns);
+  }
+  if (customColumns.length) {
+    columns.push(...customColumns);
   }
 
   const tableStyle = {

--- a/plugins/kubernetes/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes/src/components/Pods/PodsTable.tsx
@@ -16,7 +16,6 @@
 
 import React, { useContext } from 'react';
 import { V1Pod } from '@kubernetes/client-node';
-import { PodDrawer } from './PodDrawer';
 import { Table, TableColumn } from '@backstage/core-components';
 import { PodNamesWithMetricsContext } from '../../hooks/PodNamesWithMetrics';
 import * as columnFactories from './columns';

--- a/plugins/kubernetes/src/components/Pods/columns.tsx
+++ b/plugins/kubernetes/src/components/Pods/columns.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useContext } from 'react';
+import React from 'react';
 import { V1Pod } from '@kubernetes/client-node';
 import { TableColumn } from '@backstage/core-components';
 import { PodDrawer } from './PodDrawer';
@@ -64,7 +64,9 @@ export function createStatusColumn(): TableColumn<V1Pod> {
   };
 }
 
-export function createCPUUsageColumn(podNamesWithMetrics): TableColumn<V1Pod> {
+export function createCPUUsageColumn(
+  podNamesWithMetrics: object,
+): TableColumn<V1Pod> {
   return {
     title: 'CPU usage %',
     render: (pod: V1Pod) => {
@@ -80,7 +82,7 @@ export function createCPUUsageColumn(podNamesWithMetrics): TableColumn<V1Pod> {
 }
 
 export function createMemoryUsageColumn(
-  podNamesWithMetrics,
+  podNamesWithMetrics: object,
 ): TableColumn<V1Pod> {
   return {
     title: 'Memory usage %',

--- a/plugins/kubernetes/src/components/Pods/columns.tsx
+++ b/plugins/kubernetes/src/components/Pods/columns.tsx
@@ -25,6 +25,7 @@ import {
   podStatusToMemoryUtil,
   totalRestarts,
 } from '../../utils/pod';
+import { ClientPodStatus } from '@backstage/plugin-kubernetes-common';
 
 export function createNameColumn(): TableColumn<V1Pod> {
   return {
@@ -65,7 +66,7 @@ export function createStatusColumn(): TableColumn<V1Pod> {
 }
 
 export function createCPUUsageColumn(
-  podNamesWithMetrics: object,
+  podNamesWithMetrics: Map<string, ClientPodStatus>,
 ): TableColumn<V1Pod> {
   return {
     title: 'CPU usage %',
@@ -82,7 +83,7 @@ export function createCPUUsageColumn(
 }
 
 export function createMemoryUsageColumn(
-  podNamesWithMetrics: object,
+  podNamesWithMetrics: Map<string, ClientPodStatus>,
 ): TableColumn<V1Pod> {
   return {
     title: 'Memory usage %',

--- a/plugins/kubernetes/src/components/Pods/columns.tsx
+++ b/plugins/kubernetes/src/components/Pods/columns.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useContext } from 'react';
+import { V1Pod } from '@kubernetes/client-node';
+import { TableColumn } from '@backstage/core-components';
+import { PodDrawer } from './PodDrawer';
+import {
+  containersReady,
+  containerStatuses,
+  podStatusToCpuUtil,
+  podStatusToMemoryUtil,
+  totalRestarts,
+} from '../../utils/pod';
+
+export function createNameColumn(): TableColumn<V1Pod> {
+  return {
+    title: 'name',
+    highlight: true,
+    render: (pod: V1Pod) => <PodDrawer pod={pod} />,
+  };
+}
+
+export function createPhaseColumn(): TableColumn<V1Pod> {
+  return {
+    title: 'phase',
+    render: (pod: V1Pod) => pod.status?.phase ?? 'unknown',
+  };
+}
+export function createContainersReadyColumn(): TableColumn<V1Pod> {
+  return {
+    title: 'containers ready',
+    align: 'center',
+    render: containersReady,
+  };
+}
+
+export function createTotalRestartsColumn(): TableColumn<V1Pod> {
+  return {
+    title: 'total restarts',
+    align: 'center',
+    render: totalRestarts,
+    type: 'numeric',
+  };
+}
+
+export function createStatusColumn(): TableColumn<V1Pod> {
+  return {
+    title: 'status',
+    render: containerStatuses,
+  };
+}
+
+export function createCPUUsageColumn(podNamesWithMetrics): TableColumn<V1Pod> {
+  return {
+    title: 'CPU usage %',
+    render: (pod: V1Pod) => {
+      const metrics = podNamesWithMetrics.get(pod.metadata?.name ?? '');
+
+      if (!metrics) {
+        return 'unknown';
+      }
+
+      return podStatusToCpuUtil(metrics);
+    },
+  };
+}
+
+export function createMemoryUsageColumn(
+  podNamesWithMetrics,
+): TableColumn<V1Pod> {
+  return {
+    title: 'Memory usage %',
+    render: (pod: V1Pod) => {
+      const metrics = podNamesWithMetrics.get(pod.metadata?.name ?? '');
+
+      if (!metrics) {
+        return 'unknown';
+      }
+
+      return podStatusToMemoryUtil(metrics);
+    },
+  };
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Moved from https://github.com/backstage/backstage/pull/8308
Export a CustomisationProps object from the k8s plugin, which includes a customPodTableColumns argument, to allow users to add additional custom columns to the Pod Table in the Deployments Accordion. I.e. the table shown below

![](https://user-images.githubusercontent.com/85505764/145889222-a44ade7f-7a2b-44ff-bc74-ec8675162760.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
