### PR TITLE
config: make ConfigReader#get always return a clone

### DIFF
--- a/.changeset/clean-wolves-jog.md
+++ b/.changeset/clean-wolves-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config': patch
+---
+
+The `ConfigReader#get` method now always returns a deep clone of the configuration data.

--- a/packages/config/src/reader.test.ts
+++ b/packages/config/src/reader.test.ts
@@ -673,4 +673,51 @@ describe('ConfigReader.get()', () => {
       },
     });
   });
+
+  it('should return deep clones of the backing data', () => {
+    const data1 = {
+      foo: {
+        bar: [],
+        baz: {},
+      },
+    };
+    const data2 = {
+      x: {
+        y: {
+          z: {},
+        },
+      },
+    };
+
+    const reader = ConfigReader.fromConfigs([
+      { data: data1, context: '1' },
+      { data: data2, context: '2' },
+    ]);
+
+    reader.get<any>().foo.bar.push(1);
+    reader.get<any>('foo').bar.push(1);
+    reader.get<any>('foo.bar').push(1);
+    reader.get<any>().foo.baz.x = 1;
+    reader.get<any>('foo').baz.x = 1;
+    reader.get<any>('foo.baz').x = 1;
+    reader.get<any>().x.y.z.w = 1;
+    reader.get<any>('x').y.z.w = 1;
+    reader.get<any>('x.y').z.w = 1;
+    reader.get<any>('x.y.z').w = 1;
+
+    const readerSingle = ConfigReader.fromConfigs([
+      { data: data1, context: '1' },
+    ]);
+
+    readerSingle.get<any>().foo.bar.push(1);
+    readerSingle.get<any>('foo').bar.push(1);
+    readerSingle.get<any>('foo.bar').push(1);
+    readerSingle.get<any>().foo.baz.x = 1;
+    readerSingle.get<any>('foo').baz.x = 1;
+    readerSingle.get<any>('foo.baz').x = 1;
+
+    expect(data1.foo.bar).toEqual([]);
+    expect(data1.foo.baz).toEqual({});
+    expect(data2.x.y.z).toEqual({});
+  });
 });

--- a/packages/config/src/reader.test.ts
+++ b/packages/config/src/reader.test.ts
@@ -265,6 +265,19 @@ describe('ConfigReader', () => {
       withLogCollector(() => config.getOptionalConfigArray('b')),
     ).toMatchObject({ warn: [] });
   });
+
+  it('should coerce number strings to numbers', () => {
+    const config = ConfigReader.fromConfigs([
+      {
+        data: {
+          port: '123',
+        },
+        context: '1',
+      },
+    ]);
+
+    expect(config.getNumber('port')).toEqual(123);
+  });
 });
 
 describe('ConfigReader with fallback', () => {
@@ -659,18 +672,5 @@ describe('ConfigReader.get()', () => {
         c: 'c1',
       },
     });
-  });
-
-  it('coerces number strings to numbers', () => {
-    const config = ConfigReader.fromConfigs([
-      {
-        data: {
-          port: '123',
-        },
-        context: '1',
-      },
-    ]);
-
-    expect(config.getNumber('port')).toEqual(123);
   });
 });

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -126,7 +126,7 @@ export class ConfigReader implements Config {
 
   /** {@inheritdoc Config.getOptional} */
   getOptional<T = JsonValue>(key?: string): T | undefined {
-    const value = this.readValue(key);
+    const value = cloneDeep(this.readValue(key));
     const fallbackValue = this.fallback?.getOptional<T>(key);
 
     if (value === undefined) {
@@ -153,11 +153,8 @@ export class ConfigReader implements Config {
 
     // Avoid merging arrays and primitive values, since that's how merging works for other
     // methods for reading config.
-    return mergeWith(
-      {},
-      { value: cloneDeep(fallbackValue) },
-      { value },
-      (into, from) => (!isObject(from) || !isObject(into) ? from : undefined),
+    return mergeWith({}, { value: fallbackValue }, { value }, (into, from) =>
+      !isObject(from) || !isObject(into) ? from : undefined,
     ).value as T;
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previously we where returning a clone of the data in some situations, now `config.get()` always returns a deep clone of the config data. This avoids mutations to the internal config data.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
