### PR TITLE
removes `ignoreChildEvent`utility

### DIFF
--- a/.changeset/cool-hats-scream.md
+++ b/.changeset/cool-hats-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Remove the `ignoreChildEvent` utility from the sidebar component to avoid conflicts with popovers

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -182,13 +182,9 @@ const DesktopSidebar = (props: SidebarProps) => {
           className={classes.root}
           data-testid="sidebar-root"
           onMouseEnter={disableExpandOnHover ? () => {} : handleOpen}
-          onFocus={
-            disableExpandOnHover ? () => {} : ignoreChildEvent(handleOpen)
-          }
+          onFocus={disableExpandOnHover ? () => {} : handleOpen}
           onMouseLeave={disableExpandOnHover ? () => {} : handleClose}
-          onBlur={
-            disableExpandOnHover ? () => {} : ignoreChildEvent(handleClose)
-          }
+          onBlur={disableExpandOnHover ? () => {} : handleClose}
         >
           <div
             className={classnames(classes.drawer, {
@@ -241,14 +237,4 @@ function A11ySkipSidebar() {
       Skip to content
     </Button>
   );
-}
-
-function ignoreChildEvent(handlerFn: (e?: any) => void) {
-  // TODO type the event
-  return (event: any) => {
-    const currentTarget = event?.currentTarget as HTMLElement;
-    if (!currentTarget?.contains(event.relatedTarget as HTMLElement)) {
-      handlerFn(event);
-    }
-  };
 }


### PR DESCRIPTION
Remove the `ignoreChildEvent` utility from the sidebar component to avoid conflicts with popovers

The ignoreChildEvent is not really needed

fixes #9073 
Signed-off-by: Juan Pablo Garcia Ripa <sarabadu@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
