### PR TITLE
Fixed bug in UI | Fix for issue #9157

### DIFF
--- a/.changeset/shiny-radios-deliver.md
+++ b/.changeset/shiny-radios-deliver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Encode the `formData` in the `queryString` using `JSON.stringify` to keep the types in the decoded value

--- a/plugins/scaffolder/src/components/TaskPage/TaskPage.tsx
+++ b/plugins/scaffolder/src/components/TaskPage/TaskPage.tsx
@@ -302,7 +302,9 @@ export const TaskPage = ({ loadingText }: TaskPageProps) => {
 
     navigate(
       generatePath(
-        `${rootLink()}/templates/:templateName?${qs.stringify({ formData })}`,
+        `${rootLink()}/templates/:templateName?${qs.stringify({
+          formData: JSON.stringify(formData),
+        })}`,
         {
           templateName: taskStream.task!.spec.metadata!.name,
         },

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -127,7 +127,12 @@ export const TemplatePage = ({
     const query = qs.parse(window.location.search, {
       ignoreQueryPrefix: true,
     });
-
+    const obj = query?.formData;
+    for (const key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        obj[key] = obj[key] === 'true';
+      }
+    }
     return query.formData ?? {};
   });
   const handleFormReset = () => setFormState({});

--- a/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
+++ b/plugins/scaffolder/src/components/TemplatePage/TemplatePage.tsx
@@ -127,13 +127,12 @@ export const TemplatePage = ({
     const query = qs.parse(window.location.search, {
       ignoreQueryPrefix: true,
     });
-    const obj = query?.formData;
-    for (const key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        obj[key] = obj[key] === 'true';
-      }
+
+    try {
+      return JSON.parse(query.formData as string);
+    } catch (e) {
+      return query.formData ?? {};
     }
-    return query.formData ?? {};
   });
   const handleFormReset = () => setFormState({});
   const handleChange = useCallback(


### PR DESCRIPTION
Signed-off-by: snehaljos <joyalsnehal3421@gmail.com>

## Hey, I just made a Pull Request!

Fixed bug in the UI 
datatype was a string for boolean, for that reason, the checkbox shows always enabled after clicking start over 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
