### PR TITLE
Fixes: Change Events Unable to be Listed

### DIFF
--- a/.changeset/tall-rats-lie.md
+++ b/.changeset/tall-rats-lie.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-pagerduty': patch
 ---
 
-Fixes change events tab from erroring when change events exist
+Fix change events tab error when change events exist

--- a/.changeset/tall-rats-lie.md
+++ b/.changeset/tall-rats-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-pagerduty': patch
+---
+
+Fixes change events tab from erroring when change events exist

--- a/plugins/pagerduty/README.md
+++ b/plugins/pagerduty/README.md
@@ -7,6 +7,7 @@
 
 - The Backstage PagerDuty plugin allows PagerDuty information about a Backstage entity to be displayed within Backstage. This includes active incidents, recent change events, as well as the current on-call responders' names, email addresses, and links to their profiles in PagerDuty.
 - Incidents can be manually triggered via the plugin with a user-provided description, which will in turn notify the current on-call responders.
+- Change events will be displayed in a separate tab. If the change event payload has additional links the first link only will be rendered.
 
 # Requirements
 

--- a/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
+++ b/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
@@ -86,7 +86,7 @@ export const ChangeEventListItem = ({ changeEvent }: Props) => {
       />
       <ListItemSecondaryAction>
         {externalLinkElem}
-        {changeEvent.html_url === undefined ? null :
+        {changeEvent.html_url === undefined ? null : (
           <Tooltip title="View in PagerDuty" placement="top">
             <IconButton
               href={changeEvent.html_url}
@@ -97,7 +97,7 @@ export const ChangeEventListItem = ({ changeEvent }: Props) => {
               <OpenInBrowserIcon />
             </IconButton>
           </Tooltip>
-        }
+        )}
       </ListItemSecondaryAction>
     </ListItem>
   );

--- a/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
+++ b/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
@@ -47,7 +47,6 @@ type Props = {
 };
 
 export const ChangeEventListItem = ({ changeEvent }: Props) => {
-  console.log(changeEvent)
   const classes = useStyles();
   const duration =
     new Date().getTime() - new Date(changeEvent.timestamp).getTime();

--- a/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
+++ b/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { Link } from '@backstage/core-components';
 import {
   ListItem,
   ListItemSecondaryAction,
@@ -58,12 +59,7 @@ export const ChangeEventListItem = ({ changeEvent }: Props) => {
     const text: string = changeEvent.links[0].text;
     externalLinkElem = (
       <Tooltip title={text} placement="top">
-        <IconButton
-          href={changeEvent.links[0].href}
-          target="_blank"
-          rel="noopener noreferrer"
-          color="primary"
-        >
+        <IconButton component={Link} to={changeEvent.links[0].href}>
           <OpenInBrowserIcon />
         </IconButton>
       </Tooltip>
@@ -89,9 +85,8 @@ export const ChangeEventListItem = ({ changeEvent }: Props) => {
         {changeEvent.html_url === undefined ? null : (
           <Tooltip title="View in PagerDuty" placement="top">
             <IconButton
-              href={changeEvent.html_url}
-              target="_blank"
-              rel="noopener noreferrer"
+              component={Link}
+              to={changeEvent.html_url}
               color="primary"
             >
               <OpenInBrowserIcon />

--- a/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
+++ b/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
@@ -28,7 +28,6 @@ import { DateTime, Duration } from 'luxon';
 import { ChangeEvent } from '../types';
 import OpenInBrowserIcon from '@material-ui/icons/OpenInBrowser';
 import { BackstageTheme } from '@backstage/theme';
-import { Link } from '@backstage/core-components';
 
 const useStyles = makeStyles<BackstageTheme>({
   denseListIcon: {
@@ -48,6 +47,7 @@ type Props = {
 };
 
 export const ChangeEventListItem = ({ changeEvent }: Props) => {
+  console.log(changeEvent)
   const classes = useStyles();
   const duration =
     new Date().getTime() - new Date(changeEvent.timestamp).getTime();
@@ -60,8 +60,9 @@ export const ChangeEventListItem = ({ changeEvent }: Props) => {
     externalLinkElem = (
       <Tooltip title={text} placement="top">
         <IconButton
-          component={Link}
-          to={changeEvent.links[0].href}
+          href={changeEvent.links[0].href}
+          target="_blank"
+          rel="noopener noreferrer"
           color="primary"
         >
           <OpenInBrowserIcon />
@@ -86,15 +87,18 @@ export const ChangeEventListItem = ({ changeEvent }: Props) => {
       />
       <ListItemSecondaryAction>
         {externalLinkElem}
-        <Tooltip title="View in PagerDuty" placement="top">
-          <IconButton
-            component={Link}
-            to={changeEvent.html_url}
-            color="primary"
-          >
-            <OpenInBrowserIcon />
-          </IconButton>
-        </Tooltip>
+        {changeEvent.html_url === undefined ? null :
+          <Tooltip title="View in PagerDuty" placement="top">
+            <IconButton
+              href={changeEvent.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              color="primary"
+            >
+              <OpenInBrowserIcon />
+            </IconButton>
+          </Tooltip>
+        }
       </ListItemSecondaryAction>
     </ListItem>
   );

--- a/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
+++ b/plugins/pagerduty/src/components/ChangeEvents/ChangeEventListItem.tsx
@@ -59,7 +59,11 @@ export const ChangeEventListItem = ({ changeEvent }: Props) => {
     const text: string = changeEvent.links[0].text;
     externalLinkElem = (
       <Tooltip title={text} placement="top">
-        <IconButton component={Link} to={changeEvent.links[0].href}>
+        <IconButton
+          component={Link}
+          to={changeEvent.links[0].href}
+          color="primary"
+        >
           <OpenInBrowserIcon />
         </IconButton>
       </Tooltip>

--- a/plugins/pagerduty/src/components/ChangeEvents/ChangeEvents.test.tsx
+++ b/plugins/pagerduty/src/components/ChangeEvents/ChangeEvents.test.tsx
@@ -92,6 +92,54 @@ describe('Incidents', () => {
     expect(getAllByTitle('View in PagerDuty').length).toEqual(2);
   });
 
+  it('Does not render a pagerduty link when html_url is not present in response', async () => {
+    mockPagerDutyApi.getChangeEventsByServiceId = jest
+      .fn()
+      .mockImplementationOnce(
+        async () =>
+          [
+            {
+              id: 'id1',
+              source: 'changeSource1',
+              links: [
+                {
+                  href: 'www.externalLink1.com',
+                  text: 'link1',
+                },
+              ],
+              summary: 'summary of event',
+              timestamp: '2020-07-17T08:42:58.315+0000',
+            },
+            {
+              id: 'id2',
+              source: 'changeSource1',
+              html_url: 'www.pdlink.com/link',
+              links: [
+                {
+                  href: 'www.externalLink1.com',
+                  text: 'link1',
+                },
+              ],
+              summary: 'sum of EVENT',
+              timestamp: '2020-07-18T08:42:58.315+0000',
+            },
+          ] as ChangeEvent[],
+      );
+    const { getByText, getAllByTitle, queryByTestId } = render(
+      wrapInTestApp(
+        <ApiProvider apis={apis}>
+          <ChangeEvents serviceId="abc" refreshEvents={false} />
+        </ApiProvider>,
+      ),
+    );
+    await waitFor(() => !queryByTestId('progress'));
+    expect(getByText('summary of event')).toBeInTheDocument();
+    expect(getByText('sum of EVENT')).toBeInTheDocument();
+
+    // assert links, mailto and hrefs, date calculation
+    expect(getAllByTitle('View in PagerDuty').length).toEqual(1);
+  });
+
   it('Handle errors', async () => {
     mockPagerDutyApi.getChangeEventsByServiceId = jest
       .fn()


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/8409 - Allowing for change events to be rendered when they exist.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
