### PR TITLE
test-utils: add MockConfigApi

### DIFF
--- a/.changeset/brave-pugs-fold.md
+++ b/.changeset/brave-pugs-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Add new `MockConfigApi` as a more discoverable and leaner method for mocking configuration.

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -8,10 +8,13 @@ import { AnalyticsEvent } from '@backstage/core-plugin-api';
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { ApiRef } from '@backstage/core-plugin-api';
 import { ComponentType } from 'react';
+import { Config } from '@backstage/config';
+import { ConfigApi } from '@backstage/core-plugin-api';
 import { ErrorApi } from '@backstage/core-plugin-api';
 import { ErrorApiError } from '@backstage/core-plugin-api';
 import { ErrorApiErrorContext } from '@backstage/core-plugin-api';
 import { ExternalRouteRef } from '@backstage/core-plugin-api';
+import { JsonObject } from '@backstage/types';
 import { JsonValue } from '@backstage/types';
 import { Observable } from '@backstage/types';
 import { ReactElement } from 'react';
@@ -51,6 +54,43 @@ export class MockAnalyticsApi implements AnalyticsApi {
 
 // @public
 export function mockBreakpoint(options: { matches: boolean }): void;
+
+// @public
+export class MockConfigApi implements ConfigApi {
+  constructor(data: JsonObject);
+  // (undocumented)
+  get<T = JsonValue>(key?: string): T;
+  // (undocumented)
+  getBoolean(key: string): boolean;
+  // (undocumented)
+  getConfig(key: string): Config;
+  // (undocumented)
+  getConfigArray(key: string): Config[];
+  // (undocumented)
+  getNumber(key: string): number;
+  // (undocumented)
+  getOptional<T = JsonValue>(key?: string): T | undefined;
+  // (undocumented)
+  getOptionalBoolean(key: string): boolean | undefined;
+  // (undocumented)
+  getOptionalConfig(key: string): Config | undefined;
+  // (undocumented)
+  getOptionalConfigArray(key: string): Config[] | undefined;
+  // (undocumented)
+  getOptionalNumber(key: string): number | undefined;
+  // (undocumented)
+  getOptionalString(key: string): string | undefined;
+  // (undocumented)
+  getOptionalStringArray(key: string): string[] | undefined;
+  // (undocumented)
+  getString(key: string): string;
+  // (undocumented)
+  getStringArray(key: string): string[];
+  // (undocumented)
+  has(key: string): boolean;
+  // (undocumented)
+  keys(): string[];
+}
 
 // @public
 export class MockErrorApi implements ErrorApi {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -29,6 +29,7 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
+    "@backstage/config": "^0.1.11",
     "@backstage/core-app-api": "^0.3.0",
     "@backstage/core-plugin-api": "^0.4.0",
     "@backstage/theme": "^0.2.14",

--- a/packages/test-utils/src/testUtils/apis/ConfigApi/MockConfigApi.test.ts
+++ b/packages/test-utils/src/testUtils/apis/ConfigApi/MockConfigApi.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MockConfigApi } from './MockConfigApi';
+
+describe('MockConfigApi', () => {
+  it('is able to read some basic config', () => {
+    const mock = new MockConfigApi({
+      app: {
+        title: 'Hello',
+      },
+      x: 1,
+      y: false,
+      z: [{ a: 3 }],
+    });
+
+    expect(mock.getString('app.title')).toEqual('Hello');
+    expect(mock.getNumber('x')).toEqual(1);
+    expect(mock.getBoolean('y')).toEqual(false);
+    expect(mock.getConfigArray('z')[0].getOptionalNumber('a')).toEqual(3);
+
+    expect(() => mock.getString('x')).toThrow(
+      "Invalid type in config for key 'x' in 'mock-config', got number, wanted string",
+    );
+    expect(() => mock.getString('missing')).toThrow(
+      "Missing required config value at 'missing'",
+    );
+  });
+});

--- a/packages/test-utils/src/testUtils/apis/ConfigApi/MockConfigApi.ts
+++ b/packages/test-utils/src/testUtils/apis/ConfigApi/MockConfigApi.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Config, ConfigReader } from '@backstage/config';
+import { JsonObject, JsonValue } from '@backstage/types';
+import { ConfigApi } from '@backstage/core-plugin-api';
+
+/**
+ * MockConfigApi is a thin wrapper around {@link @backstage/config#ConfigReader}
+ * that can be used to mock configuration using a plain object.
+ *
+ * @public
+ * @example
+ * ```tsx
+ * const mockConfig = new MockConfigApi({
+ *   app: { baseUrl: 'https://example.com' },
+ * });
+ *
+ * const rendered = await renderInTestApp(
+ *   <TestApiProvider apis={[[configApiRef, mockConfig]]}>
+ *     <MyTestedComponent />
+ *   </TestApiProvider>,
+ * );
+ * ```
+ */
+export class MockConfigApi implements ConfigApi {
+  readonly #config: ConfigReader;
+
+  // NOTE: not extending in order to avoid inheriting the static `.fromConfigs`
+  constructor(data: JsonObject) {
+    this.#config = new ConfigReader(data);
+  }
+
+  /** {@inheritdoc @backstage/config#Config.has} */
+  has(key: string): boolean {
+    return this.#config.has(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.keys} */
+  keys(): string[] {
+    return this.#config.keys();
+  }
+  /** {@inheritdoc @backstage/config#Config.get} */
+  get<T = JsonValue>(key?: string): T {
+    return this.#config.get(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getOptional} */
+  getOptional<T = JsonValue>(key?: string): T | undefined {
+    return this.#config.getOptional(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getConfig} */
+  getConfig(key: string): Config {
+    return this.#config.getConfig(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getOptionalConfig} */
+  getOptionalConfig(key: string): Config | undefined {
+    return this.#config.getOptionalConfig(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getConfigArray} */
+  getConfigArray(key: string): Config[] {
+    return this.#config.getConfigArray(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getOptionalConfigArray} */
+  getOptionalConfigArray(key: string): Config[] | undefined {
+    return this.#config.getOptionalConfigArray(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getNumber} */
+  getNumber(key: string): number {
+    return this.#config.getNumber(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getOptionalNumber} */
+  getOptionalNumber(key: string): number | undefined {
+    return this.#config.getOptionalNumber(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getBoolean} */
+  getBoolean(key: string): boolean {
+    return this.#config.getBoolean(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getOptionalBoolean} */
+  getOptionalBoolean(key: string): boolean | undefined {
+    return this.#config.getOptionalBoolean(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getString} */
+  getString(key: string): string {
+    return this.#config.getString(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getOptionalString} */
+  getOptionalString(key: string): string | undefined {
+    return this.#config.getOptionalString(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getStringArray} */
+  getStringArray(key: string): string[] {
+    return this.#config.getStringArray(key);
+  }
+  /** {@inheritdoc @backstage/config#Config.getOptionalStringArray} */
+  getOptionalStringArray(key: string): string[] | undefined {
+    return this.#config.getOptionalStringArray(key);
+  }
+}

--- a/packages/test-utils/src/testUtils/apis/ConfigApi/index.ts
+++ b/packages/test-utils/src/testUtils/apis/ConfigApi/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,4 @@
  * limitations under the License.
  */
 
-export * from './AnalyticsApi';
-export * from './ConfigApi';
-export * from './ErrorApi';
-export * from './StorageApi';
+export { MockConfigApi } from './MockConfigApi';


### PR DESCRIPTION
Signed-off-by: Patrik Oldsberg <poldsberg@gmail.com>

## Hey, I just made a Pull Request!

The `ConfigReader` from `@backstage/config` is a bit hard to find, and it also has some weird extra options and the perhaps a bit confusing `.fromConfig` static method. This adds a more plain `MockConfigApi` to `test-utils` that just takes a single object that is the backing config data, and nothing else.

Fixes #7696

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
