### PR TITLE
Fix techdocs links to the CLI

### DIFF
--- a/docs/features/techdocs/configuring-ci-cd.md
+++ b/docs/features/techdocs/configuring-ci-cd.md
@@ -10,7 +10,7 @@ TechDocs reads the static generated documentation files from a cloud storage
 bucket (GCS, AWS S3, etc.). The documentation site is generated on the CI/CD
 workflow associated with the repository containing the documentation files. This
 document explains the steps needed to generate docs on CI and publish to a cloud
-storage using [`techdocs-cli`](https://github.com/backstage/techdocs-cli).
+storage using [`techdocs-cli`](./cli.md).
 
 The steps here target all kinds of CI providers (GitHub Actions, CircleCI,
 Jenkins, etc.). Specific tools for individual providers will also be made
@@ -40,9 +40,8 @@ techdocs-cli publish --publisher-type awsS3 --storage-name <bucket/container> --
 
 That's it!
 
-Take a look at
-[`techdocs-cli` README](https://github.com/backstage/techdocs-cli) for the
-complete command reference, details, and options.
+Take a look at [`techdocs-cli`](./cli.md) for the complete command reference,
+details, and options.
 
 ## Steps
 
@@ -74,7 +73,7 @@ Install [`npx`](https://www.npmjs.com/package/npx) to use it for running
 `techdocs-cli`. Or you can install using `npm install -g @techdocs/cli`.
 
 We are going to use the
-[`techdocs-cli generate`](https://github.com/backstage/techdocs-cli#generate-techdocs-site-from-a-documentation-project)
+[`techdocs-cli generate`](./cli.md#generate-techdocs-site-from-a-documentation-project)
 command in this step.
 
 ```sh
@@ -93,8 +92,7 @@ necessary authentication environment variables.
 - [AWS authentication](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html)
 
 And then run the
-[`techdocs-cli publish`](https://github.com/backstage/techdocs-cli#publish-generated-techdocs-sites)
-command.
+[`techdocs-cli publish`](./cli.md#publish-generated-techdocs-sites) command.
 
 ```sh
 npx @techdocs/cli publish --publisher-type <awsS3|googleGcs> --storage-name <bucket/container> --entity <namespace/kind/name> --directory ./site


### PR DESCRIPTION
The techdocs docs were written prior to the techdocs-cli being
crunched into the monorepo. This commit fixes a few links that
still point to the old separte spotify/techdocs-cli repo.

Signed-off-by: Greg Taylor <snagglepants@gmail.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
