### PR TITLE
Integrate permissions into `entityAncestry` endpoint in catalog-backend

### DIFF
--- a/.changeset/many-jokes-mix.md
+++ b/.changeset/many-jokes-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Integrate permissions into entity ancestry endpoint in catalog-backend

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -554,7 +554,12 @@ export type EntitiesCatalog = {
       authorizationToken?: string;
     },
   ): Promise<void>;
-  entityAncestry(entityRef: string): Promise<EntityAncestryResponse>;
+  entityAncestry(
+    entityRef: string,
+    options?: {
+      authorizationToken?: string;
+    },
+  ): Promise<EntityAncestryResponse>;
 };
 
 // Warning: (ae-missing-release-tag) "EntitiesRequest" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -111,5 +111,8 @@ export type EntitiesCatalog = {
    *
    * @param entityRef - An entity reference to the root of the tree
    */
-  entityAncestry(entityRef: string): Promise<EntityAncestryResponse>;
+  entityAncestry(
+    entityRef: string,
+    options?: { authorizationToken?: string },
+  ): Promise<EntityAncestryResponse>;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We call the underlying EntityCatalog's `entityAncestry` method from within the authorized service, and then batch authorize the resulting entities and filter out any unauthorized entities and their parents. Note: entityRefs to unauthorized parents may still appear within the returned results if the root child is authorized, but this was previously discussed as an acceptable tradeoff.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
