### PR TITLE
cli: tweak lint rules and switch ESLint invocation method

### DIFF
--- a/.changeset/pretty-glasses-admire.md
+++ b/.changeset/pretty-glasses-admire.md
@@ -1,0 +1,9 @@
+---
+'@backstage/cli': patch
+---
+
+Removed the `import/no-duplicates` lint rule from the frontend and backend ESLint configurations. This rule is quite expensive to execute and only provides a purely cosmetic benefit, so we opted to remove it from the set of default rules. If you would like to keep this rule you can add it back in your local ESLint configuration:
+
+```js
+  'import/no-duplicates': 'warn'
+```

--- a/.changeset/three-dolls-fly.md
+++ b/.changeset/three-dolls-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Switched the `lint` command to invoke ESLint directly through its Node.js API rather than spawning a new process.

--- a/packages/cli/config/eslint.backend.js
+++ b/packages/cli/config/eslint.backend.js
@@ -54,7 +54,6 @@ module.exports = {
     'no-console': 0, // Permitted in console programs
     'new-cap': ['error', { capIsNew: false }], // Because Express constructs things e.g. like 'const r = express.Router()'
     'import/newline-after-import': 'error',
-    'import/no-duplicates': 'warn',
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/packages/cli/config/eslint.backend.js
+++ b/packages/cli/config/eslint.backend.js
@@ -58,7 +58,7 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: false,
+        devDependencies: ['**/*.test.*', 'src/setupTests.*', 'dev/**'],
         optionalDependencies: true,
         peerDependencies: true,
         bundledDependencies: true,
@@ -97,16 +97,6 @@ module.exports = {
     {
       files: ['*.test.*', 'src/setupTests.*', 'dev/**'],
       rules: {
-        // Tests are allowed to import dev dependencies
-        'import/no-extraneous-dependencies': [
-          'error',
-          {
-            devDependencies: true,
-            optionalDependencies: true,
-            peerDependencies: true,
-            bundledDependencies: true,
-          },
-        ],
         'no-restricted-syntax': ['error', ...globalRestrictedSyntax],
       },
     },

--- a/packages/cli/config/eslint.js
+++ b/packages/cli/config/eslint.js
@@ -53,7 +53,12 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: false,
+        devDependencies: [
+          '**/*.test.*',
+          '**/*.stories.*',
+          'src/setupTests.*',
+          'dev/**',
+        ],
         optionalDependencies: true,
         peerDependencies: true,
         bundledDependencies: true,
@@ -99,21 +104,6 @@ module.exports = {
         'react/prop-types': 0,
         '@typescript-eslint/no-unused-vars': 'off',
         'no-undef': 'off',
-      },
-    },
-    {
-      files: ['*.test.*', '*.stories.*', 'src/setupTests.*', 'dev/**'],
-      rules: {
-        // Tests are allowed to import dev dependencies
-        'import/no-extraneous-dependencies': [
-          'error',
-          {
-            devDependencies: true,
-            optionalDependencies: true,
-            peerDependencies: true,
-            bundledDependencies: true,
-          },
-        ],
       },
     },
   ],

--- a/packages/cli/config/eslint.js
+++ b/packages/cli/config/eslint.js
@@ -49,7 +49,6 @@ module.exports = {
     '@typescript-eslint/no-redeclare': 'error',
     'no-undef': 'off',
     'import/newline-after-import': 'error',
-    'import/no-duplicates': 'warn',
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -15,19 +15,29 @@
  */
 
 import { Command } from 'commander';
-import { run } from '../lib/run';
 import { paths } from '../lib/paths';
+import { ESLint } from 'eslint';
 
-export default async (cmd: Command, cmdArgs: string[]) => {
-  const args = [
-    '--ext=js,jsx,ts,tsx,mjs,cjs',
-    '--max-warnings=0',
-    `--format=${cmd.format}`,
-    ...(cmdArgs ?? [paths.targetDir]),
-  ];
+export default async (cmd: Command) => {
+  const eslint = new ESLint({
+    cwd: paths.targetDir,
+    fix: cmd.fix,
+    extensions: ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs'],
+  });
+
+  const results = await eslint.lintFiles(['.']);
+
   if (cmd.fix) {
-    args.push('--fix');
+    await ESLint.outputFixes(results);
   }
 
-  await run('eslint', args);
+  const formatter = await eslint.loadFormatter(cmd.format);
+  const resultText = formatter.format(results);
+
+  // If there is any feedback at all, we treat it as a lint failure. This should be
+  // consistent with our old behavior of passing `--max-warnings=0` when invoking eslint.
+  if (resultText) {
+    console.log(resultText);
+    process.exit(1);
+  }
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Using the Node.js API from ESLint to invoke it seems a bit cleaner, and also is a bit of a preparation for some future optimizations :grin:

The deduplication of the `import/no-extraneous-dependencies` rule seems to improve the lint speed by some amount, but also seems like a cleaner way to declare it.

While profiling the lint performance I also noticed that the `import/no-duplicates` is actually quite expensive, accounting for some 20-30% of the work. I figured it doesn't provide enough benefit to be worth the slowdown, so removing it from the default set.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
