### PR TITLE
fixing refresh token Okta provider #8632

### DIFF
--- a/.changeset/eleven-pianos-fail.md
+++ b/.changeset/eleven-pianos-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed bug on refresh token on Okta provider, now it gets the refresh token and it sends it into providerInfo

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -148,11 +148,12 @@ export class OktaAuthProvider implements OAuthHandlers {
   }
 
   async refresh(req: OAuthRefreshRequest): Promise<OAuthResponse> {
-    const { accessToken, params } = await executeRefreshTokenStrategy(
-      this._strategy,
-      req.refreshToken,
-      req.scope,
-    );
+    const { accessToken, refreshToken, params } =
+      await executeRefreshTokenStrategy(
+        this._strategy,
+        req.refreshToken,
+        req.scope,
+      );
 
     const fullProfile = await executeFetchUserProfileStrategy(
       this._strategy,
@@ -163,7 +164,7 @@ export class OktaAuthProvider implements OAuthHandlers {
       fullProfile,
       params,
       accessToken,
-      refreshToken: req.refreshToken,
+      refreshToken,
     });
   }
 
@@ -176,6 +177,7 @@ export class OktaAuthProvider implements OAuthHandlers {
         accessToken: result.accessToken,
         scope: result.params.scope,
         expiresInSeconds: result.params.expires_in,
+        refreshToken: result.refreshToken,
       },
       profile,
     };


### PR DESCRIPTION
Signed-off-by: Carlo Giuseppe Sergi <carlo.sergi@klarna.com>

Fix:
While the refresh the function executeRefreshTokenStrategy resolves with the new refresh token, the method refresh takes this new token. It saves it on the object result providerInfo, and the method refresh OAuthAdapter saves the new refresh token into the cookie.


