### PR TITLE
core-app-api: fix saml and github session types

### DIFF
--- a/.changeset/shaggy-emus-look.md
+++ b/.changeset/shaggy-emus-look.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed an issue where valid SAML and GitHub sessions would be considered invalid and not be stored.
+
+Deprecated the `SamlSession` and `GithubSession` types.

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -410,7 +410,7 @@ export class GithubAuth implements OAuthApi, SessionApi {
   signOut(): Promise<void>;
 }
 
-// @public
+// @public @deprecated
 export type GithubSession = {
   providerInfo: {
     accessToken: string;
@@ -562,7 +562,7 @@ export class SamlAuth
   signOut(): Promise<void>;
 }
 
-// @public
+// @public @deprecated
 export type SamlSession = {
   userId: string;
   profile: ProfileInfo;

--- a/packages/core-app-api/src/apis/implementations/auth/github/types.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/github/types.ts
@@ -17,10 +17,13 @@
 import { ProfileInfo, BackstageIdentity } from '@backstage/core-plugin-api';
 import { z } from 'zod';
 
+// TODO(Rugvip): Make GithubSession internal
+
 /**
  * Session information for GitHub auth.
  *
  * @public
+ * @deprecated This type is internal and will be removed
  */
 export type GithubSession = {
   providerInfo: {
@@ -29,6 +32,7 @@ export type GithubSession = {
     expiresAt?: Date;
   };
   profile: ProfileInfo;
+  // TODO(Rugvip): This should be made optional once the type is no longer public
   backstageIdentity: BackstageIdentity;
 };
 

--- a/packages/core-app-api/src/apis/implementations/auth/saml/index.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/saml/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 export { default as SamlAuth } from './SamlAuth';
-export type { SamlSession } from './types';
+export type { ExportedSamlSession as SamlSession } from './types';

--- a/packages/core-app-api/src/apis/implementations/auth/saml/types.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/saml/types.ts
@@ -21,15 +21,22 @@ import { z } from 'zod';
  * Session information for SAML auth.
  *
  * @public
+ * @deprecated This type is internal and will be removed
  */
-export type SamlSession = {
+export type ExportedSamlSession = {
   userId: string;
   profile: ProfileInfo;
   backstageIdentity: BackstageIdentity;
 };
 
+/** @internal */
+export type SamlSession = {
+  profile: ProfileInfo;
+  backstageIdentity: BackstageIdentity;
+};
+
+/** @internal */
 export const samlSessionSchema: z.ZodSchema<SamlSession> = z.object({
-  userId: z.string(),
   profile: z.object({
     email: z.string().optional(),
     displayName: z.string().optional(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The most important fix here is removing `userId` as a required property on SAML sessions, since it doesn't exist. The GitHub update isn't needed yet in practice, but it's how it's intended to work in the future.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
