### PR TITLE
catalog-react: improve handling of groups with 0 items in UserListPicker

### DIFF
--- a/.changeset/itchy-bulldogs-dance.md
+++ b/.changeset/itchy-bulldogs-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix bug with filter resetting based on user ownership

--- a/.changeset/itchy-bulldogs-dance.md
+++ b/.changeset/itchy-bulldogs-dance.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-Fix bug with filter resetting based on user ownership
+Fix bug: previously the filter would be set to "all" on page load, even if the `initiallySelectedFilter` on the `DefaultCatalogPage` was set to something else, or a different query param was supplied. Now, the prop and query params control the filter as expected. Additionally, after this change any filters which match 0 items will be disabled, and the filter will be reverted to 'all' if they're set on page load.

--- a/.changeset/itchy-bulldogs-dance.md
+++ b/.changeset/itchy-bulldogs-dance.md
@@ -2,4 +2,9 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-Fix bug: previously the filter would be set to "all" on page load, even if the `initiallySelectedFilter` on the `DefaultCatalogPage` was set to something else, or a different query param was supplied. Now, the prop and query params control the filter as expected. Additionally, after this change any filters which match 0 items will be disabled, and the filter will be reverted to 'all' if they're set on page load.
+Fix bug: previously the filter would be set to "all" on page load, even if the
+`initiallySelectedFilter` on the `DefaultCatalogPage` was set to something else,
+or a different query parameter was supplied. Now, the prop and query parameters
+control the filter as expected. Additionally, after this change any filters
+which match 0 items will be disabled, and the filter will be reverted to 'all'
+if they're set on page load.

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -233,6 +233,7 @@ export const UserListPicker = ({
                   onClick={() => setSelectedUserFilter(item.id)}
                   selected={item.id === filters.user?.value}
                   className={classes.menuItem}
+                  disabled={getFilterCount(item.id) === 0}
                 >
                   {item.icon && (
                     <ListItemIcon className={classes.listIcon}>

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -231,6 +231,7 @@ export const UserListPicker = ({
                   selected={item.id === filters.user?.value}
                   className={classes.menuItem}
                   disabled={filterCounts[item.id] === 0}
+                  data-testid={`user-picker-${item.id}`}
                 >
                   {item.icon && (
                     <ListItemIcon className={classes.listIcon}>
@@ -238,12 +239,7 @@ export const UserListPicker = ({
                     </ListItemIcon>
                   )}
                   <ListItemText>
-                    <Typography
-                      variant="body1"
-                      data-testid={`user-picker-${item.id}`}
-                    >
-                      {item.label}
-                    </Typography>
+                    <Typography variant="body1">{item.label}</Typography>
                   </ListItemText>
                   <ListItemSecondaryAction>
                     {filterCounts[item.id] ?? '-'}

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -263,10 +263,12 @@ describe('DefaultCatalogPage', () => {
     const { getByTestId } = await renderWrapped(<DefaultCatalogPage />);
     fireEvent.click(getByTestId('user-picker-owned'));
     await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('user-picker-starred'));
-    await expect(
-      screen.findByText(/Starred \(0\)/),
-    ).resolves.toBeInTheDocument();
+    // The "Starred" menu option should initially be disabled, since there
+    // aren't any starred entities.
+    await expect(screen.getByTestId('user-picker-starred')).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
     fireEvent.click(screen.getByTestId('user-picker-all'));
     await expect(screen.findByText(/All \(2\)/)).resolves.toBeInTheDocument();
 
@@ -274,6 +276,12 @@ describe('DefaultCatalogPage', () => {
     fireEvent.click(starredIcons[0]);
     await expect(screen.findByText(/All \(2\)/)).resolves.toBeInTheDocument();
 
+    // Now that we've starred an entity, the "Starred" menu option should be
+    // enabled.
+    await expect(screen.getByTestId('user-picker-starred')).not.toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
     fireEvent.click(screen.getByTestId('user-picker-starred'));
     await expect(
       screen.findByText(/Starred \(1\)/),


### PR DESCRIPTION
Relates to #8929.

## Hey, I just made a Pull Request!

Previously, the UserListPicker would set the initial value for the selected filter to "all" when the total number of owned entities was 0. However, when the page loads, the total number of owned entities always starts at 0 while the entities are loading from the backend, so this meant that both the `initiallySelectedFilter` in the `CatalogIndexPage` component and the filter in the URL were being ignored.

This PR adjusts the behavior in the following ways:
- The initial value for the user filter is only set based on the query params or initial filter, as it was before #8220.
- When entities finish loading, the active group will be set to "all" if the currently-selected group has 0 items
- Groups with 0 items are disabled in the UI. This is as much for implementation convenience as anything else - the way the effect is currently constructed means that the groups aren't actually selectable - the selected filter gets immediately reset to "all" by the new effect.

This is all very up for discussion - I'm coming into this cold, and looking for the best way to keep initial / URL filters working while retaining the automatic group switching behavior introduced in #8220. Another possibility is to drop the automatic group switching entirely.

There's a bit more to do in this PR - particularly, it would be good to generalize the tests to cover the "starred" group as well as the "owned" group, but it seems worth gathering a bit of feedback before sinking more time into it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
