### PR TITLE
remove internal and inline css

### DIFF
--- a/.changeset/chatty-wombats-buy.md
+++ b/.changeset/chatty-wombats-buy.md
@@ -8,11 +8,11 @@ To make this change to an existing app, apply the following changes to the `app/
 Remove internal style
 
 ```diff
- - <style>
- -  #root {
- -    min-height: 100%;
- -  }
- - </style>
+- <style>
+-  #root {
+-    min-height: 100%;
+-  }
+- </style>
 ```
 
 Remove inline style from the body tag

--- a/.changeset/chatty-wombats-buy.md
+++ b/.changeset/chatty-wombats-buy.md
@@ -4,7 +4,8 @@
 
 removed inline and internal CSS from index.html
 
-To make this change to an existing app, apply the following changes to the `app/public/index.html` file:
+To make this change to an existing app, apply the following changes to the `packages/app/public/index.html` file:
+
 Remove internal style
 
 ```diff

--- a/.changeset/chatty-wombats-buy.md
+++ b/.changeset/chatty-wombats-buy.md
@@ -1,0 +1,23 @@
+---
+'@backstage/create-app': patch
+---
+
+removed inline and internal CSS from index.html
+
+To make this change to an existing app, apply the following changes to the `app/public/index.html` file:
+Remove internal style
+
+```diff
+ - <style>
+ -  #root {
+ -    min-height: 100%;
+ -  }
+ - </style>
+```
+
+Remove inline style from the body tag
+
+```diff
+- <body style="margin: 0">
++ <body>
+```

--- a/.changeset/long-waves-hear.md
+++ b/.changeset/long-waves-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+remove inline CSS from serve_index.html

--- a/.changeset/new-tips-shop.md
+++ b/.changeset/new-tips-shop.md
@@ -1,5 +1,5 @@
 ---
-'embedded-techdocs-app': patch
+'@techdocs/cli': patch
 ---
 
 remove internal and inline CSS from index.html

--- a/.changeset/new-tips-shop.md
+++ b/.changeset/new-tips-shop.md
@@ -1,0 +1,5 @@
+---
+'embedded-techdocs-app': patch
+---
+
+remove internal and inline CSS from index.html

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -42,11 +42,6 @@
       href="<%= publicPath %>/safari-pinned-tab.svg"
       color="#5bbad5"
     />
-    <style>
-      #root {
-        min-height: 100%;
-      }
-    </style>
     <title><%= config.getString('app.title') %></title>
 
     <% if (config.has('app.googleAnalyticsTrackingId')) { %>
@@ -103,7 +98,7 @@
     <% } %>
   </head>
 
-  <body style="margin: 0">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/packages/cli/templates/serve_index.html
+++ b/packages/cli/templates/serve_index.html
@@ -10,7 +10,7 @@
     />
     <title>Backstage</title>
   </head>
-  <body style="margin: 0">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/packages/create-app/templates/default-app/packages/app/public/index.html
+++ b/packages/create-app/templates/default-app/packages/app/public/index.html
@@ -42,11 +42,6 @@
       href="<%= publicPath %>/safari-pinned-tab.svg"
       color="#5bbad5"
     />
-    <style>
-      #root {
-        min-height: 100%;
-      }
-    </style>
     <title><%= config.getString('app.title') %></title>
     <% if (config.has('app.googleAnalyticsTrackingId')) { %>
     <script
@@ -67,7 +62,7 @@
     </script>
     <% } %>
   </head>
-  <body style="margin: 0">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/packages/embedded-techdocs-app/public/index.html
+++ b/packages/embedded-techdocs-app/public/index.html
@@ -42,14 +42,9 @@
       href="<%= publicPath %>/safari-pinned-tab.svg"
       color="#5bbad5"
     />
-    <style>
-      #root {
-        min-height: 100%;
-      }
-    </style>
     <title><%= config.getString('app.title') %></title>
   </head>
-  <body style="margin: 0">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--


### PR DESCRIPTION
Signed-off-by: mufaddal motiwala <mufaddalmm.52@gmail.com>

## Hey, I just made a Pull Request!

We can safely remove the inline CSS from index.html. 

The backstage App is wrapped in `<CssBaseline/>` ,it provides an elegant, consistent, and simple baseline. This component appends CSS which includes what we are  removing from index.html. 

![Screenshot 2021-12-23 at 12 59 46 PM](https://user-images.githubusercontent.com/42934221/147205433-55c8f5ca-1d29-45e4-8c4e-8fa5448e2df2.png)

Secondly, I even tested in different browsers as suggested by @freben in #8600 , I have attached the screenshots captured after removing the CSS from index.html. 

[Index.html Test cases for removing css.pdf](https://github.com/backstage/backstage/files/7767544/Index.html.Test.cases.for.removing.css.pdf)

Hope this helps. 

