### PR TITLE
STYLE: recommend prefixed type parameter names

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -15,6 +15,7 @@ Our TypeScript style is inspired by the [style guidelines](https://github.com/Mi
 1. Use camelCase for property names and local variables.
 1. Do not use `_` as a prefix for private properties.
 1. Use whole words in names when possible.
+1. Give type parameters names prefixed with `T`, for example `Request<TBody>`.
 
 ## Syntax and Types
 


### PR DESCRIPTION
A suggestion 😁 

Seeing this used pretty widely in new code. We've typically used `T` or unprefixed names, but this is much nicer in all ways imo