### PR TITLE
scripts: updates to support new release process

### DIFF
--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -201,7 +201,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Creates the next available tag with format "release-<year>-<month>-<day>[.<n>]"
+      # Grabs the version in the root package.json and creates a tag on GitHub
       - name: Create a release tag
         id: create_tag
         run: node scripts/create-release-tag.js

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "lint-staged": "^12.2.0",
     "minimist": "^1.2.5",
     "prettier": "^2.2.1",
+    "semver": "^7.3.2",
     "shx": "^0.3.2",
     "ts-node": "^10.4.0",
     "typescript": "~4.5.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "**/@roadiehq/**/@backstage/plugin-catalog": "*",
     "**/@roadiehq/**/@backstage/catalog-model": "*"
   },
-  "version": "1.0.0",
+  "version": "0.65.0",
   "dependencies": {
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.15.0",

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -41,6 +41,7 @@
  */
 
 const { Octokit } = require('@octokit/rest');
+const semver = require('semver');
 
 // See Examples above to learn about these command line arguments.
 const [TAG_NAME, BOOL_CREATE_RELEASE] = process.argv.slice(2);
@@ -160,7 +161,7 @@ async function createRelease(releaseDescription) {
     name: TAG_NAME,
     body: releaseDescription,
     draft: boolCreateDraft,
-    prerelease: false,
+    prerelease: Boolean(semver.prerelease(TAG_NAME)),
   });
 
   if (releaseResponse.status === 201) {


### PR DESCRIPTION
This updates our release process to switch from timestamp-based `release-*` tags to version-base `v*` tags.

The overall release version is tracked in the root package.json, and is automatically bumped when running `yarn release`