### PR TITLE
workflows: fix for changeset flow not using service account

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
       - name: Install Dependencies
         run: yarn --frozen-lockfile
       - name: Run release preparations


### PR DESCRIPTION
The "Version Packages" builds aren't being triggered correctly because we're not using the service account to push changes anymore. This is likely a regression while migrating to `checkout@v2`, as I'm assuming the token that is used for the checkout action also ends up being used to push changes later on. Switching to use the service account token for cloning the repo should hopefully fix things https://github.com/actions/checkout#usage