### PR TITLE
Bug fix: Create a delay when a Sidebar submenu opens

### DIFF
--- a/.changeset/dull-bulldogs-laugh.md
+++ b/.changeset/dull-bulldogs-laugh.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Add a delay on opening submenus in the sidebar
+Create a delay when a Sidebar submenu opens

--- a/.changeset/dull-bulldogs-laugh.md
+++ b/.changeset/dull-bulldogs-laugh.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Create a delay when a Sidebar submenu opens
+Create a short delay when `<SidebarSubmenu/>` is opened

--- a/.changeset/dull-bulldogs-laugh.md
+++ b/.changeset/dull-bulldogs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add a delay on opening submenus in the sidebar

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /*
  * Copyright 2021 The Backstage Authors
  *
@@ -16,7 +17,13 @@
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import classnames from 'classnames';
-import React, { ReactNode, useContext } from 'react';
+import React, {
+  ReactNode,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   SidebarItemWithSubmenuContext,
   sidebarConfig,
@@ -48,7 +55,6 @@ const useStyles = (props: { left: number }) =>
       scrollbarWidth: 'none',
       cursor: 'default',
       width: submenuConfig.drawerWidthClosed,
-      borderRight: `1px solid #383838`,
       '& > *': {
         flexShrink: 0,
       },
@@ -91,10 +97,25 @@ export const SidebarSubmenu = (props: SidebarSubmenuProps) => {
   const classes = useStyles({ left: left })();
 
   const { isHoveredOn } = useContext(SidebarItemWithSubmenuContext);
+  const [isSubmenuOpen, setIsSubmenuOpen] = useState(false);
+  const hoverTimerRef = useRef<number>();
+
+  useEffect(() => {
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = undefined;
+    }
+    if (isHoveredOn) {
+      hoverTimerRef.current = window.setTimeout(() => {
+        hoverTimerRef.current = undefined;
+        setIsSubmenuOpen(true);
+      }, submenuConfig.defaultOpenDelayMs);
+    }
+  }, [isHoveredOn]);
   return (
     <div
       className={classnames(classes.drawer, {
-        [classes.drawerOpen]: isHoveredOn,
+        [classes.drawerOpen]: isSubmenuOpen,
       })}
     >
       <Typography variant="h5" className={classes.title}>

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /*
  * Copyright 2021 The Backstage Authors
  *
@@ -55,6 +54,7 @@ const useStyles = (props: { left: number }) =>
       scrollbarWidth: 'none',
       cursor: 'default',
       width: submenuConfig.drawerWidthClosed,
+      transitionDelay: `${submenuConfig.defaultOpenDelayMs}ms`,
       '& > *': {
         flexShrink: 0,
       },
@@ -98,20 +98,11 @@ export const SidebarSubmenu = (props: SidebarSubmenuProps) => {
 
   const { isHoveredOn } = useContext(SidebarItemWithSubmenuContext);
   const [isSubmenuOpen, setIsSubmenuOpen] = useState(false);
-  const hoverTimerRef = useRef<number>();
 
   useEffect(() => {
-    if (hoverTimerRef.current) {
-      clearTimeout(hoverTimerRef.current);
-      hoverTimerRef.current = undefined;
-    }
-    if (isHoveredOn) {
-      hoverTimerRef.current = window.setTimeout(() => {
-        hoverTimerRef.current = undefined;
-        setIsSubmenuOpen(true);
-      }, submenuConfig.defaultOpenDelayMs);
-    }
+    setIsSubmenuOpen(isHoveredOn);
   }, [isHoveredOn]);
+
   return (
     <div
       className={classnames(classes.drawer, {

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenu.tsx
@@ -16,13 +16,7 @@
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import classnames from 'classnames';
-import React, {
-  ReactNode,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { ReactNode, useContext, useEffect, useState } from 'react';
 import {
   SidebarItemWithSubmenuContext,
   sidebarConfig,

--- a/packages/core-components/src/layout/Sidebar/config.ts
+++ b/packages/core-components/src/layout/Sidebar/config.ts
@@ -40,18 +40,7 @@ export const sidebarConfig = {
 export const submenuConfig = {
   drawerWidthClosed: 0,
   drawerWidthOpen: 202,
-  // As per NN/g's guidance on timing for exposing hidden content
-  // See https://www.nngroup.com/articles/timing-exposing-content/
-  defaultOpenDelayMs: 100,
-  defaultCloseDelayMs: 0,
-  defaultFadeDuration: 200,
-  logoHeight: 32,
-  iconContainerWidth: drawerWidthClosed,
-  iconSize: drawerWidthClosed - iconPadding * 2,
-  iconPadding,
-  selectedIndicatorWidth: 3,
-  userBadgePadding,
-  userBadgeDiameter: drawerWidthClosed - userBadgePadding * 2,
+  defaultOpenDelayMs: sidebarConfig.defaultOpenDelayMs + 200,
 };
 
 export const SIDEBAR_INTRO_LOCAL_STORAGE =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
When using the new sidebar items with submenus feature, there is an issue with how the submenu opens up if you do not disable the 'expand-on-hover' effect for the sidebar. Please view the videos attached, showing the issue and what the fix looks like.

The changes in this PR include adding a delay for the opening of the submenu so that it always opens after the Sidebar opens. The delay doesn't make much of a difference when the sidebar expansion is disabled either, as it is only 3 milliseconds. 

Other changes:
- Removed the unused/unnecessary properties in submenuConfig.
- Removed right border on submenu (not in the initial design)

Before:
https://user-images.githubusercontent.com/72443252/148581683-d0cf7f70-c72c-47f2-b5e5-0a1d3cce232c.mp4

After:
https://user-images.githubusercontent.com/72443252/148582308-a8427bdb-9542-4093-90b7-9d5daf99839b.mp4

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
