### PR TITLE
Overridable components for components in plugin catalog react

### DIFF
--- a/.changeset/purple-trains-matter.md
+++ b/.changeset/purple-trains-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Add Override Components for Components in @backstage/plugin-catalog-react

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -19,12 +19,14 @@ import { IconButton } from '@material-ui/core';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { LinkProps } from '@backstage/core-components';
 import { Observable } from '@backstage/types';
+import { Overrides } from '@material-ui/core/styles/overrides';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { StorageApi } from '@backstage/core-plugin-api';
+import { StyleRules } from '@material-ui/core/styles/withStyles';
 import { SystemEntity } from '@backstage/catalog-model';
 import { TableColumn } from '@backstage/core-components';
 import { UserEntity } from '@backstage/catalog-model';
@@ -52,6 +54,15 @@ export interface AsyncEntityProviderProps {
   refresh?: VoidFunction;
 }
 
+// Warning: (ae-forgotten-export) The symbol "BackstageComponentsNameToClassKey" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type BackstageOverrides = Overrides & {
+  [Name in keyof BackstageComponentsNameToClassKey]?: Partial<
+    StyleRules<BackstageComponentsNameToClassKey[Name]>
+  >;
+};
+
 export { CATALOG_FILTER_EXISTS };
 
 export { CatalogApi };
@@ -60,6 +71,36 @@ export { CatalogApi };
 //
 // @public (undocumented)
 export const catalogApiRef: ApiRef<CatalogApi>;
+
+// Warning: (ae-missing-release-tag) "CatalogReactEntityLifecyclePickerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CatalogReactEntityLifecyclePickerClassKey = 'input';
+
+// Warning: (ae-missing-release-tag) "CatalogReactEntityOwnerPickerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CatalogReactEntityOwnerPickerClassKey = 'input';
+
+// Warning: (ae-missing-release-tag) "CatalogReactEntitySearchBarClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CatalogReactEntitySearchBarClassKey = 'searchToolbar' | 'input';
+
+// Warning: (ae-missing-release-tag) "CatalogReactEntityTagPickerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CatalogReactEntityTagPickerClassKey = 'input';
+
+// Warning: (ae-missing-release-tag) "CatalogReactUserListPickerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CatalogReactUserListPickerClassKey =
+  | 'root'
+  | 'title'
+  | 'listIcon'
+  | 'menuItem'
+  | 'groupWrapper';
 
 // Warning: (ae-missing-release-tag) "catalogRouteRef" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -54,8 +54,6 @@ export interface AsyncEntityProviderProps {
   refresh?: VoidFunction;
 }
 
-// Warning: (ae-forgotten-export) The symbol "CatalogReactComponentsNameToClassKey" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export type BackstageOverrides = Overrides & {
   [Name in keyof CatalogReactComponentsNameToClassKey]?: Partial<
@@ -71,6 +69,15 @@ export { CatalogApi };
 //
 // @public (undocumented)
 export const catalogApiRef: ApiRef<CatalogApi>;
+
+// @public (undocumented)
+export type CatalogReactComponentsNameToClassKey = {
+  CatalogReactUserListPicker: CatalogReactUserListPickerClassKey;
+  CatalogReactEntityLifecyclePicker: CatalogReactEntityLifecyclePickerClassKey;
+  CatalogReactEntitySearchBar: CatalogReactEntitySearchBarClassKey;
+  CatalogReactEntityTagPicker: CatalogReactEntityTagPickerClassKey;
+  CatalogReactEntityOwnerPicker: CatalogReactEntityOwnerPickerClassKey;
+};
 
 // @public (undocumented)
 export type CatalogReactEntityLifecyclePickerClassKey = 'input';

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -54,12 +54,12 @@ export interface AsyncEntityProviderProps {
   refresh?: VoidFunction;
 }
 
-// Warning: (ae-forgotten-export) The symbol "BackstageComponentsNameToClassKey" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "CatalogReactComponentsNameToClassKey" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type BackstageOverrides = Overrides & {
-  [Name in keyof BackstageComponentsNameToClassKey]?: Partial<
-    StyleRules<BackstageComponentsNameToClassKey[Name]>
+  [Name in keyof CatalogReactComponentsNameToClassKey]?: Partial<
+    StyleRules<CatalogReactComponentsNameToClassKey[Name]>
   >;
 };
 
@@ -72,28 +72,18 @@ export { CatalogApi };
 // @public (undocumented)
 export const catalogApiRef: ApiRef<CatalogApi>;
 
