### PR TITLE
[Plugin] Splunk On-Call plugin support for 'splunk.com/on-call-routing-key' annotation

### DIFF
--- a/.changeset/honest-foxes-scream.md
+++ b/.changeset/honest-foxes-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-splunk-on-call': minor
+---
+
+Add Splunk On-Call plugin support for a 'splunk.com/on-call-routing-key' annotation. If the 'splunk.com/on-call-routing-key' is provided, the plugin displays a Splunk On-Call card for each of the teams associated with the routing key.

--- a/.changeset/honest-foxes-scream.md
+++ b/.changeset/honest-foxes-scream.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-splunk-on-call': minor
 ---
 
-Add Splunk On-Call plugin support for a 'splunk.com/on-call-routing-key' annotation. If the 'splunk.com/on-call-routing-key' is provided, the plugin displays a Splunk On-Call card for each of the teams associated with the routing key.
+Add Splunk On-Call plugin support for a `splunk.com/on-call-routing-key` annotation. If the `splunk.com/on-call-routing-key` is provided, the plugin displays a Splunk On-Call card for each of the teams associated with the routing key.

--- a/.changeset/honest-foxes-scream.md
+++ b/.changeset/honest-foxes-scream.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-splunk-on-call': minor
+'@backstage/plugin-splunk-on-call': patch
 ---
 
 Add Splunk On-Call plugin support for a `splunk.com/on-call-routing-key` annotation. If the `splunk.com/on-call-routing-key` is provided, the plugin displays a Splunk On-Call card for each of the teams associated with the routing key.

--- a/plugins/splunk-on-call/README.md
+++ b/plugins/splunk-on-call/README.md
@@ -4,14 +4,14 @@
 
 This plugin displays Splunk On-Call (formerly VictorOps) information associated with an entity.
 
-It also provides the ability to trigger new incidents directly to specific users or/and specific teams from within Backstage.
+It also provides the ability to trigger new incidents to specific users and/or specific teams from within Backstage.
 
 This plugin requires that entities feature either a `splunk.com/on-call-team` or a `splunk.com/on-call-routing-key` annotation. See below for further details.
 
 This plugin provides:
 
 - A list of incidents
-- A way to trigger a new incident to specific users or/and teams
+- A way to trigger a new incident to specific users and/or teams
 - A way to acknowledge/resolve an incident
 - Information details about the persons on-call
 
