### PR TITLE
fix(catalog-backend): support bitbucket servers with custom baseUrls

### DIFF
--- a/.changeset/metal-worms-flash.md
+++ b/.changeset/metal-worms-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Provide support for Bitbucket servers with custom BaseURLs.

--- a/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
@@ -230,14 +230,18 @@ function parseUrl(urlString: string): {
   catalogPath: string;
 } {
   const url = new URL(urlString);
-  const path = url.pathname.substr(1).split('/');
+  const indexOfProjectSegment =
+    url.pathname.toLowerCase().indexOf('/projects/') + 1;
+  const path = url.pathname.substr(indexOfProjectSegment).split('/');
 
   // /projects/backstage/repos/techdocs-*/catalog-info.yaml
   if (path.length > 3 && path[1].length && path[3].length) {
     return {
       projectSearchPath: escapeRegExp(decodeURIComponent(path[1])),
       repoSearchPath: escapeRegExp(decodeURIComponent(path[3])),
-      catalogPath: `/${decodeURIComponent(path.slice(4).join('/'))}`,
+      catalogPath: `/${decodeURIComponent(
+        path.slice(4).join('/') + url.search,
+      )}`,
     };
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previously, the `BitbucketDiscoveryProcessor` assumed that all Bitbucket servers would have paths formed in the pattern of `/projects/{project}/repos/{repo}`.  However, since Bitbucket servers have the ability to configure custom baseUrls, this assumption does not always hold true. Instead of evaluating project and repo terms from the full target path, the processor will find the `/projects/` url segment and start path evaluations from its index instead. This path substring is then used to determine the `projectSearchPath` and the `repoSearchPath`. Support is also added to accept search params for the `catalogPath` as well.

Fixes #8771

Signed-off-by: Dhruval Darji <dhruvaldarji@gmail.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
