### PR TITLE
cli: avoid preprack failure if dist/embedded-app doesn't exist

### DIFF
--- a/packages/techdocs-cli/scripts/prepack.sh
+++ b/packages/techdocs-cli/scripts/prepack.sh
@@ -21,6 +21,6 @@ TECHDOCS_CLI_DIR="$SCRIPT_DIR"/..
 TECHDOCS_CLI_EMBEDDED_APP_DIR="$TECHDOCS_CLI_DIR"/../techdocs-cli-embedded-app
 
 echo "🚚 Copying embedded app into dist/embedded-app"
-rm -r "$TECHDOCS_CLI_DIR"/dist/embedded-app
+rm -rf "$TECHDOCS_CLI_DIR"/dist/embedded-app
 cp -r "$TECHDOCS_CLI_EMBEDDED_APP_DIR"/dist "$TECHDOCS_CLI_DIR"/dist/embedded-app
 echo "🏁 Ready!"


### PR DESCRIPTION
This is the fix we're looking for