### PR TITLE
core-components: update ProxiedSignInPage for IdentityApi deprecation removals

### DIFF
--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.test.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.test.ts
@@ -79,7 +79,6 @@ describe('ProxiedSignInIdentity', () => {
             picture: 'p',
           },
           backstageIdentity: {
-            id: 'i',
             token: [
               'eyJhbGciOiJFUzI1NiIsImtpZCI6ImMxNTMzNDRiLWZjYzktNGIwOS1iN2ZhLTU3ZmM5MDhjMjBiNiJ9',
               btoa(
@@ -96,8 +95,8 @@ describe('ProxiedSignInIdentity', () => {
             ].join('.'),
             identity: {
               type: 'user',
-              userEntityRef: 'ue',
-              ownershipEntityRefs: ['oe'],
+              userEntityRef: 'k:ns/ue',
+              ownershipEntityRefs: ['k:ns/oe'],
             },
           },
         };
@@ -125,6 +124,28 @@ describe('ProxiedSignInIdentity', () => {
       expect(getBaseUrl).toBeCalledTimes(1);
       expect(getBaseUrl).lastCalledWith('auth');
       expect(serverCalled).toBeCalledTimes(1);
+
+      // All information should now be available
+      await expect(identity.getBackstageIdentity()).resolves.toEqual({
+        type: 'user',
+        userEntityRef: 'k:ns/ue',
+        ownershipEntityRefs: ['k:ns/oe'],
+      });
+      await expect(identity.getIdToken()).resolves.toEqual(expect.any(String));
+      await expect(identity.getCredentials()).resolves.toEqual({
+        token: expect.any(String),
+      });
+      await expect(identity.getProfileInfo()).resolves.toEqual({
+        email: 'e',
+        displayName: 'd',
+        picture: 'p',
+      });
+      expect(identity.getUserId()).toBe('ue');
+      expect(identity.getProfile()).toEqual({
+        email: 'e',
+        displayName: 'd',
+        picture: 'p',
+      });
 
       await identity.getSessionAsync(); // no need to fetch again just yet
       expect(serverCalled).toBeCalledTimes(1);

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.ts
@@ -94,8 +94,14 @@ export class ProxiedSignInIdentity implements IdentityApi {
 
   /** {@inheritdoc @backstage/core-plugin-api#IdentityApi.getUserId} */
   getUserId(): string {
-    const session = this.getSessionSync();
-    return session.backstageIdentity.id;
+    const { backstageIdentity } = this.getSessionSync();
+    const ref = backstageIdentity.identity.userEntityRef;
+    const match = /^([^:/]+:)?([^:/]+\/)?([^:/]+)$/.exec(ref);
+    if (!match) {
+      throw new TypeError(`Invalid user entity reference "${ref}"`);
+    }
+
+    return match[3];
   }
 
   /** {@inheritdoc @backstage/core-plugin-api#IdentityApi.getIdToken} */

--- a/packages/core-components/src/layout/ProxiedSignInPage/types.test.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/types.test.ts
@@ -28,12 +28,11 @@ describe('types', () => {
       picture: 'p',
     },
     backstageIdentity: {
-      id: 'i',
       token: 't',
       identity: {
         type: 'user',
-        userEntityRef: 'ue',
-        ownershipEntityRefs: ['oe'],
+        userEntityRef: 'k:ns/ue',
+        ownershipEntityRefs: ['k:ns/oe'],
       },
     },
   };

--- a/packages/core-components/src/layout/ProxiedSignInPage/types.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/types.ts
@@ -28,7 +28,6 @@ export const proxiedSessionSchema = z.object({
     picture: z.string().optional(),
   }),
   backstageIdentity: z.object({
-    id: z.string(),
     token: z.string(),
     identity: z.object({
       type: z.literal('user'),
@@ -47,5 +46,5 @@ export const proxiedSessionSchema = z.object({
 export type ProxiedSession = {
   providerInfo?: { [key: string]: unknown };
   profile: ProfileInfo;
-  backstageIdentity: BackstageIdentityResponse;
+  backstageIdentity: Omit<BackstageIdentityResponse, 'id'>;
 };


### PR DESCRIPTION
Quick followup piggybacking on the existing changeset. This lines the logic up with the [UserIdentity](https://github.com/backstage/backstage/blob/bc5fe6c6c48c863d3ed7b55855489168bc4dc719/packages/core-components/src/layout/SignInPage/UserIdentity.ts#L86) API