### PR TITLE
Catalog permission rules

### DIFF
--- a/.changeset/eight-rats-raise.md
+++ b/.changeset/eight-rats-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add catalog permission rules.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -1391,6 +1391,8 @@ export function parseEntityYaml(
 export const permissionRules: {
   hasAnnotation: CatalogPermissionRule;
   hasLabel: CatalogPermissionRule;
+  hasMetadata: CatalogPermissionRule;
+  hasSpec: CatalogPermissionRule;
   isEntityKind: CatalogPermissionRule;
   isEntityOwner: CatalogPermissionRule;
 };

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -25,6 +25,7 @@ import { Location as Location_2 } from '@backstage/catalog-model';
 import { LocationSpec } from '@backstage/catalog-model';
 import { Logger as Logger_2 } from 'winston';
 import { Organizations } from 'aws-sdk';
+import { PermissionRule } from '@backstage/plugin-permission-node';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { ResourceEntityV1alpha1 } from '@backstage/catalog-model';
@@ -302,6 +303,12 @@ export type CatalogEnvironment = {
   config: Config;
   reader: UrlReader;
 };
+
+// @public
+export type CatalogPermissionRule = PermissionRule<
+  Entity,
+  EntitiesSearchFilter
+>;
 
 // Warning: (ae-missing-release-tag) "CatalogProcessingEngine" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -1379,6 +1386,14 @@ export function parseEntityYaml(
   data: Buffer,
   location: LocationSpec,
 ): Iterable<CatalogProcessorResult>;
+
+// @public
+export const permissionRules: {
+  hasAnnotation: CatalogPermissionRule;
+  hasLabel: CatalogPermissionRule;
+  isEntityKind: CatalogPermissionRule;
+  isEntityOwner: CatalogPermissionRule;
+};
 
 // Warning: (ae-missing-release-tag) "PlaceholderProcessor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -36,6 +36,7 @@
     "@backstage/config": "^0.1.11",
     "@backstage/errors": "^0.1.5",
     "@backstage/integration": "^0.7.0",
+    "@backstage/plugin-permission-node": "^0.2.3",
     "@backstage/search-common": "^0.2.1",
     "@backstage/types": "^0.1.1",
     "@octokit/graphql": "^4.5.8",

