### PR TITLE
scripts: update package private check to handle undefined

### DIFF
--- a/scripts/assemble-manifest.js
+++ b/scripts/assemble-manifest.js
@@ -45,7 +45,7 @@ async function main() {
       p =>
         (p.packageJson.name.startsWith('@backstage/') ||
           p.packageJson.name.startsWith('@techdocs/')) &&
-        p.packageJson.private === false,
+        p.packageJson.private !== true,
     )
     .map(p => {
       return { name: p.packageJson.name, version: p.packageJson.version };


### PR DESCRIPTION
The absence of private in some package json caused packages to be excluded from the release manifest since private defaults to undefined. Updating the if statement to instead check for `if !== true` will make sure it handle both `false` and `undefined`