### PR TITLE
Techdocs: Require access to related catalog entities

### DIFF
--- a/cypress/src/support/commands.ts
+++ b/cypress/src/support/commands.ts
@@ -93,12 +93,12 @@ Cypress.Commands.add('interceptTechDocsAPICalls', () => {
 
   cy.intercept(
     'GET',
-    '**/techdocs/static/docs/default/Component/techdocs-e2e-fixture/sub-page-two/index.html',
+    '**/techdocs/static/entity/docs/default/Component/techdocs-e2e-fixture/sub-page-two/index.html',
   ).as('sectionTwoHTML');
 
   cy.intercept(
     'GET',
-    '**/techdocs/static/docs/default/Component/techdocs-e2e-fixture/index.html',
+    '**/techdocs/static/entity/docs/default/Component/techdocs-e2e-fixture/index.html',
   ).as('homeHTML');
 });
 

--- a/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
+++ b/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
@@ -85,19 +85,23 @@ describe('createCacheMiddleware', () => {
       expect(cache.set).not.toHaveBeenCalled();
     });
 
-    it('sets cache when content is cacheable', async () => {
-      const expectedPath = 'default/api/xyz/index.html';
-      await request(app)
-        .get(`/static/docs/${expectedPath}`)
-        .expect(200, 'default-response');
+    it.each(['/static/docs', '/static/entity/docs'])(
+      'sets cache when content is cacheable',
+      async prefix => {
+        const expectedPath = 'default/api/xyz/index.html';
+        await request(app)
+          .get(`${prefix}/${expectedPath}`)
+          .expect(200, 'default-response');
 
-      await waitForSocketClose();
-      expect(cache.set).toHaveBeenCalled();
+        await waitForSocketClose();
+        expect(cache.set).toHaveBeenCalled();
 
-      const [actualPath, actualBuffer] = (cache.set as jest.Mock).mock.calls[0];
-      expect(actualPath).toBe(expectedPath);
-      expect(actualBuffer.toString()).toContain('default-response');
-    });
+        const [actualPath, actualBuffer] = (cache.set as jest.Mock).mock
+          .calls[0];
+        expect(actualPath).toBe(expectedPath);
+        expect(actualBuffer.toString()).toContain('default-response');
+      },
+    );
 
     it('does not set cache on error', async () => {
       await request(app).get('/static/docs/error.png').expect(500);

--- a/plugins/techdocs-backend/src/cache/cacheMiddleware.ts
+++ b/plugins/techdocs-backend/src/cache/cacheMiddleware.ts
@@ -31,11 +31,12 @@ export const createCacheMiddleware = ({
   const cacheMiddleware = router();
 
   // Middleware that, through socket monkey patching, captures responses as
-  // they're sent over /static/docs/* and caches them. Subsequent requests are
-  // loaded from cache. Cache key is the object's path (after `/static/docs/`).
+  // they're sent over /static(/entity)?/docs/* and caches them. Subsequent requests are
+  // loaded from cache. Cache key is the object's path (after `/static(/entity)?/docs/`).
   cacheMiddleware.use(async (req, res, next) => {
     const socket = res.socket;
-    const isCacheable = req.path.startsWith('/static/docs/');
+    const pathRegex = /^\/static(\/entity)?\/docs\/(.*)$/;
+    const isCacheable = pathRegex.test(req.path);
 
     // Continue early if this is non-cacheable, or there's no socket.
     if (!isCacheable || !socket) {
@@ -44,7 +45,7 @@ export const createCacheMiddleware = ({
     }
 
     // Make concrete references to these things.
-    const reqPath = decodeURI(req.path.match(/\/static\/docs\/(.*)$/)![1]);
+    const reqPath = decodeURI(req.path.match(pathRegex)![2]);
     const realEnd = socket.end.bind(socket);
     const realWrite = socket.write.bind(socket);
     let writeToCache = true;

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.test.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.test.ts
@@ -116,7 +116,7 @@ describe('DefaultTechDocsCollator with legacyPathCasing configuration', () => {
 
     worker.use(
       rest.get(
-        'http://test-backend/static/docs/default/Component/test-entity-with-docs/search/search_index.json',
+        'http://test-backend/static/entity/docs/default/Component/test-entity-with-docs/search/search_index.json',
         (_, res, ctx) => res(ctx.status(200), ctx.json(mockSearchDocIndex)),
       ),
       rest.get('http://test-backend/entities', (_, res, ctx) =>
@@ -176,7 +176,7 @@ describe('DefaultTechDocsCollator', () => {
 
     worker.use(
       rest.get(
-        'http://test-backend/static/docs/default/component/test-entity-with-docs/search/search_index.json',
+        'http://test-backend/static/entity/docs/default/component/test-entity-with-docs/search/search_index.json',
         (_, res, ctx) => res(ctx.status(200), ctx.json(mockSearchDocIndex)),
       ),
       rest.get('http://test-backend/entities', (_, res, ctx) =>

--- a/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
+++ b/plugins/techdocs-backend/src/search/DefaultTechDocsCollator.ts
@@ -176,7 +176,7 @@ export class DefaultTechDocsCollator implements DocumentCollator {
     techDocsBaseUrl: string,
     entityInfo: { kind: string; namespace: string; name: string },
   ) {
-    return `${techDocsBaseUrl}/static/docs/${entityInfo.namespace}/${entityInfo.kind}/${entityInfo.name}/search/search_index.json`;
+    return `${techDocsBaseUrl}/static/entity/docs/${entityInfo.namespace}/${entityInfo.kind}/${entityInfo.name}/search/search_index.json`;
   }
 
   private static handleEntityInfoCasing(

--- a/plugins/techdocs-backend/src/service/DocsSynchronizer.ts
+++ b/plugins/techdocs-backend/src/service/DocsSynchronizer.ts
@@ -192,7 +192,7 @@ export class DocsSynchronizer {
       const [sourceMetadata, cachedMetadata] = await Promise.all([
         this.publisher.fetchTechDocsMetadata({ namespace, kind, name }),
         fetch(
-          `${baseUrl}/static/docs/${entityTripletPath}/techdocs_metadata.json`,
+          `${baseUrl}/static/entity/docs/${entityTripletPath}/techdocs_metadata.json`,
           {
             headers: token ? { Authorization: `Bearer ${token}` } : {},
           },

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -231,9 +231,10 @@ export async function createRouter(
     );
   });
 
-  // Ensures that the related entity exists and the current user has permission to view it.
+  // Route treated similarly to /static/docs
+  // Requires an existing entity in the catalog for authorization
   router.use(
-    '/static/docs/entity/:namespace/:kind/:name',
+    '/static/entity/docs/:namespace/:kind/:name',
     async (req, _res, next) => {
       const { kind, namespace, name } = req.params;
       const entityName = { kind, namespace, name };
@@ -257,7 +258,8 @@ export async function createRouter(
   }
 
   // Route middleware which serves files from the storage set in the publisher.
-  router.use('/static/docs/(entity)?', publisher.docsRouter());
+  // Can either be authorized /static/entity/docs or unauthorized /static/docs
+  router.use('/static(/entity)?/docs', publisher.docsRouter());
 
   return router;
 }

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -18,7 +18,7 @@ import {
   PluginCacheManager,
 } from '@backstage/backend-common';
 import { CatalogClient } from '@backstage/catalog-client';
-import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { stringifyEntityRef } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import { NotFoundError, NotModifiedError } from '@backstage/errors';
 import {
@@ -27,7 +27,6 @@ import {
   PreparerBuilder,
   PublisherBase,
 } from '@backstage/techdocs-common';
-import fetch from 'node-fetch';
 import express, { Response } from 'express';
 import Router from 'express-promise-router';
 import { Knex } from 'knex';
@@ -107,6 +106,16 @@ export async function createRouter(
   router.get('/metadata/techdocs/:namespace/:kind/:name', async (req, res) => {
     const { kind, namespace, name } = req.params;
     const entityName = { kind, namespace, name };
+    const token = getBearerToken(req.headers.authorization);
+
+    // Verify that the related entity exists and the current user has permission to view it.
+    const entity = await catalogClient.getEntityByName(entityName, { token });
+
+    if (!entity) {
+      throw new NotFoundError(
+        `Unable to get metadata for '${stringifyEntityRef(entityName)}'`,
+      );
+    }
 
     try {
       const techdocsMetadata = await publisher.fetchTechDocsMetadata(
@@ -128,23 +137,19 @@ export async function createRouter(
   });
 
   router.get('/metadata/entity/:namespace/:kind/:name', async (req, res) => {
-    const catalogUrl = await discovery.getBaseUrl('catalog');
-
     const { kind, namespace, name } = req.params;
     const entityName = { kind, namespace, name };
+    const token = getBearerToken(req.headers.authorization);
+
+    const entity = await catalogClient.getEntityByName(entityName, { token });
+
+    if (!entity) {
+      throw new NotFoundError(
+        `Unable to get metadata for '${stringifyEntityRef(entityName)}'`,
+      );
+    }
 
     try {
-      const token = getBearerToken(req.headers.authorization);
-      // TODO: Consider using the catalog client here
-      const entity = (await (
-        await fetch(
-          `${catalogUrl}/entities/by-name/${kind}/${namespace}/${name}`,
-          {
-            headers: token ? { Authorization: `Bearer ${token}` } : {},
-          },
-        )
-      ).json()) as Entity;
-
       const locationMetadata = getLocationForEntity(entity, scmIntegrations);
       res.json({ ...entity, locationMetadata });
     } catch (err) {
@@ -226,13 +231,33 @@ export async function createRouter(
     );
   });
 
+  // Ensures that the related entity exists and the current user has permission to view it.
+  router.use(
+    '/static/docs/entity/:namespace/:kind/:name',
+    async (req, _res, next) => {
+      const { kind, namespace, name } = req.params;
+      const entityName = { kind, namespace, name };
+      const token = getBearerToken(req.headers.authorization);
+
+      const entity = await catalogClient.getEntityByName(entityName, { token });
+
+      if (!entity) {
+        throw new NotFoundError(
+          `Entity not found for ${stringifyEntityRef(entityName)}`,
+        );
+      }
+
+      next();
+    },
+  );
+
   // If a cache manager was provided, attach the cache middleware.
   if (cache) {
     router.use(createCacheMiddleware({ logger, cache }));
   }
 
   // Route middleware which serves files from the storage set in the publisher.
-  router.use('/static/docs', publisher.docsRouter());
+  router.use('/static/docs/(entity)?', publisher.docsRouter());
 
   return router;
 }

--- a/plugins/techdocs/src/client.test.ts
+++ b/plugins/techdocs/src/client.test.ts
@@ -60,13 +60,13 @@ describe('TechDocsStorageClient', () => {
     await expect(
       storageApi.getBaseUrl('test.js', mockEntity, ''),
     ).resolves.toEqual(
-      `${mockBaseUrl}/static/docs/${mockEntity.namespace}/${mockEntity.kind}/${mockEntity.name}/test.js`,
+      `${mockBaseUrl}/static/entity/docs/${mockEntity.namespace}/${mockEntity.kind}/${mockEntity.name}/test.js`,
     );
 
     await expect(
       storageApi.getBaseUrl('../test.js', mockEntity, 'some-docs-path'),
     ).resolves.toEqual(
-      `${mockBaseUrl}/static/docs/${mockEntity.namespace}/${mockEntity.kind}/${mockEntity.name}/test.js`,
+      `${mockBaseUrl}/static/entity/docs/${mockEntity.namespace}/${mockEntity.kind}/${mockEntity.name}/test.js`,
     );
   });
 
@@ -77,7 +77,7 @@ describe('TechDocsStorageClient', () => {
     await expect(
       storageApi.getBaseUrl('test/', mockEntity, ''),
     ).resolves.toEqual(
-      `${mockBaseUrl}/static/docs/${mockEntity.namespace}/${mockEntity.kind}/${mockEntity.name}/test/`,
+      `${mockBaseUrl}/static/entity/docs/${mockEntity.namespace}/${mockEntity.kind}/${mockEntity.name}/test/`,
     );
   });
 

--- a/plugins/techdocs/src/client.ts
+++ b/plugins/techdocs/src/client.ts
@@ -143,7 +143,7 @@ export class TechDocsStorageClient implements TechDocsStorageApi {
   async getStorageUrl(): Promise<string> {
     return (
       this.configApi.getOptionalString('techdocs.storageUrl') ??
-      `${await this.discoveryApi.getBaseUrl('techdocs')}/static/docs`
+      `${await this.discoveryApi.getBaseUrl('techdocs')}/static/docs/entity`
     );
   }
 
@@ -263,7 +263,7 @@ export class TechDocsStorageClient implements TechDocsStorageApi {
     const { kind, namespace, name } = entityId;
 
     const apiOrigin = await this.getApiOrigin();
-    const newBaseUrl = `${apiOrigin}/static/docs/${namespace}/${kind}/${name}/${path}`;
+    const newBaseUrl = `${apiOrigin}/static/docs/entity/${namespace}/${kind}/${name}/${path}`;
 
     return new URL(
       oldBaseUrl,

--- a/plugins/techdocs/src/client.ts
+++ b/plugins/techdocs/src/client.ts
@@ -143,7 +143,7 @@ export class TechDocsStorageClient implements TechDocsStorageApi {
   async getStorageUrl(): Promise<string> {
     return (
       this.configApi.getOptionalString('techdocs.storageUrl') ??
-      `${await this.discoveryApi.getBaseUrl('techdocs')}/static/docs/entity`
+      `${await this.discoveryApi.getBaseUrl('techdocs')}/static/entity/docs`
     );
   }
 
@@ -263,7 +263,7 @@ export class TechDocsStorageClient implements TechDocsStorageApi {
     const { kind, namespace, name } = entityId;
 
     const apiOrigin = await this.getApiOrigin();
-    const newBaseUrl = `${apiOrigin}/static/docs/entity/${namespace}/${kind}/${name}/${path}`;
+    const newBaseUrl = `${apiOrigin}/static/entity/docs/${namespace}/${kind}/${name}/${path}`;
 
     return new URL(
       oldBaseUrl,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Authorization of access to techdocs will be based on existing catalog permissions (i.e. if a user has read access for a given component, they will have access to the component's techdocs). Requesting the related entity from the catalog will implicitly check the given user's permissions. Doing this implicitly removes the need to make techdocs aware of the permission system and keeps policy writing more simple. In the future, it may be beneficial to provide more granular control of access to techdocs.

- Add an entity-specific assets endpoint (`/static/entity/docs`) for the default StorageApi and Publisher implementations to use. Requests to this endpoint are authorized via express middleware and all other asset requests will not be authorized unless done in the custom Publisher implementation. Specifically, requests made using a custom techdocs api, without an entity triplet in the path, are unauthorized.
- Updated the `/metadata/techdocs` and `/static/entity/docs` backend routes to request the related entity on the current user's behalf
- Replaced use of fetch with the catalogClient to request an entity (specifically for `/metadata/entity`)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
