### PR TITLE
Support conditionally showing software template form sections based on app-config.yaml values

### DIFF
--- a/.changeset/violet-ladybugs-share.md
+++ b/.changeset/violet-ladybugs-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+add support for conditionally showing/hiding form sections in software templates based on values in app-config.yaml

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -153,7 +153,7 @@ export async function createRouter(
             .filter(parameter => {
               if (!parameter.if) return true;
 
-              const shouldShow = config.get(parameter.if);
+              const shouldShow = config.getOptional(parameter.if);
 
               return shouldShow;
             });

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -148,7 +148,16 @@ export async function createRouter(
           token: getBearerToken(req.headers.authorization),
         });
         if (isSupportedTemplate(template)) {
-          const parameters = [template.spec.parameters ?? []].flat();
+          const parameters = [template.spec.parameters ?? []]
+            .flat()
+            .filter(parameter => {
+              if (!parameter.if) return true;
+
+              const shouldShow = config.get(parameter.if);
+
+              return shouldShow;
+            });
+
           res.json({
             title: template.metadata.title ?? template.metadata.name,
             steps: parameters.map(schema => ({

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -153,7 +153,7 @@ export async function createRouter(
             .filter(parameter => {
               if (!parameter.if) return true;
 
-              const shouldShow = config.getOptional(parameter.if);
+              const shouldShow = config.getOptional(parameter.if as string);
 
               return shouldShow;
             });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This makes it possible to conditionally show/hide sections of form fields in software templates based on values in `app-config.yaml`.

Here's the example software template I used for testing this:
https://github.com/ConnorDY/backstage-conditional-form-fields-example-template/blob/main/template.yaml

`template.yaml`:
![image](https://user-images.githubusercontent.com/945062/148575572-96e1d82f-b4ff-47f6-a274-a339e9ee9c31.png)

With `templates.showConditionalSection` in `app-config.yaml` set to `true`:
![image](https://user-images.githubusercontent.com/945062/148575934-9543a362-7111-4356-abcf-bba2029cdcf8.png)

With `templates.showConditionalSection` in `app-config.yaml` set to `false` (or not set at all):
![image](https://user-images.githubusercontent.com/945062/148576191-ffbb914b-09d1-4905-a8df-bed0d6caabb6.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
