### PR TITLE
Support for non-amazonaws.com hosts in AwsS3UrlReader

### DIFF
--- a/.changeset/proud-rocks-lick.md
+++ b/.changeset/proud-rocks-lick.md
@@ -2,4 +2,4 @@
 '@backstage/backend-common': patch
 ---
 
-Added support for non-"amazonaws.com" hosts (for example when testing with localstack) in AwsS3UrlReader.
+Added support for non-"amazonaws.com" hosts (for example when testing with LocalStack) in AwsS3UrlReader.

--- a/.changeset/proud-rocks-lick.md
+++ b/.changeset/proud-rocks-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Added support for non-"amazonaws.com" hosts (for example when testing with localstack) in AwsS3UrlReader.

--- a/.changeset/red-chefs-travel.md
+++ b/.changeset/red-chefs-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Added `endpoint` and `s3ForcePathStyle` as optional configuration for AWS S3 integrations.

--- a/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
@@ -332,4 +332,47 @@ describe('AwsS3UrlReader', () => {
       expect(body.toString().trim()).toBe('site_name: Test');
     });
   });
+
+  describe('readNonAwsHost', () => {
+    let awsS3UrlReader: AwsS3UrlReader;
+
+    beforeAll(() => {
+      AWSMock.setSDKInstance(aws);
+      AWSMock.mock(
+        'S3',
+        'getObject',
+        Buffer.from(
+          require('fs').readFileSync(
+            path.resolve(
+              __dirname,
+              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+            ),
+          ),
+        ),
+      );
+
+      const s3 = new aws.S3();
+      awsS3UrlReader = new AwsS3UrlReader(
+        new AwsS3Integration(
+          readAwsS3IntegrationConfig(
+            new ConfigReader({
+              host: 'localhost:4566',
+              accessKeyId: 'fake-access-key',
+              secretAccessKey: 'fake-secret-key',
+              validateHost: false,
+              ssl: false,
+            }),
+          ),
+        ),
+        { s3, treeResponseFactory },
+      );
+    });
+
+    it('returns contents of an object in a bucket', async () => {
+      const response = await awsS3UrlReader.read(
+        'http://test-bucket.localhost:4566/awsS3-mock-object.yaml',
+      );
+      expect(response.toString().trim()).toBe('site_name: Test');
+    });
+  });
 });

--- a/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.test.ts
@@ -178,7 +178,7 @@ describe('AwsS3UrlReader', () => {
         ),
       ).rejects.toThrow(
         Error(
-          `Could not retrieve file from S3; caused by Error: not a valid AWS S3 URL: https://test-bucket.s3.us-east-2.NOTamazonaws.com/file.yaml`,
+          `Could not retrieve file from S3; caused by Error: invalid AWS S3 URL, cannot parse region from host in https://test-bucket.s3.us-east-2.NOTamazonaws.com/file.yaml`,
         ),
       );
     });
@@ -234,7 +234,7 @@ describe('AwsS3UrlReader', () => {
         ),
       ).rejects.toThrow(
         Error(
-          `Could not retrieve file from S3; caused by Error: not a valid AWS S3 URL: https://test-bucket.s3.us-east-2.NOTamazonaws.com/file.yaml`,
+          `Could not retrieve file from S3; caused by Error: invalid AWS S3 URL, cannot parse region from host in https://test-bucket.s3.us-east-2.NOTamazonaws.com/file.yaml`,
         ),
       );
     });
@@ -359,8 +359,8 @@ describe('AwsS3UrlReader', () => {
               host: 'localhost:4566',
               accessKeyId: 'fake-access-key',
               secretAccessKey: 'fake-secret-key',
-              validateHost: false,
-              ssl: false,
+              endpoint: 'http://localhost:4566',
+              s3ForcePathStyle: true,
             }),
           ),
         ),
