### PR TITLE
scripts/prepare-release: more main branches

### DIFF
--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -25,6 +25,9 @@ const { promisify } = require('util');
 
 const execFile = promisify(execFileCb);
 
+// All of these are considered to be main-line release branches
+const MAIN_BRANCHES = ['master', 'origin/master', 'changeset-release/master'];
+
 const DEPENDENCY_TYPES = [
   'dependencies',
   'devDependencies',
@@ -147,7 +150,7 @@ async function updateBackstageReleaseVersion() {
   const { version: currentVersion } = package;
 
   let nextVersion;
-  if (branchName === 'master') {
+  if (MAIN_BRANCHES.includes(branchName)) {
     if (preMode === 'pre') {
       if (semver.prerelease(currentVersion)) {
         nextVersion = semver.inc(currentVersion, 'pre', preTag);


### PR DESCRIPTION
Fixes the issue seen in https://github.com/backstage/backstage/runs/5003999355?check_suite_focus=true

The branch that's used for the changeset "Version Packages" preparation is `changeset-release/master`, and I'm adding `origin/master` too just in case.

Patch releases always happen on branches that we've crafted ourselves and don't use the "Version Packages" flow.
