### PR TITLE
Fixing package name in @backstage/create-app@0.4.15 patch changes

### DIFF
--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -30,7 +30,7 @@
 
   To make this change to an existing app:
 
-  Add `@backstage/catalog-graph-plugin` as a `dependency` in `packages/app/package.json`
+  Add `@backstage/plugin-catalog-graph` as a `dependency` in `packages/app/package.json`
 
   Apply the following changes to the `packages/app/src/components/catalog/EntityPage.tsx` file:
 

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -15,6 +15,11 @@
     tokenManager,
   }: PluginEnvironment) {
     /* ... */
+    indexBuilder.addCollator({
+      defaultRefreshIntervalSeconds: 600,
+  -   collator: DefaultCatalogCollator.fromConfig(config, { discovery }),
+  +   collator: DefaultCatalogCollator.fromConfig(config, { discovery, tokenManager }),
+    });
 
     return await createRouter({
       engine: indexBuilder.getSearchEngine(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changing `@backstage/catalog-graph-plugin` to `@backstage/plugin-catalog-graph` in @backstage/create-app@0.4.15 patch changes.

```
jorgelopezjohnson@MacBook-Pro app % yarn add @backstage/catalog-graph-plugin
yarn add v1.22.15
[1/4] 🔍  Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/@backstage%2fcatalog-graph-plugin: Not found".
```

also addding missing `tokenManager` arg in the search plugin
```
collator: DefaultCatalogCollator.fromConfig(config, { discovery, tokenManager })
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
