### PR TITLE
[TechInsights] add operation to run checks for multiple entities in one operation

### DIFF
--- a/.changeset/seven-swans-glow.md
+++ b/.changeset/seven-swans-glow.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-tech-insights': minor
+'@backstage/plugin-tech-insights-backend': minor
+'@backstage/plugin-tech-insights-common': minor
+'@backstage/plugin-tech-insights-backend-module-jsonfc': patch
+---
+
+adding new operation to run checks for multiple entities in one request

--- a/.changeset/seven-swans-glow.md
+++ b/.changeset/seven-swans-glow.md
@@ -1,7 +1,7 @@
 ---
-'@backstage/plugin-tech-insights': minor
-'@backstage/plugin-tech-insights-backend': minor
-'@backstage/plugin-tech-insights-common': minor
+'@backstage/plugin-tech-insights': patch
+'@backstage/plugin-tech-insights-backend': patch
+'@backstage/plugin-tech-insights-common': patch
 '@backstage/plugin-tech-insights-backend-module-jsonfc': patch
 ---
 

--- a/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
+++ b/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
@@ -35,6 +35,7 @@ import { pick } from 'lodash';
 import Ajv, { SchemaObject } from 'ajv';
 import * as validationSchema from './validation-schema.json';
 import { JSON_RULE_ENGINE_CHECK_TYPE } from '../constants';
+import { isError } from '@backstage/errors';
 
 const noopEvent = {
   type: 'noop',
@@ -138,8 +139,11 @@ export class JsonRulesEngineFactChecker
         techInsightChecks,
         Object.values(facts),
       );
-    } catch (e: any) {
-      throw new Error(`Failed to run rules engine, ${e.message}`);
+    } catch (e) {
+      if (isError(e)) {
+        throw new Error(`Failed to run rules engine, ${e.message}`);
+      }
+      throw e;
     }
   }
 

