### PR TITLE
Publish pre-releases under `next` npm dist tag

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -192,7 +192,12 @@ jobs:
 
       # Publishes current version of packages that are not already present in the registry
       - name: publish
-        run: yarn lerna -- publish from-package --yes
+        run: |
+          if [ -f ".changeset/pre.json" ]; then
+              yarn lerna -- publish from-package --yes --dist-tag next
+          else
+              yarn lerna -- publish from-package --yes
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Make sure that as long as there is a `changeset/pre.json` all packages should be published under the `next` dist tag in npm.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
