### PR TITLE
Techdocs: dynamically set primary sidebar position based on backstage sidebar pinned state

### DIFF
--- a/.changeset/techdocs-light-onions-cover.md
+++ b/.changeset/techdocs-light-onions-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix an issue where the TechDocs sidebar is hidden when the Backstage sidebar is pinned at smaller screen sizes

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -31,6 +31,7 @@ import { EntityName } from '@backstage/catalog-model';
 import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
 import { BackstageTheme } from '@backstage/theme';
+import { SidebarPinStateContext } from '@backstage/core-components';
 
 import { techdocsStorageApiRef } from '../../api';
 
@@ -144,6 +145,9 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
   const [sidebars, setSidebars] = useState<HTMLElement[]>();
   const [dom, setDom] = useState<HTMLElement | null>(null);
 
+  // sidebar pinned status to be used in computing CSS style injections
+  const { isPinned } = useContext(SidebarPinStateContext);
+
   const updateSidebarPosition = useCallback(() => {
     if (!dom || !sidebars) return;
     // set sidebar height so they don't initially render in wrong position
@@ -252,7 +256,9 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
               transition: none !important
             }
             .md-sidebar--secondary { display: none; }
-            .md-sidebar--primary { left: 72px; width: 10rem }
+            .md-sidebar--primary { left: ${
+              isPinned ? '242px' : '72px'
+            }; width: 10rem }
             .md-content { margin-left: 10rem; max-width: calc(100% - 10rem); }
             .md-content__inner { font-size: 0.9rem }
             .md-footer {
@@ -348,6 +354,7 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
       theme.palette.success.main,
       theme.palette.text.primary,
       theme.typography.fontFamily,
+      isPinned,
     ],
   );
 


### PR DESCRIPTION
Closes #8787 

## Hey, I just made a Pull Request!

Dynamically set the CSS property `left` of `md-sidebar--primary` depending on the Backstage sidebar `isPinned` state. This resolves an issue in which the TechDocs sidebar is hidden at smaller display sizes when the sidebar is pinned.

The following screenshots below show before and after the fix has been applied.

Before:
![image](https://user-images.githubusercontent.com/5807118/148428534-b863bab5-69e3-4497-947a-765e85065966.png)

After:
![image](https://user-images.githubusercontent.com/5807118/148446370-0d6a3cbd-8f5e-4cdc-94da-46b213e6ce1b.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
