### PR TITLE
cli: wrap minified code in iife

### DIFF
--- a/.changeset/neat-icons-fry.md
+++ b/.changeset/neat-icons-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Tweaked frontend bundling configuration to avoid leaking declarations into global scope.

--- a/packages/cli/src/lib/bundler/optimization.ts
+++ b/packages/cli/src/lib/bundler/optimization.ts
@@ -29,6 +29,7 @@ export const optimization = (
     minimizer: [
       new ESBuildMinifyPlugin({
         target: 'es2019',
+        format: 'iife',
       }),
     ],
     runtimeChunk: 'single',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a misconfiguration where some modules in the output pollute the global scope. For example, looking at the main entry point it tends to start something like this:

```
var Ki=Object.defineProperty;
```

This makes `Ki` available in global scope, which we very much do not want. In the worst case this can lead to broken builds if any of these global helpers are reassigned later on.

Enabling `'iife'` formatting wraps the entire output in a IIFE, which then looks something like this:

```
(()=>{var Ki=Object.defineProperty;
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
