### PR TITLE
Fix component type comparison in Sidebar

### DIFF
--- a/.changeset/famous-walls-yell.md
+++ b/.changeset/famous-walls-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fix issue where component types are not recognized causing the `MobileSidebar` to not render as intended.

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -284,6 +284,8 @@ function isButtonItem(
   return (props as SidebarItemLinkProps).to === undefined;
 }
 
+const sidebarSubmenuType = React.createElement(SidebarSubmenu).type;
+
 // TODO(Rugvip): Remove this once NavLink is updated in react-router-dom.
 //               This is needed because react-router doesn't handle the path comparison
 //               properly yet, matching for example /foobar with /foo.
@@ -490,9 +492,7 @@ export const SidebarItem = forwardRef<any, SidebarItemProps>((props, ref) => {
     // combination with react-hot-loader
     //
     // https://github.com/gaearon/react-hot-loader/issues/304#issuecomment-456569720
-    elements
-      .getElements()
-      .filter(child => child.type === React.createElement(SidebarSubmenu).type),
+    elements.getElements().filter(child => child.type === sidebarSubmenuType),
   );
 
   if (submenu) {

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -486,7 +486,13 @@ const SidebarItemWithSubmenu = ({
 export const SidebarItem = forwardRef<any, SidebarItemProps>((props, ref) => {
   // Filter children for SidebarSubmenu components
   const [submenu] = useElementFilter(props.children, elements =>
-    elements.getElements().filter(child => child.type === SidebarSubmenu),
+    // Directly comparing child.type with SidebarSubmenu will not work with in
+    // combination with react-hot-loader
+    //
+    // https://github.com/gaearon/react-hot-loader/issues/304#issuecomment-456569720
+    elements
+      .getElements()
+      .filter(child => child.type === React.createElement(SidebarSubmenu).type),
   );
 
   if (submenu) {

--- a/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
+++ b/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
@@ -162,8 +162,15 @@ export const MobileSidebar = (props: MobileSidebarProps) => {
   }, [location.pathname]);
 
   // Filter children for SidebarGroups
+  //
+  // Directly comparing child.type with SidebarSubmenu will not work with in
+  // combination with react-hot-loader
+  //
+  // https://github.com/gaearon/react-hot-loader/issues/304#issuecomment-456569720
   let sidebarGroups = useElementFilter(children, elements =>
-    elements.getElements().filter(child => child.type === SidebarGroup),
+    elements
+      .getElements()
+      .filter(child => child.type === React.createElement(SidebarGroup).type),
   );
 
   if (!children) {

--- a/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
+++ b/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
@@ -102,6 +102,8 @@ const sortSidebarGroupsForPriority = (children: React.ReactElement[]) =>
     'desc',
   );
 
+const sidebarGroupType = React.createElement(SidebarGroup).type;
+
 const OverlayMenu = ({
   children,
   label = 'Menu',
@@ -168,9 +170,7 @@ export const MobileSidebar = (props: MobileSidebarProps) => {
   //
   // https://github.com/gaearon/react-hot-loader/issues/304#issuecomment-456569720
   let sidebarGroups = useElementFilter(children, elements =>
-    elements
-      .getElements()
-      .filter(child => child.type === React.createElement(SidebarGroup).type),
+    elements.getElements().filter(child => child.type === sidebarGroupType),
   );
 
   if (!children) {


### PR DESCRIPTION
Fix issue where component types are not recognized causing the Sidebar to look weird. Directly comparing child.type with components will not work with in combination with react-hot-loader.

Related to this: https://github.com/backstage/backstage/blob/b738adebe3a1e970c383d9eb961586e2975e79[…]ackages/components/src/components/TabbedLayout/TabbedLayout.tsx

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