@@ -47,7 +47,7 @@ const overviewContent = (
 
 ## Client configuration
 
-In order to be able to perform certain action (create-acknowledge-resolve an action), you need to provide a REST Endpoint.
+In order to be able to perform certain actions (create-acknowledge-resolve an action), you need to provide a REST Endpoint.
 
 To enable the REST Endpoint integration you can go on https://portal.victorops.com/ inside Integrations > 3rd Party Integrations > REST – Generic.
 You can now copy the URL to notify: `<SPLUNK_ON_CALL_REST_ENDPOINT>/$routing_key`

--- a/plugins/splunk-on-call/README.md
+++ b/plugins/splunk-on-call/README.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-This plugin displays Splunk On-Call, formerly VictorOps, information about an entity.
+This plugin displays Splunk On-Call (formerly VictorOps) information associated with an entity.
 
-There is a way to trigger an new incident directly to specific users or/and specific teams.
+It also provides the ability to trigger new incidents directly to specific users or/and specific teams from within Backstage.
 
-This plugin requires that entities are annotated with a team name. See more further down in this document.
+This plugin requires that entities feature either a `splunk.com/on-call-team` or a `splunk.com/on-call-routing-key` annotation. See below for further details.
 
 This plugin provides:
 
@@ -76,12 +76,22 @@ In addition, to make certain API calls (trigger-resolve-acknowledge an incident)
 
 ### Adding your team name to the entity annotation
 
-The information displayed for each entity is based on the team name.
-If you want to use this plugin for an entity, you need to label it with the below annotation:
+The information displayed for each entity is based on either an associated team name or an associated routing key.
+
+To use this plugin for an entity, the entity must be labeled with either a `splunk.com/on-call-team` or a `splunk.com/on-call-routing-key` annotation.
+
+For example, by specifying a `splunk.com/on-call-team`, the plugin displays Splunk On-Call data associated with the specified team:
 
 ```yaml
 annotations:
-  splunk.com/on-call-team': <SPLUNK_ON_CALL_TEAM_NAME>
+  splunk.com/on-call-team: <SPLUNK_ON_CALL_TEAM_NAME>
+```
+
+Alternatively, by specifying a `splunk.com/on-call-routing-key`, the plugin displays Splunk On-Call data associated with _each_ of the teams associated with the specified routing key:
+
+```yaml
+annotations:
+  splunk.com/on-call-routing-key: <SPLUNK_ON_CALL_ROUTING_KEY>
 ```
 
 ### Create the Routing Key

--- a/plugins/splunk-on-call/api-report.md
+++ b/plugins/splunk-on-call/api-report.md
@@ -51,6 +51,10 @@ export class SplunkOnCallClient implements SplunkOnCallApi {
   //
   // (undocumented)
   getOnCallUsers(): Promise<OnCall[]>;
+  // Warning: (ae-forgotten-export) The symbol "RoutingKey" needs to be exported by the entry point index.d.ts
+  //
+  // (undocumented)
+  getRoutingKeys(): Promise<RoutingKey[]>;
   // Warning: (ae-forgotten-export) The symbol "Team" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)

--- a/plugins/splunk-on-call/src/api/client.ts
+++ b/plugins/splunk-on-call/src/api/client.ts
@@ -19,6 +19,7 @@ import {
   OnCall,
   User,
   EscalationPolicyInfo,
+  RoutingKey,
   Team,
 } from '../components/types';
 import {
@@ -30,6 +31,7 @@ import {
   RequestOptions,
   ListUserResponse,
   EscalationPolicyResponse,
+  ListRoutingKeyResponse,
 } from './types';
 import {
   createApiRef,
@@ -80,6 +82,15 @@ export class SplunkOnCallClient implements SplunkOnCallApi {
     const teams = await this.getByUrl<Team[]>(url);
 
     return teams;
+  }
+
+  async getRoutingKeys(): Promise<RoutingKey[]> {
+    const url = `${await this.config.discoveryApi.getBaseUrl(
+      'proxy',
+    )}/splunk-on-call/v1/org/routing-keys`;
+    const { routingKeys } = await this.getByUrl<ListRoutingKeyResponse>(url);
+
+    return routingKeys;
   }
 
   async getUsers(): Promise<User[]> {

--- a/plugins/splunk-on-call/src/api/mocks.ts
+++ b/plugins/splunk-on-call/src/api/mocks.ts
@@ -17,6 +17,7 @@
 import {
   EscalationPolicyInfo,
   Incident,
+  RoutingKey,
   Team,
   User,
 } from '../components/types';
@@ -86,6 +87,18 @@ export const MOCK_TEAM: Team = {
   memberCount: 1,
   version: 1,
   isDefaultTeam: false,
+};
+
+export const MOCK_ROUTING_KEY: RoutingKey = {
+  routingKey: 'test-routing-key',
+  targets: [
+    {
+      policyName: 'some policy',
+      policySlug: MOCK_TEAM.slug || '',
+      _teamUrl: `/api-public/v1/team/${MOCK_TEAM.slug}`,
+    },
+  ],
+  isDefault: false,
 };
 
 export const MOCK_TEAM_NO_INCIDENTS: Team = {

--- a/plugins/splunk-on-call/src/api/types.ts
+++ b/plugins/splunk-on-call/src/api/types.ts
@@ -18,6 +18,7 @@ import {
   EscalationPolicyInfo,
   Incident,
   OnCall,
+  RoutingKey,
   Team,
   User,
 } from '../components/types';
@@ -66,6 +67,11 @@ export interface SplunkOnCallApi {
   getTeams(): Promise<Team[]>;
 
   /**
+   * Get a list of routing keys for your organization.
+   */
+  getRoutingKeys(): Promise<RoutingKey[]>;
+
+  /**
    * Get a list of escalation policies for your organization.
    */
   getEscalationPolicies(): Promise<EscalationPolicyInfo[]>;
@@ -77,6 +83,11 @@ export type EscalationPolicyResponse = {
 
 export type ListUserResponse = {
   users: User[];
+  _selfUrl?: string;
+};
+
+export type ListRoutingKeyResponse = {
+  routingKeys: RoutingKey[];
   _selfUrl?: string;
 };
 

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
@@ -170,7 +170,9 @@ describe('SplunkOnCallCard', () => {
     );
     await waitFor(() => !queryByTestId('progress'));
     expect(
-      getByText('Could not find team named "test" in the Splunk On-Call API'),
+      getByText(
+        'Splunk On-Call API returned no record of teams associated with the "test" team name',
+      ),
     ).toBeInTheDocument();
   });
 

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
@@ -154,8 +154,7 @@ describe('SplunkOnCallCard', () => {
     await waitFor(() => !queryByTestId('progress'));
     expect(getByText(`Team: ${MOCK_TEAM.name}`)).toBeInTheDocument();
     await waitFor(
-      () =>
-        expect(getByText(MOCK_INCIDENT.entityDisplayName)).toBeInTheDocument(),
+      () => expect(getByText('test-incident')).toBeInTheDocument(),
       { timeout: 2000 },
     );
   });

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
@@ -212,7 +212,7 @@ describe('SplunkOnCallCard', () => {
       ),
     );
     await waitFor(() => !queryByTestId('progress'));
-    expect(getAllByText('Missing Annotation').length).toEqual(2);
+    expect(getAllByText('Missing Annotation').length).toEqual(1);
   });
 
   it('handles warning for incorrect team annotation', async () => {

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
@@ -131,6 +131,35 @@ describe('SplunkOnCallCard', () => {
     expect(getByText('Empty escalation policy')).toBeInTheDocument();
   });
 
+  it('handles a "splunk.com/on-call-routing-key" annotation', async () => {
+    mockSplunkOnCallApi.getUsers = jest
+      .fn()
+      .mockImplementationOnce(async () => [MOCKED_USER]);
+    mockSplunkOnCallApi.getRoutingKeys = jest
+      .fn()
+      .mockImplementationOnce(async () => [MOCK_ROUTING_KEY]);
+    mockSplunkOnCallApi.getTeams = jest
+      .fn()
+      .mockImplementation(async () => [MOCK_TEAM]);
+
+    const { getByText, queryByTestId } = render(
+      wrapInTestApp(
+        <ApiProvider apis={apis}>
+          <EntityProvider entity={mockEntityWithRoutingKeyAnnotation}>
+            <EntitySplunkOnCallCard />
+          </EntityProvider>
+        </ApiProvider>,
+      ),
+    );
+    await waitFor(() => !queryByTestId('progress'));
+    expect(getByText(`Team: ${MOCK_TEAM.name}`)).toBeInTheDocument();
+    await waitFor(
+      () =>
+        expect(getByText(MOCK_INCIDENT.entityDisplayName)).toBeInTheDocument(),
+      { timeout: 2000 },
+    );
+  });
+
   it('Handles custom error for missing token', async () => {
     mockSplunkOnCallApi.getUsers = jest
       .fn()

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
@@ -84,6 +84,15 @@ const mockEntityWithRoutingKeyAnnotation = {
   },
 } as Entity;
 
+const mockEntityNoAnnotation = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'splunkoncall-test',
+    annotations: {},
+  },
+} as Entity;
+
 const mockEntityNoIncidents = {
   apiVersion: 'backstage.io/v1alpha1',
   kind: 'Component',
@@ -162,6 +171,20 @@ describe('SplunkOnCallCard', () => {
         'Error encountered while fetching information. An error occurred',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('handles warning for missing required annotations', async () => {
+    const { getAllByText, queryByTestId } = render(
+      wrapInTestApp(
+        <ApiProvider apis={apis}>
+          <EntityProvider entity={mockEntityNoAnnotation}>
+            <EntitySplunkOnCallCard />
+          </EntityProvider>
+        </ApiProvider>,
+      ),
+    );
+    await waitFor(() => !queryByTestId('progress'));
+    expect(getAllByText('Missing Annotation').length).toEqual(2);
   });
 
   it('handles warning for incorrect team annotation', async () => {

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -68,12 +68,12 @@ export const InvalidAnnotation = ({
 }) => {
   let titleSuffix = 'provided annotation';
 
-  if (teamName) {
-    titleSuffix = `"${teamName}" team name`;
-  }
-
   if (routingKey) {
     titleSuffix = `"${routingKey}" routing key`;
+  }
+
+  if (teamName) {
+    titleSuffix = `"${teamName}" team name`;
   }
 
   return (

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -55,7 +55,6 @@ export const MissingAnnotation = () => (
       <code>{SPLUNK_ON_CALL_ROUTING_KEY}</code> annotation.
     </Typography>
     <MissingAnnotationEmptyState annotation={SPLUNK_ON_CALL_TEAM} />
-    <MissingAnnotationEmptyState annotation={SPLUNK_ON_CALL_ROUTING_KEY} />
   </div>
 );
 

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -161,12 +161,14 @@ export const EntitySplunkOnCallCard = () => {
         key => key.routingKey === routingKeyAnnotation,
       );
       foundTeams = foundRoutingKey
-        ? foundRoutingKey.targets.map(target => {
-            const teamUrlParts = target._teamUrl.split('/');
-            const teamSlug = teamUrlParts[teamUrlParts.length - 1];
+        ? foundRoutingKey.targets
+            .map(target => {
+              const teamUrlParts = target._teamUrl.split('/');
+              const teamSlug = teamUrlParts[teamUrlParts.length - 1];
 
-            return teams.find(teamValue => teamValue.slug === teamSlug);
-          })
+              return teams.find(teamValue => teamValue.slug === teamSlug);
+            })
+            .filter(team => team !== undefined)
         : [];
     }
 
@@ -195,6 +197,15 @@ export const EntitySplunkOnCallCard = () => {
 
   if (loading) {
     return <Progress />;
+  }
+
+  if (!usersAndTeams?.foundTeams || !usersAndTeams?.foundTeams.length) {
+    return (
+      <InvalidAnnotation
+        teamName={teamAnnotation}
+        routingKey={routingKeyAnnotation}
+      />
+    );
   }
 
   const Content = ({
@@ -236,15 +247,6 @@ export const EntitySplunkOnCallCard = () => {
   };
 
   const teams = usersAndTeams?.foundTeams || [];
-
-  if (!teams.length) {
-    return (
-      <InvalidAnnotation
-        teamName={teamAnnotation}
-        routingKey={routingKeyAnnotation}
-      />
-    );
-  }
 
   return (
     <>

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -22,6 +22,7 @@ import {
   CardContent,
   CardHeader,
   Divider,
+  makeStyles,
   Typography,
 } from '@material-ui/core';
 import AlarmAddIcon from '@material-ui/icons/AlarmAdd';
@@ -82,7 +83,14 @@ export const isSplunkOnCallAvailable = (entity: Entity) =>
   Boolean(entity.metadata.annotations?.[SPLUNK_ON_CALL_TEAM]) ||
   Boolean(entity.metadata.annotations?.[SPLUNK_ON_CALL_ROUTING_KEY]);
 
+const useStyles = makeStyles({
+  onCallCard: {
+    marginBottom: '1em',
+  },
+});
+
 export const EntitySplunkOnCallCard = () => {
+  const classes = useStyles();
   const config = useApi(configApiRef);
   const api = useApi(splunkOnCallApiRef);
   const { entity } = useEntity();
@@ -219,7 +227,7 @@ export const EntitySplunkOnCallCard = () => {
   return (
     <>
       {teams.map((team, i) => (
-        <Card key={i}>
+        <Card key={i} className={classes.onCallCard}>
           <CardHeader
             title="Splunk On-Call"
             subheader={[

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -215,7 +215,7 @@ export const EntitySplunkOnCallCard = () => {
     team: Team | undefined;
     usersHashMap: any;
   }) => {
-    const teamName = team && team.name ? team.name : '';
+    const teamName = team?.name ?? '';
 
     return (
       <>

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -59,15 +59,36 @@ export const MissingAnnotation = () => (
   </div>
 );
 
-export const InvalidTeamAnnotation = ({ teamName }: { teamName: string }) => (
-  <CardContent>
-    <EmptyState
-      title={`Could not find team named "${teamName}" in the Splunk On-Call API`}
-      missing="info"
-      description={`Escalation Policy and incident information unavailable. Please verify that the team you added "${teamName}" is valid if you want to enable Splunk On-Call.`}
-    />
-  </CardContent>
-);
+export const InvalidAnnotation = ({
+  teamName,
+  routingKey,
+}: {
+  teamName: string | undefined;
+  routingKey: string | undefined;
+}) => {
+  let titleSuffix = 'provided annotation';
+
+  if (teamName) {
+    titleSuffix = `"${teamName}" team name`;
+  }
+
+  if (routingKey) {
+    titleSuffix = `"${routingKey}" routing key`;
+  }
+
+  return (
+    <Card>
+      <CardHeader title="Splunk On-Call" />
+      <CardContent>
+        <EmptyState
+          title={`Splunk On-Call API returned no record of teams associated with the ${titleSuffix}`}
+          missing="info"
+          description="Escalation Policy and incident information unavailable. Splunk On-Call requires a valid team name or routing key."
+        />
+      </CardContent>
+    </Card>
+  );
+};
 
 export const MissingEventsRestEndpoint = () => (
   <CardContent>
@@ -181,17 +202,9 @@ export const EntitySplunkOnCallCard = () => {
     usersHashMap,
   }: {
     team: Team | undefined;
-    usersHashMap: any | undefined;
+    usersHashMap: any;
   }) => {
-    if (!team) {
-      return (
-        <InvalidTeamAnnotation
-          teamName={teamAnnotation || routingKeyAnnotation || ''}
-        />
-      );
-    }
-
-    const teamName = team.name || '';
+    const teamName = team && team.name ? team.name : '';
 
     return (
       <>
@@ -223,6 +236,15 @@ export const EntitySplunkOnCallCard = () => {
   };
 
   const teams = usersAndTeams?.foundTeams || [];
+
+  if (!teams.length) {
+    return (
+      <InvalidAnnotation
+        teamName={teamAnnotation}
+        routingKey={routingKeyAnnotation}
+      />
+    );
+  }
 
   return (
     <>

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -152,6 +152,14 @@ export const EntitySplunkOnCallCard = () => {
     return { usersHashMap, foundTeams };
   });
 
+  if (!teamAnnotation && !routingKeyAnnotation) {
+    return <MissingAnnotation />;
+  }
+
+  if (!eventsRestEndpoint) {
+    return <MissingEventsRestEndpoint />;
+  }
+
   if (error instanceof UnauthorizedError) {
     return <MissingApiKeyOrApiIdError />;
   }
@@ -175,20 +183,12 @@ export const EntitySplunkOnCallCard = () => {
     team: Team | undefined;
     usersHashMap: any | undefined;
   }) => {
-    if (!teamAnnotation && !routingKeyAnnotation) {
-      return <MissingAnnotation />;
-    }
-
     if (!team) {
       return (
         <InvalidTeamAnnotation
           teamName={teamAnnotation || routingKeyAnnotation || ''}
         />
       );
-    }
-
-    if (!eventsRestEndpoint) {
-      return <MissingEventsRestEndpoint />;
     }
 
     const teamName = team.name || '';

--- a/plugins/splunk-on-call/src/components/types.ts
+++ b/plugins/splunk-on-call/src/components/types.ts
@@ -117,3 +117,15 @@ export type EscalationPolicyTeam = {
   name: string;
   slug: string;
 };
+
+export type RoutingKey = {
+  routingKey: string;
+  targets: RoutingKeyTarget[];
+  isDefault: boolean;
+};
+
+export type RoutingKeyTarget = {
+  policyName: string;
+  policySlug: string;
+  _teamUrl: string;
+};


### PR DESCRIPTION
Thanks for your work on Backstage! This PR addresses issue #9360 to add Splunk On-Call plugin support for a `splunk.com/on-call-routing-key` annotation in addition to its existing support for a `splunk.com/on-call-team` annotation. 

This PR implements the business logic outlined in issue #9360 :

* If neither the `splunk.com/on-call-team` nor the `splunk.com/on-call-routing-key` annotations are present, display a warning with appropriate messaging about the missing required annotations
* If only the `splunk.com/on-call-team` annotation is present, display the `EntitySplunkOnCallCard` as it currently appears/behaves
* If both the `splunk.com/on-call-team` and `splunk.com/on-call-routing-key` annotations are present, use the `splunk.com/on-call-team` annotation and display the `EntitySplunkOnCallCard` as it currently appears/behaves
* If only the `splunk.com/on-call-routing-key` annotation is present, use the routing key to fetch each of the associated teams from [the API](https://portal.victorops.com/public/api-docs.html) and display a [Splunk On-Call card](https://github.com/backstage/backstage/blob/master/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx#L174-L189) (as it currently appears/behaves) for _each_ of the associated teams.

Is this something the Backstage community would be receptive to? Thanks!

#### Screenshots

The new warning state when the API returns no record of the cited `splunk.com/on-call-team` value (note that the language has been slightly tuned; the previous language can be seen [here](https://github.com/backstage/backstage/blob/master/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx#L53-L61)):

![splunk_on_call_no_team](https://user-images.githubusercontent.com/184109/152529694-b4eda8de-2de0-48ad-87f3-6411adeea56c.png)

The new warning state when the API returns no record of the cited `splunk.com/on-call-routing-key` value (note that the language has been slightly tuned to account for the new annotation; the previous language can be seen [here](https://github.com/backstage/backstage/blob/master/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx#L53-L61)):

![splunk_on_call_no_routing_key](https://user-images.githubusercontent.com/184109/152529727-0d38d5b9-7bd4-4734-8a65-db21c606e106.png)

The new warning state when neither of the required annotations is present (note that a Missing Annotation card is displayed for each of the annotations):

![splunk_on_call_no_annotation](https://user-images.githubusercontent.com/184109/152529759-c756c058-cef1-479d-8fbf-c03e83de73f9.png)

The plugin UX when a `splunk.com/on-call-routing-key` annotation has been used whose value is associated with multiple teams (note that a Splunk On-Call card is displayed for _each_ of the associated teams but otherwise the UX is unchanged. Also note that I've anonymized the data by blocking out incident and team details):

![splunk_on_call_multiple_teams](https://user-images.githubusercontent.com/184109/152529774-52690e8b-60b3-4a45-8976-bc8a90b2a264.jpg)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
