### PR TITLE
Support cmd/ctrl+click to open internal Techdoc links in a new tab

### DIFF
--- a/.changeset/hot-lobsters-yell.md
+++ b/.changeset/hot-lobsters-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Adds support for opening internal Techdocs links in a new tab with CTRL+Click or CMD+Click

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -338,17 +338,23 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
         scrollIntoAnchor(),
         addLinkClickListener({
           baseUrl: window.location.origin,
-          onClick: (_: MouseEvent, url: string) => {
+          onClick: (event: MouseEvent, url: string) => {
+            // use `window.open` to open links in a new tab when CTRL or META keys are pressed
+            const navigateFn =
+              event.ctrlKey || event.metaKey
+                ? (u: string) => window.open(u, '_blank')
+                : navigate;
+
             const parsedUrl = new URL(url);
             // hash exists when anchor is clicked on secondary sidebar
             if (parsedUrl.hash) {
-              navigate(`${parsedUrl.pathname}${parsedUrl.hash}`);
+              navigateFn(`${parsedUrl.pathname}${parsedUrl.hash}`);
               // Scroll to hash if it's on the current page
               transformedElement
                 ?.querySelector(`#${parsedUrl.hash.slice(1)}`)
                 ?.scrollIntoView();
             } else {
-              navigate(parsedUrl.pathname);
+              navigateFn(parsedUrl.pathname);
               // Scroll to top of reader if primary sidebar link is clicked
               transformedElement
                 ?.querySelector('.md-content__inner')

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -339,26 +339,31 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
         addLinkClickListener({
           baseUrl: window.location.origin,
           onClick: (event: MouseEvent, url: string) => {
-            // use `window.open` to open links in a new tab when CTRL or META keys are pressed
-            const navigateFn =
-              event.ctrlKey || event.metaKey
-                ? (u: string) => window.open(u, '_blank')
-                : navigate;
-
+            // detect if CTRL or META keys are pressed so that links can be opened in a new tab with `window.open`
+            const modifierActive = event.ctrlKey || event.metaKey;
             const parsedUrl = new URL(url);
+
             // hash exists when anchor is clicked on secondary sidebar
             if (parsedUrl.hash) {
-              navigateFn(`${parsedUrl.pathname}${parsedUrl.hash}`);
-              // Scroll to hash if it's on the current page
-              transformedElement
-                ?.querySelector(`#${parsedUrl.hash.slice(1)}`)
-                ?.scrollIntoView();
+              if (modifierActive) {
+                window.open(`${parsedUrl.pathname}${parsedUrl.hash}`, '_blank');
+              } else {
+                navigate(`${parsedUrl.pathname}${parsedUrl.hash}`);
+                // Scroll to hash if it's on the current page
+                transformedElement
+                  ?.querySelector(`#${parsedUrl.hash.slice(1)}`)
+                  ?.scrollIntoView();
+              }
             } else {
-              navigateFn(parsedUrl.pathname);
-              // Scroll to top of reader if primary sidebar link is clicked
-              transformedElement
-                ?.querySelector('.md-content__inner')
-                ?.scrollIntoView();
+              if (modifierActive) {
+                window.open(parsedUrl.pathname, '_blank');
+              } else {
+                navigate(parsedUrl.pathname);
+                // Scroll to top of reader if primary sidebar link is clicked
+                transformedElement
+                  ?.querySelector('.md-content__inner')
+                  ?.scrollIntoView();
+              }
             }
           },
         }),


### PR DESCRIPTION
Signed-off-by: Colton Padden <colton.padden@fastmail.com>

## Hey, I just made a Pull Request!

Closes #7247

This PR adds support to open internal tech docs links in a new tab by either using cmd+click or ctrl+click by using `window.open(<url>, '_blank')` when keydown is detected on click event.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
