### PR TITLE
azure-devops-backend: only warn if teams fail to load at startup

### DIFF
--- a/.changeset/cold-plums-hunt.md
+++ b/.changeset/cold-plums-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+Only warn if teams fail to load at startup.

--- a/plugins/azure-devops-backend/src/service/router.test.ts
+++ b/plugins/azure-devops-backend/src/service/router.test.ts
@@ -49,7 +49,7 @@ describe('createRouter', () => {
       getPullRequests: jest.fn(),
       getBuilds: jest.fn(),
       getBuildRuns: jest.fn(),
-      getAllTeams: jest.fn().mockReturnValue([]),
+      getAllTeams: jest.fn(),
       getTeamMembers: jest.fn(),
     } as any;
     const router = await createRouter({
@@ -411,6 +411,7 @@ describe('createRouter', () => {
 
   describe('GET /users/:userId/team-ids', () => {
     it('fetches a a list of teams', async () => {
+      azureDevOpsApi.getAllTeams.mockResolvedValue([]);
       const response = await request(app).get('/users/user1/team-ids');
       expect(response.status).toEqual(200);
     });

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -176,7 +176,7 @@ export async function createRouter(
 
   router.get('/users/:userId/team-ids', async (req, res) => {
     const { userId } = req.params;
-    const teamIds = pullRequestsDashboardProvider.getUserTeamIds(userId);
+    const teamIds = await pullRequestsDashboardProvider.getUserTeamIds(userId);
     res.status(200).json(teamIds);
   });
 


### PR DESCRIPTION
This is causing a bit of trouble in the example backend in master atm. Another option is to remove the azure-backend from the example backend for now

CC @marleypowell