### PR TITLE
feat: Support passthrough of the `ui:options` of a field to `validators`

### DIFF
--- a/.changeset/clean-grapes-greet.md
+++ b/.changeset/clean-grapes-greet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Provide `ui:options` to validator functions in order to use the incoming props to the custom field extension to affect the validator

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -37,13 +37,14 @@ export function createScaffolderFieldExtension<T = any>(
 ): Extension<() => null>;
 
 // @public
-export type CustomFieldValidator<T> =
+export type CustomFieldValidator<T, UiOptions extends {} = {}> =
   | ((data: T, field: FieldValidation) => void)
   | ((
       data: T,
       field: FieldValidation,
       context: {
         apiHolder: ApiHolder;
+        uiOptions?: UiOptions;
       },
     ) => void);
 

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -93,11 +93,10 @@ export const createValidator = (
         const fieldName =
           isObject(propSchema) && (propSchema['ui:field'] as string);
         if (fieldName && typeof validators[fieldName] === 'function') {
-          validators[fieldName]!(
-            propData as JsonValue,
-            propValidation,
-            context,
-          );
+          validators[fieldName]!(propData as JsonValue, propValidation, {
+            ...context,
+            uiOptions: propSchema['ui:options'] ?? {},
+          });
         }
       }
     }

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/validation.ts
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/validation.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-import { FieldValidation } from '@rjsf/core';
-import { ApiHolder } from '@backstage/core-plugin-api';
 import { scmIntegrationsApiRef } from '@backstage/integration-react';
+import { RepoUrlPickerUiOptions } from './RepoUrlPicker';
+import { CustomFieldValidator } from '../../../extensions/types';
 
-export const repoPickerValidation = (
-  value: string,
-  validation: FieldValidation,
-  context: { apiHolder: ApiHolder },
-) => {
+export const repoPickerValidation: CustomFieldValidator<
+  string,
+  RepoUrlPickerUiOptions
+> = (value, validation, context) => {
   try {
     const { host, searchParams } = new URL(`https://${value}`);
 

--- a/plugins/scaffolder/src/extensions/types.ts
+++ b/plugins/scaffolder/src/extensions/types.ts
@@ -26,7 +26,7 @@ export type CustomFieldValidator<T, UiOptions extends {} = {}> =
   | ((
       data: T,
       field: FieldValidation,
-      context: { apiHolder: ApiHolder; uiOptions: UiOptions },
+      context: { apiHolder: ApiHolder; uiOptions?: UiOptions },
     ) => void);
 
 /**

--- a/plugins/scaffolder/src/extensions/types.ts
+++ b/plugins/scaffolder/src/extensions/types.ts
@@ -21,12 +21,12 @@ import { FieldValidation, FieldProps } from '@rjsf/core';
  *
  * @public
  */
-export type CustomFieldValidator<T> =
+export type CustomFieldValidator<T, UiOptions extends {} = {}> =
   | ((data: T, field: FieldValidation) => void)
   | ((
       data: T,
       field: FieldValidation,
-      context: { apiHolder: ApiHolder },
+      context: { apiHolder: ApiHolder; uiOptions: UiOptions },
     ) => void);
 
 /**


### PR DESCRIPTION
This is to enable the validation of the `token` for the `RepoUrlPicker` to support #9168 but didn't want to bundle this change in with the rest.

Unfortunately testing this is pretty hard given the state of the plugin, but when the upcoming refactor and re-writing of some components it should become much easier to test the plugin as a whole.