### PR TITLE
docs(auth): align provider reference with config example

### DIFF
--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -89,7 +89,7 @@ credentials fresh.
 When using the OAuth2-Proxy, the Backstage UI can only be accessed after the
 user has already been authenticated at the proxy. Instead of showing the user
 another login page when accessing Backstage, it will handle the login in the
-background. Backstage provides for this case a special `SignInPage` component
+background. Backstage provides for this case the `ProxiedSignInPage` component
 which has no UI.
 
 Update your `createApp` call in `packages/app/src/App.tsx`, as follows.
@@ -98,7 +98,7 @@ Update your `createApp` call in `packages/app/src/App.tsx`, as follows.
 +import { ProxiedSignInPage } from '@backstage/core-components';
  const app = createApp({
    components: {
-+    SignInPage: props => <ProxiedSignInPage {...props} provider="oauth2-proxy" />,
++    SignInPage: props => <ProxiedSignInPage {...props} provider="oauth2proxy" />,
 ```
 
 After this, your app should be ready to leverage the OAuth2-Proxy for


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
The used provider reference was not aligned with the config example.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
