### PR TITLE
[Search] SearchBar Analytics tracking

### DIFF
--- a/.changeset/search-odd-starfishes-raise.md
+++ b/.changeset/search-odd-starfishes-raise.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search': patch
 ---
 
-Captures Google Analytics Events for SearchBar if app config is provided.
+Captures the search term entered in the SearchBar as a `search` event.

--- a/.changeset/search-odd-starfishes-raise.md
+++ b/.changeset/search-odd-starfishes-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Captures Google Analytics Events for SearchBar if app config is provided.

--- a/.changeset/search-odd-starfishes-raise.md
+++ b/.changeset/search-odd-starfishes-raise.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search': patch
 ---
 
-Captures the search term entered in the SearchBar as a `search` event.
+Captures the search term entered in the SearchBarBase as a `search` event.

--- a/docs/plugins/analytics.md
+++ b/docs/plugins/analytics.md
@@ -55,10 +55,11 @@ learn how to contribute the integration yourself!
 The following table summarizes events that, depending on the plugins you have
 installed, may be captured.
 
-| Action     | Provided By    | Subject                                   |
-| ---------- | -------------- | ----------------------------------------- |
-| `navigate` | Backstage Core | The URL of the page that was navigated to |
-| `click`    | Backstage Core | The text of the link that was clicked on  |
+| Action     | Provided By    | Subject                                             |
+| ---------- | -------------- | --------------------------------------------------- |
+| `navigate` | Backstage Core | The URL of the page that was navigated to           |
+| `click`    | Backstage Core | The text of the link that was clicked on            |
+| `search`   | Backstage Core | The search term entered in any search bar component |
 
 If there is an event you'd like to see captured, please [open an
 issue][add-event] describing the event you want to see and the questions it

--- a/plugins/search/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.test.tsx
@@ -314,7 +314,7 @@ describe('SearchBar', () => {
         extension: 'App',
         pluginId: 'root',
         routeRef: 'unknown',
-        types: 'techdocs,software-catalog',
+        searchTypes: 'software-catalog,techdocs',
       },
       subject: 'value',
     });

--- a/plugins/search/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.test.tsx
@@ -218,7 +218,7 @@ describe('SearchBar', () => {
     );
   });
 
