### PR TITLE
feat: give component EntityMembersListCard a memberType prop

### DIFF
--- a/.changeset/gold-birds-happen.md
+++ b/.changeset/gold-birds-happen.md
@@ -6,7 +6,7 @@ For the component `EntityMembersListCard` you can now specify the type of member
 
 ```tsx
 <Grid item xs={12}>
-  <EntityMembersListCard memberType="Ninja's" />
+  <EntityMembersListCard memberDisplayTitle="Ninja's" />
 </Grid>
 ```
 

--- a/.changeset/gold-birds-happen.md
+++ b/.changeset/gold-birds-happen.md
@@ -1,0 +1,13 @@
+---
+'@backstage/plugin-org': patch
+---
+
+For the component `EntityMembersListCard` you can now specify the type of members you have in a group. For example:
+
+```tsx
+<Grid item xs={12}>
+  <EntityMembersListCard memberType="Ninja's" />
+</Grid>
+```
+
+If left empty it will by default use 'Members'.

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -26,6 +26,7 @@ export const EntityGroupProfileCard: ({
 // @public (undocumented)
 export const EntityMembersListCard: (_props: {
   entity?: GroupEntity | undefined;
+  memberType?: string | undefined;
 }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "EntityOwnershipCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -63,7 +64,10 @@ export const GroupProfileCard: ({
 // Warning: (ae-missing-release-tag) "MembersListCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const MembersListCard: (_props: { entity?: GroupEntity }) => JSX.Element;
+export const MembersListCard: (_props: {
+  entity?: GroupEntity;
+  memberType?: string;
+}) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "orgPlugin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -26,7 +26,7 @@ export const EntityGroupProfileCard: ({
 // @public (undocumented)
 export const EntityMembersListCard: (_props: {
   entity?: GroupEntity | undefined;
-  memberType?: string | undefined;
+  memberDisplayTitle?: string | undefined;
 }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "EntityOwnershipCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -66,7 +66,7 @@ export const GroupProfileCard: ({
 // @public (undocumented)
 export const MembersListCard: (_props: {
   entity?: GroupEntity;
-  memberType?: string;
+  memberDisplayTitle?: string;
 }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "orgPlugin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -138,7 +138,7 @@ describe('MemberTab Test', () => {
       wrapInTestApp(
         <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
           <EntityProvider entity={groupEntity}>
-            <MembersListCard memberType="Testers" />
+            <MembersListCard memberDisplayTitle="Testers" />
           </EntityProvider>
           ,
         </TestApiProvider>,

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -132,4 +132,19 @@ describe('MemberTab Test', () => {
 
     expect(rendered.getByText('Members (1)')).toBeInTheDocument();
   });
+
+  it('Can render different member type', async () => {
+    const rendered = await renderWithEffects(
+      wrapInTestApp(
+        <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+          <EntityProvider entity={groupEntity}>
+            <MembersListCard memberType="Testers" />
+          </EntityProvider>
+          ,
+        </TestApiProvider>,
+      ),
+    );
+
+    expect(rendered.getByText('Testers (1)')).toBeInTheDocument();
+  });
 });

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -133,14 +133,13 @@ describe('MemberTab Test', () => {
     expect(rendered.getByText('Members (1)')).toBeInTheDocument();
   });
 
-  it('Can render different member type', async () => {
+  it('Can render different member display title', async () => {
     const rendered = await renderWithEffects(
       wrapInTestApp(
         <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
           <EntityProvider entity={groupEntity}>
             <MembersListCard memberDisplayTitle="Testers" />
           </EntityProvider>
-          ,
         </TestApiProvider>,
       ),
     );

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -111,10 +111,10 @@ const MemberComponent = ({ member }: { member: UserEntity }) => {
 export const MembersListCard = (_props: {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: GroupEntity;
-  memberType?: string;
+  memberDisplayTitle?: string;
 }) => {
   const { entity: groupEntity } = useEntity<GroupEntity>();
-  let { memberType } = _props;
+  let { memberDisplayTitle } = _props;
   const {
     metadata: { name: groupName, namespace: grpNamespace },
     spec: { profile },
@@ -130,7 +130,7 @@ export const MembersListCard = (_props: {
     setPage(pageIndex);
   };
   const pageSize = 50;
-  memberType = memberType ? memberType : 'Members';
+  memberDisplayTitle = memberDisplayTitle ? memberDisplayTitle : 'Members';
 
   const {
     loading,
@@ -176,7 +176,9 @@ export const MembersListCard = (_props: {
   return (
     <Grid item>
       <InfoCard
-        title={`${memberType} (${members?.length || 0}${paginationLabel})`}
+        title={`${memberDisplayTitle} (${
+          members?.length || 0
+        }${paginationLabel})`}
         subheader={`of ${displayName}`}
         {...(nbPages <= 1 ? {} : { actions: pagination })}
       >
@@ -190,7 +192,7 @@ export const MembersListCard = (_props: {
           ) : (
             <Box p={2}>
               <Typography>
-                This group has no ${memberType.toLocaleLowerCase()}.
+                This group has no ${memberDisplayTitle.toLocaleLowerCase()}.
               </Typography>
             </Box>
           )}

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -111,8 +111,10 @@ const MemberComponent = ({ member }: { member: UserEntity }) => {
 export const MembersListCard = (_props: {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: GroupEntity;
+  memberType?: string;
 }) => {
   const { entity: groupEntity } = useEntity<GroupEntity>();
+  let { memberType } = _props;
   const {
     metadata: { name: groupName, namespace: grpNamespace },
     spec: { profile },
@@ -128,6 +130,7 @@ export const MembersListCard = (_props: {
     setPage(pageIndex);
   };
   const pageSize = 50;
+  memberType = memberType ? memberType : 'Members';
 
   const {
     loading,
@@ -173,7 +176,7 @@ export const MembersListCard = (_props: {
   return (
     <Grid item>
       <InfoCard
-        title={`Members (${members?.length || 0}${paginationLabel})`}
+        title={`${memberType} (${members?.length || 0}${paginationLabel})`}
         subheader={`of ${displayName}`}
         {...(nbPages <= 1 ? {} : { actions: pagination })}
       >
@@ -186,7 +189,9 @@ export const MembersListCard = (_props: {
               ))
           ) : (
             <Box p={2}>
-              <Typography>This group has no members.</Typography>
+              <Typography>
+                This group has no ${memberType.toLocaleLowerCase()}.
+              </Typography>
             </Box>
           )}
         </Grid>


### PR DESCRIPTION
Signed-off-by: djamaile <rdjamaile@gmail.com>

## Hey, I just made a Pull Request!

I wanted to use this component when showing the contributors of a certain Gitlab repo. In that context having members doesn't really make sense because a contributor doesn't have to be a member of the repo. Another use case I can see for this is companies having their own specific name for their engineers. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ x] Tests for new functionality and regression tests for bug fixes
- [x ] Screenshots attached (for UI changes)
- [ x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

![screencapture-localhost-3000-catalog-default-group-team-a-2022-01-08-19_40_22](https://user-images.githubusercontent.com/15789670/148656007-f244c69d-7527-42b3-9155-ef70086adccf.png)

