### PR TITLE
org: add relations.memberof filter to catalog api call in MembersListCard

### DIFF
--- a/.changeset/nasty-pets-glow.md
+++ b/.changeset/nasty-pets-glow.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-org': patch
 ---
 
-Added relations.memberof filter to the catalog api call in MemberListCard to avoid fetching the whole User kind entity from catalog-backend.
+Added `relations.memberof` filter to the catalog api call in `MemberListCard` to avoid fetching all the User entity kinds from catalog-backend.

--- a/.changeset/nasty-pets-glow.md
+++ b/.changeset/nasty-pets-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Added relations.memberof filter to the catalog api call in MemberListCard to avoid fetching the whole User kind entity from catalog-backend.

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.test.tsx
@@ -75,33 +75,6 @@ describe('MemberTab Test', () => {
               memberOf: ['team-d'],
             },
           },
-          {
-            apiVersion: 'backstage.io/v1alpha1',
-            kind: 'User',
-            metadata: {
-              name: 'sara.macgovern',
-              namespace: 'default',
-              uid: 'a5gerth57',
-            },
-            relations: [
-              {
-                type: 'memberOf',
-                target: {
-                  kind: 'group',
-                  name: 'team-d',
-                  namespace: 'foo-bar',
-                },
-              },
-            ],
-            spec: {
-              profile: {
-                displayName: 'Sara MacGovern',
-                email: 'sara-macgovern@example.com',
-                picture: 'https://example.com/staff/sara.jpeg',
-              },
-              memberOf: ['foo-bar/team-d'],
-            },
-          },
         ] as Entity[],
       }),
   };

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -16,8 +16,8 @@
 import {
   ENTITY_DEFAULT_NAMESPACE,
   GroupEntity,
-  RELATION_MEMBER_OF,
   UserEntity,
+  stringifyEntityRef,
 } from '@backstage/catalog-model';
 import {
   catalogApiRef,
@@ -139,20 +139,19 @@ export const MembersListCard = (_props: {
     value: members,
   } = useAsync(async () => {
     const membersList = await catalogApi.getEntities({
-      filter: { kind: 'User' },
+      filter: {
+        kind: 'User',
+        'relations.memberof': [
+          stringifyEntityRef({
+            kind: 'group',
+            namespace: groupNamespace.toLocaleLowerCase('en-US'),
+            name: groupName.toLocaleLowerCase('en-US'),
+          }),
+        ],
+      },
     });
-    const groupMembersList = (membersList.items as UserEntity[]).filter(
-      member =>
-        member?.relations?.some(
-          r =>
-            r.type === RELATION_MEMBER_OF &&
-            r.target.name.toLocaleLowerCase('en-US') ===
-              groupName.toLocaleLowerCase('en-US') &&
-            r.target.namespace.toLocaleLowerCase('en-US') ===
-              groupNamespace.toLocaleLowerCase('en-US'),
-        ),
-    );
-    return groupMembersList;
+
+    return membersList.items as UserEntity[];
   }, [catalogApi, groupEntity]);
 
   if (loading) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I noticed that MembersListCard fetch the entire user entities and do the filtering in the frontend. It's okay if you don't have many users. But in our case, we have more than 10K user entities so fetching the entire user entities it is not so effective.

This PR adds `relations.memberof` filter to the API call so that filtering can be done in the backend to improve overall performance of the MemberListCard.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
