### PR TITLE
fix(HomePageSearchBar): fix missing search context issue

### DIFF
--- a/.changeset/great-mayflies-travel.md
+++ b/.changeset/great-mayflies-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Fix missing search context issue with `HomePageSearchBar`

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -20,6 +20,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useContext,
 } from 'react';
 import { useDebounce } from 'react-use';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
@@ -32,7 +33,11 @@ import {
 import SearchIcon from '@material-ui/icons/Search';
 import ClearButton from '@material-ui/icons/Clear';
 
-import { useSearch } from '../SearchContext';
+import {
+  SearchContext,
+  SearchContextProvider,
+  useSearch,
+} from '../SearchContext';
 import { TrackSearch } from '../SearchTracker';
 
 /**
@@ -46,6 +51,11 @@ export type SearchBarBaseProps = Omit<InputBaseProps, 'onChange'> & {
   onClear?: () => void;
   onSubmit?: () => void;
   onChange: (value: string) => void;
+};
+
+const useSearchContextCheck = () => {
+  const context = useContext(SearchContext);
+  return context !== undefined;
 };
 
 /**
@@ -69,6 +79,7 @@ export const SearchBarBase = ({
 }: SearchBarBaseProps) => {
   const configApi = useApi(configApiRef);
   const [value, setValue] = useState<string>(defaultValue as string);
+  const hasSearchContext = useSearchContextCheck();
 
   useEffect(() => {
     setValue(prevValue =>
@@ -119,7 +130,7 @@ export const SearchBarBase = ({
     </InputAdornment>
   );
 
-  return (
+  const searchBar = (
     <TrackSearch>
       <InputBase
         data-testid="search-bar-next"
@@ -134,6 +145,12 @@ export const SearchBarBase = ({
         {...props}
       />
     </TrackSearch>
+  );
+
+  return hasSearchContext ? (
+    searchBar
+  ) : (
+    <SearchContextProvider>{searchBar}</SearchContextProvider>
   );
 };
 


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!
Fix a regression caused by https://github.com/backstage/backstage/pull/8656 resulting in the following error with the `HomePageSearchBar`:

![Screen Shot 2021-12-30 at 2 56 48 PM](https://user-images.githubusercontent.com/6998196/147785738-a840ce75-5897-4ef3-9b0a-9f806ea99976.png)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
