### PR TITLE
Change subtitle of Header style to be more customizable

### DIFF
--- a/.changeset/flat-cars-begin.md
+++ b/.changeset/flat-cars-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Change subtitle of Header style to use palette.bursts.fontColor

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -71,7 +71,7 @@ const useStyles = makeStyles<BackstageTheme>(
       marginBottom: 0,
     },
     subtitle: {
-      color: theme.palette.common.white,
+      color: theme.palette.bursts.fontColor,
       opacity: 0.8,
       display: 'inline-block', // prevents margin collapse of adjacent siblings
       marginTop: theme.spacing(1),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I've changed the styles of the API page Header subtitle, so now it can be easily changed by the user. Before it was just common.white color, so if we wanted to change it we had to override common, white with another color, which wasn't the best solution. Right now it's using palette.bursts.FontColor which by default is "#FEFEFE", so almost white.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
