### PR TITLE
docs: add link to upgrade helper in keeping backstage updated page

### DIFF
--- a/docs/getting-started/keeping-backstage-updated.md
+++ b/docs/getting-started/keeping-backstage-updated.md
@@ -41,7 +41,10 @@ For this reason, any changes made to the template are documented along with
 upgrade instructions in the
 [changelog](https://github.com/backstage/backstage/blob/master/packages/create-app/CHANGELOG.md)
 of the `@backstage/create-app` package. We recommend peeking at this changelog
-for any applicable updates when upgrading packages.
+-for any applicable updates when upgrading packages. As an alternative, the
+[Backstage Upgrade Helper](https://backstage.github.io/upgrade-helper/) provides
+a consolidated view of all the changes between two versions of Backstage. You
+can find the current version of your Backstage installation in `backstage.json`.
 
 ## More information on dependency mismatches
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hoping to make the upgrade helper a bit more discoverable by linking to it in [Keeping Backstage Updated](https://backstage.io/docs/getting-started/keeping-backstage-updated).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
