### PR TITLE
Reset permission to default after mkdtemp command

### DIFF
--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -175,6 +175,7 @@ export class DocsBuilder {
     const outputDir = await fs.mkdtemp(
       path.join(tmpdirResolvedPath, 'techdocs-tmp-'),
     );
+    await fs.chmod(outputDir, 0o775);
 
     const parsedLocationAnnotation = getLocationForEntity(
       this.entity,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Reset permission to default after mkdtemp command.
You can see the background in Discord https://discord.com/channels/687207715902193673/714754240933003266/924606903122792469

In short: I found that by using mkdtemp the permission is set to 700. This blocks the copy process if you build the docs locally. If I chmod to 777 or 755 in the container at the right time (just before copying) if works for me.

You can experience this if you run backstage in a docker file like this with all techdocs settings set to local:

The base node:16-alpine3.14-mkdocs image we build as a starting point.
```
FROM docker.io/node:16-alpine3.14

RUN apk --no-cache update \
    && apk --no-cache upgrade \
    && apk --no-cache add python3 py3-pip \
    && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz ttf-dejavu fontconfig \
    && rm -rf /var/cache/apk/*

# Download plantuml file, Validate checksum & Move plantuml file
RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.12.jar/download && echo "a3d10c17ab1158843a7a7120dd064ba2eda4363f  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar

RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.2.1

# Create script to call plantuml.jar from a location in path
#   When adding TechDocs to the Backstage Backend container, avoid this
#   error (OSError: [Errno 8] Exec format error: 'plantuml') by using the
#   following RUN command instead:
RUN echo '#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml
# RUN echo $'#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml
RUN chmod 755 /usr/local/bin/plantuml

ENV NODE_TLS_REJECT_UNAUTHORIZED=1 \
    CYPRESS_DOWNLOAD_MIRROR=https://xxx/cypress-mirror/ \
    NG_CLI_ANALYTICS=ci

COPY .npmrc /root/
```

And the backstage image we build:
```
# Stage 1 - Create yarn install skeleton layer
FROM base-images/node:16-alpine3.14-mkdocs AS packages

WORKDIR /app
COPY package.json yarn.lock ./

COPY packages packages
# Comment this out if you don't have any internal plugins
# COPY plugins plugins

RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+

# Stage 2 - Install dependencies and build packages
FROM base-images/node:16-alpine3.14-mkdocs AS build

WORKDIR /app
COPY --from=packages /app .

RUN yarn install --frozen-lockfile --network-timeout 600000 && rm -rf "$(yarn cache dir)"

COPY . .

RUN yarn tsc
RUN yarn --cwd packages/backend backstage-cli backend:bundle --build-dependencies

# Stage 3 - Build the actual backend image and install production dependencies
FROM base-images/node:16-alpine3.14-mkdocs

WORKDIR /app

# Copy the install dependencies from the build stage and context
COPY --from=build /app/yarn.lock /app/package.json /app/packages/backend/dist/skeleton.tar.gz ./
RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz

RUN yarn install --frozen-lockfile --production --network-timeout 600000 && rm -rf "$(yarn cache dir)"

# Copy the built packages from the build stage
COPY --from=build /app/packages/backend/dist/bundle.tar.gz .
RUN tar xzf bundle.tar.gz && rm bundle.tar.gz

# Copy any other files that we need at runtime
COPY app-config.yaml ./

CMD ["node", "packages/backend", "--config", "app-config.yaml"]
```

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
