### PR TITLE
Warn users of deprecated keys in app configurations

### DIFF
--- a/.changeset/light-trainers-allow.md
+++ b/.changeset/light-trainers-allow.md
@@ -1,0 +1,22 @@
+---
+'@backstage/backend-common': patch
+'@backstage/config': patch
+'@backstage/config-loader': patch
+'@backstage/plugin-app-backend': patch
+---
+
+Loading of app configurations now reference the `@deprecated` construct from
+JSDoc to determine if a property in-use has been deprecated. Users are notified
+of deprecated keys in the format:
+
+```txt
+The configuration key 'catalog.processors.githubOrg' of app-config.yaml is deprecated and may be removed soon. Configure a GitHub integration instead.
+```
+
+When the `withDeprecatedKeys` option is set to `true` in the `process` method
+of `loadConfigSchema`, the user will be notified that deprecated keys have been
+identified in their app configuration.
+
+The `backend-common` and `plugin-app-backend` packages have been updated to set
+`withDeprecatedKeys` to true so that users are notified of deprecated settings
+by default.

--- a/.changeset/long-clouds-rest.md
+++ b/.changeset/long-clouds-rest.md
@@ -1,0 +1,12 @@
+---
+'@backstage/cli': patch
+---
+
+Introduce `--deprecated` option to `config:check` to log all deprecated app configuration properties
+
+```sh
+$ yarn backstage-cli config:check --lax --deprecated
+config:check --lax --deprecated
+Loaded config from app-config.yaml
+The configuration key 'catalog.processors.githubOrg' of app-config.yaml is deprecated and may be removed soon. Configure a GitHub integration instead.
+```

--- a/docs/local-dev/cli-commands.md
+++ b/docs/local-dev/cli-commands.md
@@ -556,6 +556,7 @@ Options:
   --package &lt;name&gt;  Only load config schema that applies to the given package
   --lax             Do not require environment variables to be set
   --frontend        Only validate the frontend configuration
