### PR TITLE
cli: fix app:serve dependency warning

### DIFF
--- a/.changeset/late-donuts-eat.md
+++ b/.changeset/late-donuts-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Updated the dependency warning that is baked into `app:serve` to only warn about packages that are not allowed to have duplicates.

--- a/packages/cli/src/commands/app/serve.ts
+++ b/packages/cli/src/commands/app/serve.ts
@@ -33,7 +33,7 @@ export default async (cmd: Command) => {
     .map(({ name }) => name)
     .filter(name => forbiddenDuplicatesFilter(name));
 
-  if (problemPackages.length > 1) {
+  if (problemPackages.length > 0) {
     console.log(
       chalk.yellow(
         `⚠️ Some of the following packages may be outdated or have duplicate installations:

--- a/packages/cli/src/commands/app/serve.ts
+++ b/packages/cli/src/commands/app/serve.ts
@@ -22,16 +22,16 @@ import { serveBundle } from '../../lib/bundler';
 import { loadCliConfig } from '../../lib/config';
 import { paths } from '../../lib/paths';
 import { Lockfile } from '../../lib/versioning';
-import { includedFilter } from '../versions/lint';
+import { forbiddenDuplicatesFilter, includedFilter } from '../versions/lint';
 
 export default async (cmd: Command) => {
   const lockfile = await Lockfile.load(paths.resolveTargetRoot('yarn.lock'));
   const result = lockfile.analyze({
     filter: includedFilter,
   });
-  const problemPackages = [...result.newVersions, ...result.newRanges].map(
-    ({ name }) => name,
-  );
+  const problemPackages = [...result.newVersions, ...result.newRanges]
+    .map(({ name }) => name)
+    .filter(name => forbiddenDuplicatesFilter(name));
 
   if (problemPackages.length > 1) {
     console.log(
@@ -44,7 +44,7 @@ export default async (cmd: Command) => {
     );
     console.log(
       chalk.yellow(
-        `⚠️ This can be resolved using the following command:
+        `⚠️ The following command may fix the issue, but it could also be an issue within one of your dependencies:
 
           yarn backstage-cli versions:check --fix
       `,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Have seen this causing confusion recently. This avoids warnings about duplicates of `@backstage/core-plugin-api` and similar, since it's completely fine to have duplicates of those.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
