### PR TITLE
scripts/api-extractor: forbid warnings for a couple of core packages

### DIFF
--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -23,8 +23,6 @@ export type ConfigSchemaProcessingOptions = {
   withFilteredKeys?: boolean;
 };
 
-// Warning: (ae-missing-release-tag) "ConfigTarget" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type ConfigTarget =
   | {
@@ -51,15 +49,11 @@ export type LoadConfigOptions = {
   watch?: LoadConfigOptionsWatch;
 };
 
-// Warning: (ae-missing-release-tag) "LoadConfigOptionsRemote" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type LoadConfigOptionsRemote = {
   reloadIntervalSeconds: number;
 };
 
-// Warning: (ae-missing-release-tag) "LoadConfigOptionsWatch" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type LoadConfigOptionsWatch = {
   onChange: (configs: AppConfig[]) => void;

--- a/packages/config-loader/src/loader.ts
+++ b/packages/config-loader/src/loader.ts
@@ -29,8 +29,10 @@ import {
 } from './lib';
 import fetch from 'node-fetch';
 
+/** @public */
 export type ConfigTarget = { path: string } | { url: string };
 
+/** @public */
 export type LoadConfigOptionsWatch = {
   /**
    * A listener that is called when a config file is changed.
@@ -43,6 +45,7 @@ export type LoadConfigOptionsWatch = {
   stopSignal?: Promise<void>;
 };
 
+/** @public */
 export type LoadConfigOptionsRemote = {
   /**
    * A remote config reloading period, in seconds

--- a/scripts/api-extractor.ts
+++ b/scripts/api-extractor.ts
@@ -198,6 +198,44 @@ const SKIPPED_PACKAGES = [
   join('packages', 'techdocs-cli'),
 ];
 
+const NO_WARNING_PACKAGES = [
+  'packages/app-defaults',
+  'packages/backend-common',
+  'packages/backend-tasks',
+  'packages/backend-test-utils',
+  'packages/catalog-client',
+  'packages/cli-common',
+  'packages/config',
+  'packages/config-loader',
+  'packages/core-app-api',
+  'packages/core-plugin-api',
+  'packages/dev-utils',
+  'packages/errors',
+  'packages/integration',
+  'packages/integration-react',
+  'packages/test-utils',
+  'packages/theme',
+  'packages/types',
+  'packages/version-bridge',
+  'plugins/catalog-backend-module-ldap',
+  'plugins/catalog-common',
+  'plugins/permission-backend',
+  'plugins/permission-common',
+  'plugins/permission-node',
+  'plugins/permission-react',
+  'plugins/scaffolder-backend-module-cookiecutter',
+  'plugins/scaffolder-backend-module-rails',
+  'plugins/scaffolder-backend-module-yeoman',
+  'plugins/scaffolder-common',
+  'plugins/tech-insights',
+  'plugins/tech-insights-backend',
+  'plugins/tech-insights-backend-module-jsonfc',
+  'plugins/tech-insights-common',
+  'plugins/tech-insights-node',
+  'plugins/todo',
+  'plugins/todo-backend',
+];
+
 async function resolvePackagePath(
   packagePath: string,
 ): Promise<string | undefined> {
@@ -505,6 +543,11 @@ async function runApiExtraction({
     }
 
     const warningCountAfter = await countApiReportWarnings(projectFolder);
+    if (NO_WARNING_PACKAGES.includes(packageDir) && warningCountAfter > 0) {
+      throw new Error(
+        `The API Report for ${packageDir} is not allowed to have warnings`,
+      );
+    }
     if (warningCountAfter > warningCountBefore) {
       warnings.push(
         `The API Report for ${packageDir} introduces new warnings. ` +


### PR DESCRIPTION
Fixes #7688, config-loader was the last couple of warnings we had to fix. Skipping changeset since it's a very minor docs change.

The change to api-extractor.ts makes sure we don't regress
