### PR TITLE
Reroute register api

### DIFF
--- a/.changeset/friendly-weeks-cry.md
+++ b/.changeset/friendly-weeks-cry.md
@@ -13,7 +13,7 @@ const App = createApp({
     ...
     bind(apiDocsPlugin.externalRoutes, {
 -     createComponent: scaffolderPlugin.routes.root,
-+     registerComponent: catalogImportPlugin.routes.importPage,
++     registerApi: catalogImportPlugin.routes.importPage,
     });
     ...
   },

--- a/.changeset/friendly-weeks-cry.md
+++ b/.changeset/friendly-weeks-cry.md
@@ -1,0 +1,21 @@
+---
+'@backstage/create-app': patch
+---
+
+Rebind external route for catalog import plugin from `scaffolderPlugin.routes.root` to `catalogImportPlugin.routes.importPage`.
+
+To make this change to an existing app, make the following change to `packages/app/src/App.tsx`
+
+```diff
+const App = createApp({
+  ...
+  bindRoutes({ bind }) {
+    ...
+    bind(apiDocsPlugin.externalRoutes, {
+-     createComponent: scaffolderPlugin.routes.root,
++     registerComponent: catalogImportPlugin.routes.importPage,
+    });
+    ...
+  },
+});
+```

--- a/.changeset/serious-roses-stare.md
+++ b/.changeset/serious-roses-stare.md
@@ -1,6 +1,6 @@
 ---
-'example-app': patch
-'@backstage/plugin-api-docs': patch
+'@backstage/plugin-api-docs': minor
 ---
 
-Link 'Register Existing API' button on API page to /catalog-import instead of /create
+Link 'Register Existing API' button on API page to /catalog-import instead of /create .
+We now expect to `bind` the route for `apiDocsPlugin` to `registerComponent` instead of `createComponent`.

--- a/.changeset/serious-roses-stare.md
+++ b/.changeset/serious-roses-stare.md
@@ -2,5 +2,4 @@
 '@backstage/plugin-api-docs': minor
 ---
 
-Link 'Register Existing API' button on API page to /catalog-import instead of /create .
-We now expect to `bind` the route for `apiDocsPlugin` to `registerComponent` instead of `createComponent`.
+Renamed the `createComponent` external route to `registerApi` since it's now recommended to link to the entity registration page rather than the creation page.

--- a/.changeset/serious-roses-stare.md
+++ b/.changeset/serious-roses-stare.md
@@ -1,0 +1,6 @@
+---
+'example-app': patch
+'@backstage/plugin-api-docs': patch
+---
+
+Link 'Register Existing API' button on API page to /catalog-import instead of /create

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -117,7 +117,7 @@ const app = createApp({
       catalogEntity: catalogPlugin.routes.catalogEntity,
     });
     bind(apiDocsPlugin.externalRoutes, {
-      registerComponent: catalogImportPlugin.routes.importPage,
+      registerApi: catalogImportPlugin.routes.importPage,
     });
     bind(explorePlugin.externalRoutes, {
       catalogEntity: catalogPlugin.routes.catalogEntity,

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -117,7 +117,7 @@ const app = createApp({
       catalogEntity: catalogPlugin.routes.catalogEntity,
     });
     bind(apiDocsPlugin.externalRoutes, {
-      createComponent: scaffolderPlugin.routes.root,
+      registerComponent: catalogImportPlugin.routes.importPage,
     });
     bind(explorePlugin.externalRoutes, {
       catalogEntity: catalogPlugin.routes.catalogEntity,

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -37,7 +37,7 @@ const app = createApp({
       viewTechDoc: techdocsPlugin.routes.docRoot,
     });
     bind(apiDocsPlugin.externalRoutes, {
-      registerComponent: catalogImportPlugin.routes.importPage,
+      registerApi: catalogImportPlugin.routes.importPage,
     });
     bind(scaffolderPlugin.externalRoutes, {
       registerComponent: catalogImportPlugin.routes.importPage,

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -37,7 +37,7 @@ const app = createApp({
       viewTechDoc: techdocsPlugin.routes.docRoot,
     });
     bind(apiDocsPlugin.externalRoutes, {
-      createComponent: scaffolderPlugin.routes.root,
+      registerComponent: catalogImportPlugin.routes.importPage,
     });
     bind(scaffolderPlugin.externalRoutes, {
       registerComponent: catalogImportPlugin.routes.importPage,

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -47,7 +47,7 @@ const apiDocsPlugin: BackstagePlugin<
     root: RouteRef<undefined>;
   },
   {
-    createComponent: ExternalRouteRef<undefined, true>;
+    registerComponent: ExternalRouteRef<undefined, true>;
   }
 >;
 export { apiDocsPlugin };

--- a/plugins/api-docs/api-report.md
+++ b/plugins/api-docs/api-report.md
@@ -47,7 +47,7 @@ const apiDocsPlugin: BackstagePlugin<
     root: RouteRef<undefined>;
   },
   {
-    registerComponent: ExternalRouteRef<undefined, true>;
+    registerApi: ExternalRouteRef<undefined, true>;
   }
 >;
 export { apiDocsPlugin };

--- a/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
+++ b/plugins/api-docs/src/components/ApiExplorerPage/DefaultApiExplorerPage.tsx
@@ -42,7 +42,7 @@ import {
   UserListPicker,
 } from '@backstage/plugin-catalog-react';
 import React from 'react';
-import { createComponentRouteRef } from '../../routes';
+import { registerComponentRouteRef } from '../../routes';
 
 const defaultColumns: TableColumn<CatalogTableRow>[] = [
   CatalogTable.columns.createNameColumn({ defaultKind: 'API' }),
@@ -77,7 +77,7 @@ export const DefaultApiExplorerPage = ({
   const generatedSubtitle = `${
     configApi.getOptionalString('organization.name') ?? 'Backstage'
   } API Explorer`;
-  const createComponentLink = useRouteRef(createComponentRouteRef);
+  const registerComponentLink = useRouteRef(registerComponentRouteRef);
 
   return (
     <PageWithHeader
@@ -90,7 +90,7 @@ export const DefaultApiExplorerPage = ({
         <ContentHeader title="">
           <CreateButton
             title="Register Existing API"
-            to={createComponentLink?.()}
+            to={registerComponentLink?.()}
           />
           <SupportButton>All your APIs</SupportButton>
         </ContentHeader>

--- a/plugins/api-docs/src/plugin.ts
+++ b/plugins/api-docs/src/plugin.ts
@@ -45,7 +45,7 @@ export const apiDocsPlugin = createPlugin({
     }),
   ],
   externalRoutes: {
-    registerComponent: registerComponentRouteRef,
+    registerApi: registerComponentRouteRef,
   },
 });
 

--- a/plugins/api-docs/src/plugin.ts
+++ b/plugins/api-docs/src/plugin.ts
@@ -17,7 +17,7 @@
 import { ApiEntity } from '@backstage/catalog-model';
 import { defaultDefinitionWidgets } from './components/ApiDefinitionCard';
 import { apiDocsConfigRef } from './config';
-import { createComponentRouteRef, rootRoute } from './routes';
+import { registerComponentRouteRef, rootRoute } from './routes';
 import {
   createApiFactory,
   createComponentExtension,
@@ -45,7 +45,7 @@ export const apiDocsPlugin = createPlugin({
     }),
   ],
   externalRoutes: {
-    createComponent: createComponentRouteRef,
+    registerComponent: registerComponentRouteRef,
   },
 });
 

--- a/plugins/api-docs/src/routes.ts
+++ b/plugins/api-docs/src/routes.ts
@@ -23,7 +23,7 @@ export const rootRoute = createRouteRef({
   id: 'api-docs',
 });
 
-export const createComponentRouteRef = createExternalRouteRef({
-  id: 'create-component',
+export const registerComponentRouteRef = createExternalRouteRef({
+  id: 'register-component',
   optional: true,
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've updated the 'Register existing API' button under `/api-docs` to point to `/catalog-import/` instead of `/create` since we can't create APIs there.

Based off a [discussion on the #support Discord channel ](https://discord.com/channels/687207715902193673/687235481154617364/928346447450079282)with @timbonicus 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~~Added or updated documentation~~
- [ ] ~~Tests for new functionality and regression tests for bug fixes~~
- [ ] ~~Screenshots attached (for UI changes)~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
