### PR TITLE
fix: typo in MembersListCard component

### DIFF
--- a/.changeset/late-carrots-end.md
+++ b/.changeset/late-carrots-end.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fixed typo in `MembersListCard` component

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -192,7 +192,7 @@ export const MembersListCard = (_props: {
           ) : (
             <Box p={2}>
               <Typography>
-                This group has no ${memberDisplayTitle.toLocaleLowerCase()}.
+                This group has no {memberDisplayTitle.toLocaleLowerCase()}.
               </Typography>
             </Box>
           )}


### PR DESCRIPTION
Signed-off-by: djamaile <rdjamaile@gmail.com>

## Hey, I just made a Pull Request!

Made a typo last time, small PR for a fix

#### :heavy_check_mark: Checklist

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
