### PR TITLE
auth-backend: switch over to use auto secure cookies

### DIFF
--- a/.changeset/slimy-eggs-carry.md
+++ b/.changeset/slimy-eggs-carry.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Switched the secure cookie mode set on the `express-session` to use `'auto'` rather than `true`. This works around an issue where cookies would not be set if TLS termination was handled in a proxy rather than having the backend served directly with HTTPS.
+
+The downside of this change is that secure cookies won't be used unless the backend is directly served with HTTPS. This will be remedied in a future update that allows the backend to configured for trusted proxy mode.

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -74,7 +74,7 @@ export async function createRouter(
         secret,
         saveUninitialized: false,
         resave: false,
-        cookie: { secure: enforceCookieSSL },
+        cookie: { secure: enforceCookieSSL ? 'auto' : false },
       }),
     );
     router.use(passport.initialize());


### PR DESCRIPTION
Fixes #8767

Figuring that this is the sane fix for now. I think the followup fix is to refactor the service builder from backend-common to make the express app accessible.