### PR TITLE
[TechDocs] Chill out on the 'copy to clipboard' buttons

### DIFF
--- a/.changeset/techdocs-not-that-many-copies.md
+++ b/.changeset/techdocs-not-that-many-copies.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed a bug where copy-to-clipboard buttons were appended to unintended elements.

--- a/plugins/techdocs/src/reader/transformers/copyToClipboard.test.ts
+++ b/plugins/techdocs/src/reader/transformers/copyToClipboard.test.ts
@@ -32,7 +32,7 @@ describe('copyToClipboard', () => {
       <!DOCTYPE html>
       <html>
         <body>
-          <code><span>${expectedClipboard}</span></code>
+          <pre><code><span>${expectedClipboard}</span></code></pre>
         </body>
       </html>
     `,
@@ -45,5 +45,26 @@ describe('copyToClipboard', () => {
     shadowDom.querySelector('button')?.click();
 
     expect(clipboardSpy).toHaveBeenCalledWith(expectedClipboard);
+  });
+
+  it('only gets applied to code blocks', async () => {
+    const expectedClipboard = 'function foo() {return "bar";}';
+    const shadowDom = await createTestShadowDom(
+      `
+      <!DOCTYPE html>
+      <html>
+        <body>
+          <code><span>${expectedClipboard}</span></code>
+        </body>
+      </html>
+    `,
+      {
+        preTransformers: [],
+        postTransformers: [copyToClipboard()],
+      },
+    );
+
+    const copyButton = shadowDom.querySelector('button');
+    expect(copyButton).toBe(null);
   });
 });

--- a/plugins/techdocs/src/reader/transformers/copyToClipboard.ts
+++ b/plugins/techdocs/src/reader/transformers/copyToClipboard.ts
@@ -22,7 +22,7 @@ import type { Transformer } from './transformer';
  */
 export const copyToClipboard = (): Transformer => {
   return dom => {
-    Array.from(dom.querySelectorAll('code')).forEach(codeElem => {
+    Array.from(dom.querySelectorAll('pre > code')).forEach(codeElem => {
       const button = document.createElement('button');
       const toBeCopied = codeElem.textContent || '';
       button.className = 'md-clipboard md-icon';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Whoops!  We only want to apply the copy-to-clipboard button on `<code>` blocks within `<pre>` tags.

Otherwise, we get stuff like this:

![Screenshot 2022-02-02 at 18 10 56](https://user-images.githubusercontent.com/3496491/152202985-0c5fb48f-2887-4f3a-b2e5-cde8b43dae75.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
