### PR TITLE
[Search] search engine pg case insensitive

### DIFF
--- a/plugins/search-backend-module-pg/src/database/DatabaseDocumentStore.ts
+++ b/plugins/search-backend-module-pg/src/database/DatabaseDocumentStore.ts
@@ -156,9 +156,11 @@ export class DatabaseDocumentStore implements DatabaseStore {
         const valueArray = Array.isArray(value) ? value : [value];
         const valueCompare = valueArray
           .map(v => ({ [key]: v }))
-          .map(v => JSON.stringify(v));
+          .map(v => JSON.stringify(v).toLowerCase());
         query.whereRaw(
-          `(${valueCompare.map(() => 'document @> ?').join(' OR ')})`,
+          `(${valueCompare
+            .map(() => 'lower(document::text)::jsonb @> ?')
+            .join(' OR ')})`,
           valueCompare,
         );
       });

--- a/plugins/search/src/components/SearchFilter/SearchFilter.tsx
+++ b/plugins/search/src/components/SearchFilter/SearchFilter.tsx
@@ -155,7 +155,7 @@ const SelectFilter = ({
           <em>All</em>
         </MenuItem>
         {values.map((value: string) => (
-          <MenuItem key={value} value={value}>
+          <MenuItem key={value} value={value.toLocaleLowerCase('en-US')}>
             {value}
           </MenuItem>
         ))}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes: https://github.com/backstage/backstage/issues/8390

This PR is a suggestion for how we can continue to support inconsistent casing when using the postgres search engine by lowercase both value and column. Another alternative is to change the datatype when inserting the documents which I believe can be a bit less performance heavy. Happy to get input on other ways forward too! 

Before change:
No results when filter value of Kind being for example "template" instead of "Template". No results when using TechDocs in Context search.

After change:
<img width="1440" alt="Screen Shot 2021-12-29 at 4 57 33 PM" src="https://user-images.githubusercontent.com/25153114/147681462-7c962f77-9df5-431f-898d-291b1a062035.png">

<img width="1437" alt="Screen Shot 2021-12-30 at 2 03 19 PM" src="https://user-images.githubusercontent.com/25153114/147754471-58895ba7-6fd9-455b-97af-13db3b00eeb4.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
