### PR TITLE
workflows/sync_release-manifest: skip v prefix in release manifests

### DIFF
--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number'
+        description: Version number, without any 'v' prefix
         required: true
 jobs:
   create-new-version:
@@ -21,7 +21,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: backstage
-          ref: ${{ github.event.inputs.version }}
+          # 'v' prefix is added here for the tag, we keep it out of the manifest logic
+          ref: v${{ github.event.inputs.version }}
 
       # Checkout backstage/versions into /backstage/versions, which is where store the output
       - name: Checkout versions


### PR DESCRIPTION
Prolly better to have e.g. `/v1/releases/0.1.0/manifest.json` rather than `/v1/releases/v0.1.0/manifest.json`.