### PR TITLE
[Tech Insights] remove unecessary http request when running all checks

### DIFF
--- a/.changeset/small-monkeys-live.md
+++ b/.changeset/small-monkeys-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': patch
+---
+
+remove unecessary http request when running all checks

--- a/.changeset/small-monkeys-live.md
+++ b/.changeset/small-monkeys-live.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-tech-insights': patch
 ---
 
-remove unecessary http request when running all checks
+remove unnecessary http request when running all checks

--- a/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -71,7 +71,7 @@ export class TechInsightsClient implements TechInsightsApi {
     const url = await this.discoveryApi.getBaseUrl('tech-insights');
     const token = await this.identityApi.getIdToken();
     const { namespace, kind, name } = entityParams;
-    const checkIds = checks ? checks.map((check: Check) => check.id) : [];
+    const checkIds = checks ? checks.map(check => check.id) : [];
     const requestBody = { checks: checkIds.length > 0 ? checkIds : null };
     const response = await fetch(
       `${url}/checks/run/${encodeURIComponent(namespace)}/${encodeURIComponent(

--- a/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -72,7 +72,7 @@ export class TechInsightsClient implements TechInsightsApi {
     const token = await this.identityApi.getIdToken();
     const { namespace, kind, name } = entityParams;
     const checkIds = checks ? checks.map(check => check.id) : [];
-    const requestBody = { checks: checkIds.length > 0 ? checkIds : null };
+    const requestBody = { checks: checkIds.length > 0 ? checkIds : undefined };
     const response = await fetch(
       `${url}/checks/run/${encodeURIComponent(namespace)}/${encodeURIComponent(
         kind,

--- a/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -66,20 +66,20 @@ export class TechInsightsClient implements TechInsightsApi {
 
   async runChecks(
     entityParams: EntityName,
-    checks: Check[],
+    checks?: Check[],
   ): Promise<CheckResult[]> {
     const url = await this.discoveryApi.getBaseUrl('tech-insights');
     const token = await this.identityApi.getIdToken();
     const { namespace, kind, name } = entityParams;
-    const allChecks = checks ? checks : await this.getAllChecks();
-    const checkIds = allChecks.map((check: Check) => check.id);
+    const checkIds = checks ? checks.map((check: Check) => check.id) : [];
+    const requestBody = { checks: checkIds.length > 0 ? checkIds : null };
     const response = await fetch(
       `${url}/checks/run/${encodeURIComponent(namespace)}/${encodeURIComponent(
         kind,
       )}/${encodeURIComponent(name)}`,
       {
         method: 'POST',
-        body: JSON.stringify({ checks: checkIds }),
+        body: JSON.stringify(requestBody),
         headers: {
           'Content-Type': 'application/json',
           ...(token && { Authorization: `Bearer ${token}` }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The UI client was calling getAllChecks unnecessarily as the server already does that by default.

https://github.com/backstage/backstage/blob/0fdac13e7d20a19b7244c95c567a56662c620d9b/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts#L96-L107 

Also changed the function signature to match the interface.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
