### PR TITLE
Fixed several typos in the Architecture Overview docs

### DIFF
--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -202,14 +202,14 @@ with a smaller collection of plugins.
 ### Plugin Packages
 
 A typical plugin consists of up to five packages, two frontend ones, two
-backend, and one isomorphic package. All packages within the plugin must share
-a common prefix, typically of the form `@<scope>/plugin-<plugin-id>`, but
+backend, and one isomorphic package. All packages within the plugin must share a
+common prefix, typically of the form `@<scope>/plugin-<plugin-id>`, but
 alternatives like `backstage-plugin-<plugin-id>` or
 `@scope/backstage-plugin-<plugin-id>` are also valid. Along with this prefix,
 each of the packages have their own unique suffix that denotes their role. In
-addition to these five plugin packages it's also possible for a plugin to
-have additional frontend and backend modules that can be installed to enable
-optional features. For a full list of suffixes and their roles, see the
+addition to these five plugin packages it's also possible for a plugin to have
+additional frontend and backend modules that can be installed to enable optional
+features. For a full list of suffixes and their roles, see the
 [Plugin Package Structure ADR](../architecture-decisions/adr011-plugin-package-structure.md).
 
 The `-react`, `-common`, and `-node` plugin packages together form the external
@@ -246,10 +246,10 @@ however likely to change in the future.
 
 ### Common Packages
 
-The common packages are the packages effectively depended on by all other
-pages. This is a much smaller set of packages but they are also very pervasive.
-Because the common packages are isomorphic and must execute both in the frontend
-and backend, they are never allowed to depend on any of the frontend of backend
+The common packages are the packages effectively depended on by all other pages.
+This is a much smaller set of packages but they are also very pervasive. Because
+the common packages are isomorphic and must execute both in the frontend and
+backend, they are never allowed to depend on any of the frontend of backend
 packages.
 
 The Backstage CLI is in a category of its own and is depended on by virtually

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -202,12 +202,12 @@ with a smaller collection of plugins.
 ### Plugin Packages
 
 A typical plugin consists of up to five packages, two frontend ones, two
-backend, and one isomorphic packages. All packages within the plugin must share
+backend, and one isomorphic package. All packages within the plugin must share
 a common prefix, typically of the form `@<scope>/plugin-<plugin-id>`, but
 alternatives like `backstage-plugin-<plugin-id>` or
 `@scope/backstage-plugin-<plugin-id>` are also valid. Along with this prefix,
 each of the packages have their own unique suffix that denotes their role. In
-addition to these five plugin packages it's also possible for to a plugin to
+addition to these five plugin packages it's also possible for a plugin to
 have additional frontend and backend modules that can be installed to enable
 optional features. For a full list of suffixes and their roles, see the
 [Plugin Package Structure ADR](../architecture-decisions/adr011-plugin-package-structure.md).
@@ -230,7 +230,7 @@ The frontend packages are grouped into two main groups. The first one is
 as well as provide a foundation for the plugin libraries to rely upon.
 
 The second group is the rest of the shared packages, further divided into
-"Frontend Plugin Core" and "Frontend Libraries". The core packages that are
+"Frontend Plugin Core" and "Frontend Libraries". The core packages are
 considered particularly stable and form the core of the frontend framework.
 Their most important role is to form the boundary around each plugin and provide
 a set of tools that helps you combine a collection of plugins into a running
@@ -246,7 +246,7 @@ however likely to change in the future.
 
 ### Common Packages
 
-The common packages are the packages are effectively depended on by all other
+The common packages are the packages effectively depended on by all other
 pages. This is a much smaller set of packages but they are also very pervasive.
 Because the common packages are isomorphic and must execute both in the frontend
 and backend, they are never allowed to depend on any of the frontend of backend


### PR DESCRIPTION
Signed-off-by: Kurt King <kurtaking@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

I found several typos and sentences that could be reworded in the architecture-overview.md doc.

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
