### PR TITLE
search: fix slow build + cli: fix import rule edge-case

### DIFF
--- a/.changeset/rotten-olives-shop.md
+++ b/.changeset/rotten-olives-shop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Update `config/eslint.js` to forbid imports of `@material-ui/icons/` as well.

--- a/packages/cli/config/eslint.js
+++ b/packages/cli/config/eslint.js
@@ -80,6 +80,10 @@ module.exports = {
             name: '@material-ui/icons',
             message: "Please import '@material-ui/icons/<Icon>' instead.",
           },
+          {
+            name: '@material-ui/icons/', // because this is possible too ._.
+            message: "Please import '@material-ui/icons/<Icon>' instead.",
+          },
           ...require('module').builtinModules,
         ],
         // Avoid cross-package imports

--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -25,7 +25,7 @@ import {
   List,
   Paper,
 } from '@material-ui/core';
-import { Launch } from '@material-ui/icons/';
+import LaunchIcon from '@material-ui/icons/Launch';
 import { makeStyles } from '@material-ui/core/styles';
 import { SearchBar } from '../SearchBar';
 import { DefaultResultListItem } from '../DefaultResultListItem';
@@ -96,7 +96,7 @@ export const Modal = ({ open = true, toggleModal }: SearchModalProps) => {
           <Grid item>
             <Link onClick={toggleModal} to={`${getSearchLink()}?query=${term}`}>
               <span className={classes.viewResultsLink}>View Full Results</span>
-              <Launch color="primary" />
+              <LaunchIcon color="primary" />
             </Link>
           </Grid>
         </Grid>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The search plugin was taking almost a minute to build, which I thought was a bit odd. This brings it back down to 3s 😅 

Skipping changeset for search since rollup was still only bringing in the individual icon, it just slowed down the build a ton.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
