### PR TITLE
Integrate permissions into catalog-backend location endpoints

### DIFF
--- a/.changeset/silly-doors-exist.md
+++ b/.changeset/silly-doors-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-common': patch
+---
+
+Remove Catalog Location resource type

--- a/.changeset/soft-socks-pay.md
+++ b/.changeset/soft-socks-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Integrate permissions into catalog-backend location endpoints

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -879,17 +879,32 @@ export interface LocationService {
   createLocation(
     spec: LocationSpec,
     dryRun: boolean,
+    options?: {
+      authorizationToken?: string;
+    },
   ): Promise<{
     location: Location_2;
     entities: Entity[];
     exists?: boolean;
   }>;
   // (undocumented)
-  deleteLocation(id: string): Promise<void>;
+  deleteLocation(
+    id: string,
+    options?: {
+      authorizationToken?: string;
+    },
+  ): Promise<void>;
   // (undocumented)
-  getLocation(id: string): Promise<Location_2>;
+  getLocation(
+    id: string,
+    options?: {
+      authorizationToken?: string;
+    },
+  ): Promise<Location_2>;
   // (undocumented)
-  listLocations(): Promise<Location_2[]>;
+  listLocations(options?: {
+    authorizationToken?: string;
+  }): Promise<Location_2[]>;
 }
 
 // Warning: (ae-missing-release-tag) "LocationStore" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/catalog-backend/src/service/AuthorizedLocationService.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedLocationService.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NotAllowedError, NotFoundError } from '@backstage/errors';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { AuthorizedLocationService } from './AuthorizedLocationService';
+
+describe('AuthorizedLocationService', () => {
+  const fakeLocationService = {
+    createLocation: jest.fn(),
+    listLocations: jest.fn(),
+    getLocation: jest.fn(),
+    deleteLocation: jest.fn(),
+  };
+  const fakePermissionApi = {
+    authorize: jest.fn(),
+  };
+
+  const mockAllow = () => {
+    fakePermissionApi.authorize.mockResolvedValueOnce([
+      { result: AuthorizeResult.ALLOW },
+    ]);
+  };
+  const mockDeny = () => {
+    fakePermissionApi.authorize.mockResolvedValueOnce([
+      { result: AuthorizeResult.DENY },
+    ]);
+  };
+
+  const createService = () =>
+    new AuthorizedLocationService(fakeLocationService, fakePermissionApi);
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('createLocation', () => {
+    it('calls underlying service to create location on ALLOW', async () => {
+      mockAllow();
+      const service = createService();
+
+      const spec = { type: 'type', target: 'target' };
+      await service.createLocation(spec, false, {
+        authorizationToken: 'Bearer authtoken',
+      });
+
+      expect(fakeLocationService.createLocation).toHaveBeenCalledWith(
+        spec,
+        false,
+      );
+    });
+
+    it('throws Error on DENY', async () => {
+      mockDeny();
+      const service = createService();
+
+      const spec = { type: 'type', target: 'target' };
+      await expect(() =>
+        service.createLocation(spec, false, {
+          authorizationToken: 'Bearer authtoken',
+        }),
+      ).rejects.toThrowError(NotAllowedError);
+    });
+  });
+
+  describe('listLocations', () => {
+    it('calls underlying service to list locations on ALLOW', async () => {
+      mockAllow();
+      const service = createService();
+
+      await service.listLocations({ authorizationToken: 'Bearer authtoken' });
+
+      expect(fakeLocationService.listLocations).toHaveBeenCalled();
+    });
+
+    it('returns empty array on DENY', async () => {
+      mockDeny();
+      const service = createService();
+
+      const locations = await service.listLocations({
+        authorizationToken: 'Bearer authtoken',
+      });
+
+      expect(locations).toEqual([]);
+    });
+  });
+
+  describe('getLocation', () => {
+    it('calls underlying service to get location on ALLOW', async () => {
+      mockAllow();
+      const service = createService();
+
+      await service.getLocation('id', {
+        authorizationToken: 'Bearer authtoken',
+      });
+
+      expect(fakeLocationService.getLocation).toHaveBeenCalledWith('id');
+    });
+
+    it('throws error on DENY', async () => {
+      mockDeny();
+      const service = createService();
+
+      await expect(() =>
+        service.getLocation('id', { authorizationToken: 'Bearer authtoken' }),
+      ).rejects.toThrowError(NotFoundError);
+    });
+  });
+
+  describe('deleteLocation', () => {
+    it('calls underlying service to delete location on ALLOW', async () => {
+      mockAllow();
+      const service = createService();
+
+      await service.deleteLocation('id', {
+        authorizationToken: 'Bearer authtoken',
+      });
+
+      expect(fakeLocationService.deleteLocation).toHaveBeenCalledWith('id');
+    });
+
+    it('throws error on DENY', async () => {
+      mockDeny();
+      const service = createService();
+
+      await expect(() =>
+        service.deleteLocation('id', {
+          authorizationToken: 'Bearer authtoken',
+        }),
+      ).rejects.toThrowError(NotAllowedError);
+    });
+  });
+});

