### PR TITLE
Memory cache client should use shared memory

### DIFF
--- a/.changeset/dar-jag-gar.md
+++ b/.changeset/dar-jag-gar.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+In-memory cache clients instantiated from the same cache manager now share the same memory space.

--- a/packages/backend-common/src/cache/CacheManager.test.ts
+++ b/packages/backend-common/src/cache/CacheManager.test.ts
@@ -147,6 +147,22 @@ describe('CacheManager', () => {
       });
     });
 
+    it('shares memory across multiple instances of the memory client', () => {
+      const manager = CacheManager.fromConfig(defaultConfig());
+      const plugin = 'test-plugin';
+
+      // Instantiate two in-memory clients.
+      manager.forPlugin(plugin).getClient({ defaultTtl: 10 });
+      manager.forPlugin(plugin).getClient({ defaultTtl: 10 });
+
+      const cache = Keyv as unknown as jest.Mock;
+      const mockCall2 = cache.mock.calls.splice(-1)[0][0];
+      const mockCall1 = cache.mock.calls.splice(-1)[0][0];
+
+      // Note: .toBe() checks referential identity of object instances.
+      expect(mockCall1.store).toBe(mockCall2.store);
+    });
+
     it('returns a memcache client when configured', () => {
       const expectedHost = '127.0.0.1:11211';
       const manager = CacheManager.fromConfig(

--- a/packages/backend-common/src/cache/CacheManager.ts
+++ b/packages/backend-common/src/cache/CacheManager.ts
@@ -42,6 +42,13 @@ export class CacheManager {
     none: this.getNoneClient,
   };
 
+  /**
+   * Shared memory store for the in-memory cache client. Sharing the same Map
+   * instance ensures get/set/delete operations hit the same store, regardless
+   * of where/when a client is instantiated.
+   */
+  private readonly memoryStore = new Map();
+
   private readonly logger: Logger;
   private readonly store: keyof CacheManager['storeFactories'];
   private readonly connection: string;
@@ -133,6 +140,7 @@ export class CacheManager {
     return new Keyv({
       namespace: pluginId,
       ttl: defaultTtl,
+      store: this.memoryStore,
     });
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Consider the following code, imagine it is within the same plugin:

```ts
const createRouterOne = ({ cache: cacheManager }: PluginEnvironment): Router => {
  const clientOne = cacheManager.getClient({ defaultTtl: 123 });

  clientOne.set('key', 'value');
  // ...
};

const createRouterTwo = ({ cache: cacheManager }: PluginEnvironment): Router => {
  const clientTwo = cacheManager.getClient({ defaultTtl: 123 });

  clientTwo.get('key');
  // ...
};
```

When `memcache` is configured as Backstage's cache store...  If router one is created, then router two is created, `clientTwo` will be able to successfully read `value` from cache.

However, when the in-memory cache is configured, `clientOne` and `clientTwo` reference totally independent objects in memory, so `clientTwo` will never be able to read `value` from cache.

These should behave the same way.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
