### PR TITLE
Add routeRef in catalog customization example

### DIFF
--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -30,12 +30,15 @@ export const CustomCatalogPage = ({
   actions,
   initiallySelectedFilter = 'owned',
 }: CatalogPageProps) => {
+  const createComponentLink = useRouteRef(
+    catalogPlugin.externalRoutes.createComponent,
+  );
   return (
     <PageWithHeader title={`${orgName} Catalog`} themeId="home">
       <EntityListProvider>
         <Content>
           <ContentHeader titleComponent={<CatalogKindHeader />}>
-            <CreateButton title="Create Component" to={link} />
+            <CreateButton title="Create Component" to={createComponentLink()} />
             <SupportButton>All your software catalog entities</SupportButton>
           </ContentHeader>
           <FilteredEntityLayout>


### PR DESCRIPTION
Minor enhancement for the catalog customization doc, this was left as an exercise for the reader to figure out previously.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