@@ -370,7 +370,7 @@ describe('AwsS3UrlReader', () => {
 
     it('returns contents of an object in a bucket', async () => {
       const response = await awsS3UrlReader.read(
-        'http://test-bucket.localhost:4566/awsS3-mock-object.yaml',
+        'http://localhost:4566/test-bucket/awsS3-mock-object.yaml',
       );
       expect(response.toString().trim()).toBe('site_name: Test');
     });

--- a/packages/backend-common/src/reading/AwsS3UrlReader.ts
+++ b/packages/backend-common/src/reading/AwsS3UrlReader.ts
@@ -30,7 +30,6 @@ import getRawBody from 'raw-body';
 import {
   AwsS3Integration,
   ScmIntegrations,
-  AMAZON_AWS_HOST,
   AwsS3IntegrationConfig,
 } from '@backstage/integration';
 import { ForwardedError, NotModifiedError } from '@backstage/errors';
@@ -75,9 +74,9 @@ const parseURL = (
   }
 
   // Only extract region from *.amazonaws.com hosts
-  if (config.host === AMAZON_AWS_HOST) {
+  if (config.host === 'amazonaws.com') {
     // At this point bucket prefix is removed from host for virtual hosted URLs
-    const match = host.match(/^s3\.([a-z\d-]+)\.amazonaws.com$/);
+    const match = host.match(/^s3\.([a-z\d-]+)\.amazonaws\.com$/);
     if (!match) {
       throw new Error(
         `invalid AWS S3 URL, cannot parse region from host in ${url}`,
@@ -105,10 +104,7 @@ export class AwsS3UrlReader implements UrlReader {
       const s3 = new S3({
         apiVersion: '2006-03-01',
         credentials: creds,
-        endpoint:
-          integration.config.host === AMAZON_AWS_HOST
-            ? undefined
-            : integration.config.endpoint,
+        endpoint: integration.config.endpoint,
         s3ForcePathStyle: integration.config.s3ForcePathStyle,
       });
       const reader = new AwsS3UrlReader(integration, {

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -30,6 +30,8 @@ export class AwsS3Integration implements ScmIntegration {
 // @public
 export type AwsS3IntegrationConfig = {
   host: string;
+  endpoint?: string;
+  s3ForcePathStyle?: boolean;
   accessKeyId?: string;
   secretAccessKey?: string;
   roleArn?: string;

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -167,6 +167,24 @@ export interface Config {
     /** Integration configuration for AWS S3 Service */
     awsS3?: Array<{
       /**
+       * AWS Endpoint.
+       * The endpoint URI to send requests to. The default endpoint is built from the configured region.
+       * @see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property
+       *
+       * Supports non-AWS providers, e.g. for LocalStack, endpoint may look like http://localhost:4566
+       * @visibility frontend
+       */
+      endpoint?: string;
+
+      /**
+       * Whether to use path style URLs when communicating with S3.
+       * Defaults to false.
+       * This allows providers like LocalStack, Minio and Wasabi (and possibly others) to be used.
+       * @visibility frontend
+       */
+      s3ForcePathStyle?: boolean;
+
+      /**
        * Account access key used to authenticate requests.
        * @visibility backend
        */

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -167,11 +167,6 @@ export interface Config {
     /** Integration configuration for AWS S3 Service */
     awsS3?: Array<{
       /**
-       * The host of the target that this matches on, e.g. "amazonaws.com".
-       * @visibility frontend
-       */
-      host: string;
-      /**
        * Account access key used to authenticate requests.
        * @visibility backend
        */

--- a/packages/integration/src/awsS3/AwsS3Integration.test.ts
+++ b/packages/integration/src/awsS3/AwsS3Integration.test.ts
@@ -24,7 +24,7 @@ describe('AwsS3Integration', () => {
         integrations: {
           awsS3: [
             {
-              host: 'a.com',
+              endpoint: 'https://a.com',
               accessKeyId: 'access key',
               secretAccessKey: 'secret key',
             },

--- a/packages/integration/src/awsS3/config.test.ts
+++ b/packages/integration/src/awsS3/config.test.ts
@@ -26,10 +26,9 @@ describe('readAwsS3IntegrationConfig', () => {
     return new ConfigReader(data);
   }
 
-  it('reads all values', () => {
+  it('reads all values (default)', () => {
     const output = readAwsS3IntegrationConfig(
       buildConfig({
-        host: 'amazonaws.com',
         accessKeyId: 'fake-key',
         secretAccessKey: 'fake-secret-key',
       }),
@@ -37,6 +36,23 @@ describe('readAwsS3IntegrationConfig', () => {
     expect(output).toEqual({
       host: 'amazonaws.com',
       s3ForcePathStyle: false,
+      accessKeyId: 'fake-key',
+      secretAccessKey: 'fake-secret-key',
+    });
+  });
+  it('reads all values (endpoint)', () => {
+    const output = readAwsS3IntegrationConfig(
+      buildConfig({
+        endpoint: 'http://localhost:4566',
+        s3ForcePathStyle: true,
+        accessKeyId: 'fake-key',
+        secretAccessKey: 'fake-secret-key',
+      }),
+    );
+    expect(output).toEqual({
+      host: 'localhost:4566',
+      endpoint: 'http://localhost:4566',
+      s3ForcePathStyle: true,
       accessKeyId: 'fake-key',
       secretAccessKey: 'fake-secret-key',
     });

--- a/packages/integration/src/awsS3/config.test.ts
+++ b/packages/integration/src/awsS3/config.test.ts
@@ -36,6 +36,7 @@ describe('readAwsS3IntegrationConfig', () => {
     );
     expect(output).toEqual({
       host: 'amazonaws.com',
+      s3ForcePathStyle: false,
       accessKeyId: 'fake-key',
       secretAccessKey: 'fake-secret-key',
     });
@@ -59,6 +60,7 @@ describe('readAwsS3IntegrationConfigs', () => {
     );
     expect(output).toContainEqual({
       host: 'amazonaws.com',
+      s3ForcePathStyle: false,
       accessKeyId: 'key',
       secretAccessKey: 'secret',
     });

--- a/packages/integration/src/awsS3/config.ts
+++ b/packages/integration/src/awsS3/config.ts
@@ -17,7 +17,7 @@
 import { Config } from '@backstage/config';
 import { isValidHost } from '../helpers';
 
-const AMAZON_AWS_HOST = 'amazonaws.com';
+export const AMAZON_AWS_HOST = 'amazonaws.com';
 
 /**
  * The configuration parameters for a single AWS S3 provider.
@@ -28,7 +28,9 @@ export type AwsS3IntegrationConfig = {
   /**
    * The host of the target that this matches on, e.g. "amazonaws.com"
    *
-   * Currently only "amazonaws.com" is supported.
+   * If validateHost is true, "amazonaws.com" host is enforced. To test with localstack or similar AWS S3 emulators,
+   * setting validateHost to false allows hosts like "localhost:4566". Set ssl to false to access emulated S3
+   * endpoint over http (vs https). In that case, S3 urls would look like "http://<bucket>.localhost:4566/<path>".
    */
   host: string;
 
@@ -46,6 +48,16 @@ export type AwsS3IntegrationConfig = {
    * roleArn
    */
   roleArn?: string;
+
+  /**
+   * validateHost
+   */
+  validateHost: boolean;
+
+  /**
+   * ssl
+   */
+  ssl: boolean;
 };
 
 /**
@@ -62,6 +74,8 @@ export function readAwsS3IntegrationConfig(
   const accessKeyId = config.getOptionalString('accessKeyId');
   const secretAccessKey = config.getOptionalString('secretAccessKey');
   const roleArn = config.getOptionalString('roleArn');
+  const validateHost = config.getOptionalBoolean('validateHost') ?? true;
+  const ssl = config.getOptionalBoolean('ssl') ?? true;
 
   if (!isValidHost(host)) {
     throw new Error(
@@ -69,7 +83,7 @@ export function readAwsS3IntegrationConfig(
     );
   }
 
-  return { host, accessKeyId, secretAccessKey, roleArn };
+  return { host, accessKeyId, secretAccessKey, roleArn, validateHost, ssl };
 }
 
 /**
@@ -90,6 +104,8 @@ export function readAwsS3IntegrationConfigs(
   if (!result.some(c => c.host === AMAZON_AWS_HOST)) {
     result.push({
       host: AMAZON_AWS_HOST,
+      validateHost: true,
+      ssl: true,
     });
   }
   return result;

--- a/packages/integration/src/awsS3/config.ts
+++ b/packages/integration/src/awsS3/config.ts
@@ -125,7 +125,9 @@ export function readAwsS3IntegrationConfigs(
   // If no explicit amazonaws.com integration was added, put one in the list as
   // a convenience
   if (!result.some(c => c.host === AMAZON_AWS_HOST)) {
-    result.push({ host: AMAZON_AWS_HOST });
+    result.push({
+      host: AMAZON_AWS_HOST,
+    });
   }
   return result;
 }

--- a/packages/integration/src/awsS3/config.ts
+++ b/packages/integration/src/awsS3/config.ts
@@ -16,7 +16,7 @@
 
 import { Config } from '@backstage/config';
 
-export const AMAZON_AWS_HOST = 'amazonaws.com';
+const AMAZON_AWS_HOST = 'amazonaws.com';
 
 /**
  * The configuration parameters for a single AWS S3 provider.
@@ -83,12 +83,12 @@ export function readAwsS3IntegrationConfig(
       pathname = url.pathname;
     } catch {
       throw new Error(
-        `Invalid awsS3 integration config, endpoint '${endpoint}' is not a valid URL`,
+        `invalid awsS3 integration config, endpoint '${endpoint}' is not a valid URL`,
       );
     }
     if (pathname !== '/') {
       throw new Error(
-        `Invalid awsS3 integration config, endpoints cannot contain path, got '${endpoint}'`,
+        `invalid awsS3 integration config, endpoints cannot contain path, got '${endpoint}'`,
       );
     }
   } else {

--- a/packages/integration/src/awsS3/index.ts
+++ b/packages/integration/src/awsS3/index.ts
@@ -17,6 +17,5 @@ export { AwsS3Integration } from './AwsS3Integration';
 export {
   readAwsS3IntegrationConfig,
   readAwsS3IntegrationConfigs,
-  AMAZON_AWS_HOST,
 } from './config';
 export type { AwsS3IntegrationConfig } from './config';

--- a/packages/integration/src/awsS3/index.ts
+++ b/packages/integration/src/awsS3/index.ts
@@ -17,5 +17,6 @@ export { AwsS3Integration } from './AwsS3Integration';
 export {
   readAwsS3IntegrationConfig,
   readAwsS3IntegrationConfigs,
+  AMAZON_AWS_HOST,
 } from './config';
 export type { AwsS3IntegrationConfig } from './config';


### PR DESCRIPTION
Signed-off-by: Leon Stein <leons727@gmail.com>

## Hey, I just made a Pull Request!

Added support for non-"amazonaws.com" hosts in `AwsS3UrlReader` (for example, when testing with localstack S3). 

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. 
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message.
