### PR TITLE
Update GitHub credentials provider

### DIFF
--- a/.changeset/chatty-pens-try.md
+++ b/.changeset/chatty-pens-try.md
@@ -2,5 +2,5 @@
 '@backstage/integration': patch
 ---
 
-Return an empty token rather than fail where the owner is not in the allowed installation owners
+Do not return a token rather than fail where the owner is not in the allowed installation owners
 for a GitHub app. This allows anonymous access to public files in the organisation.

--- a/.changeset/chatty-pens-try.md
+++ b/.changeset/chatty-pens-try.md
@@ -1,0 +1,6 @@
+---
+'@backstage/integration': patch
+---
+
+Return an empty token rather than fail where the owner is not in the allowed installation owners
+for a GitHub app. This allows anonymous access to public files in the organisation.

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -96,9 +96,7 @@ class GithubAppManager {
     const { installationId, suspended } = await this.getInstallationData(owner);
     if (this.allowedInstallationOwners) {
       if (!this.allowedInstallationOwners?.includes(owner)) {
-        throw new Error(
-          `The GitHub application for ${owner} is not included in the allowed installation list (${installationId}).`,
-        );
+        return { accessToken: '' }; // An empty token allows anonymous access to public repos
       }
     }
     if (suspended) {

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -92,11 +92,11 @@ class GithubAppManager {
   async getInstallationCredentials(
     owner: string,
     repo?: string,
-  ): Promise<{ accessToken: string }> {
+  ): Promise<{ accessToken: string | undefined }> {
     const { installationId, suspended } = await this.getInstallationData(owner);
     if (this.allowedInstallationOwners) {
       if (!this.allowedInstallationOwners?.includes(owner)) {
-        return { accessToken: '' }; // An empty token allows anonymous access to public repos
+        return { accessToken: undefined }; // An empty token allows anonymous access to public repos
       }
     }
     if (suspended) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Return an empty token rather than fail where the owner is not in the allowed installation owners
for a GitHub app. This allows anonymous access to public files in the organisation (in our case example data).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
