### PR TITLE
Allow for bare clone and retrieving commit history

### DIFF
--- a/.changeset/few-plums-enjoy.md
+++ b/.changeset/few-plums-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Updated Git to allow for bare clone

--- a/.changeset/few-plums-enjoy.md
+++ b/.changeset/few-plums-enjoy.md
@@ -2,4 +2,7 @@
 '@backstage/backend-common': patch
 ---
 
-Updated Git to allow for bare clone
+Updated the Git class with the following:
+
+- Added `depth` and `noCheckout` options to Git clone, using these you can create a bare clone that includes just the git history
+- New `log` function which you can use to view the commit history of a git repo

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -234,7 +234,6 @@ export class Git {
     remote: string;
     url: string;
   }): Promise<void>;
-  // (undocumented)
   clone(options: {
     url: string;
     dir: string;
@@ -255,12 +254,10 @@ export class Git {
       email: string;
     };
   }): Promise<string>;
-  // (undocumented)
   currentBranch(options: {
     dir: string;
     fullName?: boolean;
   }): Promise<string | undefined>;
-  // (undocumented)
   fetch(options: { dir: string; remote?: string }): Promise<void>;
   // (undocumented)
   static fromAuth: (options: {
@@ -270,9 +267,7 @@ export class Git {
   }) => Git;
   // (undocumented)
   init(options: { dir: string; defaultBranch?: string }): Promise<void>;
-  // (undocumented)
   log(options: { dir: string; ref?: string }): Promise<ReadCommitResult[]>;
-  // (undocumented)
   merge(options: {
     dir: string;
     theirs: string;
@@ -288,9 +283,7 @@ export class Git {
   }): Promise<MergeResult>;
   // (undocumented)
   push(options: { dir: string; remote: string }): Promise<PushResult>;
-  // (undocumented)
   readCommit(options: { dir: string; sha: string }): Promise<ReadCommitResult>;
-  // (undocumented)
   resolveRef(options: { dir: string; ref: string }): Promise<string>;
 }
 

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -235,7 +235,13 @@ export class Git {
     url: string;
   }): Promise<void>;
   // (undocumented)
