### PR TITLE
feat(explore): give filter prop the DomainExplorerContent component 

### DIFF
--- a/.changeset/real-timers-trade.md
+++ b/.changeset/real-timers-trade.md
@@ -1,0 +1,17 @@
+---
+'@backstage/plugin-explore': patch
+---
+
+The component `DomainExplorerContent` now has a filter prop. This allows for the user to only display certain `Domains` or even custom `Entities`. In your explore page you can declare the component like this:
+
+```tsx
+const filter = { kind: 'Domain', 'spec.owner': 'team-a' }
+<ExploreLayout
+    title={`Explore the ${organizationName} ecosystem`}
+    subtitle="Discover solutions available in your ecosystem"
+  >
+    <ExploreLayout.Route path="domains" title="Domains">
+      <DomainExplorerContent filter={filter}/>
+    </ExploreLayout.Route>
+</ExploreLayout>
+```

--- a/plugins/explore/api-report.md
+++ b/plugins/explore/api-report.md
@@ -35,8 +35,10 @@ export const DomainCard: ({ entity }: DomainCardProps) => JSX.Element;
 // @public (undocumented)
 export const DomainExplorerContent: ({
   title,
+  filter,
 }: {
   title?: string | undefined;
+  filter?: Record<string, string | symbol | (string | symbol)[]> | undefined;
 }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "ExploreLayout" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -51,29 +51,40 @@ describe('<DomainExplorerContent />', () => {
     jest.resetAllMocks();
   });
 
+  const entities: DomainEntity[] = [
+    {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Domain',
+      metadata: {
+        name: 'playback',
+      },
+      spec: {
+        owner: 'guest',
+      },
+    },
+    {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Domain',
+      metadata: {
+        name: 'artists',
+      },
+      spec: {
+        owner: 'guest',
+      },
+    },
+    {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Domain',
+      metadata: {
+        name: 'customFilterDomain',
+      },
+      spec: {
+        owner: 'boss',
+      },
+    },
+  ];
+
   it('renders a grid of domains', async () => {
-    const entities: DomainEntity[] = [
-      {
-        apiVersion: 'backstage.io/v1alpha1',
-        kind: 'Domain',
-        metadata: {
-          name: 'playback',
-        },
-        spec: {
-          owner: 'guest',
-        },
-      },
-      {
-        apiVersion: 'backstage.io/v1alpha1',
-        kind: 'Domain',
-        metadata: {
-          name: 'artists',
-        },
-        spec: {
-          owner: 'guest',
-        },
-      },
-    ];
     catalogApi.getEntities.mockResolvedValue({ items: entities });
 
     const { getByText } = await renderInTestApp(
@@ -131,5 +142,24 @@ describe('<DomainExplorerContent />', () => {
     await waitFor(() =>
       expect(getByText(/Could not load domains/)).toBeInTheDocument(),
     );
+  });
+
+  it('renders domains with a custom filter', async () => {
+    const customFilter = { kind: 'Domain', 'spec.owner': 'boss' };
+    catalogApi.getEntities.mockResolvedValue({ items: entities });
+
+    await renderInTestApp(
+      <Wrapper>
+        <DomainExplorerContent filter={customFilter} />
+      </Wrapper>,
+      mountedRoutes,
+    );
+
+    expect(catalogApi.getEntities).toHaveBeenCalledWith({
+      filter: {
+        kind: 'Domain',
+        'spec.owner': 'boss',
+      },
+    });
   });
 });

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -79,7 +79,7 @@ describe('<DomainExplorerContent />', () => {
         name: 'customFilterDomain',
       },
       spec: {
-        owner: 'boss',
+        owner: 'team-a',
       },
     },
   ];
@@ -145,7 +145,7 @@ describe('<DomainExplorerContent />', () => {
   });
 
   it('renders domains with a custom filter', async () => {
-    const customFilter = { kind: 'Domain', 'spec.owner': 'boss' };
+    const customFilter = { kind: 'Domain', 'spec.owner': 'team-a' };
     catalogApi.getEntities.mockResolvedValue({ items: entities });
 
     await renderInTestApp(
@@ -158,7 +158,7 @@ describe('<DomainExplorerContent />', () => {
     expect(catalogApi.getEntities).toHaveBeenCalledWith({
       filter: {
         kind: 'Domain',
-        'spec.owner': 'boss',
+        'spec.owner': 'team-a',
       },
     });
   });

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.tsx
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import React, { PropsWithChildren } from 'react';
 import { DomainEntity } from '@backstage/catalog-model';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { Button } from '@material-ui/core';
-import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { DomainCard } from '../DomainCard';
 
@@ -32,7 +32,11 @@ import {
 
 import { useApi } from '@backstage/core-plugin-api';
 
-const Body = () => {
+type BodyProps = PropsWithChildren<{
+  filter: Record<string, string | symbol | (string | symbol)[]>;
+}>;
+const Body = (props: BodyProps) => {
+  const { filter } = props;
   const catalogApi = useApi(catalogApiRef);
   const {
     value: entities,
@@ -40,7 +44,7 @@ const Body = () => {
     error,
   } = useAsync(async () => {
     const response = await catalogApi.getEntities({
-      filter: { kind: 'domain' },
+      filter: filter,
     });
     return response.items as DomainEntity[];
   }, [catalogApi]);
@@ -87,17 +91,23 @@ const Body = () => {
 
 type DomainExplorerContentProps = {
   title?: string;
+  filter?: Record<string, string | symbol | (string | symbol)[]>;
 };
 
 export const DomainExplorerContent = ({
   title,
+  filter,
 }: DomainExplorerContentProps) => {
+  const defaultFilter = filter ? filter : { kind: 'Domain' };
   return (
     <Content noPadding>
       <ContentHeader title={title ?? 'Domains'}>
-        <SupportButton>Discover the domains in your ecosystem.</SupportButton>
+        <SupportButton>
+          Discover the {title?.toLocaleLowerCase('en-US') ?? 'domains'} in your
+          ecosystem.
+        </SupportButton>
       </ContentHeader>
-      <Body />
+      <Body filter={defaultFilter} />
     </Content>
   );
 };

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, { PropsWithChildren } from 'react';
 import { DomainEntity } from '@backstage/catalog-model';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This will probably need some tweaking along the way. But the Goal in this PR is give the user control over what type of Entities to show with the `DomainExplorerContent` Component.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
