### PR TITLE
[Home] homepage component starred entities

### DIFF
--- a/.changeset/wise-plants-tease.md
+++ b/.changeset/wise-plants-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Adds new StarredEntities component responsible for rendering a list of starred entities on the home page

--- a/plugins/home/api-report.md
+++ b/plugins/home/api-report.md
@@ -113,6 +113,13 @@ export const HomePageRandomJoke: (
   },
 ) => JSX.Element;
 
+// @public
+export const HomePageStarredEntities: (
+  props: ComponentRenderer & {
+    title?: string | undefined;
+  },
+) => JSX.Element;
+
 // Warning: (ae-forgotten-export) The symbol "ToolkitContentProps" needs to be exported by the entry point index.d.ts
 //
 // @public

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -21,10 +21,12 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
+    "@backstage/catalog-model": "^0.9.10",
     "@backstage/core-components": "^0.8.7",
     "@backstage/core-plugin-api": "^0.6.0",
-    "@backstage/theme": "^0.2.14",
+    "@backstage/plugin-catalog-react": "^0.6.13",
     "@backstage/plugin-search": "^0.6.1",
+    "@backstage/theme": "^0.2.14",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.test.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  renderInTestApp,
+  TestApiProvider,
+  MockStorageApi,
+} from '@backstage/test-utils';
+import {
+  starredEntitiesApiRef,
+  entityRouteRef,
+  DefaultStarredEntitiesApi,
+} from '@backstage/plugin-catalog-react';
+import React from 'react';
+import { Content } from './Content';
+
+describe('StarredEntitiesContent', () => {
+  it('should render list of tools', async () => {
+    const mockStorageApi = MockStorageApi.create();
+    await mockStorageApi
+      .forBucket('starredEntities')
+      .set('entityRefs', [
+        'component:default/mock-starred-entity',
+        'component:default/mock-starred-entity-2',
+      ]);
+
+    const { getByText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            starredEntitiesApiRef,
+            new DefaultStarredEntitiesApi({
+              storageApi: mockStorageApi,
+            }),
+          ],
+        ]}
+      >
+        <Content />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(getByText('mock-starred-entity')).toBeInTheDocument();
+    expect(getByText('mock-starred-entity-2')).toBeInTheDocument();
+    expect(getByText('mock-starred-entity').closest('a')).toHaveAttribute(
+      'href',
+      '/catalog/default/component/mock-starred-entity',
+    );
+    expect(getByText('mock-starred-entity-2').closest('a')).toHaveAttribute(
+      'href',
+      '/catalog/default/component/mock-starred-entity-2',
+    );
+  });
+});

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  useStarredEntities,
+  entityRouteRef,
+} from '@backstage/plugin-catalog-react';
+import { parseEntityRef } from '@backstage/catalog-model';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import { Link } from '@backstage/core-components';
+import {
+  List,
+  ListItem,
+  ListItemSecondaryAction,
+  IconButton,
+  ListItemText,
+  Tooltip,
+} from '@material-ui/core';
+import StarIcon from '@material-ui/icons/Star';
+import React from 'react';
+
+/**
+ * A component to display a list of tools for the user.
+ *
+ * @public
+ */
+
+export const Content = () => {
+  const catalogEntityRoute = useRouteRef(entityRouteRef);
+  const { starredEntities, toggleStarredEntity } = useStarredEntities();
+
+  if (starredEntities.size === 0) return null;
+
+  return (
+    <List>
+      {Array.from(starredEntities).map(entity => (
+        <ListItem key={entity}>
+          <Link to={catalogEntityRoute(parseEntityRef(entity))}>
+            <ListItemText primary={parseEntityRef(entity).name} />
+          </Link>
+          <ListItemSecondaryAction>
+            <Tooltip title="Remove from starred">
+              <IconButton
+                edge="end"
+                aria-label="unstar"
+                onClick={() => toggleStarredEntity(entity)}
+              >
+                <StarIcon />
+              </IconButton>
+            </Tooltip>
+          </ListItemSecondaryAction>
+        </ListItem>
+      ))}
+    </List>
+  );
+};

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -28,12 +28,13 @@ import {
   IconButton,
   ListItemText,
   Tooltip,
+  Typography,
 } from '@material-ui/core';
 import StarIcon from '@material-ui/icons/Star';
 import React from 'react';
 
 /**
- * A component to display a list of tools for the user.
+ * A component to display a list of starred entities for the user.
  *
  * @public
  */
