### PR TITLE
fix(shortcuts): make writable copies of saved shortcuts from storageApi

### DIFF
--- a/.changeset/hip-hounds-remember.md
+++ b/.changeset/hip-hounds-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-shortcuts': patch
+---
+
+Properly read saved shortcuts from StorageApi

--- a/plugins/shortcuts/src/api/LocalStoredShortcuts.ts
+++ b/plugins/shortcuts/src/api/LocalStoredShortcuts.ts
@@ -82,11 +82,9 @@ export class LocalStoredShortcuts implements ShortcutApi {
   };
 
   private get() {
-    return (
-      (this.storageApi.get('items') as Shortcut[])?.sort((a, b) =>
-        a.title >= b.title ? 1 : -1,
-      ) ?? []
-    );
+    return Array.from(
+      this.storageApi.snapshot<Shortcut[]>('items').value ?? [],
+    ).sort((a, b) => (a.title >= b.title ? 1 : -1));
   }
 
   private notify() {


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

This change fixes a regression caused by https://github.com/backstage/backstage/pull/8524 where this plugin attempted to directly update read-only objects returned by the `StorageApi` resulting in an access errors: https://github.com/backstage/backstage/blob/5284458e18f7da3bc0ba5eb8043e902108518726/packages/core-app-api/src/apis/implementations/StorageApi/WebStorage.ts#L57

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
