### PR TITLE
feat(integration): add support for a Bitbucket baseUrl config

### DIFF
--- a/.changeset/brave-grapes-provide.md
+++ b/.changeset/brave-grapes-provide.md
@@ -1,0 +1,8 @@
+---
+'@backstage/integration': minor
+'@backstage/plugin-catalog-backend': minor
+---
+
+The Bitbucket config now accepts a `baseUrl` property for organization servers. When provided, processors will now be able to make use of the config for url evaluations. If the config is not specified, it will be automatically inferred from the `host` config property. With this change, the config reader will also enforce the formatting of the `baseUrl` and `apiBaseUrl` properties to ensure that they are proper URL's.
+
+For it's initial usage, the `baseUrl` config property is being used by the Bitbucket Discovery Processor to evaluate project and repo terms from a target repository url. When the `baseUrl` is not specified, this logic will fallback to using the previous pattern of indexing the `/project/` term from the target url.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -179,7 +179,8 @@ integrations:
       appPassword: ${BITBUCKET_APP_PASSWORD}
     ### Example for how to add your bitbucket server instance using the API:
     # - host: server.bitbucket.com
-    #   apiBaseUrl: server.bitbucket.com
+    # - baseUrl: https://server.bitbucket.com
+    #   apiBaseUrl: https://server.bitbucket.com/rest/api/1.0
     #   username: ${BITBUCKET_SERVER_USERNAME}
     #   appPassword: ${BITBUCKET_SERVER_APP_PASSWORD}
   azure:

--- a/docs/integrations/bitbucket/locations.md
+++ b/docs/integrations/bitbucket/locations.md
@@ -35,6 +35,10 @@ a structure with up to four elements:
   neither a username nor token are supplied, anonymous access will be used.
 - `appPassword` (optional): The password for the Bitbucket user. Only needed
   when using `username` instead of `token`.
+- `baseUrl` (optional): The base URL of the Bitbucket server. For self-hosted
+  installations, this can be configured in the server settings, and is commonly
+  set as `https://<host>`. For bitbucket.org, this configuration is not needed
+  as it can be inferred.
 - `apiBaseUrl` (optional): The URL of the Bitbucket API. For self-hosted
   installations, it is commonly at `https://<host>/rest/api/1.0`. For
   bitbucket.org, this configuration is not needed as it can be inferred.

