### PR TITLE
[auth-backend]: Support callbackUrl when setting cookie configuration

### DIFF
--- a/.changeset/quiet-rivers-wave.md
+++ b/.changeset/quiet-rivers-wave.md
@@ -2,12 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-Supports callbackUrls when setting cookie configuration.
-Cookie paths will no longer be scoped to include the handler of the provider:
-
-```diff
-cookie = {
--  path=`${pathname}/${provider}/handler`
-+  path=`${pathname}/${provider}`
-}
-```
+Running the `auth-backend` on multiple domains, perhaps different domains depending on the `auth.environment`, was previously not possible as the `domain` name of the cookie was taken from `backend.baseUrl`. This prevented any cookies to be set in the start of the auth flow as the domain of the cookie would not match the domain of the callbackUrl configured in the OAuth app. This change checks if a provider supports custom `callbackUrl`'s to be configured in the application configuration and uses the domain from that, allowing the `domain`'s to match and the cookie to be set.

--- a/.changeset/quiet-rivers-wave.md
+++ b/.changeset/quiet-rivers-wave.md
@@ -1,0 +1,13 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Supports callbackUrls when setting cookie configuration.
+Cookie paths will no longer be scoped to include the handler of the provider:
+
+```diff
+cookie = {
+-  path=`${pathname}/${provider}/handler`
++  path=`${pathname}/${provider}`
+}
+```

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -478,7 +478,11 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
     handlers: OAuthHandlers,
     options: Pick<
       Options,
-      'providerId' | 'persistScopes' | 'disableRefresh' | 'tokenIssuer'
+      | 'providerId'
+      | 'persistScopes'
+      | 'disableRefresh'
+      | 'tokenIssuer'
+      | 'callbackUrl'
     >,
   ): OAuthAdapter;
   // (undocumented)

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.test.ts
@@ -383,7 +383,7 @@ describe('OAuthAdapter', () => {
       expect.any(String),
       expect.objectContaining({
         domain: 'domain.org',
-        path: '/auth/test-provider',
+        path: '/auth/test-provider/handler',
         secure: false,
       }),
     );
@@ -423,7 +423,7 @@ describe('OAuthAdapter', () => {
       expect.any(String),
       expect.objectContaining({
         domain: 'authdomain.org',
-        path: '/auth/test-provider',
+        path: '/auth/test-provider/handler',
         secure: true,
       }),
     );

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -270,7 +270,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
       secure: this.options.secure,
       sameSite: 'lax',
       domain: this.options.cookieDomain,
-      path: this.options.cookiePath,
+      path: `${this.options.cookiePath}/handler`,
       httpOnly: true,
     });
   };
@@ -281,7 +281,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
       secure: this.options.secure,
       sameSite: 'lax',
       domain: this.options.cookieDomain,
-      path: this.options.cookiePath,
+      path: `${this.options.cookiePath}/handler`,
       httpOnly: true,
     });
   };

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -35,7 +35,7 @@ import {
   NotAllowedError,
 } from '@backstage/errors';
 import { TokenIssuer } from '../../identity/types';
-import { readState, verifyNonce } from './helpers';
+import { getCookieConfig, readState, verifyNonce } from './helpers';
 import { postMessageResponse, ensuresXRequestedWith } from '../flow';
 import {
   OAuthHandlers,
@@ -58,25 +58,32 @@ export type Options = {
   appOrigin: string;
   tokenIssuer: TokenIssuer;
   isOriginAllowed: (origin: string) => boolean;
+  callbackUrl?: string;
 };
-
 export class OAuthAdapter implements AuthProviderRouteHandlers {
   static fromConfig(
     config: AuthProviderConfig,
     handlers: OAuthHandlers,
     options: Pick<
       Options,
-      'providerId' | 'persistScopes' | 'disableRefresh' | 'tokenIssuer'
+      | 'providerId'
+      | 'persistScopes'
+      | 'disableRefresh'
+      | 'tokenIssuer'
+      | 'callbackUrl'
     >,
   ): OAuthAdapter {
     const { origin: appOrigin } = new URL(config.appUrl);
-    const secure = config.baseUrl.startsWith('https://');
-    const url = new URL(config.baseUrl);
-    const cookiePath = `${url.pathname}/${options.providerId}`;
+    const authUrl = new URL(options.callbackUrl ?? config.baseUrl);
+    const { cookieDomain, cookiePath, secure } = getCookieConfig(
+      authUrl,
+      options.providerId,
+    );
+
     return new OAuthAdapter(handlers, {
       ...options,
       appOrigin,
-      cookieDomain: url.hostname,
+      cookieDomain,
       cookiePath,
       secure,
       isOriginAllowed: config.isOriginAllowed,
@@ -263,7 +270,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
       secure: this.options.secure,
       sameSite: 'lax',
       domain: this.options.cookieDomain,
-      path: `${this.options.cookiePath}/handler`,
+      path: this.options.cookiePath,
       httpOnly: true,
     });
   };
@@ -274,7 +281,7 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
       secure: this.options.secure,
       sameSite: 'lax',
       domain: this.options.cookieDomain,
-      path: `${this.options.cookiePath}/handler`,
+      path: this.options.cookiePath,
       httpOnly: true,
     });
   };

