### PR TITLE
azure-dev-ops: don't break backend on startup

### DIFF
--- a/.changeset/big-dots-carry.md
+++ b/.changeset/big-dots-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+do not break backend if the plugin is unable to fetch teams

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -40,7 +40,12 @@ export class PullRequestsDashboardProvider {
     azureDevOpsApi: AzureDevOpsApi,
   ): Promise<PullRequestsDashboardProvider> {
     const provider = new PullRequestsDashboardProvider(logger, azureDevOpsApi);
-    await provider.readTeams();
+    try {
+      await provider.readTeams();
+    } catch (error) {
+      logger.warn('Problem with starting Azure DevOps backend (reading teams)');
+      logger.error(error);
+    }
     return provider;
   }
 


### PR DESCRIPTION
Currently the backend will fail to start if the user does not have teams and credentials setup in Azure DevOps. The plugin should log the error but let the backend continue to start.

Signed-off-by: Himanshu Mishra <himanshu@orkohunter.net>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
