### PR TITLE
Add line clamping to search results on modal search screen.

### DIFF
--- a/.changeset/old-phones-draw.md
+++ b/.changeset/old-phones-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Modify modal search to clamp result length to 5 rows.

--- a/plugins/search/api-report.md
+++ b/plugins/search/api-report.md
@@ -27,10 +27,12 @@ export const DefaultResultListItem: ({
   result,
   icon,
   secondaryAction,
+  lineClamp,
 }: {
   icon?: ReactNode;
   secondaryAction?: ReactNode;
   result: IndexableDocument;
+  lineClamp?: number | undefined;
 }) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "FiltersProps" needs to be exported by the entry point index.d.ts

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -45,6 +45,7 @@
     "qs": "^6.9.4",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",
+    "react-text-truncate": "^0.17.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {

--- a/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.test.tsx
+++ b/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.test.tsx
@@ -20,6 +20,11 @@ import { renderInTestApp } from '@backstage/test-utils';
 import FindInPageIcon from '@material-ui/icons/FindInPage';
 import { DefaultResultListItem } from './DefaultResultListItem';
 
+// Using canvas to render text..
+jest.mock('react-text-truncate', () => {
+  return ({ text }: { text: string }) => <span>{text}</span>;
+});
+
 describe('DefaultResultListItem', () => {
   const result = {
     title: 'title',
@@ -44,10 +49,10 @@ describe('DefaultResultListItem', () => {
     await renderInTestApp(
       <DefaultResultListItem
         result={result}
-        icon={<FindInPageIcon title="icon" />}
+        icon={<FindInPageIcon aria-label="icon" />}
       />,
     );
-    expect(screen.getByTitle('icon')).toBeInTheDocument();
+    expect(screen.getByLabelText('icon')).toBeInTheDocument();
   });
 
   it('should render secondary action if prop is specified', async () => {

--- a/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.tsx
+++ b/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.tsx
@@ -24,17 +24,20 @@ import {
   Divider,
 } from '@material-ui/core';
 import { Link } from '@backstage/core-components';
+import TextTruncate from 'react-text-truncate';
 
 type Props = {
   icon?: ReactNode;
   secondaryAction?: ReactNode;
   result: IndexableDocument;
+  lineClamp?: number;
 };
 
 export const DefaultResultListItem = ({
   result,
   icon,
   secondaryAction,
+  lineClamp = 5,
 }: Props) => {
   return (
     <Link to={result.location}>
@@ -43,7 +46,14 @@ export const DefaultResultListItem = ({
         <ListItemText
           primaryTypographyProps={{ variant: 'h6' }}
           primary={result.title}
-          secondary={result.text}
+          secondary={
+            <TextTruncate
+              line={lineClamp}
+              truncateText="…"
+              text={result.text}
+              element="span"
+            />
+          }
         />
         {secondaryAction && <Box alignItems="flex-end">{secondaryAction}</Box>}
       </ListItem>


### PR DESCRIPTION
Signed-off-by: Jussi Hallila <jussi@hallila.com>

## Hey, I just made a Pull Request!

Search result on the modal screen get a bit funky, especially when looking at doc indexes. Adding line clamping to the mix makes it a bit more readable.

Old:
![image](https://user-images.githubusercontent.com/2392775/152327392-9b993fb2-23ee-4542-b580-17ee0cbb392a.png)


New: 
![image](https://user-images.githubusercontent.com/2392775/152327406-48aeff46-cccf-4eea-9e58-f67d563e3c13.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [n/a] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
