### PR TITLE
Don't remove the `awaiting-review` label if the author was the last event

### DIFF
--- a/scripts/goalie-labels.js
+++ b/scripts/goalie-labels.js
@@ -88,17 +88,40 @@ module.exports = async ({ github, context, core }) => {
       }
     }
 
+    // if all required reviewers have reviewed
     if (hasReviewed.size === expectedReviewers.size) {
-      await github.rest.issues
-        .removeLabel({
+      const recentEventsForPR = await github.paginate(
+        github.issues.listEvents,
+        {
           issue_number: pullRequest.number,
           owner: context.repo.owner,
           repo: context.repo.repo,
-          name: 'awaiting-review',
-        })
-        .catch(e => {
-          console.error(e);
-        });
+        },
+      );
+
+      const { data: pr } = await github.pulls.get({
+        issue_number: pullRequest.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+      });
+
+      // if the last event for the issue is not by the author, remove the label
+      if (
+        recentEventsForPR[recentEventsForPR.length - 1].actor.login !==
+        pr.author.login
+      ) {
+        await github.rest.issues
+          .removeLabel({
+            issue_number: pullRequest.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: 'awaiting-review',
+          })
+          .catch(e => {
+            console.error(e);
+          });
+      }
+      // add the awaiting-review label to tell us that the PR is waiting on reviews
     } else {
       await github.rest.issues
         .addLabels({


### PR DESCRIPTION
If we had complete reviews, we would remove the label, however, we shouldn't remove the labels if the last event is from the author as we don't want this to go stale waiting for our reply from the user or when new code is pushed.
