### PR TITLE
expose techInsightsApiRef

### DIFF
--- a/.changeset/slimy-socks-pump.md
+++ b/.changeset/slimy-socks-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': patch
+---
+
+expose apiRef

--- a/.changeset/slimy-socks-pump.md
+++ b/.changeset/slimy-socks-pump.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-tech-insights': patch
 ---
 
-expose apiRef
+Export `techInsightsApiRef` and associated types.

--- a/plugins/tech-insights/api-report.md
+++ b/plugins/tech-insights/api-report.md
@@ -12,13 +12,40 @@ import { EntityName } from '@backstage/catalog-model';
 import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 
+// @public
+export type Check = {
+  id: string;
+  type: string;
+  name: string;
+  description: string;
+  factIds: string[];
+};
+
+// @public
+export type CheckResultRenderer = {
+  type: string;
+  title: string;
+  description: string;
+  component: React_2.ReactElement;
+};
+
 // @public (undocumented)
 export const EntityTechInsightsScorecardContent: () => JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "TechInsightsApi" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "techInsightsApiRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
+export interface TechInsightsApi {
+  // (undocumented)
+  getAllChecks(): Promise<Check[]>;
+  // (undocumented)
+  getScorecardsDefinition: (
+    type: string,
+    value: CheckResult[],
+  ) => CheckResultRenderer | undefined;
+  // (undocumented)
+  runChecks(entityParams: EntityName, checks?: Check[]): Promise<CheckResult[]>;
+}
+
+// @public
 export const techInsightsApiRef: ApiRef<TechInsightsApi>;
 
 // @public (undocumented)

--- a/plugins/tech-insights/api-report.md
+++ b/plugins/tech-insights/api-report.md
@@ -5,11 +5,21 @@
 ```ts
 /// <reference types="react" />
 
+import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { CheckResult } from '@backstage/plugin-tech-insights-common';
+import { EntityName } from '@backstage/catalog-model';
+import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // @public (undocumented)
 export const EntityTechInsightsScorecardContent: () => JSX.Element;
+
+// Warning: (ae-forgotten-export) The symbol "TechInsightsApi" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "techInsightsApiRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const techInsightsApiRef: ApiRef<TechInsightsApi>;
 
 // @public (undocumented)
 export const techInsightsPlugin: BackstagePlugin<

--- a/plugins/tech-insights/package.json
+++ b/plugins/tech-insights/package.json
@@ -35,6 +35,7 @@
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
+    "@types/react": "^16.13.1 || ^17.0.0",
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {

--- a/plugins/tech-insights/src/api/TechInsightsApi.ts
+++ b/plugins/tech-insights/src/api/TechInsightsApi.ts
@@ -20,10 +20,20 @@ import { Check } from './types';
 import { CheckResultRenderer } from '../components/CheckResultRenderer';
 import { EntityName } from '@backstage/catalog-model';
 
+/**
+ * {@link @backstage/core-plugin-api#ApiRef} for the {@link TechInsightsApi}
+ *
+ * @public
+ */
 export const techInsightsApiRef = createApiRef<TechInsightsApi>({
   id: 'plugin.techinsights.service',
 });
 
+/**
+ * API client interface for the Tech Insights plugin
+ *
+ * @public
+ */
 export interface TechInsightsApi {
   getScorecardsDefinition: (
     type: string,

--- a/plugins/tech-insights/src/api/types.ts
+++ b/plugins/tech-insights/src/api/types.ts
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * Represents a single check defined on the TechInsights backend.
+ *
+ * @public
+ */
 export type Check = {
   id: string;
   type: string;

--- a/plugins/tech-insights/src/components/CheckResultRenderer.tsx
+++ b/plugins/tech-insights/src/components/CheckResultRenderer.tsx
@@ -18,6 +18,11 @@ import { CheckResult } from '@backstage/plugin-tech-insights-common';
 import React from 'react';
 import { BooleanCheck } from './BooleanCheck';
 
+/**
+ * Defines a react component that is responsible for rendering a results of a given type.
+ *
+ * @public
+ */
 export type CheckResultRenderer = {
   type: string;
   title: string;

--- a/plugins/tech-insights/src/index.ts
+++ b/plugins/tech-insights/src/index.ts
@@ -19,3 +19,6 @@ export {
 } from './plugin';
 
 export { techInsightsApiRef } from './api/TechInsightsApi';
+export type { TechInsightsApi } from './api/TechInsightsApi';
+export type { Check } from './api/types';
+export type { CheckResultRenderer } from './components/CheckResultRenderer';

--- a/plugins/tech-insights/src/index.ts
+++ b/plugins/tech-insights/src/index.ts
@@ -17,3 +17,5 @@ export {
   techInsightsPlugin,
   EntityTechInsightsScorecardContent,
 } from './plugin';
+
+export { techInsightsApiRef } from './api/TechInsightsApi';


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

## Hey, I just made a Pull Request!

I want to create a custom page which uses tech-insights API and I want to do something like the following, but the apiRef was not publicly exposed. I had a look on other packages and they usually expose it, so hence this PR!

```ts
  const api = useApi(techInsightsApiRef);
  const { namespace, kind, name } = useParams();

  const { value, loading, error } = useAsync(
    async () => await api.runChecks({ namespace, kind, name }),
  );
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
