### PR TITLE
Added description to UserProfileCard

### DIFF
--- a/.changeset/ninety-brooms-lay.md
+++ b/.changeset/ninety-brooms-lay.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-org': patch
 ---
 
-The description from `metadata.description` will now show as the subheader on the UserProfileCard in the same way as the GroupProfileCard
+The description from `metadata.description` will now show as the `subheader` on the UserProfileCard in the same way as the GroupProfileCard

--- a/.changeset/ninety-brooms-lay.md
+++ b/.changeset/ninety-brooms-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+The description from `metadata.description` will now show as the subheader on the UserProfileCard in the same way as the GroupProfileCard

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.stories.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.stories.tsx
@@ -40,6 +40,7 @@ const defaultEntity: UserEntity = {
   kind: 'User',
   metadata: {
     name: 'guest',
+    description: 'Description for guest',
   },
   spec: {
     profile: {
@@ -70,6 +71,7 @@ const noImageEntity: UserEntity = {
   kind: 'User',
   metadata: {
     name: 'guest',
+    description: 'Description for guest',
   },
   spec: {
     profile: {

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.test.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.test.tsx
@@ -29,6 +29,7 @@ describe('UserSummary Test', () => {
     kind: 'User',
     metadata: {
       name: 'calum.leavy',
+      description: 'Super awesome human',
     },
     spec: {
       profile: {
@@ -73,5 +74,6 @@ describe('UserSummary Test', () => {
       'href',
       '/catalog/default/group/ExampleGroup',
     );
+    expect(rendered.getByText('Super awesome human')).toBeInTheDocument();
   });
 });

--- a/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
+++ b/plugins/org/src/components/Cards/User/UserProfileCard/UserProfileCard.tsx
@@ -61,7 +61,7 @@ export const UserProfileCard = ({
   }
 
   const {
-    metadata: { name: metaName },
+    metadata: { name: metaName, description },
     spec: { profile },
   } = user;
   const displayName = profile?.displayName ?? metaName;
@@ -71,7 +71,11 @@ export const UserProfileCard = ({
   });
 
   return (
-    <InfoCard title={<CardTitle title={displayName} />} variant={variant}>
+    <InfoCard
+      title={<CardTitle title={displayName} />}
+      subheader={description}
+      variant={variant}
+    >
       <Grid container spacing={3} alignItems="flex-start">
         <Grid item xs={12} sm={2} xl={1}>
           <Avatar displayName={displayName} picture={profile?.picture} />


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <awanlin@rapidrtc.com>

## Hey, I just made a Pull Request!

The description from `metadata.description` will now show as the subheader on the UserProfileCard in the same way as the GroupProfileCard

![image](https://user-images.githubusercontent.com/67169551/152170048-e344b089-23d3-4c62-81cc-85734d7612ff.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
