### PR TITLE
[TechDocs] Fix download 404 when backend/app hosts are the same

### DIFF
--- a/.changeset/techdocs-funkar-varje-gang.md
+++ b/.changeset/techdocs-funkar-varje-gang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed a bug where links to files within a TechDocs site that use the `download` attribute would result in a 404 in cases where the TechDocs backend and Backstage frontend application are on the same host.

--- a/plugins/techdocs-backend/examples/documented-component/docs/extensions.md
+++ b/plugins/techdocs-backend/examples/documented-component/docs/extensions.md
@@ -88,6 +88,12 @@ Weather: :sunny: :umbrella: :cloud: :snowflake:
 
 Animals: :tiger: :horse: :turtle: :wolf: :frog:
 
+### Attributes
+
+[A Download Link](./images/backstage-logo-cncf.svg){: download }
+
+![A Scaled Image](./images/backstage-logo-cncf.svg){: style="width: 100px" }
+
 ### MDX truly sane lists
 
 - attributes

--- a/plugins/techdocs/src/reader/transformers/addLinkClickListener.test.ts
+++ b/plugins/techdocs/src/reader/transformers/addLinkClickListener.test.ts
@@ -71,4 +71,31 @@ describe('addLinkClickListener', () => {
 
     expect(fn).toHaveBeenCalledTimes(0);
   });
+
+  it('does not call onClick when a link has a download attribute', async () => {
+    const fn = jest.fn();
+    const shadowDom = await createTestShadowDom(
+      `
+      <!DOCTYPE html>
+      <html>
+        <body>
+          <a download href="http://localhost:3000/file.pdf">Download</a>
+        </body>
+      </html>
+    `,
+      {
+        preTransformers: [],
+        postTransformers: [
+          addLinkClickListener({
+            baseUrl: 'http://localhost:3000',
+            onClick: fn,
+          }),
+        ],
+      },
+    );
+
+    shadowDom.querySelector('a')?.click();
+
+    expect(fn).toHaveBeenCalledTimes(0);
+  });
 });

--- a/plugins/techdocs/src/reader/transformers/addLinkClickListener.ts
+++ b/plugins/techdocs/src/reader/transformers/addLinkClickListener.ts
@@ -32,7 +32,7 @@ export const addLinkClickListener = ({
         const href = target.getAttribute('href');
 
         if (!href) return;
-        if (href.startsWith(baseUrl)) {
+        if (href.startsWith(baseUrl) && !elem.hasAttribute('download')) {
           e.preventDefault();
           onClick(e, href);
         }


### PR DESCRIPTION
## What / Why

In situations where a TechDocs backend shares the same host as the Backstage application, the `addLinkClickListener` would interpret a click to an instance of `<a download href=""></a>` as an internal navigation and try and use `react-router` to navigate to the file.  ...Resulting in a 404, because it's not a valid route (e.g. `backstage.example.com/api/techdocs/static/docs/etc.pdf`)

This prevents the link click listener from firing on any `a[download]` (and adds an example in the backend's example docs on how one might end up in this situation).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
