### PR TITLE
github-actions: Add assemble release workflow

### DIFF
--- a/.github/workflows/assemble-release.yml
+++ b/.github/workflows/assemble-release.yml
@@ -1,0 +1,37 @@
+name: Assemble release and generate versions file
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number'
+        required: true
+jobs:
+  create-new-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Checkout versions
+        uses: actions/checkout@v2
+        with:
+          repository: backstage/versions
+          path: versions
+          token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+      - name: Configure Git
+        run: |
+          git config --global user.email noreply@backstage.io
+          git config --global user.name 'Github versions workflow'
+      - name: Create release
+        run: |
+          node scripts/assemble-manifest.js ${{ github.event.inputs.version }} versions/v1/releases
+          cd versions
+          if [[ "${{ github.event.inputs.version }}" == *"next"* ]]; then
+            echo Updating next tag
+            rm -f v1/tags/next && ln -s ../releases/${{ github.event.inputs.version }} v1/tags/next
+            else
+            echo Updating main tag
+            rm -f v1/tags/main && ln -s ../releases/${{ github.event.inputs.version }} v1/tags/main
+          fi
+          git add .
+          git commit -am "${{ github.event.inputs.version }}"
+          git push

--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: {{ github.event.inputs.version }}
+          ref: ${{ github.event.inputs.version }}
       - name: Install dependencies
         run: yarn install
       - name: Checkout versions

--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -23,15 +23,8 @@ jobs:
           git config --global user.name 'Github versions workflow'
       - name: Create release
         run: |
-          node scripts/assemble-manifest.js ${{ github.event.inputs.version }} versions/v1/releases
+          node scripts/assemble-manifest.js ${{ github.event.inputs.version }}
           cd versions
-          if [[ "${{ github.event.inputs.version }}" == *"next"* ]]; then
-            echo Updating next tag
-            rm -f v1/tags/next && ln -s ../releases/${{ github.event.inputs.version }} v1/tags/next
-            else
-            echo Updating main tag
-            rm -f v1/tags/main && ln -s ../releases/${{ github.event.inputs.version }} v1/tags/main
-          fi
           git add .
           git commit -am "${{ github.event.inputs.version }}"
           git push

--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -1,4 +1,4 @@
-name: Assemble release and generate versions file
+name: Sync Release Manifest
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: {{ github.event.inputs.version }}
+      - name: Install dependencies
+        run: yarn install
       - name: Checkout versions
         uses: actions/checkout@v2
         with:

--- a/scripts/assemble-manifest.js
+++ b/scripts/assemble-manifest.js
@@ -21,9 +21,9 @@ const { getPackages } = require('@manypkg/get-packages');
 const path = require('path');
 
 async function main() {
-  const [version, outputPath] = process.argv.slice(2);
+  const [script, version, outputPath] = process.argv.slice(1);
   if (!version || !outputPath) {
-    throw new Error('Argument must be script.js <version> <outputPath>');
+    throw new Error(`Argument must be ${script} <version> <outputPath>`);
   }
 
   const manifestDir = path.resolve(outputPath, version);

--- a/scripts/assemble-manifest.js
+++ b/scripts/assemble-manifest.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/* eslint-disable import/no-extraneous-dependencies */
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs-extra');
+const { getPackages } = require('@manypkg/get-packages');
+const path = require('path');
+
+async function main() {
+  const [version, outputPath] = process.argv.slice(2);
+  if (!version || !outputPath) {
+    throw new Error('Argument must be script.js <version> <outputPath>');
+  }
+
+  const manifestDir = path.resolve(outputPath, version);
+  if (await fs.pathExists(manifestDir)) {
+    throw new Error(
+      `Release manifest path for version ${version} already exists`,
+    );
+  }
+
+  console.log(`Assembling packages for backstage release ${version}`);
+  const { packages } = await getPackages(path.resolve('.'));
+
+  const versions = packages
+    .filter(
+      p =>
+        (p.packageJson.name.startsWith('@backstage/') ||
+          p.packageJson.name.startsWith('@techdocs/')) &&
+        p.packageJson.private === false,
+    )
+    .map(p => {
+      return { name: p.packageJson.name, version: p.packageJson.version };
+    });
+  await fs.mkdir(manifestDir);
+  await fs.writeJSON(
+    path.resolve(manifestDir, 'manifest.json'),
+    { packages: versions },
+    { spaces: 2 },
+  );
+}
+
+main().catch(error => {
+  console.error(error.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
Creates a new github actions workflow that assembles all packages into a release manifest which gets published at http://versions.backstage.io/

This is currently manually triggered during testing phase but will eventually be trigged automatically on new releases.

