### PR TITLE
[Home] forward classes to HomePageSearchBar instead of using className

### DIFF
--- a/.changeset/good-poets-change.md
+++ b/.changeset/good-poets-change.md
@@ -1,5 +1,13 @@
 ---
-'@backstage/plugin-search': patch
+'@backstage/plugin-search': minor
 ---
 
-Forward classes to HomePageSearchBar instead of className.
+Forwarding classes to HomePageSearchBar instead of using className prop. For custom styles of the HomePageSearchBar, use classes prop instead:
+
+```diff
+<HomePageSearchBar
+-  className={searchBar}
++  classes={{ root: classes.searchBar }}
+  placeholder="Search"
+/>
+```

--- a/.changeset/good-poets-change.md
+++ b/.changeset/good-poets-change.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search': patch
 ---
 
-Now fully overrides styles of HomePageSearchBar if className property is passed to the component
+Forward classes to HomePageSearchBar instead of className.

--- a/.changeset/good-poets-change.md
+++ b/.changeset/good-poets-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Now fully overrides styles of HomePageSearchBar if className property is passed to the component

--- a/plugins/home/src/templates/DefaultTemplate.stories.tsx
+++ b/plugins/home/src/templates/DefaultTemplate.stories.tsx
@@ -47,14 +47,12 @@ export default {
 };
 
 const useStyles = makeStyles(theme => ({
-  search: {
+  searchBar: {
+    display: 'flex',
+    maxWidth: '60vw',
     backgroundColor: theme.palette.background.paper,
     boxShadow: theme.shadows[1],
-    maxWidth: '60vw',
-    display: 'flex',
-    justifyContent: 'space-between',
     padding: '8px 0',
-    borderColor: 'transparent',
     borderRadius: '50px',
     margin: 'auto',
   },
@@ -74,7 +72,7 @@ const useLogoStyles = makeStyles(theme => ({
 }));
 
 export const DefaultTemplate = () => {
-  const { search } = useStyles();
+  const { searchBar } = useStyles();
   const { svg, path, container } = useLogoStyles();
 
   return (
@@ -88,7 +86,7 @@ export const DefaultTemplate = () => {
             />
             <Grid container item xs={12} alignItems="center" direction="row">
               <HomePageSearchBar
-                className={search}
+                className={searchBar}
                 placeholder="Search"
               />
             </Grid>

--- a/plugins/home/src/templates/DefaultTemplate.stories.tsx
+++ b/plugins/home/src/templates/DefaultTemplate.stories.tsx
@@ -72,7 +72,7 @@ const useLogoStyles = makeStyles(theme => ({
 }));
 
 export const DefaultTemplate = () => {
-  const { searchBar } = useStyles();
+  const classes = useStyles();
   const { svg, path, container } = useLogoStyles();
 
   return (
@@ -86,7 +86,7 @@ export const DefaultTemplate = () => {
             />
             <Grid container item xs={12} alignItems="center" direction="row">
               <HomePageSearchBar
-                className={searchBar}
+                classes={{root: classes.searchBar}}
                 placeholder="Search"
               />
             </Grid>

--- a/plugins/search/api-report.md
+++ b/plugins/search/api-report.md
@@ -66,7 +66,6 @@ export type FiltersState = {
 //
 // @public (undocumented)
 export const HomePageSearchBar: ({
-  className: defaultClassName,
   ...props
 }: Partial<Omit<SearchBarBaseProps, 'onChange' | 'onSubmit'>>) => JSX.Element;
 

--- a/plugins/search/src/components/HomePageComponent/HomePageSearchBar.stories.tsx
+++ b/plugins/search/src/components/HomePageComponent/HomePageSearchBar.stories.tsx
@@ -69,7 +69,10 @@ export const CustomStyles = () => {
   return (
     <Grid container justifyContent="center" spacing={6}>
       <Grid container item xs={12} alignItems="center" direction="row">
-        <HomePageSearchBar className={classes.searchBar} placeholder="Search" />
+        <HomePageSearchBar
+          classes={{ root: classes.searchBar }}
+          placeholder="Search"
+        />
       </Grid>
     </Grid>
   );

--- a/plugins/search/src/components/HomePageComponent/HomePageSearchBar.stories.tsx
+++ b/plugins/search/src/components/HomePageComponent/HomePageSearchBar.stories.tsx
@@ -41,27 +41,35 @@ export default {
   ],
 };
 
+export const Default = () => {
+  return (
+    <Grid container justifyContent="center" spacing={6}>
+      <Grid container item xs={12} alignItems="center" direction="row">
+        <HomePageSearchBar placeholder="Search" />
+      </Grid>
+    </Grid>
+  );
+};
+
 const useStyles = makeStyles(theme => ({
-  search: {
+  searchBar: {
+    display: 'flex',
+    maxWidth: '60vw',
     backgroundColor: theme.palette.background.paper,
     boxShadow: theme.shadows[1],
-    maxWidth: '60vw',
-    display: 'flex',
-    justifyContent: 'space-between',
     padding: '8px 0',
-    borderColor: 'transparent',
     borderRadius: '50px',
     margin: 'auto',
   },
 }));
 
-export const Default = () => {
-  const { search } = useStyles();
+export const CustomStyles = () => {
+  const classes = useStyles();
 
   return (
     <Grid container justifyContent="center" spacing={6}>
       <Grid container item xs={12} alignItems="center" direction="row">
-        <HomePageSearchBar className={search} placeholder="Search" />
+        <HomePageSearchBar className={classes.searchBar} placeholder="Search" />
       </Grid>
     </Grid>
   );

--- a/plugins/search/src/components/HomePageComponent/HomePageSearchBar.tsx
+++ b/plugins/search/src/components/HomePageComponent/HomePageSearchBar.tsx
@@ -21,7 +21,7 @@ import { SearchBarBase, SearchBarBaseProps } from '../SearchBar';
 import { useNavigateToQuery } from '../util';
 
 const useStyles = makeStyles({
-  searchBar: {
+  root: {
     border: '1px solid #555',
     borderRadius: '6px',
     fontSize: '1.5em',
@@ -43,7 +43,7 @@ export type HomePageSearchBarProps = Partial<
  * @public
  */
 export const HomePageSearchBar = ({ ...props }: HomePageSearchBarProps) => {
-  const classes = useStyles();
+  const classes = useStyles(props);
   const [query, setQuery] = useState('');
   const handleSearch = useNavigateToQuery();
 
@@ -60,7 +60,7 @@ export const HomePageSearchBar = ({ ...props }: HomePageSearchBarProps) => {
 
   return (
     <SearchBarBase
-      className={props.className ? props.className : classes.searchBar}
+      classes={{ root: classes.root }}
       value={query}
       onSubmit={handleSubmit}
       onChange={handleChange}

--- a/plugins/search/src/components/HomePageComponent/HomePageSearchBar.tsx
+++ b/plugins/search/src/components/HomePageComponent/HomePageSearchBar.tsx
@@ -42,17 +42,10 @@ export type HomePageSearchBarProps = Partial<
  *
  * @public
  */
-export const HomePageSearchBar = ({
-  className: defaultClassName,
-  ...props
-}: HomePageSearchBarProps) => {
+export const HomePageSearchBar = ({ ...props }: HomePageSearchBarProps) => {
   const classes = useStyles();
   const [query, setQuery] = useState('');
   const handleSearch = useNavigateToQuery();
-
-  const className = defaultClassName
-    ? `${classes.searchBar} ${defaultClassName}`
-    : classes.searchBar;
 
   const handleSubmit = () => {
     handleSearch({ query });
@@ -67,7 +60,7 @@ export const HomePageSearchBar = ({
 
   return (
     <SearchBarBase
-      className={className}
+      className={props.className ? props.className : classes.searchBar}
       value={query}
       onSubmit={handleSubmit}
       onChange={handleChange}


### PR DESCRIPTION
Signed-off-by: Emma Indal <emma.indahl@gmail.com>

## Hey, I just made a Pull Request!

The custom styles of HomePageSearchBar did not properly override default styles when a className property was passed to the component (see comments below), this PR fixes that to instead forward classes. Also adds a separate story for the HomePageSearchBar with custom styles, to show examples of both.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
