### PR TITLE
Use server token for catalog identity client

### DIFF
--- a/.changeset/bright-buttons-rescue.md
+++ b/.changeset/bright-buttons-rescue.md
@@ -1,0 +1,27 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+**BREAKING** Added `tokenManager` as a required property for the auth-backend `createRouter` function. This dependency is used to issue server tokens that are used by the `CatalogIdentityClient` when looking up users and their group membership during authentication.
+
+These changes are **required** to `packages/backend/src/plugins/auth.ts`:
+
+```diff
+export default async function createPlugin({
+  logger,
+  database,
+  config,
+  discovery,
++ tokenManager,
+}: PluginEnvironment): Promise<Router> {
+  return await createRouter({
+    logger,
+    config,
+    database,
+    discovery,
++   tokenManager,
+  });
+}
+```
+
+**BREAKING** The `CatalogIdentityClient` constructor now expects a `TokenManager` instead of a `TokenIssuer`. The `TokenManager` interface is used to generate a server token when [resolving a user's identity and membership through the catalog](https://backstage.io/docs/auth/identity-resolver). Using server tokens for these requests allows the auth-backend to bypass authorization checks when permissions are enabled for Backstage. This change will break apps that rely on the user tokens that were previously used by the client. Refer to the ["Backend-to-backend Authentication" tutorial](https://backstage.io/docs/tutorials/backend-to-backend-auth) for more information on server token usage.

--- a/.changeset/sour-chairs-double.md
+++ b/.changeset/sour-chairs-double.md
@@ -1,0 +1,25 @@
+---
+'@backstage/create-app': patch
+---
+
+Added `tokenManager` as a required property for the auth-backend `createRouter` function. This dependency is used to issue server tokens that are used by the `CatalogIdentityClient` when looking up users and their group membership during authentication.
+
+These changes are **required** to `packages/backend/src/plugins/auth.ts`:
+
+```diff
+export default async function createPlugin({
+  logger,
+  database,
+  config,
+  discovery,
++ tokenManager,
+}: PluginEnvironment): Promise<Router> {
+  return await createRouter({
+    logger,
+    config,
+    database,
+    discovery,
++   tokenManager,
+  });
+}
+```

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -23,6 +23,13 @@ export default async function createPlugin({
   database,
   config,
   discovery,
+  tokenManager,
 }: PluginEnvironment): Promise<Router> {
-  return await createRouter({ logger, config, database, discovery });
+  return await createRouter({
+    logger,
+    config,
+    database,
+    discovery,
+    tokenManager,
+  });
 }

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/auth.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/auth.ts
@@ -7,6 +7,7 @@ export default async function createPlugin({
   database,
   config,
   discovery,
+  tokenManager,
 }: PluginEnvironment): Promise<Router> {
-  return await createRouter({ logger, config, database, discovery });
+  return await createRouter({ logger, config, database, discovery, tokenManager });
 }

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/auth.ts
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/auth.ts
@@ -9,5 +9,11 @@ export default async function createPlugin({
   discovery,
   tokenManager,
 }: PluginEnvironment): Promise<Router> {
-  return await createRouter({ logger, config, database, discovery, tokenManager });
+  return await createRouter({
+    logger,
+    config,
+    database,
+    discovery,
+    tokenManager,
+  });
 }

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -15,6 +15,7 @@ import { Logger as Logger_2 } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { Profile } from 'passport';
+import { TokenManager } from '@backstage/backend-common';
 import { TokenSet } from 'openid-client';
 import { UserEntity } from '@backstage/catalog-model';
 import { UserinfoResponse } from 'openid-client';
@@ -85,6 +86,7 @@ export type AuthProviderFactoryOptions = {
   globalConfig: AuthProviderConfig;
   config: Config;
   logger: Logger_2;
+  tokenManager: TokenManager;
   tokenIssuer: TokenIssuer;
   discovery: PluginEndpointDiscovery;
   catalogApi: CatalogApi;
@@ -205,7 +207,7 @@ export const bitbucketUsernameSignInResolver: SignInResolver<BitbucketOAuthResul
 //
 // @public
 export class CatalogIdentityClient {
-  constructor(options: { catalogApi: CatalogApi; tokenIssuer: TokenIssuer });
+  constructor(options: { catalogApi: CatalogApi; tokenManager: TokenManager });
   // Warning: (ae-forgotten-export) The symbol "UserQuery" needs to be exported by the entry point index.d.ts
   findUser(query: UserQuery): Promise<UserEntity>;
   // Warning: (ae-forgotten-export) The symbol "MemberClaimQuery" needs to be exported by the entry point index.d.ts
@@ -671,6 +673,8 @@ export interface RouterOptions {
   //
   // (undocumented)
   providerFactories?: ProviderFactories;
+  // (undocumented)
+  tokenManager: TokenManager;
 }
 
 // @public (undocumented)

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
@@ -60,7 +60,6 @@ export class CatalogIdentityClient {
       filter[`metadata.annotations.${key}`] = value;
     }
 
-    // TODO(Rugvip): cache the token
     const { token } = await this.tokenManager.getToken();
     const { items } = await this.catalogApi.getEntities({ filter }, { token });
 

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.ts
@@ -24,7 +24,7 @@ import {
   stringifyEntityRef,
   UserEntity,
 } from '@backstage/catalog-model';
-import { TokenIssuer } from '../../identity';
+import { TokenManager } from '@backstage/backend-common';
 
 type UserQuery = {
   annotations: Record<string, string>;
@@ -40,11 +40,11 @@ type MemberClaimQuery = {
  */
 export class CatalogIdentityClient {
   private readonly catalogApi: CatalogApi;
-  private readonly tokenIssuer: TokenIssuer;
+  private readonly tokenManager: TokenManager;
 
-  constructor(options: { catalogApi: CatalogApi; tokenIssuer: TokenIssuer }) {
+  constructor(options: { catalogApi: CatalogApi; tokenManager: TokenManager }) {
     this.catalogApi = options.catalogApi;
-    this.tokenIssuer = options.tokenIssuer;
+    this.tokenManager = options.tokenManager;
   }
 
   /**
@@ -61,9 +61,7 @@ export class CatalogIdentityClient {
     }
 
     // TODO(Rugvip): cache the token
-    const token = await this.tokenIssuer.issueToken({
-      claims: { sub: 'backstage.io/auth-backend' },
-    });
+    const { token } = await this.tokenManager.getToken();
     const { items } = await this.catalogApi.getEntities({ filter }, { token });
 
     if (items.length !== 1) {
@@ -106,8 +104,9 @@ export class CatalogIdentityClient {
       'metadata.namespace': ref.namespace,
       'metadata.name': ref.name,
     }));
+    const { token } = await this.tokenManager.getToken();
     const entities = await this.catalogApi
-      .getEntities({ filter })
+      .getEntities({ filter }, { token })
       .then(r => r.items);
 
     if (entityRefs.length !== entities.length) {

--- a/plugins/auth-backend/src/providers/atlassian/provider.ts
+++ b/plugins/auth-backend/src/providers/atlassian/provider.ts
@@ -197,6 +197,7 @@ export const createAtlassianProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -208,7 +209,7 @@ export const createAtlassianProvider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<OAuthResult> =

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -220,6 +220,7 @@ export const createAuth0Provider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -231,7 +232,7 @@ export const createAuth0Provider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<OAuthResult> = options?.authHandler

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -241,7 +241,7 @@ export type AwsAlbProviderOptions = {
 export const createAwsAlbProvider = (
   options?: AwsAlbProviderOptions,
 ): AuthProviderFactory => {
-  return ({ config, tokenIssuer, catalogApi, logger }) => {
+  return ({ config, tokenIssuer, catalogApi, logger, tokenManager }) => {
     const region = config.getString('region');
     const issuer = config.getOptionalString('iss');
 
@@ -253,7 +253,7 @@ export const createAwsAlbProvider = (
 
     const catalogIdentityClient = new CatalogIdentityClient({
       catalogApi,
-      tokenIssuer,
+      tokenManager,
     });
 
     const authHandler: AuthHandler<AwsAlbResult> = options?.authHandler

--- a/plugins/auth-backend/src/providers/bitbucket/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.ts
@@ -273,6 +273,7 @@ export const createBitbucketProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -283,7 +284,7 @@ export const createBitbucketProvider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<BitbucketOAuthResult> =

--- a/plugins/auth-backend/src/providers/gcp-iap/provider.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/provider.ts
@@ -102,7 +102,7 @@ export class GcpIapProvider implements AuthProviderRouteHandlers {
 export function createGcpIapProvider(
   options: GcpIapProviderOptions,
 ): AuthProviderFactory {
-  return ({ config, tokenIssuer, catalogApi, logger }) => {
+  return ({ config, tokenIssuer, catalogApi, logger, tokenManager }) => {
     const audience = config.getString('audience');
 
     const authHandler = options.authHandler ?? defaultAuthHandler;
@@ -111,7 +111,7 @@ export function createGcpIapProvider(
 
     const catalogIdentityClient = new CatalogIdentityClient({
       catalogApi,
-      tokenIssuer,
+      tokenManager,
     });
 
     return new GcpIapProvider({

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -245,6 +245,7 @@ export const createGithubProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -270,7 +271,7 @@ export const createGithubProvider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<GithubOAuthResult> = options?.authHandler

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -227,6 +227,7 @@ export const createGitlabProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -239,7 +240,7 @@ export const createGitlabProvider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<OAuthResult> =

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -259,6 +259,7 @@ export const createGoogleProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -269,7 +270,7 @@ export const createGoogleProvider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<OAuthResult> = options?.authHandler

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -267,6 +267,7 @@ export const createMicrosoftProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -281,7 +282,7 @@ export const createMicrosoftProvider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<OAuthResult> = options?.authHandler

--- a/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
@@ -182,12 +182,12 @@ export const createOauth2ProxyProvider =
   <JWTPayload>(
     options: Oauth2ProxyProviderOptions<JWTPayload>,
   ): AuthProviderFactory =>
-  ({ catalogApi, logger, tokenIssuer }) => {
+  ({ catalogApi, logger, tokenIssuer, tokenManager }) => {
     const signInResolver = options.signIn.resolver;
     const authHandler = options.authHandler;
     const catalogIdentityClient = new CatalogIdentityClient({
       catalogApi,
-      tokenIssuer,
+      tokenManager,
     });
     return new Oauth2ProxyAuthProvider<JWTPayload>({
       logger,

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -233,6 +233,7 @@ export const createOAuth2Provider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -249,7 +250,7 @@ export const createOAuth2Provider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<OAuthResult> = options?.authHandler

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -257,6 +257,7 @@ export const createOidcProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -272,7 +273,7 @@ export const createOidcProvider = (
       const prompt = envConfig.getOptionalString('prompt');
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<OidcAuthResult> = options?.authHandler

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -268,6 +268,7 @@ export const createOktaProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -286,7 +287,7 @@ export const createOktaProvider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<OAuthResult> = _options?.authHandler

--- a/plugins/auth-backend/src/providers/onelogin/provider.ts
+++ b/plugins/auth-backend/src/providers/onelogin/provider.ts
@@ -219,6 +219,7 @@ export const createOneLoginProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) =>
@@ -230,7 +231,7 @@ export const createOneLoginProvider = (
 
       const catalogIdentityClient = new CatalogIdentityClient({
         catalogApi,
-        tokenIssuer,
+        tokenManager,
       });
 
       const authHandler: AuthHandler<OAuthResult> = options?.authHandler

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -187,12 +187,13 @@ export const createSamlProvider = (
     globalConfig,
     config,
     tokenIssuer,
+    tokenManager,
     catalogApi,
     logger,
   }) => {
     const catalogIdentityClient = new CatalogIdentityClient({
       catalogApi,
-      tokenIssuer,
+      tokenManager,
     });
 
     const authHandler: AuthHandler<SamlAuthResult> = options?.authHandler

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import {
+  PluginEndpointDiscovery,
+  TokenManager,
+} from '@backstage/backend-common';
 import { CatalogApi } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
@@ -124,6 +127,7 @@ export type AuthProviderFactoryOptions = {
   globalConfig: AuthProviderConfig;
   config: Config;
   logger: Logger;
+  tokenManager: TokenManager;
   tokenIssuer: TokenIssuer;
   discovery: PluginEndpointDiscovery;
   catalogApi: CatalogApi;

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -25,6 +25,7 @@ import {
 import {
   PluginDatabaseManager,
   PluginEndpointDiscovery,
+  TokenManager,
 } from '@backstage/backend-common';
 import { assertError, NotFoundError } from '@backstage/errors';
 import { CatalogClient } from '@backstage/catalog-client';
@@ -41,13 +42,21 @@ export interface RouterOptions {
   database: PluginDatabaseManager;
   config: Config;
   discovery: PluginEndpointDiscovery;
+  tokenManager: TokenManager;
   providerFactories?: ProviderFactories;
 }
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { logger, config, discovery, database, providerFactories } = options;
+  const {
+    logger,
+    config,
+    discovery,
+    database,
+    tokenManager,
+    providerFactories,
+  } = options;
   const router = Router();
 
   const appUrl = config.getString('app.baseUrl');
@@ -105,6 +114,7 @@ export async function createRouter(
           globalConfig: { baseUrl: authUrl, appUrl, isOriginAllowed },
           config: providersConfig.getConfig(providerId),
           logger,
+          tokenManager,
           tokenIssuer,
           discovery,
           catalogApi,

--- a/plugins/auth-backend/src/service/standaloneServer.ts
+++ b/plugins/auth-backend/src/service/standaloneServer.ts
@@ -17,6 +17,7 @@
 import {
   createServiceBuilder,
   loadBackendConfig,
+  ServerTokenManager,
   SingleHostDiscovery,
   useHotMemoize,
 } from '@backstage/backend-common';
@@ -58,6 +59,7 @@ export async function startStandaloneServer(
       },
     },
     discovery,
+    tokenManager: ServerTokenManager.noop(),
   });
 
   const service = createServiceBuilder(module)


### PR DESCRIPTION
Signed-off-by: Joe Porpeglia <josephp@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Updates the `CatalogIdentityClient` to use a server token manager instead of issuing a user token for catalog requests. This allows sign in resolvers to lookup catalog users and group membership without passing through the permission backend.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
