### PR TITLE
implement dashboard link formatter for GKE

### DIFF
--- a/.changeset/sharp-seas-remain.md
+++ b/.changeset/sharp-seas-remain.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-common': patch
+---
+
+implement dashboard link formatter for GKE

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -117,8 +117,8 @@ Note that you should specify the app used for the dashboard using the
 resources, otherwise it will assume that you're running the standard one.
 
 Note also that this attribute is optional for some kinds of dashboards, such as
-GKE, which requires additional informations specified in the
-`dashboardParameters` option.
+GKE, which requires additional parameters specified in the `dashboardParameters`
+option.
 
 ##### `clusters.\*.dashboardApp` (optional)
 
@@ -154,8 +154,8 @@ for real examples.
 
 Specifies additional information for the selected `dashboardApp` formatter.
 
-Note that, eventhough `dashboardParameters` is optional for some formatters, it
-is mandatory for others, such as GKE.
+Note that, even though `dashboardParameters` is optional, it might be mandatory
+for some dashboards, such as GKE.
 
 ###### required parameters for GKE
 

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -39,6 +39,7 @@ kubernetes:
       region: 'europe-west1'
       skipTLSVerify: true
       skipMetricsLookup: true
+      exposeDashboard: true
 ```
 
 ### `serviceLocatorMethod`

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -113,8 +113,12 @@ kubectl -n <NAMESPACE> get secret $(kubectl -n <NAMESPACE> get sa <SERVICE_ACCOU
 Specifies the link to the Kubernetes dashboard managing this cluster.
 
 Note that you should specify the app used for the dashboard using the
-**dashboardApp property**, in order to properly format links to kubernetes
+`dashboardApp` property, in order to properly format links to kubernetes
 resources, otherwise it will assume that you're running the standard one.
+
+Note also that this attribute is optional for some kinds of dashboards, such as
+GKE, which requires additional informations specified in the
+`dashboardParameters` option.
 
 ##### `clusters.\*.dashboardApp` (optional)
 
@@ -124,10 +128,13 @@ This will be used for formatting links to kubernetes objects inside the
 dashboard.
 
 The supported dashboards are: `standard`, `rancher`, `openshift`, `gke`, `aks`,
-`eks` However, not all of them are implemented yet, so please contribute!
+`eks`. However, not all of them are implemented yet, so please contribute!
 
 Note that it will default to the regular dashboard provided by the Kubernetes
 project (`standard`), that can run in any Kubernetes cluster.
+
+Note that for the `gke` app, you must provide additional information in the
+`dashboardParameters` option.
 
 Note that you can add your own formatter by registering it to the
 `clusterLinksFormatters` dictionary, in the app project.
@@ -142,6 +149,43 @@ clusterLinksFormatters.myDashboard = (options) => ...;
 See also
 https://github.com/backstage/backstage/tree/master/plugins/kubernetes/src/utils/clusterLinks/formatters
 for real examples.
+
+##### `clusters.\*.dashboardParameters` (optional)
+
+Specifies additional information for the selected `dashboardApp` formatter.
+
+Note that, eventhough `dashboardParameters` is optional for some formatters, it
+is mandatory for others, such as GKE.
+
+###### required parameters for GKE
+
+| Name        | Description                                                              |
+| ----------- | ------------------------------------------------------------------------ |
+| projectId   | the ID of the GCP project containing your Kubernetes clusters            |
+| region      | the region of GCP containing your Kubernetes clusters                    |
+| clusterName | the name of your kubernetes cluster, within your `projectId` GCP project |
+
+Note that the GKE cluster locator can automatically provide the values for the
+`dashboardApp` and `dashboardParameters` options if you set the
+`exposeDashboard` property to `true`.
+
+Example:
+
+```yaml
+kubernetes:
+  serviceLocatorMethod:
+    type: 'multiTenant'
+  clusterLocatorMethods:
+    - type: 'config'
+      clusters:
+        - url: http://127.0.0.1:9999
+          name: my-cluster
+          dashboardApp: gke
+          dashboardParameters:
+            projectId: my-project
+            region: us-east1
+            clusterName: my-cluster
+```
 
 ##### `clusters.\*.caData` (optional)
 
@@ -184,6 +228,10 @@ For example:
 Will configure the Kubernetes plugin to connect to all GKE clusters in the
 project `gke-clusters` in the region `europe-west1`.
 
+Note that the GKE cluster locator can automatically provide the values for the
+`dashboardApp` and `dashboardParameters` options if you enable the
+`exposeDashboard` option.
+
 ##### `projectId`
 
 The Google Cloud project to look for Kubernetes clusters in.
@@ -202,6 +250,14 @@ presented by the API server. Defaults to `false`.
 
 This determines whether the Kubernetes client looks up resource metrics
 CPU/Memory for pods returned by the API server. Defaults to `false`.
+
+##### `exposeDashboard`
+
+This determines wether the `dashboardApp` and `dashboardParameters` should be
+automatically configured in order to expose the GKE dashboard from the
+Kubernetes plugin.
+
+Defaults to `false`.
 
 ### `customResources` (optional)
 

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -6,6 +6,7 @@
 import { Config } from '@backstage/config';
 import express from 'express';
 import type { FetchResponse } from '@backstage/plugin-kubernetes-common';
+import type { JsonObject } from '@backstage/types';
 import type { KubernetesFetchError } from '@backstage/plugin-kubernetes-common';
 import type { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { Logger as Logger_2 } from 'winston';
@@ -31,7 +32,7 @@ export interface ClusterDetails {
   // (undocumented)
   caData?: string | undefined;
   dashboardApp?: string;
-  dashboardParameters?: any;
+  dashboardParameters?: JsonObject;
   dashboardUrl?: string;
   name: string;
   // (undocumented)

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -31,6 +31,7 @@ export interface ClusterDetails {
   // (undocumented)
   caData?: string | undefined;
   dashboardApp?: string;
+  dashboardParameters?: any;
   dashboardUrl?: string;
   name: string;
   // (undocumented)

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.test.ts
@@ -176,4 +176,76 @@ describe('ConfigClusterLocator', () => {
       },
     ]);
   });
+
+  it('one cluster with dashboardParameters', async () => {
+    const config: Config = new ConfigReader({
+      clusters: [
+        {
+          name: 'cluster1',
+          url: 'http://localhost:8080',
+          authProvider: 'serviceAccount',
+          dashboardApp: 'gke',
+          dashboardParameters: {
+            projectId: 'some-project',
+            region: 'some-region',
+            clusterName: 'cluster1',
+          },
+        },
+      ],
+    });
+
+    const sut = ConfigClusterLocator.fromConfig(config);
+
+    const result = await sut.getClusters();
+
+    expect(result).toStrictEqual([
+      {
+        name: 'cluster1',
+        serviceAccountToken: undefined,
+        url: 'http://localhost:8080',
+        authProvider: 'serviceAccount',
+        skipMetricsLookup: false,
+        skipTLSVerify: false,
+        caData: undefined,
+        dashboardApp: 'gke',
+        dashboardParameters: {
+          projectId: 'some-project',
+          region: 'some-region',
+          clusterName: 'cluster1',
+        },
+      },
+    ]);
+  });
+
+  it('one cluster with dashboardUrl', async () => {
+    const config: Config = new ConfigReader({
+      clusters: [
+        {
+          name: 'cluster1',
+          url: 'http://localhost:8080',
+          authProvider: 'serviceAccount',
+          dashboardApp: 'standard',
+          dashboardUrl: 'http://someurl',
+        },
+      ],
+    });
+
+    const sut = ConfigClusterLocator.fromConfig(config);
+
+    const result = await sut.getClusters();
+
+    expect(result).toStrictEqual([
+      {
+        name: 'cluster1',
+        serviceAccountToken: undefined,
+        url: 'http://localhost:8080',
+        authProvider: 'serviceAccount',
+        skipMetricsLookup: false,
+        skipTLSVerify: false,
+        caData: undefined,
+        dashboardApp: 'standard',
+        dashboardUrl: 'http://someurl',
+      },
+    ]);
+  });
 });

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -47,9 +47,8 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
         if (dashboardApp) {
           clusterDetails.dashboardApp = dashboardApp;
         }
-        const dashboardParameters = c.getOptionalString('dashboardParameters');
-        if (dashboardParameters) {
-          clusterDetails.dashboardParameters = dashboardParameters;
+        if (c.has('dashboardParameters')) {
+          clusterDetails.dashboardParameters = c.get('dashboardParameters');
         }
 
         switch (authProvider) {

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -47,6 +47,10 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
         if (dashboardApp) {
           clusterDetails.dashboardApp = dashboardApp;
         }
+        const dashboardParameters = c.getOptionalString('dashboardParameters');
+        if (dashboardParameters) {
+          clusterDetails.dashboardParameters = dashboardParameters;
+        }
 
         switch (authProvider) {
           case 'google': {

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.ts
@@ -255,6 +255,10 @@ export class KubernetesFanOutHandler {
             if (clusterDetailsItem.dashboardApp) {
               objects.cluster.dashboardApp = clusterDetailsItem.dashboardApp;
             }
+            if (clusterDetailsItem.dashboardParameters) {
+              objects.cluster.dashboardParameters =
+                clusterDetailsItem.dashboardParameters;
+            }
             return objects;
           });
       }),

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -111,6 +111,7 @@ export interface ClusterDetails {
    * using the dashboardApp property, in order to properly format
    * links to kubernetes resources,  otherwise it will assume that you're running the standard one.
    * @see dashboardApp
+   * @see dashboardParameters
    */
   dashboardUrl?: string;
   /**
@@ -129,6 +130,12 @@ export interface ClusterDetails {
    * ```
    */
   dashboardApp?: string;
