### PR TITLE
backend-common: reintroduce unsafe-eval

### DIFF
--- a/.changeset/plenty-lobsters-grow.md
+++ b/.changeset/plenty-lobsters-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Reverted the default CSP configuration to include `'unsafe-eval'` again, which was mistakenly removed in the previous version.

--- a/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
+++ b/packages/backend-common/src/service/lib/ServiceBuilderImpl.ts
@@ -228,6 +228,10 @@ export function applyCspDirectives(
   const result: ContentSecurityPolicyOptions['directives'] =
     helmet.contentSecurityPolicy.getDefaultDirectives();
 
+  // TODO(Rugvip): We currently use non-precompiled AJV for validation in the frontend, which uses eval.
+  //               It should be replaced by any other solution that doesn't require unsafe-eval.
+  result['script-src'] = ["'self'", "'unsafe-eval'"];
+
   if (directives) {
     for (const [key, value] of Object.entries(directives)) {
       if (value === false) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#8673 removed #3767 by mistake, this adds it back in

Fixes #8705

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
