### PR TITLE
Include buildkite in example-app again

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -57,6 +57,7 @@
     "@roadiehq/backstage-plugin-github-insights": "^1.4.2",
     "@roadiehq/backstage-plugin-github-pull-requests": "^1.3.2",
     "@roadiehq/backstage-plugin-travis-ci": "^1.3.2",
+    "@roadiehq/backstage-plugin-buildkite": "^1.3.4",
     "history": "^5.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -125,6 +125,10 @@ import {
   isTravisciAvailable,
 } from '@roadiehq/backstage-plugin-travis-ci';
 import {
+  EntityBuildkiteContent,
+  isBuildkiteAvailable,
+} from '@roadiehq/backstage-plugin-buildkite';
+import {
   isNewRelicDashboardAvailable,
   EntityNewRelicDashboardContent,
   EntityNewRelicDashboardCard,
@@ -172,6 +176,10 @@ export const cicdContent = (
   <EntitySwitch>
     <EntitySwitch.Case if={isJenkinsAvailable}>
       <EntityJenkinsContent />
+    </EntitySwitch.Case>
+
+    <EntitySwitch.Case if={isBuildkiteAvailable}>
+      <EntityBuildkiteContent />
     </EntitySwitch.Case>
 
     <EntitySwitch.Case if={isCircleCIAvailable}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4562,7 +4562,7 @@
     react-beautiful-dnd "^13.0.0"
     react-double-scrollbar "0.0.15"
 
-"@material-ui/core@^4.11.0", "@material-ui/core@^4.11.3", "@material-ui/core@^4.12.2":
+"@material-ui/core@^4.11.0", "@material-ui/core@^4.11.3", "@material-ui/core@^4.12.1", "@material-ui/core@^4.12.2":
   version "4.12.3"
   resolved "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz#80d665caf0f1f034e52355c5450c0e38b099d3ca"
   integrity sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==
@@ -5375,6 +5375,27 @@
   version "3.2.1"
   resolved "https://registry.npmjs.org/@rjsf/material-ui/-/material-ui-3.2.1.tgz#84fbf322485aee3a84101e189161f0687779ec8d"
   integrity sha512-8UiDeDbjCImFSfOegGu13otQ7OdP9FOYpcLjeouppnhs+MPeIEAtYS+jCcBKmi3reyTagC15/KVSRhde1wS1vg==
+
+"@roadiehq/backstage-plugin-buildkite@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.npmjs.org/@roadiehq/backstage-plugin-buildkite/-/backstage-plugin-buildkite-1.3.4.tgz#ca58983aa3af5bec7aa72c0f7a8433dcf725da3f"
+  integrity sha512-Cye44GXopAhYiC6QSx/sDgtnBOPD+D4DAydasKjOmt59NJVbgltbDsLXq9oMeFez1OphypU7lWUecVnhYFze4g==
+  dependencies:
+    "@backstage/catalog-model" "^0.9.7"
+    "@backstage/core-components" "^0.8.0"
+    "@backstage/core-plugin-api" "^0.4.0"
+    "@backstage/plugin-catalog-react" "^0.6.5"
+    "@backstage/theme" "^0.2.6"
+    "@material-ui/core" "^4.12.1"
+    "@material-ui/icons" "^4.11.2"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    history "^5.0.0"
+    moment "^2.29.1"
+    react "^16.13.1"
+    react-dom "^16.13.1"
+    react-router "6.0.0-beta.0"
+    react-router-dom "6.0.0-beta.0"
+    react-use "^17.2.4"
 
 "@roadiehq/backstage-plugin-github-insights@^1.4.2":
   version "1.4.2"


### PR DESCRIPTION
Signed-off-by: irma12 <irma@roadie.io>

As a part of https://github.com/backstage/backstage/pull/8417 Buildkite plugin has been removed from the `example-app`.
As we have ported over usage of `react-lazylog` in favor of `LogViewer` component, maybe we can include it back again :) 
