### PR TITLE
[Scaffolder] Fix token pass-through for software templates using beta 3 version

### DIFF
--- a/.changeset/lazy-rockets-dress.md
+++ b/.changeset/lazy-rockets-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix token pass-through for software templates using beta 3 version

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -22,7 +22,7 @@ import { NunjucksWorkflowRunner } from './NunjucksWorkflowRunner';
 import { TemplateActionRegistry } from '../actions';
 import { ScmIntegrations } from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
-import { TaskContext, TaskSpec } from './types';
+import { TaskContext, TaskSpec, TaskSecrets } from './types';
 
 const realFiles = Object.fromEntries(
   [
@@ -49,8 +49,12 @@ describe('DefaultWorkflowRunner', () => {
     }),
   );
 
-  const createMockTaskWithSpec = (spec: TaskSpec): TaskContext => ({
+  const createMockTaskWithSpec = (
+    spec: TaskSpec,
+    secrets?: TaskSecrets,
+  ): TaskContext => ({
     spec,
+    secrets,
     complete: async () => {},
     done: false,
     emitLog: async () => {},
@@ -181,6 +185,32 @@ describe('DefaultWorkflowRunner', () => {
       expect(fakeActionHandler.mock.calls[0][0].metadata).toEqual({
         name: templateName,
       });
+    });
+
+    it('should pass token through', async () => {
+      const fakeToken = 'secret';
+      const task = createMockTaskWithSpec(
+        {
+          apiVersion: 'scaffolder.backstage.io/v1beta3',
+          parameters: {},
+          output: {},
+          steps: [
+            {
+              id: 'test',
+              name: 'name',
+              action: 'jest-validated-action',
+              input: { foo: 1 },
+            },
+          ],
+        },
+        {
+          token: fakeToken,
+        },
+      );
+
+      await runner.execute(task);
+
+      expect(fakeActionHandler.mock.calls[0][0].token).toEqual(fakeToken);
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -257,6 +257,7 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
           await action.handler({
             baseUrl: task.spec.baseUrl,
             input,
+            token: task.secrets?.token,
             logger: taskLogger,
             logStream: streamLogger,
             workspacePath,


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR adds `token` property to `handle` function calls. The property contains the user's token and can be used inside tasks to call Backstage API, required for environments with requests authentication enabled.

Fix issue #8846.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
