### PR TITLE
auth-backend,core-app-api: GitHub auth refactor and fixes

### DIFF
--- a/.changeset/chilled-papayas-wonder.md
+++ b/.changeset/chilled-papayas-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed a bug where providers that tracked the granted scopes through a cookie would not take failed authentication attempts into account.

--- a/.changeset/strong-taxis-refuse.md
+++ b/.changeset/strong-taxis-refuse.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added support for storing static GitHub access tokens in cookies and using them to refresh the Backstage session.

--- a/.changeset/tasty-pandas-design.md
+++ b/.changeset/tasty-pandas-design.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Switched out the `GithubAuth` implementation to use the common `OAuth2` implementation. This relies on the simultaneous change in `@backstage/plugin-auth-backend` that enabled access token storage in cookies rather than the current solution that's based on `LocalStorage`.
+
+> **NOTE:** Make sure you upgrade the `auth-backend` deployment before or at the same time as you deploy this change.

--- a/packages/core-app-api/api-report.md
+++ b/packages/core-app-api/api-report.md
@@ -35,6 +35,7 @@ import { FeatureFlag } from '@backstage/core-plugin-api';
 import { FeatureFlagsApi } from '@backstage/core-plugin-api';
 import { FeatureFlagsSaveOptions } from '@backstage/core-plugin-api';
 import { FetchApi } from '@backstage/core-plugin-api';
+import { githubAuthApiRef } from '@backstage/core-plugin-api';
 import { gitlabAuthApiRef } from '@backstage/core-plugin-api';
 import { googleAuthApiRef } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
@@ -379,25 +380,11 @@ export type FlatRoutesProps = {
 };
 
 // @public
