### PR TITLE
app-backend: disallow all iframe embedding of the app

### DIFF
--- a/.changeset/honest-chefs-mate.md
+++ b/.changeset/honest-chefs-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Set `X-Frame-Options: deny` rather than the default `sameorigin` for all content served by the `app-backend`.`

--- a/plugins/app-backend/package.json
+++ b/plugins/app-backend/package.json
@@ -38,6 +38,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "fs-extra": "9.1.0",
+    "helmet": "^4.0.0",
     "winston": "^3.2.1",
     "yn": "^4.0.0"
   },

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -16,6 +16,7 @@
 
 import { notFoundHandler, resolvePackagePath } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
+import helmet from 'helmet';
 import express from 'express';
 import Router from 'express-promise-router';
 import fs from 'fs-extra';
@@ -88,6 +89,8 @@ export async function createRouter(
   }
 
   const router = Router();
+
+  router.use(helmet.frameguard({ action: 'deny' }));
 
   // Use a separate router for static content so that a fallback can be provided by backend
   const staticRouter = Router();


### PR DESCRIPTION
This forbids any form of iframe embedding of the app itself, which is the recommended secure configuration https://owasp.org/www-project-secure-headers