### PR TITLE
workflows/dependabot-changeset-maker: only run on dependabot branches

### DIFF
--- a/.github/workflows/dependabot-changeset-maker.yml
+++ b/.github/workflows/dependabot-changeset-maker.yml
@@ -1,6 +1,7 @@
 name: 'Dependabot changeset maker'
 on:
-  - pull_request_target
+  pull_request_target:
+    branches: 'dependabot/**'
 
 jobs:
   generate-changeset:


### PR DESCRIPTION
Avoids it showing up on all PRs 🧹 