### PR TITLE
Integrate authorization into catalog-backend delete entities endpoint

### DIFF
--- a/.changeset/bright-candles-call.md
+++ b/.changeset/bright-candles-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Integrate authorization into the delete entities endpoint

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -830,7 +830,12 @@ export function durationText(startTimestamp: [number, number]): string;
 // @public (undocumented)
 export type EntitiesCatalog = {
   entities(request?: EntitiesRequest): Promise<EntitiesResponse>;
-  removeEntityByUid(uid: string, authorizationToken?: string): Promise<void>;
+  removeEntityByUid(
+    uid: string,
+    options?: {
+      authorizationToken?: string;
+    },
+  ): Promise<void>;
   batchAddOrUpdateEntities?(
     requests: EntityUpsertRequest[],
     options?: {

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -830,7 +830,7 @@ export function durationText(startTimestamp: [number, number]): string;
 // @public (undocumented)
 export type EntitiesCatalog = {
   entities(request?: EntitiesRequest): Promise<EntitiesResponse>;
-  removeEntityByUid(uid: string): Promise<void>;
+  removeEntityByUid(uid: string, authorizationToken?: string): Promise<void>;
   batchAddOrUpdateEntities?(
     requests: EntityUpsertRequest[],
     options?: {

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -113,7 +113,7 @@ export type EntitiesCatalog = {
    *
    * @param uid - The metadata.uid of the entity
    */
-  removeEntityByUid(uid: string): Promise<void>;
+  removeEntityByUid(uid: string, authorizationToken?: string): Promise<void>;
 
   /**
    * Writes a number of entities efficiently to storage.

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -113,7 +113,10 @@ export type EntitiesCatalog = {
    *
    * @param uid - The metadata.uid of the entity
    */
-  removeEntityByUid(uid: string, authorizationToken?: string): Promise<void>;
+  removeEntityByUid(
+    uid: string,
+    options?: { authorizationToken?: string },
+  ): Promise<void>;
 
   /**
    * Writes a number of entities efficiently to storage.

--- a/plugins/catalog-backend/src/service/NextRouter.test.ts
+++ b/plugins/catalog-backend/src/service/NextRouter.test.ts
@@ -213,10 +213,15 @@ describe('createNextRouter readonly disabled', () => {
     it('can remove', async () => {
       entitiesCatalog.removeEntityByUid.mockResolvedValue(undefined);
 
-      const response = await request(app).delete('/entities/by-uid/apa');
+      const response = await request(app)
+        .delete('/entities/by-uid/apa')
+        .set('authorization', 'Bearer someauthtoken');
 
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
-      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa');
+      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith(
+        'apa',
+        'someauthtoken',
+      );
       expect(response.status).toEqual(204);
     });
 
@@ -225,10 +230,15 @@ describe('createNextRouter readonly disabled', () => {
         new NotFoundError('nope'),
       );
 
-      const response = await request(app).delete('/entities/by-uid/apa');
+      const response = await request(app)
+        .delete('/entities/by-uid/apa')
+        .set('authorization', 'Bearer someauthtoken');
 
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
-      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa');
+      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith(
+        'apa',
+        'someauthtoken',
+      );
       expect(response.status).toEqual(404);
     });
   });
@@ -369,10 +379,15 @@ describe('createNextRouter readonly enabled', () => {
   describe('DELETE /entities/by-uid/:uid', () => {
     // this delete is allowed as there is no other way to remove entities
     it('is allowed', async () => {
-      const response = await request(app).delete('/entities/by-uid/apa');
+      const response = await request(app)
+        .delete('/entities/by-uid/apa')
+        .set('authorization', 'Bearer someauthtoken');
 
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
-      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa');
+      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith(
+        'apa',
+        'someauthtoken',
+      );
       expect(response.status).toEqual(204);
     });
   });

--- a/plugins/catalog-backend/src/service/NextRouter.test.ts
+++ b/plugins/catalog-backend/src/service/NextRouter.test.ts
@@ -218,10 +218,9 @@ describe('createNextRouter readonly disabled', () => {
         .set('authorization', 'Bearer someauthtoken');
 
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
-      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith(
-        'apa',
-        'someauthtoken',
-      );
+      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa', {
+        authorizationToken: 'someauthtoken',
+      });
       expect(response.status).toEqual(204);
     });
 
@@ -235,10 +234,9 @@ describe('createNextRouter readonly disabled', () => {
         .set('authorization', 'Bearer someauthtoken');
 
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
-      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith(
-        'apa',
-        'someauthtoken',
-      );
+      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa', {
+        authorizationToken: 'someauthtoken',
+      });
       expect(response.status).toEqual(404);
     });
   });
@@ -384,10 +382,9 @@ describe('createNextRouter readonly enabled', () => {
         .set('authorization', 'Bearer someauthtoken');
 
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
-      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith(
-        'apa',
-        'someauthtoken',
-      );
+      expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa', {
+        authorizationToken: 'someauthtoken',
+      });
       expect(response.status).toEqual(204);
     });
   });

--- a/plugins/catalog-backend/src/service/NextRouter.ts
+++ b/plugins/catalog-backend/src/service/NextRouter.ts
@@ -119,7 +119,10 @@ export async function createNextRouter(
       })
       .delete('/entities/by-uid/:uid', async (req, res) => {
         const { uid } = req.params;
-        await entitiesCatalog.removeEntityByUid(uid);
+        await entitiesCatalog.removeEntityByUid(
+          uid,
+          getBearerToken(req.header('authorization')),
+        );
         res.status(204).end();
       })
       .get('/entities/by-name/:kind/:namespace/:name', async (req, res) => {

--- a/plugins/catalog-backend/src/service/NextRouter.ts
+++ b/plugins/catalog-backend/src/service/NextRouter.ts
@@ -119,10 +119,9 @@ export async function createNextRouter(
       })
       .delete('/entities/by-uid/:uid', async (req, res) => {
         const { uid } = req.params;
-        await entitiesCatalog.removeEntityByUid(
-          uid,
-          getBearerToken(req.header('authorization')),
-        );
+        await entitiesCatalog.removeEntityByUid(uid, {
+          authorizationToken: getBearerToken(req.header('authorization')),
+        });
         res.status(204).end();
       })
       .get('/entities/by-name/:kind/:namespace/:name', async (req, res) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Uses the AuthorizedEntitiesCatalog established in #8711.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
