### PR TITLE
[Analytics] Convention for tying events to known users

### DIFF
--- a/.changeset/varldens-starkaste-bjorn.md
+++ b/.changeset/varldens-starkaste-bjorn.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Asynchronous methods on the identity API can now reliably be called at any time, including early in the bootstrap process or prior to successful sign-in.
+
+Previously in such situations, a `Tried to access IdentityApi before app was loaded` error would be thrown. Now, those methods will wait and resolve eventually (as soon as a concrete identity API is provided).

--- a/packages/core-app-api/src/apis/system/ApiProvider.tsx
+++ b/packages/core-app-api/src/apis/system/ApiProvider.tsx
@@ -53,6 +53,24 @@ export const ApiProvider = (props: PropsWithChildren<ApiProviderProps>) => {
   );
 };
 
+/**
+ * Same as above, but does not inherit APIs from API providers further up in
+ * the react tree.
+ *
+ * Private to (and only used in) this package.
+ */
+export const IsolatedApiProvider = (
+  props: PropsWithChildren<ApiProviderProps>,
+) => {
+  const { apis, children } = props;
+  return (
+    <ApiContext.Provider
+      value={createVersionedValueMap({ 1: apis })}
+      children={children}
+    />
+  );
+};
+
 ApiProvider.propTypes = {
   apis: PropTypes.shape({ get: PropTypes.func.isRequired }).isRequired,
   children: PropTypes.node,

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -79,6 +79,7 @@ import {
 import { AppThemeProvider } from './AppThemeProvider';
 import { defaultConfigLoader } from './defaultConfigLoader';
 import { ApiRegistry } from '../apis/system/ApiRegistry';
+import { IsolatedApiProvider } from '../apis/system/ApiProvider';
 
 type CompatiblePlugin =
   | BackstagePlugin<any, any>
@@ -346,7 +347,14 @@ export class AppManager implements BackstageApp {
       const [identityApi, setIdentityApi] = useState<IdentityApi>();
 
       if (!identityApi) {
-        return <Component onSignInSuccess={setIdentityApi} />;
+        // Encapsulate the sign in page component in an API provider which
+        // contains all APIs except the identity API. Provides fast feedback in
+        // case the identity API is accidentally required on the sign-in page.
+        return (
+          <IsolatedApiProvider apis={this.getIdentitylessApiHolder()}>
+            <Component onSignInSuccess={setIdentityApi} />
+          </IsolatedApiProvider>
+        );
       }
 
       this.appIdentityProxy.setTarget(identityApi);
@@ -482,6 +490,21 @@ export class AppManager implements BackstageApp {
 
     this.apiHolder = new ApiResolver(this.apiFactoryRegistry);
     return this.apiHolder;
+  }
+
+  private getIdentitylessApiHolder() {
+    const registrySansIdentity = new ApiFactoryRegistry();
+
+    // Assume all APIs in the current registry are valid.
+    this.apiFactoryRegistry.getAllApis().forEach(apiRef => {
+      const factory = this.apiFactoryRegistry.get(apiRef);
+      // Add all API factories except identity!
+      if (factory && apiRef !== identityApiRef) {
+        registrySansIdentity.register('default', factory);
+      }
+    });
+
+    return new ApiResolver(registrySansIdentity);
   }
 
   private verifyPlugins(plugins: Iterable<CompatiblePlugin>) {

--- a/plugins/analytics-module-ga/api-report.md
+++ b/plugins/analytics-module-ga/api-report.md
@@ -7,19 +7,24 @@ import { AnalyticsApi } from '@backstage/core-plugin-api';
 import { AnalyticsEvent } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { Config } from '@backstage/config';
+import { IdentityApi } from '@backstage/core-plugin-api';
 
-// Warning: (ae-missing-release-tag) "analyticsModuleGA" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export const analyticsModuleGA: BackstagePlugin<{}, {}>;
 
-// Warning: (ae-missing-release-tag) "GoogleAnalytics" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export class GoogleAnalytics implements AnalyticsApi {
   captureEvent(event: AnalyticsEvent): void;
-  static fromConfig(config: Config): GoogleAnalytics;
+  static fromConfig(
+    config: Config,
+    deps?: GoogleAnalyticsDependencies,
+  ): GoogleAnalytics;
 }
+
+// @public (undocumented)
+export type GoogleAnalyticsDependencies = {
+  identity?: IdentityApi;
+};
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/analytics-module-ga/config.d.ts
+++ b/plugins/analytics-module-ga/config.d.ts
@@ -35,6 +35,15 @@ export interface Config {
         scriptSrc?: string;
 
         /**
+         * When set to `true`, all pageviews and hits are deferred until an
+         * identity is known. Guarantees that all data sent to GA correlates
+         * to a user identity; prevents GA from ever receiving events for
+         * sessions in which a user does not sign in.
+         * @visibility frontend
+         */
+        requireIdentity?: boolean;
+
+        /**
          * Whether or not to log analytics debug statements to the console.
          * Defaults to false.
          *

--- a/plugins/analytics-module-ga/package.json
+++ b/plugins/analytics-module-ga/package.json
@@ -21,6 +21,7 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
+    "@backstage/catalog-model": "^0.9.9",
     "@backstage/config": "^0.1.12",
     "@backstage/core-components": "^0.8.4",
     "@backstage/core-plugin-api": "^0.5.0",

--- a/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.test.ts
+++ b/plugins/analytics-module-ga/src/apis/implementations/AnalyticsApi/GoogleAnalytics.test.ts
@@ -141,20 +141,13 @@ describe('GoogleAnalytics', () => {
         context,
       });
 
-      // Expect a set command first.
-      const [setCommand, setData] = ReactGA.testModeAPI.calls[1];
-      expect(setCommand).toBe('set');
-      expect(setData).toMatchObject({
-        dimension1: context.pluginId,
-        metric1: context.releaseNum,
-      });
-
-      // Followed by a send command.
-      const [sendCommand, sendData] = ReactGA.testModeAPI.calls[2];
-      expect(sendCommand).toBe('send');
-      expect(sendData).toMatchObject({
+      const [command, data] = ReactGA.testModeAPI.calls[1];
+      expect(command).toBe('send');
+      expect(data).toMatchObject({
         hitType: 'pageview',
         page: '/a-page',
+        dimension1: context.pluginId,
+        metric1: context.releaseNum,
       });
     });
 

--- a/plugins/analytics-module-ga/src/index.ts
+++ b/plugins/analytics-module-ga/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { analyticsModuleGA } from './plugin';
-export { GoogleAnalytics } from './apis/implementations/AnalyticsApi';
+export * from './apis/implementations/AnalyticsApi';

--- a/plugins/analytics-module-ga/src/plugin.ts
+++ b/plugins/analytics-module-ga/src/plugin.ts
@@ -15,6 +15,9 @@
  */
 import { createPlugin } from '@backstage/core-plugin-api';
 
+/**
+ * @public
+ */
 export const analyticsModuleGA = createPlugin({
   id: 'analytics-provider-ga',
 });

--- a/plugins/analytics-module-ga/src/util/DeferredCapture.ts
+++ b/plugins/analytics-module-ga/src/util/DeferredCapture.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import ReactGA from 'react-ga';
+
+type Hit = {
+  timestamp: number;
+  data: {
+    hitType: 'pageview' | 'event';
+    [x: string]: any;
+  };
+};
+
+/**
+ * A wrapper around ReactGA that can optionally handle latent capture logic.
+ *
+ * - When defer is `false`, event data is sent directly to GA.
+ * - When defer is `true`, event data is queued (with a timestamp), so that it
+ *   can be sent to GA once externally indicated to be ready. This relies on
+ *   the `qt` or `queueTime` parameter of the Measurement Protocol.
+ *
+ * @see https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#qt
+ */
+export class DeferredCapture {
+  /**
+   * Queue of deferred hits to be processed when ready.
+   */
+  private queue: Hit[] = [];
+
+  /**
+   * Marker indicating when it's okay to revert to synchronous capture.
+   */
+  private doneDeferring = false;
+
+  /**
+   * Whether or not deferred capture is desired.
+   */
+  private defer: boolean;
+
+  /**
+   * Holds a reference to the internal promise's resolver. When called, it will
+   * begin processing hits in the queue.
+   */
+  private isReady: () => void = () => {};
+
+  constructor({ defer = false }: { defer: boolean }) {
+    this.defer = defer;
+
+    // Set up a readiness promise that, when resolved from the outside, goes
+    // through all queued hits and sends them.
+    new Promise<void>(resolve => {
+      this.isReady = resolve;
+    }).then(() => {
+      this.queue.forEach(this.sendDeferred);
+    });
+  }
+
+  /**
+   * Indicates that deferred capture may now proceed.
+   */
+  setReady() {
+    if (!this.doneDeferring) {
+      this.isReady();
+      this.doneDeferring = true;
+    }
+  }
+
+  /**
+   * Either forwards the pageview directly to GA, or (if configured) enqueues
+   * the pageview hit to be captured when ready.
+   */
+  pageview(path: string, metadata: ReactGA.FieldsObject = {}) {
+    if (this.shouldDefer()) {
+      this.queue.push({
+        timestamp: Date.now(),
+        data: {
+          hitType: 'pageview',
+          page: path,
+          ...metadata,
+        },
+      });
+      return;
+    }
+
+    ReactGA.send({
+      hitType: 'pageview',
+      page: path,
+      ...metadata,
+    });
+  }
+
+  /**
+   * Either forwards the event directly to GA, or (if configured) enqueues the
+   * event hit to be captured when ready.
+   */
+  event(eventDetails: ReactGA.EventArgs) {
+    if (this.shouldDefer()) {
+      this.queue.push({
+        timestamp: Date.now(),
+        data: {
+          ...eventDetails,
+          hitType: 'event',
+        },
+      });
+      return;
+    }
+
+    ReactGA.event(eventDetails);
+  }
+
+  /**
+   * Only defer if configured and if we are still not ready.
+   */
+  private shouldDefer() {
+    return this.defer && !this.doneDeferring;
+  }
+
+  /**
+   * Sends a given hit to GA, decorated with the correct queue time.
+   */
+  private sendDeferred(hit: Hit) {
+    // Send the hit with the appropriate queue time (`qt`).
+    ReactGA.send({
+      ...hit.data,
+      queueTime: Date.now() - hit.timestamp,
+    });
+  }
+}

--- a/plugins/analytics-module-ga/src/util/index.ts
+++ b/plugins/analytics-module-ga/src/util/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-export { GoogleAnalytics } from './GoogleAnalytics';
-export type { GoogleAnalyticsDependencies } from './GoogleAnalytics';
+export { DeferredCapture } from './DeferredCapture';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Proposal is to establish a pattern/convention whereby Analytics API implementors rely on the `namespace` and `name` parts of the `userEntityRef` returned by `identytApi.getBackstageIdentity()` for uniquely identifying users (and thus be able to provide, at least conceptually, `MAU`-type metrics).

### GA-Specific Logic
- GA is somewhat unique in that it specifically prohibits PII from being sent to the platform.  ...Because the `name` of a user entity could almost certainly be considered PII, the default implementation performs a simple hash.
- For organizations with stricter data governance / controls around PII, or for those organization who intend to use the `userId` sent to GA as a foreign key in some other dataset, a (somewhat cumbersome, but at least existent) mechanism to override the default hashing logic is in place: implementors would need to wrap the `identityApi` provided to the GA analytics API such that the `userEntityRef` value it resolves has its `kind` set to the literal string `PrivateUser` and its `name` set as needed (e.g. `PrivateUser:s0m3hxsh3dvalu3`)
- Adds an optional mechanism for deferred capture that works around a bug we have encountered at Spotify (where some hits are dropped because they are captured before an identity can be resolved)

Thus: for the 80% case, one simply needs to update `GoogleAnalytics.from(config)` to `GoogleAnalytics.from(config, { identity })` to start tracking user-level details.

Closes #8811 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
