### PR TITLE
scaffolder: Collect the users `oauth` token using `RepoUrlPicker` and allow templating of `secrets` in template inputs

### DIFF
--- a/.changeset/lemon-jars-teach.md
+++ b/.changeset/lemon-jars-teach.md
@@ -1,0 +1,6 @@
+---
+'@backstage/integration-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Added the ability to collect users `oauth` token from the `RepoUrlPicker` for use in the template manifest

--- a/.changeset/twenty-queens-scream.md
+++ b/.changeset/twenty-queens-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Added support for templating secrets into actions input, and also added an extra `token` input argument to all publishers to provide a token that would override the `integrations.config`

--- a/.changeset/twenty-queens-scream.md
+++ b/.changeset/twenty-queens-scream.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Added support for templating secrets into actions input, and also added an extra `token` input argument to all publishers to provide a token that would override the `integrations.config`
+Added support for templating secrets into actions input, and also added an extra `token` input argument to all publishers to provide a token that would override the `integrations.config`.
+You can find more information over at [Writing Templates](https://backstage.io/docs/features/software-templates/writing-templates#using-the-users-oauth-token)

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -300,10 +300,8 @@ perform operations on top of an existing repository.
 A sample template that takes advantage of this is like so:
 
 ```yaml
-# Notice the v1beta3 version
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
-# some metadata about the template itself
 metadata:
   name: v1beta3-demo
   title: Test Action template
@@ -312,27 +310,9 @@ spec:
   owner: backstage/techdocs-core
   type: service
 
-  # these are the steps which are rendered in the frontend with the form input
   parameters:
-    - title: Fill in some steps
-      required:
-        - name
-      properties:
-        name:
-          title: Name
-          type: string
-          description: Unique name of the component
-          ui:autofocus: true
-          ui:options:
-            rows: 5
-        owner:
-          title: Owner
-          type: string
-          description: Owner of the component
-          ui:field: OwnerPicker
-          ui:options:
-            allowedKinds:
-              - Group
+    ...
+
     - title: Choose a location
       required:
         - repoUrl
@@ -342,6 +322,7 @@ spec:
           type: string
           ui:field: RepoUrlPicker
           ui:options:
+            # here's the new option you can pass to the RepoUrlPicker
             requestUserCredentials:
               resultSecretsKey: USER_OAUTH_TOKEN
               additionalScopes:
@@ -349,24 +330,10 @@ spec:
                   - workflow:write
             allowedHosts:
               - github.com
+    ...
 
-  # here's the steps that are executed in series in the scaffolder backend
   steps:
-    - id: fetch-base
-      name: Fetch Base
-      action: fetch:template
-      input:
-        url: ./template
-        values:
-          name: ${{ parameters.name }}
-          owner: ${{ parameters.owner }}
-
-    - id: fetch-docs
-      name: Fetch Docs
-      action: fetch:plain
-      input:
-        targetPath: ./community
-        url: https://github.com/backstage/community/tree/main/backstage-community-sessions
+    ...
 
     - id: publish
       name: Publish
@@ -375,19 +342,10 @@ spec:
         allowedHosts: ['github.com']
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
+        # here's where the secret can be used
         token: ${{ secrets.USER_OAUTH_TOKEN }}
 
-    - id: register
-      name: Register
-      action: catalog:register
-      input:
-        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-        catalogInfoPath: '/catalog-info.yaml'
-
-  # some outputs which are saved along with the job for use in the frontend
-  output:
-    remoteUrl: ${{ steps.publish.output.remoteUrl }}
-    entityRef: ${{ steps.register.output.entityRef }}
+    ...
 ```
 
 You will see from above that there is an additional `requestUserCredentials`

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -322,9 +322,9 @@ spec:
           type: string
           ui:field: RepoUrlPicker
           ui:options:
-            # here's the new option you can pass to the RepoUrlPicker
+            # Here's the option you can pass to the RepoUrlPicker
             requestUserCredentials:
-              resultSecretsKey: USER_OAUTH_TOKEN
+              secretsKey: USER_OAUTH_TOKEN
               additionalScopes:
                 github:
                   - workflow:write

--- a/packages/integration-react/api-report.md
+++ b/packages/integration-react/api-report.md
@@ -29,6 +29,7 @@ export class ScmAuth implements ScmAuthApi {
         ProfileInfoApi &
         BackstageIdentityApi &
         SessionApi;
+      bitbucket: OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi;
     }
   >;
   static forAuthApi(
@@ -82,6 +83,12 @@ export const scmAuthApiRef: ApiRef<ScmAuthApi>;
 export interface ScmAuthTokenOptions extends AuthRequestOptions {
   additionalScope?: {
     repoWrite?: boolean;
+    customScopes?: {
+      github?: string[];
+      azure?: string[];
+      bitbucket?: string[];
+      gitlab?: string[];
+    };
   };
   url: string;
 }

--- a/packages/integration-react/src/api/ScmAuth.ts
+++ b/packages/integration-react/src/api/ScmAuth.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  bitbucketAuthApiRef,
   createApiFactory,
   githubAuthApiRef,
   gitlabAuthApiRef,

--- a/packages/integration-react/src/api/ScmAuthApi.ts
+++ b/packages/integration-react/src/api/ScmAuthApi.ts
@@ -44,6 +44,16 @@ export interface ScmAuthTokenOptions extends AuthRequestOptions {
      * the ability to create things like issues and pull requests.
      */
     repoWrite?: boolean;
+    /**
+     * Allow an arbitrary list of scopes provided from the user
+     * to request from the provider.
+     */
+    customScopes?: {
+      github?: string[];
+      azure?: string[];
+      bitbucket?: string[];
+      gitlab?: string[];
+    };
   };
 }
 

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -299,7 +299,12 @@ export class OctokitProvider {
     githubCredentialsProvider?: GithubCredentialsProvider,
   );
   // Warning: (ae-forgotten-export) The symbol "OctokitIntegration" needs to be exported by the entry point index.d.ts
-  getOctokit(repoUrl: string): Promise<OctokitIntegration>;
+  getOctokit(
+    repoUrl: string,
+    options?: {
+      token?: string;
+    },
+  ): Promise<OctokitIntegration>;
 }
 
 // @public

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.test.ts
@@ -74,4 +74,15 @@ describe('getOctokit', () => {
     expect(owner).toBe('owner');
     expect(repo).toBe('bob');
   });
