### PR TITLE
[Bazaar Plugin]fix dependency which breaks datepicker

### DIFF
--- a/.changeset/blue-ads-smoke.md
+++ b/.changeset/blue-ads-smoke.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-bazaar': patch
 ---
 
-Downgrade denpendency to fix broken date picker
+Downgrade @date-io/luxon from `2.*` to `^1.3.31`

--- a/.changeset/blue-ads-smoke.md
+++ b/.changeset/blue-ads-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Downgrade @date-io/luxon to version 1.3.13 to fix broken date picker

--- a/.changeset/blue-ads-smoke.md
+++ b/.changeset/blue-ads-smoke.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-bazaar': patch
 ---
 
-Downgrade @date-io/luxon to version 1.3.13 to fix broken date picker
+Downgrade denpendency to fix broken date picker

--- a/.changeset/blue-ads-smoke.md
+++ b/.changeset/blue-ads-smoke.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-bazaar': patch
 ---
 
-Downgrade @date-io/luxon from `2.*` to `^1.3.31`
+Downgrade @date-io/luxon from `2.*` to `^1.3.13`

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -28,7 +28,7 @@
     "@backstage/core-plugin-api": "^0.6.0",
     "@backstage/plugin-catalog": "^0.7.10",
     "@backstage/plugin-catalog-react": "^0.6.12",
-    "@date-io/luxon": "2.x",
+    "@date-io/luxon": " 1.3.13",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -28,7 +28,7 @@
     "@backstage/core-plugin-api": "^0.6.0",
     "@backstage/plugin-catalog": "^0.7.10",
     "@backstage/plugin-catalog-react": "^0.6.12",
-    "@date-io/luxon": "1.3.13",
+    "@date-io/luxon": "^1.3.31",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -28,7 +28,7 @@
     "@backstage/core-plugin-api": "^0.6.0",
     "@backstage/plugin-catalog": "^0.7.10",
     "@backstage/plugin-catalog-react": "^0.6.12",
-    "@date-io/luxon": " 1.3.13",
+    "@date-io/luxon": "1.3.13",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",

--- a/plugins/ilert/package.json
+++ b/plugins/ilert/package.json
@@ -27,7 +27,7 @@
     "@backstage/errors": "^0.2.0",
     "@backstage/plugin-catalog-react": "^0.6.12",
     "@backstage/theme": "^0.2.14",
-    "@date-io/luxon": "2.x",
+    "@date-io/luxon": "^1.3.13",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Hi I am not sure if we could disable dependent bot for this dependency.

But upgrade `@date-io/luxon` to `2.*` breaks the DataPicker in this plugin.

Previous commit:  https://github.com/backstage/backstage/commit/b47965beecadbc0cc753b8f32bec6856bbb92e66

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
