### PR TITLE
Fix slightly out of date docs

### DIFF
--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -727,7 +727,7 @@ filtering templates, and should ideally match the Component
 You can find out more about the `parameters` key
 [here](../software-templates/writing-templates.md)
 
-### `spec.steps` [optional]
+### `spec.steps` [required]
 
 You can find out more about the `steps` key
 [here](../software-templates/writing-templates.md)


### PR DESCRIPTION
So these docs really need updating after the `v3` templates were released, but feeling that we should update these docs at the same time we deprecate `v2`. This value was made optional because `v1` didn't have these `steps` at all. But now the two supported versions require `steps`.
Signed-off-by: blam <ben@blam.sh>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