-// Warning: (ae-missing-release-tag) "CatalogReactEntityLifecyclePickerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type CatalogReactEntityLifecyclePickerClassKey = 'input';
 
-// Warning: (ae-missing-release-tag) "CatalogReactEntityOwnerPickerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type CatalogReactEntityOwnerPickerClassKey = 'input';
 
-// Warning: (ae-missing-release-tag) "CatalogReactEntitySearchBarClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type CatalogReactEntitySearchBarClassKey = 'searchToolbar' | 'input';
 
-// Warning: (ae-missing-release-tag) "CatalogReactEntityTagPickerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type CatalogReactEntityTagPickerClassKey = 'input';
 
-// Warning: (ae-missing-release-tag) "CatalogReactUserListPickerClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type CatalogReactUserListPickerClassKey =
   | 'root'

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -31,6 +31,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
 import { EntityLifecycleFilter } from '../../filters';
 
+export type CatalogReactEntityLifecyclePickerClassKey = 'input';
+
 const useStyles = makeStyles(
   {
     input: {},

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -31,6 +31,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
 import { EntityLifecycleFilter } from '../../filters';
 
+/** @public */
 export type CatalogReactEntityLifecyclePickerClassKey = 'input';
 
 const useStyles = makeStyles(

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/index.ts
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { EntityLifecyclePicker } from './EntityLifecyclePicker';
+export type { CatalogReactEntityLifecyclePickerClassKey } from './EntityLifecyclePicker';

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -33,6 +33,7 @@ import { EntityOwnerFilter } from '../../filters';
 import { getEntityRelations } from '../../utils';
 import { formatEntityRefTitle } from '../EntityRefLink';
 
+/** @public */
 export type CatalogReactEntityOwnerPickerClassKey = 'input';
 
 const useStyles = makeStyles(

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -33,6 +33,8 @@ import { EntityOwnerFilter } from '../../filters';
 import { getEntityRelations } from '../../utils';
 import { formatEntityRefTitle } from '../EntityRefLink';
 
+export type CatalogReactEntityOwnerPickerClassKey = 'input';
+
 const useStyles = makeStyles(
   {
     input: {},

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/index.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { EntityOwnerPicker } from './EntityOwnerPicker';
+export type { CatalogReactEntityOwnerPickerClassKey } from './EntityOwnerPicker';

--- a/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
+++ b/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
@@ -29,6 +29,8 @@ import { useDebounce } from 'react-use';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
 import { EntityTextFilter } from '../../filters';
 
+export type CatalogReactEntitySearchBarClassKey = 'searchToolbar' | 'input';
+
 const useStyles = makeStyles(
   _theme => ({
     searchToolbar: {

--- a/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
+++ b/plugins/catalog-react/src/components/EntitySearchBar/EntitySearchBar.tsx
@@ -29,6 +29,7 @@ import { useDebounce } from 'react-use';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
 import { EntityTextFilter } from '../../filters';
 
+/** @public */
 export type CatalogReactEntitySearchBarClassKey = 'searchToolbar' | 'input';
 
 const useStyles = makeStyles(

--- a/plugins/catalog-react/src/components/EntitySearchBar/index.ts
+++ b/plugins/catalog-react/src/components/EntitySearchBar/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { EntitySearchBar } from './EntitySearchBar';
+export type { CatalogReactEntitySearchBarClassKey } from './EntitySearchBar';

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -31,6 +31,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
 import { EntityTagFilter } from '../../filters';
 
+/** @public */
 export type CatalogReactEntityTagPickerClassKey = 'input';
 
 const useStyles = makeStyles(

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -31,6 +31,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useEntityListProvider } from '../../hooks/useEntityListProvider';
 import { EntityTagFilter } from '../../filters';
 
+export type CatalogReactEntityTagPickerClassKey = 'input';
+
 const useStyles = makeStyles(
   {
     input: {},

--- a/plugins/catalog-react/src/components/EntityTagPicker/index.ts
+++ b/plugins/catalog-react/src/components/EntityTagPicker/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { EntityTagPicker } from './EntityTagPicker';
+export type { CatalogReactEntityTagPickerClassKey } from './EntityTagPicker';

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -43,6 +43,13 @@ import {
 import { UserListFilterKind } from '../../types';
 import { reduceEntityFilters } from '../../utils';
 
+export type CatalogReactUserListPickerClassKey =
+  | 'root'
+  | 'title'
+  | 'listIcon'
+  | 'menuItem'
+  | 'groupWrapper';
+
 const useStyles = makeStyles<Theme>(
   theme => ({
     root: {

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -43,6 +43,7 @@ import {
 import { UserListFilterKind } from '../../types';
 import { reduceEntityFilters } from '../../utils';
 
+/** @public */
 export type CatalogReactUserListPickerClassKey =
   | 'root'
   | 'title'

--- a/plugins/catalog-react/src/components/UserListPicker/index.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { UserListPicker } from './UserListPicker';
+export type { CatalogReactUserListPickerClassKey } from './UserListPicker';

--- a/plugins/catalog-react/src/index.ts
+++ b/plugins/catalog-react/src/index.ts
@@ -37,3 +37,4 @@ export {
 export * from './testUtils';
 export * from './types';
 export * from './utils';
+export * from './overridableComponents';

--- a/plugins/catalog-react/src/overridableComponents.ts
+++ b/plugins/catalog-react/src/overridableComponents.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Overrides } from '@material-ui/core/styles/overrides';
+import { StyleRules } from '@material-ui/core/styles/withStyles';
+
+import {
+  CatalogReactUserListPickerClassKey,
+  CatalogReactEntityLifecyclePickerClassKey,
+  CatalogReactEntitySearchBarClassKey,
+  CatalogReactEntityTagPickerClassKey,
+  CatalogReactEntityOwnerPickerClassKey,
+} from './components';
+
+type BackstageComponentsNameToClassKey = {
+  CatalogReactUserListPicker: CatalogReactUserListPickerClassKey;
+  CatalogReactEntityLifecyclePicker: CatalogReactEntityLifecyclePickerClassKey;
+  CatalogReactEntitySearchBar: CatalogReactEntitySearchBarClassKey;
+  CatalogReactEntityTagPicker: CatalogReactEntityTagPickerClassKey;
+  CatalogReactEntityOwnerPicker: CatalogReactEntityOwnerPickerClassKey;
+};
+
+/** @public */
+export type BackstageOverrides = Overrides & {
+  [Name in keyof BackstageComponentsNameToClassKey]?: Partial<
+    StyleRules<BackstageComponentsNameToClassKey[Name]>
+  >;
+};

--- a/plugins/catalog-react/src/overridableComponents.ts
+++ b/plugins/catalog-react/src/overridableComponents.ts
@@ -24,7 +24,7 @@ import {
   CatalogReactEntityOwnerPickerClassKey,
 } from './components';
 
-type BackstageComponentsNameToClassKey = {
+type CatalogReactComponentsNameToClassKey = {
   CatalogReactUserListPicker: CatalogReactUserListPickerClassKey;
   CatalogReactEntityLifecyclePicker: CatalogReactEntityLifecyclePickerClassKey;
   CatalogReactEntitySearchBar: CatalogReactEntitySearchBarClassKey;
@@ -34,7 +34,7 @@ type BackstageComponentsNameToClassKey = {
 
 /** @public */
 export type BackstageOverrides = Overrides & {
-  [Name in keyof BackstageComponentsNameToClassKey]?: Partial<
-    StyleRules<BackstageComponentsNameToClassKey[Name]>
+  [Name in keyof CatalogReactComponentsNameToClassKey]?: Partial<
+    StyleRules<CatalogReactComponentsNameToClassKey[Name]>
   >;
 };

--- a/plugins/catalog-react/src/overridableComponents.ts
+++ b/plugins/catalog-react/src/overridableComponents.ts
@@ -24,7 +24,8 @@ import {
   CatalogReactEntityOwnerPickerClassKey,
 } from './components';
 
-type CatalogReactComponentsNameToClassKey = {
+/** @public */
+export type CatalogReactComponentsNameToClassKey = {
   CatalogReactUserListPicker: CatalogReactUserListPickerClassKey;
   CatalogReactEntityLifecyclePicker: CatalogReactEntityLifecyclePickerClassKey;
   CatalogReactEntitySearchBar: CatalogReactEntitySearchBarClassKey;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Current overridable components are only for components that reside in @backstage/core-components. This PR is for exporting overridable components in @backstage/plugin-catalog-react.

We can use it like this in backstage app.

```
import { BackstageOverrides } from '@backstage/core-components';
import { BackstageOverrides as PluginCatalogReactBackstageOverrides } from '@backstage/plugin-catalog-react';

type MergedBackstageOverrides = BackstageOverrides &
  PluginCatalogReactBackstageOverrides;

```



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
~- [ ] Added or updated documentation~
~- [ ] Tests for new functionality and regression tests for bug fixes~
~- [ ] Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
