### PR TITLE
github-actions: Use SA token for checkout

### DIFF
--- a/.github/workflows/sync_dependabot-changesets.yml
+++ b/.github/workflows/sync_dependabot-changesets.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           fetch-depth: 2
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
       - name: Configure Git
         run: |
           git config --global user.email noreply@backstage.io


### PR DESCRIPTION
Needed to fool github actions to run workflows when changes are made by a bot
