### PR TITLE
Allow manual refresh of file enties

### DIFF
--- a/.changeset/wicked-weeks-knock.md
+++ b/.changeset/wicked-weeks-knock.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Allow enties from file locations to be manually refreshed through the UI
+Allow entities from `file` locations to be manually refreshed through the UI

--- a/.changeset/wicked-weeks-knock.md
+++ b/.changeset/wicked-weeks-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Allow enties from file locations to be manually refreshed through the UI

--- a/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.test.tsx
@@ -43,6 +43,10 @@ describe('<AboutCard />', () => {
     refreshEntity: jest.fn(),
   } as any;
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders info', async () => {
     const entity = {
       apiVersion: 'v1',
@@ -248,14 +252,16 @@ describe('<AboutCard />', () => {
     expect(getByText('View Source').closest('a')).not.toHaveAttribute('href');
   });
 
-  it('triggers a refresh', async () => {
+  it.each([
+    'url:https://backstage.io/catalog-info.yaml',
+    'file:../../catalog-info.yaml',
+  ])('triggers a refresh for %s', async location => {
     const entity = {
       apiVersion: 'v1',
       kind: 'Component',
       metadata: {
         annotations: {
-          'backstage.io/managed-by-location':
-            'url:https://backstage.io/catalog-info.yaml',
+          'backstage.io/managed-by-location': location,
         },
         name: 'software',
       },
@@ -298,7 +304,7 @@ describe('<AboutCard />', () => {
     );
   });
 
-  it('should not render refresh button if the location is not an url', async () => {
+  it('should not render refresh button if the location is not an url or file', async () => {
     const entity = {
       apiVersion: 'v1',
       kind: 'Component',

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -127,8 +127,10 @@ export function AboutCard({ variant }: AboutCardProps) {
     cardContentClass = classes.fullHeightCardContent;
   }
 
-  const isUrl =
-    entity.metadata.annotations?.[LOCATION_ANNOTATION]?.startsWith('url:');
+  const entityLocation = entity.metadata.annotations?.[LOCATION_ANNOTATION];
+  // Limiting the ability to manually refresh to the less expensive locations
+  const allowRefresh =
+    entityLocation?.startsWith('url:') || entityLocation?.startsWith('file:');
   const refreshEntity = useCallback(async () => {
     await catalogApi.refreshEntity(stringifyEntityRef(entity));
     alertApi.post({ message: 'Refresh scheduled', severity: 'info' });
@@ -140,7 +142,7 @@ export function AboutCard({ variant }: AboutCardProps) {
         title="About"
         action={
           <>
-            {isUrl && (
+            {allowRefresh && (
               <IconButton
                 aria-label="Refresh"
                 title="Schedule entity refresh"


### PR DESCRIPTION
Fixes #8525 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Allowed the refresh button to render for entities coming from `file` locations in addition to `url`. Was able to test with my dev server and refresh file entities.

![image](https://user-images.githubusercontent.com/58954013/147961295-8ed3aa5e-eca5-4852-8d88-55b24678c441.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
