### PR TITLE
Update link to moved repository - techdocs-cli

### DIFF
--- a/docs/features/techdocs/creating-and-publishing.md
+++ b/docs/features/techdocs/creating-and-publishing.md
@@ -114,7 +114,7 @@ updated documentation next time you run Backstage!
 
 ## Writing and previewing your documentation
 
-Using the [techdocs-cli](https://github.com/backstage/techdocs-cli) you can
+Using the [techdocs-cli](https://github.com/backstage/backstage/tree/master/packages/techdocs-cli) you can
 preview your docs inside a local Backstage instance and get live reload on
 changes. This is useful when you want to preview your documentation while
 writing.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

According to the previously linked repository, it has moved. This change updates the link to the new location.

Previous Location: https://github.com/backstage/techdocs-cli

> Development of the TechDocs CLI has moved back to the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

#### :heavy_check_mark: Checklist

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
~- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
~- [ ] Tests for new functionality and regression tests for bug fixes~
~- [ ] Screenshots attached (for UI changes)~