### PR TITLE
auth-backend: moved test-utils dependency to devDeps

### DIFF
--- a/.changeset/short-shoes-fail.md
+++ b/.changeset/short-shoes-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Removed `@backstage/test-utils` dependency.

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -35,7 +35,6 @@
     "@backstage/catalog-model": "^0.9.8",
     "@backstage/config": "^0.1.11",
     "@backstage/errors": "^0.1.5",
-    "@backstage/test-utils": "^0.2.1",
     "@backstage/types": "^0.1.1",
     "@google-cloud/firestore": "^4.15.1",
     "@types/express": "^4.17.6",
@@ -75,6 +74,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.5",
+    "@backstage/test-utils": "^0.2.1",
     "@types/body-parser": "^1.19.0",
     "@types/cookie-parser": "^1.4.2",
     "@types/express-session": "^1.17.2",


### PR DESCRIPTION
🧹 