### PR TITLE
feat(catalog-import): Make catalog filename and branch customizable

### DIFF
--- a/.changeset/tame-ads-exercise.md
+++ b/.changeset/tame-ads-exercise.md
@@ -1,0 +1,34 @@
+---
+'@backstage/plugin-catalog-import': minor
+---
+
+Make filename, branch name and examples URLs used in catalog import customizable.
+
+Catalog backend ingestion loop can be already configured to fetch targets with custom catalog filename (other than `catalog-info.yaml`). It's now possible to customize said filename and branch name used in pull requests created by catalog import flow too. This allows organizations to further customize Backstage experience and to better reflect their branding.
+
+Filename (default: `catalog-info.yaml`) and branch name (default: `backstage-integration`) used in pull requests can be configured in `app-config.yaml` as follows:
+
+```yaml
+// app-config.yaml
+
+catalog:
+  import:
+    entityFilename: anvil.yaml
+    pullRequestBranchName: anvil-integration
+```
+
+Following React components have also been updated to accept optional props for providing example entity and repository paths:
+
+```tsx
+<StepInitAnalyzeUrl
+  ...
+  exampleLocationUrl="https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml"
+/>
+```
+
+```tsx
+<ImportInfoCard
+  exampleLocationUrl="https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml"
+  exampleRepositoryUrl="https://github.com/acme-corp/our-awesome-api"
+/>
+```

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -196,6 +196,7 @@ integrations:
 catalog:
   import:
     entityFilename: catalog-info.yaml
+    pullRequestBranchName: backstage-integration
   rules:
     - allow:
         - Component

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -194,6 +194,8 @@ integrations:
       secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
 
 catalog:
+  import:
+    entityFilename: catalog-info.yaml
   rules:
     - allow:
         - Component

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -82,6 +82,7 @@ scaffolder:
 catalog:
   import:
     entityFilename: catalog-info.yaml
+    pullRequestBranchName: backstage-integration
   rules:
     - allow: [Component, System, API, Group, User, Resource, Location]
   locations:

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -80,6 +80,8 @@ scaffolder:
   # see https://backstage.io/docs/features/software-templates/configuration for software template options
 
 catalog:
+  import:
+    entityFilename: catalog-info.yaml
   rules:
     - allow: [Component, System, API, Group, User, Resource, Location]
   locations:

--- a/plugins/catalog-import/README.md
+++ b/plugins/catalog-import/README.md
@@ -35,41 +35,42 @@ import { CatalogImportPage } from '@backstage/plugin-catalog-import';
 
 ## Customizations
 
-### Disable the creation of Pull Requests
+A custom layout can be passed to the import page, as it's already
+supported by the search page. If no custom layout is passed, the default layout
+is used.
 
-The pull request feature can be disabled by options that are passed to the `CatalogImportPage`:
+```typescript
+<Route path="/catalog-import" element={<CatalogImportPage />}>
+  <Page themeId="home">
+    <Header title="Register an existing component" />
+    <Content>
+      <ContentHeader title="Start tracking your components">
+        <SupportButton>
+          Start tracking your component in Backstage by adding it to the
+          software catalog.
+        </SupportButton>
+      </ContentHeader>
 
-```tsx
-// packages/app/src/App.tsx
+      <Grid container spacing={2} direction="row-reverse">
+        <Grid item xs={12} md={4} lg={6} xl={8}>
+          Hello World
+        </Grid>
 
