### PR TITLE
fix: Register plugin to prioritise Component kind for entityRef

### DIFF
--- a/.changeset/cold-steaks-flash.md
+++ b/.changeset/cold-steaks-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+fix: Register plugin to prioritise Component kind for entityRef

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.test.ts
@@ -117,7 +117,7 @@ describe('catalog:register', () => {
     );
   });
 
-  it('should register location in catalog and return the entity and not the generated location', async () => {
+  it('should return entityRef with the Component entity and not the generated location', async () => {
     addLocation
       .mockResolvedValueOnce({
         entities: [],
@@ -136,7 +136,21 @@ describe('catalog:register', () => {
               namespace: 'default',
               name: 'test',
             },
+            kind: 'Api',
+          } as Entity,
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'test',
+            },
             kind: 'Component',
+          } as Entity,
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'test',
+            },
+            kind: 'Template',
           } as Entity,
         ],
       });
@@ -146,32 +160,103 @@ describe('catalog:register', () => {
         catalogInfoUrl: 'http://foo/var',
       },
     });
-
-    expect(addLocation).toHaveBeenNthCalledWith(
-      1,
-      {
-        type: 'url',
-        target: 'http://foo/var',
-      },
-      {},
-    );
-    expect(addLocation).toHaveBeenNthCalledWith(
-      2,
-      {
-        dryRun: true,
-        type: 'url',
-        target: 'http://foo/var',
-      },
-      {},
-    );
-
     expect(mockContext.output).toBeCalledWith(
       'entityRef',
       'component:default/test',
     );
+  });
+
+  it('should return entityRef with the next non-generated entity if no Component kind can be found', async () => {
+    addLocation
+      .mockResolvedValueOnce({
+        entities: [],
+      })
+      .mockResolvedValueOnce({
+        entities: [
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'generated-1238',
+            },
+            kind: 'Location',
+          } as Entity,
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'test',
+            },
+            kind: 'Api', // should return this one
+          } as Entity,
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'test',
+            },
+            kind: 'Template',
+          } as Entity,
+        ],
+      });
+    await action.handler({
+      ...mockContext,
+      input: {
+        catalogInfoUrl: 'http://foo/var',
+      },
+    });
+    expect(mockContext.output).toBeCalledWith('entityRef', 'api:default/test');
+  });
+
+  it('should return entityRef with the first entity if no non-generated entities can be found', async () => {
+    addLocation
+      .mockResolvedValueOnce({
+        entities: [],
+      })
+      .mockResolvedValueOnce({
+        entities: [
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'generated-1238',
+            },
+            kind: 'Location',
+          } as Entity,
+          {
+            metadata: {
+              namespace: 'default',
+              name: 'generated-1238',
+            },
+            kind: 'Template',
+          } as Entity,
+        ],
+      });
+    await action.handler({
+      ...mockContext,
+      input: {
+        catalogInfoUrl: 'http://foo/var',
+      },
+    });
     expect(mockContext.output).toBeCalledWith(
-      'catalogInfoUrl',
-      'http://foo/var',
+      'entityRef',
+      'location:default/generated-1238',
+    );
+  });
+
+  it('should not return entityRef if there are no entites', async () => {
+    addLocation
+      .mockResolvedValueOnce({
+        entities: [],
+      })
+      .mockResolvedValueOnce({
+        entities: [],
+      });
+    await action.handler({
+      ...mockContext,
+      input: {
+        catalogInfoUrl: 'http://foo/var',
+      },
+    });
+    expect(mockContext.output).not.toBeCalledWith(
+      'entityRef',
+      expect.any(String),
     );
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.ts
@@ -125,9 +125,22 @@ export function createCatalogRegisterAction(options: {
 
         if (result.entities.length > 0) {
           const { entities } = result;
-          const entity =
-            entities.find(e => !e.metadata.name.startsWith('generated-')) ??
-            entities[0];
+          let entity: any;
+          // prioritise 'Component' type as it is the most central kind of entity
+          entity = entities.find(
+            (e: any) =>
+              !e.metadata.name.startsWith('generated-') &&
+              e.kind === 'Component',
+          );
+          if (!entity) {
+            entity = entities.find(
+              (e: any) => !e.metadata.name.startsWith('generated-'),
+            );
+          }
+          if (!entity) {
+            entity = entities[0];
+          }
+
           ctx.output('entityRef', stringifyEntityRef(entity));
         }
       } catch (e) {


### PR DESCRIPTION
## PR for issue #8527

##### Old behaviour:
After registering the catalog, when determining the `entityRef`, picking the first non-generated entity (which can be `api`, `component`, or `template`), and use that to form the url.

##### New behaviour:
After registering the catalog, when determining the `entityRef`, instead of picking the first non-generated entity, prioritise "Component" kind first. Maintain the old behavior if no entity of kind "Component" is found.

#### Changeset
```
plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.ts
plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/register.test.ts
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages.
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message.
- [ ] Added or updated documentation (N/A)
- [ ] Screenshots attached (for UI changes) (N/A)

