### PR TITLE
Make AWS session token optional

### DIFF
--- a/.changeset/warm-crews-flash.md
+++ b/.changeset/warm-crews-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Exclude the AWS session token from credential validation, because it's not necessary in this context.

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/AwsIamKubernetesAuthTranslator.ts
@@ -41,9 +41,7 @@ export class AwsIamKubernetesAuthTranslator
   implements KubernetesAuthTranslator
 {
   validCredentials(creds: SigningCreds): boolean {
-    return (creds?.accessKeyId &&
-      creds?.secretAccessKey &&
-      creds?.sessionToken) as unknown as boolean;
+    return (creds?.accessKeyId && creds?.secretAccessKey) as unknown as boolean;
   }
 
   awsGetCredentials = async (): Promise<Credentials> => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I removed the validation of AWS session token when reading AWS credentials. The session token is not necessary to sign the request. https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
