### PR TITLE
[TechInsights] Add expiration configurations to fact retrievers

### DIFF
--- a/.changeset/six-coins-admire.md
+++ b/.changeset/six-coins-admire.md
@@ -6,7 +6,7 @@
 BREAKING CHANGES:
 
 - The helper function to create a fact retriever registration is now expecting an object of configuration items instead of individual arguments.
-  Modify your techInsights.ts plugin configuration in `packages/backend/src/plugins/techInsights.ts` (or equivalent) the following way:
+  Modify your `techInsights.ts` plugin configuration in `packages/backend/src/plugins/techInsights.ts` (or equivalent) the following way:
 
 ```diff
 -createFactRetrieverRegistration(
@@ -18,6 +18,17 @@ BREAKING CHANGES:
 +  factRetriever: entityOwnershipFactRetriever,
 +}),
 
+```
+
+- `TechInsightsStore` interface has changed its signature of `insertFacts` method. If you have created your own implementation of either `TechInsightsDatabase` or `FactRetrieverEngine` you need to modify the implementation/call to this method to accept/pass-in an object instead if individual arguments. The interface now accepts an additional `lifecycle` argument which is optional (defined below). An example modification to fact retriever engine:
+
+```diff
+-await this.repository.insertFacts(factRetriever.id, facts);
++await this.repository.insertFacts({
++ id: factRetriever.id,
++ facts,
++ lifecycle,
++});
 ```
 
 Adds a configuration option to fact retrievers to define lifecycle for facts the retriever persists. Possible values are either 'max items' or 'time-to-live'. The former will keep only n number of items in the database for each fact per entity. The latter will remove all facts that are older than the TTL value.

--- a/.changeset/six-coins-admire.md
+++ b/.changeset/six-coins-admire.md
@@ -3,10 +3,10 @@
 '@backstage/plugin-tech-insights-node': patch
 ---
 
-Adds a configuration option to fact retrievers to define lifecycle for facts the retriever persists. Possible values are either 'items-to-live' or 'time-to-live'. The former will only n number of items in to the database for each fact per entity. The latter will remove all facts that are older than the TTL value.
+Adds a configuration option to fact retrievers to define lifecycle for facts the retriever persists. Possible values are either 'items-to-live' or 'time-to-live'. The former will keep only n number of items in to the database for each fact per entity. The latter will remove all facts that are older than the TTL value.
 
 Possible values:
 
-- { itl: 5 } // Deletes all facts for the retriever/entity pair, apart from the last five
-- { ttl: 1209600000 } // (2 weeks) Deletes all facts older than 2 weeks for the retriever/entity pair
-- { ttl: { weeks: 2 } } // Deletes all facts older than 2 weeks for the retriever/entity pair
+- `{ itl: 5 }` // Deletes all facts for the retriever/entity pair, apart from the last five
+- `{ ttl: 1209600000 }` // (2 weeks) Deletes all facts older than 2 weeks for the retriever/entity pair
+- `{ ttl: { weeks: 2 } }` // Deletes all facts older than 2 weeks for the retriever/entity pair

--- a/.changeset/six-coins-admire.md
+++ b/.changeset/six-coins-admire.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-tech-insights-backend': patch
+'@backstage/plugin-tech-insights-node': patch
+---
+
+Adds a configuration option to fact retrievers to define lifecycle for facts the retriever persists. Possible values are either 'items-to-live' or 'time-to-live'. The former will only n number of items in to the database for each fact per entity. The latter will remove all facts that are older than the TTL value.
+
+Possible values:
+
+- { itl: 5 } // Deletes all facts for the retriever/entity pair, apart from the last five
+- { ttl: 1209600000 } // (2 weeks) Deletes all facts older than 2 weeks for the retriever/entity pair
+- { ttl: { weeks: 2 } } // Deletes all facts older than 2 weeks for the retriever/entity pair

--- a/.changeset/six-coins-admire.md
+++ b/.changeset/six-coins-admire.md
@@ -1,12 +1,29 @@
 ---
-'@backstage/plugin-tech-insights-backend': patch
-'@backstage/plugin-tech-insights-node': patch
+'@backstage/plugin-tech-insights-backend': minor
+'@backstage/plugin-tech-insights-node': minor
 ---
 
-Adds a configuration option to fact retrievers to define lifecycle for facts the retriever persists. Possible values are either 'items-to-live' or 'time-to-live'. The former will keep only n number of items in to the database for each fact per entity. The latter will remove all facts that are older than the TTL value.
+BREAKING CHANGES:
+
+- The helper function to create a fact retriever registration is now expecting an object of configuration items instead of individual arguments.
+  Modify your techInsights.ts plugin configuration in `packages/backend/src/plugins/techInsights.ts` (or equivalent) the following way:
+
+```diff
+-createFactRetrieverRegistration(
+-  '1 1 1 * *', // Example cron, At 01:01 on day-of-month 1.
+-  entityOwnershipFactRetriever,
+-),
++createFactRetrieverRegistration({
++  cadende: '1 1 1 * *', // Example cron, At 01:01 on day-of-month 1.
++  factRetriever: entityOwnershipFactRetriever,
++}),
+
+```
+
+Adds a configuration option to fact retrievers to define lifecycle for facts the retriever persists. Possible values are either 'max items' or 'time-to-live'. The former will keep only n number of items in the database for each fact per entity. The latter will remove all facts that are older than the TTL value.
 
 Possible values:
 
