### PR TITLE
Replace GoCD plugin logo

### DIFF
--- a/microsite/data/plugins/gocd.yaml
+++ b/microsite/data/plugins/gocd.yaml
@@ -5,7 +5,7 @@ authorUrl: https://github.com/soundcloud
 category: CI/CD
 description: GoCD is an open-source tool which is used in software development to help teams and organizations automate the continuous delivery of software.
 documentation: https://github.com/backstage/backstage/tree/master/plugins/gocd
-iconUrl: https://pics.freeicons.io/uploads/icons/png/13646383971540553613-512.png
+iconUrl: https://www.gocd.org/assets/images/go_logo-5b5ca9e1.svg
 npmPackageName: '@backstage/plugin-gocd'
 tags:
   - ci


### PR DESCRIPTION
The original link does not render on the plugins page, replace it with an asset from the official website.

Signed-off-by: Julio Zynger <julio.zynger@soundcloud.com>

