### PR TITLE
feat(catalog:write): support custom filenames

### DIFF
--- a/.changeset/sharp-eagles-peel.md
+++ b/.changeset/sharp-eagles-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Support custom file name for `catalog:write` action

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.test.ts
@@ -69,4 +69,33 @@ describe('catalog:write', () => {
       yaml.stringify(entity),
     );
   });
+
+  it('should support a custom filename', async () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'n',
+        namespace: 'ns',
+        annotations: {
+          [ORIGIN_LOCATION_ANNOTATION]: 'url:https://example.com',
+        },
+      },
+      spec: {},
+    };
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        filePath: 'some-dir/entity-info.yaml',
+        entity,
+      },
+    });
+
+    expect(fsMock.writeFile).toHaveBeenCalledTimes(1);
+    expect(fsMock.writeFile).toHaveBeenCalledWith(
+      resolvePath(mockContext.workspacePath, 'some-dir/entity-info.yaml'),
+      yaml.stringify(entity),
+    );
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/write.ts
@@ -21,13 +21,18 @@ import { Entity } from '@backstage/catalog-model';
 import { resolveSafeChildPath } from '@backstage/backend-common';
 
 export function createCatalogWriteAction() {
-  return createTemplateAction<{ name?: string; entity: Entity }>({
+  return createTemplateAction<{ filePath?: string; entity: Entity }>({
     id: 'catalog:write',
     description: 'Writes the catalog-info.yaml for your template',
     schema: {
       input: {
         type: 'object',
         properties: {
+          filePath: {
+            title: 'Catalog file path',
+            description: 'Defaults to catalog-info.yaml',
+            type: 'string',
+          },
           entity: {
             title: 'Entity info to write catalog-info.yaml',
             description:
@@ -39,10 +44,11 @@ export function createCatalogWriteAction() {
     },
     async handler(ctx) {
       ctx.logStream.write(`Writing catalog-info.yaml`);
-      const { entity } = ctx.input;
+      const { filePath, entity } = ctx.input;
+      const path = filePath ?? 'catalog-info.yaml';
 
       await fs.writeFile(
-        resolveSafeChildPath(ctx.workspacePath, 'catalog-info.yaml'),
+        resolveSafeChildPath(ctx.workspacePath, path),
         yaml.stringify(entity),
       );
     },


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!
Support custom file name for `catalog:write` action
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