--- a/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
+++ b/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
@@ -117,7 +117,7 @@ export class JsonRulesEngineFactChecker
       if (hasAllFacts) {
         engine.addRule({ ...techInsightCheck.rule, event: noopEvent });
       } else {
-        this.logger.warn(
+        this.logger.debug(
           `Skipping ${
             rule.name
           } due to missing facts: ${techInsightCheck.factIds
@@ -138,7 +138,7 @@ export class JsonRulesEngineFactChecker
         techInsightChecks,
         Object.values(facts),
       );
-    } catch (e) {
+    } catch (e: any) {
       throw new Error(`Failed to run rules engine, ${e.message}`);
     }
   }

--- a/plugins/tech-insights-backend/src/service/router.ts
+++ b/plugins/tech-insights-backend/src/service/router.ts
@@ -32,6 +32,7 @@ import {
   parseEntityName,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
+import { errorHandler } from '@backstage/backend-common';
 
 /**
  * @public
@@ -92,36 +93,26 @@ export async function createRouter<
 
     router.post('/checks/run/:namespace/:kind/:name', async (req, res) => {
       const { namespace, kind, name } = req.params;
-      try {
-        const { checks }: { checks: string[] } = req.body;
-        const entityTriplet = stringifyEntityRef({ namespace, kind, name });
-        const checkResult = await factChecker.runChecks(entityTriplet, checks);
-        return res.send(checkResult);
-      } catch (e: any) {
-        return res.status(500).json({ message: e.message }).send();
-      }
+      const { checks }: { checks: string[] } = req.body;
+      const entityTriplet = stringifyEntityRef({ namespace, kind, name });
+      const checkResult = await factChecker.runChecks(entityTriplet, checks);
+      return res.send(checkResult);
     });
 
     router.post('/checks/run', async (req, res) => {
-      try {
-        const {
-          checks,
-          entities,
-        }: { checks: string[]; entities: EntityName[] } = req.body;
-        const tasks = entities.map(async entity => {
-          const entityTriplet =
-            typeof entity === 'string' ? entity : stringifyEntityRef(entity);
-          const results = await factChecker.runChecks(entityTriplet, checks);
-          return {
-            entity: entityTriplet,
-            results,
-          };
-        });
-        const results = await Promise.all(tasks);
-        return res.send(results);
-      } catch (e: any) {
-        return res.status(500).json({ message: e.message }).send();
-      }
+      const { checks, entities }: { checks: string[]; entities: EntityName[] } =
+        req.body;
+      const tasks = entities.map(async entity => {
+        const entityTriplet =
+          typeof entity === 'string' ? entity : stringifyEntityRef(entity);
+        const results = await factChecker.runChecks(entityTriplet, checks);
+        return {
+          entity: entityTriplet,
+          results,
+        };
+      });
+      const results = await Promise.all(tasks);
+      return res.send(results);
     });
   } else {
     logger.info(
@@ -176,5 +167,7 @@ export async function createRouter<
       ),
     );
   });
+
+  router.use(errorHandler());
   return router;
 }

--- a/plugins/tech-insights-common/api-report.md
+++ b/plugins/tech-insights-common/api-report.md
@@ -13,6 +13,12 @@ export interface BooleanCheckResult extends CheckResult {
 }
 
 // @public
+export type BulkCheckResponse = Array<{
+  entity: string;
+  results: CheckResult[];
+}>;
+
+// @public
 export interface CheckResponse {
   description: string;
   factIds: string[];

--- a/plugins/tech-insights-common/src/index.ts
+++ b/plugins/tech-insights-common/src/index.ts
@@ -124,3 +124,13 @@ export type CheckResult = {
 export interface BooleanCheckResult extends CheckResult {
   result: boolean;
 }
+
+/**
+ * Response type for bulk check opretation. Contains a list of entities and their respective check results.
+ *
+ * @public
+ */
+export type BulkCheckResponse = Array<{
+  entity: string;
+  results: CheckResult[];
+}>;

--- a/plugins/tech-insights/api-report.md
+++ b/plugins/tech-insights/api-report.md
@@ -7,6 +7,7 @@
 
 import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { BulkCheckResponse } from '@backstage/plugin-tech-insights-common';
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
 import { EntityName } from '@backstage/catalog-model';
 import { default as React_2 } from 'react';
@@ -49,6 +50,11 @@ export interface TechInsightsApi {
     title?: string,
     description?: string,
   ) => CheckResultRenderer | undefined;
+  // (undocumented)
+  runBulkChecks(
+    entities: EntityName[],
+    checks?: Check[],
+  ): Promise<BulkCheckResponse>;
   // (undocumented)
   runChecks(entityParams: EntityName, checks?: Check[]): Promise<CheckResult[]>;
 }

--- a/plugins/tech-insights/src/api/TechInsightsApi.ts
+++ b/plugins/tech-insights/src/api/TechInsightsApi.ts
@@ -15,7 +15,10 @@
  */
 
 import { createApiRef } from '@backstage/core-plugin-api';
-import { CheckResult } from '@backstage/plugin-tech-insights-common';
+import {
+  CheckResult,
+  BulkCheckResponse,
+} from '@backstage/plugin-tech-insights-common';
 import { Check } from './types';
 import { CheckResultRenderer } from '../components/CheckResultRenderer';
 import { EntityName } from '@backstage/catalog-model';
@@ -43,4 +46,8 @@ export interface TechInsightsApi {
   ) => CheckResultRenderer | undefined;
   getAllChecks(): Promise<Check[]>;
   runChecks(entityParams: EntityName, checks?: Check[]): Promise<CheckResult[]>;
+  runBulkChecks(
+    entities: EntityName[],
+    checks?: Check[],
+  ): Promise<BulkCheckResponse>;
 }


### PR DESCRIPTION
Signed-off-by: goenning <me@goenning.net>

## Hey, I just made a Pull Request!

closes #8848

So here's my take on the new operation to run checks for multiple entities in one operation

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