--- a/packages/integration/src/bitbucket/BitbucketIntegration.test.ts
+++ b/packages/integration/src/bitbucket/BitbucketIntegration.test.ts
@@ -25,7 +25,8 @@ describe('BitbucketIntegration', () => {
           bitbucket: [
             {
               host: 'h.com',
-              apiBaseUrl: 'a',
+              baseUrl: 'https://h.com/a',
+              apiBaseUrl: 'https://h.com/rest/api/1.0',
               token: 't',
               username: 'u',
               appPassword: 'p',

--- a/packages/integration/src/bitbucket/config.test.ts
+++ b/packages/integration/src/bitbucket/config.test.ts
@@ -57,7 +57,8 @@ describe('readBitbucketIntegrationConfig', () => {
     const output = readBitbucketIntegrationConfig(
       buildConfig({
         host: 'a.com',
-        apiBaseUrl: 'https://a.com/api',
+        baseUrl: 'https://a.com',
+        apiBaseUrl: 'https://a.com/rest/api/1.0',
         token: 't',
         username: 'u',
         appPassword: 'p',
@@ -65,7 +66,8 @@ describe('readBitbucketIntegrationConfig', () => {
     );
     expect(output).toEqual({
       host: 'a.com',
-      apiBaseUrl: 'https://a.com/api',
+      baseUrl: 'https://a.com',
+      apiBaseUrl: 'https://a.com/rest/api/1.0',
       token: 't',
       username: 'u',
       appPassword: 'p',
@@ -77,15 +79,27 @@ describe('readBitbucketIntegrationConfig', () => {
     expect(output).toEqual(
       expect.objectContaining({
         host: 'bitbucket.org',
+        baseUrl: 'https://bitbucket.org',
         apiBaseUrl: 'https://api.bitbucket.org/2.0',
       }),
     );
   });
 
+  it('injects the correct Bitbucket API base URL when missing', () => {
+    const output = readBitbucketIntegrationConfig(buildConfig({}));
+
+    expect(output).toEqual({
+      host: 'bitbucket.org',
+      baseUrl: 'https://bitbucket.org',
+      apiBaseUrl: 'https://api.bitbucket.org/2.0',
+    });
+  });
+
   it('rejects funky configs', () => {
     const valid: any = {
       host: 'a.com',
-      apiBaseUrl: 'https://a.com/api',
+      baseUrl: 'https://a.com',
+      apiBaseUrl: 'https://a.com/rest/api/1.0',
       token: 't',
       username: 'u',
       appPassword: 'p',
@@ -93,6 +107,9 @@ describe('readBitbucketIntegrationConfig', () => {
     expect(() =>
       readBitbucketIntegrationConfig(buildConfig({ ...valid, host: 7 })),
     ).toThrow(/host/);
+    expect(() =>
+      readBitbucketIntegrationConfig(buildConfig({ ...valid, baseUrl: 7 })),
+    ).toThrow(/baseUrl/);
     expect(() =>
       readBitbucketIntegrationConfig(buildConfig({ ...valid, apiBaseUrl: 7 })),
     ).toThrow(/apiBaseUrl/);
@@ -112,7 +129,8 @@ describe('readBitbucketIntegrationConfig', () => {
       readBitbucketIntegrationConfig(
         await buildFrontendConfig({
           host: 'a.com',
-          apiBaseUrl: 'https://a.com/api',
+          baseUrl: 'https://a.com',
+          apiBaseUrl: 'https://a.com/rest/api/1.0',
           token: 't',
           username: 'u',
           appPassword: 'p',
@@ -120,7 +138,8 @@ describe('readBitbucketIntegrationConfig', () => {
       ),
     ).toEqual({
       host: 'a.com',
-      apiBaseUrl: 'https://a.com/api',
+      baseUrl: 'https://a.com',
+      apiBaseUrl: 'https://a.com/rest/api/1.0',
     });
   });
 });
@@ -135,7 +154,8 @@ describe('readBitbucketIntegrationConfigs', () => {
       buildConfig([
         {
           host: 'a.com',
-          apiBaseUrl: 'https://a.com/api',
+          baseUrl: 'https://a.com',
+          apiBaseUrl: 'https://a.com/rest/api/1.0',
           token: 't',
           username: 'u',
           appPassword: 'p',
@@ -144,7 +164,8 @@ describe('readBitbucketIntegrationConfigs', () => {
     );
     expect(output).toContainEqual({
       host: 'a.com',
-      apiBaseUrl: 'https://a.com/api',
+      baseUrl: 'https://a.com',
+      apiBaseUrl: 'https://a.com/rest/api/1.0',
       token: 't',
       username: 'u',
       appPassword: 'p',
@@ -156,6 +177,7 @@ describe('readBitbucketIntegrationConfigs', () => {
     expect(output).toEqual([
       {
         host: 'bitbucket.org',
+        baseUrl: 'https://bitbucket.org',
         apiBaseUrl: 'https://api.bitbucket.org/2.0',
       },
     ]);
@@ -168,7 +190,21 @@ describe('readBitbucketIntegrationConfigs', () => {
     expect(output).toEqual([
       {
         host: 'bitbucket.org',
+        baseUrl: 'https://bitbucket.org',
         apiBaseUrl: 'https://api.bitbucket.org/2.0',
+      },
+    ]);
+  });
+
+  it('injects the correct Bitbucket Cloud base URL when missing', () => {
+    const output = readBitbucketIntegrationConfigs(
+      buildConfig([{ host: 'bitbucket.org' }]),
+    );
+    expect(output).toEqual([
+      {
+        host: 'bitbucket.org',
+        apiBaseUrl: 'https://api.bitbucket.org/2.0',
+        baseUrl: 'https://bitbucket.org',
       },
     ]);
   });

--- a/packages/integration/src/bitbucket/core.test.ts
+++ b/packages/integration/src/bitbucket/core.test.ts
@@ -33,11 +33,13 @@ describe('bitbucket core', () => {
     it('inserts a token when needed', () => {
       const withToken: BitbucketIntegrationConfig = {
         host: '',
+        baseUrl: '',
         apiBaseUrl: '',
         token: 'A',
       };
       const withoutToken: BitbucketIntegrationConfig = {
         host: '',
+        baseUrl: '',
         apiBaseUrl: '',
       };
       expect(
@@ -51,12 +53,14 @@ describe('bitbucket core', () => {
     it('insert basic auth when needed', () => {
       const withUsernameAndPassword: BitbucketIntegrationConfig = {
         host: '',
+        baseUrl: '',
         apiBaseUrl: '',
         username: 'some-user',
         appPassword: 'my-secret',
       };
       const withoutUsernameAndPassword: BitbucketIntegrationConfig = {
         host: '',
+        baseUrl: '',
         apiBaseUrl: '',
       };
       expect(
@@ -72,7 +76,11 @@ describe('bitbucket core', () => {
 
   describe('getBitbucketFileFetchUrl', () => {
     it('rejects targets that do not look like URLs', () => {
-      const config: BitbucketIntegrationConfig = { host: '', apiBaseUrl: '' };
+      const config: BitbucketIntegrationConfig = {
+        host: '',
+        baseUrl: '',
+        apiBaseUrl: '',
+      };
       expect(() => getBitbucketFileFetchUrl('a/b', config)).toThrow(
         /Incorrect URL: a\/b/,
       );
@@ -81,6 +89,7 @@ describe('bitbucket core', () => {
     it('happy path for Bitbucket Cloud', () => {
       const config: BitbucketIntegrationConfig = {
         host: 'bitbucket.org',
+        baseUrl: 'https://bitbucket.org',
         apiBaseUrl: 'https://api.bitbucket.org/2.0',
       };
       expect(
@@ -96,6 +105,7 @@ describe('bitbucket core', () => {
     it('happy path for Bitbucket Server', () => {
       const config: BitbucketIntegrationConfig = {
         host: 'bitbucket.mycompany.net',
+        baseUrl: 'https://bitbucket.mycompany.net',
         apiBaseUrl: 'https://bitbucket.mycompany.net/rest/api/1.0',
       };
       expect(
@@ -128,6 +138,7 @@ describe('bitbucket core', () => {
 
       const config: BitbucketIntegrationConfig = {
         host: 'bitbucket.mycompany.net',
+        baseUrl: 'https://bitbucket.mycompany.net',
         apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
       };
       const result = await getBitbucketDownloadUrl(
@@ -156,6 +167,7 @@ describe('bitbucket core', () => {
       );
       const config: BitbucketIntegrationConfig = {
         host: 'bitbucket.mycompany.net',
+        baseUrl: 'https://bitbucket.mycompany.net',
         apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
       };
       const result = await getBitbucketDownloadUrl(
@@ -171,6 +183,7 @@ describe('bitbucket core', () => {
     it('get by branch for Bitbucket Server', async () => {
       const config: BitbucketIntegrationConfig = {
         host: 'bitbucket.mycompany.net',
+        baseUrl: 'https://bitbucket.mycompany.net',
         apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
       };
       const result = await getBitbucketDownloadUrl(
@@ -185,6 +198,7 @@ describe('bitbucket core', () => {
     it('do not add path param for Bitbucket Cloud', async () => {
       const config: BitbucketIntegrationConfig = {
         host: 'bitbucket.org',
+        baseUrl: 'https://bitbucket.org',
         apiBaseUrl: 'https://api.bitbucket.org/2.0',
       };
       const result = await getBitbucketDownloadUrl(
@@ -217,6 +231,7 @@ describe('bitbucket core', () => {
       );
       const config: BitbucketIntegrationConfig = {
         host: 'bitbucket.org',
+        baseUrl: 'https://bitbucket.org',
         apiBaseUrl: 'https://api.bitbucket.org/2.0',
       };
       const defaultBranch = await getBitbucketDefaultBranch(
@@ -243,6 +258,7 @@ describe('bitbucket core', () => {
       );
       const config: BitbucketIntegrationConfig = {
         host: 'bitbucket.mycompany.net',
+        baseUrl: 'https://bitbucket.mycompany.net',
         apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
       };
       const defaultBranch = await getBitbucketDefaultBranch(
@@ -278,6 +294,7 @@ describe('bitbucket core', () => {
       );
       const config: BitbucketIntegrationConfig = {
         host: 'bitbucket.mycompany.net',
+        baseUrl: 'https://bitbucket.mycompany.net',
         apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
       };
       const defaultBranch = await getBitbucketDefaultBranch(

--- a/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.test.ts
@@ -334,6 +334,7 @@ describe('BitbucketDiscoveryProcessor', () => {
             {
               host: 'bitbucket.mycompany.com',
               token: 'blob',
+              baseUrl: 'https://bitbucket.mycompany.com/custom-path',
               apiBaseUrl:
                 'https://bitbucket.mycompany.com/custom-path/api/rest/1.0',
             },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

With the addition of the Bitbucket BaseUrl configuration property, users can now explicitly define the baseUrl for their organization server. With that provided, processors can now strictly evaluate target urls instead of searching for the index of a potentially arbitrary term, which is now relegated as a backup solution.

If not specified, the config will be automatically constructed using the `host` config property. With this change, the config reader will also enforce the formatting of the `baseUrl` and `apiBaseUrl` properties to ensure that they are proper URL's.

Resolves #8771

Signed-off-by: Dhruval Darji <dhruvaldarji@gmail.com>

--- 

This change is a follow-up to #8815 based on the suggestions provided in https://github.com/backstage/backstage/pull/8815#issuecomment-1011844430 

---

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) (N/A)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
