### PR TITLE
feat: [#8920] Add `nunjucksFilters` option for user-provided filters

### DIFF
--- a/.changeset/rude-clouds-chew.md
+++ b/.changeset/rude-clouds-chew.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Expose a new option to provide additional template filters via `@backstage/scaffolder-backend`'s `createRouter()` function.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -76,6 +76,7 @@ export const createBuiltinActions: (options: {
   catalogClient: CatalogApi;
   containerRunner?: ContainerRunner;
   config: Config;
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
 }) => TemplateAction<any>[];
 
 // Warning: (ae-missing-release-tag) "createCatalogRegisterAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -112,6 +113,7 @@ export function createFetchPlainAction(options: {
 export function createFetchTemplateAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
 }): TemplateAction<any>;
 
 // Warning: (ae-missing-release-tag) "createFilesystemDeleteAction" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -219,6 +221,7 @@ export type CreateWorkerOptions = {
   integrations: ScmIntegrations;
   workingDirectory: string;
   logger: Logger_2;
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
 };
 
 // @public
@@ -303,6 +306,8 @@ export class OctokitProvider {
 export interface RouterOptions {
   // (undocumented)
   actions?: TemplateAction<any>[];
+  // (undocumented)
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
   // (undocumented)
   catalogClient: CatalogApi;
   // (undocumented)
@@ -544,6 +549,11 @@ export class TemplateActionRegistry {
     action: TemplateAction<Parameters>,
   ): void;
 }
+
+// Warning: (ae-missing-release-tag) "TemplateFilter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TemplateFilter = (...args: JsonValue[]) => JsonValue | undefined;
 
 export { TemplateMetadata };
 ```

--- a/plugins/scaffolder-backend/src/lib/index.ts
+++ b/plugins/scaffolder-backend/src/lib/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,5 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that helps you create new things
- *
- * @packageDocumentation
- */
-
-export * from './scaffolder';
-export * from './service/router';
-export * from './lib';
-export * from './processor';
+export * from './catalog';
+export * from './templating';

--- a/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.test.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.test.ts
@@ -104,7 +104,7 @@ describe('SecureTemplater', () => {
     const mockFilter2 = jest.fn((var1, var2) => `${var1} ${var2}`);
     const mockFilter3 = jest.fn((var1, var2) => ({ var1, var2 }));
     const renderWith = await SecureTemplater.loadRenderer({
-      nunjucksFilters: { mockFilter1, mockFilter2, mockFilter3 },
+      additionalTemplateFilters: { mockFilter1, mockFilter2, mockFilter3 },
     });
     const renderWithout = await SecureTemplater.loadRenderer();
 

--- a/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.test.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.test.ts
@@ -104,7 +104,7 @@ describe('SecureTemplater', () => {
     const mockFilter2 = jest.fn((var1, var2) => `${var1} ${var2}`);
     const mockFilter3 = jest.fn((var1, var2) => ({ var1, var2 }));
     const renderWith = await SecureTemplater.loadRenderer({
-      additionalFilters: { mockFilter1, mockFilter2, mockFilter3 },
+      nunjucksFilters: { mockFilter1, mockFilter2, mockFilter3 },
     });
     const renderWithout = await SecureTemplater.loadRenderer();
 

--- a/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.test.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.test.ts
@@ -99,6 +99,52 @@ describe('SecureTemplater', () => {
     ]);
   });
 
+  it('should make additional filters available when requested', async () => {
+    const mockFilter1 = jest.fn(() => 'filtered text');
+    const mockFilter2 = jest.fn((var1, var2) => `${var1} ${var2}`);
+    const mockFilter3 = jest.fn((var1, var2) => ({ var1, var2 }));
+    const renderWith = await SecureTemplater.loadRenderer({
+      additionalFilters: { mockFilter1, mockFilter2, mockFilter3 },
+    });
+    const renderWithout = await SecureTemplater.loadRenderer();
+
+    const ctx = { inputValue: 'the input value' };
+
+    expect(renderWith('${{ inputValue | mockFilter1 }}', ctx)).toBe(
+      'filtered text',
+    );
+    expect(
+      renderWith('${{ inputValue | mockFilter2("extra arg") }}', ctx),
+    ).toBe('the input value extra arg');
+    expect(
+      renderWith(
+        '${{ inputValue | mockFilter3("another extra arg") | dump }}',
+        ctx,
+      ),
+    ).toBe(
+      JSON.stringify({
+        var1: 'the input value',
+        var2: 'another extra arg',
+      }),
+    );
+
+    expect(() => renderWithout('${{ inputValue | mockFilter1 }}', ctx)).toThrow(
+      /Error: filter not found: mockFilter1/,
+    );
+    expect(() =>
+      renderWithout('${{ inputValue | mockFilter2("extra arg") }}', ctx),
+    ).toThrow(/Error: filter not found: mockFilter2/);
+    expect(() =>
+      renderWithout('${{ inputValue | mockFilter3("extra arg") }}', ctx),
+    ).toThrow(/Error: filter not found: mockFilter3/);
+
+    expect(mockFilter1.mock.calls).toEqual([['the input value']]);
+    expect(mockFilter2.mock.calls).toEqual([['the input value', 'extra arg']]);
+    expect(mockFilter3.mock.calls).toEqual([
+      ['the input value', 'another extra arg'],
+    ]);
+  });
+
   it('should not allow helpers to be rewritten', async () => {
     const render = await SecureTemplater.loadRenderer({
       parseRepoUrl: () => ({

--- a/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.ts
@@ -58,8 +58,8 @@ const { render, renderCompat } = (() => {
     });
   }
 
-  if (typeof nunjucksFilters !== 'undefined') {
-    for (const [filterName, filterFn] of Object.entries(nunjucksFilters)) {
+  if (typeof additionalTemplateFilters !== 'undefined') {
+    for (const [filterName, filterFn] of Object.entries(additionalTemplateFilters)) {
       env.addFilter(filterName, (...args) => JSON.parse(filterFn(...args)));
     }
   }
@@ -95,7 +95,7 @@ const { render, renderCompat } = (() => {
 })();
 `;
 
-export type NunjucksFilter = (...args: JsonValue[]) => JsonValue | undefined;
+export type TemplateFilter = (...args: JsonValue[]) => JsonValue | undefined;
 
 export interface SecureTemplaterOptions {
   /* Optional implementation of the parseRepoUrl filter */
@@ -105,7 +105,7 @@ export interface SecureTemplaterOptions {
   cookiecutterCompat?: boolean;
 
   /* Extra user-provided nunjucks filters */
-  nunjucksFilters?: Record<string, NunjucksFilter>;
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
 }
 
 export type SecureTemplateRenderer = (
@@ -115,16 +115,17 @@ export type SecureTemplateRenderer = (
 
 export class SecureTemplater {
   static async loadRenderer(options: SecureTemplaterOptions = {}) {
-    const { parseRepoUrl, cookiecutterCompat, nunjucksFilters } = options;
+    const { parseRepoUrl, cookiecutterCompat, additionalTemplateFilters } =
+      options;
     const sandbox: Record<string, any> = {};
 
     if (parseRepoUrl) {
       sandbox.parseRepoUrl = (url: string) => JSON.stringify(parseRepoUrl(url));
     }
 
-    if (nunjucksFilters) {
-      sandbox.nunjucksFilters = Object.fromEntries(
-        Object.entries(nunjucksFilters)
+    if (additionalTemplateFilters) {
+      sandbox.additionalTemplateFilters = Object.fromEntries(
+        Object.entries(additionalTemplateFilters)
           .filter(([_, filterFunction]) => !!filterFunction)
           .map(([filterName, filterFunction]) => [
             filterName,

--- a/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/SecureTemplater.ts
@@ -93,6 +93,9 @@ export interface SecureTemplaterOptions {
 
   /* Enables jinja compatibility and the "jsonify" filter */
   cookiecutterCompat?: boolean;
+
+  /* Extra user-provided nunjucks filters */
+  additionalFilters?: Record<string, (data: any) => any>;
 }
 
 export type SecureTemplateRenderer = (
@@ -102,7 +105,7 @@ export type SecureTemplateRenderer = (
 
 export class SecureTemplater {
   static async loadRenderer(options: SecureTemplaterOptions = {}) {
-    const { parseRepoUrl, cookiecutterCompat } = options;
+    const { parseRepoUrl, cookiecutterCompat, additionalFilters } = options;
     let sandbox = undefined;
 
     if (parseRepoUrl) {
@@ -110,6 +113,10 @@ export class SecureTemplater {
         parseRepoUrl: (url: string) => JSON.stringify(parseRepoUrl(url)),
       };
     }
+    sandbox = {
+      ...sandbox,
+      ...additionalFilters,
+    };
 
     const vm = new VM({ sandbox });
 

--- a/plugins/scaffolder-backend/src/lib/templating/index.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export type { NunjucksFilter } from './SecureTemplater';
+export type { TemplateFilter } from './SecureTemplater';

--- a/plugins/scaffolder-backend/src/lib/templating/index.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,4 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that helps you create new things
- *
- * @packageDocumentation
- */
-
-export * from './scaffolder';
-export * from './service/router';
-export * from './lib';
-export * from './processor';
+export type { NunjucksFilter } from './SecureTemplater';

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -46,7 +46,7 @@ import {
   createGithubActionsDispatchAction,
   createGithubWebhookAction,
 } from './github';
-import { NunjucksFilter } from '../../../lib/templating/SecureTemplater';
+import { TemplateFilter } from '../../../lib';
 
 export const createBuiltinActions = (options: {
   reader: UrlReader;
@@ -54,7 +54,7 @@ export const createBuiltinActions = (options: {
   catalogClient: CatalogApi;
   containerRunner?: ContainerRunner;
   config: Config;
-  nunjucksFilters?: Record<string, NunjucksFilter>;
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
 }) => {
   const {
     reader,
@@ -62,7 +62,7 @@ export const createBuiltinActions = (options: {
     containerRunner,
     catalogClient,
     config,
-    nunjucksFilters,
+    additionalTemplateFilters,
   } = options;
   const githubCredentialsProvider: GithubCredentialsProvider =
     DefaultGithubCredentialsProvider.fromIntegrations(integrations);
@@ -75,7 +75,7 @@ export const createBuiltinActions = (options: {
     createFetchTemplateAction({
       integrations,
       reader,
-      nunjucksFilters,
+      additionalTemplateFilters,
     }),
     createPublishGithubAction({
       integrations,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -53,9 +53,16 @@ export const createBuiltinActions = (options: {
   catalogClient: CatalogApi;
   containerRunner?: ContainerRunner;
   config: Config;
+  nunjucksFilters?: Record<string, (data: any) => any>;
 }) => {
-  const { reader, integrations, containerRunner, catalogClient, config } =
-    options;
+  const {
+    reader,
+    integrations,
+    containerRunner,
+    catalogClient,
+    config,
+    nunjucksFilters,
+  } = options;
   const githubCredentialsProvider: GithubCredentialsProvider =
     DefaultGithubCredentialsProvider.fromIntegrations(integrations);
 
@@ -67,6 +74,7 @@ export const createBuiltinActions = (options: {
     createFetchTemplateAction({
       integrations,
       reader,
+      nunjucksFilters,
     }),
     createPublishGithubAction({
       integrations,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/createBuiltinActions.ts
@@ -46,6 +46,7 @@ import {
   createGithubActionsDispatchAction,
   createGithubWebhookAction,
 } from './github';
+import { NunjucksFilter } from '../../../lib/templating/SecureTemplater';
 
 export const createBuiltinActions = (options: {
   reader: UrlReader;
@@ -53,7 +54,7 @@ export const createBuiltinActions = (options: {
   catalogClient: CatalogApi;
   containerRunner?: ContainerRunner;
   config: Config;
-  nunjucksFilters?: Record<string, (data: any) => any>;
+  nunjucksFilters?: Record<string, NunjucksFilter>;
 }) => {
   const {
     reader,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -23,7 +23,10 @@ import { createTemplateAction } from '../../createTemplateAction';
 import globby from 'globby';
 import fs from 'fs-extra';
 import { isBinaryFile } from 'isbinaryfile';
-import { SecureTemplater } from '../../../../lib/templating/SecureTemplater';
+import {
+  NunjucksFilter,
+  SecureTemplater,
+} from '../../../../lib/templating/SecureTemplater';
 
 type CookieCompatInput = {
   copyWithoutRender?: string[];
@@ -44,7 +47,7 @@ export type FetchTemplateInput = {
 export function createFetchTemplateAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
-  nunjucksFilters?: Record<string, (data: any) => any>;
+  nunjucksFilters?: Record<string, NunjucksFilter>;
 }) {
   const { reader, integrations, nunjucksFilters } = options;
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -24,7 +24,7 @@ import globby from 'globby';
 import fs from 'fs-extra';
 import { isBinaryFile } from 'isbinaryfile';
 import {
-  NunjucksFilter,
+  TemplateFilter,
   SecureTemplater,
 } from '../../../../lib/templating/SecureTemplater';
 
@@ -47,9 +47,9 @@ export type FetchTemplateInput = {
 export function createFetchTemplateAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
-  nunjucksFilters?: Record<string, NunjucksFilter>;
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
 }) {
-  const { reader, integrations, nunjucksFilters } = options;
+  const { reader, integrations, additionalTemplateFilters } = options;
 
   return createTemplateAction<FetchTemplateInput>({
     id: 'fetch:template',
@@ -186,7 +186,7 @@ export function createFetchTemplateAction(options: {
 
       const renderTemplate = await SecureTemplater.loadRenderer({
         cookiecutterCompat: ctx.input.cookiecutterCompat,
-        nunjucksFilters: nunjucksFilters,
+        additionalTemplateFilters,
       });
 
       for (const location of allEntriesInTemplate) {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -186,7 +186,7 @@ export function createFetchTemplateAction(options: {
 
       const renderTemplate = await SecureTemplater.loadRenderer({
         cookiecutterCompat: ctx.input.cookiecutterCompat,
-        additionalFilters: nunjucksFilters,
+        nunjucksFilters: nunjucksFilters,
       });
 
       for (const location of allEntriesInTemplate) {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/fetch/template.ts
@@ -44,8 +44,9 @@ export type FetchTemplateInput = {
 export function createFetchTemplateAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
+  nunjucksFilters?: Record<string, (data: any) => any>;
 }) {
-  const { reader, integrations } = options;
+  const { reader, integrations, nunjucksFilters } = options;
 
   return createTemplateAction<FetchTemplateInput>({
     id: 'fetch:template',
@@ -182,6 +183,7 @@ export function createFetchTemplateAction(options: {
 
       const renderTemplate = await SecureTemplater.loadRenderer({
         cookiecutterCompat: ctx.input.cookiecutterCompat,
+        additionalFilters: nunjucksFilters,
       });
 
       for (const location of allEntriesInTemplate) {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -35,7 +35,7 @@ import { validate as validateJsonSchema } from 'jsonschema';
 import { parseRepoUrl } from '../actions/builtin/publish/util';
 import { TemplateActionRegistry } from '../actions';
 import {
-  NunjucksFilter,
+  TemplateFilter,
   SecureTemplater,
   SecureTemplateRenderer,
 } from '../../lib/templating/SecureTemplater';
@@ -45,7 +45,7 @@ type NunjucksWorkflowRunnerOptions = {
   actionRegistry: TemplateActionRegistry;
   integrations: ScmIntegrations;
   logger: winston.Logger;
-  nunjucksFilters?: Record<string, NunjucksFilter>;
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
 };
 
 type TemplateContext = {
@@ -192,7 +192,7 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
       parseRepoUrl(url: string) {
         return parseRepoUrl(url, integrations);
       },
-      nunjucksFilters: this.options.nunjucksFilters,
+      additionalTemplateFilters: this.options.additionalTemplateFilters,
     });
 
     try {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -45,7 +45,7 @@ type NunjucksWorkflowRunnerOptions = {
   actionRegistry: TemplateActionRegistry;
   integrations: ScmIntegrations;
   logger: winston.Logger;
-  additionalFilters?: Record<string, NunjucksFilter>;
+  nunjucksFilters?: Record<string, NunjucksFilter>;
 };
 
 type TemplateContext = {
@@ -192,7 +192,7 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
       parseRepoUrl(url: string) {
         return parseRepoUrl(url, integrations);
       },
-      additionalFilters: this.options.additionalFilters,
+      nunjucksFilters: this.options.nunjucksFilters,
     });
 
     try {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -44,6 +44,7 @@ type NunjucksWorkflowRunnerOptions = {
   actionRegistry: TemplateActionRegistry;
   integrations: ScmIntegrations;
   logger: winston.Logger;
+  additionalFilters?: Record<string, (data: any) => any>;
 };
 
 type TemplateContext = {
@@ -190,6 +191,7 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
       parseRepoUrl(url: string) {
         return parseRepoUrl(url, integrations);
       },
+      additionalFilters: this.options.additionalFilters,
     });
 
     try {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -35,6 +35,7 @@ import { validate as validateJsonSchema } from 'jsonschema';
 import { parseRepoUrl } from '../actions/builtin/publish/util';
 import { TemplateActionRegistry } from '../actions';
 import {
+  NunjucksFilter,
   SecureTemplater,
   SecureTemplateRenderer,
 } from '../../lib/templating/SecureTemplater';
@@ -44,7 +45,7 @@ type NunjucksWorkflowRunnerOptions = {
   actionRegistry: TemplateActionRegistry;
   integrations: ScmIntegrations;
   logger: winston.Logger;
-  additionalFilters?: Record<string, (data: any) => any>;
+  additionalFilters?: Record<string, NunjucksFilter>;
 };
 
 type TemplateContext = {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -21,7 +21,7 @@ import { Logger } from 'winston';
 import { TemplateActionRegistry } from '../actions';
 import { ScmIntegrations } from '@backstage/integration';
 import { assertError } from '@backstage/errors';
-import { NunjucksFilter } from '../../lib/templating/SecureTemplater';
+import { TemplateFilter } from '../../lib/templating/SecureTemplater';
 
 /**
  * TaskWorkerOptions
@@ -47,7 +47,7 @@ export type CreateWorkerOptions = {
   integrations: ScmIntegrations;
   workingDirectory: string;
   logger: Logger;
-  nunjucksFilters?: Record<string, NunjucksFilter>;
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
 };
 
 /**
@@ -65,7 +65,7 @@ export class TaskWorker {
       actionRegistry,
       integrations,
       workingDirectory,
-      nunjucksFilters,
+      additionalTemplateFilters,
     } = options;
 
     const legacyWorkflowRunner = new HandlebarsWorkflowRunner({
@@ -80,7 +80,7 @@ export class TaskWorker {
       integrations,
       logger,
       workingDirectory,
-      nunjucksFilters: nunjucksFilters,
+      additionalTemplateFilters,
     });
 
     return new TaskWorker({

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -46,6 +46,7 @@ export type CreateWorkerOptions = {
   integrations: ScmIntegrations;
   workingDirectory: string;
   logger: Logger;
+  nunjucksFilters?: Record<string, (data: any) => any>;
 };
 
 /**
@@ -63,6 +64,7 @@ export class TaskWorker {
       actionRegistry,
       integrations,
       workingDirectory,
+      nunjucksFilters,
     } = options;
 
     const legacyWorkflowRunner = new HandlebarsWorkflowRunner({
@@ -77,6 +79,7 @@ export class TaskWorker {
       integrations,
       logger,
       workingDirectory,
+      additionalFilters: nunjucksFilters,
     });
 
     return new TaskWorker({

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -21,6 +21,7 @@ import { Logger } from 'winston';
 import { TemplateActionRegistry } from '../actions';
 import { ScmIntegrations } from '@backstage/integration';
 import { assertError } from '@backstage/errors';
+import { NunjucksFilter } from '../../lib/templating/SecureTemplater';
 
 /**
  * TaskWorkerOptions
@@ -46,7 +47,7 @@ export type CreateWorkerOptions = {
   integrations: ScmIntegrations;
   workingDirectory: string;
   logger: Logger;
-  nunjucksFilters?: Record<string, (data: any) => any>;
+  nunjucksFilters?: Record<string, NunjucksFilter>;
 };
 
 /**

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -80,7 +80,7 @@ export class TaskWorker {
       integrations,
       logger,
       workingDirectory,
-      additionalFilters: nunjucksFilters,
+      nunjucksFilters: nunjucksFilters,
     });
 
     return new TaskWorker({

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -29,7 +29,7 @@ import express from 'express';
 import Router from 'express-promise-router';
 import { validate } from 'jsonschema';
 import { Logger } from 'winston';
-import { CatalogEntityClient, NunjucksFilter } from '../lib';
+import { CatalogEntityClient, TemplateFilter } from '../lib';
 import {
   createBuiltinActions,
   DatabaseTaskStore,
@@ -57,7 +57,7 @@ export interface RouterOptions {
   taskWorkers?: number;
   containerRunner?: ContainerRunner;
   taskBroker?: TaskBroker;
-  nunjucksFilters?: Record<string, NunjucksFilter>;
+  additionalTemplateFilters?: Record<string, TemplateFilter>;
 }
 
 function isSupportedTemplate(
@@ -84,7 +84,7 @@ export async function createRouter(
     actions,
     containerRunner,
     taskWorkers,
-    nunjucksFilters,
+    additionalTemplateFilters,
   } = options;
 
   const logger = parentLogger.child({ plugin: 'scaffolder' });
@@ -112,7 +112,7 @@ export async function createRouter(
       integrations,
       logger,
       workingDirectory,
-      nunjucksFilters,
+      additionalTemplateFilters,
     });
     workers.push(worker);
   }
@@ -125,7 +125,7 @@ export async function createRouter(
         containerRunner,
         reader,
         config,
-        nunjucksFilters,
+        additionalTemplateFilters,
       });
 
   actionsToRegister.forEach(action => actionRegistry.register(action));

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -41,6 +41,7 @@ import {
 } from '../scaffolder';
 import { StorageTaskBroker } from '../scaffolder/tasks/StorageTaskBroker';
 import { getEntityBaseUrl, getWorkingDirectory } from './helpers';
+import { NunjucksFilter } from '../lib/templating/SecureTemplater';
 
 /**
  * RouterOptions
@@ -57,7 +58,7 @@ export interface RouterOptions {
   taskWorkers?: number;
   containerRunner?: ContainerRunner;
   taskBroker?: TaskBroker;
-  nunjucksFilters?: Record<string, (data: any) => any>;
+  nunjucksFilters?: Record<string, NunjucksFilter>;
 }
 
 function isSupportedTemplate(

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -57,6 +57,7 @@ export interface RouterOptions {
   taskWorkers?: number;
   containerRunner?: ContainerRunner;
   taskBroker?: TaskBroker;
+  nunjucksFilters?: Record<string, (data: any) => any>;
 }
 
 function isSupportedTemplate(
@@ -83,6 +84,7 @@ export async function createRouter(
     actions,
     containerRunner,
     taskWorkers,
+    nunjucksFilters,
   } = options;
 
   const logger = parentLogger.child({ plugin: 'scaffolder' });
@@ -110,6 +112,7 @@ export async function createRouter(
       integrations,
       logger,
       workingDirectory,
+      nunjucksFilters,
     });
     workers.push(worker);
   }
@@ -122,6 +125,7 @@ export async function createRouter(
         containerRunner,
         reader,
         config,
+        nunjucksFilters,
       });
 
   actionsToRegister.forEach(action => actionRegistry.register(action));

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -29,7 +29,7 @@ import express from 'express';
 import Router from 'express-promise-router';
 import { validate } from 'jsonschema';
 import { Logger } from 'winston';
-import { CatalogEntityClient } from '../lib/catalog';
+import { CatalogEntityClient, NunjucksFilter } from '../lib';
 import {
   createBuiltinActions,
   DatabaseTaskStore,
@@ -41,7 +41,6 @@ import {
 } from '../scaffolder';
 import { StorageTaskBroker } from '../scaffolder/tasks/StorageTaskBroker';
 import { getEntityBaseUrl, getWorkingDirectory } from './helpers';
-import { NunjucksFilter } from '../lib/templating/SecureTemplater';
 
 /**
  * RouterOptions


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Expose option for user-injected Nunjucks filters in software templates (both for v1beta3 templates and via the `fetch:template` action).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Resolves #8920