-- `{ itl: 5 }` // Deletes all facts for the retriever/entity pair, apart from the last five
+- `{ maxItems: 5 }` // Deletes all facts for the retriever/entity pair, apart from the last five
 - `{ ttl: 1209600000 }` // (2 weeks) Deletes all facts older than 2 weeks for the retriever/entity pair
 - `{ ttl: { weeks: 2 } }` // Deletes all facts older than 2 weeks for the retriever/entity pair

--- a/packages/backend/src/plugins/techInsights.ts
+++ b/packages/backend/src/plugins/techInsights.ts
@@ -40,12 +40,18 @@ export default async function createPlugin({
     database,
     discovery,
     factRetrievers: [
-      createFactRetrieverRegistration(
-        '1 1 1 * *', // Example cron, At 01:01 on day-of-month 1.
-        entityOwnershipFactRetriever,
-      ),
-      createFactRetrieverRegistration('1 1 1 * *', entityMetadataFactRetriever),
-      createFactRetrieverRegistration('1 1 1 * *', techdocsFactRetriever),
+      createFactRetrieverRegistration({
+        cadence: '1 1 1 * *', // Example cron, At 01:01 on day-of-month 1.
+        factRetriever: entityOwnershipFactRetriever,
+      }),
+      createFactRetrieverRegistration({
+        cadence: '1 1 1 * *',
+        factRetriever: entityMetadataFactRetriever,
+      }),
+      createFactRetrieverRegistration({
+        cadence: '1 1 1 * *',
+        factRetriever: techdocsFactRetriever,
+      }),
     ],
     factCheckerFactory: new JsonRulesEngineFactCheckerFactory({
       checks: [

--- a/plugins/tech-insights-backend/README.md
+++ b/plugins/tech-insights-backend/README.md
@@ -91,7 +91,7 @@ const myFactRetrieverRegistration = createFactRetrieverRegistration(
 );
 ```
 
-FactRetrieverRegistration also accepts an optional `lifecycle` configuration value. This can be either ITL (items to live) or TTL (time to live). Valid options for this value are either a number for itl or a Luxon duration like object for ttl. For example:
+FactRetrieverRegistration also accepts an optional `lifecycle` configuration value. This can be either ITL (items to live) or TTL (time to live). Valid options for this value are either a number for ITL or a Luxon duration like object for TTL. For example:
 
 ```ts
 const itl = { itl: 7 }; // Deletes all but 7 latest facts for each id/entity pair

--- a/plugins/tech-insights-backend/README.md
+++ b/plugins/tech-insights-backend/README.md
@@ -91,7 +91,15 @@ const myFactRetrieverRegistration = createFactRetrieverRegistration(
 );
 ```
 
-Then you can modify the example `techInsights.ts` file shown above like this:
+FactRetrieverRegistration also accepts an optional `lifecycle` configuration value. This can be either ITL (items to live) or TTL (time to live). Valid options for this value are either a number for itl or a Luxon duration like object for ttl. For example:
+
+```ts
+const itl = { itl: 7 }; // Deletes all but 7 latest facts for each id/entity pair
+const ttl = { ttl: 1209600000 }; // (2 weeks) Deletes items older than 2 weeks
+const ttlWithAHumanReadableValue = { ttl: { weeks: 2 } }; // Deletes items older than 2 weeks
+```
+
+To register these fact retrievers to your application you can modify the example `techInsights.ts` file shown above like this:
 
 ```diff
 const builder = new DefaultTechInsightsBuilder({

--- a/plugins/tech-insights-backend/README.md
+++ b/plugins/tech-insights-backend/README.md
@@ -91,10 +91,10 @@ const myFactRetrieverRegistration = createFactRetrieverRegistration(
 );
 ```
 
-FactRetrieverRegistration also accepts an optional `lifecycle` configuration value. This can be either ITL (items to live) or TTL (time to live). Valid options for this value are either a number for ITL or a Luxon duration like object for TTL. For example:
+FactRetrieverRegistration also accepts an optional `lifecycle` configuration value. This can be either MaxItems or TTL (time to live). Valid options for this value are either a number for MaxItems or a Luxon duration like object for TTL. For example:
 
 ```ts
-const itl = { itl: 7 }; // Deletes all but 7 latest facts for each id/entity pair
+const maxItems = { maxItems: 7 }; // Deletes all but 7 latest facts for each id/entity pair
 const ttl = { ttl: 1209600000 }; // (2 weeks) Deletes items older than 2 weeks
 const ttlWithAHumanReadableValue = { ttl: { weeks: 2 } }; // Deletes items older than 2 weeks
 ```

--- a/plugins/tech-insights-backend/api-report.md
+++ b/plugins/tech-insights-backend/api-report.md
@@ -8,6 +8,7 @@ import { Config } from '@backstage/config';
 import express from 'express';
 import { FactChecker } from '@backstage/plugin-tech-insights-node';
 import { FactCheckerFactory } from '@backstage/plugin-tech-insights-node';
+import { FactLifecycle } from '@backstage/plugin-tech-insights-node';
 import { FactRetriever } from '@backstage/plugin-tech-insights-node';
 import { FactRetrieverRegistration } from '@backstage/plugin-tech-insights-node';
 import { Logger as Logger_2 } from 'winston';
@@ -28,6 +29,7 @@ export const buildTechInsightsContext: <
 export function createFactRetrieverRegistration(
   cadence: string,
   factRetriever: FactRetriever,
+  lifecycle?: FactLifecycle,
 ): FactRetrieverRegistration;
 
 // @public

--- a/plugins/tech-insights-backend/api-report.md
+++ b/plugins/tech-insights-backend/api-report.md
@@ -26,11 +26,11 @@ export const buildTechInsightsContext: <
 ) => Promise<TechInsightsContext<CheckType, CheckResultType>>;
 
 // @public
-export function createFactRetrieverRegistration(
-  cadence: string,
-  factRetriever: FactRetriever,
-  lifecycle?: FactLifecycle,
-): FactRetrieverRegistration;
+export function createFactRetrieverRegistration({
+  cadence,
+  factRetriever,
+  lifecycle,
+}: FactRetrieverRegistrationOptions): FactRetrieverRegistration;
 
 // @public
 export function createRouter<
@@ -43,6 +43,13 @@ export const entityMetadataFactRetriever: FactRetriever;
 
 // @public
 export const entityOwnershipFactRetriever: FactRetriever;
+
+// @public (undocumented)
+export type FactRetrieverRegistrationOptions = {
+  cadence: string;
+  factRetriever: FactRetriever;
+  lifecycle?: FactLifecycle;
+};
 
 // @public
 export type PersistenceContext = {

--- a/plugins/tech-insights-backend/src/index.ts
+++ b/plugins/tech-insights-backend/src/index.ts
@@ -25,4 +25,5 @@ export type {
 
 export type { PersistenceContext } from './service/persistence/persistenceContext';
 export { createFactRetrieverRegistration } from './service/fact/createFactRetriever';
+export type { FactRetrieverRegistrationOptions } from './service/fact/createFactRetriever';
 export * from './service/fact/factRetrievers';

--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+  FactLifecycle,
   FactRetriever,
   FactRetrieverContext,
   TechInsightsStore,
@@ -75,7 +76,7 @@ export class FactRetrieverEngine {
     const registrations = this.factRetrieverRegistry.listRegistrations();
     const newRegs: string[] = [];
     registrations.forEach(registration => {
-      const { factRetriever, cadence } = registration;
+      const { factRetriever, cadence, lifecycle } = registration;
       if (!this.scheduledJobs.has(factRetriever.id)) {
         const cronExpression =
           cadence || this.defaultCadence || randomDailyCron();
@@ -87,7 +88,7 @@ export class FactRetrieverEngine {
         }
         const job = schedule(
           cronExpression,
-          this.createFactRetrieverHandler(factRetriever),
+          this.createFactRetrieverHandler(factRetriever, lifecycle),
         );
         this.scheduledJobs.set(factRetriever.id, job);
         newRegs.push(factRetriever.id);
@@ -102,7 +103,10 @@ export class FactRetrieverEngine {
     return this.scheduledJobs.get(ref);
   }
 
-  private createFactRetrieverHandler(factRetriever: FactRetriever) {
+  private createFactRetrieverHandler(
+    factRetriever: FactRetriever,
+    lifecycle?: FactLifecycle,
+  ) {
     return async () => {
       const startTimestamp = process.hrtime();
       this.logger.info(
@@ -121,7 +125,7 @@ export class FactRetrieverEngine {
       }
 
       try {
-        await this.repository.insertFacts(factRetriever.id, facts);
+        await this.repository.insertFacts(factRetriever.id, facts, lifecycle);
         this.logger.info(
           `Stored ${facts.length} facts for fact retriever ${
             factRetriever.id

--- a/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
+++ b/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.ts
@@ -125,7 +125,11 @@ export class FactRetrieverEngine {
       }
 
       try {
-        await this.repository.insertFacts(factRetriever.id, facts, lifecycle);
+        await this.repository.insertFacts({
+          id: factRetriever.id,
+          facts,
+          lifecycle,
+        });
         this.logger.info(
           `Stored ${facts.length} facts for fact retriever ${
             factRetriever.id

--- a/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
+++ b/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
@@ -19,6 +19,12 @@ import {
   FactRetrieverRegistration,
 } from '@backstage/plugin-tech-insights-node';
 
+export type FactRetrieverRegistrationOptions = {
+  cadence: string;
+  factRetriever: FactRetriever;
+  lifecycle?: FactLifecycle;
+};
+
 /**
  * @public
  *
@@ -47,11 +53,11 @@ import {
  * \{ itl: 7 \} -- This fact retriever will leave 7 newest items in the database when it is run
  *
  */
-export function createFactRetrieverRegistration(
-  cadence: string,
-  factRetriever: FactRetriever,
-  lifecycle?: FactLifecycle,
-): FactRetrieverRegistration {
+export function createFactRetrieverRegistration({
+  cadence,
+  factRetriever,
+  lifecycle,
+}: FactRetrieverRegistrationOptions): FactRetrieverRegistration {
   return {
     cadence,
     factRetriever,

--- a/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
+++ b/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+  FactLifecycle,
   FactRetriever,
   FactRetrieverRegistration,
 } from '@backstage/plugin-tech-insights-node';
@@ -25,6 +26,7 @@ import {
  *
  * @param cadence - cron expression to indicate when the fact retriever should be triggered
  * @param factRetriever - Implementation of fact retriever consisting of at least id, version, schema and handler
+ * @param lifecycle - Optional lifecycle definition indicating the cleanup logic of facts when this retriever is run
  *
  *
  * @remarks
@@ -40,13 +42,19 @@ import {
  # │ │ │ │ │ │
  # * * * * * *
  *
+ * Valid lifecycle values:
+ * \{ ttl: \{ weeks: 2 \} \} -- This fact retriever will remove items that are older than 2 weeks when it is run
+ * \{ itl: 7 \} -- This fact retriever will leave 7 newest items in the database when it is run
+ *
  */
 export function createFactRetrieverRegistration(
   cadence: string,
   factRetriever: FactRetriever,
+  lifecycle?: FactLifecycle,
 ): FactRetrieverRegistration {
   return {
     cadence,
     factRetriever,
+    lifecycle,
   };
 }

--- a/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
+++ b/plugins/tech-insights-backend/src/service/fact/createFactRetriever.ts
@@ -19,6 +19,14 @@ import {
   FactRetrieverRegistration,
 } from '@backstage/plugin-tech-insights-node';
 
+/**
+ * @public
+ *
+ * @param cadence - cron expression to indicate when the fact retriever should be triggered
+ * @param factRetriever - Implementation of fact retriever consisting of at least id, version, schema and handler
+ * @param lifecycle - Optional lifecycle definition indicating the cleanup logic of facts when this retriever is run
+ *
+ */
 export type FactRetrieverRegistrationOptions = {
   cadence: string;
   factRetriever: FactRetriever;
@@ -50,7 +58,7 @@ export type FactRetrieverRegistrationOptions = {
  *
  * Valid lifecycle values:
  * \{ ttl: \{ weeks: 2 \} \} -- This fact retriever will remove items that are older than 2 weeks when it is run
- * \{ itl: 7 \} -- This fact retriever will leave 7 newest items in the database when it is run
+ * \{ maxItems: 7 \} -- This fact retriever will leave 7 newest items in the database when it is run
  *
  */
 export function createFactRetrieverRegistration({

--- a/plugins/tech-insights-backend/src/service/fact/factRetrievers/utils.ts
+++ b/plugins/tech-insights-backend/src/service/fact/factRetrievers/utils.ts
@@ -16,9 +16,18 @@
 import camelCase from 'lodash/camelCase';
 import { Entity } from '@backstage/catalog-model';
 import { get } from 'lodash';
+import { FactLifecycle, ITL, TTL } from '@backstage/plugin-tech-insights-node';
 
 export const generateAnnotationFactName = (annotation: string) =>
   camelCase(`hasAnnotation-${annotation}`);
 
 export const entityHasAnnotation = (entity: Entity, annotation: string) =>
   Boolean(get(entity, ['metadata', 'annotations', annotation]));
+
+export const isTtl = (lifecycle: FactLifecycle): lifecycle is TTL => {
+  return !!(lifecycle as TTL).ttl;
+};
+
+export const isItl = (lifecycle: FactLifecycle): lifecycle is ITL => {
+  return !!(lifecycle as ITL).itl;
+};

--- a/plugins/tech-insights-backend/src/service/fact/factRetrievers/utils.ts
+++ b/plugins/tech-insights-backend/src/service/fact/factRetrievers/utils.ts
@@ -16,7 +16,11 @@
 import camelCase from 'lodash/camelCase';
 import { Entity } from '@backstage/catalog-model';
 import { get } from 'lodash';
-import { FactLifecycle, ITL, TTL } from '@backstage/plugin-tech-insights-node';
+import {
+  FactLifecycle,
+  MaxItems,
+  TTL,
+} from '@backstage/plugin-tech-insights-node';
 
 export const generateAnnotationFactName = (annotation: string) =>
   camelCase(`hasAnnotation-${annotation}`);
@@ -25,9 +29,9 @@ export const entityHasAnnotation = (entity: Entity, annotation: string) =>
   Boolean(get(entity, ['metadata', 'annotations', annotation]));
 
 export const isTtl = (lifecycle: FactLifecycle): lifecycle is TTL => {
-  return !!(lifecycle as TTL).ttl;
+  return !!(lifecycle as TTL).timeToLive;
 };
 
-export const isItl = (lifecycle: FactLifecycle): lifecycle is ITL => {
-  return !!(lifecycle as ITL).itl;
+export const isMaxItems = (lifecycle: FactLifecycle): lifecycle is MaxItems => {
+  return !!(lifecycle as MaxItems).maxItems;
 };

--- a/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.test.ts
+++ b/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.test.ts
@@ -310,6 +310,81 @@ describe('Tech Insights database', () => {
     });
   });
 
+  it('should delete extraneous rows for each entity when MaxItems is defined. Should leave only n latest', async () => {
+    const deviledFact = (it: {}) => ({
+      ...it,
+      facts: JSON.stringify({
+        testNumberFact: 666,
+      }),
+    });
+    await testDbClient.batchInsert('facts', additionalFacts.map(deviledFact));
+
+    const preInsertionFacts = await testDbClient('facts').select();
+
+    expect(preInsertionFacts).toHaveLength(3);
+
+    await testDbClient.batchInsert(
+      'facts',
+      preInsertionFacts.map(it => ({ ...it, entity: 'b:b/b' })),
+    );
+
+    const timestamp = DateTime.now().plus(Duration.fromMillis(1111));
+    const factsToBeInserted = [
+      {
+        timestamp: timestamp,
+        entity: {
+          namespace: 'a',
+          kind: 'a',
+          name: 'a',
+        },
+        facts: {
+          testNumberFact: 555,
+        },
+      },
+      {
+        timestamp: timestamp,
+        entity: {
+          namespace: 'b',
+          kind: 'b',
+          name: 'b',
+        },
+        facts: {
+          testNumberFact: 555,
+        },
+      },
+    ];
+    const maxItems = 2;
+    await store.insertFacts({
+      id: 'test-fact',
+      facts: factsToBeInserted,
+      lifecycle: { maxItems },
+    });
+
+    const afterInsertionFacts = await testDbClient('facts').select();
+
+    const inserted = {
+      id: 'test-fact',
+      version: '0.0.1-test',
+      timestamp: timestamp.toISO(),
+      entity: 'a:a/a',
+      facts: JSON.stringify({ testNumberFact: 555 }),
+    };
+    expect(afterInsertionFacts).toHaveLength(maxItems * 2);
+    expect(afterInsertionFacts[0]).toMatchObject(
+      deviledFact(additionalFacts[0]),
+    );
+
+    expect(afterInsertionFacts[1]).toMatchObject({
+      ...deviledFact(additionalFacts[0]),
+      entity: 'b:b/b',
+    });
+    expect(afterInsertionFacts[2]).toMatchObject(inserted);
+    expect(afterInsertionFacts[3]).toMatchObject({
+      ...inserted,
+      entity: 'b:b/b',
+    });
+  });
+
   it('should delete extraneous rows when TTL is defined. Should leave only items with timestamp greater than TTL', async () => {
     const oldStaledOutFact = (it: {}) => ({
       ...it,
@@ -361,5 +436,96 @@ describe('Tech Insights database', () => {
     expect(afterInsertionFacts).not.toContainEqual(
       oldStaledOutFact(additionalFacts[0]),
     );
+  });
+
+  it('should delete extraneous rows for each entity when TTL expired', async () => {
+    const oldStaledOutFact = (it: {}) => ({
+      ...it,
+      facts: JSON.stringify({
+        testNumberFact: 666,
+      }),
+      timestamp: DateTime.now().minus({ weeks: 3 }).toISO(),
+    });
+    await testDbClient.batchInsert(
+      'facts',
+      additionalFacts.map(oldStaledOutFact),
+    );
+
+    const preInsertionFacts = await testDbClient('facts').select();
+    expect(preInsertionFacts).toHaveLength(3);
+
+    await testDbClient.batchInsert(
+      'facts',
+      preInsertionFacts.map(it => ({ ...it, entity: 'b:b/b' })),
+    );
+
+    const timestamp = DateTime.now().plus(Duration.fromMillis(1111));
+    const factsToBeInserted = [
+      {
+        timestamp: timestamp,
+        entity: {
+          namespace: 'a',
+          kind: 'a',
+          name: 'a',
+        },
+        facts: {
+          testNumberFact: 555,
+        },
+      },
+      {
+        timestamp: timestamp,
+        entity: {
+          namespace: 'b',
+          kind: 'b',
+          name: 'b',
+        },
+        facts: {
+          testNumberFact: 555,
+        },
+      },
+    ];
+    await store.insertFacts({
+      id: 'test-fact',
+      facts: factsToBeInserted,
+      lifecycle: { timeToLive: { weeks: 2 } },
+    });
+
+    const afterInsertionFacts = await testDbClient('facts')
+      .select()
+      .orderBy('timestamp', 'desc');
+
+    expect(afterInsertionFacts).toHaveLength(6);
+    expect(afterInsertionFacts[0]).toMatchObject({
+      id: 'test-fact',
+      version: '0.0.1-test',
+      timestamp: timestamp.toISO(),
+      entity: 'a:a/a',
+      facts: JSON.stringify({ testNumberFact: 555 }),
+    });
+    expect(afterInsertionFacts[1]).toMatchObject({
+      id: 'test-fact',
+      version: '0.0.1-test',
+      timestamp: timestamp.toISO(),
+      entity: 'b:b/b',
+      facts: JSON.stringify({ testNumberFact: 555 }),
+    });
+    expect(afterInsertionFacts[2]).toMatchObject(facts[1]);
+    expect(afterInsertionFacts[3]).toMatchObject({
+      ...facts[1],
+      entity: 'b:b/b',
+    });
+    expect(afterInsertionFacts[4]).toMatchObject(facts[0]);
+    expect(afterInsertionFacts[5]).toMatchObject({
+      ...facts[0],
+      entity: 'b:b/b',
+    });
+
+    expect(afterInsertionFacts).not.toContainEqual(
+      oldStaledOutFact(additionalFacts[0]),
+    );
+    expect(afterInsertionFacts).not.toContainEqual({
+      ...oldStaledOutFact(additionalFacts[0]),
+      entity: 'b:b/b',
+    });
   });
 });

--- a/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.test.ts
+++ b/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.test.ts
@@ -265,7 +265,7 @@ describe('Tech Insights database', () => {
     });
   });
 
-  it('should delete extraneous rows when ITL is defined. Should leave only n latest', async () => {
+  it('should delete extraneous rows when MaxItems is defined. Should leave only n latest', async () => {
     const deviledFact = (it: {}) => ({
       ...it,
       facts: JSON.stringify({
@@ -289,11 +289,11 @@ describe('Tech Insights database', () => {
         testNumberFact: 555,
       },
     };
-    const itl = 2;
-    await store.insertFacts('test-fact', [factToBeInserted], { itl });
+    const maxItems = 2;
+    await store.insertFacts('test-fact', [factToBeInserted], { maxItems });
 
     const afterInsertionFacts = await testDbClient('facts').select();
-    expect(afterInsertionFacts).toHaveLength(itl);
+    expect(afterInsertionFacts).toHaveLength(maxItems);
     expect(afterInsertionFacts[0]).toMatchObject(
       deviledFact(additionalFacts[0]),
     );
@@ -335,7 +335,7 @@ describe('Tech Insights database', () => {
       },
     };
     await store.insertFacts('test-fact', [factToBeInserted], {
-      ttl: { weeks: 2 },
+      timeToLive: { weeks: 2 },
     });
 
     const afterInsertionFacts = await testDbClient('facts')

--- a/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.test.ts
+++ b/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.test.ts
@@ -290,7 +290,11 @@ describe('Tech Insights database', () => {
       },
     };
     const maxItems = 2;
-    await store.insertFacts('test-fact', [factToBeInserted], { maxItems });
+    await store.insertFacts({
+      id: 'test-fact',
+      facts: [factToBeInserted],
+      lifecycle: { maxItems },
+    });
 
     const afterInsertionFacts = await testDbClient('facts').select();
     expect(afterInsertionFacts).toHaveLength(maxItems);
@@ -334,8 +338,10 @@ describe('Tech Insights database', () => {
         testNumberFact: 555,
       },
     };
-    await store.insertFacts('test-fact', [factToBeInserted], {
-      timeToLive: { weeks: 2 },
+    await store.insertFacts({
+      id: 'test-fact',
+      facts: [factToBeInserted],
+      lifecycle: { timeToLive: { weeks: 2 } },
     });
 
     const afterInsertionFacts = await testDbClient('facts')

--- a/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.test.ts
+++ b/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.test.ts
@@ -126,9 +126,14 @@ describe('Tech Insights database', () => {
         logger: getVoidLogger(),
       })
     ).techInsightsStore;
-
+  });
+  beforeEach(async () => {
     await testDbClient.batchInsert('fact_schemas', factSchemas);
     await testDbClient.batchInsert('facts', facts);
+  });
+  afterEach(async () => {
+    await testDbClient('facts').delete();
+    await testDbClient('fact_schemas').delete();
   });
 
   const baseAssertionFact = {
@@ -183,15 +188,11 @@ describe('Tech Insights database', () => {
     expect(schemas).toHaveLength(2);
     expect(schemas[0]).toMatchObject({
       id: 'test-fact',
-      version: '1.2.1-test',
+      version: '0.0.1-test',
       entityFilter: [{ kind: 'component' }],
       testNumberFact: {
         type: 'integer',
         description: 'Test fact with a number type',
-      },
-      testStringFact: {
-        type: 'string',
-        description: 'Test fact with a string type',
       },
     });
     expect(schemas[1]).toMatchObject({
@@ -262,5 +263,97 @@ describe('Tech Insights database', () => {
       timestamp: DateTime.fromISO(farInTheFuture),
       facts: { testNumberFact: 3 },
     });
+  });
+
+  it('should delete extraneous rows when ITL is defined. Should leave only n latest', async () => {
+    const deviledFact = (it: {}) => ({
+      ...it,
+      facts: JSON.stringify({
+        testNumberFact: 666,
+      }),
+    });
+    await testDbClient.batchInsert('facts', additionalFacts.map(deviledFact));
+
+    const preInsertionFacts = await testDbClient('facts').select();
+    expect(preInsertionFacts).toHaveLength(3);
+
+    const timestamp = DateTime.now().plus(Duration.fromMillis(1111));
+    const factToBeInserted = {
+      timestamp: timestamp,
+      entity: {
+        namespace: 'a',
+        kind: 'a',
+        name: 'a',
+      },
+      facts: {
+        testNumberFact: 555,
+      },
+    };
+    const itl = 2;
+    await store.insertFacts('test-fact', [factToBeInserted], { itl });
+
+    const afterInsertionFacts = await testDbClient('facts').select();
+    expect(afterInsertionFacts).toHaveLength(itl);
+    expect(afterInsertionFacts[0]).toMatchObject(
+      deviledFact(additionalFacts[0]),
+    );
+    expect(afterInsertionFacts[1]).toMatchObject({
+      id: 'test-fact',
+      version: '0.0.1-test',
+      timestamp: timestamp.toISO(),
+      entity: 'a:a/a',
+      facts: JSON.stringify({ testNumberFact: 555 }),
+    });
+  });
+
+  it('should delete extraneous rows when TTL is defined. Should leave only items with timestamp greater than TTL', async () => {
+    const oldStaledOutFact = (it: {}) => ({
+      ...it,
+      facts: JSON.stringify({
+        testNumberFact: 666,
+      }),
+      timestamp: DateTime.now().minus({ weeks: 3 }).toISO(),
+    });
+    await testDbClient.batchInsert(
+      'facts',
+      additionalFacts.map(oldStaledOutFact),
+    );
+
+    const preInsertionFacts = await testDbClient('facts').select();
+    expect(preInsertionFacts).toHaveLength(3);
+
+    const timestamp = DateTime.now().plus(Duration.fromMillis(1111));
+    const factToBeInserted = {
+      timestamp: timestamp,
+      entity: {
+        namespace: 'a',
+        kind: 'a',
+        name: 'a',
+      },
+      facts: {
+        testNumberFact: 555,
+      },
+    };
+    await store.insertFacts('test-fact', [factToBeInserted], {
+      ttl: { weeks: 2 },
+    });
+
+    const afterInsertionFacts = await testDbClient('facts')
+      .select()
+      .orderBy('timestamp', 'desc');
+    expect(afterInsertionFacts).toHaveLength(3);
+    expect(afterInsertionFacts[0]).toMatchObject({
+      id: 'test-fact',
+      version: '0.0.1-test',
+      timestamp: timestamp.toISO(),
+      entity: 'a:a/a',
+      facts: JSON.stringify({ testNumberFact: 555 }),
+    });
+    expect(afterInsertionFacts[1]).toMatchObject(facts[1]);
+    expect(afterInsertionFacts[2]).toMatchObject(facts[0]);
+
+    expect(afterInsertionFacts).not.toContainEqual(
+      oldStaledOutFact(additionalFacts[0]),
+    );
   });
 });

--- a/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.ts
+++ b/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.ts
@@ -87,11 +87,15 @@ export class TechInsightsDatabase implements TechInsightsStore {
     }
   }
 
-  async insertFacts(
-    id: string,
-    facts: TechInsightFact[],
-    lifecycle?: FactLifecycle,
-  ): Promise<void> {
+  async insertFacts({
+    id,
+    facts,
+    lifecycle,
+  }: {
+    id: string;
+    facts: TechInsightFact[];
+    lifecycle?: FactLifecycle;
+  }): Promise<void> {
     if (facts.length === 0) return;
     const currentSchema = await this.getLatestSchema(id);
     const factRows = facts.map(it => {

--- a/plugins/tech-insights-node/api-report.md
+++ b/plugins/tech-insights-node/api-report.md
@@ -39,7 +39,7 @@ export interface FactCheckerFactory<
 }
 
 // @public
-export type FactLifecycle = TTL | ITL;
+export type FactLifecycle = TTL | MaxItems;
 
 // @public
 export interface FactRetriever {
@@ -88,8 +88,8 @@ export type FlatTechInsightFact = TechInsightFact & {
 };
 
 // @public
-export type ITL = {
-  itl: number;
+export type MaxItems = {
+  maxItems: number;
 };
 
 // @public
@@ -154,17 +154,21 @@ export interface TechInsightsStore {
     [factRef: string]: FlatTechInsightFact;
   }>;
   getLatestSchemas(ids?: string[]): Promise<FactSchema[]>;
-  insertFacts(
-    id: string,
-    facts: TechInsightFact[],
-    lifecycle?: FactLifecycle,
-  ): Promise<void>;
+  insertFacts({
+    id,
+    facts,
+    lifecycle,
+  }: {
+    id: string;
+    facts: TechInsightFact[];
+    lifecycle?: FactLifecycle;
+  }): Promise<void>;
   insertFactSchema(schemaDefinition: FactSchemaDefinition): Promise<void>;
 }
 
 // @public
 export type TTL = {
-  ttl: DurationLike;
+  timeToLive: DurationLike;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/tech-insights-node/api-report.md
+++ b/plugins/tech-insights-node/api-report.md
@@ -6,6 +6,7 @@
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
 import { Config } from '@backstage/config';
 import { DateTime } from 'luxon';
+import { DurationLike } from 'luxon';
 import { Logger as Logger_2 } from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 
@@ -38,6 +39,9 @@ export interface FactCheckerFactory<
 }
 
 // @public
+export type FactLifecycle = TTL | ITL;
+
+// @public
 export interface FactRetriever {
   entityFilter?:
     | Record<string, string | symbol | (string | symbol)[]>[]
@@ -62,6 +66,7 @@ export type FactRetrieverContext = {
 export type FactRetrieverRegistration = {
   factRetriever: FactRetriever;
   cadence?: string;
+  lifecycle?: FactLifecycle;
 };
 
 // @public
@@ -80,6 +85,11 @@ export type FactSchemaDefinition = Omit<FactRetriever, 'handler'>;
 // @public
 export type FlatTechInsightFact = TechInsightFact & {
   id: string;
+};
+
+// @public
+export type ITL = {
+  itl: number;
 };
 
 // @public
@@ -144,9 +154,18 @@ export interface TechInsightsStore {
     [factRef: string]: FlatTechInsightFact;
   }>;
   getLatestSchemas(ids?: string[]): Promise<FactSchema[]>;
-  insertFacts(id: string, facts: TechInsightFact[]): Promise<void>;
+  insertFacts(
+    id: string,
+    facts: TechInsightFact[],
+    lifecycle?: FactLifecycle,
+  ): Promise<void>;
   insertFactSchema(schemaDefinition: FactSchemaDefinition): Promise<void>;
 }
+
+// @public
+export type TTL = {
+  ttl: DurationLike;
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/tech-insights-node/src/facts.ts
+++ b/plugins/tech-insights-node/src/facts.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DateTime } from 'luxon';
+import { DateTime, DurationLike } from 'luxon';
 import { Config } from '@backstage/config';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { Logger } from 'winston';
@@ -193,6 +193,36 @@ export interface FactRetriever {
 /**
  * @public
  *
+ * A Luxon duration like object for time to live value
+ *
+ * @example
+ * \{ ttl: 1209600000 \}
+ * \{ ttl: \{ weeks: 4 \} \}
+ *
+ **/
+export type TTL = { ttl: DurationLike };
+
+/**
+ * @public
+ *
+ * A number for items to live value
+ *
+ * @example
+ * \{ itl: 10 \}
+ *
+ **/
+export type ITL = { itl: number };
+
+/**
+ * @public
+ *
+ * A fact lifecycle definition. Determines which strategy to use to purge expired facts from the database.
+ */
+export type FactLifecycle = TTL | ITL;
+
+/**
+ * @public
+ *
  * A flat serializable structure for Facts.
  * Containing information about fact schema, version, id, and entity filters
  */
@@ -216,4 +246,11 @@ export type FactRetrieverRegistration = {
    *
    */
   cadence?: string;
+
+  /**
+   * Fact lifecycle definition
+   *
+   * If defined this value will be used to determine expired items which will deleted when this fact retriever is run
+   */
+  lifecycle?: FactLifecycle;
 };

--- a/plugins/tech-insights-node/src/facts.ts
+++ b/plugins/tech-insights-node/src/facts.ts
@@ -196,29 +196,29 @@ export interface FactRetriever {
  * A Luxon duration like object for time to live value
  *
  * @example
- * \{ ttl: 1209600000 \}
- * \{ ttl: \{ weeks: 4 \} \}
+ * \{ timeToLive: 1209600000 \}
+ * \{ timeToLive: \{ weeks: 4 \} \}
  *
  **/
-export type TTL = { ttl: DurationLike };
+export type TTL = { timeToLive: DurationLike };
 
 /**
  * @public
  *
- * A number for items to live value
+ * A maximum number for items to be kept in the database for each fact retriever/entity pair
  *
  * @example
- * \{ itl: 10 \}
+ * \{ maxItems: 10 \}
  *
  **/
-export type ITL = { itl: number };
+export type MaxItems = { maxItems: number };
 
 /**
  * @public
  *
  * A fact lifecycle definition. Determines which strategy to use to purge expired facts from the database.
  */
-export type FactLifecycle = TTL | ITL;
+export type FactLifecycle = TTL | MaxItems;
 
 /**
  * @public

--- a/plugins/tech-insights-node/src/persistence.ts
+++ b/plugins/tech-insights-node/src/persistence.ts
@@ -18,6 +18,7 @@ import {
   TechInsightFact,
   FlatTechInsightFact,
   FactSchemaDefinition,
+  FactLifecycle,
 } from './facts';
 import { DateTime } from 'luxon';
 
@@ -35,8 +36,13 @@ export interface TechInsightsStore {
    *
    * @param id - Unique identifier of the fact retriever these facts relate to
    * @param facts - A collection of TechInsightFacts
+   * @param lifecycle - (Optional) Fact lifecycle object indicating the expiration logic for these items
    */
-  insertFacts(id: string, facts: TechInsightFact[]): Promise<void>;
+  insertFacts(
+    id: string,
+    facts: TechInsightFact[],
+    lifecycle?: FactLifecycle,
+  ): Promise<void>;
 
   /**
    * @param ids - A collection of fact row identifiers

--- a/plugins/tech-insights-node/src/persistence.ts
+++ b/plugins/tech-insights-node/src/persistence.ts
@@ -38,11 +38,15 @@ export interface TechInsightsStore {
    * @param facts - A collection of TechInsightFacts
    * @param lifecycle - (Optional) Fact lifecycle object indicating the expiration logic for these items
    */
-  insertFacts(
-    id: string,
-    facts: TechInsightFact[],
-    lifecycle?: FactLifecycle,
-  ): Promise<void>;
+  insertFacts({
+    id,
+    facts,
+    lifecycle,
+  }: {
+    id: string;
+    facts: TechInsightFact[];
+    lifecycle?: FactLifecycle;
+  }): Promise<void>;
 
   /**
    * @param ids - A collection of fact row identifiers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a configuration option to fact retrievers to define lifecycle for facts the retriever persists. Possible values are either 'max items' or 'time-to-live'. The former will only n number of items in to the database for each fact per entity. The latter will remove all facts that are older than the TTL value.

Possible values:
* `{ maxItems: 5 }` // Deletes all facts for the retriever/entity pair, apart from the last five
* `{ ttl: 1209600000 }` // (2 weeks) Deletes all facts older than 2 weeks for the retriever/entity pair
* `{ ttl: { weeks: 2 } }` // Deletes all facts older than 2 weeks for the retriever/entity pair

The purging of stale values happens after insertion, after new items have been inserted. 

### Additional thoughts

This implementation handles items that are returned from the fact retriever, possibly leaving facts tied to removed entities behind. Future improvements should likely be made on two fronts:
1. Removing facts regardless of their ties to the current fact retriever/entity. 
  * This is something that should likely be introduced as a secondary, timed clean-up loop that handles items the way user wants to set this up
  * A lot of the time the fact data is important for historical purposes so a lot of use cases will leave this unconfigured
2. Adding the possibility to create snapshots of fact data, based on user preferences
  * This can be implemented in a similar way as the lifecycle option within this PR
    * Adding a configuration option to registration that takes in a function
    * This function receives predetermined amount of fact values from the database
    * This function does calculations on the received data, for example calculating the avg value of the fact per week of fact data
    * This function returns this calculated snapshot value, FactRetrieverEngine persists that and possibly deletes the stale individual data
  * The configuration option should be called _smoosh_ to pay homage to the JS ecosystem

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [n/a] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
