### PR TITLE
Bug fix Techdocs footer navigation going off the screen

### DIFF
--- a/.changeset/tidy-wombats-remember.md
+++ b/.changeset/tidy-wombats-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Updated Techdocs footer navigation to dynamically resize to the width of the dom, resolving an issue where a pinned sidebar causes navigation to go off of the screen

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -167,6 +167,21 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
     // an update to "state" might lead to an updated UI so we include it as a trigger
   }, [updateSidebarPosition, state]);
 
+  // dynamically set width of footer to accommodate for pinning of the sidebar
+  const updateFooterWidth = useCallback(() => {
+    if (!dom) return;
+    const footer = dom.querySelector('.md-footer') as HTMLElement;
+    footer.style.width = `${dom.getBoundingClientRect().width}px`;
+  }, [dom]);
+
+  useEffect(() => {
+    updateFooterWidth();
+    window.addEventListener('resize', updateFooterWidth);
+    return () => {
+      window.removeEventListener('resize', updateFooterWidth);
+    };
+  });
+
   // a function that performs transformations that are executed prior to adding it to the DOM
   const preRender = useCallback(
     (rawContent: string, contentPath: string) =>
@@ -199,7 +214,7 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
           .md-sidebar {  position: fixed; bottom: 100px; width: 20rem; }
           .md-sidebar--secondary { right: 2rem; }
           .md-content { margin-bottom: 50px }
-          .md-footer { position: fixed; bottom: 0px; width: 100vw; }
+          .md-footer { position: fixed; bottom: 0px; }
           .md-footer-nav__link { width: 20rem;}
           .md-content { margin-left: 20rem; max-width: calc(100% - 20rem * 2 - 3rem); }
           .md-typeset { font-size: 1rem; }
@@ -241,7 +256,6 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
             .md-footer {
               position: static;
               margin-left: 10rem;
-              width: calc(100% - 10rem);
             }
             .md-nav--primary .md-nav__title {
               white-space: normal;

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -257,7 +257,11 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
             .md-content__inner { font-size: 0.9rem }
             .md-footer {
               position: static;
-              margin-left: 10rem;
+              padding-left: 10rem;
+            }
+            .md-footer-nav__link {
+              /* footer links begin to overlap at small sizes without setting width */
+              width: 50%;
             }
             .md-nav--primary .md-nav__title {
               white-space: normal;

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -171,7 +171,9 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
   const updateFooterWidth = useCallback(() => {
     if (!dom) return;
     const footer = dom.querySelector('.md-footer') as HTMLElement;
-    footer.style.width = `${dom.getBoundingClientRect().width}px`;
+    if (footer) {
+      footer.style.width = `${dom.getBoundingClientRect().width}px`;
+    }
   }, [dom]);
 
   useEffect(() => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #7494.

There is an issue where a pinned sidebar causes the techdocs footer to go off of the screen. This POC demonstrates how we can dynamically update the footer width to resolve this issue.

Because `md-footer` has `position: fixed`, there is no easy way (to my knowledge) to inherit the width of the `md-container` parent element. So this solution relies on javascript to get the width of the _dom_ and apply that to the footer width style.

![image](https://user-images.githubusercontent.com/5807118/147769133-795ad35e-eb57-47e1-a5bd-36afe3f9ce3b.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