+
+  it('should return an octokit client with the passed in token if it is provided', async () => {
+    const { client, token, owner, repo } = await octokitProvider.getOctokit(
+      'github.com?repo=bob&owner=owner',
+      { token: 'tokenlols2' },
+    );
+    expect(client).toBeDefined();
+    expect(token).toBe('tokenlols2');
+    expect(owner).toBe('owner');
+    expect(repo).toBe('bob');
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
@@ -37,6 +37,7 @@ export function createGithubActionsDispatchAction(options: {
     workflowId: string;
     branchOrTagName: string;
     workflowInputs?: { [key: string]: string };
+    token?: string;
   }>({
     id: 'github:actions:dispatch',
     description:
@@ -68,18 +69,31 @@ export function createGithubActionsDispatchAction(options: {
               'Inputs keys and values to send to GitHub Action configured on the workflow file. The maximum number of properties is 10. ',
             type: 'object',
           },
+          token: {
+            title: 'Authentication Token',
+            type: 'string',
+            description: 'The GITHUB_TOKEN to use for authorization to GitHub',
+          },
         },
       },
     },
     async handler(ctx) {
-      const { repoUrl, workflowId, branchOrTagName, workflowInputs } =
-        ctx.input;
+      const {
+        repoUrl,
+        workflowId,
+        branchOrTagName,
+        workflowInputs,
+        token: providedToken,
+      } = ctx.input;
 
       ctx.logger.info(
         `Dispatching workflow ${workflowId} for repo ${repoUrl} on ${branchOrTagName}`,
       );
 
-      const { client, owner, repo } = await octokitProvider.getOctokit(repoUrl);
+      const { client, owner, repo } = await octokitProvider.getOctokit(
+        repoUrl,
+        { token: providedToken },
+      );
 
       await client.rest.actions.createWorkflowDispatch({
         owner,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
@@ -47,6 +47,7 @@ export function createGithubWebhookAction(options: {
     active?: boolean;
     contentType?: ContentType;
     insecureSsl?: boolean;
+    token?: string;
   }>({
     id: 'github:webhook',
     description: 'Creates webhook for a repository on GitHub.',
@@ -107,6 +108,11 @@ export function createGithubWebhookAction(options: {
             type: 'boolean',
             description: `Determines whether the SSL certificate of the host for url will be verified when delivering payloads. Default 'false'`,
           },
+          token: {
+            title: 'Authentication Token',
+            type: 'string',
+            description: 'The GITHUB_TOKEN to use for authorization to GitHub',
+          },
         },
       },
     },
@@ -119,11 +125,15 @@ export function createGithubWebhookAction(options: {
         active = true,
         contentType = 'form',
         insecureSsl = false,
+        token: providedToken,
       } = ctx.input;
 
       ctx.logger.info(`Creating webhook ${webhookUrl} for repo ${repoUrl}`);
 
-      const { client, owner, repo } = await octokitProvider.getOctokit(repoUrl);
+      const { client, owner, repo } = await octokitProvider.getOctokit(
+        repoUrl,
+        { token: providedToken },
+      );
 
       try {
         const insecure_ssl = insecureSsl ? '1' : '0';

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.test.ts
@@ -119,6 +119,32 @@ describe('publish:azure', () => {
     ).rejects.toThrow(/Unable to create the repository/);
   });
 
+  it('should not throw if there is a token provided through ctx.input', async () => {
+    mockGitClient.createRepository.mockImplementation(() => ({
+      remoteUrl: 'http://google.com',
+    }));
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        repoUrl: 'myazurehostnotoken.com?repo=bob&owner=owner&organization=org',
+        token: 'lols',
+      },
+    });
+
+    expect(WebApi).toHaveBeenCalledWith(
+      'https://myazurehostnotoken.com/org',
+      expect.any(Function),
+    );
+
+    expect(mockGitClient.createRepository).toHaveBeenCalledWith(
+      {
+        name: 'bob',
+      },
+      'owner',
+    );
+  });
+
   it('should throw if there is no remoteUrl returned', async () => {
     mockGitClient.createRepository.mockImplementation(() => ({
       remoteUrl: null,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
@@ -34,6 +34,7 @@ export function createPublishAzureAction(options: {
     description?: string;
     defaultBranch?: string;
     sourcePath?: string;
+    token?: string;
   }>({
     id: 'publish:azure',
     description:
@@ -57,9 +58,15 @@ export function createPublishAzureAction(options: {
             description: `Sets the default branch on the repository. The default value is 'master'`,
           },
           sourcePath: {
-            title:
+            title: 'Source Path',
+            description:
               'Path within the workspace that will be used as the repository root. If omitted, the entire workspace will be published as the repository.',
             type: 'string',
+          },
+          token: {
+            title: 'Authentication Token',
+            type: 'string',
+            description: 'The AZURE_TOKEN to use for authorization to Azure',
           },
         },
       },
@@ -98,12 +105,13 @@ export function createPublishAzureAction(options: {
           `No matching integration configuration for host ${host}, please check your integrations config`,
         );
       }
-      if (!integrationConfig.config.token) {
+
+      if (!integrationConfig.config.token && !ctx.input.token) {
         throw new InputError(`No token provided for Azure Integration ${host}`);
       }
-      const authHandler = getPersonalAccessTokenHandler(
-        integrationConfig.config.token,
-      );
+
+      const token = ctx.input.token ?? integrationConfig.config.token!;
+      const authHandler = getPersonalAccessTokenHandler(token);
 
       const webApi = new WebApi(`https://${host}/${organization}`, authHandler);
       const client = await webApi.getGitApi();
@@ -139,7 +147,7 @@ export function createPublishAzureAction(options: {
         defaultBranch,
         auth: {
           username: 'notempty',
-          password: integrationConfig.config.token,
+          password: token,
         },
         logger: ctx.logger,
         commitMessage: config.getOptionalString(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
@@ -66,7 +66,7 @@ export function createPublishAzureAction(options: {
           token: {
             title: 'Authentication Token',
             type: 'string',
-            description: 'The AZURE_TOKEN to use for authorization to Azure',
+            description: 'The token to use for authorization to Azure',
           },
         },
       },

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
@@ -194,6 +194,45 @@ describe('publish:bitbucket', () => {
     });
   });
 
+  it('should work if the token is provided through ctx.input', async () => {
+    expect.assertions(2);
+    server.use(
+      rest.post(
+        'https://notoken.bitbucket.com/rest/api/1.0/projects/project/repos',
+        (req, res, ctx) => {
+          expect(req.headers.get('Authorization')).toBe('Bearer lols');
+          expect(req.body).toEqual({ public: false, name: 'repo' });
+          return res(
+            ctx.status(201),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                self: [
+                  {
+                    href: 'https://bitbucket.mycompany.com/projects/project/repos/repo',
+                  },
+                ],
+                clone: [
+                  {
+                    name: 'http',
+                    href: 'https://bitbucket.mycompany.com/scm/project/repo',
+                  },
+                ],
+              },
+            }),
+          );
+        },
+      ),
+    );
+    await action.handler({
+      ...mockContext,
+      input: {
+        repoUrl: 'notoken.bitbucket.com?project=project&repo=repo',
+        token: 'lols',
+      },
+    });
+  });
+
   describe('LFS for hosted bitbucket', () => {
     const repoCreationResponse = {
       links: {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
@@ -248,8 +248,7 @@ export function createPublishBitbucketAction(options: {
           token: {
             title: 'Authentication Token',
             type: 'string',
-            description:
-              'The BITBUCKET_TOKEN to use for authorization to BitBucket',
+            description: 'The token to use for authorization to BitBucket',
           },
         },
       },

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -122,7 +122,7 @@ export function createPublishGithubAction(options: {
           token: {
             title: 'Authentication Token',
             type: 'string',
-            description: 'The GITHUB_TOKEN to use for authorization to GitHub',
+            description: 'The token to use for authorization to GitHub',
           },
           topics: {
             title: 'Topics',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -52,6 +52,7 @@ export function createPublishGithubAction(options: {
     requireCodeOwnerReviews?: boolean;
     repoVisibility: 'private' | 'internal' | 'public';
     collaborators: Collaborator[];
+    token?: string;
     topics?: string[];
   }>({
     id: 'publish:github',
@@ -77,7 +78,8 @@ export function createPublishGithubAction(options: {
             type: 'string',
           },
           requireCodeOwnerReviews: {
-            title:
+            title: 'Require CODEOWNER Reviews?',
+            description:
               'Require an approved review in PR including files with a designated Code Owner',
             type: 'boolean',
           },
@@ -92,7 +94,8 @@ export function createPublishGithubAction(options: {
             description: `Sets the default branch on the repository. The default value is 'master'`,
           },
           sourcePath: {
-            title:
+            title: 'Source Path',
+            description:
               'Path within the workspace that will be used as the repository root. If omitted, the entire workspace will be published as the repository.',
             type: 'string',
           },
@@ -115,6 +118,11 @@ export function createPublishGithubAction(options: {
                 },
               },
             },
+          },
+          token: {
+            title: 'Authentication Token',
+            type: 'string',
+            description: 'The GITHUB_TOKEN to use for authorization to GitHub',
           },
           topics: {
             title: 'Topics',
@@ -149,10 +157,12 @@ export function createPublishGithubAction(options: {
         defaultBranch = 'master',
         collaborators,
         topics,
+        token: providedToken,
       } = ctx.input;
 
       const { client, token, owner, repo } = await octokitProvider.getOctokit(
         repoUrl,
+        { token: providedToken },
       );
 
       const user = await client.rest.users.getByUsername({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -163,7 +163,7 @@ export const createPublishGithubPullRequestAction = ({
           token: {
             title: 'Authentication Token',
             type: 'string',
-            description: 'The GITHUB_TOKEN to use for authorization to GitHub',
+            description: 'The token to use for authorization to GitHub',
           },
         },
       },

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
@@ -96,6 +96,28 @@ describe('publish:gitlab', () => {
     ).rejects.toThrow(/No token available for host/);
   });
 
+  it('should work when there is a token provided through ctx.input', async () => {
+    mockGitlabClient.Namespaces.show.mockResolvedValue({ id: 1234 });
+    mockGitlabClient.Projects.create.mockResolvedValue({
+      http_url_to_repo: 'http://mockurl.git',
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        repoUrl: 'hosted.gitlab.com?repo=bob&owner=owner',
+        token: 'token',
+      },
+    });
+
+    expect(mockGitlabClient.Namespaces.show).toHaveBeenCalledWith('owner');
+    expect(mockGitlabClient.Projects.create).toHaveBeenCalledWith({
+      namespace_id: 1234,
+      name: 'bob',
+      visibility: 'private',
+    });
+  });
+
   it('should call the correct Gitlab APIs when the owner is an organization', async () => {
     mockGitlabClient.Namespaces.show.mockResolvedValue({ id: 1234 });
     mockGitlabClient.Projects.create.mockResolvedValue({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -66,7 +66,7 @@ export function createPublishGitlabAction(options: {
           token: {
             title: 'Authentication Token',
             type: 'string',
-            description: 'The GITLAB_TOKEN to use for authorization to GitLab',
+            description: 'The token to use for authorization to GitLab',
           },
         },
       },

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -31,6 +31,7 @@ export type GitlabMergeRequestActionInput = {
   description: string;
   branchName: string;
   targetPath: string;
+  token?: string;
 };
 
 export const createPublishGitlabMergeRequestAction = (options: {
@@ -75,6 +76,11 @@ export const createPublishGitlabMergeRequestAction = (options: {
             title: 'Repository Subdirectory',
             description: 'Subdirectory of repository to apply changes to',
           },
+          token: {
+            title: 'Authentication Token',
+            type: 'string',
+            description: 'The GITLAB_TOKEN to use for authorization to GitLab',
+          },
         },
       },
       output: {
@@ -107,13 +113,15 @@ export const createPublishGitlabMergeRequestAction = (options: {
         );
       }
 
-      if (!integrationConfig.config.token) {
+      if (!integrationConfig.config.token && !ctx.input.token) {
         throw new InputError(`No token available for host ${host}`);
       }
 
+      const token = ctx.input.token ?? integrationConfig.config.token!;
+
       const api = new Gitlab({
         host: integrationConfig.config.baseUrl,
-        token: integrationConfig.config.token,
+        token,
       });
 
       const fileRoot = ctx.workspacePath;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlabMergeRequest.ts
@@ -79,7 +79,7 @@ export const createPublishGitlabMergeRequestAction = (options: {
           token: {
             title: 'Authentication Token',
             type: 'string',
-            description: 'The GITLAB_TOKEN to use for authorization to GitLab',
+            description: 'The token to use for authorization to GitLab',
           },
         },
       },

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -53,6 +53,7 @@ type TemplateContext = {
   steps: {
     [stepName: string]: { output: { [outputName: string]: JsonValue } };
   };
+  secrets?: Record<string, string>;
 };
 
 const isValidTaskSpec = (taskSpec: TaskSpec): taskSpec is TaskSpecV1beta3 => {
@@ -231,8 +232,14 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
           const action = this.options.actionRegistry.get(step.action);
           const { taskLogger, streamLogger } = createStepLogger({ task, step });
 
+          // Secrets are only passed when templating the input to actions for security reasons
           const input =
-            (step.input && this.render(step.input, context, renderTemplate)) ??
+            (step.input &&
+              this.render(
+                step.input,
+                { ...context, secrets: task.secrets ?? {} },
+                renderTemplate,
+              )) ??
             {};
 
           if (action.schema?.input) {

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -164,6 +164,16 @@ export interface RepoUrlPickerUiOptions {
   allowedHosts?: string[];
   // (undocumented)
   allowedOwners?: string[];
+  // (undocumented)
+  requestUserCredentials?: {
+    resultSecretsKey: string;
+    additionalScopes?: {
+      github?: string[];
+      gitlab?: string[];
+      bitbucket?: string[];
+      azure?: string[];
+    };
+  };
 }
 
 // @public
@@ -317,4 +327,9 @@ export const TextValuePicker: ({
   idSchema,
   placeholder,
 }: FieldProps<string>) => JSX.Element;
+
+// @public
+export const useSecretsContext: () => {
+  setSecret: (input: Record<string, string>) => void;
+};
 ```

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -166,7 +166,7 @@ export interface RepoUrlPickerUiOptions {
   allowedOwners?: string[];
   // (undocumented)
   requestUserCredentials?: {
-    resultSecretsKey: string;
+    secretsKey: string;
     additionalScopes?: {
       github?: string[];
       gitlab?: string[];
@@ -329,7 +329,7 @@ export const TextValuePicker: ({
 }: FieldProps<string>) => JSX.Element;
 
 // @public
-export const useSecretsContext: () => {
+export const useTemplateSecrets: () => {
   setSecret: (input: Record<string, string>) => void;
 };
 ```

--- a/plugins/scaffolder/src/components/Router.tsx
+++ b/plugins/scaffolder/src/components/Router.tsx
@@ -21,6 +21,7 @@ import { ScaffolderPage } from './ScaffolderPage';
 import { TemplatePage } from './TemplatePage';
 import { TaskPage } from './TaskPage';
 import { ActionsPage } from './ActionsPage';
+import { SecretsContextProvider } from './secrets/SecretsContext';
 
 import {
   FieldExtensionOptions,
@@ -77,7 +78,11 @@ export const Router = ({ TemplateCardComponent, groups }: RouterProps) => {
       />
       <Route
         path="/templates/:templateName"
-        element={<TemplatePage customFieldExtensions={fieldExtensions} />}
+        element={
+          <SecretsContextProvider>
+            <TemplatePage customFieldExtensions={fieldExtensions} />
+          </SecretsContextProvider>
+        }
       />
       <Route path="/tasks/:taskId" element={<TaskPage />} />
       <Route path="/actions" element={<ActionsPage />} />

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -17,12 +17,13 @@ import { JsonObject, JsonValue } from '@backstage/types';
 import { LinearProgress } from '@material-ui/core';
 import { FormValidation, IChangeEvent } from '@rjsf/core';
 import qs from 'qs';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import { generatePath, Navigate, useNavigate } from 'react-router';
 import { useParams } from 'react-router-dom';
 import useAsync from 'react-use/lib/useAsync';
 import { scaffolderApiRef } from '../../api';
 import { CustomFieldValidator, FieldExtensionOptions } from '../../extensions';
+import { SecretsContext } from '../secrets/SecretsContext';
 import { rootRouteRef } from '../../routes';
 import { MultistepJsonForm } from '../MultistepJsonForm';
 
@@ -115,6 +116,7 @@ export const TemplatePage = ({
   customFieldExtensions?: FieldExtensionOptions[];
 }) => {
   const apiHolder = useApiHolder();
+  const secretsContext = useContext(SecretsContext);
   const errorApi = useApi(errorApiRef);
   const scaffolderApi = useApi(scaffolderApiRef);
   const { templateName } = useParams();
@@ -135,7 +137,11 @@ export const TemplatePage = ({
   );
 
   const handleCreate = async () => {
-    const id = await scaffolderApi.scaffold(templateName, formState);
+    const id = await scaffolderApi.scaffold(
+      templateName,
+      formState,
+      secretsContext?.secrets,
+    );
 
     const formParams = qs.stringify(
       { formData: formState },

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -14,26 +14,37 @@
  * limitations under the License.
  */
 import React from 'react';
-import { render } from '@testing-library/react';
 import { RepoUrlPicker } from './RepoUrlPicker';
 import Form from '@rjsf/core';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import {
   scmIntegrationsApiRef,
+  ScmIntegrationsApi,
   scmAuthApiRef,
 } from '@backstage/integration-react';
 import { scaffolderApiRef } from '../../../api';
 import { SecretsContextProvider } from '../../secrets/SecretsContext';
+import { ScaffolderApi } from '../../..';
 
 describe('RepoUrlPicker', () => {
+  const mockScaffolderApi: Partial<ScaffolderApi> = {
+    getIntegrationsList: async () => [
+      { host: 'github.com', type: 'github', title: 'github.com' },
+    ],
+  };
+
+  const mockIntegrationsApi: Partial<ScmIntegrationsApi> = {
+    byHost: () => ({ type: 'github' }),
+  };
+
   describe('happy path rendering', () => {
     it('should render the repo url picker', async () => {
       const { getByRole } = await renderInTestApp(
         <TestApiProvider
           apis={[
-            [scmIntegrationsApiRef, {}],
+            [scmIntegrationsApiRef, mockIntegrationsApi],
             [scmAuthApiRef, {}],
-            [scaffolderApiRef, {}],
+            [scaffolderApiRef, mockScaffolderApi],
           ]}
         >
           <SecretsContextProvider>
@@ -46,6 +57,8 @@ describe('RepoUrlPicker', () => {
           ,
         </TestApiProvider>,
       );
+
+      await new Promise(resolve => setTimeout(resolve, 3000));
 
       console.log(getByRole('form'));
     });

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { RepoUrlPicker } from './RepoUrlPicker';
+import Form from '@rjsf/core';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import {
+  scmIntegrationsApiRef,
+  scmAuthApiRef,
+} from '@backstage/integration-react';
+import { scaffolderApiRef } from '../../../api';
+import { SecretsContextProvider } from '../../secrets/SecretsContext';
+
+describe('RepoUrlPicker', () => {
+  describe('happy path rendering', () => {
+    it('should render the repo url picker', async () => {
+      const { getByRole } = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [scmIntegrationsApiRef, {}],
+            [scmAuthApiRef, {}],
+            [scaffolderApiRef, {}],
+          ]}
+        >
+          <SecretsContextProvider>
+            <Form
+              schema={{ type: 'string' }}
+              uiSchema={{ 'ui:field': 'RepoUrlPicker' }}
+              fields={{ RepoUrlPicker: RepoUrlPicker }}
+            />
+          </SecretsContextProvider>
+          ,
+        </TestApiProvider>,
+      );
+
+      console.log(getByRole('form'));
+    });
+  });
+});

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -112,7 +112,7 @@ describe('RepoUrlPicker', () => {
 
   describe('requestUserCredentials', () => {
     it('should call the scmAuthApi with the correct params', async () => {
-      const { getByRole, getAllByRole } = await renderInTestApp(
+      const { getAllByRole } = await renderInTestApp(
         <TestApiProvider
           apis={[
             [scmIntegrationsApiRef, mockIntegrationsApi],

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -158,5 +158,7 @@ describe('RepoUrlPicker', () => {
         },
       });
     });
+
+    // TODO(blam): need a test here for making sure that the secret is pushed to the context
   });
 });

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -25,6 +25,7 @@ import {
 import { scaffolderApiRef } from '../../../api';
 import { SecretsContextProvider } from '../../secrets/SecretsContext';
 import { ScaffolderApi } from '../../..';
+import { fireEvent } from '@testing-library/react';
 
 describe('RepoUrlPicker', () => {
   const mockScaffolderApi: Partial<ScaffolderApi> = {
@@ -38,8 +39,9 @@ describe('RepoUrlPicker', () => {
   };
 
   describe('happy path rendering', () => {
-    it('should render the repo url picker', async () => {
-      const { getByRole } = await renderInTestApp(
+    it('should render the repo url picker with minimal props', async () => {
+      const onSubmit = jest.fn();
+      const { getAllByRole, getByRole } = await renderInTestApp(
         <TestApiProvider
           apis={[
             [scmIntegrationsApiRef, mockIntegrationsApi],
@@ -52,15 +54,26 @@ describe('RepoUrlPicker', () => {
               schema={{ type: 'string' }}
               uiSchema={{ 'ui:field': 'RepoUrlPicker' }}
               fields={{ RepoUrlPicker: RepoUrlPicker }}
+              onSubmit={onSubmit}
             />
           </SecretsContextProvider>
-          ,
         </TestApiProvider>,
       );
 
-      await new Promise(resolve => setTimeout(resolve, 3000));
+      const [ownerInput, repoInput] = getAllByRole('textbox');
+      const submitButton = getByRole('button');
 
-      console.log(getByRole('form'));
+      fireEvent.change(ownerInput, { target: { value: 'backstage' } });
+      fireEvent.change(repoInput, { target: { value: 'repo123' } });
+
+      fireEvent.click(submitButton);
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formData: 'github.com?owner=backstage&repo=repo123',
+        }),
+        expect.anything(),
+      );
     });
   });
 });

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -134,7 +134,7 @@ describe('RepoUrlPicker', () => {
                 'ui:field': 'RepoUrlPicker',
                 'ui:options': {
                   requestUserCredentials: {
-                    resultSecretsKey: 'testKey',
+                    secretsKey: 'testKey',
                     additionalScopes: { github: ['workflow:write'] },
                   },
                 },

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -23,12 +23,11 @@ import {
   scmAuthApiRef,
   ScmAuthApi,
 } from '@backstage/integration-react';
-import { scaffolderApiRef } from '../../../api';
+import { scaffolderApiRef, ScaffolderApi } from '../../../api';
 import {
   SecretsContextProvider,
   SecretsContext,
 } from '../../secrets/SecretsContext';
-import { ScaffolderApi } from '../../..';
 import { act, fireEvent } from '@testing-library/react';
 
 describe('RepoUrlPicker', () => {

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -87,7 +87,7 @@ export const RepoUrlPicker = (
 
       if (
         !requestUserCredentials ||
-        !(state.host && state.owner && !state.repoName)
+        !(state.host && state.owner && state.repoName)
       ) {
         return;
       }
@@ -107,7 +107,7 @@ export const RepoUrlPicker = (
       // in the templating the manifest with ${{ secrets[resultSecretsKey] }}
       setSecret({ [requestUserCredentials.resultSecretsKey]: token });
     },
-    1000,
+    500,
     [state, uiSchema],
   );
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -93,6 +93,8 @@ export const RepoUrlPicker = (
       }
 
       // user has requested that we use the users credentials
+      // so lets grab them using the scmAuthApi and pass through
+      // any additional scopes from the ui:options
       const { token } = await scmAuthApi.getCredentials({
         url: `https://${state.host}/${state.owner}/${state.repoName}`,
         additionalScope: {
@@ -101,10 +103,12 @@ export const RepoUrlPicker = (
         },
       });
 
+      // set the secret using the key provided in the the ui:options for use
+      // in the templating the manifest with ${{ secrets[resultSecretsKey] }}
       setSecret({ [requestUserCredentials.resultSecretsKey]: token });
     },
     1000,
-    [state],
+    [state, uiSchema],
   );
 
   const hostType =

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -28,13 +28,13 @@ import { RepoUrlPickerHost } from './RepoUrlPickerHost';
 import { parseRepoPickerUrl, serializeRepoPickerUrl } from './utils';
 import { RepoUrlPickerState } from './types';
 import useDebounce from 'react-use/lib/useDebounce';
-import { useSecretsContext } from '../../secrets';
+import { useTemplateSecrets } from '../../secrets';
 
 export interface RepoUrlPickerUiOptions {
   allowedHosts?: string[];
   allowedOwners?: string[];
   requestUserCredentials?: {
-    resultSecretsKey: string;
+    secretsKey: string;
     additionalScopes?: {
       github?: string[];
       gitlab?: string[];
@@ -53,7 +53,7 @@ export const RepoUrlPicker = (
   );
   const integrationApi = useApi(scmIntegrationsApiRef);
   const scmAuthApi = useApi(scmAuthApiRef);
-  const { setSecret } = useSecretsContext();
+  const { setSecret } = useTemplateSecrets();
   const allowedHosts = useMemo(
     () => uiSchema?.['ui:options']?.allowedHosts ?? [],
     [uiSchema],
@@ -104,8 +104,8 @@ export const RepoUrlPicker = (
       });
 
       // set the secret using the key provided in the the ui:options for use
-      // in the templating the manifest with ${{ secrets[resultSecretsKey] }}
-      setSecret({ [requestUserCredentials.resultSecretsKey]: token });
+      // in the templating the manifest with ${{ secrets[secretsKey] }}
+      setSecret({ [requestUserCredentials.secretsKey]: token });
     },
     500,
     [state, uiSchema],

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -92,11 +92,17 @@ export const RepoUrlPicker = (
         return;
       }
 
+      const [host, owner, repoName] = [
+        state.host,
+        state.owner,
+        state.repoName,
+      ].map(encodeURIComponent);
+
       // user has requested that we use the users credentials
       // so lets grab them using the scmAuthApi and pass through
       // any additional scopes from the ui:options
       const { token } = await scmAuthApi.getCredentials({
-        url: `https://${state.host}/${state.owner}/${state.repoName}`,
+        url: `https://${host}/${owner}/${repoName}`,
         additionalScope: {
           repoWrite: true,
           customScopes: requestUserCredentials.additionalScopes,

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
@@ -37,7 +37,7 @@ export const RepoUrlPickerHost = (props: {
   });
 
   useEffect(() => {
-    if (hosts && !host) {
+    if (hosts && hosts.length && !host) {
       // This is only hear to set the default as the first one in the hosts array
       // if the host is not set yet and there is a list of hosts.
       onChange(hosts[0]);

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerHost.tsx
@@ -37,16 +37,23 @@ export const RepoUrlPickerHost = (props: {
   });
 
   useEffect(() => {
-    if (hosts && hosts.length && !host) {
-      // This is only hear to set the default as the first one in the hosts array
-      // if the host is not set yet and there is a list of hosts.
-      onChange(hosts[0]);
+    // If there is no host chosen currently
+    if (!host) {
+      // Set the first of the allowedHosts option if that available
+      if (hosts?.length) {
+        onChange(hosts[0]);
+        // if there's no hosts provided, fallback to using the first integration
+      } else if (integrations?.length) {
+        onChange(integrations[0].host);
+      }
     }
-  }, [hosts, host, onChange]);
+  }, [hosts, host, onChange, integrations]);
 
+  // If there are no allowedHosts provided, then show all integrations. Otherwise, only show integrations
+  // that are provided in the dropdown for the user to choose from.
   const hostsOptions: SelectItem[] = integrations
     ? integrations
-        .filter(i => hosts?.includes(i.host))
+        .filter(i => (hosts?.length ? hosts?.includes(i.host) : true))
         .map(i => ({ label: i.title, value: i.host }))
     : [{ label: 'Loading...', value: 'loading' }];
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/utils.ts
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/utils.ts
@@ -44,22 +44,22 @@ export function serializeRepoPickerUrl(data: RepoUrlPickerState) {
 export function parseRepoPickerUrl(
   url: string | undefined,
 ): RepoUrlPickerState {
-  let host = undefined;
-  let owner = undefined;
-  let repoName = undefined;
-  let organization = undefined;
-  let workspace = undefined;
-  let project = undefined;
+  let host = '';
+  let owner = '';
+  let repoName = '';
+  let organization = '';
+  let workspace = '';
+  let project = '';
 
   try {
     if (url) {
       const parsed = new URL(`https://${url}`);
       host = parsed.host;
-      owner = parsed.searchParams.get('owner') || undefined;
-      repoName = parsed.searchParams.get('repo') || undefined;
-      organization = parsed.searchParams.get('organization') || undefined;
-      workspace = parsed.searchParams.get('workspace') || undefined;
-      project = parsed.searchParams.get('project') || undefined;
+      owner = parsed.searchParams.get('owner') || '';
+      repoName = parsed.searchParams.get('repo') || '';
+      organization = parsed.searchParams.get('organization') || '';
+      workspace = parsed.searchParams.get('workspace') || '';
+      project = parsed.searchParams.get('project') || '';
     }
   } catch {
     /* ok */

--- a/plugins/scaffolder/src/components/secrets/SecretsContext.test.tsx
+++ b/plugins/scaffolder/src/components/secrets/SecretsContext.test.tsx
@@ -34,8 +34,10 @@ describe('SecretsContext', () => {
         ),
       },
     );
+    expect(result.current.context?.secrets.foo).toEqual(undefined);
 
     act(() => result.current.hook.setSecret({ foo: 'bar' }));
+
     expect(result.current.context?.secrets.foo).toEqual('bar');
   });
 });

--- a/plugins/scaffolder/src/components/secrets/SecretsContext.test.tsx
+++ b/plugins/scaffolder/src/components/secrets/SecretsContext.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useContext } from 'react';
+import {
+  useSecretsContext,
+  SecretsContextProvider,
+  SecretsContext,
+} from './SecretsContext';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+describe('SecretsContext', () => {
+  it('should allow the setting of secrets in the context', async () => {
+    const { result } = renderHook(
+      () => ({
+        hook: useSecretsContext(),
+        context: useContext(SecretsContext),
+      }),
+      {
+        wrapper: ({ children }) => (
+          <SecretsContextProvider>{children}</SecretsContextProvider>
+        ),
+      },
+    );
+
+    act(() => result.current.hook.setSecret({ foo: 'bar' }));
+    expect(result.current.context?.secrets.foo).toEqual('bar');
+  });
+});

--- a/plugins/scaffolder/src/components/secrets/SecretsContext.test.tsx
+++ b/plugins/scaffolder/src/components/secrets/SecretsContext.test.tsx
@@ -15,7 +15,7 @@
  */
 import React, { useContext } from 'react';
 import {
-  useSecretsContext,
+  useTemplateSecrets,
   SecretsContextProvider,
   SecretsContext,
 } from './SecretsContext';
@@ -25,7 +25,7 @@ describe('SecretsContext', () => {
   it('should allow the setting of secrets in the context', async () => {
     const { result } = renderHook(
       () => ({
-        hook: useSecretsContext(),
+        hook: useTemplateSecrets(),
         context: useContext(SecretsContext),
       }),
       {

--- a/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
+++ b/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, {
+  useState,
+  useCallback,
+  useContext,
+  createContext,
+  PropsWithChildren,
+} from 'react';
+import { JsonObject } from '@backstage/types';
+
+type SecretsContextContents = {
+  secrets: JsonObject;
+  setSecrets: React.Dispatch<React.SetStateAction<JsonObject>>;
+};
+
+/**
+ * The actual context object.
+ */
+export const SecretsContext = createContext<SecretsContextContents | undefined>(
+  undefined,
+);
+
+/**
+ * The Context Provider that holds the state for the secrets.
+ *
+ * @public
+ */
+export const SecretsContextProvider = ({ children }: PropsWithChildren<{}>) => {
+  const [secrets, setSecrets] = useState<JsonObject>({});
+
+  return (
+    <SecretsContext.Provider value={{ secrets, setSecrets }}>
+      {children}
+    </SecretsContext.Provider>
+  );
+};
+
+/**
+ * Hook to access the secrets context.
+ * @public
+ */
+export const useSecretsContext = () => {
+  const value = useContext(SecretsContext);
+  if (!value) {
+    throw new Error(
+      'useSecretsContext must be used within a SecretsContextProvider',
+    );
+  }
+
+  const { secrets, setSecrets } = value;
+
+  const setSecret = useCallback(
+    (input: JsonObject) => {
+      setSecrets({ ...secrets, ...input });
+    },
+    [secrets, setSecrets],
+  );
+
+  return { setSecret };
+};

--- a/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
+++ b/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
@@ -60,7 +60,7 @@ export const useSecretsContext = () => {
     );
   }
 
-  const { secrets, setSecrets } = value;
+  const { setSecrets } = value;
 
   const setSecret = useCallback(
     (input: Record<string, string>) => {

--- a/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
+++ b/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
@@ -64,9 +64,9 @@ export const useSecretsContext = () => {
 
   const setSecret = useCallback(
     (input: Record<string, string>) => {
-      setSecrets({ ...secrets, ...input });
+      setSecrets(currentSecrets => ({ ...currentSecrets, ...input }));
     },
-    [secrets, setSecrets],
+    [setSecrets],
   );
 
   return { setSecret };

--- a/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
+++ b/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
@@ -20,11 +20,10 @@ import React, {
   createContext,
   PropsWithChildren,
 } from 'react';
-import { JsonObject } from '@backstage/types';
 
 type SecretsContextContents = {
-  secrets: JsonObject;
-  setSecrets: React.Dispatch<React.SetStateAction<JsonObject>>;
+  secrets: Record<string, string>;
+  setSecrets: React.Dispatch<React.SetStateAction<Record<string, string>>>;
 };
 
 /**
@@ -40,7 +39,7 @@ export const SecretsContext = createContext<SecretsContextContents | undefined>(
  * @public
  */
 export const SecretsContextProvider = ({ children }: PropsWithChildren<{}>) => {
-  const [secrets, setSecrets] = useState<JsonObject>({});
+  const [secrets, setSecrets] = useState<Record<string, string>>({});
 
   return (
     <SecretsContext.Provider value={{ secrets, setSecrets }}>
@@ -64,7 +63,7 @@ export const useSecretsContext = () => {
   const { secrets, setSecrets } = value;
 
   const setSecret = useCallback(
-    (input: JsonObject) => {
+    (input: Record<string, string>) => {
       setSecrets({ ...secrets, ...input });
     },
     [secrets, setSecrets],

--- a/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
+++ b/plugins/scaffolder/src/components/secrets/SecretsContext.tsx
@@ -52,11 +52,11 @@ export const SecretsContextProvider = ({ children }: PropsWithChildren<{}>) => {
  * Hook to access the secrets context.
  * @public
  */
-export const useSecretsContext = () => {
+export const useTemplateSecrets = () => {
   const value = useContext(SecretsContext);
   if (!value) {
     throw new Error(
-      'useSecretsContext must be used within a SecretsContextProvider',
+      'useTemplateSecrets must be used within a SecretsContextProvider',
     );
   }
 

--- a/plugins/scaffolder/src/components/secrets/index.ts
+++ b/plugins/scaffolder/src/components/secrets/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { useSecretsContext } from './SecretsContext';

--- a/plugins/scaffolder/src/components/secrets/index.ts
+++ b/plugins/scaffolder/src/components/secrets/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { useSecretsContext } from './SecretsContext';
+export { useTemplateSecrets } from './SecretsContext';

--- a/plugins/scaffolder/src/index.ts
+++ b/plugins/scaffolder/src/index.ts
@@ -56,3 +56,4 @@ export { FavouriteTemplate } from './components/FavouriteTemplate';
 export { TemplateList } from './components/TemplateList';
 export type { TemplateListProps } from './components/TemplateList';
 export { TemplateTypePicker } from './components/TemplateTypePicker';
+export * from './components/secrets';


### PR DESCRIPTION
This will be the last PR in a long list of stuff to get #5214 across the line. There's a little bit left to do to open up some of the actions to receive the token as a parameter, so the action doesn't assume the name of the secret and some more documentation and one more test. But opening this up so we can see it all so far.