### PR TITLE
implement url parsing in integrations

### DIFF
--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -106,6 +106,9 @@ export class DefaultGithubCredentialsProvider
 }
 
 // @public
+export function defaultScmParseUrl(url: string): ScmLocation;
+
+// @public
 export function defaultScmResolveUrl(options: {
   url: string;
   base: string;
@@ -384,6 +387,7 @@ export interface ScmIntegrationRegistry
   github: ScmIntegrationsGroup<GitHubIntegration>;
   // (undocumented)
   gitlab: ScmIntegrationsGroup<GitLabIntegration>;
+  parseUrl(url: string): ScmLocation;
   resolveEditUrl(url: string): string;
   resolveUrl(options: {
     url: string;
@@ -414,6 +418,8 @@ export class ScmIntegrations implements ScmIntegrationRegistry {
   // (undocumented)
   list(): ScmIntegration[];
   // (undocumented)
+  parseUrl(url: string): ScmLocation;
+  // (undocumented)
   resolveEditUrl(url: string): string;
   // (undocumented)
   resolveUrl(options: {
@@ -434,6 +440,24 @@ export interface ScmIntegrationsGroup<T extends ScmIntegration> {
   byUrl(url: string | URL): T | undefined;
   list(): T[];
 }
+
+// @public
+export type ScmLocation = {
+  url: {
+    host: string;
+    root: string;
+  };
+  repository: {
+    organization: string | undefined;
+    owner: string;
+    name: string;
+  };
+  target: {
+    ref: string | undefined;
+    path: string | undefined;
+    pathType: string | undefined;
+  };
+};
 
 // @public
 export class SingleInstanceGithubCredentialsProvider

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@backstage/config": "^0.1.14",
+    "@backstage/errors": "^0.2.0",
     "cross-fetch": "^3.1.5",
     "git-url-parse": "^11.6.0",
     "@octokit/rest": "^18.5.3",

--- a/packages/integration/src/ScmIntegrationRegistry.ts
+++ b/packages/integration/src/ScmIntegrationRegistry.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { ScmIntegration, ScmIntegrationsGroup } from './types';
 import { AwsS3Integration } from './awsS3/AwsS3Integration';
 import { AzureIntegration } from './azure/AzureIntegration';
 import { BitbucketIntegration } from './bitbucket/BitbucketIntegration';
 import { GitHubIntegration } from './github/GitHubIntegration';
 import { GitLabIntegration } from './gitlab/GitLabIntegration';
+import { ScmIntegration, ScmIntegrationsGroup, ScmLocation } from './types';
 
 /**
  * Holds all registered SCM integrations, of all types.
@@ -73,4 +73,11 @@ export interface ScmIntegrationRegistry
    * @param url - The absolute URL to the file that should be edited.
    */
   resolveEditUrl(url: string): string;
+
+  /**
+   * Takes a URL and parses it into its constituent parts.
+   *
+   * @param url - The URL to parse
+   */
+  parseUrl(url: string): ScmLocation;
 }

--- a/packages/integration/src/ScmIntegrations.ts
+++ b/packages/integration/src/ScmIntegrations.ts
@@ -20,9 +20,13 @@ import { AzureIntegration } from './azure/AzureIntegration';
 import { BitbucketIntegration } from './bitbucket/BitbucketIntegration';
 import { GitHubIntegration } from './github/GitHubIntegration';
 import { GitLabIntegration } from './gitlab/GitLabIntegration';
-import { defaultScmResolveUrl } from './helpers';
-import { ScmIntegration, ScmIntegrationsGroup } from './types';
-import { ScmIntegrationRegistry } from './registry';
+import {
+  defaultScmParseUrl,
+  defaultScmResolveUrl,
+  parseShorthandScmUrl,
+} from './helpers';
+import { ScmIntegrationRegistry } from './ScmIntegrationRegistry';
+import { ScmIntegration, ScmIntegrationsGroup, ScmLocation } from './types';
 
 /**
  * The set of supported integrations.
@@ -117,5 +121,14 @@ export class ScmIntegrations implements ScmIntegrationRegistry {
     }
 
     return integration.resolveEditUrl(url);
+  }
+
+  parseUrl(url: string): ScmLocation {
+    const shorthand = parseShorthandScmUrl(url);
+    if (shorthand) {
+      return shorthand;
+    }
+
+    return defaultScmParseUrl(url);
   }
 }

--- a/packages/integration/src/ScmIntegrations.ts
+++ b/packages/integration/src/ScmIntegrations.ts
@@ -26,7 +26,8 @@ import {
   parseShorthandScmUrl,
 } from './helpers';
 import { ScmIntegrationRegistry } from './ScmIntegrationRegistry';
-import { ScmIntegration, ScmIntegrationsGroup, ScmLocation } from './types';
+import { ScmUrl } from './ScmUrl';
+import { ScmIntegration, ScmIntegrationsGroup } from './types';
 
 /**
  * The set of supported integrations.
@@ -123,11 +124,13 @@ export class ScmIntegrations implements ScmIntegrationRegistry {
     return integration.resolveEditUrl(url);
   }
 
-  parseUrl(url: string): ScmLocation {
+  parseUrl(url: string): ScmUrl {
     const shorthand = parseShorthandScmUrl(url);
     if (shorthand) {
       return shorthand;
     }
+
+    // TODO: Call per-integration parseUrl when available
 
     return defaultScmParseUrl(url);
   }

--- a/packages/integration/src/ScmUrl.ts
+++ b/packages/integration/src/ScmUrl.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * References an SCM based location.
+ *
+ * @public
+ */
+export interface ScmUrl {
+  /** The host name of the SCM integration, e.g. "github.com". */
+  host: string;
+  /** The root URL of the SCM integration, including protocol and root path, e.g. "https://dev.example.com:8080/git". */
+  root: string;
+  /** The organization the repository owner belongs to, if any (only applies to some providers). */
+  organization?: string | undefined;
+  /** The repository owner. */
+  owner?: string | undefined;
+  /** The repository name. */
+  name?: string | undefined;
+  /** The targeted ref (e.g. "master" or "dev"). */
+  ref?: string | undefined;
+  /** The file path relative to the repo root, if any, including the leading slash. */
+  path?: string | undefined;
+  /** The type of file path, if any, e.g. "blob" or "edit" */
+  pathType?: string | undefined;
+}

--- a/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
@@ -15,7 +15,7 @@
  */
 
 import { GithubCredentials, GithubCredentialsProvider } from './types';
-import { ScmIntegrationRegistry } from '../registry';
+import { ScmIntegrationRegistry } from '../ScmIntegrationRegistry';
 import { SingleInstanceGithubCredentialsProvider } from './SingleInstanceGithubCredentialsProvider';
 
 /**

--- a/packages/integration/src/helpers.ts
+++ b/packages/integration/src/helpers.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+import { InputError } from '@backstage/errors';
 import parseGitUrl from 'git-url-parse';
 import { trimEnd } from 'lodash';
-import { InputError } from '@backstage/errors';
-import { ScmIntegration, ScmIntegrationsGroup, ScmLocation } from './types';
+import { ScmUrl } from './ScmUrl';
+import { ScmIntegration, ScmIntegrationsGroup } from './types';
 
 /** Checks whether the given argument is a valid URL hostname */
 export function isValidHost(host: string): boolean {
@@ -113,7 +114,7 @@ export function defaultScmResolveUrl(options: {
  *
  * @public
  */
-export function defaultScmParseUrl(url: string): ScmLocation {
+export function defaultScmParseUrl(url: string): ScmUrl {
   try {
     const result = parseGitUrl(url);
     const raw = new URL(url);
@@ -123,20 +124,14 @@ export function defaultScmParseUrl(url: string): ScmLocation {
     }
 
     return {
-      url: {
-        host: raw.hostname,
-        root: `${raw.protocol}//${raw.host}`,
-      },
-      repository: {
-        organization: result.organization || undefined,
-        owner: result.owner,
-        name: result.name,
-      },
-      target: {
-        ref: result.ref || undefined,
-        path: ensureLeadingSlash(result.filepath),
-        pathType: result.filepathtype || undefined,
-      },
+      host: raw.hostname,
+      root: `${raw.protocol}//${raw.host}`,
+      organization: result.organization || undefined,
+      owner: result.owner,
+      name: result.name,
+      ref: result.ref || undefined,
+      path: ensureLeadingSlash(result.filepath),
+      pathType: result.filepathtype || undefined,
     };
   } catch (error) {
     throw new InputError(`Unparseable URL, ${error}`);
@@ -162,7 +157,7 @@ export function defaultScmParseUrl(url: string): ScmLocation {
  *
  * @public
  */
-export function parseShorthandScmUrl(url: string): ScmLocation | false {
+export function parseShorthandScmUrl(url: string): ScmUrl | false {
   try {
     // Support shorthands both with and without a protocol part
     const urlWithProtocol = url.includes('://') ? url : `https://${url}`;
@@ -192,20 +187,14 @@ export function parseShorthandScmUrl(url: string): ScmLocation | false {
     }
 
     return {
-      url: {
-        host: raw.hostname,
-        root: `${raw.protocol}//${raw.host}${raw.pathname}`.replace(/\/$/, ''),
-      },
-      repository: {
-        organization: organization || undefined,
-        owner,
-        name,
-      },
-      target: {
-        ref: ref || undefined,
-        path: ensureLeadingSlash(path),
-        pathType: pathType || undefined,
-      },
+      host: raw.hostname,
+      root: `${raw.protocol}//${raw.host}${raw.pathname}`.replace(/\/$/, ''),
+      organization: organization || undefined,
+      owner,
+      name,
+      ref: ref || undefined,
+      path: ensureLeadingSlash(path),
+      pathType: pathType || undefined,
     };
   } catch {
     return false;

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -20,18 +20,19 @@
  * @packageDocumentation
  */
 
+export * from './awsS3';
 export * from './azure';
 export * from './bitbucket';
 export * from './github';
 export * from './gitlab';
 export * from './googleGcs';
-export * from './awsS3';
-export { defaultScmResolveUrl } from './helpers';
+export { defaultScmParseUrl, defaultScmResolveUrl } from './helpers';
+export type { ScmIntegrationRegistry } from './ScmIntegrationRegistry';
 export { ScmIntegrations } from './ScmIntegrations';
 export type { IntegrationsByType } from './ScmIntegrations';
 export type {
   ScmIntegration,
   ScmIntegrationsFactory,
   ScmIntegrationsGroup,
+  ScmLocation,
 } from './types';
-export type { ScmIntegrationRegistry } from './registry';

--- a/packages/integration/src/types.ts
+++ b/packages/integration/src/types.ts
@@ -108,3 +108,33 @@ export interface ScmIntegrationsGroup<T extends ScmIntegration> {
 export type ScmIntegrationsFactory<T extends ScmIntegration> = (options: {
   config: Config;
 }) => ScmIntegrationsGroup<T>;
+
+/**
+ * References an SCM based location.
+ *
+ * @public
+ */
+export type ScmLocation = {
+  url: {
+    /** The host name of the SCM integration, e.g. "github.com". */
+    host: string;
+    /** The root URL of the SCM integration, including protocol and root path, e.g. "https://dev.example.com:8080/git". */
+    root: string;
+  };
+  repository: {
+    /** The organization the repository owner belongs to, if any (only applies to some providers). */
+    organization: string | undefined;
+    /** The repository owner. */
+    owner: string;
+    /** The repository name. */
+    name: string;
+  };
+  target: {
+    /** The targeted ref (e.g. "master" or "dev"). */
+    ref: string | undefined;
+    /** The file path relative to the repo root, if any, including the leading slash. */
+    path: string | undefined;
+    /** The type of file path, if any, e.g. "blob" or "edit" */
+    pathType: string | undefined;
+  };
+};

--- a/packages/integration/src/types.ts
+++ b/packages/integration/src/types.ts
@@ -108,33 +108,3 @@ export interface ScmIntegrationsGroup<T extends ScmIntegration> {
 export type ScmIntegrationsFactory<T extends ScmIntegration> = (options: {
   config: Config;
 }) => ScmIntegrationsGroup<T>;
-
-/**
- * References an SCM based location.
- *
- * @public
- */
-export type ScmLocation = {
-  url: {
-    /** The host name of the SCM integration, e.g. "github.com". */
-    host: string;
-    /** The root URL of the SCM integration, including protocol and root path, e.g. "https://dev.example.com:8080/git". */
-    root: string;
-  };
-  repository: {
-    /** The organization the repository owner belongs to, if any (only applies to some providers). */
-    organization: string | undefined;
-    /** The repository owner. */
-    owner: string;
-    /** The repository name. */
-    name: string;
-  };
-  target: {
-    /** The targeted ref (e.g. "master" or "dev"). */
-    ref: string | undefined;
-    /** The file path relative to the repo root, if any, including the leading slash. */
-    path: string | undefined;
-    /** The type of file path, if any, e.g. "blob" or "edit" */
-    pathType: string | undefined;
-  };
-};


### PR DESCRIPTION
Movement towards addressing #2815.

We've been using `git-url-parse` for years, by directly importing it in code all over the place. This has mostly worked out OK, but has some drawbacks. It can't leverage pre-existing knowledge of what SCM solution is being targeted - this could be deduced based on our `integrations` config. There is also no way of properly supporting branches with forward slashes in them through that library. To be able to address that we would have to wrap up the parsing code, and either support returning promises (and asking e.g. the GitHub API to resolve the URL for us), or support custom URL formats [as suggested](https://github.com/backstage/backstage/issues/2815#issuecomment-876753256) in the above ticket.

This PR gets the ball rolling by exposing a new `parseURL` method on the `ScmIntegrationRegistry` interface.