### PR TITLE
catalog-backend: make sure tasks aren't loaded too eagerly in TaskPipeline test

### DIFF
--- a/plugins/catalog-backend/src/processing/TaskPipeline.test.ts
+++ b/plugins/catalog-backend/src/processing/TaskPipeline.test.ts
@@ -42,7 +42,7 @@ function createLimitedLoader(count: number, loadDelay?: number) {
   };
   const processTask = async (item: number) => {
     processedTasks.push(item);
-    await new Promise(resolve => setTimeout(resolve)); // emulate a bit of work
+    await new Promise(resolve => setTimeout(resolve, 10)); // emulate a bit of work
     if (processedTasks.length === count) {
       resolveDone({ processedTasks, loadCounts });
     }


### PR DESCRIPTION
This has been a bit flaky lately. Not sure why it would start happening now but figuring that actually emulating some work for each task will avoid the situation where one test worker completes and picks up more processing before the other one gets a chance to start