-<Route
-  path="/catalog-import"
-  element={<CatalogImportPage pullRequest={{ disable: true }} />}
-/>
+        <Grid item xs={12} md={8} lg={6} xl={4}>
+          <ImportStepper />
+        </Grid>
+      </Grid>
+    </Content>
+  </Page>
+</Route>
 ```
 
-### Customize the title and body of the Pull Request
-
-The pull request form is filled with a default title and body.
-This can be configured by options that are passed to the `CatalogImportPage`:
-
-```tsx
-// packages/app/src/App.tsx
-
-<Route
-  path="/catalog-import"
-  element={
-    <CatalogImportPage
-      pullRequest={{
-        preparePullRequest: () => ({
-          title: 'My title',
-          body: 'My **markdown** body',
-        }),
-      }}
-    />
-  }
-/>
-```
+Previously it was possible to disable and customize the automatic pull request
+feature by passing options to `<CatalogImportPage>` (`pullRequest.disable` and
+`pullRequest.preparePullRequest`). This functionality is moved to the
+`CatalogImportApi` which now provides an optional `preparePullRequest()`
+function. The function can either be overridden to generate a different content
+for the pull request, or removed to disable this feature.
 
 ## Development
 

--- a/plugins/catalog-import/README.md
+++ b/plugins/catalog-import/README.md
@@ -35,6 +35,8 @@ import { CatalogImportPage } from '@backstage/plugin-catalog-import';
 
 ## Customizations
 
+### Custom layout
+
 A custom layout can be passed to the import page, as it's already
 supported by the search page. If no custom layout is passed, the default layout
 is used.
@@ -71,6 +73,37 @@ feature by passing options to `<CatalogImportPage>` (`pullRequest.disable` and
 `CatalogImportApi` which now provides an optional `preparePullRequest()`
 function. The function can either be overridden to generate a different content
 for the pull request, or removed to disable this feature.
+
+### Entity filename and branch name
+
+Entity filename (default: `catalog-info.yaml`) and branch name (default: `backstage-integration`) used in pull requests can be configured in `app-config.yaml` as follows:
+
+```yaml
+// app-config.yaml
+
+catalog:
+  import:
+    entityFilename: anvil.yaml
+    pullRequestBranchName: anvil-integration
+```
+
+### Entity examples
+
+Following React components accept optional props for providing custom example entity and repository paths:
+
+```tsx
+<StepInitAnalyzeUrl
+  ...
+  exampleLocationUrl="https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml"
+/>
+```
+
+```tsx
+<ImportInfoCard
+  exampleLocationUrl="https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml"
+  exampleRepositoryUrl="https://github.com/acme-corp/our-awesome-api"
+/>
+```
 
 ## Development
 

--- a/plugins/catalog-import/api-report.md
+++ b/plugins/catalog-import/api-report.md
@@ -60,7 +60,7 @@ export const AutocompleteTextField: <TFieldValue extends string>({
   helperText,
   errorHelperText,
   textFieldProps,
-}: Props_4<TFieldValue>) => JSX.Element;
+}: Props_5<TFieldValue>) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "CatalogImportApi" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -171,10 +171,14 @@ export const EntityListComponent: ({
   withLinks,
 }: Props) => JSX.Element;
 
+// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ImportInfoCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const ImportInfoCard: () => JSX.Element;
+export const ImportInfoCard: ({
+  exampleLocationUrl,
+  exampleRepositoryUrl,
+}: Props_2) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "ImportStepper" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -184,7 +188,7 @@ export const ImportStepper: ({
   initialUrl,
   generateStepper,
   variant,
-}: Props_2) => JSX.Element;
+}: Props_3) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "PreparePullRequestForm" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -196,7 +200,7 @@ export const PreparePullRequestForm: <
   defaultValues,
   onSubmit,
   render,
-}: Props_5<TFieldValues>) => JSX.Element;
+}: Props_6<TFieldValues>) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "PreviewCatalogInfoComponent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -206,7 +210,7 @@ export const PreviewCatalogInfoComponent: ({
   repositoryUrl,
   entities,
   classes,
-}: Props_6) => JSX.Element;
+}: Props_7) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "PreviewPullRequestComponent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -216,7 +220,7 @@ export const PreviewPullRequestComponent: ({
   title,
   description,
   classes,
-}: Props_7) => JSX.Element;
+}: Props_8) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "StepInitAnalyzeUrl" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -226,7 +230,8 @@ export const StepInitAnalyzeUrl: ({
   onAnalysis,
   analysisUrl,
   disablePullRequest,
-}: Props_3) => JSX.Element;
+  exampleLocationUrl,
+}: Props_4) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "StepPrepareCreatePullRequest" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -237,7 +242,7 @@ export const StepPrepareCreatePullRequest: ({
   onPrepare,
   onGoBack,
   renderFormFields,
-}: Props_8) => JSX.Element;
+}: Props_9) => JSX.Element;
 
 // Warnings were encountered during analysis:
 //

--- a/plugins/catalog-import/config.d.ts
+++ b/plugins/catalog-import/config.d.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  /**
+   * Configuration options for the catalog plugin.
+   */
+  catalog?: {
+    /**
+     * List of import flow specific options and attributes
+     */
+    import?: {
+      /**
+       * Catalog entity descriptor filename, defaults to "catalog-info.yaml"
+       * @visibility frontend
+       */
+      entityFilename?: string;
+    };
+  };
+}

--- a/plugins/catalog-import/config.d.ts
+++ b/plugins/catalog-import/config.d.ts
@@ -28,6 +28,13 @@ export interface Config {
        * @visibility frontend
        */
       entityFilename?: string;
+      /**
+       * A branch name used in pull request when registering existing component via UI
+       * Valid git refname required, see: https://git-scm.com/docs/git-check-ref-format
+       * Defaults to "backstage-integration"
+       * @visibility frontend
+       */
+      pullRequestBranchName?: string;
     };
   };
 }

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -69,6 +69,8 @@
     "msw": "^0.35.0"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -34,6 +34,7 @@
     "@backstage/catalog-client": "^0.5.5",
     "@backstage/catalog-model": "^0.9.10",
     "@backstage/core-components": "^0.8.6",
+    "@backstage/config": "^0.1.13",
     "@backstage/core-plugin-api": "^0.6.0",
     "@backstage/errors": "^0.2.0",
     "@backstage/integration": "^0.7.2",

--- a/plugins/catalog-import/src/api/CatalogImportClient.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.test.ts
@@ -396,6 +396,84 @@ describe('CatalogImportClient', () => {
         ],
       });
     });
+
+    it('should find location with custom catalog filename', async () => {
+      const repositoryUrl = 'https://github.com/acme-corp/our-awesome-api';
+      const entityFilename = 'anvil.yaml';
+
+      catalogImportClient = new CatalogImportClient({
+        discoveryApi,
+        scmAuthApi,
+        scmIntegrationsApi,
+        identityApi,
+        catalogApi,
+        configApi: new ConfigReader({
+          catalog: {
+            import: {
+              entityFilename,
+            },
+          },
+        }),
+      });
+
+      (new Octokit().search.code as any as jest.Mock).mockImplementationOnce(
+        async params => ({
+          data: {
+            total_count: 1,
+            items: [{ path: params.q.split('+filename:').slice(-1)[0] }],
+          },
+        }),
+      );
+
+      catalogApi.addLocation.mockImplementation(async ({ type, target }) => ({
+        location: {
+          id: 'id-0',
+          type: type ?? 'url',
+          target,
+        },
+        entities: [
+          {
+            apiVersion: '1',
+            kind: 'Location',
+            metadata: {
+              name: 'my-entity',
+              namespace: 'my-namespace',
+            },
+          },
+          {
+            apiVersion: '1',
+            kind: 'Component',
+            metadata: {
+              name: 'my-entity',
+              namespace: 'my-namespace',
+            },
+          },
+        ],
+      }));
+
+      await expect(
+        catalogImportClient.analyzeUrl(repositoryUrl),
+      ).resolves.toEqual({
+        locations: [
+          {
+            entities: [
+              {
+                kind: 'Location',
+                namespace: 'my-namespace',
+                name: 'my-entity',
+              },
+              {
+                kind: 'Component',
+                namespace: 'my-namespace',
+                name: 'my-entity',
+              },
+            ],
+            target: `${repositoryUrl}/blob/main/${entityFilename}`,
+          },
+        ],
+        type: 'locations',
+      });
+    });
   });
 
   describe('submitPullRequest', () => {
@@ -443,12 +521,102 @@ describe('CatalogImportClient', () => {
         base: 'main',
       });
     });
+
+    it('should create GitHub pull request with custom filename and branch name', async () => {
+      const entityFilename = 'anvil.yaml';
+      const pullRequestBranchName = 'anvil-integration';
+
+      catalogImportClient = new CatalogImportClient({
+        discoveryApi,
+        scmAuthApi,
+        scmIntegrationsApi,
+        identityApi,
+        catalogApi,
+        configApi: new ConfigReader({
+          catalog: {
+            import: {
+              entityFilename,
+              pullRequestBranchName,
+            },
+          },
+        }),
+      });
+
+      await expect(
+        catalogImportClient.submitPullRequest({
+          repositoryUrl: 'https://github.com/acme-corp/our-awesome-api',
+          fileContent: '',
+          title: `Add ${entityFilename} config file`,
+          body: `Add ${entityFilename} config file`,
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          link: 'http://pull/request/0',
+          location: `https://github.com/acme-corp/our-awesome-api/blob/main/${entityFilename}`,
+        }),
+      );
+
+      expect(
+        (new Octokit().git.createRef as any as jest.Mock).mock.calls[0][0],
+      ).toEqual(
+        expect.objectContaining({
+          ref: `refs/heads/${pullRequestBranchName}`,
+        }),
+      );
+
+      expect(
+        (new Octokit().repos.createOrUpdateFileContents as any as jest.Mock)
+          .mock.calls[0][0],
+      ).toEqual(
+        expect.objectContaining({
+          path: entityFilename,
+          branch: pullRequestBranchName,
+        }),
+      );
+
+      expect(
+        (new Octokit().pulls.create as any as jest.Mock).mock.calls[0][0],
+      ).toEqual(
+        expect.objectContaining({
+          head: pullRequestBranchName,
+        }),
+      );
+    });
   });
 
   describe('preparePullRequest', () => {
     test('should prepare pull request details', async () => {
       await expect(catalogImportClient.preparePullRequest()).resolves.toEqual({
         title: 'Add catalog-info.yaml config file',
+        body: expect.any(String),
+      });
+    });
+
+    test('should prepare pull request details with custom filename', async () => {
+      const entityFilename = 'anvil.yaml';
+      const pullRequestBranchName = 'anvil-integration';
+
+      catalogImportClient = new CatalogImportClient({
+        discoveryApi,
+        scmAuthApi,
+        scmIntegrationsApi,
+        identityApi,
+        catalogApi,
+        configApi: new ConfigReader({
+          catalog: {
+            import: {
+              entityFilename,
+              pullRequestBranchName,
+            },
+          },
+          app: {
+            baseUrl: 'https://demo.backstage.io/',
+          },
+        }),
+      });
+
+      await expect(catalogImportClient.preparePullRequest()).resolves.toEqual({
+        title: `Add ${entityFilename} config file`,
         body: expect.any(String),
       });
     });

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -87,13 +87,17 @@ export class CatalogImportClient implements CatalogImportApi {
     const ghConfig = getGithubIntegrationConfig(this.scmIntegrationsApi, url);
     if (!ghConfig) {
       const other = this.scmIntegrationsApi.byUrl(url);
+      const catalogFilename =
+        this.configApi.getOptionalString('catalog.import.entityFilename') ??
+        'catalog-info.yaml';
+
       if (other) {
         throw new Error(
-          `The ${other.title} integration only supports full URLs to catalog-info.yaml files. Did you try to pass in the URL of a directory instead?`,
+          `The ${other.title} integration only supports full URLs to ${catalogFilename} files. Did you try to pass in the URL of a directory instead?`,
         );
       }
       throw new Error(
-        'This URL was not recognized as a valid GitHub URL because there was no configured integration that matched the given host name. You could try to paste the full URL to a catalog-info.yaml file instead.',
+        `This URL was not recognized as a valid GitHub URL because there was no configured integration that matched the given host name. You could try to paste the full URL to a ${catalogFilename} file instead.`,
       );
     }
 
@@ -127,9 +131,12 @@ export class CatalogImportClient implements CatalogImportApi {
     const appTitle =
       this.configApi.getOptionalString('app.title') ?? 'Backstage';
     const appBaseUrl = this.configApi.getString('app.baseUrl');
+    const catalogFilename =
+      this.configApi.getOptionalString('catalog.import.entityFilename') ??
+      'catalog-info.yaml';
 
     return {
-      title: 'Add catalog-info.yaml config file',
+      title: `Add ${catalogFilename} config file`,
       body: `This pull request adds a **Backstage entity metadata file** \
 to this repository so that the component can be added to the \
 [${appTitle} software catalog](${appBaseUrl}).\n\nAfter this pull request is merged, \
@@ -221,8 +228,10 @@ the component will become available.\n\nFor more information, read an \
       auth: token,
       baseUrl: githubIntegrationConfig.apiBaseUrl,
     });
-    const catalogFileName = 'catalog-info.yaml';
-    const query = `repo:${owner}/${repo}+filename:${catalogFileName}`;
+    const catalogFilename =
+      this.configApi.getOptionalString('catalog.import.entityFilename') ??
+      'catalog-info.yaml';
+    const query = `repo:${owner}/${repo}+filename:${catalogFilename}`;
 
     const searchResult = await octo.search.code({ q: query }).catch(e => {
       throw new Error(
@@ -295,7 +304,9 @@ the component will become available.\n\nFor more information, read an \
     });
 
     const branchName = 'backstage-integration';
-    const fileName = 'catalog-info.yaml';
+    const fileName =
+      this.configApi.getOptionalString('catalog.import.entityFilename') ??
+      'catalog-info.yaml';
 
     const repoData = await octo.repos
       .get({

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -303,7 +303,9 @@ the component will become available.\n\nFor more information, read an \
       baseUrl: githubIntegrationConfig.apiBaseUrl,
     });
 
-    const branchName = 'backstage-integration';
+    const branchName =
+      this.configApi.getOptionalString('catalog.pullRequestBranchName') ??
+      'backstage-integration';
     const fileName =
       this.configApi.getOptionalString('catalog.import.entityFilename') ??
       'catalog-info.yaml';

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -32,6 +32,7 @@ import { PartialEntity } from '../types';
 import { AnalyzeResult, CatalogImportApi } from './CatalogImportApi';
 import { getGithubIntegrationConfig } from './GitHub';
 import { trimEnd } from 'lodash';
+import { getBranchName, getCatalogFilename } from '../components/helpers';
 
 export class CatalogImportClient implements CatalogImportApi {
   private readonly discoveryApi: DiscoveryApi;
@@ -87,9 +88,7 @@ export class CatalogImportClient implements CatalogImportApi {
     const ghConfig = getGithubIntegrationConfig(this.scmIntegrationsApi, url);
     if (!ghConfig) {
       const other = this.scmIntegrationsApi.byUrl(url);
-      const catalogFilename =
-        this.configApi.getOptionalString('catalog.import.entityFilename') ??
-        'catalog-info.yaml';
+      const catalogFilename = getCatalogFilename(this.configApi);
 
       if (other) {
         throw new Error(
@@ -131,9 +130,7 @@ export class CatalogImportClient implements CatalogImportApi {
     const appTitle =
       this.configApi.getOptionalString('app.title') ?? 'Backstage';
     const appBaseUrl = this.configApi.getString('app.baseUrl');
-    const catalogFilename =
-      this.configApi.getOptionalString('catalog.import.entityFilename') ??
-      'catalog-info.yaml';
+    const catalogFilename = getCatalogFilename(this.configApi);
 
     return {
       title: `Add ${catalogFilename} config file`,
@@ -228,9 +225,7 @@ the component will become available.\n\nFor more information, read an \
       auth: token,
       baseUrl: githubIntegrationConfig.apiBaseUrl,
     });
-    const catalogFilename =
-      this.configApi.getOptionalString('catalog.import.entityFilename') ??
-      'catalog-info.yaml';
+    const catalogFilename = getCatalogFilename(this.configApi);
     const query = `repo:${owner}/${repo}+filename:${catalogFilename}`;
 
     const searchResult = await octo.search.code({ q: query }).catch(e => {
@@ -303,12 +298,8 @@ the component will become available.\n\nFor more information, read an \
       baseUrl: githubIntegrationConfig.apiBaseUrl,
     });
 
-    const branchName =
-      this.configApi.getOptionalString('catalog.pullRequestBranchName') ??
-      'backstage-integration';
-    const fileName =
-      this.configApi.getOptionalString('catalog.import.entityFilename') ??
-      'catalog-info.yaml';
+    const branchName = getBranchName(this.configApi);
+    const fileName = getCatalogFilename(this.configApi);
 
     const repoData = await octo.repos
       .get({

--- a/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
+++ b/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
@@ -28,6 +28,10 @@ export const ImportInfoCard = () => {
   const integrations = configApi.getConfig('integrations');
   const hasGithubIntegration = integrations.has('github');
 
+  const catalogFilename =
+    configApi.getOptionalString('catalog.import.entityFilename') ??
+    'catalog-info.yaml';
+
   return (
     <InfoCard
       title="Register an existing component"
@@ -60,14 +64,14 @@ export const ImportInfoCard = () => {
             Example: <code>https://github.com/backstage/backstage</code>
           </Typography>
           <Typography variant="body2" paragraph>
-            The wizard discovers all <code>catalog-info.yaml</code> files in the
+            The wizard discovers all <code>{catalogFilename}</code> files in the
             repository, previews the entities, and adds them to the {appTitle}{' '}
             catalog.
           </Typography>
           {catalogImportApi.preparePullRequest && (
             <Typography variant="body2" paragraph>
               If no entities are found, the wizard will prepare a Pull Request
-              that adds an example <code>catalog-info.yaml</code> and prepares
+              that adds an example <code>{catalogFilename}</code> and prepares
               the {appTitle} catalog to load all entities as soon as the Pull
               Request is merged.
             </Typography>

--- a/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
+++ b/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
@@ -19,6 +19,7 @@ import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { Chip, Typography } from '@material-ui/core';
 import React from 'react';
 import { catalogImportApiRef } from '../../api';
+import { useCatalogFilename } from '../../hooks';
 
 type Props = {
   exampleLocationUrl?: string;
@@ -36,9 +37,7 @@ export const ImportInfoCard = ({
   const integrations = configApi.getConfig('integrations');
   const hasGithubIntegration = integrations.has('github');
 
-  const catalogFilename =
-    configApi.getOptionalString('catalog.import.entityFilename') ??
-    'catalog-info.yaml';
+  const catalogFilename = useCatalogFilename();
 
   return (
     <InfoCard

--- a/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
+++ b/plugins/catalog-import/src/components/ImportInfoCard/ImportInfoCard.tsx
@@ -20,7 +20,15 @@ import { Chip, Typography } from '@material-ui/core';
 import React from 'react';
 import { catalogImportApiRef } from '../../api';
 
-export const ImportInfoCard = () => {
+type Props = {
+  exampleLocationUrl?: string;
+  exampleRepositoryUrl?: string;
+};
+
+export const ImportInfoCard = ({
+  exampleLocationUrl = 'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+  exampleRepositoryUrl = 'https://github.com/backstage/backstage',
+}: Props) => {
   const configApi = useApi(configApiRef);
   const appTitle = configApi.getOptional('app.title') || 'Backstage';
   const catalogImportApi = useApi(catalogImportApiRef);
@@ -45,10 +53,7 @@ export const ImportInfoCard = () => {
       </Typography>
       <Typography variant="h6">Link to an existing entity file</Typography>
       <Typography variant="subtitle2" color="textSecondary" paragraph>
-        Example:{' '}
-        <code>
-          https://github.com/backstage/backstage/blob/master/catalog-info.yaml
-        </code>
+        Example: <code>{exampleLocationUrl}</code>
       </Typography>
       <Typography variant="body2" paragraph>
         The wizard analyzes the file, previews the entities, and adds them to
@@ -61,7 +66,7 @@ export const ImportInfoCard = () => {
             <Chip label="GitHub only" variant="outlined" size="small" />
           </Typography>
           <Typography variant="subtitle2" color="textSecondary" paragraph>
-            Example: <code>https://github.com/backstage/backstage</code>
+            Example: <code>{exampleRepositoryUrl}</code>
           </Typography>
           <Typography variant="body2" paragraph>
             The wizard discovers all <code>{catalogFilename}</code> files in the

--- a/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
+++ b/plugins/catalog-import/src/components/StepInitAnalyzeUrl/StepInitAnalyzeUrl.tsx
@@ -36,6 +36,7 @@ type Props = {
   ) => void;
   disablePullRequest?: boolean;
   analysisUrl?: string;
+  exampleLocationUrl?: string;
 };
 
 /**
@@ -49,6 +50,7 @@ export const StepInitAnalyzeUrl = ({
   onAnalysis,
   analysisUrl = '',
   disablePullRequest = false,
+  exampleLocationUrl = 'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
 }: Props) => {
   const errorApi = useApi(errorApiRef);
   const catalogImportApi = useApi(catalogImportApiRef);
@@ -138,7 +140,7 @@ export const StepInitAnalyzeUrl = ({
         fullWidth
         id="url"
         label="Repository URL"
-        placeholder="https://github.com/backstage/backstage/blob/master/catalog-info.yaml"
+        placeholder={exampleLocationUrl}
         helperText="Enter the full path to your entity file to start tracking your component"
         margin="normal"
         variant="outlined"

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreviewCatalogInfoComponent.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreviewCatalogInfoComponent.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { ApiProvider } from '@backstage/core-app-api';
 import { configApiRef } from '@backstage/core-plugin-api';
-import { TestApiRegistry, MockConfigApi } from '@backstage/test-utils';
+import { MockConfigApi, TestApiProvider } from '@backstage/test-utils';
 import { makeStyles } from '@material-ui/core';
 import { render, screen } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
@@ -48,18 +47,17 @@ const entities: Entity[] = [
 ];
 
 const mockConfigApi = new MockConfigApi({});
-
-const apis = TestApiRegistry.from([configApiRef, mockConfigApi]);
+const apis = [[configApiRef, mockConfigApi]] as const;
 
 describe('<PreviewCatalogInfoComponent />', () => {
   it('renders without exploding', () => {
     render(
-      <ApiProvider apis={apis}>
+      <TestApiProvider apis={apis}>
         <PreviewCatalogInfoComponent
           repositoryUrl="http://my-repository/a/"
           entities={entities}
         />
-      </ApiProvider>,
+      </TestApiProvider>,
     );
 
     const repositoryUrl = screen.getByText(
@@ -76,13 +74,13 @@ describe('<PreviewCatalogInfoComponent />', () => {
     const { result } = renderHook(() => useStyles());
 
     render(
-      <ApiProvider apis={apis}>
+      <TestApiProvider apis={apis}>
         <PreviewCatalogInfoComponent
           repositoryUrl="http://my-repository/a/"
           entities={entities}
           classes={{ card: result.current.displayNone }}
         />
-      </ApiProvider>,
+      </TestApiProvider>,
     );
 
     const repositoryUrl = screen.getByText(
@@ -99,13 +97,13 @@ describe('<PreviewCatalogInfoComponent />', () => {
     const { result } = renderHook(() => useStyles());
 
     render(
-      <ApiProvider apis={apis}>
+      <TestApiProvider apis={apis}>
         <PreviewCatalogInfoComponent
           repositoryUrl="http://my-repository/a/"
           entities={entities}
           classes={{ cardContent: result.current.displayNone }}
         />
-      </ApiProvider>,
+      </TestApiProvider>,
     );
 
     const repositoryUrl = screen.getByText(
@@ -120,23 +118,25 @@ describe('<PreviewCatalogInfoComponent />', () => {
 
   it('renders with custom catalog filename', () => {
     render(
-      <ApiProvider
-        apis={TestApiRegistry.from([
-          configApiRef,
-          new MockConfigApi({
-            catalog: {
-              import: {
-                entityFilename: 'anvil.yaml',
+      <TestApiProvider
+        apis={[
+          [
+            configApiRef,
+            new MockConfigApi({
+              catalog: {
+                import: {
+                  entityFilename: 'anvil.yaml',
+                },
               },
-            },
-          }),
-        ])}
+            }),
+          ],
+        ]}
       >
         <PreviewCatalogInfoComponent
           repositoryUrl="http://acme-corp/awesome-api/"
           entities={entities}
         />
-      </ApiProvider>,
+      </TestApiProvider>,
     );
 
     const repositoryUrl = screen.getByText(

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreviewCatalogInfoComponent.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreviewCatalogInfoComponent.tsx
@@ -19,8 +19,8 @@ import { Card, CardContent, CardHeader } from '@material-ui/core';
 import React from 'react';
 import YAML from 'yaml';
 import { CodeSnippet } from '@backstage/core-components';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { trimEnd } from 'lodash';
+import { useCatalogFilename } from '../../hooks';
 
 type Props = {
   repositoryUrl: string;
@@ -33,10 +33,7 @@ export const PreviewCatalogInfoComponent = ({
   entities,
   classes,
 }: Props) => {
-  const configApi = useApi(configApiRef);
-  const catalogFilename =
-    configApi.getOptionalString('catalog.import.entityFilename') ??
-    'catalog-info.yaml';
+  const catalogFilename = useCatalogFilename();
 
   return (
     <Card variant="outlined" className={classes?.card}>

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreviewCatalogInfoComponent.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/PreviewCatalogInfoComponent.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent, CardHeader } from '@material-ui/core';
 import React from 'react';
 import YAML from 'yaml';
 import { CodeSnippet } from '@backstage/core-components';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { trimEnd } from 'lodash';
 
 type Props = {
@@ -32,11 +33,16 @@ export const PreviewCatalogInfoComponent = ({
   entities,
   classes,
 }: Props) => {
+  const configApi = useApi(configApiRef);
+  const catalogFilename =
+    configApi.getOptionalString('catalog.import.entityFilename') ??
+    'catalog-info.yaml';
+
   return (
     <Card variant="outlined" className={classes?.card}>
       <CardHeader
         title={
-          <code>{`${trimEnd(repositoryUrl, '/')}/catalog-info.yaml`}</code>
+          <code>{`${trimEnd(repositoryUrl, '/')}/${catalogFilename}`}</code>
         }
       />
 

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { errorApiRef } from '@backstage/core-plugin-api';
+import { configApiRef, errorApiRef } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
-import { TestApiProvider } from '@backstage/test-utils';
+import { TestApiProvider, MockConfigApi } from '@backstage/test-utils';
 import { TextField } from '@material-ui/core';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -53,12 +53,15 @@ describe('<StepPrepareCreatePullRequest />', () => {
     post: jest.fn(),
   };
 
+  const configApi = new MockConfigApi({});
+
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (
     <TestApiProvider
       apis={[
         [catalogImportApiRef, catalogImportApi],
         [catalogApiRef, catalogApi],
         [errorApiRef, errorApi],
+        [configApiRef, configApi],
       ]}
     >
       {children}

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { configApiRef, errorApiRef, useApi } from '@backstage/core-plugin-api';
+import { errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { assertError } from '@backstage/errors';
 import {
   catalogApiRef,
@@ -28,6 +28,7 @@ import { UnpackNestedValue, UseFormReturn } from 'react-hook-form';
 import useAsync from 'react-use/lib/useAsync';
 import YAML from 'yaml';
 import { AnalyzeResult, catalogImportApiRef } from '../../api';
+import { useCatalogFilename } from '../../hooks';
 import { PartialEntity } from '../../types';
 import { BackButton, NextButton } from '../Buttons';
 import { PrepareResult } from '../useImportState';
@@ -102,14 +103,11 @@ export const StepPrepareCreatePullRequest = ({
   const catalogApi = useApi(catalogApiRef);
   const catalogImportApi = useApi(catalogImportApiRef);
   const errorApi = useApi(errorApiRef);
-  const configApi = useApi(configApiRef);
 
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string>();
 
-  const catalogFilename =
-    configApi.getOptionalString('catalog.import.entityFilename') ??
-    'catalog-info.yaml';
+  const catalogFilename = useCatalogFilename();
 
   const {
     loading: prDefaultsLoading,

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { errorApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { assertError } from '@backstage/errors';
 import {
   catalogApiRef,
@@ -102,9 +102,14 @@ export const StepPrepareCreatePullRequest = ({
   const catalogApi = useApi(catalogApiRef);
   const catalogImportApi = useApi(catalogImportApiRef);
   const errorApi = useApi(errorApiRef);
+  const configApi = useApi(configApiRef);
 
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string>();
+
+  const catalogFilename =
+    configApi.getOptionalString('catalog.import.entityFilename') ??
+    'catalog-info.yaml';
 
   const {
     loading: prDefaultsLoading,
@@ -193,7 +198,7 @@ export const StepPrepareCreatePullRequest = ({
     <>
       <Typography>
         You entered a link to a {analyzeResult.integrationType} repository but a{' '}
-        <code>catalog-info.yaml</code> could not be found. Use this form to open
+        <code>{catalogFilename}</code> could not be found. Use this form to open
         a Pull Request that creates one.
       </Typography>
 

--- a/plugins/catalog-import/src/components/helpers.ts
+++ b/plugins/catalog-import/src/components/helpers.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { Config } from '@backstage/config';
 import { UseFormRegisterReturn } from 'react-hook-form';
 
 /**
@@ -30,4 +31,18 @@ export function asInputRef(renderResult: UseFormRegisterReturn) {
     inputRef: ref,
     ...rest,
   };
+}
+
+export function getCatalogFilename(config: Config): string {
+  return (
+    config.getOptionalString('catalog.import.entityFilename') ??
+    'catalog-info.yaml'
+  );
+}
+
+export function getBranchName(config: Config): string {
+  return (
+    config.getOptionalString('catalog.import.pullRequestBranchName') ??
+    'backstage-integration'
+  );
 }

--- a/plugins/catalog-import/src/hooks/index.ts
+++ b/plugins/catalog-import/src/hooks/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { useCatalogFilename } from './useCatalogFilename';

--- a/plugins/catalog-import/src/hooks/useCatalogFilename.ts
+++ b/plugins/catalog-import/src/hooks/useCatalogFilename.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
+import { getCatalogFilename } from '../components/helpers';
+
+export function useCatalogFilename(): string {
+  const config = useApi(configApiRef);
+
+  return getCatalogFilename(config);
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

[Documentation](https://backstage.io/docs/features/software-catalog/descriptor-format) suggest using `catalog-info.yaml` as entity descriptor filename but as mentioned in ADR [here](https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr008-default-catalog-file-name.md) it's not a requirement. Based on Discord discussion related to [this](https://discord.com/channels/687207715902193673/928654066538647552) matter and how core plugins [should](https://discord.com/channels/687207715902193673/687207715902193679/791036454767165480) be configurable enough I decided to give this a shot and implement it as a system configuration option.

The use case for this is as presented in Discord dicussion; our organization is already using custom filename for catalog entity descriptors which work fine with the automatic catalog ingestion loop. However catalog import (`plugin-catalog-import`) / register an existing component -flow uses a hardcoded value of `catalog-info.yaml` which we would like to also customize. 

This PR introduces configuration options for both catalog filename and the branch name used in pull requests. Besides these, optional props for `StepInitAnalyzeUrl` and `ImportInfoCard` are introduced to allow customization of the example paths. 
This is the part I'm a bit unsure of; as `StepInitAnalyzeUrl` is used deep in the state machine of `ImportStepper`. I wouldn't like to have to copy-paste the entire implementation just to customize this one example path. However, such as implemented providing this prop by using custom stepper with `ImportStepper` can be achieved with minimal effort. 
If you have alternative ideas I'm happy to hear them.

```tsx
const customStepper = (
  flow: ImportFlows,
  defaults: StepperProvider,
): StepperProvider => {
  const stepper = defaultGenerateStepper(flow, defaults);

  return {
    ...stepper,
    analyze: (state, { apis }) => ({
      stepLabel: <StepLabel>Select URL</StepLabel>,
      content: (
        <StepInitAnalyzeUrl
          key="analyze"
          analysisUrl={state.analysisUrl}
          onAnalysis={state.onAnalysis}
          disablePullRequest={!apis.catalogImportApi.preparePullRequest}
          exampleEntityFilepath="https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml"
        />
      ),
    }),
  };
};

// App.tsx
const routes = (
    ...
    <Route path="/catalog-import" element={<CatalogImportPage />}>
      <Page themeId="home">
        <Header title="Register an existing component" />
        <Content>
          <ContentHeader title="Start tracking your components">
            <SupportButton>
              Start tracking your component in ACME Developer Portal by adding it to the
              software catalog.
            </SupportButton>
          </ContentHeader>

          <Grid container spacing={2} direction="row-reverse">
            <Grid item xs={12} md={4} lg={6} xl={8}>
              <ImportInfoCard
                exampleEntityFilepath="https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml"
                exampleRepositoryPath="https://github.com/acme-corp/our-awesome-api"
              />
            </Grid>

            <Grid item xs={12} md={8} lg={6} xl={4}>
              <ImportStepper generateStepper={customStepper} />
            </Grid>
          </Grid>
        </Content>
      </Page>
    </Route>
);
```

Screenshots of the catalog import flow showcasing the customizations:

<img width="1383" alt="Screenshot 2022-01-14 at 13 15 44" src="https://user-images.githubusercontent.com/2776729/149507401-79c5ad0c-8d67-481e-9920-1442e5f237a3.png">
<img width="685" alt="Screenshot 2022-01-14 at 13 14 36" src="https://user-images.githubusercontent.com/2776729/149507456-ed7045cf-d767-424f-b510-450124f53353.png">
<img width="686" alt="Screenshot 2022-01-14 at 13 15 24" src="https://user-images.githubusercontent.com/2776729/149507475-a658fdf2-ffa4-4832-95fe-d32b5540a09d.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
