### PR TITLE
[TechInsights] log errors when tech insights throws an error

### DIFF
--- a/.changeset/great-points-design.md
+++ b/.changeset/great-points-design.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-tech-insights-backend': patch
 ---
 
-log errors on tech insights fact retriever
+Catch errors from a fact retriever and log them.

--- a/.changeset/great-points-design.md
+++ b/.changeset/great-points-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights-backend': patch
+---
+
+log errors on tech insights fact retriever

--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
@@ -116,13 +116,11 @@ export class FactRetrieverEngine {
           ...this.factRetrieverContext,
           entityFilter: factRetriever.entityFilter,
         });
-        if (this.logger.isDebugEnabled()) {
-          this.logger.debug(
-            `Retrieved ${facts.length} facts for fact retriever ${
-              factRetriever.id
-            } in ${duration(startTimestamp)}`,
-          );
-        }
+        this.logger.debug(
+          `Retrieved ${facts.length} facts for fact retriever ${
+            factRetriever.id
+          } in ${duration(startTimestamp)}`,
+        );
       } catch (e) {
         this.logger.error(
           `Failed to retrieve facts for retriever ${factRetriever.id}`,

--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
@@ -16,6 +16,7 @@
 import {
   FactRetriever,
   FactRetrieverContext,
+  TechInsightFact,
   TechInsightsStore,
 } from '@backstage/plugin-tech-insights-node';
 import { FactRetrieverRegistry } from './FactRetrieverRegistry';
@@ -108,15 +109,24 @@ export class FactRetrieverEngine {
       this.logger.info(
         `Retrieving facts for fact retriever ${factRetriever.id}`,
       );
-      const facts = await factRetriever.handler({
-        ...this.factRetrieverContext,
-        entityFilter: factRetriever.entityFilter,
-      });
-      if (this.logger.isDebugEnabled()) {
-        this.logger.debug(
-          `Retrieved ${facts.length} facts for fact retriever ${
-            factRetriever.id
-          } in ${duration(startTimestamp)}`,
+
+      let facts: TechInsightFact[] = [];
+      try {
+        facts = await factRetriever.handler({
+          ...this.factRetrieverContext,
+          entityFilter: factRetriever.entityFilter,
+        });
+        if (this.logger.isDebugEnabled()) {
+          this.logger.debug(
+            `Retrieved ${facts.length} facts for fact retriever ${
+              factRetriever.id
+            } in ${duration(startTimestamp)}`,
+          );
+        }
+      } catch (e) {
+        this.logger.error(
+          `Failed to retrieve facts for retriever ${factRetriever.id}`,
+          e,
         );
       }
 


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

## Hey, I just made a Pull Request!

We spent a couple of hours trying to understand why our handler was not working in certain scenarios, until we found that when the `handler` of a fact retriever throws an error, it doesn't get logged anywhere and the job just exit silently.

Developers are still encouraged to handle the errors themselves in the handler, but in case they forget and purposely do not add them, this PR will at least ensure we have a trace of what happened. No facts are stored when an error is thrown.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
