### PR TITLE
[Header] remove flex wrap and add max width of characters for subtitle

### DIFF
--- a/.changeset/perfect-apples-act.md
+++ b/.changeset/perfect-apples-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Updates styling of Header component by removing flex wrap and add max width of characters for subtitle

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -49,7 +49,6 @@ const useStyles = makeStyles<BackstageTheme>(
       zIndex: 100,
       display: 'flex',
       flexDirection: 'row',
-      flexWrap: 'wrap',
       alignItems: 'center',
       backgroundImage: theme.page.backgroundImage,
       backgroundPosition: 'center',
@@ -73,6 +72,7 @@ const useStyles = makeStyles<BackstageTheme>(
       opacity: 0.8,
       display: 'inline-block', // prevents margin collapse of adjacent siblings
       marginTop: theme.spacing(1),
+      maxWidth: '75ch',
     },
     type: {
       textTransform: 'uppercase',

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -53,6 +53,9 @@ const useStyles = makeStyles<BackstageTheme>(
       backgroundImage: theme.page.backgroundImage,
       backgroundPosition: 'center',
       backgroundSize: 'cover',
+      [theme.breakpoints.down('sm')]: {
+        flexWrap: 'wrap',
+      },
     },
     leftItemsBox: {
       maxWidth: '100%',


### PR DESCRIPTION
Signed-off-by: emmaindal <emma.indahl@gmail.com>

This PR suggest a max width of 75 characters for the subtitle of the Header, as more than that is not ideal for reading anyways (?). As well as suggest that the flex wrap is taken away and default to nowrap to keep the items on one line.

**Before**
<img width="1280" alt="Skärmavbild 2022-01-26 kl  11 14 48" src="https://user-images.githubusercontent.com/25153114/151145708-8eaa6ca5-3463-4093-b358-93ff096f81e8.png">
<img width="1280" alt="Skärmavbild 2022-01-26 kl  11 15 05" src="https://user-images.githubusercontent.com/25153114/151145711-85d55ef0-4ae3-4564-a2b1-df8e91c3418a.png">

**After**
<img width="1280" alt="Skärmavbild 2022-01-26 kl  11 13 52" src="https://user-images.githubusercontent.com/25153114/151145688-1d3f9d18-516a-40e6-9221-3fe36461f7f5.png">
<img width="1280" alt="Skärmavbild 2022-01-26 kl  11 14 16" src="https://user-images.githubusercontent.com/25153114/151145701-b24ba705-1860-407e-bf62-6ddcd5e42af7.png">


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
