### PR TITLE
test-utils: freeze and serialize MockStorageApi values

### DIFF
--- a/.changeset/curly-pillows-provide.md
+++ b/.changeset/curly-pillows-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+JSON serialize and freeze values stored by the `MockStorageApi`.

--- a/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.ts
+++ b/packages/test-utils/src/testUtils/apis/StorageApi/MockStorageApi.ts
@@ -84,12 +84,18 @@ export class MockStorageApi implements StorageApi {
   }
 
   async set<T>(key: string, data: T): Promise<void> {
-    this.data[this.getKeyName(key)] = data;
+    const serialized = JSON.parse(JSON.stringify(data), (_key, value) => {
+      if (typeof value === 'object' && value !== null) {
+        Object.freeze(value);
+      }
+      return value;
+    });
+    this.data[this.getKeyName(key)] = serialized;
     this.notifyChanges({
       key,
       presence: 'present',
-      value: data,
-      newValue: data,
+      value: serialized,
+      newValue: serialized,
     });
   }
 

--- a/plugins/catalog-react/src/apis/StarredEntitiesApi/migration.test.ts
+++ b/plugins/catalog-react/src/apis/StarredEntitiesApi/migration.test.ts
@@ -88,7 +88,7 @@ describe('performMigrationToTheNewBucket', () => {
     await performMigrationToTheNewBucket({ storageApi: mockStorage });
 
     // read NEW bucket
-    expect(newBucket.get('entityRefs')).toBe(expectedEntries);
+    expect(newBucket.get('entityRefs')).toEqual(expectedEntries);
   });
 
   it('should skip migration with non-array old starred entities', async () => {
@@ -105,7 +105,7 @@ describe('performMigrationToTheNewBucket', () => {
     await performMigrationToTheNewBucket({ storageApi: mockStorage });
 
     // read NEW bucket
-    expect(newBucket.get('entityRefs')).toBe(expectedEntries);
+    expect(newBucket.get('entityRefs')).toEqual(expectedEntries);
 
     // OLD bucket should be unchanged
     expect(oldBucket.get('starredEntities')).toBe('invalid');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This makes the `MockStorageApi` behave more like the default `WebStorage` implementation. Helps avoid bugs that only show up in the browser.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
