### PR TITLE
backend-common: get default csp policy from helmet

### DIFF
--- a/.changeset/eight-worms-report.md
+++ b/.changeset/eight-worms-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Use the default CSP policy provided by `helmet` directly rather than a copy.

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -19,6 +19,7 @@ import compression from 'compression';
 import cors from 'cors';
 import express, { Router, ErrorRequestHandler } from 'express';
 import helmet from 'helmet';
+import { ContentSecurityPolicyOptions } from 'helmet/dist/middlewares/content-security-policy';
 import * as http from 'http';
 import stoppable from 'stoppable';
 import { Logger } from 'winston';
@@ -43,19 +44,6 @@ import { createHttpServer, createHttpsServer } from './hostFactory';
 export const DEFAULT_PORT = 7007;
 // '' is express default, which listens to all interfaces
 const DEFAULT_HOST = '';
-// taken from the helmet source code - don't seem to be exported
-const DEFAULT_CSP = {
-  'default-src': ["'self'"],
-  'base-uri': ["'self'"],
-  'block-all-mixed-content': [],
-  'font-src': ["'self'", 'https:', 'data:'],
-  'frame-ancestors': ["'self'"],
-  'img-src': ["'self'", 'data:'],
-  'object-src': ["'none'"],
-  'script-src': ["'self'", "'unsafe-eval'"],
-  'script-src-attr': ["'none'"],
-  'style-src': ["'self'", 'https:', "'unsafe-inline'"],
-};
 
 export class ServiceBuilderImpl implements ServiceBuilder {
   private port: number | undefined;
@@ -236,8 +224,9 @@ export class ServiceBuilderImpl implements ServiceBuilder {
 
 export function applyCspDirectives(
   directives: Record<string, string[] | false> | undefined,
-): CspOptions | undefined {
-  const result: CspOptions = { ...DEFAULT_CSP };
+): ContentSecurityPolicyOptions['directives'] {
+  const result: ContentSecurityPolicyOptions['directives'] =
+    helmet.contentSecurityPolicy.getDefaultDirectives();
 
   if (directives) {
     for (const [key, value] of Object.entries(directives)) {

--- a/packages/backend-common/src/service/lib/config.ts
+++ b/packages/backend-common/src/service/lib/config.ts
@@ -42,8 +42,6 @@ export type CertificateAttributes = {
 
 /**
  * A map from CSP directive names to their values.
- *
- * Added here since helmet doesn't export this type publicly.
  */
 export type CspOptions = Record<string, string[]>;
 


### PR DESCRIPTION
🧹 