### PR TITLE
catalog-backend: fix getResources

### DIFF
--- a/.changeset/neat-rice-stare.md
+++ b/.changeset/neat-rice-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix bug with resource loading in permission integration

--- a/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/NextCatalogBuilder.ts
@@ -417,7 +417,7 @@ export class NextCatalogBuilder {
     const permissionIntegrationRouter = createPermissionIntegrationRouter({
       resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
       getResources: async (resourceRefs: string[]) => {
-        const { entities } = await entitiesCatalog.entities({
+        const { entities } = await unauthorizedEntitiesCatalog.entities({
           filter: {
             anyOf: resourceRefs.map(resourceRef => {
               const { kind, namespace, name } = parseEntityRef(resourceRef);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The getResources method in catalog-backend should use the unauthorizedEntitiesCatalog to load resources, otherwise we end up authorizing access to entities during application of conditions.

This won't have any impact on consumers of the catalog-backend, since we're not expecting people to actually be using the permissions framework yet. Even in environments where permissions are enabled and the permission backend is running, this causes incorrect DENY responses, rather than errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
