### PR TITLE
Resource dependency of

### DIFF
--- a/.changeset/fast-ducks-sell.md
+++ b/.changeset/fast-ducks-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Support "dependencyOf" relation in Resource entities

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -1121,6 +1121,17 @@ This field is optional.
 | [`Component`](#kind-component)          | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
 | [`Resource`](#kind-resource)            | Same as this entity, typically `default`   | [`dependsOn`, and reverse `dependencyOf`](well-known-relations.md#dependson-and-dependencyof) |
 
+### `spec.dependencyOf` [optional]
+
+An array of [entity references](references.md#string-references) to the
+components and resources that the resource is a dependency of, e.g. `artist-lookup`.
+This field is optional.
+
+| [`kind`](#apiversion-and-kind-required) | Default [`namespace`](#namespace-optional) | Generated [relation](well-known-relations.md) type                                            |
+| --------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| [`Component`](#kind-component)          | Same as this entity, typically `default`   | [`dependencyOf`, and reverse `dependsOn`](well-known-relations.md#dependson-and-dependencyof) |
+| [`Resource`](#kind-resource)            | Same as this entity, typically `default`   | [`dependencyOf`, and reverse `dependsOn`](well-known-relations.md#dependson-and-dependencyof) |
+
 ## Kind: System
 
 Describes the following entity kind:

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -479,6 +479,7 @@ interface ResourceEntityV1alpha1 extends Entity {
     type: string;
     owner: string;
     dependsOn?: string[];
+    dependencyOf?: string[];
     system?: string;
   };
 }

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
@@ -34,6 +34,7 @@ export interface ResourceEntityV1alpha1 extends Entity {
     type: string;
     owner: string;
     dependsOn?: string[];
+    dependencyOf?: string[];
     system?: string;
   };
 }

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
@@ -251,13 +251,14 @@ describe('BuiltinKindsEntityProcessor', () => {
           type: 'database',
           owner: 'o',
           dependsOn: ['Component:c', 'Resource:r'],
+          dependencyOf: ['Component:d'],
           system: 's',
         },
       };
 
       await processor.postProcessEntity(entity, location, emit);
 
-      expect(emit).toBeCalledTimes(8);
+      expect(emit).toBeCalledTimes(10);
       expect(emit).toBeCalledWith({
         type: 'relation',
         relation: {
@@ -323,6 +324,23 @@ describe('BuiltinKindsEntityProcessor', () => {
           source: { kind: 'Resource', namespace: 'default', name: 'n' },
           type: 'partOf',
           target: { kind: 'System', namespace: 'default', name: 's' },
+        },
+      });
+
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'n' },
+          type: 'dependencyOf',
+          target: { kind: 'Component', namespace: 'default', name: 'd' },
+        },
+      });
+      expect(emit).toBeCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Component', namespace: 'default', name: 'd' },
+          type: 'dependsOn',
+          target: { kind: 'Resource', namespace: 'default', name: 'n' },
         },
       });
     });

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
@@ -226,6 +226,12 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
         RELATION_DEPENDENCY_OF,
       );
       doEmit(
+        resource.spec.dependencyOf,
+        { defaultNamespace: selfRef.namespace },
+        RELATION_DEPENDENCY_OF,
+        RELATION_DEPENDS_ON,
+      );
+      doEmit(
         resource.spec.system,
         { defaultKind: 'System', defaultNamespace: selfRef.namespace },
         RELATION_PART_OF,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have a use-case where `Resource` catalog manifests are generated based on the resources themselves.

While information on relations is easily accessible as metadata on the resource, the Backstage model currently doesn't support declaring a Resource as being a dependency of another entity. Only as "depending on" another.

This PR is meant to address this.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
