### PR TITLE
build(deps): bump @asyncapi/react-component to 1.0.0-next.26

### DIFF
--- a/.changeset/selfish-bikes-sleep.md
+++ b/.changeset/selfish-bikes-sleep.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Update @asyncapi/react-component to 1.0.0-next.26, which will fix the
+`ResizeObserver loop limit exceeded` errors which we encountered in several E2E
+tests.
+
+For more details check the following links:
+
+- https://github.com/backstage/backstage/pull/8088#issuecomment-991183968
+- https://github.com/asyncapi/asyncapi-react/issues/498

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -30,7 +30,7 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@asyncapi/react-component": "^1.0.0-next.25",
+    "@asyncapi/react-component": "1.0.0-next.26",
     "@backstage/catalog-model": "^0.9.7",
     "@backstage/core-components": "^0.8.3",
     "@backstage/core-plugin-api": "^0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,10 +96,10 @@
     node-fetch "^2.6.0"
     tiny-merge-patch "^0.1.2"
 
-"@asyncapi/react-component@^1.0.0-next.25":
-  version "1.0.0-next.25"
-  resolved "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.25.tgz#76b27e0e239b03c32499ee5cd8977e5ceb74f754"
-  integrity sha512-S+HguQ6IltQWiy+jO7hlmANJYxJ2UOvH7iMAw+YTcDtYGOe/mrDr7vbrrB3HigZRYIyZSV34cNgNOhw/psVHlg==
+"@asyncapi/react-component@1.0.0-next.26":
+  version "1.0.0-next.26"
+  resolved "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.26.tgz#d5658f89c8aa7a88e86f8d1918ef63cbf7f7634e"
+  integrity sha512-30UnzdbS7EVcdxIHru8O04mxqGPmTA0o2HtzykV9+Y0Ye+k9gqto8SK1my+qqQUs+7EwwyzA1dFaTmf2CHrJIg==
   dependencies:
     "@asyncapi/avro-schema-parser" "^0.3.0"
     "@asyncapi/openapi-schema-parser" "^2.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Update `@asyncapi/react-component` to `1.0.0-next.26`, which will fix the
`ResizeObserver loop limit exceeded` errors which we encountered in several E2E
tests.

For more details check the following links:

- https://github.com/backstage/backstage/pull/8088#issuecomment-991183968
- https://github.com/asyncapi/asyncapi-react/issues/498

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
