### PR TITLE
use link: rather than file: for local dependencies

### DIFF
--- a/.changeset/nasty-socks-exist.md
+++ b/.changeset/nasty-socks-exist.md
@@ -1,0 +1,14 @@
+---
+'@backstage/create-app': patch
+---
+
+Switched the `file:` dependency for a `link:` dependency in the `backend` package. This makes sure that the `app` package is linked in rather than copied.
+
+To apply this update to an existing app, make the following change to `packages/backend/package.json`:
+
+```diff
+   "dependencies": {
+-    "app": "file:../app",
++    "app": "link:../app",
+     "@backstage/backend-common": "^{{version '@backstage/backend-common'}}",
+```

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -60,7 +60,7 @@
     "@octokit/rest": "^18.5.3",
     "azure-devops-node-api": "^11.0.1",
     "dockerode": "^3.3.1",
-    "example-app": "file:../app",
+    "example-app": "link:../app",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "express-prom-bundle": "^6.3.6",

--- a/packages/create-app/templates/default-app/packages/backend/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/backend/package.json.hbs
@@ -14,7 +14,7 @@
     "migrate:create": "knex migrate:make -x ts"
   },
   "dependencies": {
-    "app": "file:../app",
+    "app": "link:../app",
     "@backstage/backend-common": "^{{version '@backstage/backend-common'}}",
     "@backstage/backend-tasks": "^{{version '@backstage/backend-tasks'}}",
     "@backstage/catalog-model": "^{{version '@backstage/catalog-model'}}",

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^14.14.32",
     "@types/serve-handler": "^6.1.0",
     "@types/webpack-env": "^1.15.3",
-    "techdocs-cli-embedded-app": "file:../techdocs-cli-embedded-app",
+    "techdocs-cli-embedded-app": "link:../techdocs-cli-embedded-app",
     "find-process": "^1.4.5",
     "nodemon": "^2.0.2",
     "ts-node": "^10.0.0"

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -24,9 +24,9 @@
     "storybook-dark-mode": "^1.0.8"
   },
   "peerDependencies": {
-    "@backstage/theme": "file:../packages/theme",
-    "@backstage/test-utils": "file:../packages/test-utils",
-    "@backstage/core-app-api": "file:../packages/core-app-api",
-    "@backstage/core-plugin-api": "file:../packages/core-plugin-api"
+    "@backstage/theme": "link:../packages/theme",
+    "@backstage/test-utils": "link:../packages/test-utils",
+    "@backstage/core-app-api": "link:../packages/core-app-api",
+    "@backstage/core-plugin-api": "link:../packages/core-plugin-api"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11437,7 +11437,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-"example-app@file:packages/app":
+"example-app@link:packages/app":
   version "0.2.63"
   dependencies:
     "@backstage/app-defaults" "^0.1.6"
@@ -22962,7 +22962,7 @@ tdigest@^0.1.1:
   dependencies:
     bintrees "1.0.1"
 
-"techdocs-cli-embedded-app@file:packages/techdocs-cli-embedded-app":
+"techdocs-cli-embedded-app@link:packages/techdocs-cli-embedded-app":
   version "0.2.62"
   dependencies:
     "@backstage/app-defaults" "^0.1.6"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Turns out `file:` copies when using yarn, meaning the package will only update whenever you run `yarn install`, and also leads to duplication. Using `link:` instead means yarn creates a symlink, which also seems to work well with workspaces with the link being created in the root `node_modules` rather than within the local package `node_modules`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
