### PR TITLE
Techdocs: use lighter color for block quotes and horizontal rulers

### DIFF
--- a/.changeset/red-meals-turn.md
+++ b/.changeset/red-meals-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+use lighter color for block quotes and horizontal rulers

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -205,6 +205,13 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
           .md-typeset h1, .md-typeset h2, .md-typeset h3 { font-weight: bold; }
           .md-nav { font-size: 1rem; }
           .md-grid { max-width: 90vw; margin: 0 }
+          .md-typeset blockquote {
+            color: ${theme.palette.textSubtle};
+            border-left: 0.2rem solid ${theme.palette.textVerySubtle};
+          }
+          .md-typeset hr {
+            border-bottom: 0.05rem dotted ${theme.palette.textVerySubtle};
+          }
           .md-typeset table:not([class]) {
             font-size: 1rem;
             border: 1px solid ${theme.palette.text.primary};
@@ -325,6 +332,8 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
       theme.palette.primary.main,
       theme.palette.success.main,
       theme.palette.text.primary,
+      theme.palette.textSubtle,
+      theme.palette.textVerySubtle,
       theme.typography.fontFamily,
     ],
   );


### PR DESCRIPTION
Signed-off-by: Erik Larsson <erik.larsson@schibsted.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Both blockquotes and horizontal rulers (see examples below) are currently missing expected colors in Techdocs, making them not distinguishable (the css variables are not set). The default from mkdocs material theme is a "lighter" left border and "light" text color on blockquotes and a "lighter" border on hrs. I found `textSubtle` and `textVerySubtle` colors in the palette that seemed to fit the bill and work in both light and dark themes.

> Blockquotes

<hr>


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
