### PR TITLE
cli: make lint path output relative to repo root

### DIFF
--- a/.changeset/metal-clouds-fail.md
+++ b/.changeset/metal-clouds-fail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The file path printed by the default lint formatter is now relative to the repository root, rather than the individual package.

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -32,6 +32,11 @@ export default async (cmd: Command) => {
   }
 
   const formatter = await eslint.loadFormatter(cmd.format);
+
+  // This formatter uses the cwd to format file paths, so let's have that happen from the root instead
+  if (cmd.format === 'eslint-formatter-friendly') {
+    process.chdir(paths.targetRoot);
+  }
   const resultText = formatter.format(results);
 
   // If there is any feedback at all, we treat it as a lint failure. This should be


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Finding that this is more useful, as it makes it a clickable link more often, and also makes it easier to identity the actual file in CI.

![image](https://user-images.githubusercontent.com/4984472/152813794-268ce69e-72c9-49f8-bf9c-da687fa05c4d.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