+  --deprecated      List all deprecated configuration settings
   --config &lt;path&gt;   Config files to load instead of app-config.yaml (default: [])
   -h, --help        display help for command
 ```

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -38,7 +38,10 @@ const updateRedactionList = (
   configs: AppConfig[],
   logger: Logger,
 ) => {
-  const secretAppConfigs = schema.process(configs, { visibility: ['secret'] });
+  const secretAppConfigs = schema.process(configs, {
+    visibility: ['secret'],
+    withDeprecatedKeys: true,
+  });
   const secretConfig = ConfigReader.fromConfigs(secretAppConfigs);
   const values = new Set<string>();
   const data = secretConfig.get();

--- a/packages/cli/src/commands/config/validate.ts
+++ b/packages/cli/src/commands/config/validate.ts
@@ -23,5 +23,6 @@ export default async (cmd: Command) => {
     fromPackage: cmd.package,
     mockEnv: cmd.lax,
     fullVisibility: !cmd.frontend,
+    withDeprecatedKeys: cmd.deprecated,
   });
 };

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -193,6 +193,7 @@ export function registerCommands(program: CommanderStatic) {
     )
     .option('--lax', 'Do not require environment variables to be set')
     .option('--frontend', 'Only validate the frontend configuration')
+    .option('--deprecated', 'Output deprecated configuration settings')
     .option(...configOption)
     .description(
       'Validate that the given configuration loads and matches schema',

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -28,6 +28,7 @@ type Options = {
   fromPackage?: string;
   mockEnv?: boolean;
   withFilteredKeys?: boolean;
+  withDeprecatedKeys?: boolean;
   fullVisibility?: boolean;
 };
 
@@ -82,6 +83,7 @@ export async function loadCliConfig(options: Options) {
         ? ['frontend', 'backend', 'secret']
         : ['frontend'],
       withFilteredKeys: options.withFilteredKeys,
+      withDeprecatedKeys: options.withDeprecatedKeys,
     });
     const frontendConfig = ConfigReader.fromConfigs(frontendAppConfigs);
 

--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -21,6 +21,7 @@ export type ConfigSchemaProcessingOptions = {
   visibility?: ConfigVisibility[];
   valueTransform?: TransformFunc<any>;
   withFilteredKeys?: boolean;
+  withDeprecatedKeys?: boolean;
 };
 
 // Warning: (ae-missing-release-tag) "ConfigTarget" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -41,7 +41,6 @@
     "json-schema": "^0.4.0",
     "json-schema-merge-allof": "^0.8.1",
     "json-schema-traverse": "^1.0.0",
-    "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "typescript-json-schema": "^0.52.0",
     "yaml": "^1.9.2",

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -41,6 +41,7 @@
     "json-schema": "^0.4.0",
     "json-schema-merge-allof": "^0.8.1",
     "json-schema-traverse": "^1.0.0",
+    "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "typescript-json-schema": "^0.52.0",
     "yaml": "^1.9.2",

--- a/packages/config-loader/src/lib/schema/collect.ts
+++ b/packages/config-loader/src/lib/schema/collect.ts
@@ -182,10 +182,10 @@ function compileTsSchemas(paths: string[]) {
         program,
         // All schemas should export a `Config` symbol
         'Config',
-        // This enables usage of @visibility is doc comments
+        // This enables usage of @visibility and @deprecated is doc comments
         {
           required: true,
-          validationKeywords: ['visibility'],
+          validationKeywords: ['visibility', 'deprecated'],
         },
         [path.split(sep).join('/')], // Unix paths are expected for all OSes here
       ) as JsonObject | null;

--- a/packages/config-loader/src/lib/schema/collect.ts
+++ b/packages/config-loader/src/lib/schema/collect.ts
@@ -182,7 +182,7 @@ function compileTsSchemas(paths: string[]) {
         program,
         // All schemas should export a `Config` symbol
         'Config',
-        // This enables usage of @visibility and @deprecated is doc comments
+        // This enables usage of @visibility and @deprecated in doc comments
         {
           required: true,
           validationKeywords: ['visibility', 'deprecated'],

--- a/packages/config-loader/src/lib/schema/compile.test.ts
+++ b/packages/config-loader/src/lib/schema/compile.test.ts
@@ -40,6 +40,7 @@ describe('compileConfigSchemas', () => {
       ],
       visibilityByDataPath: new Map(),
       visibilityBySchemaPath: new Map(),
+      deprecationBySchemaPath: new Map(),
     });
     expect(validate([{ data: { b: 'b' }, context: 'test' }])).toEqual({
       errors: [
@@ -53,6 +54,7 @@ describe('compileConfigSchemas', () => {
       ],
       visibilityByDataPath: new Map(),
       visibilityBySchemaPath: new Map(),
+      deprecationBySchemaPath: new Map(),
     });
   });
 
@@ -112,6 +114,7 @@ describe('compileConfigSchemas', () => {
           '/properties/d/items': 'frontend',
         }),
       ),
+      deprecationBySchemaPath: new Map(),
     });
   });
 
@@ -136,5 +139,35 @@ describe('compileConfigSchemas', () => {
     ).toThrow(
       "Config schema visibility is both 'frontend' and 'secret' for properties/a/visibility",
     );
+  });
+
+  it('should discover deprecations', () => {
+    const validate = compileConfigSchemas([
+      {
+        path: 'a1',
+        value: {
+          type: 'object',
+          properties: {
+            a: { type: 'string', deprecated: 'deprecation reason for a' },
+            b: { type: 'string', deprecated: 'deprecation reason for b' },
+            c: { type: 'string' },
+          },
+        },
+      },
+    ]);
+    expect(
+      validate([
+        { data: { a: 'a', b: 'b', c: 'c', d: ['d'] }, context: 'test' },
+      ]),
+    ).toEqual({
+      deprecationBySchemaPath: new Map(
+        Object.entries({
+          '/properties/a': 'deprecation reason for a',
+          '/properties/b': 'deprecation reason for b',
+        }),
+      ),
+      visibilityByDataPath: new Map(),
+      visibilityBySchemaPath: new Map(),
+    });
   });
 });

--- a/packages/config-loader/src/lib/schema/compile.test.ts
+++ b/packages/config-loader/src/lib/schema/compile.test.ts
@@ -40,7 +40,7 @@ describe('compileConfigSchemas', () => {
       ],
       visibilityByDataPath: new Map(),
       visibilityBySchemaPath: new Map(),
-      deprecationBySchemaPath: new Map(),
+      deprecationByDataPath: new Map(),
     });
     expect(validate([{ data: { b: 'b' }, context: 'test' }])).toEqual({
       errors: [
@@ -54,7 +54,7 @@ describe('compileConfigSchemas', () => {
       ],
       visibilityByDataPath: new Map(),
       visibilityBySchemaPath: new Map(),
-      deprecationBySchemaPath: new Map(),
+      deprecationByDataPath: new Map(),
     });
   });
 
@@ -114,7 +114,7 @@ describe('compileConfigSchemas', () => {
           '/properties/d/items': 'frontend',
         }),
       ),
-      deprecationBySchemaPath: new Map(),
+      deprecationByDataPath: new Map(),
     });
   });
 
@@ -160,10 +160,10 @@ describe('compileConfigSchemas', () => {
         { data: { a: 'a', b: 'b', c: 'c', d: ['d'] }, context: 'test' },
       ]),
     ).toEqual({
-      deprecationBySchemaPath: new Map(
+      deprecationByDataPath: new Map(
         Object.entries({
-          '/properties/a': 'deprecation reason for a',
-          '/properties/b': 'deprecation reason for b',
+          '/a': 'deprecation reason for a',
+          '/b': 'deprecation reason for b',
         }),
       ),
       visibilityByDataPath: new Map(),

--- a/packages/config-loader/src/lib/schema/compile.ts
+++ b/packages/config-loader/src/lib/schema/compile.ts
@@ -81,6 +81,13 @@ export function compileConfigSchemas(
   const merged = mergeConfigSchemas(schemas.map(_ => _.value));
   const validate = ajv.compile(merged);
 
+  const deprecationBySchemaPath = new Map<string, string>();
+  traverse(merged, (schema, path) => {
+    if ('deprecated' in schema) {
+      deprecationBySchemaPath.set(path, schema.deprecated);
+    }
+  });
+
   const visibilityBySchemaPath = new Map<string, ConfigVisibility>();
   traverse(merged, (schema, path) => {
     if (schema.visibility && schema.visibility !== 'backend') {
@@ -99,12 +106,14 @@ export function compileConfigSchemas(
         errors: validate.errors ?? [],
         visibilityByDataPath: new Map(visibilityByDataPath),
         visibilityBySchemaPath,
+        deprecationBySchemaPath,
       };
     }
 
     return {
       visibilityByDataPath: new Map(visibilityByDataPath),
       visibilityBySchemaPath,
+      deprecationBySchemaPath,
     };
   };
 }

--- a/packages/config-loader/src/lib/schema/filtering.test.ts
+++ b/packages/config-loader/src/lib/schema/filtering.test.ts
@@ -16,7 +16,11 @@
 
 import { JsonObject } from '@backstage/types';
 import { ConfigVisibility } from './types';
-import { filterByVisibility, filterErrorsByVisibility } from './filtering';
+import {
+  filterByVisibility,
+  filterErrorsByVisibility,
+  filterByDeprecated,
+} from './filtering';
 
 const data = {
   arr: ['f', 'b', 's'],
@@ -61,6 +65,13 @@ const visibility = new Map<string, ConfigVisibility>(
     '/objF': 'frontend',
     '/objB': 'backend',
     '/objS': 'secret',
+  }),
+);
+
+const deprecations = new Map<string, string>(
+  Object.entries({
+    '/properties/arr': 'deprecated array',
+    '/properties/objB/properties/never': 'deprecated nested property',
   }),
 );
 
@@ -379,5 +390,19 @@ describe('filterErrorsByVisibility', () => {
       expect.objectContaining({ message: 'a' }),
       expect.objectContaining({ message: 'c' }),
     ]);
+  });
+});
+
+describe('filterByDeprecated', () => {
+  it('should allow empty list of deprecations', () => {
+    expect(filterByDeprecated(data, new Map())).toEqual({ deprecatedKeys: [] });
+  });
+  it('should return a list of deprecated properties', () => {
+    expect(filterByDeprecated(data, deprecations)).toEqual({
+      deprecatedKeys: [
+        { key: 'arr', description: 'deprecated array' },
+        { key: 'objB.never', description: 'deprecated nested property' },
+      ],
+    });
   });
 });

--- a/packages/config-loader/src/lib/schema/filtering.ts
+++ b/packages/config-loader/src/lib/schema/filtering.ts
@@ -15,7 +15,6 @@
  */
 
 import { JsonObject, JsonValue } from '@backstage/types';
-import { has } from 'lodash';
 import {
   ConfigVisibility,
   DEFAULT_CONFIG_VISIBILITY,

--- a/packages/config-loader/src/lib/schema/load.test.ts
+++ b/packages/config-loader/src/lib/schema/load.test.ts
@@ -65,7 +65,6 @@ describe('loadConfigSchema', () => {
       {
         data: { key1: 'a' },
         context: 'test',
-        deprecatedKeys: [],
       },
     ]);
     expect(
@@ -79,7 +78,6 @@ describe('loadConfigSchema', () => {
         data: { key1: 'X' },
         context: 'test',
         filteredKeys: ['key2'],
-        deprecatedKeys: [],
       },
     ]);
     expect(
@@ -92,7 +90,6 @@ describe('loadConfigSchema', () => {
         data: { key1: 'X', key2: 'X' },
         context: 'test',
         filteredKeys: [],
-        deprecatedKeys: [],
       },
     ]);
 
@@ -103,7 +100,6 @@ describe('loadConfigSchema', () => {
       {
         data: { key1: 'a' },
         context: 'test',
-        deprecatedKeys: [],
       },
     ]);
     expect(() =>
@@ -152,7 +148,6 @@ describe('loadConfigSchema', () => {
         {
           data: { key1: 'a' },
           context: 'test',
-          deprecatedKeys: [],
         },
       ]);
       expect(() => schema.process(configs, { visibility: ['secret'] })).toThrow(
@@ -205,7 +200,6 @@ describe('loadConfigSchema', () => {
         {
           data: { nested: [{}] },
           context: 'test',
-          deprecatedKeys: [],
         },
       ]);
       expect(() => schema.process(mkConfig({ y: 1 }))).toThrow(
@@ -222,7 +216,6 @@ describe('loadConfigSchema', () => {
         {
           data: { nested: [{}] },
           context: 'test',
-          deprecatedKeys: [],
         },
       ]);
       expect(
@@ -231,7 +224,6 @@ describe('loadConfigSchema', () => {
         {
           data: { nested: [{ y: 'aaa' }] },
           context: 'test',
-          deprecatedKeys: [],
         },
       ]);
       expect(() =>

--- a/packages/config-loader/src/lib/schema/load.test.ts
+++ b/packages/config-loader/src/lib/schema/load.test.ts
@@ -62,7 +62,11 @@ describe('loadConfigSchema', () => {
 
     expect(schema.process(configs)).toEqual(configs);
     expect(schema.process(configs, { visibility: ['frontend'] })).toEqual([
-      { data: { key1: 'a' }, context: 'test' },
+      {
+        data: { key1: 'a' },
+        context: 'test',
+        deprecatedKeys: [],
+      },
     ]);
     expect(
       schema.process(configs, {
@@ -71,7 +75,12 @@ describe('loadConfigSchema', () => {
         withFilteredKeys: true,
       }),
     ).toEqual([
-      { data: { key1: 'X' }, context: 'test', filteredKeys: ['key2'] },
+      {
+        data: { key1: 'X' },
+        context: 'test',
+        filteredKeys: ['key2'],
+        deprecatedKeys: [],
+      },
     ]);
     expect(
       schema.process(configs, {
@@ -79,14 +88,23 @@ describe('loadConfigSchema', () => {
         withFilteredKeys: true,
       }),
     ).toEqual([
-      { data: { key1: 'X', key2: 'X' }, context: 'test', filteredKeys: [] },
+      {
+        data: { key1: 'X', key2: 'X' },
+        context: 'test',
+        filteredKeys: [],
+        deprecatedKeys: [],
+      },
     ]);
 
     const serialized = schema.serialize();
 
     const schema2 = await loadConfigSchema({ serialized });
     expect(schema2.process(configs, { visibility: ['frontend'] })).toEqual([
-      { data: { key1: 'a' }, context: 'test' },
+      {
+        data: { key1: 'a' },
+        context: 'test',
+        deprecatedKeys: [],
+      },
     ]);
     expect(() =>
       schema2.process([...configs, { data: { key1: 3 }, context: 'test2' }]),
@@ -131,7 +149,11 @@ describe('loadConfigSchema', () => {
         'Config validation failed, Config should be number { type=number } at /key2',
       );
       expect(schema.process(configs, { visibility: ['frontend'] })).toEqual([
-        { data: { key1: 'a' }, context: 'test' },
+        {
+          data: { key1: 'a' },
+          context: 'test',
+          deprecatedKeys: [],
+        },
       ]);
       expect(() => schema.process(configs, { visibility: ['secret'] })).toThrow(
         'Config validation failed, Config should be number { type=number } at /key2',
@@ -179,7 +201,13 @@ describe('loadConfigSchema', () => {
       ];
       expect(
         schema.process(mkConfig({ x: 1 }), { visibility: ['frontend'] }),
-      ).toEqual([{ data: { nested: [{}] }, context: 'test' }]);
+      ).toEqual([
+        {
+          data: { nested: [{}] },
+          context: 'test',
+          deprecatedKeys: [],
+        },
+      ]);
       expect(() => schema.process(mkConfig({ y: 1 }))).toThrow(
         'Config validation failed, Config should be string { type=string } at /nested/0/y',
       );
@@ -190,10 +218,22 @@ describe('loadConfigSchema', () => {
       );
       expect(
         schema.process(mkConfig({ x: 'a' }), { visibility: ['frontend'] }),
-      ).toEqual([{ data: { nested: [{}] }, context: 'test' }]);
+      ).toEqual([
+        {
+          data: { nested: [{}] },
+          context: 'test',
+          deprecatedKeys: [],
+        },
+      ]);
       expect(
         schema.process(mkConfig({ y: 'aaa' }), { visibility: ['frontend'] }),
-      ).toEqual([{ data: { nested: [{ y: 'aaa' }] }, context: 'test' }]);
+      ).toEqual([
+        {
+          data: { nested: [{ y: 'aaa' }] },
+          context: 'test',
+          deprecatedKeys: [],
+        },
+      ]);
       expect(() =>
         schema.process(mkConfig({ y: 'aaaa' }), { visibility: ['frontend'] }),
       ).toThrow(

--- a/packages/config-loader/src/lib/schema/load.ts
+++ b/packages/config-loader/src/lib/schema/load.ts
@@ -18,11 +18,7 @@ import { AppConfig } from '@backstage/config';
 import { JsonObject } from '@backstage/types';
 import { compileConfigSchemas } from './compile';
 import { collectConfigSchemas } from './collect';
-import {
-  filterByVisibility,
-  filterErrorsByVisibility,
-  filterByDeprecated,
-} from './filtering';
+import { filterByVisibility, filterErrorsByVisibility } from './filtering';
 import {
   ValidationError,
   ConfigSchema,

--- a/packages/config-loader/src/lib/schema/load.ts
+++ b/packages/config-loader/src/lib/schema/load.ts
@@ -109,12 +109,9 @@ export async function loadConfigSchema(
             data,
             visibility,
             result.visibilityByDataPath,
+            result.deprecationByDataPath,
             valueTransform,
             withFilteredKeys,
-          ),
-          ...filterByDeprecated(
-            data,
-            result.deprecationBySchemaPath,
             withDeprecatedKeys,
           ),
         }));
@@ -125,12 +122,9 @@ export async function loadConfigSchema(
             data,
             Array.from(CONFIG_VISIBILITIES),
             result.visibilityByDataPath,
+            result.deprecationByDataPath,
             valueTransform,
             withFilteredKeys,
-          ),
-          ...filterByDeprecated(
-            data,
-            result.deprecationBySchemaPath,
             withDeprecatedKeys,
           ),
         }));

--- a/packages/config-loader/src/lib/schema/load.ts
+++ b/packages/config-loader/src/lib/schema/load.ts
@@ -18,7 +18,11 @@ import { AppConfig } from '@backstage/config';
 import { JsonObject } from '@backstage/types';
 import { compileConfigSchemas } from './compile';
 import { collectConfigSchemas } from './collect';
-import { filterByVisibility, filterErrorsByVisibility } from './filtering';
+import {
+  filterByVisibility,
+  filterErrorsByVisibility,
+  filterByDeprecated,
+} from './filtering';
 import {
   ValidationError,
   ConfigSchema,
@@ -82,7 +86,7 @@ export async function loadConfigSchema(
   return {
     process(
       configs: AppConfig[],
-      { visibility, valueTransform, withFilteredKeys } = {},
+      { visibility, valueTransform, withFilteredKeys, withDeprecatedKeys } = {},
     ): AppConfig[] {
       const result = validate(configs);
 
@@ -108,6 +112,11 @@ export async function loadConfigSchema(
             valueTransform,
             withFilteredKeys,
           ),
+          ...filterByDeprecated(
+            data,
+            result.deprecationBySchemaPath,
+            withDeprecatedKeys,
+          ),
         }));
       } else if (valueTransform) {
         processedConfigs = processedConfigs.map(({ data, context }) => ({
@@ -118,6 +127,11 @@ export async function loadConfigSchema(
             result.visibilityByDataPath,
             valueTransform,
             withFilteredKeys,
+          ),
+          ...filterByDeprecated(
+            data,
+            result.deprecationBySchemaPath,
+            withDeprecatedKeys,
           ),
         }));
       }

--- a/packages/config-loader/src/lib/schema/types.ts
+++ b/packages/config-loader/src/lib/schema/types.ts
@@ -85,9 +85,9 @@ type ValidationResult = {
   /**
    * The deprecated options that were discovered during validation.
    *
-   * The path in the key uses the form `/properties/<key>/items/additionalProperties/<leaf-key>`
+   * The path in the key uses the form `/<key>/<sub-key>/<array-index>/<leaf-key>`
    */
-  deprecationBySchemaPath: Map<string, string>;
+  deprecationByDataPath: Map<string, string>;
 };
 
 /**

--- a/packages/config-loader/src/lib/schema/types.ts
+++ b/packages/config-loader/src/lib/schema/types.ts
@@ -81,6 +81,13 @@ type ValidationResult = {
    * The path in the key uses the form `/properties/<key>/items/additionalProperties/<leaf-key>`
    */
   visibilityBySchemaPath: Map<string, ConfigVisibility>;
+
+  /**
+   * The deprecated options that were discovered during validation.
+   *
+   * The path in the key uses the form `/properties/<key>/items/additionalProperties/<leaf-key>`
+   */
+  deprecationBySchemaPath: Map<string, string>;
 };
 
 /**
@@ -124,6 +131,13 @@ export type ConfigSchemaProcessingOptions = {
    * Default: `false`.
    */
   withFilteredKeys?: boolean;
+
+  /**
+   * Whether or not to include the `deprecatedKeys` property in the output `AppConfig`s.
+   *
+   * Default: `true`.
+   */
+  withDeprecatedKeys?: boolean;
 };
 
 /**

--- a/packages/config/api-report.md
+++ b/packages/config/api-report.md
@@ -13,6 +13,10 @@ export type AppConfig = {
   context: string;
   data: JsonObject_2;
   filteredKeys?: string[];
+  deprecatedKeys?: {
+    key: string;
+    description: string;
+  }[];
 };
 
 // @public

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -83,9 +83,27 @@ export class ConfigReader implements Config {
     // Merge together all configs into a single config with recursive fallback
     // readers, giving the first config object in the array the lowest priority.
     return configs.reduce<ConfigReader>(
-      (previousReader, { data, context, filteredKeys }) => {
+      (previousReader, { data, context, filteredKeys, deprecatedKeys }) => {
         const reader = new ConfigReader(data, context, previousReader);
         reader.filteredKeys = filteredKeys;
+
+        // TODO(cmpadden) introduce `deprecatedKeys` and `notifiedDeprecatedKeys` & use logger
+        if (deprecatedKeys) {
+          for (const { key, description } of deprecatedKeys) {
+            if (description) {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `The configuration key '${key}' is deprecated and may be removed soon. (reason: ${description})`,
+              );
+            } else {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `The configuration key '${key}' is deprecated and may be removed soon.`,
+              );
+            }
+          }
+        }
+
         return reader;
       },
       undefined!,

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -87,20 +87,15 @@ export class ConfigReader implements Config {
         const reader = new ConfigReader(data, context, previousReader);
         reader.filteredKeys = filteredKeys;
 
-        // TODO(cmpadden) introduce `deprecatedKeys` and `notifiedDeprecatedKeys` & use logger
+        // TODO(cmpadden) `withDeprecatedKeys` is defaulting to false on app start
         if (deprecatedKeys) {
           for (const { key, description } of deprecatedKeys) {
-            if (description) {
-              // eslint-disable-next-line no-console
-              console.warn(
-                `The configuration key '${key}' is deprecated and may be removed soon. (reason: ${description})`,
-              );
-            } else {
-              // eslint-disable-next-line no-console
-              console.warn(
-                `The configuration key '${key}' is deprecated and may be removed soon.`,
-              );
-            }
+            // eslint-disable-next-line no-console
+            console.warn(
+              `The configuration key '${key}' of ${context} is deprecated and may be removed soon. ${
+                description || ''
+              }`,
+            );
           }
         }
 

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -87,7 +87,6 @@ export class ConfigReader implements Config {
         const reader = new ConfigReader(data, context, previousReader);
         reader.filteredKeys = filteredKeys;
 
-        // TODO(cmpadden) `withDeprecatedKeys` is defaulting to false on app start
         if (deprecatedKeys) {
           for (const { key, description } of deprecatedKeys) {
             // eslint-disable-next-line no-console

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -36,6 +36,12 @@ export type AppConfig = {
    * This can be used to warn the user if they try to read any of these keys.
    */
   filteredKeys?: string[];
+  /**
+   * A list of deprecated keys that were found in the  configuration when it was loaded.
+   *
+   * This can be used to warn the user if they are using deprecated properties.
+   */
+  deprecatedKeys?: { key: string; description: string }[];
 };
 
 /**

--- a/plugins/app-backend/src/lib/config.ts
+++ b/plugins/app-backend/src/lib/config.ts
@@ -91,7 +91,7 @@ export async function readConfigs(options: ReadOptions): Promise<AppConfig[]> {
 
       const frontendConfigs = await schema.process(
         [{ data: config.get() as JsonObject, context: 'app' }],
-        { visibility: ['frontend'] },
+        { visibility: ['frontend'], withDeprecatedKeys: true },
       );
       appConfigs.push(...frontendConfigs);
     } catch (error) {


### PR DESCRIPTION
Signed-off-by: Colton Padden <colton.padden@fastmail.com>

## Hey, I just made a Pull Request!

Closes #8311

This PR introduces logic to warn users if they are using deprecated keys in their app configurations.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
