### PR TITLE
tech-insights-backend: fixed type assignment

### DIFF
--- a/.changeset/dull-nails-repeat.md
+++ b/.changeset/dull-nails-repeat.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-tech-insights-backend': patch
----
-
-Fixed invalid access that caused an immediate crash with a `TypeError` when loading the package.

--- a/.changeset/dull-nails-repeat.md
+++ b/.changeset/dull-nails-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights-backend': patch
+---
+
+Fixed invalid access that caused an immediate crash with a `TypeError` when loading the package.

--- a/plugins/tech-insights-backend/CHANGELOG.md
+++ b/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-tech-insights-backend
 
+## 0.2.1
+
+### Patch Changes
+
+- ad0a7eb088: Fixed invalid access that caused an immediate crash with a `TypeError` when loading the package.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/tech-insights-backend/package.json
+++ b/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-tech-insights-backend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.ts
+++ b/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.ts
@@ -28,7 +28,8 @@ import { DateTime } from 'luxon';
 import { Logger } from 'winston';
 import { parseEntityName, stringifyEntityRef } from '@backstage/catalog-model';
 import { isMaxItems, isTtl } from '../fact/factRetrievers/utils';
-import Transaction = Knex.Transaction;
+
+type Transaction = Knex.Transaction;
 
 export type RawDbFactRow = {
   id: string;


### PR DESCRIPTION
This is a patch release of `@backstage/plugin-tech-insights-backend` that fixes the following crash:

```
TypeError: Cannot read properties of undefined (reading 'Transaction')
```