-  clone(options: { url: string; dir: string; ref?: string }): Promise<void>;
+  clone(options: {
+    url: string;
+    dir: string;
+    ref?: string;
+    depth?: number;
+    noCheckout?: boolean;
+  }): Promise<void>;
   // (undocumented)
   commit(options: {
     dir: string;

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -271,6 +271,8 @@ export class Git {
   // (undocumented)
   init(options: { dir: string; defaultBranch?: string }): Promise<void>;
   // (undocumented)
+  log(options: { dir: string; ref?: string }): Promise<ReadCommitResult[]>;
+  // (undocumented)
   merge(options: {
     dir: string;
     theirs: string;

--- a/packages/backend-common/src/scm/git.test.ts
+++ b/packages/backend-common/src/scm/git.test.ts
@@ -105,6 +105,7 @@ describe('Git', () => {
         dir,
         singleBranch: true,
         depth: 1,
+        noCheckout: false,
         onProgress: expect.any(Function),
         headers: {
           'user-agent': 'git/@isomorphic-git',
@@ -314,6 +315,23 @@ describe('Git', () => {
       await git.resolveRef({ dir, ref });
 
       expect(isomorphic.resolveRef).toHaveBeenCalledWith({
+        fs,
+        dir,
+        ref,
+      });
+    });
+  });
+
+  describe('log', () => {
+    it('should call isomorphic-git with the correct arguments', async () => {
+      const dir = '/some/mock/dir';
+      const ref = 'as43bd7';
+
+      const git = Git.fromAuth({});
+
+      await git.log({ dir, ref });
+
+      expect(isomorphic.log).toHaveBeenCalledWith({
         fs,
         dir,
         ref,

--- a/packages/backend-common/src/scm/git.test.ts
+++ b/packages/backend-common/src/scm/git.test.ts
@@ -105,7 +105,6 @@ describe('Git', () => {
         dir,
         singleBranch: true,
         depth: 1,
-        noCheckout: false,
         onProgress: expect.any(Function),
         headers: {
           'user-agent': 'git/@isomorphic-git',

--- a/packages/backend-common/src/scm/git.ts
+++ b/packages/backend-common/src/scm/git.ts
@@ -76,7 +76,7 @@ export class Git {
     return git.commit({ fs, dir, message, author, committer });
   }
 
-  // https://isomorphic-git.org/docs/en/clone
+  /** https://isomorphic-git.org/docs/en/clone */
   async clone(options: {
     url: string;
     dir: string;
@@ -103,7 +103,7 @@ export class Git {
     });
   }
 
-  // https://isomorphic-git.org/docs/en/currentBranch
+  /** https://isomorphic-git.org/docs/en/currentBranch */
   async currentBranch(options: {
     dir: string;
     fullName?: boolean;
@@ -114,7 +114,7 @@ export class Git {
     >;
   }
 
-  // https://isomorphic-git.org/docs/en/fetch
+  /** https://isomorphic-git.org/docs/en/fetch */
   async fetch(options: { dir: string; remote?: string }): Promise<void> {
     const { dir, remote = 'origin' } = options;
     this.config.logger?.info(
@@ -142,7 +142,7 @@ export class Git {
     });
   }
 
-  // https://isomorphic-git.org/docs/en/merge
+  /** https://isomorphic-git.org/docs/en/merge */
   async merge(options: {
     dir: string;
     theirs: string;
@@ -184,7 +184,7 @@ export class Git {
     });
   }
 
-  // https://isomorphic-git.org/docs/en/readCommit
+  /** https://isomorphic-git.org/docs/en/readCommit */
   async readCommit(options: {
     dir: string;
     sha: string;
@@ -193,13 +193,13 @@ export class Git {
     return git.readCommit({ fs, dir, oid: sha });
   }
 
-  // https://isomorphic-git.org/docs/en/resolveRef
+  /** https://isomorphic-git.org/docs/en/resolveRef */
   async resolveRef(options: { dir: string; ref: string }): Promise<string> {
     const { dir, ref } = options;
     return git.resolveRef({ fs, dir, ref });
   }
 
-  // https://isomorphic-git.org/docs/en/log
+  /** https://isomorphic-git.org/docs/en/log */
   async log(options: {
     dir: string;
     ref?: string;

--- a/packages/backend-common/src/scm/git.ts
+++ b/packages/backend-common/src/scm/git.ts
@@ -94,7 +94,7 @@ export class Git {
       ref,
       singleBranch: true,
       depth: depth ?? 1,
-      noCheckout: noCheckout ?? false,
+      noCheckout,
       onProgress: this.onProgressHandler(),
       headers: {
         'user-agent': 'git/@isomorphic-git',

--- a/packages/backend-common/src/scm/git.ts
+++ b/packages/backend-common/src/scm/git.ts
@@ -76,12 +76,15 @@ export class Git {
     return git.commit({ fs, dir, message, author, committer });
   }
 
+  // https://isomorphic-git.org/docs/en/clone
   async clone(options: {
     url: string;
     dir: string;
     ref?: string;
+    depth?: number;
+    noCheckout?: boolean;
   }): Promise<void> {
-    const { url, dir, ref } = options;
+    const { url, dir, ref, depth, noCheckout } = options;
     this.config.logger?.info(`Cloning repo {dir=${dir},url=${url}}`);
     return git.clone({
       fs,
@@ -90,7 +93,8 @@ export class Git {
       dir,
       ref,
       singleBranch: true,
-      depth: 1,
+      depth: depth ?? 1,
+      noCheckout: noCheckout ?? false,
       onProgress: this.onProgressHandler(),
       headers: {
         'user-agent': 'git/@isomorphic-git',

--- a/packages/backend-common/src/scm/git.ts
+++ b/packages/backend-common/src/scm/git.ts
@@ -199,6 +199,19 @@ export class Git {
     return git.resolveRef({ fs, dir, ref });
   }
 
+  // https://isomorphic-git.org/docs/en/log
+  async log(options: {
+    dir: string;
+    ref?: string;
+  }): Promise<ReadCommitResult[]> {
+    const { dir, ref } = options;
+    return git.log({
+      fs,
+      dir,
+      ref: ref ?? 'HEAD',
+    });
+  }
+
   private onAuth = () => ({
     username: this.config.username,
     password: this.config.password,


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <awanlin@rapidrtc.com>

## Hey, I just made a Pull Request!

These changes allow for a bare git clone which gives you just the git history in the `.git` folder and also adds a git log function to get commit history

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
