### PR TITLE
Kubernetes plugin:  Loading default Kube configuration 

### DIFF
--- a/.changeset/eleven-eagles-do.md
+++ b/.changeset/eleven-eagles-do.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': patch
 ---
 
-If serviceAccountToken not provided, use default Kube configuration from cluster
+If serviceAccountToken not provided, use default config file from cluster

--- a/.changeset/eleven-eagles-do.md
+++ b/.changeset/eleven-eagles-do.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': patch
 ---
 
-If serviceAccountToken not provided, use defaul kubeconfig from cluster
+If serviceAccountToken not provided, use default Kube configuration from cluster

--- a/.changeset/eleven-eagles-do.md
+++ b/.changeset/eleven-eagles-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+If serviceAccountToken not provided, use defaul kubeconfig from cluster

--- a/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesClientProvider.ts
@@ -45,12 +45,17 @@ export class KubernetesClientProvider {
     };
 
     const kc = new KubeConfig();
-    kc.loadFromOptions({
-      clusters: [cluster],
-      users: [user],
-      contexts: [context],
-      currentContext: context.name,
-    });
+    if (clusterDetails.serviceAccountToken) {
+      kc.loadFromOptions({
+        clusters: [cluster],
+        users: [user],
+        contexts: [context],
+        currentContext: context.name,
+      });
+    } else {
+      kc.loadFromDefault();
+    }
+
     return kc;
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Load default kubeconfig from cluster if KSA token not provided.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
