### PR TITLE
Code coverage plugin - fix explore files breadcrumbs bug

### DIFF
--- a/.changeset/blue-ligers-allow.md
+++ b/.changeset/blue-ligers-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-code-coverage': patch
+---
+
+Fixed a bug in the FileExplorer component which made it impossible to navigate upwards to a containing folder by clicking on the folder breadcrumb.

--- a/plugins/code-coverage/src/components/FileExplorer/FileExplorer.test.tsx
+++ b/plugins/code-coverage/src/components/FileExplorer/FileExplorer.test.tsx
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { groupByPath, buildFileStructure } from './FileExplorer';
+import {
+  groupByPath,
+  buildFileStructure,
+  getObjectsAtPath,
+} from './FileExplorer';
 
 const dummyFiles = [
   {
@@ -207,6 +211,28 @@ const coverageTableRowResults = {
   path: '',
 };
 
+const pathTestLeaf = {
+  files: [],
+  coverage: 1,
+  missing: 3,
+  tracked: 2,
+  path: 'file5',
+};
+
+const dummyFilesPathTest = {
+  files: [
+    ...dummyFiles,
+    {
+      ...pathTestLeaf,
+      filename: 'dir3/dir7/file5',
+    },
+  ],
+  coverage: 1,
+  missing: 1,
+  tracked: 1,
+  path: '',
+};
+
 describe('groupByPath function', () => {
   it('should group files by their root directory,as per their filename', () => {
     expect(groupByPath(dummyFiles)).toStrictEqual(dummyDataGroupedByPath);
@@ -218,5 +244,21 @@ describe('buildFileStructure function', () => {
     expect(buildFileStructure(coverageTableRow)).toStrictEqual(
       coverageTableRowResults,
     );
+  });
+});
+
+describe('getObjectsAtPath function', () => {
+  const structure = buildFileStructure(dummyFilesPathTest);
+
+  it('should return the the dirs/files at the given path', () => {
+    expect(getObjectsAtPath(structure, ['dir3', 'dir7'])).toStrictEqual([
+      pathTestLeaf,
+    ]);
+  });
+
+  it('should return undefined for a nonexistent path', () => {
+    expect(
+      getObjectsAtPath(structure, ['dir3', 'doesnt-exist']),
+    ).toBeUndefined();
   });
 });

--- a/plugins/code-coverage/src/components/FileExplorer/FileExplorer.tsx
+++ b/plugins/code-coverage/src/components/FileExplorer/FileExplorer.tsx
@@ -131,6 +131,17 @@ const formatInitialData = (value: any) => {
   });
 };
 
+export const getObjectsAtPath = (
+  curData: CoverageTableRow | undefined,
+  path: string[],
+): CoverageTableRow[] | undefined => {
+  let data = curData?.files;
+  for (const fragment of path) {
+    data = data?.find(d => d.path === fragment)?.files;
+  }
+  return data;
+};
+
 export const FileExplorer = () => {
   const { entity } = useEntity();
   const [curData, setCurData] = useState<CoverageTableRow | undefined>();
@@ -175,14 +186,10 @@ export const FileExplorer = () => {
     }
   };
 
-  const moveUpIntoPath = (path: string) => {
-    const pathArray = path.split('/').filter(p => p.length);
-    let data = curData?.files;
-    pathArray.forEach(p => {
-      data = data?.find(d => d.path === p)?.files;
-    });
-    setCurPath(path);
-    setTableData(data);
+  const moveUpIntoPath = (idx: number) => {
+    const path = curPath.split('/').slice(0, idx + 1);
+    setCurPath(path.join('/'));
+    setTableData(getObjectsAtPath(curData, path.slice(1)));
   };
 
   const columns: TableColumn<CoverageTableRow>[] = [
@@ -270,8 +277,8 @@ export const FileExplorer = () => {
                   color: `${idx !== lastPathElementIndex && 'lightblue'}`,
                   cursor: `${idx !== lastPathElementIndex && 'pointer'}`,
                 }}
-                onKeyDown={() => moveUpIntoPath(pathElement)}
-                onClick={() => moveUpIntoPath(pathElement)}
+                onKeyDown={() => moveUpIntoPath(idx)}
+                onClick={() => moveUpIntoPath(idx)}
               >
                 {pathElement || 'root'}
               </div>


### PR DESCRIPTION
##  Fix for code coverage plugin "explore files" breadcrumbs bug

Fixed https://github.com/backstage/backstage/issues/7867, a UI bug from the code coverage plugin. Navigating upwards through the file tree was triggering an error which left the UI in an unusable state.

I replicated the bug as follows:
1. Import the test data from `plugins/code-coverage-backend/src/service/__fixtures__/cobertura-testdata-1.xml`
2. Under "explore files", click on "com", then "example", then "utils". This should navigate through the file tree.
3. Click on "example" in the breadcrumbs to go back up to that folder.
4. "No files found" appears, and the breadcrumbs become broken and unclickable. Refreshing the page restores correct behaviour.


After my fix, it is now possible to navigate back up the file tree (e.g. by clicking on "example" in the screenshot) without breaking the UI or causing console errors.

<img width="965" alt="Screenshot 2022-02-01 at 19 41 24" src="https://user-images.githubusercontent.com/1396207/152031731-9de10cb7-32f3-461e-ab29-0d2dc760e6a0.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] N/A Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
