### PR TITLE
fixes api auth bug in tech-insights plugin

### DIFF
--- a/.changeset/fluffy-toys-tease.md
+++ b/.changeset/fluffy-toys-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': minor
+---
+
+fixes api auth in tech-insights plugin

--- a/plugins/tech-insights/src/plugin.ts
+++ b/plugins/tech-insights/src/plugin.ts
@@ -18,6 +18,7 @@ import {
   createRoutableExtension,
   createApiFactory,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 import { rootRouteRef } from './routes';
 import { techInsightsApiRef } from './api/TechInsightsApi';

--- a/plugins/tech-insights/src/plugin.ts
+++ b/plugins/tech-insights/src/plugin.ts
@@ -31,8 +31,9 @@ export const techInsightsPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: techInsightsApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new TechInsightsClient({ discoveryApi }),
+      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
+      factory: ({ discoveryApi, identityApi }) =>
+        new TechInsightsClient({ discoveryApi, identityApi }),
     }),
   ],
   routes: {


### PR DESCRIPTION
Signed-off-by: Erik Larsson <erik.larsson@schibsted.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Tech Insights plugin does not supply an API token when fetching data from the backend, causing 401 errors for adopters requiring API authentication. This PR fixes that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
