### PR TITLE
correct spelling of 'Acknowledge' in tooltip

### DIFF
--- a/.changeset/shaggy-buckets-confess.md
+++ b/.changeset/shaggy-buckets-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-splunk-on-call': patch
+---
+
+Correct spelling of 'Acknowledge' in tooltip.

--- a/plugins/splunk-on-call/src/components/Incident/IncidentListItem.tsx
+++ b/plugins/splunk-on-call/src/components/Incident/IncidentListItem.tsx
@@ -106,7 +106,7 @@ const IncidentAction = ({
   switch (currentPhase) {
     case 'UNACKED':
       return (
-        <Tooltip title="Aknowledge" placement="top">
+        <Tooltip title="Acknowledge" placement="top">
           <IconButton
             onClick={() =>
               acknowledgeAction({ incidentId, incidentType: 'ACKNOWLEDGEMENT' })


### PR DESCRIPTION
This PR corrects the spelling of 'Acknowledge' in a Splunk On Call plugin tooltip title. Thanks!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))