### PR TITLE
catalog-backend: pass token to locationService in location routes

### DIFF
--- a/.changeset/thirty-houses-juggle.md
+++ b/.changeset/thirty-houses-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Pass authorization token to location service inside location api routes

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -250,8 +250,14 @@ describe('createRouter readonly disabled', () => {
       ];
       locationService.listLocations.mockResolvedValueOnce(locations);
 
-      const response = await request(app).get('/locations');
+      const response = await request(app)
+        .get('/locations')
+        .set('authorization', 'Bearer someauthtoken');
 
+      expect(locationService.listLocations).toHaveBeenCalledTimes(1);
+      expect(locationService.listLocations).toHaveBeenCalledWith({
+        authorizationToken: 'someauthtoken',
+      });
       expect(response.status).toEqual(200);
       expect(response.body).toEqual([
         { data: { id: 'foo', target: 'example.com', type: 'url' } },
@@ -266,7 +272,10 @@ describe('createRouter readonly disabled', () => {
         target: 'c',
       } as unknown as LocationSpec;
 
-      const response = await request(app).post('/locations').send(spec);
+      const response = await request(app)
+        .post('/locations')
+        .set('authorization', 'Bearer someauthtoken')
+        .send(spec);
 
       expect(locationService.createLocation).not.toHaveBeenCalled();
       expect(response.status).toEqual(400);
@@ -283,10 +292,15 @@ describe('createRouter readonly disabled', () => {
         entities: [],
       });
 
-      const response = await request(app).post('/locations').send(spec);
+      const response = await request(app)
+        .post('/locations')
+        .set('authorization', 'Bearer someauthtoken')
+        .send(spec);
 
       expect(locationService.createLocation).toHaveBeenCalledTimes(1);
-      expect(locationService.createLocation).toHaveBeenCalledWith(spec, false);
+      expect(locationService.createLocation).toHaveBeenCalledWith(spec, false, {
+        authorizationToken: 'someauthtoken',
+      });
       expect(response.status).toEqual(201);
       expect(response.body).toEqual(
         expect.objectContaining({
@@ -308,10 +322,13 @@ describe('createRouter readonly disabled', () => {
 
       const response = await request(app)
         .post('/locations?dryRun=true')
+        .set('authorization', 'Bearer someauthtoken')
         .send(spec);
 
       expect(locationService.createLocation).toHaveBeenCalledTimes(1);
-      expect(locationService.createLocation).toHaveBeenCalledWith(spec, true);
+      expect(locationService.createLocation).toHaveBeenCalledWith(spec, true, {
+        authorizationToken: 'someauthtoken',
+      });
       expect(response.status).toEqual(201);
       expect(response.body).toEqual(
         expect.objectContaining({
@@ -397,7 +414,14 @@ describe('createRouter readonly enabled', () => {
       ];
       locationService.listLocations.mockResolvedValueOnce(locations);
 
-      const response = await request(app).get('/locations');
+      const response = await request(app)
+        .get('/locations')
+        .set('authorization', 'Bearer someauthtoken');
+
+      expect(locationService.listLocations).toHaveBeenCalledTimes(1);
+      expect(locationService.listLocations).toHaveBeenCalledWith({
+        authorizationToken: 'someauthtoken',
+      });
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual([
@@ -413,7 +437,10 @@ describe('createRouter readonly enabled', () => {
         target: 'c',
       };
 
-      const response = await request(app).post('/locations').send(spec);
+      const response = await request(app)
+        .post('/locations')
+        .set('authorization', 'Bearer someauthtoken')
+        .send(spec);
 
       expect(locationService.createLocation).not.toHaveBeenCalled();
       expect(response.status).toEqual(403);
@@ -433,10 +460,13 @@ describe('createRouter readonly enabled', () => {
 
       const response = await request(app)
         .post('/locations?dryRun=true')
+        .set('authorization', 'Bearer someauthtoken')
         .send(spec);
 
       expect(locationService.createLocation).toHaveBeenCalledTimes(1);
-      expect(locationService.createLocation).toHaveBeenCalledWith(spec, true);
+      expect(locationService.createLocation).toHaveBeenCalledWith(spec, true, {
+        authorizationToken: 'someauthtoken',
+      });
       expect(response.status).toEqual(201);
       expect(response.body).toEqual(
         expect.objectContaining({

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -265,6 +265,33 @@ describe('createRouter readonly disabled', () => {
     });
   });
 
+  describe('GET /locations/:id', () => {
+    it('happy path: gets location by id', async () => {
+      const location: Location = {
+        id: 'foo',
+        type: 'url',
+        target: 'example.com',
+      };
+      locationService.getLocation.mockResolvedValueOnce(location);
+
+      const response = await request(app)
+        .get('/locations/foo')
+        .set('authorization', 'Bearer someauthtoken');
+
+      expect(locationService.getLocation).toHaveBeenCalledTimes(1);
+      expect(locationService.getLocation).toHaveBeenCalledWith('foo', {
+        authorizationToken: 'someauthtoken',
+      });
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        id: 'foo',
+        target: 'example.com',
+        type: 'url',
+      });
+    });
+  });
+
   describe('POST /locations', () => {
     it('rejects malformed locations', async () => {
       const spec = {
@@ -335,6 +362,23 @@ describe('createRouter readonly disabled', () => {
           location: { id: 'a', ...spec },
         }),
       );
+    });
+  });
+
+  describe('DELETE /locations', () => {
+    it('deletes the location', async () => {
+      locationService.deleteLocation.mockResolvedValueOnce(undefined);
+
+      const response = await request(app)
+        .delete('/locations/foo')
+        .set('authorization', 'Bearer someauthtoken');
+
+      expect(locationService.deleteLocation).toHaveBeenCalledTimes(1);
+      expect(locationService.deleteLocation).toHaveBeenCalledWith('foo', {
+        authorizationToken: 'someauthtoken',
+      });
+
+      expect(response.status).toEqual(204);
     });
   });
 });
@@ -430,6 +474,33 @@ describe('createRouter readonly enabled', () => {
     });
   });
 
+  describe('GET /locations/:id', () => {
+    it('happy path: gets location by id', async () => {
+      const location: Location = {
+        id: 'foo',
+        type: 'url',
+        target: 'example.com',
+      };
+      locationService.getLocation.mockResolvedValueOnce(location);
+
+      const response = await request(app)
+        .get('/locations/foo')
+        .set('authorization', 'Bearer someauthtoken');
+
+      expect(locationService.getLocation).toHaveBeenCalledTimes(1);
+      expect(locationService.getLocation).toHaveBeenCalledWith('foo', {
+        authorizationToken: 'someauthtoken',
+      });
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        id: 'foo',
+        target: 'example.com',
+        type: 'url',
+      });
+    });
+  });
+
   describe('POST /locations', () => {
     it('is not allowed', async () => {
       const spec: LocationSpec = {
@@ -473,6 +544,17 @@ describe('createRouter readonly enabled', () => {
           location: { id: 'a', ...spec },
         }),
       );
+    });
+  });
+
+  describe('DELETE /locations', () => {
+    it('is not allowed', async () => {
+      const response = await request(app)
+        .delete('/locations/foo')
+        .set('authorization', 'Bearer someauthtoken');
+
+      expect(locationService.deleteLocation).not.toHaveBeenCalled();
+      expect(response.status).toEqual(403);
     });
   });
 });

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -174,24 +174,32 @@ export async function createRouter(
           disallowReadonlyMode(readonlyEnabled);
         }
 
-        const output = await locationService.createLocation(input, dryRun);
+        const output = await locationService.createLocation(input, dryRun, {
+          authorizationToken: getBearerToken(req.header('authorization')),
+        });
         res.status(201).json(output);
       })
-      .get('/locations', async (_req, res) => {
-        const locations = await locationService.listLocations();
+      .get('/locations', async (req, res) => {
+        const locations = await locationService.listLocations({
+          authorizationToken: getBearerToken(req.header('authorization')),
+        });
         res.status(200).json(locations.map(l => ({ data: l })));
       })
 
       .get('/locations/:id', async (req, res) => {
         const { id } = req.params;
-        const output = await locationService.getLocation(id);
+        const output = await locationService.getLocation(id, {
+          authorizationToken: getBearerToken(req.header('authorization')),
+        });
         res.status(200).json(output);
       })
       .delete('/locations/:id', async (req, res) => {
         disallowReadonlyMode(readonlyEnabled);
 
         const { id } = req.params;
-        await locationService.deleteLocation(id);
+        await locationService.deleteLocation(id, {
+          authorizationToken: getBearerToken(req.header('authorization')),
+        });
         res.status(204).end();
       });
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We don't currently pass the authorization token to the location service, which means that when permissions are enabled, location api calls are authorized as if the user is not logged in. This is likely due to a bad merge of a previous PR, since this wouldn't have worked at all otherwise.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
