### PR TITLE
backend-common: fix config schema using address rather than host

### DIFF
--- a/.changeset/smart-mangos-fly.md
+++ b/.changeset/smart-mangos-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Fixed configuration schema incorrectly declaring `backend.listen.address` to exist, rather than `backend.listen.host`, which is the correct key.

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -41,7 +41,7 @@ export interface Config {
       | string
       | {
           /** Address of the interface that the backend should bind to. */
-          address?: string;
+          host?: string;
           /** Port that the backend should listen to. */
           port?: string | number;
         };


### PR DESCRIPTION
This has been around for a while 😅 

https://github.com/backstage/backstage/blob/3bbf6125c65842be59faba2a6a62892862e41ecf/packages/backend-common/src/service/lib/config.ts#L93