-  it('does not capture google analytics event if not enabled in app', async () => {
+  it('does not capture analytics event if not enabled in app', async () => {
     jest.useFakeTimers();
 
     const debounceTime = 600;
@@ -251,7 +251,7 @@ describe('SearchBar', () => {
     expect(analyticsApiSpy.getEvents()).toHaveLength(0);
   });
 
-  it('captures google analytics events if enabled in app', async () => {
+  it('captures analytics events if enabled in app', async () => {
     jest.useFakeTimers();
 
     const debounceTime = 600;

--- a/plugins/search/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.test.tsx
@@ -276,7 +276,13 @@ describe('SearchBar', () => {
 
     render(
       <ApiProvider apis={apiRegistry}>
-        <SearchContextProvider initialState={initialState}>
+        <SearchContextProvider
+          initialState={{
+            term: '',
+            types: ['techdocs', 'software-catalog'],
+            filters: {},
+          }}
+        >
           <SearchBar debounceTime={debounceTime} />
         </SearchContextProvider>
         ,
@@ -302,9 +308,14 @@ describe('SearchBar', () => {
     await waitFor(() => expect(textbox).toHaveValue(value));
 
     expect(analyticsApiSpy.getEvents()).toHaveLength(1);
-    expect(analyticsApiSpy.getEvents()[0]).toMatchObject({
+    expect(analyticsApiSpy.getEvents()[0]).toEqual({
       action: 'search',
-      context: { extension: 'App', pluginId: 'root', routeRef: 'unknown' },
+      context: {
+        extension: 'App',
+        pluginId: 'root',
+        routeRef: 'unknown',
+        types: 'techdocs,software-catalog',
+      },
       subject: 'value',
     });
   });

--- a/plugins/search/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.test.tsx
@@ -20,10 +20,10 @@ import userEvent from '@testing-library/user-event';
 import { SearchContextProvider } from '../SearchContext';
 
 import { SearchBar } from './SearchBar';
-import { configApiRef } from '@backstage/core-plugin-api';
+import { configApiRef, analyticsApiRef } from '@backstage/core-plugin-api';
 import { ApiProvider, ConfigReader } from '@backstage/core-app-api';
 import { searchApiRef } from '../../apis';
-import { TestApiRegistry } from '@backstage/test-utils';
+import { MockAnalyticsApi, TestApiRegistry } from '@backstage/test-utils';
 
 jest.mock('@backstage/core-plugin-api', () => ({
   ...jest.requireActual('@backstage/core-plugin-api'),
@@ -38,9 +38,16 @@ describe('SearchBar', () => {
   };
 
   const query = jest.fn().mockResolvedValue({});
+  const analyticsApiSpy = new MockAnalyticsApi();
+  let apiRegistry: TestApiRegistry;
 
-  const apiRegistry = TestApiRegistry.from(
-    [configApiRef, new ConfigReader({ app: { title: 'Mock title' } })],
+  apiRegistry = TestApiRegistry.from(
+    [
+      configApiRef,
+      new ConfigReader({
+        app: { title: 'Mock title' },
+      }),
+    ],
     [searchApiRef, { query }],
   );
 
@@ -209,5 +216,96 @@ describe('SearchBar', () => {
     expect(query).toHaveBeenLastCalledWith(
       expect.objectContaining({ term: value }),
     );
+  });
+
+  it('does not capture google analytics event if not enabled in app', async () => {
+    jest.useFakeTimers();
+
+    const debounceTime = 600;
+
+    render(
+      <ApiProvider apis={apiRegistry}>
+        <SearchContextProvider initialState={initialState}>
+          <SearchBar debounceTime={debounceTime} />
+        </SearchContextProvider>
+        ,
+      </ApiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name })).toBeInTheDocument();
+    });
+
+    const textbox = screen.getByRole('textbox', { name });
+
+    const value = 'value';
+
+    userEvent.type(textbox, value);
+
+    act(() => {
+      jest.advanceTimersByTime(debounceTime);
+    });
+
+    await waitFor(() => expect(textbox).toHaveValue(value));
+
+    expect(analyticsApiSpy.getEvents()).toHaveLength(0);
+  });
+
+  it('captures google analytics events if enabled in app', async () => {
+    jest.useFakeTimers();
+
+    const debounceTime = 600;
+
+    apiRegistry = TestApiRegistry.from(
+      [analyticsApiRef, analyticsApiSpy],
+      [
+        configApiRef,
+        new ConfigReader({
+          app: {
+            title: 'Mock title',
+            analytics: {
+              ga: {
+                trackingId: 'xyz123',
+              },
+            },
+          },
+        }),
+      ],
+      [searchApiRef, { query }],
+    );
+
+    render(
+      <ApiProvider apis={apiRegistry}>
+        <SearchContextProvider initialState={initialState}>
+          <SearchBar debounceTime={debounceTime} />
+        </SearchContextProvider>
+        ,
+      </ApiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name })).toBeInTheDocument();
+    });
+
+    const textbox = screen.getByRole('textbox', { name });
+
+    const value = 'value';
+
+    userEvent.type(textbox, value);
+
+    expect(analyticsApiSpy.getEvents()).toHaveLength(0);
+
+    act(() => {
+      jest.advanceTimersByTime(debounceTime);
+    });
+
+    await waitFor(() => expect(textbox).toHaveValue(value));
+
+    expect(analyticsApiSpy.getEvents()).toHaveLength(1);
+    expect(analyticsApiSpy.getEvents()[0]).toMatchObject({
+      action: 'search',
+      context: { extension: 'App', pluginId: 'root', routeRef: 'unknown' },
+      subject: 'value',
+    });
   });
 });

--- a/plugins/search/src/components/SearchBar/SearchBar.test.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.test.tsx
@@ -285,7 +285,6 @@ describe('SearchBar', () => {
         >
           <SearchBar debounceTime={debounceTime} />
         </SearchContextProvider>
-        ,
       </ApiProvider>,
     );
 
@@ -317,6 +316,29 @@ describe('SearchBar', () => {
         searchTypes: 'software-catalog,techdocs',
       },
       subject: 'value',
+    });
+
+    userEvent.clear(textbox);
+
+    // make sure new term is captured
+    userEvent.type(textbox, 'new value');
+
+    act(() => {
+      jest.advanceTimersByTime(debounceTime);
+    });
+
+    await waitFor(() => expect(textbox).toHaveValue('new value'));
+
+    expect(analyticsApiSpy.getEvents()).toHaveLength(2);
+    expect(analyticsApiSpy.getEvents()[1]).toEqual({
+      action: 'search',
+      context: {
+        extension: 'App',
+        pluginId: 'root',
+        routeRef: 'unknown',
+        searchTypes: 'software-catalog,techdocs',
+      },
+      subject: 'new value',
     });
   });
 });

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -152,11 +152,14 @@ export const SearchBar = ({ onChange, ...props }: SearchBarProps) => {
   const { term, setTerm } = useSearch();
 
   const handleChange = (newValue: string) => {
-    setTerm(newValue);
-    if (onChange) onChange(newValue);
     if (configApi.getOptionalConfig('app.analytics.ga')) {
       // only capture GA events if analytics configuration is provided
       analytics.captureEvent('search', newValue);
+    }
+    if (onChange) {
+      onChange(newValue);
+    } else {
+      setTerm(newValue);
     }
   };
 

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -147,15 +147,12 @@ export type SearchBarProps = Partial<SearchBarBaseProps>;
  * @public
  */
 export const SearchBar = ({ onChange, ...props }: SearchBarProps) => {
-  const configApi = useApi(configApiRef);
   const analytics = useAnalytics();
   const { term, setTerm } = useSearch();
 
   const handleChange = (newValue: string) => {
-    if (configApi.getOptionalConfig('app.analytics.ga')) {
-      // only capture GA events if analytics configuration is provided
-      analytics.captureEvent('search', newValue);
-    }
+    // Catpure analytics search event with search term provided as value
+    analytics.captureEvent('search', newValue);
     if (onChange) {
       onChange(newValue);
     } else {

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -22,12 +22,7 @@ import React, {
   useCallback,
 } from 'react';
 import { useDebounce } from 'react-use';
-import {
-  configApiRef,
-  AnalyticsContext,
-  useAnalytics,
-  useApi,
-} from '@backstage/core-plugin-api';
+import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
 import {
   InputBase,
   InputBaseProps,
@@ -161,7 +156,7 @@ export type SearchBarProps = Partial<SearchBarBaseProps>;
  * @public
  */
 export const SearchBar = ({ onChange, ...props }: SearchBarProps) => {
-  const { term, setTerm, types } = useSearch();
+  const { term, setTerm } = useSearch();
 
   const handleChange = (newValue: string) => {
     if (onChange) {
@@ -171,9 +166,5 @@ export const SearchBar = ({ onChange, ...props }: SearchBarProps) => {
     }
   };
 
-  return (
-    <AnalyticsContext attributes={{ types: types.join(',') }}>
-      <SearchBarBase value={term} onChange={handleChange} {...props} />
-    </AnalyticsContext>
-  );
+  return <SearchBarBase value={term} onChange={handleChange} {...props} />;
 };

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -67,6 +67,7 @@ export const SearchBarBase = ({
   ...props
 }: SearchBarBaseProps) => {
   const configApi = useApi(configApiRef);
+  const analytics = useAnalytics();
   const [value, setValue] = useState<string>(defaultValue as string);
 
   useEffect(() => {
@@ -75,7 +76,15 @@ export const SearchBarBase = ({
     );
   }, [defaultValue]);
 
-  useDebounce(() => onChange(value), debounceTime, [value]);
+  useDebounce(
+    () => {
+      // Capture analytics search event with search term provided as value
+      analytics.captureEvent('search', value);
+      onChange(value);
+    },
+    debounceTime,
+    [value],
+  );
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -147,12 +156,9 @@ export type SearchBarProps = Partial<SearchBarBaseProps>;
  * @public
  */
 export const SearchBar = ({ onChange, ...props }: SearchBarProps) => {
-  const analytics = useAnalytics();
   const { term, setTerm } = useSearch();
 
   const handleChange = (newValue: string) => {
-    // Catpure analytics search event with search term provided as value
-    analytics.captureEvent('search', newValue);
     if (onChange) {
       onChange(newValue);
     } else {

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -22,7 +22,7 @@ import React, {
   useCallback,
 } from 'react';
 import { useDebounce } from 'react-use';
-import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import {
   InputBase,
   InputBaseProps,
@@ -33,6 +33,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import ClearButton from '@material-ui/icons/Clear';
 
 import { useSearch } from '../SearchContext';
+import { TrackSearch } from '../SearchTracker';
 
 /**
  * Props for {@link SearchBarBase}.
@@ -67,7 +68,6 @@ export const SearchBarBase = ({
   ...props
 }: SearchBarBaseProps) => {
   const configApi = useApi(configApiRef);
-  const analytics = useAnalytics();
   const [value, setValue] = useState<string>(defaultValue as string);
 
   useEffect(() => {
@@ -76,15 +76,7 @@ export const SearchBarBase = ({
     );
   }, [defaultValue]);
 
-  useDebounce(
-    () => {
-      // Capture analytics search event with search term provided as value
-      analytics.captureEvent('search', value);
-      onChange(value);
-    },
-    debounceTime,
-    [value],
-  );
+  useDebounce(() => onChange(value), debounceTime, [value]);
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -128,18 +120,20 @@ export const SearchBarBase = ({
   );
 
   return (
-    <InputBase
-      data-testid="search-bar-next"
-      value={value}
-      placeholder={placeholder}
-      startAdornment={startAdornment}
-      endAdornment={clearButton ? endAdornment : defaultEndAdornment}
-      inputProps={{ 'aria-label': 'Search', ...defaultInputProps }}
-      fullWidth={fullWidth}
-      onChange={handleChange}
-      onKeyDown={handleKeyDown}
-      {...props}
-    />
+    <TrackSearch>
+      <InputBase
+        data-testid="search-bar-next"
+        value={value}
+        placeholder={placeholder}
+        startAdornment={startAdornment}
+        endAdornment={clearButton ? endAdornment : defaultEndAdornment}
+        inputProps={{ 'aria-label': 'Search', ...defaultInputProps }}
+        fullWidth={fullWidth}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        {...props}
+      />
+    </TrackSearch>
   );
 };
 

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -22,7 +22,7 @@ import React, {
   useCallback,
 } from 'react';
 import { useDebounce } from 'react-use';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
 import {
   InputBase,
   InputBaseProps,
@@ -147,11 +147,17 @@ export type SearchBarProps = Partial<SearchBarBaseProps>;
  * @public
  */
 export const SearchBar = ({ onChange, ...props }: SearchBarProps) => {
+  const configApi = useApi(configApiRef);
+  const analytics = useAnalytics();
   const { term, setTerm } = useSearch();
 
   const handleChange = (newValue: string) => {
     setTerm(newValue);
     if (onChange) onChange(newValue);
+    if (configApi.getOptionalConfig('app.analytics.ga')) {
+      // only capture GA events if analytics configuration is provided
+      analytics.captureEvent('search', newValue);
+    }
   };
 
   return <SearchBarBase value={term} onChange={handleChange} {...props} />;

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -22,7 +22,12 @@ import React, {
   useCallback,
 } from 'react';
 import { useDebounce } from 'react-use';
-import { configApiRef, useAnalytics, useApi } from '@backstage/core-plugin-api';
+import {
+  configApiRef,
+  AnalyticsContext,
+  useAnalytics,
+  useApi,
+} from '@backstage/core-plugin-api';
 import {
   InputBase,
   InputBaseProps,
@@ -156,7 +161,7 @@ export type SearchBarProps = Partial<SearchBarBaseProps>;
  * @public
  */
 export const SearchBar = ({ onChange, ...props }: SearchBarProps) => {
-  const { term, setTerm } = useSearch();
+  const { term, setTerm, types } = useSearch();
 
   const handleChange = (newValue: string) => {
     if (onChange) {
@@ -166,5 +171,9 @@ export const SearchBar = ({ onChange, ...props }: SearchBarProps) => {
     }
   };
 
-  return <SearchBarBase value={term} onChange={handleChange} {...props} />;
+  return (
+    <AnalyticsContext attributes={{ types: types.join(',') }}>
+      <SearchBarBase value={term} onChange={handleChange} {...props} />
+    </AnalyticsContext>
+  );
 };

--- a/plugins/search/src/components/SearchContext/SearchContext.tsx
+++ b/plugins/search/src/components/SearchContext/SearchContext.tsx
@@ -15,7 +15,7 @@
  */
 
 import { JsonObject } from '@backstage/types';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, AnalyticsContext } from '@backstage/core-plugin-api';
 import { SearchResultSet } from '@backstage/search-common';
 import React, {
   createContext,
@@ -130,7 +130,11 @@ export const SearchContextProvider = ({
     fetchPreviousPage: hasPreviousPage ? fetchPreviousPage : undefined,
   };
 
-  return <SearchContext.Provider value={value} children={children} />;
+  return (
+    <AnalyticsContext attributes={{ searchTypes: types.sort().join(',') }}>
+      <SearchContext.Provider value={value} children={children} />
+    </AnalyticsContext>
+  );
 };
 
 export const useSearch = () => {

--- a/plugins/search/src/components/SearchTracker/SearchTracker.tsx
+++ b/plugins/search/src/components/SearchTracker/SearchTracker.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect } from 'react';
+import { useAnalytics } from '@backstage/core-plugin-api';
+import { useSearch } from '../SearchContext';
+
+/**
+ * Capture search event on term change.
+ */
+export const TrackSearch = ({ children }: { children: React.ReactChild }) => {
+  const analytics = useAnalytics();
+  const { term } = useSearch();
+
+  useEffect(() => {
+    if (term) {
+      // Capture analytics search event with search term provided as value
+      analytics.captureEvent('search', term);
+    }
+  }, [analytics, term]);
+
+  return <>{children}</>;
+};

--- a/plugins/search/src/components/SearchTracker/index.ts
+++ b/plugins/search/src/components/SearchTracker/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { TrackSearch } from './SearchTracker';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes: https://github.com/backstage/backstage/issues/7600

This PR adds analytics tracking to the search bar events.

At the same time I took the opportunity to change how the onChange prop is used so that it only runs the provided onChange method if provided, otherwise setTerm. This makes it possible for anyone to provide their own change handler together with a onSubmit for example. To e.g. only search on "enter".

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
