### PR TITLE
actions: Comment information about DCO signing when failing

### DIFF
--- a/.github/workflows/verify_dco.yaml
+++ b/.github/workflows/verify_dco.yaml
@@ -1,0 +1,60 @@
+name: Verify DCO
+on:
+  schedule:
+    - cron:  '*/15 * * * *'
+
+jobs:
+  dco-helper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify DCO status for open pull requests
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const owner = "backstage";
+            const repo = "backstage";
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              state: "open",
+              owner,
+              repo,
+            });
+
+            for (const pull of pulls) {
+              // Pick out the PRs that have the DCO check
+              const checks = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: pull.head.sha,
+                check_name: "DCO",
+                status: "completed",
+              });
+              // Skip if there are no checks
+              if (!checks.data.check_runs.length) {
+                continue;
+              }
+              // Skip if the conclusion is not action_required
+              if (checks.data.check_runs[0].conclusion !== "action_required") {
+                console.log(`No checks found for PR #${pull.number}, skipping`);
+                continue;
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pull.number,
+              });
+
+              if (comments.find((c) => c.user.login === "github-actions[bot]")) {
+                console.log(`already commented on PR #${pull.number}, skipping`);
+                continue;
+              }
+
+              console.log(`creating comment on PR #${pull.number}`);
+              const body = `Thanks for the contribution!\nAll commits need to be DCO signed before merging. Please refer to the the DCO section in [CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.`;
+              await github.rest.issues.createComment({
+                repo,
+                owner,
+                issue_number: pull.number,
+                body,
+              });
+            }

--- a/.github/workflows/verify_dco.yaml
+++ b/.github/workflows/verify_dco.yaml
@@ -45,15 +45,14 @@ jobs:
               });
               if (comments.find((c) =>
                   c.user.login === "github-actions[bot]" &&
-                  c.body.includes("<dco-helper>")
+                  c.body.includes("<!-- dco -->")
                   )
               ) {
                 console.log(`already commented on PR #${pull.number}, skipping`);
                 continue;
               }
-
               console.log(`creating comment on PR #${pull.number}`);
-              const body = `Thanks for the contribution!\nAll commits need to be DCO signed before merging. Please refer to the the [DCO section in CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.<dco-helper>`;
+              const body = `Thanks for the contribution!\nAll commits need to be DCO signed before merging. Please refer to the the [DCO section in CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.<!-- dco -->`;
               await github.rest.issues.createComment({
                 repo,
                 owner,

--- a/.github/workflows/verify_dco.yaml
+++ b/.github/workflows/verify_dco.yaml
@@ -1,7 +1,7 @@
 name: Verify DCO
 on:
   schedule:
-    - cron:  '*/15 * * * *'
+    - cron: '*/15 * * * *'
 
 jobs:
   dco-helper:

--- a/.github/workflows/verify_dco.yaml
+++ b/.github/workflows/verify_dco.yaml
@@ -43,14 +43,17 @@ jobs:
                 repo,
                 issue_number: pull.number,
               });
-
-              if (comments.find((c) => c.user.login === "github-actions[bot]")) {
+              if (comments.find((c) =>
+                  c.user.login === "github-actions[bot]" &&
+                  c.body.includes("<dco-helper>")
+                  )
+              ) {
                 console.log(`already commented on PR #${pull.number}, skipping`);
                 continue;
               }
 
               console.log(`creating comment on PR #${pull.number}`);
-              const body = `Thanks for the contribution!\nAll commits need to be DCO signed before merging. Please refer to the the [DCO section in CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.`;
+              const body = `Thanks for the contribution!\nAll commits need to be DCO signed before merging. Please refer to the the [DCO section in CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.<dco-helper>`;
               await github.rest.issues.createComment({
                 repo,
                 owner,

--- a/.github/workflows/verify_dco.yaml
+++ b/.github/workflows/verify_dco.yaml
@@ -52,7 +52,10 @@ jobs:
                 continue;
               }
               console.log(`creating comment on PR #${pull.number}`);
-              const body = `Thanks for the contribution!\nAll commits need to be DCO signed before merging. Please refer to the the [DCO section in CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.<!-- dco -->`;
+              const body = `
+              Thanks for the contribution!
+              All commits need to be DCO signed before merging. Please refer to the the [DCO section in CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.
+              <!-- dco -->`;
               await github.rest.issues.createComment({
                 repo,
                 owner,

--- a/.github/workflows/verify_dco.yaml
+++ b/.github/workflows/verify_dco.yaml
@@ -50,7 +50,7 @@ jobs:
               }
 
               console.log(`creating comment on PR #${pull.number}`);
-              const body = `Thanks for the contribution!\nAll commits need to be DCO signed before merging. Please refer to the the DCO section in [CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.`;
+              const body = `Thanks for the contribution!\nAll commits need to be DCO signed before merging. Please refer to the the [DCO section in CONTRIBUTING.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) or the [DCO](${checks.data.check_runs[0].html_url}) status for more info.`;
               await github.rest.issues.createComment({
                 repo,
                 owner,


### PR DESCRIPTION
This actions runs periodically and adds a comment to all open PRs with failing DCO check in order to make it more visible for the PR author(s).

<img width="1007" alt="Screenshot 2022-02-04 at 16 01 22" src="https://user-images.githubusercontent.com/68980/152551602-3d6f4a58-55f2-4a7f-a9f6-5ec029ed3649.png">

This currently uses the github-actions user. An improvement could be to make this a separate bot by creating a new app for this integration. 