### PR TITLE
todo-backend: add authorization support

### DIFF
--- a/.changeset/spotty-terms-care.md
+++ b/.changeset/spotty-terms-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-todo': patch
+---
+
+Updated backend plugin installation instructions in `README.md`.

--- a/.changeset/warm-doors-deny.md
+++ b/.changeset/warm-doors-deny.md
@@ -1,0 +1,27 @@
+---
+'@backstage/plugin-todo-backend': minor
+---
+
+Added support for authorizing access to TODOs using the permissions plugin.
+
+This is a breaking change because `createRouter` now requires `permissions` option to be forwarded from the plugin environment in the backend setup.
+
+To update your existing plugin setup, apply the following change to `packages/backend/src/plugins/todo.ts`:
+
+```diff
+ export default async function createPlugin({
+   logger,
+   reader,
+   config,
+   discovery,
++  permissions,
+ }: PluginEnvironment): Promise<Router> {
+
+ // ...
+
+-  return await createRouter({ todoService });
++  return await createRouter({ todoService, permissions });
+ }
+```
+
+Access to reading TODOs is granted based on the `'catalog.entity.read'` permission.

--- a/packages/backend/src/plugins/todo.ts
+++ b/packages/backend/src/plugins/todo.ts
@@ -27,6 +27,7 @@ export default async function createPlugin({
   reader,
   config,
   discovery,
+  permissions,
 }: PluginEnvironment): Promise<Router> {
   const todoReader = TodoScmReader.fromConfig(config, {
     logger,
@@ -38,5 +39,5 @@ export default async function createPlugin({
     catalogClient,
   });
 
-  return await createRouter({ todoService });
+  return await createRouter({ todoService, permissions });
 }

--- a/plugins/todo-backend/README.md
+++ b/plugins/todo-backend/README.md
@@ -21,6 +21,7 @@ export default async function createPlugin({
   reader,
   config,
   discovery,
+  permissions,
 }: PluginEnvironment): Promise<Router> {
   const todoReader = TodoScmReader.fromConfig(config, {
     logger,
@@ -32,7 +33,7 @@ export default async function createPlugin({
     catalogClient,
   });
 
-  return await createRouter({ todoService });
+  return await createRouter({ todoService, permissions });
 }
 ```
 

--- a/plugins/todo-backend/api-report.md
+++ b/plugins/todo-backend/api-report.md
@@ -8,6 +8,7 @@ import { Config } from '@backstage/config';
 import { EntityName } from '@backstage/catalog-model';
 import express from 'express';
 import { Logger as Logger_2 } from 'winston';
+import { PermissionAuthorizer } from '@backstage/plugin-permission-common';
 import { ScmIntegrations } from '@backstage/integration';
 import { UrlReader } from '@backstage/backend-common';
 
@@ -52,6 +53,8 @@ export type ReadTodosResult = {
 
 // @public (undocumented)
 export interface RouterOptions {
+  // (undocumented)
+  permissions: PermissionAuthorizer;
   // (undocumented)
   todoService: TodoService;
 }

--- a/plugins/todo-backend/package.json
+++ b/plugins/todo-backend/package.json
@@ -31,6 +31,8 @@
     "@backstage/config": "^0.1.10",
     "@backstage/errors": "^0.1.3",
     "@backstage/integration": "^0.7.0",
+    "@backstage/plugin-catalog-common": "^0.1.0",
+    "@backstage/plugin-permission-common": "^0.3.0",
     "@types/express": "^4.17.6",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/plugins/todo-backend/src/service/AuthorizedTodoService.test.ts
+++ b/plugins/todo-backend/src/service/AuthorizedTodoService.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AuthorizeResult,
+  PermissionAuthorizer,
+} from '@backstage/plugin-permission-common';
+import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common';
+import { TodoService } from './types';
+import { AuthorizedTodoService } from './AuthorizedTodoService';
+import { NotAllowedError } from '@backstage/errors';
+
+describe('AuthorizedTodoService', () => {
+  const mockService: jest.Mocked<TodoService> = {
+    listTodos: jest.fn(),
+  };
+  const mockAuthorizer: jest.Mocked<PermissionAuthorizer> = {
+    authorize: jest.fn(),
+  };
+  const service = new AuthorizedTodoService(mockService, mockAuthorizer);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should pass through requests without an entity filter', async () => {
+    const mockRes = { items: [], offset: 0, limit: 10, totalCount: 0 };
+    mockService.listTodos.mockResolvedValueOnce(mockRes);
+
+    await expect(service.listTodos({}, {})).resolves.toBe(mockRes);
+
+    expect(mockService.listTodos).toHaveBeenCalledWith({}, {});
+    expect(mockAuthorizer.authorize).not.toHaveBeenCalled();
+  });
+
+  it('allows authorized reads', async () => {
+    const mockRes = { items: [], offset: 0, limit: 10, totalCount: 0 };
+    mockService.listTodos.mockResolvedValueOnce(mockRes);
+    mockAuthorizer.authorize.mockResolvedValueOnce([
+      { result: AuthorizeResult.ALLOW },
+    ]);
+
+    const req = { entity: { kind: 'k', namespace: 'ns', name: 'n' } };
+    const options = { token: 'abc' };
+    await expect(service.listTodos(req, options)).resolves.toBe(mockRes);
+
+    expect(mockService.listTodos).toHaveBeenCalledWith(req, options);
+    expect(mockAuthorizer.authorize).toHaveBeenCalledWith(
+      [{ permission: catalogEntityReadPermission, resourceRef: 'k:ns/n' }],
+      { token: 'abc' },
+    );
+  });
+
+  it('rejects unauthorized reads', async () => {
+    mockAuthorizer.authorize.mockResolvedValueOnce([
+      { result: AuthorizeResult.DENY },
+    ]);
+
+    const req = { entity: { kind: 'k', namespace: 'ns', name: 'n' } };
+    await expect(service.listTodos(req, {})).rejects.toThrow(NotAllowedError);
+
+    expect(mockService.listTodos).not.toHaveBeenCalled();
+    expect(mockAuthorizer.authorize).toHaveBeenCalledWith(
+      [{ permission: catalogEntityReadPermission, resourceRef: 'k:ns/n' }],
+      {},
+    );
+  });
+});

--- a/plugins/todo-backend/src/service/AuthorizedTodoService.ts
+++ b/plugins/todo-backend/src/service/AuthorizedTodoService.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  AuthorizeResult,
+  PermissionAuthorizer,
+} from '@backstage/plugin-permission-common';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { NotAllowedError } from '@backstage/errors';
+import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common';
+import { ListTodosRequest, ListTodosResponse, TodoService } from './types';
+
+/** @internal */
+export class AuthorizedTodoService implements TodoService {
+  readonly #delegate: TodoService;
+  readonly #authorizer: PermissionAuthorizer;
+
+  constructor(delegate: TodoService, authorizer: PermissionAuthorizer) {
+    this.#delegate = delegate;
+    this.#authorizer = authorizer;
+  }
+
+  async listTodos(
+    req: ListTodosRequest,
+    options?: { token?: string },
+  ): Promise<ListTodosResponse> {
+    // Permissions are only applied when filtering by entity.
+    // In practice there is no other way to list TODOs, but if one is
+    // added in the future it is important to protect that method too.
+    if (req.entity) {
+      const resourceRef = stringifyEntityRef(req.entity);
+      const [response] = await this.#authorizer.authorize(
+        [{ permission: catalogEntityReadPermission, resourceRef }],
+        { token: options?.token },
+      );
+      if (response.result !== AuthorizeResult.ALLOW) {
+        throw new NotAllowedError();
+      }
+    }
+
+    return this.#delegate.listTodos(req, options);
+  }
+}

--- a/plugins/todo-backend/src/service/router.ts
+++ b/plugins/todo-backend/src/service/router.ts
@@ -16,8 +16,10 @@
 
 import { EntityName, parseEntityName } from '@backstage/catalog-model';
 import { InputError } from '@backstage/errors';
+import { PermissionAuthorizer } from '@backstage/plugin-permission-common';
 import express from 'express';
 import Router from 'express-promise-router';
+import { AuthorizedTodoService } from './AuthorizedTodoService';
 import { TodoService } from './types';
 
 const TODO_FIELDS = [
@@ -31,13 +33,17 @@ const TODO_FIELDS = [
 /** @public */
 export interface RouterOptions {
   todoService: TodoService;
+  permissions: PermissionAuthorizer;
 }
 
 /** @public */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { todoService } = options;
+  const todoService = new AuthorizedTodoService(
+    options.todoService,
+    options.permissions,
+  );
 
   const router = Router();
   router.use(express.json());

--- a/plugins/todo/README.md
+++ b/plugins/todo/README.md
@@ -31,6 +31,7 @@ export default async function createPlugin({
   reader,
   config,
   discovery,
+  permissions,
 }: PluginEnvironment): Promise<Router> {
   const todoReader = TodoScmReader.fromConfig(config, {
     logger,
@@ -42,7 +43,7 @@ export default async function createPlugin({
     catalogClient,
   });
 
-  return await createRouter({ todoService });
+  return await createRouter({ todoService, permissions });
 }
 ```
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This implements authorization for the todo-backend, based on the `permissions` plugin.

Authorization is granted based on the `'catalog.entity.read'` permission - if you are allowed to read an entity, you are also allowed to see its TODOs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
