### PR TITLE
workflows: fix dependabot changeset maker condition

### DIFF
--- a/.github/workflows/dependabot-changeset-maker.yml
+++ b/.github/workflows/dependabot-changeset-maker.yml
@@ -1,7 +1,9 @@
 name: 'Dependabot changeset maker'
 on:
   pull_request_target:
-    branches: 'dependabot/**'
+    paths:
+      - .github/workflows/dependabot-changeset-maker.yml
+      - '**/yarn.lock'
 
 jobs:
   generate-changeset:


### PR DESCRIPTION
#8908 was a derp, since it's the target branch that's being filtered rather than the source.

Thinking a yarn.lock filter is probably the best we can do