--- a/plugins/auth-backend/src/lib/oauth/helpers.test.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.test.ts
@@ -15,7 +15,12 @@
  */
 
 import express from 'express';
-import { verifyNonce, encodeState, readState } from './helpers';
+import {
+  verifyNonce,
+  encodeState,
+  readState,
+  getCookieConfig,
+} from './helpers';
 
 describe('OAuthProvider Utils', () => {
   describe('encodeState', () => {
@@ -102,6 +107,33 @@ describe('OAuthProvider Utils', () => {
       expect(() => {
         verifyNonce(mockRequest, 'providera');
       }).not.toThrow();
+    });
+  });
+
+  describe('getCookieConfig', () => {
+    it('should set the correct domain and path for a base url', () => {
+      const mockAuthUrl = new URL('http://domain.org/auth');
+      expect(getCookieConfig(mockAuthUrl, 'test-provider')).toMatchObject({
+        cookieDomain: 'domain.org',
+        cookiePath: '/auth/test-provider',
+      });
+    });
+
+    it('should set the correct domain and path for a url containing a frame handler', () => {
+      const mockAuthUrl = new URL(
+        'http://domain.org/auth/test-provider/handler/frame',
+      );
+      expect(getCookieConfig(mockAuthUrl, 'test-provider')).toMatchObject({
+        cookieDomain: 'domain.org',
+        cookiePath: '/auth/test-provider',
+      });
+    });
+
+    it('should set the secure flag if url is using https', () => {
+      const mockAuthUrl = new URL('https://domain.org/auth');
+      expect(getCookieConfig(mockAuthUrl, 'test-provider')).toMatchObject({
+        secure: true,
+      });
     });
   });
 });

--- a/plugins/auth-backend/src/lib/oauth/helpers.test.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.test.ts
@@ -116,6 +116,7 @@ describe('OAuthProvider Utils', () => {
       expect(getCookieConfig(mockAuthUrl, 'test-provider')).toMatchObject({
         cookieDomain: 'domain.org',
         cookiePath: '/auth/test-provider',
+        secure: false,
       });
     });
 
@@ -126,6 +127,7 @@ describe('OAuthProvider Utils', () => {
       expect(getCookieConfig(mockAuthUrl, 'test-provider')).toMatchObject({
         cookieDomain: 'domain.org',
         cookiePath: '/auth/test-provider',
+        secure: false,
       });
     });
 

--- a/plugins/auth-backend/src/lib/oauth/helpers.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.ts
@@ -57,3 +57,27 @@ export const verifyNonce = (req: express.Request, providerId: string) => {
     throw new Error('Invalid nonce');
   }
 };
+
+export const getCookieConfig = (authUrl: URL, providerId: string) => {
+  const { hostname: cookieDomain, pathname, protocol } = authUrl;
+  const secure = protocol === 'https:';
+
+  // If the provider supports callbackUrls, the pathname will
+  // contain the complete path to the frame handler.
+  // The regex captures the leading path including the provider.
+  //
+  // Example match:  /api/auth/provider/handler/frame
+  // Example result: /api/auth/provider
+  const matcher = pathname.match(
+    new RegExp(`(?<path>^\/.*?\/${providerId})\/handler\/frame$`),
+  )?.groups;
+
+  // If there's no match we can manually construct the path
+  const cookiePath = matcher?.path ?? `${pathname}/${providerId}`;
+
+  return {
+    cookieDomain,
+    cookiePath,
+    secure,
+  };
+};

--- a/plugins/auth-backend/src/lib/oauth/helpers.ts
+++ b/plugins/auth-backend/src/lib/oauth/helpers.ts
@@ -63,17 +63,11 @@ export const getCookieConfig = (authUrl: URL, providerId: string) => {
   const secure = protocol === 'https:';
 
   // If the provider supports callbackUrls, the pathname will
-  // contain the complete path to the frame handler.
-  // The regex captures the leading path including the provider.
-  //
-  // Example match:  /api/auth/provider/handler/frame
-  // Example result: /api/auth/provider
-  const matcher = pathname.match(
-    new RegExp(`(?<path>^\/.*?\/${providerId})\/handler\/frame$`),
-  )?.groups;
-
-  // If there's no match we can manually construct the path
-  const cookiePath = matcher?.path ?? `${pathname}/${providerId}`;
+  // contain the complete path to the frame handler so we need
+  // to slice off the trailing part of the path.
+  const cookiePath = pathname.endsWith(`${providerId}/handler/frame`)
+    ? pathname.slice(0, -'/handler/frame'.length)
+    : `${pathname}/${providerId}`;
 
   return {
     cookieDomain,

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -313,6 +313,7 @@ export const createGithubProvider = (
         persistScopes: true,
         providerId,
         tokenIssuer,
+        callbackUrl,
       });
     });
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Some providers supports setting a custom `callbackUrl` in the application configuration which will allow you to have multiple urls configured for your auth backend.
In order for this to work we need to support that when setting the `domain` of the auth cookies. Also reducing the scope of the `path` in the cookies to be more general, to be able to support use-cases without `callbackUrl` being configured.




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