+  /**
+   * Specifies specific parameters used by some dashboard URL formatters.
+   * This is used by the GKE formatter which requires the project, region and cluster name.
+   * @see dashboardApp
+   */
+  dashboardParameters?: any;
 }
 
 export interface GKEClusterDetails extends ClusterDetails {}

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { Logger } from 'winston';
+import type { JsonObject } from '@backstage/types';
 import type {
   FetchResponse,
   KubernetesFetchError,
@@ -135,7 +136,7 @@ export interface ClusterDetails {
    * This is used by the GKE formatter which requires the project, region and cluster name.
    * @see dashboardApp
    */
-  dashboardParameters?: any;
+  dashboardParameters?: JsonObject;
 }
 
 export interface GKEClusterDetails extends ClusterDetails {}

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { Entity } from '@backstage/catalog-model';
+import type { JsonObject } from '@backstage/types';
 import { V1ConfigMap } from '@kubernetes/client-node';
 import { V1CronJob } from '@kubernetes/client-node';
 import { V1Deployment } from '@kubernetes/client-node';
@@ -62,7 +63,7 @@ export interface ClientPodStatus {
 // @public (undocumented)
 export interface ClusterAttributes {
   dashboardApp?: string;
-  dashboardParameters?: any;
+  dashboardParameters?: JsonObject;
   dashboardUrl?: string;
   name: string;
 }

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -62,6 +62,7 @@ export interface ClientPodStatus {
 // @public (undocumented)
 export interface ClusterAttributes {
   dashboardApp?: string;
+  dashboardParameters?: any;
   dashboardUrl?: string;
   name: string;
 }

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -45,6 +45,7 @@ export interface ClusterAttributes {
    * Note that you should specify the app used for the dashboard
    * using the dashboardApp property, in order to properly format
    * links to kubernetes resources,  otherwise it will assume that you're running the standard one.
+   * Also, for cloud clusters such as GKE, you should provide addititonal parameters using dashboardParameters.
    * @see dashboardApp
    */
   dashboardUrl?: string;
@@ -64,6 +65,11 @@ export interface ClusterAttributes {
    * ```
    */
   dashboardApp?: string;
+  /**
+   * Specifies specific parameters used by some dashboard URL formatters.
+   * This is used by the GKE formatter which requires the project, region and cluster name.
+   */
+  dashboardParameters?: any;
 }
 
 export interface ClusterObjects {

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { JsonObject } from '@backstage/types';
 import {
   V1ConfigMap,
   V1CronJob,
@@ -69,7 +70,7 @@ export interface ClusterAttributes {
    * Specifies specific parameters used by some dashboard URL formatters.
    * This is used by the GKE formatter which requires the project, region and cluster name.
    */
-  dashboardParameters?: any;
+  dashboardParameters?: JsonObject;
 }
 
 export interface ClusterObjects {

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -10,6 +10,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { IdentityApi } from '@backstage/core-plugin-api';
+import type { JsonObject } from '@backstage/types';
 import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { OAuthApi } from '@backstage/core-plugin-api';
 import { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';

--- a/plugins/kubernetes/src/components/KubernetesDrawer/KubernetesDrawer.tsx
+++ b/plugins/kubernetes/src/components/KubernetesDrawer/KubernetesDrawer.tsx
@@ -155,6 +155,7 @@ const KubernetesDrawerContent = <T extends KubernetesDrawerable>({
   const { clusterLink, errorMessage } = tryFormatClusterLink({
     dashboardUrl: cluster.dashboardUrl,
     dashboardApp: cluster.dashboardApp,
+    dashboardParameters: cluster.dashboardParameters,
     object,
     kind,
   });

--- a/plugins/kubernetes/src/types/types.ts
+++ b/plugins/kubernetes/src/types/types.ts
@@ -43,7 +43,8 @@ export interface GroupedResponses extends DeploymentResources {
 }
 
 export interface ClusterLinksFormatterOptions {
-  dashboardUrl: URL;
+  dashboardUrl?: URL;
+  dashboardParameters?: any;
   object: any;
   kind: string;
 }

--- a/plugins/kubernetes/src/types/types.ts
+++ b/plugins/kubernetes/src/types/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { JsonObject } from '@backstage/types';
 import {
   V1Deployment,
   V1Pod,
@@ -44,7 +45,7 @@ export interface GroupedResponses extends DeploymentResources {
 
 export interface ClusterLinksFormatterOptions {
   dashboardUrl?: URL;
-  dashboardParameters?: any;
+  dashboardParameters?: JsonObject;
   object: any;
   kind: string;
 }

--- a/plugins/kubernetes/src/utils/clusterLinks/formatClusterLink.test.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatClusterLink.test.ts
@@ -114,5 +114,47 @@ describe('clusterLinks', () => {
         );
       });
     });
+    describe('GKE app', () => {
+      it('should return an url on the deployment', () => {
+        const url = formatClusterLink({
+          dashboardApp: 'gke',
+          dashboardParameters: {
+            projectId: 'foobar-333614',
+            region: 'us-east1-c',
+            clusterName: 'cluster-1',
+          },
+          object: {
+            metadata: {
+              name: 'foobar',
+              namespace: 'bar',
+            },
+          },
+          kind: 'Deployment',
+        });
+        expect(url).toBe(
+          'https://console.cloud.google.com/kubernetes/deployment/us-east1-c/cluster-1/bar/foobar/overview?project=foobar-333614',
+        );
+      });
+      it('should return an url on the service', () => {
+        const url = formatClusterLink({
+          dashboardApp: 'gke',
+          dashboardParameters: {
+            projectId: 'foobar-333614',
+            region: 'us-east1-c',
+            clusterName: 'cluster-1',
+          },
+          object: {
+            metadata: {
+              name: 'foobar',
+              namespace: 'bar',
+            },
+          },
+          kind: 'Service',
+        });
+        expect(url).toBe(
+          'https://console.cloud.google.com/kubernetes/service/us-east1-c/cluster-1/bar/foobar/overview?project=foobar-333614',
+        );
+      });
+    });
   });
 });

--- a/plugins/kubernetes/src/utils/clusterLinks/formatClusterLink.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatClusterLink.ts
@@ -19,15 +19,16 @@ import { defaultFormatterName, clusterLinksFormatters } from './formatters';
 export type FormatClusterLinkOptions = {
   dashboardUrl?: string;
   dashboardApp?: string;
+  dashboardParameters?: any;
   object: any;
   kind: string;
 };
 
 export function formatClusterLink(options: FormatClusterLinkOptions) {
-  if (!options.dashboardUrl) {
+  if (!options.dashboardUrl && !options.dashboardParameters) {
     return undefined;
   }
-  if (!options.object) {
+  if (options.dashboardUrl && !options.object) {
     return options.dashboardUrl;
   }
   const app = options.dashboardApp || defaultFormatterName;
@@ -36,7 +37,10 @@ export function formatClusterLink(options: FormatClusterLinkOptions) {
     throw new Error(`Could not find Kubernetes dashboard app named '${app}'`);
   }
   const url = formatter({
-    dashboardUrl: new URL(options.dashboardUrl),
+    dashboardUrl: options.dashboardUrl
+      ? new URL(options.dashboardUrl)
+      : undefined,
+    dashboardParameters: options.dashboardParameters,
     object: options.object,
     kind: options.kind,
   });

--- a/plugins/kubernetes/src/utils/clusterLinks/formatClusterLink.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatClusterLink.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+import type { JsonObject } from '@backstage/types';
 import { defaultFormatterName, clusterLinksFormatters } from './formatters';
 
 export type FormatClusterLinkOptions = {
   dashboardUrl?: string;
   dashboardApp?: string;
-  dashboardParameters?: any;
+  dashboardParameters?: JsonObject;
   object: any;
   kind: string;
 };

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/gke.test.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/gke.test.ts
@@ -16,10 +16,9 @@
 import { gkeFormatter } from './gke';
 
 describe('clusterLinks - GKE formatter', () => {
-  it('should return an url on the workloads when there is a namespace only', () => {
+  it('should provide a dashboardParameters in the options', () => {
     expect(() =>
       gkeFormatter({
-        dashboardUrl: new URL('https://k8s.foo.com'),
         object: {
           metadata: {
             name: 'foobar',
@@ -28,6 +27,196 @@ describe('clusterLinks - GKE formatter', () => {
         },
         kind: 'Deployment',
       }),
-    ).toThrowError('GKE formatter is not yet implemented. Please, contribute!');
+    ).toThrowError('GKE dashboard requires a dashboardParameters option');
+  });
+  it('should provide a projectId in the dashboardParameters options', () => {
+    expect(() =>
+      gkeFormatter({
+        dashboardParameters: {
+          region: 'us-east1-c',
+          clusterName: 'cluster-1',
+        },
+        object: {
+          metadata: {
+            name: 'foobar',
+            namespace: 'bar',
+          },
+        },
+        kind: 'Deployment',
+      }),
+    ).toThrowError(
+      'GKE dashboard requires a "projectId" in the dashboardParameters option',
+    );
+  });
+  it('should provide a region in the dashboardParameters options', () => {
+    expect(() =>
+      gkeFormatter({
+        dashboardParameters: {
+          projectId: 'foobar-333614',
+          clusterName: 'cluster-1',
+        },
+        object: {
+          metadata: {
+            name: 'foobar',
+            namespace: 'bar',
+          },
+        },
+        kind: 'Deployment',
+      }),
+    ).toThrowError(
+      'GKE dashboard requires a "region" in the dashboardParameters option',
+    );
+  });
+  it('should provide a clusterName in the dashboardParameters options', () => {
+    expect(() =>
+      gkeFormatter({
+        dashboardParameters: {
+          projectId: 'foobar-333614',
+          region: 'us-east1-c',
+        },
+        object: {
+          metadata: {
+            name: 'foobar',
+            namespace: 'bar',
+          },
+        },
+        kind: 'Deployment',
+      }),
+    ).toThrowError(
+      'GKE dashboard requires a "clusterName" in the dashboardParameters option',
+    );
+  });
+  it('should return an url on the cluster when there is a namespace only', () => {
+    const url = gkeFormatter({
+      dashboardParameters: {
+        projectId: 'foobar-333614',
+        region: 'us-east1-c',
+        clusterName: 'cluster-1',
+      },
+      object: {
+        metadata: {
+          namespace: 'bar',
+        },
+      },
+      kind: 'foo',
+    });
+    expect(url.href).toBe(
+      'https://console.cloud.google.com/kubernetes/clusters/details/us-east1-c/cluster-1/details?project=foobar-333614',
+    );
+  });
+  it('should return an url on the cluster when the kind is not recognizeed', () => {
+    const url = gkeFormatter({
+      dashboardParameters: {
+        projectId: 'foobar-333614',
+        region: 'us-east1-c',
+        clusterName: 'cluster-1',
+      },
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'UnknownKind',
+    });
+    expect(url.href).toBe(
+      'https://console.cloud.google.com/kubernetes/clusters/details/us-east1-c/cluster-1/details?project=foobar-333614',
+    );
+  });
+  it('should return an url on the deployment', () => {
+    const url = gkeFormatter({
+      dashboardParameters: {
+        projectId: 'foobar-333614',
+        region: 'us-east1-c',
+        clusterName: 'cluster-1',
+      },
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'Deployment',
+    });
+    expect(url.href).toBe(
+      'https://console.cloud.google.com/kubernetes/deployment/us-east1-c/cluster-1/bar/foobar/overview?project=foobar-333614',
+    );
+  });
+
+  it('should return an url on the service', () => {
+    const url = gkeFormatter({
+      dashboardParameters: {
+        projectId: 'foobar-333614',
+        region: 'us-east1-c',
+        clusterName: 'cluster-1',
+      },
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'Service',
+    });
+    expect(url.href).toBe(
+      'https://console.cloud.google.com/kubernetes/service/us-east1-c/cluster-1/bar/foobar/overview?project=foobar-333614',
+    );
+  });
+  it('should return an url on the pod', () => {
+    const url = gkeFormatter({
+      dashboardParameters: {
+        projectId: 'foobar-333614',
+        region: 'us-east1-c',
+        clusterName: 'cluster-1',
+      },
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'Pod',
+    });
+    expect(url.href).toBe(
+      'https://console.cloud.google.com/kubernetes/pod/us-east1-c/cluster-1/bar/foobar/details?project=foobar-333614',
+    );
+  });
+  it('should return an url on the ingress', () => {
+    const url = gkeFormatter({
+      dashboardParameters: {
+        projectId: 'foobar-333614',
+        region: 'us-east1-c',
+        clusterName: 'cluster-1',
+      },
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'Ingress',
+    });
+    expect(url.href).toBe(
+      'https://console.cloud.google.com/kubernetes/ingress/us-east1-c/cluster-1/bar/foobar/details?project=foobar-333614',
+    );
+  });
+  it('should return an url on the deployment for a hpa', () => {
+    const url = gkeFormatter({
+      dashboardParameters: {
+        projectId: 'foobar-333614',
+        region: 'us-east1-c',
+        clusterName: 'cluster-1',
+      },
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'HorizontalPodAutoscaler',
+    });
+    expect(url.href).toBe(
+      'https://console.cloud.google.com/kubernetes/deployment/us-east1-c/cluster-1/bar/foobar/overview?project=foobar-333614',
+    );
   });
 });

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/gke.test.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/gke.test.ts
@@ -45,7 +45,7 @@ describe('clusterLinks - GKE formatter', () => {
         kind: 'Deployment',
       }),
     ).toThrowError(
-      'GKE dashboard requires a "projectId" in the dashboardParameters option',
+      'GKE dashboard requires a "projectId" of type string in the dashboardParameters option',
     );
   });
   it('should provide a region in the dashboardParameters options', () => {
@@ -64,7 +64,7 @@ describe('clusterLinks - GKE formatter', () => {
         kind: 'Deployment',
       }),
     ).toThrowError(
-      'GKE dashboard requires a "region" in the dashboardParameters option',
+      'GKE dashboard requires a "region" of type string in the dashboardParameters option',
     );
   });
   it('should provide a clusterName in the dashboardParameters options', () => {
@@ -83,7 +83,7 @@ describe('clusterLinks - GKE formatter', () => {
         kind: 'Deployment',
       }),
     ).toThrowError(
-      'GKE dashboard requires a "clusterName" in the dashboardParameters option',
+      'GKE dashboard requires a "clusterName" of type string in the dashboardParameters option',
     );
   });
   it('should return an url on the cluster when there is a namespace only', () => {

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/gke.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/gke.ts
@@ -51,13 +51,6 @@ export function gkeFormatter(options: ClusterLinksFormatterOptions): URL {
     options.object.metadata?.namespace ?? '',
   );
   const validKind = kindMappings[options.kind.toLocaleLowerCase('en-US')];
-  if (!basePath.pathname.endsWith('/')) {
-    // a dashboard url with a path should end with a slash otherwise
-    // the new combined URL will replace the last segment with the appended path!
-    // https://foobar.com/abc/def + k8s/cluster/projects/test  --> https://foobar.com/abc/k8s/cluster/projects/test
-    // https://foobar.com/abc/def/ + k8s/cluster/projects/test --> https://foobar.com/abc/def/k8s/cluster/projects/test
-    basePath.pathname += '/';
-  }
   let path = '';
   if (namespace && name && validKind) {
     const kindsWithDetails = ['ingress', 'pod'];

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/gke.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/gke.ts
@@ -28,19 +28,19 @@ export function gkeFormatter(options: ClusterLinksFormatterOptions): URL {
     throw new Error('GKE dashboard requires a dashboardParameters option');
   }
   const args = options.dashboardParameters;
-  if (!args.projectId) {
+  if (typeof args.projectId !== 'string') {
     throw new Error(
-      'GKE dashboard requires a "projectId" in the dashboardParameters option',
+      'GKE dashboard requires a "projectId" of type string in the dashboardParameters option',
     );
   }
-  if (!args.region) {
+  if (typeof args.region !== 'string') {
     throw new Error(
-      'GKE dashboard requires a "region" in the dashboardParameters option',
+      'GKE dashboard requires a "region" of type string in the dashboardParameters option',
     );
   }
-  if (!args.clusterName) {
+  if (typeof args.clusterName !== 'string') {
     throw new Error(
-      'GKE dashboard requires a "clusterName" in the dashboardParameters option',
+      'GKE dashboard requires a "clusterName" of type string in the dashboardParameters option',
     );
   }
   const basePath = new URL('https://console.cloud.google.com/');

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/openshift.test.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/openshift.test.ts
@@ -16,6 +16,19 @@
 import { openshiftFormatter } from './openshift';
 
 describe('clusterLinks - OpenShift formatter', () => {
+  it('should provide a dashboardUrl in the options', () => {
+    expect(() =>
+      openshiftFormatter({
+        object: {
+          metadata: {
+            name: 'foobar',
+            namespace: 'bar',
+          },
+        },
+        kind: 'Deployment',
+      }),
+    ).toThrowError('OpenShift dashboard requires a dashboardUrl option');
+  });
   it('should return an url on the workloads when there is a namespace only', () => {
     const url = openshiftFormatter({
       dashboardUrl: new URL('https://k8s.foo.com'),

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/openshift.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/openshift.ts
@@ -24,6 +24,9 @@ const kindMappings: Record<string, string> = {
 };
 
 export function openshiftFormatter(options: ClusterLinksFormatterOptions): URL {
+  if (!options.dashboardUrl) {
+    throw new Error('OpenShift dashboard requires a dashboardUrl option');
+  }
   const basePath = new URL(options.dashboardUrl.href);
   const name = encodeURIComponent(options.object.metadata?.name ?? '');
   const namespace = encodeURIComponent(

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.test.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.test.ts
@@ -16,6 +16,19 @@
 import { rancherFormatter } from './rancher';
 
 describe('clusterLinks - rancher formatter', () => {
+  it('should provide a dashboardUrl in the options', () => {
+    expect(() =>
+      rancherFormatter({
+        object: {
+          metadata: {
+            name: 'foobar',
+            namespace: 'bar',
+          },
+        },
+        kind: 'Deployment',
+      }),
+    ).toThrowError('Rancher dashboard requires a dashboardUrl option');
+  });
   it('should return a url on the workloads when there is a namespace only', () => {
     const url = rancherFormatter({
       dashboardUrl: new URL('https://k8s.foo.com'),

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/rancher.ts
@@ -23,6 +23,9 @@ const kindMappings: Record<string, string> = {
 };
 
 export function rancherFormatter(options: ClusterLinksFormatterOptions): URL {
+  if (!options.dashboardUrl) {
+    throw new Error('Rancher dashboard requires a dashboardUrl option');
+  }
   const basePath = new URL(options.dashboardUrl.href);
   const name = encodeURIComponent(options.object.metadata?.name ?? '');
   const namespace = encodeURIComponent(

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/standard.test.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/standard.test.ts
@@ -23,6 +23,19 @@ function formatUrl(url: URL) {
 }
 
 describe('clusterLinks - standard formatter', () => {
+  it('should provide a dashboardUrl in the options', () => {
+    expect(() =>
+      standardFormatter({
+        object: {
+          metadata: {
+            name: 'foobar',
+            namespace: 'bar',
+          },
+        },
+        kind: 'Deployment',
+      }),
+    ).toThrowError('standard dashboard requires a dashboardUrl option');
+  });
   it('should return an url on the workloads when there is a namespace only', () => {
     const url = standardFormatter({
       dashboardUrl: new URL('https://k8s.foo.com'),
@@ -65,6 +78,21 @@ describe('clusterLinks - standard formatter', () => {
     });
     expect(formatUrl(url)).toBe(
       'https://k8s.foo.com/#/deployment/bar/foobar?namespace=bar',
+    );
+  });
+  it('should return an url on the pod', () => {
+    const url = standardFormatter({
+      dashboardUrl: new URL('https://k8s.foo.com/'),
+      object: {
+        metadata: {
+          name: 'foobar',
+          namespace: 'bar',
+        },
+      },
+      kind: 'Pod',
+    });
+    expect(formatUrl(url)).toBe(
+      'https://k8s.foo.com/#/pod/bar/foobar?namespace=bar',
     );
   });
   it('should return an url on the deployment with a prefix 1', () => {

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/standard.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/standard.ts
@@ -17,12 +17,16 @@ import { ClusterLinksFormatterOptions } from '../../../types/types';
 
 const kindMappings: Record<string, string> = {
   deployment: 'deployment',
+  pod: 'pod',
   ingress: 'ingress',
   service: 'service',
   horizontalpodautoscaler: 'deployment',
 };
 
 export function standardFormatter(options: ClusterLinksFormatterOptions) {
+  if (!options.dashboardUrl) {
+    throw new Error('standard dashboard requires a dashboardUrl option');
+  }
   const result = new URL(options.dashboardUrl.href);
   const name = encodeURIComponent(options.object.metadata?.name ?? '');
   const namespace = encodeURIComponent(


### PR DESCRIPTION
Signed-off-by: Morgan Martinet <morgan.martinet@montreal.ca>

## Hey, I just made a Pull Request!

I've implemented the link formatter for GKE clusters and also provided an option "exposeDashboard" to the GkeClusterLocator in order to automatically configure the dashboard attributes.
I've kept the option false by default, to let the users opt in.

I've tested it with a real GKE cluster and everything's fine.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
