### PR TITLE
backend-test-utils: lazy-load testcontainers

### DIFF
--- a/.changeset/beige-wolves-kneel.md
+++ b/.changeset/beige-wolves-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Lazy-load `testcontainers` module in order to avoid side-effects.

--- a/packages/backend-test-utils/src/database/startMysqlContainer.ts
+++ b/packages/backend-test-utils/src/database/startMysqlContainer.ts
@@ -15,7 +15,6 @@
  */
 
 import createConnection, { Knex } from 'knex';
-import { GenericContainer } from 'testcontainers';
 import { v4 as uuid } from 'uuid';
 
 async function waitForMysqlReady(
@@ -49,6 +48,9 @@ async function waitForMysqlReady(
 export async function startMysqlContainer(image: string) {
   const user = 'root';
   const password = uuid();
+
+  // Lazy-load to avoid side-effect of importing testcontainers
+  const { GenericContainer } = await import('testcontainers');
 
   const container = await new GenericContainer(image)
     .withExposedPorts(3306)

--- a/packages/backend-test-utils/src/database/startPostgresContainer.ts
+++ b/packages/backend-test-utils/src/database/startPostgresContainer.ts
@@ -15,7 +15,6 @@
  */
 
 import createConnection, { Knex } from 'knex';
-import { GenericContainer } from 'testcontainers';
 import { v4 as uuid } from 'uuid';
 
 async function waitForPostgresReady(
@@ -49,6 +48,9 @@ async function waitForPostgresReady(
 export async function startPostgresContainer(image: string) {
   const user = 'postgres';
   const password = uuid();
+
+  // Lazy-load to avoid side-effect of importing testcontainers
+  const { GenericContainer } = await import('testcontainers');
 
   const container = await new GenericContainer(image)
     .withExposedPorts(5432)


### PR DESCRIPTION
Loading in `testcontainers` causes a docker discovery to go off in the background, which can break tests if docker is not available.