-export class GithubAuth implements OAuthApi, SessionApi {
+export class GithubAuth {
   // (undocumented)
-  static create(options: OAuthApiCreateOptions): GithubAuth;
-  // (undocumented)
-  getAccessToken(scope?: string, options?: AuthRequestOptions): Promise<string>;
-  // (undocumented)
-  getBackstageIdentity(
-    options?: AuthRequestOptions,
-  ): Promise<BackstageIdentityResponse | undefined>;
-  // (undocumented)
-  getProfile(options?: AuthRequestOptions): Promise<ProfileInfo | undefined>;
-  // (undocumented)
+  static create(options: OAuthApiCreateOptions): typeof githubAuthApiRef.T;
+  // @deprecated (undocumented)
   static normalizeScope(scope?: string): Set<string>;
-  // (undocumented)
-  sessionState$(): Observable<SessionState>;
-  // (undocumented)
-  signIn(): Promise<void>;
-  // (undocumented)
-  signOut(): Promise<void>;
 }
 
 // @public @deprecated

--- a/packages/core-app-api/src/apis/implementations/auth/github/GithubAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/github/GithubAuth.test.ts
@@ -14,16 +14,33 @@
  * limitations under the License.
  */
 
+import { UrlPatternDiscovery } from '../../DiscoveryApi';
+import MockOAuthApi from '../../OAuthRequestApi/MockOAuthApi';
 import GithubAuth from './GithubAuth';
 
-describe('GithubAuth', () => {
-  it('should get access token', async () => {
-    const getSession = jest
-      .fn()
-      .mockResolvedValue({ providerInfo: { accessToken: 'access-token' } });
-    const githubAuth = new (GithubAuth as any)({ getSession }) as GithubAuth;
+const getSession = jest.fn();
 
-    expect(await githubAuth.getAccessToken()).toBe('access-token');
-    expect(getSession).toBeCalledTimes(1);
+jest.mock('../../../../lib/AuthSessionManager', () => ({
+  ...(jest.requireActual('../../../../lib/AuthSessionManager') as any),
+  RefreshingAuthSessionManager: class {
+    getSession = getSession;
+  },
+}));
+
+describe('GithubAuth', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should forward access token request to session manager', async () => {
+    const githubAuth = GithubAuth.create({
+      oauthRequestApi: new MockOAuthApi(),
+      discoveryApi: UrlPatternDiscovery.compile('http://example.com'),
+    });
+
+    githubAuth.getAccessToken('repo');
+    expect(getSession).toHaveBeenCalledWith({
+      scopes: new Set(['repo']),
+    });
   });
 });

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -735,6 +735,6 @@ export type WebMessageResponse =
 //
 // src/identity/types.d.ts:31:9 - (ae-forgotten-export) The symbol "AnyJWK" needs to be exported by the entry point index.d.ts
 // src/providers/aws-alb/provider.d.ts:77:5 - (ae-forgotten-export) The symbol "AwsAlbResult" needs to be exported by the entry point index.d.ts
-// src/providers/github/provider.d.ts:81:5 - (ae-forgotten-export) The symbol "StateEncoder" needs to be exported by the entry point index.d.ts
+// src/providers/github/provider.d.ts:97:5 - (ae-forgotten-export) The symbol "StateEncoder" needs to be exported by the entry point index.d.ts
 // src/providers/types.d.ts:98:5 - (ae-forgotten-export) The symbol "AuthProviderConfig" needs to be exported by the entry point index.d.ts
 ```

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -592,6 +592,7 @@ export type OAuthState = {
   nonce: string;
   env: string;
   origin?: string;
+  scope?: string;
 };
 
 // @public

--- a/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
+++ b/plugins/auth-backend/src/lib/oauth/OAuthAdapter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import express from 'express';
+import express, { CookieOptions } from 'express';
 import crypto from 'crypto';
 import { URL } from 'url';
 import {
@@ -90,10 +90,20 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
     });
   }
 
+  private readonly baseCookieOptions: CookieOptions;
+
   constructor(
     private readonly handlers: OAuthHandlers,
     private readonly options: Options,
-  ) {}
+  ) {
+    this.baseCookieOptions = {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: this.options.secure,
+      path: this.options.cookiePath,
+      domain: this.options.cookieDomain,
+    };
+  }
 
   async start(req: express.Request, res: express.Response): Promise<void> {
     // retrieve scopes from request
@@ -105,15 +115,17 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
       throw new InputError('No env provided in request query parameters');
     }
 
-    if (this.options.persistScopes) {
-      this.setScopesCookie(res, scope);
-    }
-
     const nonce = crypto.randomBytes(16).toString('base64');
     // set a nonce cookie before redirecting to oauth provider
     this.setNonceCookie(res, nonce);
 
-    const state = { nonce, env, origin };
+    const state: OAuthState = { nonce, env, origin };
+
+    // If scopes are persisted then we pass them through the state so that we
+    // can set the cookie on successful auth
+    if (this.options.persistScopes) {
+      state.scope = scope;
+    }
     const forwardReq = Object.assign(req, { scope, state });
 
     const { url, status } = await this.handlers.start(
@@ -151,12 +163,11 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
 
       const { response, refreshToken } = await this.handlers.handler(req);
 
-      if (this.options.persistScopes) {
-        const grantedScopes = this.getScopesFromCookie(
-          req,
-          this.options.providerId,
-        );
-        response.providerInfo.scope = grantedScopes;
+      // Store the scope that we have been granted for this session. This is useful if
+      // the provider does not return granted scopes on refresh or if they are normalized.
+      if (this.options.persistScopes && state.scope) {
+        this.setGrantedScopeCookie(res, state.scope);
+        response.providerInfo.scope = state.scope;
       }
 
       if (refreshToken && !this.options.disableRefresh) {
@@ -214,8 +225,10 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
         throw new InputError('Missing session cookie');
       }
 
-      const scope = req.query.scope?.toString() ?? '';
-
+      let scope = req.query.scope?.toString() ?? '';
+      if (this.options.persistScopes) {
+        scope = this.getGrantedScopeFromCookie(req);
+      }
       const forwardReq = Object.assign(req, { scope, refreshToken });
 
       // get new access_token
@@ -267,27 +280,20 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
   private setNonceCookie = (res: express.Response, nonce: string) => {
     res.cookie(`${this.options.providerId}-nonce`, nonce, {
       maxAge: TEN_MINUTES_MS,
-      secure: this.options.secure,
-      sameSite: 'lax',
-      domain: this.options.cookieDomain,
+      ...this.baseCookieOptions,
       path: `${this.options.cookiePath}/handler`,
-      httpOnly: true,
     });
   };
 
-  private setScopesCookie = (res: express.Response, scope: string) => {
-    res.cookie(`${this.options.providerId}-scope`, scope, {
-      maxAge: TEN_MINUTES_MS,
-      secure: this.options.secure,
-      sameSite: 'lax',
-      domain: this.options.cookieDomain,
-      path: `${this.options.cookiePath}/handler`,
-      httpOnly: true,
+  private setGrantedScopeCookie = (res: express.Response, scope: string) => {
+    res.cookie(`${this.options.providerId}-granted-scope`, scope, {
+      maxAge: THOUSAND_DAYS_MS,
+      ...this.baseCookieOptions,
     });
   };
 
-  private getScopesFromCookie = (req: express.Request, providerId: string) => {
-    return req.cookies[`${providerId}-scope`];
+  private getGrantedScopeFromCookie = (req: express.Request) => {
+    return req.cookies[`${this.options.providerId}-granted-scope`];
   };
 
   private setRefreshTokenCookie = (
@@ -296,22 +302,14 @@ export class OAuthAdapter implements AuthProviderRouteHandlers {
   ) => {
     res.cookie(`${this.options.providerId}-refresh-token`, refreshToken, {
       maxAge: THOUSAND_DAYS_MS,
-      secure: this.options.secure,
-      sameSite: 'lax',
-      domain: this.options.cookieDomain,
-      path: this.options.cookiePath,
-      httpOnly: true,
+      ...this.baseCookieOptions,
     });
   };
 
   private removeRefreshTokenCookie = (res: express.Response) => {
     res.cookie(`${this.options.providerId}-refresh-token`, '', {
       maxAge: 0,
-      secure: this.options.secure,
-      sameSite: 'lax',
-      domain: this.options.cookieDomain,
-      path: this.options.cookiePath,
-      httpOnly: true,
+      ...this.baseCookieOptions,
     });
   };
 }

--- a/plugins/auth-backend/src/lib/oauth/types.ts
+++ b/plugins/auth-backend/src/lib/oauth/types.ts
@@ -87,6 +87,7 @@ export type OAuthState = {
   nonce: string;
   env: string;
   origin?: string;
+  scope?: string;
 };
 
 export type OAuthStartRequest = express.Request<{}> & {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Couple of fixes and redesigns happening at the same time here, with the goal of bringing the GitHub auth provider closer to the rest of the auth providers. There's still plenty of special logic, but it's all moved over to the backend.

First thing is a redesign of the scope storage logic in the auth-backend. Previously it was just used to communicate the scope from the `/start` endpoint to the callback handler. That communication is now instead happening through OAuth state, and we instead persist the scope in a long-lived cookie on successful auth. This lets us keep track of what scopes we've been granted so far, and with that we should fix a problem with GitHub apps where we're currently not keeping track of scopes and therefore issue unnecessary login requests. There's a little bit more work to be done here as GitHub Apps don't care about scopes at all, but leaving that as a later fix.

The next part builds on top of the scope tracking, which is to switch the storage of GitHub OAuth App tokens from `LocalStorage` in the browser, to the http-only refresh token cookie. This brings some security benefits as grabbing all of local storage no longer leaks the token, meaning an attack must be more targeted and aware of the token refresh endpoint. It also allows us to use the standard `OAuth2` client implementation, getting rid of all special handling of GitHub Auth in the frontend 🎉. Lastly it also allows us to properly refresh the Backstage token when needed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
