### PR TITLE
release shortcuts plugin patch

### DIFF
--- a/.changeset/hip-hounds-remember.md
+++ b/.changeset/hip-hounds-remember.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-shortcuts': patch
----
-
-Properly read saved shortcuts from StorageApi

--- a/plugins/shortcuts/CHANGELOG.md
+++ b/plugins/shortcuts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-shortcuts
 
+## 0.1.17
+
+### Patch Changes
+
+- b50cbd047b: Properly read saved shortcuts from StorageApi
+
 ## 0.1.16
 
 ### Patch Changes

--- a/plugins/shortcuts/package.json
+++ b/plugins/shortcuts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-shortcuts",
   "description": "A Backstage plugin that provides a shortcuts feature to the sidebar",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes a crash in the `shortcuts` plugin that was introduced on the most recent release.

Thanks to @kuangp for discovering and fixing this.
