### PR TITLE
todos: fix typo in README.md

### DIFF
--- a/.changeset/patched.json
+++ b/.changeset/patched.json
@@ -1,3 +1,5 @@
 {
-  "currentReleaseVersion": {}
+  "currentReleaseVersion": {
+    "@backstage/plugin-todo": "0.1.19"
+  }
 }

--- a/.changeset/short-games-float.md
+++ b/.changeset/short-games-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-todo': patch
+---
+
+Apply fix from the 0.1.19 patch release

--- a/plugins/todo/README.md
+++ b/plugins/todo/README.md
@@ -89,7 +89,7 @@ Below are some examples of formats that are supported by default:
 // FIXME Nobody knows why this is here
 ```
 
-Note the trailing comments are not supported, the following TODO would not be listed:
+Note that trailing comments are not supported, the following TODO would not be listed:
 
 ```ts
 function reverse(str: string) {


### PR DESCRIPTION
This fix has already been released part of #9024