### PR TITLE
cli: Log warning if unable to parse yarn.lock

### DIFF
--- a/.changeset/witty-lizards-nail.md
+++ b/.changeset/witty-lizards-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Log warning if unable to parse yarn.lock

--- a/packages/cli/src/commands/app/serve.ts
+++ b/packages/cli/src/commands/app/serve.ts
@@ -25,29 +25,54 @@ import { Lockfile } from '../../lib/versioning';
 import { forbiddenDuplicatesFilter, includedFilter } from '../versions/lint';
 
 export default async (cmd: Command) => {
-  const lockfile = await Lockfile.load(paths.resolveTargetRoot('yarn.lock'));
-  const result = lockfile.analyze({
-    filter: includedFilter,
-  });
-  const problemPackages = [...result.newVersions, ...result.newRanges]
-    .map(({ name }) => name)
-    .filter(name => forbiddenDuplicatesFilter(name));
+  const lockFilePath = paths.resolveTargetRoot('yarn.lock');
+  if (fs.existsSync(lockFilePath)) {
+    try {
+      const lockfile = await Lockfile.load(lockFilePath);
+      const result = lockfile.analyze({
+        filter: includedFilter,
+      });
+      const problemPackages = [...result.newVersions, ...result.newRanges]
+        .map(({ name }) => name)
+        .filter(name => forbiddenDuplicatesFilter(name));
 
-  if (problemPackages.length > 0) {
+      if (problemPackages.length > 0) {
+        console.log(
+          chalk.yellow(
+            `⚠️ Some of the following packages may be outdated or have duplicate installations:
+
+              ${uniq(problemPackages).join(', ')}
+            `,
+          ),
+        );
+        console.log(
+          chalk.yellow(
+            `⚠️ The following command may fix the issue, but it could also be an issue within one of your dependencies:
+
+              yarn backstage-cli versions:check --fix
+            `,
+          ),
+        );
+      }
+    } catch (error) {
+      console.log(
+        chalk.yellow(
+          `⚠️ Unable to parse yarn.lock file properly:
+
+            ${error}
+
+            skipping analyzer for outdated or duplicate installations
+          `,
+        ),
+      );
+    }
+  } else {
     console.log(
       chalk.yellow(
-        `⚠️ Some of the following packages may be outdated or have duplicate installations:
+        `⚠️ Unable to find yarn.lock file:
 
-          ${uniq(problemPackages).join(', ')}
+          skipping analyzer for outdated or duplicate installations
         `,
-      ),
-    );
-    console.log(
-      chalk.yellow(
-        `⚠️ The following command may fix the issue, but it could also be an issue within one of your dependencies:
-
-          yarn backstage-cli versions:check --fix
-      `,
       ),
     );
   }


### PR DESCRIPTION
Signed-off-by: Mustansar Anwar ul Samad <mustansar.samad@gmail.com>

## Hey, I just made a Pull Request!
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Log warning if `yarn.lock` is not available or cannot be parsed during the app startup, and still continue with the startup. This will allow to use different yarn version where `yarn.lock` has a slight different format. See #8054 . Also, will allow to use other package managers if needed. 

Not a UI but still adding screenshots :)

When `yarn.lock` file is not available
![2022-01-27 11_58_16-Window](https://user-images.githubusercontent.com/24932925/151262639-8c37912a-cd5a-46cc-aa28-688a63dda0ff.png)

When `yarn.lock` cannot be parsed
![2022-01-27 11_59_08-Window](https://user-images.githubusercontent.com/24932925/151262710-ef6ddf2e-3fa8-41db-bfb3-d57c5d964782.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
