### PR TITLE
Respect queryParameter updates in catalog pickers

### DIFF
--- a/.changeset/seven-apes-shave.md
+++ b/.changeset/seven-apes-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Updated `useEntityListProvider` and catalog pickers to respond to external changes to query parameters in the URL, such as two sidebar links that apply different catalog filters.

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.test.tsx
@@ -161,4 +161,34 @@ describe('<EntityLifecyclePicker/>', () => {
       lifecycles: undefined,
     });
   });
+
+  it('responds to external queryParameters changes', () => {
+    const updateFilters = jest.fn();
+    const rendered = render(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: { lifecycles: ['experimental'] },
+        }}
+      >
+        <EntityLifecyclePicker />
+      </MockEntityListContextProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      lifecycles: new EntityLifecycleFilter(['experimental']),
+    });
+    rendered.rerender(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: { lifecycles: ['production'] },
+        }}
+      >
+        <EntityLifecyclePicker />
+      </MockEntityListContextProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      lifecycles: new EntityLifecycleFilter(['production']),
+    });
+  });
 });

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -51,14 +51,18 @@ export const EntityLifecyclePicker = () => {
   const { updateFilters, backendEntities, filters, queryParameters } =
     useEntityListProvider();
 
-  const queryParamLifecycles = [queryParameters.lifecycles]
-    .flat()
-    .filter(Boolean) as string[];
   const [selectedLifecycles, setSelectedLifecycles] = useState(
-    queryParamLifecycles.length
-      ? queryParamLifecycles
-      : filters.lifecycles?.values ?? [],
+    filters.lifecycles?.values ?? [],
   );
+
+  // Set selected lifecycles on query parameter updates; this happens at initial page load and from
+  // external updates to the page location.
+  useEffect(() => {
+    const queryParamLifecycles = [queryParameters.lifecycles]
+      .flat()
+      .filter(Boolean) as string[];
+    setSelectedLifecycles(queryParamLifecycles);
+  }, [queryParameters]);
 
   useEffect(() => {
     updateFilters({

--- a/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityLifecyclePicker/EntityLifecyclePicker.tsx
@@ -51,18 +51,24 @@ export const EntityLifecyclePicker = () => {
   const { updateFilters, backendEntities, filters, queryParameters } =
     useEntityListProvider();
 
+  const queryParamLifecycles = useMemo(
+    () => [queryParameters.lifecycles].flat().filter(Boolean) as string[],
+    [queryParameters],
+  );
+
   const [selectedLifecycles, setSelectedLifecycles] = useState(
-    filters.lifecycles?.values ?? [],
+    queryParamLifecycles.length
+      ? queryParamLifecycles
+      : filters.lifecycles?.values ?? [],
   );
 
   // Set selected lifecycles on query parameter updates; this happens at initial page load and from
   // external updates to the page location.
   useEffect(() => {
-    const queryParamLifecycles = [queryParameters.lifecycles]
-      .flat()
-      .filter(Boolean) as string[];
-    setSelectedLifecycles(queryParamLifecycles);
-  }, [queryParameters]);
+    if (queryParamLifecycles.length) {
+      setSelectedLifecycles(queryParamLifecycles);
+    }
+  }, [queryParamLifecycles]);
 
   useEffect(() => {
     updateFilters({

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -191,4 +191,34 @@ describe('<EntityOwnerPicker/>', () => {
       owner: undefined,
     });
   });
+
+  it('responds to external queryParameters changes', () => {
+    const updateFilters = jest.fn();
+    const rendered = render(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: { owners: ['team-a'] },
+        }}
+      >
+        <EntityOwnerPicker />
+      </MockEntityListContextProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      owners: new EntityOwnerFilter(['team-a']),
+    });
+    rendered.rerender(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: { owners: ['team-b'] },
+        }}
+      >
+        <EntityOwnerPicker />
+      </MockEntityListContextProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      owners: new EntityOwnerFilter(['team-b']),
+    });
+  });
 });

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -53,18 +53,22 @@ export const EntityOwnerPicker = () => {
   const { updateFilters, backendEntities, filters, queryParameters } =
     useEntityListProvider();
 
+  const queryParamOwners = useMemo(
+    () => [queryParameters.owners].flat().filter(Boolean) as string[],
+    [queryParameters],
+  );
+
   const [selectedOwners, setSelectedOwners] = useState(
-    filters.owners?.values ?? [],
+    queryParamOwners.length ? queryParamOwners : filters.owners?.values ?? [],
   );
 
   // Set selected owners on query parameter updates; this happens at initial page load and from
   // external updates to the page location.
   useEffect(() => {
-    const queryParamOwners = [queryParameters.owners]
-      .flat()
-      .filter(Boolean) as string[];
-    setSelectedOwners(queryParamOwners);
-  }, [queryParameters]);
+    if (queryParamOwners.length) {
+      setSelectedOwners(queryParamOwners);
+    }
+  }, [queryParamOwners]);
 
   useEffect(() => {
     updateFilters({

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -53,12 +53,18 @@ export const EntityOwnerPicker = () => {
   const { updateFilters, backendEntities, filters, queryParameters } =
     useEntityListProvider();
 
-  const queryParamOwners = [queryParameters.owners]
-    .flat()
-    .filter(Boolean) as string[];
   const [selectedOwners, setSelectedOwners] = useState(
-    queryParamOwners.length ? queryParamOwners : filters.owners?.values ?? [],
+    filters.owners?.values ?? [],
   );
+
+  // Set selected owners on query parameter updates; this happens at initial page load and from
+  // external updates to the page location.
+  useEffect(() => {
+    const queryParamOwners = [queryParameters.owners]
+      .flat()
+      .filter(Boolean) as string[];
+    setSelectedOwners(queryParamOwners);
+  }, [queryParameters]);
 
   useEffect(() => {
     updateFilters({

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.test.tsx
@@ -149,4 +149,34 @@ describe('<EntityTagPicker/>', () => {
       tags: undefined,
     });
   });
+
+  it('responds to external queryParameters changes', () => {
+    const updateFilters = jest.fn();
+    const rendered = render(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: { tags: ['tag1'] },
+        }}
+      >
+        <EntityTagPicker />
+      </MockEntityListContextProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      tags: new EntityTagFilter(['tag1']),
+    });
+    rendered.rerender(
+      <MockEntityListContextProvider
+        value={{
+          updateFilters,
+          queryParameters: { tags: ['tag2'] },
+        }}
+      >
+        <EntityTagPicker />
+      </MockEntityListContextProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      tags: new EntityTagFilter(['tag2']),
+    });
+  });
 });

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -51,16 +51,22 @@ export const EntityTagPicker = () => {
   const { updateFilters, backendEntities, filters, queryParameters } =
     useEntityListProvider();
 
-  const [selectedTags, setSelectedTags] = useState(filters.tags?.values ?? []);
+  const queryParamTags = useMemo(
+    () => [queryParameters.tags].flat().filter(Boolean) as string[],
+    [queryParameters],
+  );
+
+  const [selectedTags, setSelectedTags] = useState(
+    queryParamTags.length ? queryParamTags : filters.tags?.values ?? [],
+  );
 
   // Set selected tags on query parameter updates; this happens at initial page load and from
   // external updates to the page location.
   useEffect(() => {
-    const queryParamTags = [queryParameters.tags]
-      .flat()
-      .filter(Boolean) as string[];
-    setSelectedTags(queryParamTags);
-  }, [queryParameters]);
+    if (queryParamTags.length) {
+      setSelectedTags(queryParamTags);
+    }
+  }, [queryParamTags]);
 
   useEffect(() => {
     updateFilters({

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -51,12 +51,16 @@ export const EntityTagPicker = () => {
   const { updateFilters, backendEntities, filters, queryParameters } =
     useEntityListProvider();
 
-  const queryParamTags = [queryParameters.tags]
-    .flat()
-    .filter(Boolean) as string[];
-  const [selectedTags, setSelectedTags] = useState(
-    queryParamTags.length ? queryParamTags : filters.tags?.values ?? [],
-  );
+  const [selectedTags, setSelectedTags] = useState(filters.tags?.values ?? []);
+
+  // Set selected tags on query parameter updates; this happens at initial page load and from
+  // external updates to the page location.
+  useEffect(() => {
+    const queryParamTags = [queryParameters.tags]
+      .flat()
+      .filter(Boolean) as string[];
+    setSelectedTags(queryParamTags);
+  }, [queryParameters]);
 
   useEffect(() => {
     updateFilters({

--- a/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
@@ -151,4 +151,38 @@ describe('<EntityTypePicker/>', () => {
       type: new EntityTypeFilter(['tool']),
     });
   });
+
+  it('responds to external queryParameters changes', async () => {
+    const updateFilters = jest.fn();
+    const rendered = await renderWithEffects(
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider
+          value={{
+            updateFilters,
+            queryParameters: { type: 'service' },
+          }}
+        >
+          <EntityTypePicker />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      type: new EntityTypeFilter(['service']),
+    });
+    rendered.rerender(
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider
+          value={{
+            updateFilters,
+            queryParameters: { type: 'tool' },
+          }}
+        >
+          <EntityTypePicker />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      type: new EntityTypeFilter(['tool']),
+    });
+  });
 });

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -253,6 +253,42 @@ describe('<UserListPicker />', () => {
     });
   });
 
+  it('responds to external queryParameters changes', () => {
+    const updateFilters = jest.fn();
+    const rendered = render(
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider
+          value={{
+            backendEntities,
+            updateFilters,
+            queryParameters: { user: ['all'] },
+          }}
+        >
+          <UserListPicker />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      user: new UserListFilter('all', mockIsOwnedEntity, mockIsStarredEntity),
+    });
+    rendered.rerender(
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider
+          value={{
+            backendEntities,
+            updateFilters,
+            queryParameters: { user: ['owned'] },
+          }}
+        >
+          <UserListPicker />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      user: new UserListFilter('owned', mockIsOwnedEntity, mockIsStarredEntity),
+    });
+  });
+
   describe.each`
     type         | filterFn
     ${'owned'}   | ${mockIsOwnedEntity}

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -161,7 +161,14 @@ export const UserListPicker = ({
     [isOwnedEntity, isStarredEntity],
   );
 
-  const [selectedUserFilter, setSelectedUserFilter] = useState(initialFilter);
+  const queryParamUserFilter = useMemo(
+    () => [queryParameters.user].flat()[0],
+    [queryParameters],
+  );
+
+  const [selectedUserFilter, setSelectedUserFilter] = useState(
+    queryParamUserFilter ?? initialFilter,
+  );
 
   // To show proper counts for each section, apply all other frontend filters _except_ the user
   // filter that's controlled by this picker.
@@ -191,9 +198,10 @@ export const UserListPicker = ({
   // Set selected user filter on query parameter updates; this happens at initial page load and from
   // external updates to the page location.
   useEffect(() => {
-    const queryParamUserFilter = [queryParameters.user].flat()[0];
-    setSelectedUserFilter(queryParamUserFilter as UserListFilterKind);
-  }, [queryParameters]);
+    if (queryParamUserFilter) {
+      setSelectedUserFilter(queryParamUserFilter as UserListFilterKind);
+    }
+  }, [queryParamUserFilter]);
 
   useEffect(() => {
     if (

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -161,9 +161,7 @@ export const UserListPicker = ({
     [isOwnedEntity, isStarredEntity],
   );
 
-  const [selectedUserFilter, setSelectedUserFilter] = useState(
-    [queryParameters.user].flat()[0] ?? initialFilter,
-  );
+  const [selectedUserFilter, setSelectedUserFilter] = useState(initialFilter);
 
   // To show proper counts for each section, apply all other frontend filters _except_ the user
   // filter that's controlled by this picker.
@@ -189,6 +187,13 @@ export const UserListPicker = ({
     }),
     [entitiesWithoutUserFilter, starredFilter, ownedFilter],
   );
+
+  // Set selected user filter on query parameter updates; this happens at initial page load and from
+  // external updates to the page location.
+  useEffect(() => {
+    const queryParamUserFilter = [queryParameters.user].flat()[0];
+    setSelectedUserFilter(queryParamUserFilter as UserListFilterKind);
+  }, [queryParameters]);
 
   useEffect(() => {
     if (

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -42,18 +42,22 @@ export function useEntityTypeFilter(): EntityTypeReturn {
     updateFilters,
   } = useEntityListProvider();
 
+  const queryParamTypes = useMemo(
+    () => [queryParameters.type].flat().filter(Boolean) as string[],
+    [queryParameters],
+  );
+
   const [selectedTypes, setSelectedTypes] = useState(
-    typeFilter?.getTypes() ?? [],
+    queryParamTypes.length ? queryParamTypes : typeFilter?.getTypes() ?? [],
   );
 
   // Set selected types on query parameter updates; this happens at initial page load and from
   // external updates to the page location.
   useEffect(() => {
-    const queryParamTypes = [queryParameters.type]
-      .flat()
-      .filter(Boolean) as string[];
-    setSelectedTypes(queryParamTypes);
-  }, [queryParameters]);
+    if (queryParamTypes.length) {
+      setSelectedTypes(queryParamTypes);
+    }
+  }, [queryParamTypes]);
 
   const [availableTypes, setAvailableTypes] = useState<string[]>([]);
   const kind = useMemo(() => kindFilter?.value, [kindFilter]);

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -42,12 +42,18 @@ export function useEntityTypeFilter(): EntityTypeReturn {
     updateFilters,
   } = useEntityListProvider();
 
-  const queryParamTypes = [queryParameters.type]
-    .flat()
-    .filter(Boolean) as string[];
   const [selectedTypes, setSelectedTypes] = useState(
-    queryParamTypes.length ? queryParamTypes : typeFilter?.getTypes() ?? [],
+    typeFilter?.getTypes() ?? [],
   );
+
+  // Set selected types on query parameter updates; this happens at initial page load and from
+  // external updates to the page location.
+  useEffect(() => {
+    const queryParamTypes = [queryParameters.type]
+      .flat()
+      .filter(Boolean) as string[];
+    setSelectedTypes(queryParamTypes);
+  }, [queryParameters]);
 
   const [availableTypes, setAvailableTypes] = useState<string[]>([]);
   const kind = useMemo(() => kindFilter?.value, [kindFilter]);

--- a/plugins/catalog-react/src/testUtils/providers.tsx
+++ b/plugins/catalog-react/src/testUtils/providers.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import React, { PropsWithChildren, useCallback, useState } from 'react';
+import React, {
+  PropsWithChildren,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import {
   DefaultEntityFilters,
   EntityListContext,
@@ -32,6 +37,7 @@ export const MockEntityListContextProvider = ({
   const [filters, setFilters] = useState<DefaultEntityFilters>(
     value?.filters ?? {},
   );
+
   const updateFilters = useCallback(
     (
       update:
@@ -49,23 +55,31 @@ export const MockEntityListContextProvider = ({
     [],
   );
 
-  const defaultContext: EntityListContextProps = {
-    entities: [],
-    backendEntities: [],
-    updateFilters,
-    filters,
-    loading: false,
-    queryParameters: {},
-  };
+  // Memoize the default values since pickers have useEffect triggers on these; naively defaulting
+  // below with `?? <X>` breaks referential equality on subsequent updates.
+  const defaultValues = useMemo(
+    () => ({
+      entities: [],
+      backendEntities: [],
+      queryParameters: {},
+    }),
+    [],
+  );
 
-  // Extract value.filters to avoid overwriting it; some tests exercise filter updates. The value
-  // provided is used as the initial seed in useState above.
-  const { filters: _, ...otherContextFields } = value ?? {};
+  const resolvedValue: EntityListContextProps = useMemo(
+    () => ({
+      entities: value?.entities ?? defaultValues.entities,
+      backendEntities: value?.backendEntities ?? defaultValues.backendEntities,
+      updateFilters: value?.updateFilters ?? updateFilters,
+      filters,
+      loading: value?.loading ?? false,
+      queryParameters: value?.queryParameters ?? defaultValues.queryParameters,
+    }),
+    [value, defaultValues, filters, updateFilters],
+  );
 
   return (
-    <EntityListContext.Provider
-      value={{ ...defaultContext, ...otherContextFields }}
-    >
+    <EntityListContext.Provider value={resolvedValue}>
       {children}
     </EntityListContext.Provider>
   );

--- a/plugins/catalog-react/src/testUtils/providers.tsx
+++ b/plugins/catalog-react/src/testUtils/providers.tsx
@@ -74,6 +74,7 @@ export const MockEntityListContextProvider = ({
       filters,
       loading: value?.loading ?? false,
       queryParameters: value?.queryParameters ?? defaultValues.queryParameters,
+      error: value?.error,
     }),
     [value, defaultValues, filters, updateFilters],
   );


### PR DESCRIPTION
Closes #8432.

Previously, the query parameters were fetched once off the URL on page load and thereafter the query parameters were disregarded, only pushed one way from filter changes triggered from UI actions.

This updates `useEntityListProvider` to leverage react-router's `useLocation` hook to be aware of external updates to query parameters. The catalog pickers are updated to pay attention to the exported `queryParameters` from the hook, which previously were only used for initialization.

Loops in state are avoided by the use of `replaceState` in `useEntityListProvider`.

@danielsamet I tried to push these changes to #8763 but didn't have permission 😅  This should replace that PR. I'll look to add tests to this PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