@@ -42,7 +43,12 @@ export const Content = () => {
   const catalogEntityRoute = useRouteRef(entityRouteRef);
   const { starredEntities, toggleStarredEntity } = useStarredEntities();
 
-  if (starredEntities.size === 0) return null;
+  if (starredEntities.size === 0)
+    return (
+      <Typography variant="body1">
+        You do not have any starred entities yet!
+      </Typography>
+    );
 
   return (
     <List>

--- a/plugins/home/src/homePageComponents/StarredEntities/StarredEntities.stories.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/StarredEntities.stories.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HomePageStarredEntities } from '../../plugin';
+import {
+  wrapInTestApp,
+  TestApiProvider,
+  MockStorageApi,
+} from '@backstage/test-utils';
+import {
+  starredEntitiesApiRef,
+  entityRouteRef,
+  DefaultStarredEntitiesApi,
+} from '@backstage/plugin-catalog-react';
+import { Grid } from '@material-ui/core';
+import React, { ComponentType } from 'react';
+
+const mockStorageApi = MockStorageApi.create();
+mockStorageApi
+  .forBucket('starredEntities')
+  .set('entityRefs', [
+    'component:default/example-starred-entity',
+    'component:default/example-starred-entity-2',
+    'component:default/example-starred-entity-3',
+    'component:default/example-starred-entity-4',
+  ]);
+
+export default {
+  title: 'Plugins/Home/Components/StarredEntities',
+  decorators: [
+    (Story: ComponentType<{}>) =>
+      wrapInTestApp(
+        <TestApiProvider
+          apis={[
+            [
+              starredEntitiesApiRef,
+              new DefaultStarredEntitiesApi({
+                storageApi: mockStorageApi,
+              }),
+            ],
+          ]}
+        >
+          <Story />
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      ),
+  ],
+};
+
+export const Default = () => {
+  return (
+    <Grid item xs={12} md={6}>
+      <HomePageStarredEntities />
+    </Grid>
+  );
+};

--- a/plugins/home/src/homePageComponents/StarredEntities/index.ts
+++ b/plugins/home/src/homePageComponents/StarredEntities/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,4 @@
  * limitations under the License.
  */
 
-/**
- * A Backstage plugin that helps you build a home page
- *
- * @packageDocumentation
- */
-
-export {
-  homePlugin,
-  HomepageCompositionRoot,
-  HomePageRandomJoke,
-  HomePageToolkit,
-  HomePageCompanyLogo,
-  HomePageStarredEntities,
-  ComponentAccordion,
-  ComponentTabs,
-  ComponentTab,
-  WelcomeTitle,
-} from './plugin';
-export { SettingsModal, HeaderWorldClock } from './components';
-export type { ClockConfig } from './components';
-export { createCardExtension } from './extensions';
+export { Content } from './Content';

--- a/plugins/home/src/plugin.ts
+++ b/plugins/home/src/plugin.ts
@@ -115,3 +115,16 @@ export const HomePageToolkit = homePlugin.provide(
     components: () => import('./homePageComponents/Toolkit'),
   }),
 );
+
+/**
+ * A component to display a list of starred entities for the user.
+ *
+ * @public
+ */
+export const HomePageStarredEntities = homePlugin.provide(
+  createCardExtension({
+    name: 'HomePageStarredEntities',
+    title: 'Your Starred Entities',
+    components: () => import('./homePageComponents/StarredEntities'),
+  }),
+);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Implements initial version of the starred entities component for the home page. Added to storybook + default template.

Closes: #6906 

<img width="1230" alt="Screenshot 2022-02-06 at 20 47 13" src="https://user-images.githubusercontent.com/25153114/152699940-511be327-1b30-4d90-b9b4-bacd4c468d61.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
