### PR TITLE
core-components: make useSupportConfig fall back to default config when needed

### DIFF
--- a/.changeset/three-pigs-sniff.md
+++ b/.changeset/three-pigs-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+The `ErrorPage` now falls back to using the default support configuration if the `ConfigApi` is not available.

--- a/packages/core-components/src/hooks/useSupportConfig.ts
+++ b/packages/core-components/src/hooks/useSupportConfig.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useApi, configApiRef } from '@backstage/core-plugin-api';
+import { useApiHolder, configApiRef } from '@backstage/core-plugin-api';
 
 export type SupportItemLink = {
   url: string;
@@ -50,8 +50,9 @@ const DEFAULT_SUPPORT_CONFIG: SupportConfig = {
 };
 
 export function useSupportConfig(): SupportConfig {
-  const config = useApi(configApiRef);
-  const supportConfig = config.getOptionalConfig('app.support');
+  const apiHolder = useApiHolder();
+  const config = apiHolder.get(configApiRef);
+  const supportConfig = config?.getOptionalConfig('app.support');
 
   if (!supportConfig) {
     return DEFAULT_SUPPORT_CONFIG;


### PR DESCRIPTION
🧹 , fixes a dependency issue when failing to load config 😅 