### PR TITLE
Cancel in-progress GitHub workflow run on a subsequent pull-request pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     paths-ignore:
       - 'microsite/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify_e2e-linux.yml
+++ b/.github/workflows/verify_e2e-linux.yml
@@ -8,6 +8,10 @@ on:
       - 'docs/**'
       - 'microsite/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/verify_e2e-techdocs.yml
+++ b/.github/workflows/verify_e2e-techdocs.yml
@@ -8,6 +8,10 @@ on:
       - 'docs/**'
       - 'microsite/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify_e2e-windows.yml
+++ b/.github/workflows/verify_e2e-windows.yml
@@ -10,6 +10,10 @@ on:
       - 'packages/e2e-test/**'
       - 'packages/create-app/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This will cancel any outstanding workflow runs when a commit is pushed to the active pull request. This is done by defining the `concurrency` option of the GitHub workflow  in which only a single job or workflow in a concurrency `group` is active at a single time.

Relevant documentation can be found here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run

This configuration was added to 4 of the longest running workflows. And notably, on workflows that are triggered by pull requests. The `github.heaf_ref` variable is only available on events that are triggered by `pull_request` events. A fallback can be added such that this configuration does not break for other events like so:

```
group: ${{ github.head_ref || github.run_id }}
```

**NOTE**: The thought was that this is beneficial in that it reduces the number of CPU cycles burned. With the negative being that you lose a bit of verbosity in knowing which commit may introduce the failed run.

---

To validate these changes, I pushed 2 commits to this pull request, and confirmed that the workflow runs for the previous commit were halted.

![image](https://user-images.githubusercontent.com/5807118/151063614-f1325636-43bc-4bcc-a4b1-21658cbe7171.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
