### PR TITLE
export DashboardSnapshotComponent from new-relic-dashboard plugin

### DIFF
--- a/.changeset/cool-birds-ring.md
+++ b/.changeset/cool-birds-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-newrelic-dashboard': patch
+---
+
+Export DashboardSnapshotComponent from new-relic-dashboard-plugin

--- a/plugins/newrelic-dashboard/api-report.md
+++ b/plugins/newrelic-dashboard/api-report.md
@@ -9,6 +9,21 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { RouteRef } from '@backstage/core-plugin-api';
 
+// Warning: (ae-missing-release-tag) "DashboardSnapshotComponent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const DashboardSnapshotComponent: ({
+  guid,
+  name,
+  permalink,
+  duration,
+}: {
+  guid: string;
+  name: string;
+  permalink: string;
+  duration: number;
+}) => JSX.Element;
+
 // Warning: (ae-missing-release-tag) "EntityNewRelicDashboardCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/plugins/newrelic-dashboard/api-report.md
+++ b/plugins/newrelic-dashboard/api-report.md
@@ -9,9 +9,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { RouteRef } from '@backstage/core-plugin-api';
 
-// Warning: (ae-missing-release-tag) "DashboardSnapshotComponent" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export const DashboardSnapshotComponent: ({
   guid,
   name,

--- a/plugins/newrelic-dashboard/src/index.ts
+++ b/plugins/newrelic-dashboard/src/index.ts
@@ -17,5 +17,6 @@ export {
   newRelicDashboardPlugin,
   EntityNewRelicDashboardCard,
   EntityNewRelicDashboardContent,
+  DashboardSnapshotComponent,
 } from './plugin';
 export { isNewRelicDashboardAvailable } from './Router';

--- a/plugins/newrelic-dashboard/src/plugin.ts
+++ b/plugins/newrelic-dashboard/src/plugin.ts
@@ -60,7 +60,14 @@ export const EntityNewRelicDashboardCard = newRelicDashboardPlugin.provide(
     },
   }),
 );
-
+/**
+ * Render dashboard snapshots from Newrelic in backstage. Use dashboards which have the tag `isDashboardPage: true`
+ *
+ * @remarks
+ * This can be helpful for rendering dashboards outside of Entity Catalog.
+ *
+ * @public
+ */
 export const DashboardSnapshotComponent = newRelicDashboardPlugin.provide(
   createComponentExtension({
     name: 'DashboardSnapshotComponent',

--- a/plugins/newrelic-dashboard/src/plugin.ts
+++ b/plugins/newrelic-dashboard/src/plugin.ts
@@ -60,3 +60,15 @@ export const EntityNewRelicDashboardCard = newRelicDashboardPlugin.provide(
     },
   }),
 );
+
+export const DashboardSnapshotComponent = newRelicDashboardPlugin.provide(
+  createComponentExtension({
+    name: 'DashboardSnapshotComponent',
+    component: {
+      lazy: () =>
+        import(
+          './components/NewRelicDashboard/DashboardSnapshotList/DashboardSnapshot'
+        ).then(m => m.DashboardSnapshot),
+    },
+  }),
+);


### PR DESCRIPTION
Signed-off-by: mufaddal motiwala <mufaddalmm.52@gmail.com>

## Hey, I just made a Pull Request!

I have exported an existing component used in this plugin. This could be helpful in using a dashboard outside of the Entity Catalog. 
