### PR TITLE
feat: add optional userExpand parameter for ms graph

### DIFF
--- a/.changeset/ninety-dancers-bow.md
+++ b/.changeset/ninety-dancers-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Add userExpand option to allow users to expand fields retrieved from the Graph API - for use in custom transformers

--- a/plugins/catalog-backend-module-msgraph/api-report.md
+++ b/plugins/catalog-backend-module-msgraph/api-report.md
@@ -141,6 +141,7 @@ export type MicrosoftGraphProviderConfig = {
   clientId: string;
   clientSecret: string;
   userFilter?: string;
+  userExpand?: string[];
   userGroupMemberFilter?: string;
   groupFilter?: string;
 };
@@ -170,6 +171,7 @@ export function readMicrosoftGraphOrg(
   client: MicrosoftGraphClient,
   tenantId: string,
   options: {
+    userExpand?: string[];
     userFilter?: string;
     userGroupMemberFilter?: string;
     groupFilter?: string;

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
@@ -53,6 +53,12 @@ export type MicrosoftGraphProviderConfig = {
    */
   userFilter?: string;
   /**
+   * The expand argument to apply to users.
+   *
+   * E.g. "manager"
+   */
+  userExpand?: string[];
+  /**
    * The filter to apply to extract users by groups memberships.
    *
    * E.g. "displayName eq 'Backstage Users'"

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
@@ -85,6 +85,7 @@ export async function readMicrosoftGraphUsers(
   client: MicrosoftGraphClient,
   options: {
     userFilter?: string;
+    userExpand?: string[];
     transformer?: UserTransformer;
     logger: Logger;
   },
@@ -99,6 +100,7 @@ export async function readMicrosoftGraphUsers(
 
   for await (const user of client.getUsers({
     filter: options.userFilter,
+    expand: options.userExpand,
   })) {
     // Process all users in parallel, otherwise it can take quite some time
     promises.push(
@@ -500,6 +502,7 @@ export async function readMicrosoftGraphOrg(
   client: MicrosoftGraphClient,
   tenantId: string,
   options: {
+    userExpand?: string[];
     userFilter?: string;
     userGroupMemberFilter?: string;
     groupFilter?: string;
@@ -524,6 +527,7 @@ export async function readMicrosoftGraphOrg(
   } else {
     const { users: usersWithFilter } = await readMicrosoftGraphUsers(client, {
       userFilter: options.userFilter,
+      userExpand: options.userExpand,
       transformer: options.userTransformer,
       logger: options.logger,
     });

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
@@ -102,6 +102,7 @@ export class MicrosoftGraphOrgReaderProcessor implements CatalogProcessor {
       client,
       provider.tenantId,
       {
+        userExpand: provider.userExpand,
         userFilter: provider.userFilter,
         userGroupMemberFilter: provider.userGroupMemberFilter,
         groupFilter: provider.groupFilter,


### PR DESCRIPTION
Signed-off-by: Jonah Back <jonah@jonahback.com>

## Hey, I just made a Pull Request!

This PR adds a pass-through parameter, userExpand, to the msgraph provider config. The intent of this is to allow folks who are using custom transformers to expand fields on the response that the existing client library gets. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
