### PR TITLE
cli: add experimental repo-wide build based on package roles

### DIFF
--- a/.changeset/many-terms-type.md
+++ b/.changeset/many-terms-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The experimental types build enabled by `--experimental-type-build` now runs in a separate worker thread.

--- a/.changeset/twenty-colts-applaud.md
+++ b/.changeset/twenty-colts-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Introduced an experimental and hidden `repo` sub-command, that contains commands that operate on an entire monorepo rather than individual packages.

--- a/packages/cli/src/commands/build/buildApp.ts
+++ b/packages/cli/src/commands/build/buildApp.ts
@@ -15,24 +15,27 @@
  */
 
 import fs from 'fs-extra';
+import { resolve as resolvePath } from 'path';
 import { buildBundle } from '../../lib/bundler';
 import { parseParallel, PARALLEL_ENV_VAR } from '../../lib/parallel';
 import { loadCliConfig } from '../../lib/config';
-import { paths } from '../../lib/paths';
 
 interface BuildAppOptions {
+  targetDir: string;
   writeStats: boolean;
   configPaths: string[];
 }
 
 export async function buildApp(options: BuildAppOptions) {
-  const { name } = await fs.readJson(paths.resolveTarget('package.json'));
+  const { targetDir, writeStats, configPaths } = options;
+  const { name } = await fs.readJson(resolvePath(targetDir, 'package.json'));
   await buildBundle({
+    targetDir,
     entry: 'src/index',
     parallel: parseParallel(process.env[PARALLEL_ENV_VAR]),
-    statsJsonEnabled: options.writeStats,
+    statsJsonEnabled: writeStats,
     ...(await loadCliConfig({
-      args: options.configPaths,
+      args: configPaths,
       fromPackage: name,
     })),
   });

--- a/packages/cli/src/commands/build/command.ts
+++ b/packages/cli/src/commands/build/command.ts
@@ -17,6 +17,7 @@
 import { Command } from 'commander';
 import { buildPackage, Output } from '../../lib/builder';
 import { findRoleFromCommand, getRoleInfo } from '../../lib/role';
+import { paths } from '../../lib/paths';
 import { buildApp } from './buildApp';
 import { buildBackend } from './buildBackend';
 
@@ -25,12 +26,14 @@ export async function command(cmd: Command): Promise<void> {
 
   if (role === 'app') {
     return buildApp({
+      targetDir: paths.resolveTarget('dist'),
       configPaths: cmd.config as string[],
       writeStats: Boolean(cmd.stats),
     });
   }
   if (role === 'backend') {
     return buildBackend({
+      targetDir: paths.resolveTarget('dist'),
       skipBuildDependencies: Boolean(cmd.skipBuildDependencies),
     });
   }

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -25,6 +25,21 @@ const configOption = [
   Array<string>(),
 ] as const;
 
+export function registerRepoCommand(program: CommanderStatic) {
+  const command = program
+    .command('repo [command]', { hidden: true })
+    .description(
+      'Command that run across an entire Backstage project [EXPERIMENTAL]',
+    );
+
+  command
+    .command('build')
+    .description(
+      'Build all packages in the project that use the standard backstage build script',
+    )
+    .action(lazy(() => import('./repo/build').then(m => m.command)));
+}
+
 export function registerScriptCommand(program: CommanderStatic) {
   const command = program
     .command('script [command]', { hidden: true })
@@ -312,6 +327,7 @@ export function registerCommands(program: CommanderStatic) {
     .description('Print configuration schema')
     .action(lazy(() => import('./config/schema').then(m => m.default)));
 
+  registerRepoCommand(program);
   registerScriptCommand(program);
   registerMigrateCommand(program);
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -35,7 +35,11 @@ export function registerRepoCommand(program: CommanderStatic) {
   command
     .command('build')
     .description(
-      'Build all packages in the project that use the standard backstage build script',
+      'Build packages in the project, excluding bundled app and backend packages.',
+    )
+    .option(
+      '--all',
+      'Build all packages, including bundled app and backend packages.',
     )
     .action(lazy(() => import('./repo/build').then(m => m.command)));
 }

--- a/packages/cli/src/commands/repo/build.ts
+++ b/packages/cli/src/commands/repo/build.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import chalk from 'chalk';
+import { relative as relativePath } from 'path';
+import { buildPackages, Output } from '../../lib/builder';
+import { PackageGraph } from '../../lib/monorepo';
+import { paths } from '../../lib/paths';
+import { getRoleInfo } from '../../lib/role';
+
+const outputMap = {
+  esm: Output.esm,
+  cjs: Output.cjs,
+  types: Output.types,
+  bundle: undefined,
+};
+
+export async function command(): Promise<void> {
+  const packages = await PackageGraph.listTargetPackages();
+
+  const options = packages.flatMap(pkg => {
+    const role = pkg.packageJson.backstage?.role;
+    if (!role) {
+      console.warn(`Ignored ${pkg.packageJson.name} because it has no role`);
+      return [];
+    }
+
+    const roleInfo = getRoleInfo(role);
+    const outputs = roleInfo.output
+      .map(output => outputMap[output])
+      .filter((x): x is Output => Boolean(x));
+    if (outputs.length === 0) {
+      console.warn(`Ignored ${pkg.packageJson.name} because it has no output`);
+      return [];
+    }
+
+    const buildScript = pkg.packageJson.scripts?.build;
+    if (!buildScript) {
+      console.warn(
+        `Ignored ${pkg.packageJson.name} because it has no build script`,
+      );
+      return [];
+    }
+    if (!buildScript.startsWith('backstage-cli script build')) {
+      console.warn(
+        `Ignored ${pkg.packageJson.name} because it has a custom build script, '${buildScript}'`,
+      );
+      return [];
+    }
+
+    return {
+      targetDir: pkg.dir,
+      outputs: new Set(outputs),
+      logPrefix: `${chalk.cyan(relativePath(paths.targetRoot, pkg.dir))}: `,
+      // TODO(Rugvip): Use commander to parse the script and grab these instead
+      minify: buildScript.includes('--minify'),
+      useApiExtractor: buildScript.includes('--experimental-type-build'),
+    };
+  });
+
+  await buildPackages(options);
+}

--- a/packages/cli/src/lib/builder/buildTypeDefinitions.ts
+++ b/packages/cli/src/lib/builder/buildTypeDefinitions.ts
@@ -16,92 +16,47 @@
 
 import fs from 'fs-extra';
 import chalk from 'chalk';
-import {
-  relative as relativePath,
-  resolve as resolvePath,
-  dirname,
-} from 'path';
+import { Worker } from 'worker_threads';
+import { relative as relativePath, resolve as resolvePath } from 'path';
 import { paths } from '../paths';
+import { buildTypeDefinitionsWorker } from './buildTypeDefinitionsWorker';
 
 // These message types are ignored since we want to avoid duplicating the logic of
 // handling them correctly, and we already have the API Reports warning about them.
 const ignoredMessages = new Set(['tsdoc-undefined-tag', 'ae-forgotten-export']);
 
-let apiExtractor: undefined | typeof import('@microsoft/api-extractor');
-function prepareApiExtractor() {
-  if (apiExtractor) {
-    return apiExtractor;
-  }
-
-  try {
-    apiExtractor = require('@microsoft/api-extractor');
-  } catch (error) {
-    throw new Error(
-      'Failed to resolve @microsoft/api-extractor, it must best installed ' +
-        'as a dependency of your project in order to use experimental type builds',
-    );
-  }
-
-  /**
-   * All of this monkey patching below is because MUI has these bare package.json file as a method
-   * for making TypeScript accept imports like `@material-ui/core/Button`, and improve tree-shaking
-   * by declaring them side effect free.
-   *
-   * The package.json lookup logic in api-extractor really doesn't like that though, as it enforces
-   * that the 'name' field exists in all package.json files that it discovers. This below is just
-   * making sure that we ignore those file package.json files instead of crashing.
-   */
-  const {
-    PackageJsonLookup,
-    // eslint-disable-next-line import/no-extraneous-dependencies
-  } = require('@rushstack/node-core-library/lib/PackageJsonLookup');
-
-  const old = PackageJsonLookup.prototype.tryGetPackageJsonFilePathFor;
-  PackageJsonLookup.prototype.tryGetPackageJsonFilePathFor =
-    function tryGetPackageJsonFilePathForPatch(path: string) {
-      if (
-        path.includes('@material-ui') &&
-        !dirname(path).endsWith('@material-ui')
-      ) {
-        return undefined;
-      }
-      return old.call(this, path);
-    };
-
-  return apiExtractor!;
-}
-
 export async function buildTypeDefinitions(
   targetDirs: string[] = [paths.targetDir],
 ) {
-  const { Extractor, ExtractorConfig, CompilerState } = prepareApiExtractor();
-
   const packageDirs = targetDirs.map(dir =>
     relativePath(paths.targetRoot, dir),
   );
-  const entryPoints = packageDirs.map(dir =>
-    paths.resolveTargetRoot('dist-types', dir, 'src/index.d.ts'),
+  const entryPoints = await Promise.all(
+    packageDirs.map(async dir => {
+      const entryPoint = paths.resolveTargetRoot(
+        'dist-types',
+        dir,
+        'src/index.d.ts',
+      );
+
+      const declarationsExist = await fs.pathExists(entryPoint);
+      if (!declarationsExist) {
+        throw new Error(
+          `No declaration files found at ${entryPoint}, be sure to run ${chalk.bgRed.white(
+            'yarn tsc',
+          )} to generate .d.ts files before packaging`,
+        );
+      }
+      return entryPoint;
+    }),
   );
 
-  let compilerState;
-
-  for (const packageDir of packageDirs) {
+  const workerConfigs = packageDirs.map(packageDir => {
     const targetDir = paths.resolveTargetRoot(packageDir);
     const targetTypesDir = paths.resolveTargetRoot('dist-types', packageDir);
-    const entryPoint = resolvePath(targetTypesDir, 'src/index.d.ts');
-
-    const declarationsExist = await fs.pathExists(entryPoint);
-    if (!declarationsExist) {
-      throw new Error(
-        `No declaration files found at ${entryPoint}, be sure to run ${chalk.bgRed.white(
-          'yarn tsc',
-        )} to generate .d.ts files before packaging`,
-      );
-    }
-
-    const extractorConfig = ExtractorConfig.prepare({
+    const extractorOptions = {
       configObject: {
-        mainEntryPointFilePath: entryPoint,
+        mainEntryPointFilePath: resolvePath(targetTypesDir, 'src/index.d.ts'),
         bundledPackages: [],
 
         compiler: {
@@ -122,24 +77,40 @@ export async function buildTypeDefinitions(
       },
       configObjectFullPath: targetDir,
       packageJsonFullPath: resolvePath(targetDir, 'package.json'),
+    };
+    return { extractorOptions, targetTypesDir };
+  });
+
+  const typescriptDir = paths.resolveTargetRoot('node_modules/typescript');
+  const hasTypescript = await fs.pathExists(typescriptDir);
+  const typescriptCompilerFolder = hasTypescript ? typescriptDir : undefined;
+
+  const worker = new Worker(`(${buildTypeDefinitionsWorker})()`, {
+    eval: true,
+    workerData: {
+      entryPoints,
+      workerConfigs,
+      typescriptCompilerFolder,
+    },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    worker.once('error', reject);
+    worker.once('exit', code => {
+      if (code) {
+        reject(new Error(`Worker exited with code ${code}`));
+      }
     });
+    worker.on('message', data => {
+      if (data.type === 'done') {
+        if (data.error) {
+          reject(data.error);
+        } else {
+          resolve();
+        }
+      } else if (data.type === 'message') {
+        const { message, targetTypesDir } = data;
 
-    if (!compilerState) {
-      compilerState = CompilerState.create(extractorConfig, {
-        additionalEntryPoints: entryPoints,
-      });
-    }
-
-    const typescriptDir = paths.resolveTargetRoot('node_modules/typescript');
-    const hasTypescript = await fs.pathExists(typescriptDir);
-    const extractorResult = Extractor.invoke(extractorConfig, {
-      typescriptCompilerFolder: hasTypescript ? typescriptDir : undefined,
-      compilerState,
-      localBuild: false,
-      showVerboseMessages: false,
-      showDiagnostics: false,
-      messageCallback(message) {
-        message.handled = true;
         if (ignoredMessages.has(message.messageId)) {
           return;
         }
@@ -165,14 +136,7 @@ export async function buildTypeDefinitions(
         } else {
           console.log(text);
         }
-      },
+      }
     });
-
-    if (!extractorResult.succeeded) {
-      throw new Error(
-        `Type definition build completed with ${extractorResult.errorCount} errors` +
-          ` and ${extractorResult.warningCount} warnings`,
-      );
-    }
-  }
+  });
 }

--- a/packages/cli/src/lib/builder/buildTypeDefinitionsWorker.ts
+++ b/packages/cli/src/lib/builder/buildTypeDefinitionsWorker.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * NOTE: This is a worker thread function that is stringified and executed
+ *       withing a `worker_threads.Worker`. Everything in this function must
+ *       be self-contained.
+ *       Using TypeScript is fine as it is transpiled before being stringified.
+ */
+export function buildTypeDefinitionsWorker() {
+  try {
+    require('@microsoft/api-extractor');
+  } catch (error) {
+    throw new Error(
+      'Failed to resolve @microsoft/api-extractor, it must best installed ' +
+        'as a dependency of your project in order to use experimental type builds',
+    );
+  }
+
+  const { dirname } = require('path');
+  const { workerData, parentPort } = require('worker_threads');
+  const { entryPoints, workerConfigs, typescriptCompilerFolder } = workerData;
+
+  const apiExtractor = require('@microsoft/api-extractor');
+  const { Extractor, ExtractorConfig, CompilerState } = apiExtractor;
+
+  /**
+   * All of this monkey patching below is because MUI has these bare package.json file as a method
+   * for making TypeScript accept imports like `@material-ui/core/Button`, and improve tree-shaking
+   * by declaring them side effect free.
+   *
+   * The package.json lookup logic in api-extractor really doesn't like that though, as it enforces
+   * that the 'name' field exists in all package.json files that it discovers. This below is just
+   * making sure that we ignore those file package.json files instead of crashing.
+   */
+  const {
+    PackageJsonLookup,
+    // eslint-disable-next-line import/no-extraneous-dependencies
+  } = require('@rushstack/node-core-library/lib/PackageJsonLookup');
+
+  const old = PackageJsonLookup.prototype.tryGetPackageJsonFilePathFor;
+  PackageJsonLookup.prototype.tryGetPackageJsonFilePathFor =
+    function tryGetPackageJsonFilePathForPatch(path: string) {
+      if (
+        path.includes('@material-ui') &&
+        !dirname(path).endsWith('@material-ui')
+      ) {
+        return undefined;
+      }
+      return old.call(this, path);
+    };
+
+  let success = true;
+  let compilerState;
+  for (const { extractorOptions, targetTypesDir } of workerConfigs) {
+    const extractorConfig = ExtractorConfig.prepare(extractorOptions);
+
+    if (!compilerState) {
+      compilerState = CompilerState.create(extractorConfig, {
+        additionalEntryPoints: entryPoints,
+      });
+    }
+
+    const extractorResult = Extractor.invoke(extractorConfig, {
+      compilerState,
+      localBuild: false,
+      typescriptCompilerFolder,
+      showVerboseMessages: false,
+      showDiagnostics: false,
+      messageCallback: (message: any) => {
+        message.handled = true;
+        parentPort.postMessage({ type: 'message', message, targetTypesDir });
+      },
+    });
+
+    if (!extractorResult.succeeded) {
+      parentPort.postMessage({
+        type: 'done',
+        error: new Error(
+          `Type definition build completed with ${extractorResult.errorCount} errors` +
+            ` and ${extractorResult.warningCount} warnings`,
+        ),
+      });
+      success = false;
+      break;
+    }
+  }
+
+  if (success) {
+    parentPort.postMessage({ type: 'done' });
+  }
+}

--- a/packages/cli/src/lib/builder/index.ts
+++ b/packages/cli/src/lib/builder/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { buildPackage, buildPackages } from './packager';
+export { buildPackage, buildPackages, getOutputsForRole } from './packager';
 export { Output } from './types';
 export type { BuildOptions } from './types';

--- a/packages/cli/src/lib/builder/index.ts
+++ b/packages/cli/src/lib/builder/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { buildPackage } from './packager';
+export { buildPackage, buildPackages } from './packager';
 export { Output } from './types';
 export type { BuildOptions } from './types';

--- a/packages/cli/src/lib/builder/packager.ts
+++ b/packages/cli/src/lib/builder/packager.ts
@@ -22,6 +22,7 @@ import { paths } from '../paths';
 import { makeRollupConfigs } from './config';
 import { BuildOptions, Output } from './types';
 import { buildTypeDefinitions } from './buildTypeDefinitions';
+import { getRoleInfo } from '../role';
 
 export function formatErrorMessage(error: any) {
   let msg = '';
@@ -141,3 +142,21 @@ export const buildPackages = async (
 
   await Promise.all(buildTasks);
 };
+
+export function getOutputsForRole(role: string): Set<Output> {
+  const outputs = new Set<Output>();
+
+  for (const output of getRoleInfo(role).output) {
+    if (output === 'cjs') {
+      outputs.add(Output.cjs);
+    }
+    if (output === 'esm') {
+      outputs.add(Output.esm);
+    }
+    if (output === 'types') {
+      outputs.add(Output.types);
+    }
+  }
+
+  return outputs;
+}

--- a/packages/cli/src/lib/builder/packager.ts
+++ b/packages/cli/src/lib/builder/packager.ts
@@ -118,13 +118,14 @@ export const buildPackage = async (options: BuildOptions) => {
   await Promise.all(buildTasks);
 };
 
-export const buildPackages = async (
-  options: (BuildOptions & { targetDir: string })[],
-) => {
+export const buildPackages = async (options: BuildOptions[]) => {
+  if (options.some(opt => !opt.targetDir)) {
+    throw new Error('targetDir must be set for all build options');
+  }
   const rollupConfigs = await Promise.all(options.map(makeRollupConfigs));
 
   await Promise.all(
-    options.map(({ targetDir }) => fs.remove(resolvePath(targetDir, 'dist'))),
+    options.map(({ targetDir }) => fs.remove(resolvePath(targetDir!, 'dist'))),
   );
 
   const buildTasks = rollupConfigs.flat().map(rollupBuild);
@@ -134,7 +135,7 @@ export const buildPackages = async (
       ({ outputs, useApiExtractor }) =>
         outputs.has(Output.types) && useApiExtractor,
     )
-    .map(_ => _.targetDir);
+    .map(_ => _.targetDir!);
 
   if (typeDefinitionTargetDirs.length > 0) {
     buildTasks.push(buildTypeDefinitions(typeDefinitionTargetDirs));

--- a/packages/cli/src/lib/builder/types.ts
+++ b/packages/cli/src/lib/builder/types.ts
@@ -21,6 +21,7 @@ export enum Output {
 }
 
 export type BuildOptions = {
+  targetDir?: string;
   outputs: Set<Output>;
   minify?: boolean;
   useApiExtractor?: boolean;

--- a/packages/cli/src/lib/builder/types.ts
+++ b/packages/cli/src/lib/builder/types.ts
@@ -21,6 +21,7 @@ export enum Output {
 }
 
 export type BuildOptions = {
+  logPrefix?: string;
   targetDir?: string;
   outputs: Set<Output>;
   minify?: boolean;

--- a/packages/cli/src/lib/bundler/types.ts
+++ b/packages/cli/src/lib/bundler/types.ts
@@ -35,6 +35,8 @@ export type ServeOptions = BundlingPathsOptions & {
 };
 
 export type BuildOptions = BundlingPathsOptions & {
+  // Target directory, defaulting to paths.targetDir
+  targetDir?: string;
   statsJsonEnabled: boolean;
   parallel?: ParallelOption;
   schema?: ConfigSchema;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

More work on top of #8729

This adds an experimental `backstage-cli repo build` command that builds all packages in the repo at once, rather than spinning up individual processes for each one. Looking at just the rollup build that brings the build time down from minutes to a few seconds.

This also takes the experimental type build that's based on API Extractor and shifts it into a worker thread, allowing it to be run in parallel with the rollup builds. It also enables sharing of compiler state between packages, making it possible to run the experimental type build for all packages in the repo in just a minute or so. It's probably best to keep sticking to only using it for a few packages for now, but we're now unblocked from using it everywhere as it's not prohibitively slow anymore.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
