### PR TITLE
Tradcliffe/add input option GitHub actions dispatch

### DIFF
--- a/.changeset/eight-tools-sleep.md
+++ b/.changeset/eight-tools-sleep.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-This change is for adding the option of inputs on the github:actions:dispatch Backstage Action. This will allow users to pass data from Backstage to the GitHub Action.
+This change is for adding the option of inputs on the `github:actions:dispatch` Backstage Action. This will allow users to pass data from Backstage to the GitHub Action.

--- a/.changeset/eight-tools-sleep.md
+++ b/.changeset/eight-tools-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+This change is for adding the option of inputs on the github:actions:dispatch Backstage Action. This will allow users to pass data from Backstage to the GitHub Action.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.test.ts
@@ -66,7 +66,7 @@ describe('github:actions:dispatch', () => {
     });
   });
 
-  it('should call the githubApis for creating WorkflowDispatch', async () => {
+  it('should call the githubApis for creating WorkflowDispatch without an input object', async () => {
     mockGithubClient.rest.actions.createWorkflowDispatch.mockResolvedValue({
       data: {
         foo: 'bar',
@@ -88,6 +88,33 @@ describe('github:actions:dispatch', () => {
       repo: 'repo',
       workflow_id: workflowId,
       ref: branchOrTagName,
+    });
+  });
+
+  it('should call the githubApis for creating WorkflowDispatch with an input object', async () => {
+    mockGithubClient.rest.actions.createWorkflowDispatch.mockResolvedValue({
+      data: {
+        foo: 'bar',
+      },
+    });
+
+    const repoUrl = 'github.com?repo=repo&owner=owner';
+    const workflowId = 'dispatch_workflow';
+    const branchOrTagName = 'main';
+    const workflowInputs = '{ "foo": "bar" }';
+    const ctx = Object.assign({}, mockContext, {
+      input: { repoUrl, workflowId, branchOrTagName, workflowInputs },
+    });
+    await action.handler(ctx);
+
+    expect(
+      mockGithubClient.rest.actions.createWorkflowDispatch,
+    ).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      workflow_id: workflowId,
+      ref: branchOrTagName,
+      inputs: workflowInputs,
     });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
@@ -65,7 +65,8 @@ export function createGithubActionsDispatchAction(options: {
           workflowInputs: {
             title: 'Workflow Inputs',
             description:
-              'Inputs keys and values to send to GitHub Action configured on the workflow file. The maximum number of properties is 10. Any default properties configured in the workflow file will be used when inputs are omitted.',
+              'Inputs keys and values to send to GitHub Action configured on the workflow file. The maximum number of properties is 10. ',
+            type: 'object',
           },
         },
       },

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
@@ -36,6 +36,7 @@ export function createGithubActionsDispatchAction(options: {
     repoUrl: string;
     workflowId: string;
     branchOrTagName: string;
+    workflowInputs?: { [key: string]: string };
   }>({
     id: 'github:actions:dispatch',
     description:
@@ -61,11 +62,17 @@ export function createGithubActionsDispatchAction(options: {
               'The git branch or tag name used to dispatch the workflow',
             type: 'string',
           },
+          workflowInputs: {
+            title: 'Workflow Inputs',
+            description:
+              'Inputs keys and values to send to GitHub Action configured on the workflow file. The maximum number of properties is 10. Any default properties configured in the workflow file will be used when inputs are omitted.',
+          },
         },
       },
     },
     async handler(ctx) {
-      const { repoUrl, workflowId, branchOrTagName } = ctx.input;
+      const { repoUrl, workflowId, branchOrTagName, workflowInputs } =
+        ctx.input;
 
       ctx.logger.info(
         `Dispatching workflow ${workflowId} for repo ${repoUrl} on ${branchOrTagName}`,
@@ -78,6 +85,7 @@ export function createGithubActionsDispatchAction(options: {
         repo,
         workflow_id: workflowId,
         ref: branchOrTagName,
+        inputs: workflowInputs,
       });
 
       ctx.logger.info(`Workflow ${workflowId} dispatched successfully`);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fulfills [Issue 8770](https://github.com/backstage/backstage/issues/8770), which is adding the ability to add inputs to the Backstage Action github:actions:dispatch. This is useful if the user wants to pass specific information to be used in the Github Action the Backstage Action triggers. 

![Screen Shot 2022-01-24 at 1 56 30 PM](https://user-images.githubusercontent.com/59847158/150871757-a4300256-90aa-46ad-add6-e3fe6c173982.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
