### PR TITLE
bugfix: Fix helm chart ingress template

### DIFF
--- a/contrib/chart/backstage/Chart.yaml
+++ b/contrib/chart/backstage/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/contrib/chart/backstage/templates/ingress.yaml
+++ b/contrib/chart/backstage/templates/ingress.yaml
@@ -3,10 +3,10 @@
 {{- $lighthouseUrl := urlParse .Values.appConfig.lighthouse.baseUrl}}
 
 {{/* Determine the api type for the ingress */}}
-{{- if lt .Capabilities.KubeVersion.Minor "19" }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else if ge .Capabilities.KubeVersion.Minor "19" }}
+{{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -29,31 +29,60 @@ spec:
         - {{ $frontendUrl.host }}
         - {{ $backendUrl.host }}
         - {{ $lighthouseUrl.host }}
-
   rules:
     - host: {{ $frontendUrl.host }}
       http:
         paths:
           - path: /
+            {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ include "frontend.serviceName" . }}
+                port:
+                  number: 80
+              {{- else -}}
               serviceName: {{ include "frontend.serviceName" . }}
               servicePort: 80
-          {{/* Route the backend inside the same hostname as the frontend when they are the same */}}
-          {{- if eq $frontendUrl.host $backendUrl.host}}
+              {{- end }}
+    {{/* Route the backend inside the same hostname as the frontend when they are the same */}}
+    {{- if eq $frontendUrl.host $backendUrl.host}}
           - path: /api/
+            {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ include "backend.serviceName" . }}
+                port:
+                  number: 80
+              {{- else -}}
               serviceName: {{ include "backend.serviceName" . }}
               servicePort: 80
-          {{/* Route the backend through a different host */}}
-          {{- else -}}
+              {{- end }}
+    {{/* Route the backend through a different host */}}
+    {{- else -}}
     - host: {{ $backendUrl.host }}
       http:
         paths:
           - path: {{ $backendUrl.path | default "/" }}
+            {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ include "frontend.serviceName" . }}
+                port:
+                  number: 80
+              {{- else -}}
               serviceName: {{ include "backend.serviceName" . }}
               servicePort: 80
-         {{- end }}
+              {{- end }}
+    {{- end }}
 
 {{/* Route lighthouse through a different host */}}
 {{- if not ( eq $frontendUrl.host $lighthouseUrl.host ) }}
@@ -61,13 +90,27 @@ spec:
       http:
         paths:
           - path: {{ $lighthouseUrl.path | default "/" }}
+            {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ include "lighthouse.serviceName" . }}
+                port:
+                  number: 80
+              {{- else -}}
               serviceName: {{ include "lighthouse.serviceName" . }}
               servicePort: 80
+              {{- end }}
 {{- else }}
 {{/* Route lighthouse by path with re-write rules when it is hosted under the same hostname */}}
 ---
+{{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "backstage.fullname" . }}-ingress-lighthouse
@@ -92,7 +135,17 @@ spec:
       http:
         paths:
           - path: {{$lighthouseUrl.path}}(/|$)(.*)
+            {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+            pathType: Prefix
+            {{- end }}
             backend:
+              {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ include "lighthouse.serviceName" . }}
+                port:
+                  number: 80
+              {{- else -}}
               serviceName: {{ include "lighthouse.serviceName" . }}
               servicePort: 80
+              {{- end }}
 {{- end }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes fixes the ingress spec to match the API version either v1 or v1beta1,
previously the apiVersion was change according to the K8S version but no
further changes where made to actually match the new v1 API spec. This
cause issues deploying to clusters with versions 1.19+

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