--- a/plugins/catalog-backend/src/permissions/index.ts
+++ b/plugins/catalog-backend/src/permissions/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,5 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that provides the Backstage catalog
- *
- * @packageDocumentation
- */
-
-export * from './catalog';
-export * from './ingestion';
-export * from './legacy';
-export * from './search';
-export * from './util';
-export * from './processing';
-export * from './providers';
-export * from './service';
-export * from './permissions';
+export * from './rules';
+export type { CatalogPermissionRule } from './types';

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createPropertyRule } from './createPropertyRule';
+
+describe('createPropertyRule', () => {
+  const { name, description, apply, toQuery } = createPropertyRule('metadata');
+
+  it('formats the rule name correctly', () => {
+    expect(name).toBe('HAS_METADATA');
+  });
+
+  it('formats the rule description correctly', () => {
+    expect(description).toBe(
+      'Allow entities which have the specified metadata subfield.',
+    );
+  });
+
+  describe('apply', () => {
+    describe('key only', () => {
+      it('returns false when specified key is not present', () => {
+        expect(
+          apply(
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'test-component',
+              },
+            },
+            'org.name',
+          ),
+        ).toBe(false);
+      });
+
+      it('returns true when specified key is present', () => {
+        expect(
+          apply(
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'test-component',
+                org: {
+                  name: 'test-org',
+                },
+              },
+            },
+            'org.name',
+          ),
+        ).toBe(true);
+      });
+    });
+
+    describe('key and value', () => {
+      it('returns false when specified key is not present', () => {
+        expect(
+          apply(
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'test-component',
+              },
+            },
+            'org.name',
+            'test-org',
+          ),
+        ).toBe(false);
+      });
+
+      it('returns false when specified value is not present', () => {
+        expect(
+          apply(
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'test-component',
+                org: {
+                  name: 'another-org',
+                },
+              },
+            },
+            'org.name',
+            'test-org',
+          ),
+        ).toBe(false);
+      });
+
+      it('returns true when specified key and value is present', () => {
+        expect(
+          apply(
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Component',
+              metadata: {
+                name: 'test-component',
+                org: {
+                  name: 'test-org',
+                },
+              },
+            },
+            'org.name',
+            'test-org',
+          ),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe('toQuery', () => {
+    it('returns an appropriate catalog-backend filter', () => {
+      expect(toQuery('backstage.io/test-component')).toEqual({
+        key: 'metadata.backstage.io/test-component',
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
+++ b/plugins/catalog-backend/src/permissions/rules/createPropertyRule.ts
@@ -19,10 +19,8 @@ import { EntitiesSearchFilter } from '../../catalog/types';
 import { CatalogPermissionRule } from '../types';
 import { get } from 'lodash';
 
-export type propertyType = 'metadata' | 'spec';
-
 export function createPropertyRule(
-  propertyType: propertyType,
+  propertyType: 'metadata' | 'spec',
 ): CatalogPermissionRule {
   return {
     name: `HAS_${propertyType.toUpperCase()}`,

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { hasAnnotation } from './hasAnnotation';
+
+describe('hasAnnotation permission rule', () => {
+  describe('apply', () => {
+    it('returns false when specified annotation is not present', () => {
+      expect(
+        hasAnnotation.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              annotations: {
+                'other-annotation': 'foo',
+              },
+            },
+          },
+          'backstage.io/test-annotation',
+        ),
+      ).toEqual(false);
+    });
+
+    it('returns false when no annotations are present', () => {
+      expect(
+        hasAnnotation.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+            },
+          },
+          'backstage.io/test-annotation',
+        ),
+      ).toEqual(false);
+    });
+
+    it('returns true when specified annotation is present', () => {
+      expect(
+        hasAnnotation.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              annotations: {
+                'other-annotation': 'foo',
+                'backstage.io/test-annotation': 'bar',
+              },
+            },
+          },
+          'backstage.io/test-annotation',
+        ),
+      ).toEqual(true);
+    });
+  });
+
+  describe('toQuery', () => {
+    it('returns an appropriate catalog-backend filter', () => {
+      expect(hasAnnotation.toQuery('backstage.io/test-annotation')).toEqual({
+        key: 'metadata.annotations.backstage.io/test-annotation',
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { EntitiesSearchFilter } from '../../catalog/types';
+import { CatalogPermissionRule } from '../types';
+
+/**
+ * A {@link CatalogPermissionRule} which filters for the presence of an
+ * annotation on a given entity.
+ * @public
+ */
+export const hasAnnotation: CatalogPermissionRule = {
+  name: 'HAS_ANNOTATION',
+  description:
+    'Allow entities which are annotated with the specified annotation',
+  apply: (resource: Entity, annotation: string) =>
+    !!resource.metadata.annotations?.hasOwnProperty(annotation),
+  toQuery: (annotation: string): EntitiesSearchFilter => ({
+    key: `metadata.annotations.${annotation}`,
+  }),
+};

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { hasLabel } from './hasLabel';
+
+describe('hasLabel permission rule', () => {
+  describe('apply', () => {
+    it('returns false when specified label is not present', () => {
+      expect(
+        hasLabel.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              labels: {
+                somelabel: 'foo',
+              },
+            },
+          },
+          'backstage.io/testlabel',
+        ),
+      ).toEqual(false);
+    });
+
+    it('returns false when no annotations are present', () => {
+      expect(
+        hasLabel.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+            },
+          },
+          'backstage.io/testlabel',
+        ),
+      ).toEqual(false);
+    });
+
+    it('returns true when specified annotation is present', () => {
+      expect(
+        hasLabel.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              labels: {
+                somelabel: 'foo',
+                'backstage.io/testlabel': 'bar',
+              },
+            },
+          },
+          'backstage.io/testlabel',
+        ),
+      ).toEqual(true);
+    });
+  });
+
+  describe('toQuery', () => {
+    it('returns an appropriate catalog-backend filter', () => {
+      expect(hasLabel.toQuery('backstage.io/testlabel')).toEqual({
+        key: 'metadata.labels.backstage.io/testlabel',
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that provides the Backstage catalog
- *
- * @packageDocumentation
- */
+import { Entity } from '@backstage/catalog-model';
+import { EntitiesSearchFilter } from '../../catalog/types';
+import { CatalogPermissionRule } from '../types';
 
-export * from './catalog';
-export * from './ingestion';
-export * from './legacy';
-export * from './search';
-export * from './util';
-export * from './processing';
-export * from './providers';
-export * from './service';
-export * from './permissions';
+export const hasLabel: CatalogPermissionRule = {
+  name: 'HAS_LABEL',
+  description: 'Allow entities which have the specified label metadata.',
+  apply: (resource: Entity, label: string) =>
+    !!resource.metadata.labels?.hasOwnProperty(label),
+  toQuery: (label: string): EntitiesSearchFilter => ({
+    key: `metadata.labels.${label}`,
+  }),
+};

--- a/plugins/catalog-backend/src/permissions/rules/hasMetadata.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasMetadata.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,14 @@
  * limitations under the License.
  */
 
-import { hasAnnotation } from './hasAnnotation';
-import { isEntityKind } from './isEntityKind';
-import { isEntityOwner } from './isEntityOwner';
-import { hasLabel } from './hasLabel';
-import { hasMetadata } from './hasMetadata';
-import { hasSpec } from './hasSpec';
+import { createPropertyRule } from './createPropertyRule';
 
 /**
- * These permission rules can be used to conditionally filter catalog entities
- * or describe a user's access to the entities.
+ * A {@link CatalogPermissionRule} which filters for entities with the specified
+ * metadata subfield. Also matches on values if value is provided.
+ *
+ * The key argument to the `apply` and `toQuery` methods can be nested, such as
+ * 'field.nestedfield'.
  * @public
  */
-export const permissionRules = {
-  hasAnnotation,
-  hasLabel,
-  hasMetadata,
-  hasSpec,
-  isEntityKind,
-  isEntityOwner,
-};
+export const hasMetadata = createPropertyRule('metadata');

--- a/plugins/catalog-backend/src/permissions/rules/hasSpec.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasSpec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,14 @@
  * limitations under the License.
  */
 
-import { hasAnnotation } from './hasAnnotation';
-import { isEntityKind } from './isEntityKind';
-import { isEntityOwner } from './isEntityOwner';
-import { hasLabel } from './hasLabel';
-import { hasMetadata } from './hasMetadata';
-import { hasSpec } from './hasSpec';
+import { createPropertyRule } from './createPropertyRule';
 
 /**
- * These permission rules can be used to conditionally filter catalog entities
- * or describe a user's access to the entities.
+ * A {@link CatalogPermissionRule} which filters for entities with the specified
+ * spec subfield. Also matches on values if value is provided.
+ *
+ * The key argument to the `apply` and `toQuery` methods can be nested, such as
+ * 'field.nestedfield'.
  * @public
  */
-export const permissionRules = {
-  hasAnnotation,
-  hasLabel,
-  hasMetadata,
-  hasSpec,
-  isEntityKind,
-  isEntityOwner,
-};
+export const hasSpec = createPropertyRule('spec');

--- a/plugins/catalog-backend/src/permissions/rules/index.ts
+++ b/plugins/catalog-backend/src/permissions/rules/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that provides the Backstage catalog
- *
- * @packageDocumentation
- */
+import { hasAnnotation } from './hasAnnotation';
+import { isEntityKind } from './isEntityKind';
+import { isEntityOwner } from './isEntityOwner';
+import { hasLabel } from './hasLabel';
 
-export * from './catalog';
-export * from './ingestion';
-export * from './legacy';
-export * from './search';
-export * from './util';
-export * from './processing';
-export * from './providers';
-export * from './service';
-export * from './permissions';
+/**
+ * These permission rules can be used to conditionally filter catalog entities
+ * or describe a user's access to the entities.
+ * @public
+ */
+export const permissionRules = {
+  hasAnnotation,
+  hasLabel,
+  isEntityKind,
+  isEntityOwner,
+};

--- a/plugins/catalog-backend/src/permissions/rules/isEntityKind.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityKind.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { isEntityKind } from './isEntityKind';
+
+describe('isEntityKind', () => {
+  describe('apply', () => {
+    it('returns true when entity is the correct kind', () => {
+      const component: Entity = {
+        apiVersion: 'a',
+        kind: 'b',
+        metadata: {
+          name: 'some-component',
+        },
+      };
+      expect(isEntityKind.apply(component, ['b'])).toBe(true);
+    });
+
+    it('returns false when entity is not the correct kind', () => {
+      const component: Entity = {
+        apiVersion: 'a',
+        kind: 'b',
+        metadata: {
+          name: 'some-component',
+        },
+      };
+      expect(isEntityKind.apply(component, ['c'])).toBe(false);
+    });
+  });
+
+  describe('toQuery', () => {
+    it('returns an appropriate catalog-backend filter', () => {
+      expect(isEntityKind.toQuery(['b'])).toEqual({
+        key: 'kind',
+        values: ['b'],
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityKind.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+import { EntitiesSearchFilter } from '../../catalog/types';
+import { CatalogPermissionRule } from '../types';
+
+/**
+ * A {@link CatalogPermissionRule} which filters for entities with a specified
+ * kind.
+ * @public
+ */
+export const isEntityKind: CatalogPermissionRule = {
+  name: 'IS_ENTITY_KIND',
+  description: 'Allow entities with the specified kind',
+  apply(resource: Entity, kinds: string[]) {
+    const resourceKind = resource.kind.toLocaleLowerCase('en-US');
+    return kinds.some(kind => kind.toLocaleLowerCase('en-US') === resourceKind);
+  },
+  toQuery(kinds: string[]): EntitiesSearchFilter {
+    return {
+      key: 'kind',
+      values: kinds.map(kind => kind.toLocaleLowerCase('en-US')),
+    };
+  },
+};

--- a/plugins/catalog-backend/src/permissions/rules/isEntityOwner.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityOwner.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { isEntityOwner } from './isEntityOwner';
+
+describe('isEntityOwner', () => {
+  describe('apply', () => {
+    it('returns true when entity is owned by the given user', () => {
+      const component: Entity = {
+        apiVersion: 'a',
+        kind: 'b',
+        metadata: {
+          name: 'some-component',
+        },
+        relations: [
+          {
+            type: 'ownedBy',
+            target: {
+              kind: 'user',
+              namespace: 'default',
+              name: 'spiderman',
+            },
+          },
+        ],
+      };
+      expect(isEntityOwner.apply(component, ['user:default/spiderman'])).toBe(
+        true,
+      );
+    });
+
+    it('returns false when entity is not owned by the given user', () => {
+      const component: Entity = {
+        apiVersion: 'a',
+        kind: 'b',
+        metadata: {
+          name: 'some-component',
+        },
+        relations: [
+          {
+            type: 'ownedBy',
+            target: {
+              kind: 'user',
+              namespace: 'default',
+              name: 'green-goblin',
+            },
+          },
+        ],
+      };
+      expect(isEntityOwner.apply(component, ['user:default/spiderman'])).toBe(
+        false,
+      );
+    });
+
+    it('returns false when entity does not have an owner', () => {
+      const component: Entity = {
+        apiVersion: 'a',
+        kind: 'b',
+        metadata: {
+          name: 'some-component',
+        },
+      };
+      expect(isEntityOwner.apply(component, ['user:default/spiderman'])).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('toQuery', () => {
+    it('returns an appropriate catalog-backend filter', () => {
+      expect(isEntityOwner.toQuery(['user:default/spiderman'])).toEqual({
+        key: 'relations.ownedBy',
+        values: ['user:default/spiderman'],
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
+++ b/plugins/catalog-backend/src/permissions/rules/isEntityOwner.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Entity,
+  RELATION_OWNED_BY,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
+import { EntitiesSearchFilter } from '../../catalog/types';
+import { CatalogPermissionRule } from '../types';
+
+/**
+ * A {@link CatalogPermissionRule} which filters for entities with a specified
+ * owner.
+ * @public
+ */
+export const isEntityOwner: CatalogPermissionRule = {
+  name: 'IS_ENTITY_OWNER',
+  description: 'Allow entities owned by the current user',
+  apply: (resource: Entity, claims: string[]) => {
+    if (!resource.relations) {
+      return false;
+    }
+
+    return resource.relations
+      .filter(relation => relation.type === RELATION_OWNED_BY)
+      .some(relation => claims.includes(stringifyEntityRef(relation.target)));
+  },
+  toQuery: (claims: string[]): EntitiesSearchFilter => ({
+    key: 'relations.ownedBy',
+    values: claims,
+  }),
+};

--- a/plugins/catalog-backend/src/permissions/types.ts
+++ b/plugins/catalog-backend/src/permissions/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2021 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Entity } from '@backstage/catalog-model';
+import { PermissionRule } from '@backstage/plugin-permission-node';
+import { EntitiesSearchFilter } from '../catalog/types';
 
 /**
- * The Backstage backend plugin that provides the Backstage catalog
+ * A conditional rule that can be used to filter catalog entities for an
+ * authorization request. See
+ * {@link @backstage/plugin-permission-node#PermissionRule} for more details.
  *
- * @packageDocumentation
+ * @public
  */
-
-export * from './catalog';
-export * from './ingestion';
-export * from './legacy';
-export * from './search';
-export * from './util';
-export * from './processing';
-export * from './providers';
-export * from './service';
-export * from './permissions';
+export type CatalogPermissionRule = PermissionRule<
+  Entity,
+  EntitiesSearchFilter
+>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the hasAnnotation, hasLabel, isEntityKind, and isEntityOwner permission rules as part of the catalog-backend permission integration. Also adds the two generic rules hasMetadata and hasSpec. These rules are a combination of the rules from the PRFC branch and the rules suggested in [this discussion](https://github.com/backstage/backstage/pull/8675#discussion_r778172131). I'd be interested to discuss whether we actually need a specific rule for each metadata rule listed [here](https://backstage.io/docs/features/software-catalog/descriptor-format#common-to-all-kinds-the-metadata).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