--- a/plugins/catalog-backend/src/service/AuthorizedLocationService.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedLocationService.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LocationSpec, Location, Entity } from '@backstage/catalog-model';
+import { NotAllowedError, NotFoundError } from '@backstage/errors';
+import {
+  catalogLocationCreatePermission,
+  catalogLocationDeletePermission,
+  catalogLocationReadPermission,
+} from '@backstage/plugin-catalog-common';
+import {
+  AuthorizeResult,
+  PermissionAuthorizer,
+} from '@backstage/plugin-permission-common';
+import { LocationService } from './types';
+
+export class AuthorizedLocationService implements LocationService {
+  constructor(
+    private readonly locationService: LocationService,
+    private readonly permissionApi: PermissionAuthorizer,
+  ) {}
+
+  async createLocation(
+    spec: LocationSpec,
+    dryRun: boolean,
+    options?: {
+      authorizationToken?: string;
+    },
+  ): Promise<{
+    location: Location;
+    entities: Entity[];
+    exists?: boolean | undefined;
+  }> {
+    const authorizationResponse = (
+      await this.permissionApi.authorize(
+        [{ permission: catalogLocationCreatePermission }],
+        { token: options?.authorizationToken },
+      )
+    )[0];
+
+    if (authorizationResponse.result === AuthorizeResult.DENY) {
+      throw new NotAllowedError();
+    }
+
+    return this.locationService.createLocation(spec, dryRun);
+  }
+
+  async listLocations(options?: {
+    authorizationToken?: string;
+  }): Promise<Location[]> {
+    const authorizationResponse = (
+      await this.permissionApi.authorize(
+        [{ permission: catalogLocationReadPermission }],
+        { token: options?.authorizationToken },
+      )
+    )[0];
+
+    if (authorizationResponse.result === AuthorizeResult.DENY) {
+      return [];
+    }
+
+    return this.locationService.listLocations();
+  }
+
+  async getLocation(
+    id: string,
+    options?: { authorizationToken?: string },
+  ): Promise<Location> {
+    const authorizationResponse = (
+      await this.permissionApi.authorize(
+        [{ permission: catalogLocationReadPermission }],
+        { token: options?.authorizationToken },
+      )
+    )[0];
+
+    if (authorizationResponse.result === AuthorizeResult.DENY) {
+      throw new NotFoundError(`Found no location with ID ${id}`);
+    }
+
+    return this.locationService.getLocation(id);
+  }
+
+  async deleteLocation(
+    id: string,
+    options?: { authorizationToken?: string },
+  ): Promise<void> {
+    const authorizationResponse = (
+      await this.permissionApi.authorize(
+        [{ permission: catalogLocationDeletePermission }],
+        { token: options?.authorizationToken },
+      )
+    )[0];
+
+    if (authorizationResponse.result === AuthorizeResult.DENY) {
+      throw new NotAllowedError();
+    }
+
+    return this.locationService.deleteLocation(id);
+  }
+}

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -95,6 +95,7 @@ import {
 import { AuthorizedEntitiesCatalog } from './AuthorizedEntitiesCatalog';
 import { basicEntityFilter } from './request/basicEntityFilter';
 import { RESOURCE_TYPE_CATALOG_ENTITY } from '@backstage/plugin-catalog-common';
+import { AuthorizedLocationService } from './AuthorizedLocationService';
 
 export type CatalogEnvironment = {
   logger: Logger;
@@ -455,9 +456,9 @@ export class CatalogBuilder {
 
     const locationAnalyzer =
       this.locationAnalyzer ?? new RepoLocationAnalyzer(logger, integrations);
-    const locationService = new DefaultLocationService(
-      locationStore,
-      orchestrator,
+    const locationService = new AuthorizedLocationService(
+      new DefaultLocationService(locationStore, orchestrator),
+      permissions,
     );
     const refreshService = new AuthorizedRefreshService(
       new DefaultRefreshService({ database: processingDatabase }),

--- a/plugins/catalog-backend/src/service/types.ts
+++ b/plugins/catalog-backend/src/service/types.ts
@@ -20,10 +20,19 @@ export interface LocationService {
   createLocation(
     spec: LocationSpec,
     dryRun: boolean,
+    options?: {
+      authorizationToken?: string;
+    },
   ): Promise<{ location: Location; entities: Entity[]; exists?: boolean }>;
-  listLocations(): Promise<Location[]>;
-  getLocation(id: string): Promise<Location>;
-  deleteLocation(id: string): Promise<void>;
+  listLocations(options?: { authorizationToken?: string }): Promise<Location[]>;
+  getLocation(
+    id: string,
+    options?: { authorizationToken?: string },
+  ): Promise<Location>;
+  deleteLocation(
+    id: string,
+    options?: { authorizationToken?: string },
+  ): Promise<void>;
 }
 
 /**

--- a/plugins/catalog-common/api-report.md
+++ b/plugins/catalog-common/api-report.md
@@ -25,7 +25,4 @@ export const catalogLocationReadPermission: Permission;
 
 // @public (undocumented)
 export const RESOURCE_TYPE_CATALOG_ENTITY = 'catalog-entity';
-
-// @public (undocumented)
-export const RESOURCE_TYPE_CATALOG_LOCATION = 'catalog-location';
 ```

--- a/plugins/catalog-common/src/index.ts
+++ b/plugins/catalog-common/src/index.ts
@@ -23,7 +23,6 @@
 
 export {
   RESOURCE_TYPE_CATALOG_ENTITY,
-  RESOURCE_TYPE_CATALOG_LOCATION,
   catalogEntityReadPermission,
   catalogEntityDeletePermission,
   catalogEntityRefreshPermission,

--- a/plugins/catalog-common/src/permissions.ts
+++ b/plugins/catalog-common/src/permissions.ts
@@ -23,12 +23,6 @@ import { Permission } from '@backstage/plugin-permission-common';
 export const RESOURCE_TYPE_CATALOG_ENTITY = 'catalog-entity';
 
 /**
- * {@link https://backstage.io/docs/features/software-catalog/descriptor-format#kind-location}
- * @public
- */
-export const RESOURCE_TYPE_CATALOG_LOCATION = 'catalog-location';
-
-/**
  * This permission is used to authorize actions that involve reading one or more
  * entities from the catalog.
  *
@@ -83,7 +77,6 @@ export const catalogLocationReadPermission: Permission = {
   attributes: {
     action: 'read',
   },
-  resourceType: RESOURCE_TYPE_CATALOG_LOCATION,
 };
 
 /**
@@ -96,7 +89,6 @@ export const catalogLocationCreatePermission: Permission = {
   attributes: {
     action: 'create',
   },
-  resourceType: RESOURCE_TYPE_CATALOG_LOCATION,
 };
 
 /**
@@ -109,5 +101,4 @@ export const catalogLocationDeletePermission: Permission = {
   attributes: {
     action: 'delete',
   },
-  resourceType: RESOURCE_TYPE_CATALOG_LOCATION,
 };


### PR DESCRIPTION
# The Problem

The location endpoints present a challenge for permission integration since they access a store that is separate from the EntitiesCatalog. If we allow policies to conditionally filter locations, it becomes difficult to construct meaningful rules by which policies could describe conditions, due to the fact that a location store's row is just an id, a type, and a target. This is further complicated by the fact that every row in the location store has a matching location entity in the EntitiesCatalog, but not every location entity in the EntitiesCatalog may have a corresponding row in the location store (depending on whether it was staticly declared or registered manually).

# Possible Solutions

## Separate resource type and integrations

Originally, we thought we could have a separate resource type and create a separate set of integrators/rules for this location resource type. But it quickly became clear that with the way the location store is currently structured, we couldn't develop meaningful filter rules given that the row is just an id, a type, and a target.

## Filtering using `EntitiesCatalog`

We also briefly explored allowing policies to define conditions using the same set of rules used for all other catalog entities, and applying the filtering in an `AuthorizedLocationService` by querying `EntitiesCatalog` and using the resulting location entities to relate them 1:1 to results that can/cannot be returned from the `LocationStore`. This poses some risks, such as opening the door for policy authors to use conditions that do not make sense for locations. For example, location entities do not currently have an owner - what if the policy author uses the `isEntityOwner` rule? It also seems strangely coupled to have to query a separate entity table in order to determine what can/cannot be returned from the location store, especially if some location entities may not exist in the location store at all.

## No conditional authorization for locations

@mtlewis suggested an option where we remove the ability to define conditional authorization with locations at all. Policy authors would only be able to specify access to locations based on global attributes/the user's role, _not_ any attribute of the locations. To reflect this, `RESOURCE_TYPE_CATALOG_LOCATION` is removed, so that it is clear in the permission definitions themselves that without a resource type to filter against, there can be no conditional filtering.

I think this approach is a good place to start, as we would be able to have some kind of implementation to ship for upcoming testing, and if we find that users need more flexibility with the location permissions, we can tailor our next steps to what exactly it is that they might need to be able to do with location permissions. It's also the option with the least disruptive changes to the location store & location entities, and thus is the approach laid out in the current PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
