### PR TITLE
Update techdocs mkdocs-techdocs-core version to 0.2.1

### DIFF
--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -230,7 +230,7 @@ You can do so by including the following lines in the last step of your
 
 ```Dockerfile
 RUN apt-get update && apt-get install -y python3 python3-pip
-RUN pip3 install mkdocs-techdocs-core==0.0.16
+RUN pip3 install mkdocs-techdocs-core==0.2.1
 ```
 
 Please be aware that the version requirement could change, you need to check our


### PR DESCRIPTION
The doc page includes a note to refer to a Dockerfile for the latest
version, but an update to the doc page may reduce the likelihood of
someone skimming and pulling in the now-very-old 0.0.x series.

Signed-off-by: Greg Taylor <snagglepants@gmail.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
