### PR TITLE
cost-insights: avoid re-export of all of test-utils

### DIFF
--- a/.changeset/curly-bugs-stare.md
+++ b/.changeset/curly-bugs-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cost-insights': patch
+---
+
+Fixed an accidental re-export of `@backstage/test-utils` that broke this plugin in the most recent release.

--- a/plugins/cost-insights/src/components/ProductInsights/ProductInsights.test.tsx
+++ b/plugins/cost-insights/src/components/ProductInsights/ProductInsights.test.tsx
@@ -15,13 +15,12 @@
  */
 
 import React from 'react';
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { ProductInsights } from './ProductInsights';
-import { ProductInsightsOptions } from '../../api';
+import { costInsightsApiRef, ProductInsightsOptions } from '../../api';
 import {
   mockDefaultLoadingState,
   MockConfigProvider,
-  MockCostInsightsApiProvider,
   MockCurrencyProvider,
   MockFilterProvider,
   MockBillingDateProvider,
@@ -139,7 +138,7 @@ const costInsightsApi = {
 
 function renderInContext(children: JSX.Element) {
   return renderInTestApp(
-    <MockCostInsightsApiProvider costInsightsApi={costInsightsApi}>
+    <TestApiProvider apis={[[costInsightsApiRef, costInsightsApi]]}>
       <MockConfigProvider>
         <MockFilterProvider>
           <MockCurrencyProvider>
@@ -151,7 +150,7 @@ function renderInContext(children: JSX.Element) {
           </MockCurrencyProvider>
         </MockFilterProvider>
       </MockConfigProvider>
-    </MockCostInsightsApiProvider>,
+    </TestApiProvider>,
   );
 }
 

--- a/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsCard.test.tsx
+++ b/plugins/cost-insights/src/components/ProductInsightsCard/ProductInsightsCard.test.tsx
@@ -15,15 +15,14 @@
  */
 
 import React from 'react';
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { ProductInsightsCard } from './ProductInsightsCard';
-import { CostInsightsApi } from '../../api';
+import { CostInsightsApi, costInsightsApiRef } from '../../api';
 import {
   createMockEntity,
   mockDefaultLoadingState,
   MockComputeEngine,
   MockConfigProvider,
-  MockCostInsightsApiProvider,
   MockCurrencyProvider,
   MockBillingDateProvider,
   MockScrollProvider,
@@ -55,7 +54,7 @@ const renderProductInsightsCardInTestApp = async (
   onSelectAsync = jest.fn(() => Promise.resolve(mockProductCost)),
 ) =>
   await renderInTestApp(
-    <MockCostInsightsApiProvider costInsightsApi={costInsightsApi(entity)}>
+    <TestApiProvider apis={[[costInsightsApiRef, costInsightsApi(entity)]]}>
       <MockConfigProvider>
         <MockCurrencyProvider>
           <MockLoadingProvider state={mockDefaultLoadingState}>
@@ -71,7 +70,7 @@ const renderProductInsightsCardInTestApp = async (
           </MockLoadingProvider>
         </MockCurrencyProvider>
       </MockConfigProvider>
-    </MockCostInsightsApiProvider>,
+    </TestApiProvider>,
   );
 
 describe('<ProductInsightsCard/>', () => {

--- a/plugins/cost-insights/src/testUtils/providers.tsx
+++ b/plugins/cost-insights/src/testUtils/providers.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { PropsWithChildren } from 'react';
-import { costInsightsApiRef, CostInsightsApi } from '../api';
 import { LoadingContext, LoadingContextProps } from '../hooks/useLoading';
 import { GroupsContext, GroupsContextProps } from '../hooks/useGroups';
 import { FilterContext, FilterContextProps } from '../hooks/useFilters';
@@ -27,12 +26,6 @@ import {
 } from '../hooks/useLastCompleteBillingDate';
 import { ScrollContext, ScrollContextProps } from '../hooks/useScroll';
 import { Group, Duration } from '../types';
-
-// TODO(Rugvip): Could be good to have a clear place to put test utils that is linted accordingly
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { IdentityApi, identityApiRef } from '@backstage/core-plugin-api';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { TestApiProvider } from '@backstage/test-utils';
 
 type PartialPropsWithChildren<T> = PropsWithChildren<Partial<T>>;
 
@@ -170,50 +163,5 @@ export const MockGroupsProvider = ({
     <GroupsContext.Provider value={{ ...defaultContext, ...context }}>
       {children}
     </GroupsContext.Provider>
-  );
-};
-
-export type MockCostInsightsApiProviderProps = PartialPropsWithChildren<{
-  identityApi: Partial<IdentityApi>;
-  costInsightsApi: Partial<CostInsightsApi>;
-}>;
-
-export const MockCostInsightsApiProvider = ({
-  children,
-  ...context
-}: MockCostInsightsApiProviderProps) => {
-  const defaultIdentityApi: IdentityApi = {
-    getProfile: jest.fn(),
-    getIdToken: jest.fn(),
-    getUserId: jest.fn(),
-    signOut: jest.fn(),
-    getProfileInfo: jest.fn(),
-    getBackstageIdentity: jest.fn(),
-    getCredentials: jest.fn(),
-  };
-
-  const defaultCostInsightsApi: CostInsightsApi = {
-    getAlerts: jest.fn(),
-    getDailyMetricData: jest.fn(),
-    getGroupDailyCost: jest.fn(),
-    getGroupProjects: jest.fn(),
-    getLastCompleteBillingDate: jest.fn(),
-    getProductInsights: jest.fn(),
-    getProjectDailyCost: jest.fn(),
-    getUserGroups: jest.fn(),
-  };
-
-  return (
-    <TestApiProvider
-      apis={[
-        [identityApiRef, { ...defaultIdentityApi, ...context.identityApi }],
-        [
-          costInsightsApiRef,
-          { ...defaultCostInsightsApi, ...context.costInsightsApi },
-        ],
-      ]}
-    >
-      {children}
-    </TestApiProvider>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #8554

Couple of refactors in a row here lead to some catastrophic breakage :grin:

The initial refactor to use `TestApiProvider` was done without knowing that the `src/testUtils` in `cost-insights` was exported. That was kind of still working for a while though because `react-dom` was listed as a dependency, causing it to be marked as external by the build process. With the more recent restructuring to make `react` and `react-dom` peer deps, the `react-dom` dependency was removed as it was no longer needed, so now all of `react-dom` was inlined into the build output, leading to the most recent release being broken in tests.

Fix here was to get rid of the use of `test-utils` in the shared utils code. Not adding any other check for this kind of breakage because `import/no-extraneous-dependencies` should already handle it. But there is a good reason it exists and it shouldn't be ignored too hastily :grin:

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
