### PR TITLE
CI/CD Statistics module for GitHub Actions

### DIFF
--- a/plugins/cicd-statistics-module-github/.eslintrc.js
+++ b/plugins/cicd-statistics-module-github/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint.backend')],
+};

--- a/plugins/cicd-statistics-module-github/README.md
+++ b/plugins/cicd-statistics-module-github/README.md
@@ -1,0 +1,1 @@
+# CI/CD Statistics Plugin, GitHub Actions module

--- a/plugins/cicd-statistics-module-github/package.json
+++ b/plugins/cicd-statistics-module-github/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@backstage/plugin-cicd-statistics-module-github",
+  "description": "CI/CD Statistics plugin module; GitHub Actions",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/cicd-statistics-module-github"
+  },
+  "scripts": {
+    "lint": "backstage-lint",
+    "diff": "internal-backstage-cli plugin:diff",
+    "start": "internal-backstage-cli plugin:serve"
+  },
+  "dependencies": {
+    "@backstage/catalog-model": "^0.9.10",
+    "@backstage/plugin-cicd-statistics": "^0.1.0",
+    "@backstage/plugin-github-octokit": "^0.0.0",
+    "already": "^3.2.0",
+    "lodash": "^4.17.21",
+    "luxon": "^2.0.2"
+  },
+  "peerDependencies": {
+    "@octokit/graphql": "^4.8.0",
+    "@octokit/rest": "^18.12.0",
+    "react": "^16.13.1 || ^17.0.0"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/cicd-statistics-module-github/src/apis/github.ts
+++ b/plugins/cicd-statistics-module-github/src/apis/github.ts
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { map } from 'already';
+import { uniqBy } from 'lodash';
+import {
+  Build,
+  CicdStatisticsApi,
+  CicdState,
+  FetchBuildsOptions,
+  FilterStatusType,
+  FilterBranchType,
+  AbortError,
+  CicdConfiguration,
+} from '@backstage/plugin-cicd-statistics';
+import {
+  GithubOctokitApi,
+  OctokitWithOwnerRepo,
+} from '@backstage/plugin-github-octokit';
+
+import { jobsToStages, parseBuild, ParsedBuild } from './types';
+
+const compareAsc = (a: Date, b: Date) => {
+  if (a.getTime() === b.getTime()) {
+    return 0;
+  }
+  return a.getTime() > b.getTime() ? 1 : -1;
+};
+const isBefore = (a: Date, b: Date) => a.getTime() < b.getTime();
+
+type PushProgress = (percentBuilds: number, percentJobs: number) => void;
+
+export class CicdStatisticsApiGithub implements CicdStatisticsApi {
+  constructor(private githubOctokitApi: GithubOctokitApi) {}
+
+  private async getDefaultBranch(octo: OctokitWithOwnerRepo) {
+    const { octokit, ...ownerRepo } = octo;
+    const repo = await octokit.rest.repos.get({ ...ownerRepo });
+    return repo.data.default_branch ?? 'master';
+  }
+
+  private async listWorkflowRuns(
+    { octokit, ...ownerRepo }: OctokitWithOwnerRepo,
+    pageSize = 100,
+    page = 0,
+    branch?: string,
+  ) {
+    const workflowRuns = await octokit.rest.actions.listWorkflowRunsForRepo({
+      ...ownerRepo,
+      per_page: pageSize,
+      page,
+      ...(branch ? { branch } : {}),
+    });
+    return workflowRuns.data;
+  }
+
+  private async listJobsForWorkflowRun(
+    { octokit, ...ownerRepo }: OctokitWithOwnerRepo,
+    id: number,
+    pageSize = 100,
+    page = 0,
+  ) {
+    const jobs = await octokit.rest.actions.listJobsForWorkflowRun({
+      ...ownerRepo,
+      run_id: id,
+      per_page: pageSize,
+      page,
+    });
+    return jobs.data;
+  }
+
+  /**
+   * Fetches builds (workflow runs)
+   */
+  private async fetchBuildInfos(
+    octo: OctokitWithOwnerRepo,
+    timeFrom: Date,
+    timeTo: Date,
+    filterStatus: Array<FilterStatusType | 'all'>,
+    filterType: FilterBranchType | 'all',
+    abortSignal: AbortSignal,
+    pushProgress: PushProgress,
+  ) {
+    const builds: Array<ParsedBuild> = [];
+
+    const branch =
+      filterType === 'master' ? await this.getDefaultBranch(octo) : undefined;
+
+    const rawBuilds = await this.listWorkflowRuns(
+      octo,
+      undefined,
+      undefined,
+      branch,
+    );
+
+    const pageSize = rawBuilds.workflow_runs.length;
+
+    const firstBuilds = rawBuilds.workflow_runs.map(build => parseBuild(build));
+
+    if (!firstBuilds?.length) return [];
+
+    builds.push(...firstBuilds);
+
+    const getFirstBuild = () => {
+      builds.sort((a, b) => compareAsc(a.requestedAt, b.requestedAt));
+      return builds[0];
+    };
+
+    const getProgress = () => {
+      if (builds.length === 0) return 0;
+
+      const start = timeFrom.getTime();
+
+      const first = builds[0].requestedAt.getTime();
+      const last = builds[builds.length - 1].requestedAt.getTime();
+
+      const progress = (last - first) / (last - start);
+
+      return progress > 1 ? 1 : progress;
+    };
+
+    let page = 0;
+    while (isBefore(timeFrom, getFirstBuild().requestedAt)) {
+      if (abortSignal.aborted) throw new AbortError('');
+
+      pushProgress(getProgress(), 0);
+      ++page;
+      const nextRawBuilds = await this.listWorkflowRuns(
+        octo,
+        pageSize,
+        page,
+        branch,
+      );
+
+      if (
+        nextRawBuilds.total_count === 0 ||
+        nextRawBuilds.workflow_runs.length === 0
+      ) {
+        break;
+      }
+
+      builds.push(
+        ...nextRawBuilds.workflow_runs.map(build => parseBuild(build)),
+      );
+    }
+
+    return uniqBy(builds, 'id')
+      .filter(
+        build =>
+          filterStatus.includes('all') || filterStatus.includes(build.status),
+      )
+      .filter(build => filterType === 'all' || build.branchType === filterType)
+      .filter(
+        build =>
+          isBefore(build.requestedAt, timeTo) &&
+          isBefore(timeFrom, build.requestedAt),
+      );
+  }
+
+  public async getConfiguration(): Promise<Partial<CicdConfiguration>> {
+    return {
+      availableStatuses: [
+        'succeeded',
+        'failed',
+        'enqueued',
+        'running',
+        'aborted',
+        'stalled',
+        'expired',
+        'unknown',
+      ] as const,
+    };
+  }
+
+  public async fetchBuilds(options: FetchBuildsOptions): Promise<CicdState> {
+    const {
+      entity,
+      updateProgress,
+      abortSignal,
+      timeFrom,
+      timeTo,
+      filterStatus = ['all'],
+      filterType = 'all',
+    } = options;
+
+    const octo = await this.githubOctokitApi.getOctokitForEntity(entity, [
+      'repo',
+    ]);
+
+    updateProgress(0, 0, 0);
+
+    const pushProgress = (percentBuilds: number, percentJobs: number) =>
+      updateProgress([
+        {
+          title: 'Fetching workflows runs',
+          completed: percentBuilds,
+          total: 1,
+        },
+        {
+          title: 'Fetching workflow jobs',
+          completed: percentJobs,
+          total: 1,
+        },
+      ]);
+
+    const builds = await this.fetchBuildInfos(
+      octo,
+      timeFrom,
+      timeTo,
+      filterStatus,
+      filterType,
+      abortSignal,
+      pushProgress,
+    );
+
+    let finished = 0;
+    const pushProgressJob = () => {
+      pushProgress(1, finished / builds.length);
+    };
+
+    // Fetch workflow jobs per run
+
+    const buildsWithInfo = (
+      await map(
+        builds,
+        { concurrency: 8 },
+        async (build): Promise<Build | undefined> => {
+          if (abortSignal.aborted) throw new AbortError();
+
+          pushProgressJob();
+
+          try {
+            const jobs = await this.listJobsForWorkflowRun(octo, build.raw.id);
+
+            const stages = jobsToStages(jobs);
+
+            const { raw, ...buildWithoutRaw } = build;
+
+            return { ...buildWithoutRaw, stages };
+          } catch (err: any) {
+            console.error(
+              `Failed to fetch and parse job ${build.raw.id}`,
+              err?.message,
+            );
+            return undefined;
+          } finally {
+            ++finished;
+          }
+        },
+      )
+    ).filter((v): v is NonNullable<typeof v> => !!v);
+
+    return {
+      builds: buildsWithInfo,
+    };
+  }
+}

--- a/plugins/cicd-statistics-module-github/src/apis/index.ts
+++ b/plugins/cicd-statistics-module-github/src/apis/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './github';

--- a/plugins/cicd-statistics-module-github/src/apis/types.ts
+++ b/plugins/cicd-statistics-module-github/src/apis/types.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  FilterStatusType,
+  TriggerReason,
+  Stage,
+  BuildWithRaw,
+  FilterBranchType,
+} from '@backstage/plugin-cicd-statistics';
+import { RestEndpointMethodTypes } from '@octokit/rest';
+
+export type ListWorkflowRunsResponse =
+  RestEndpointMethodTypes['actions']['listWorkflowRuns']['response']['data'];
+export type ListJobsForWorkflowRunResponse =
+  RestEndpointMethodTypes['actions']['listJobsForWorkflowRun']['response']['data'];
+
+export type WorkflowRun = ListWorkflowRunsResponse['workflow_runs'][number];
+export type JobForWorkflowRun = ListJobsForWorkflowRunResponse['jobs'][number];
+export type SimpleJobDescriptor = NonNullable<
+  JobForWorkflowRun['steps']
+>[number];
+
+export type ParsedBuild = BuildWithRaw<WorkflowRun>;
+
+export function jobsToStages(
+  jobs: ListJobsForWorkflowRunResponse,
+): Array<Stage> {
+  const jobStageToStage = (
+    job: JobForWorkflowRun | SimpleJobDescriptor,
+  ): Stage => {
+    return {
+      name: job.name,
+      status: parseStatus(job.status, job.conclusion),
+      duration:
+        !job.started_at || !job.completed_at
+          ? 0
+          : new Date(job.completed_at).getTime() -
+            new Date(job.started_at).getTime(),
+      stages: ((job as JobForWorkflowRun).steps ?? []).map(subJob =>
+        jobStageToStage(subJob),
+      ),
+    };
+  };
+
+  return (jobs.jobs ?? []).map(job => jobStageToStage(job));
+}
+
+const statusMap: Record<string, FilterStatusType> = {
+  // For jobs:
+  queued: 'enqueued',
+  in_progress: 'running',
+  // completed: // no status per se; needs 'conclusion'
+
+  // Conclusions:
+  failure: 'failed',
+  success: 'succeeded',
+  cancelled: 'aborted',
+  skipped: 'expired',
+  action_required: 'stalled',
+};
+
+const setTriggerReasonScm = new Set([
+  'push',
+  'pull_request',
+  'pull_request_target',
+]);
+const setTriggerReasonInternal = new Set([
+  'dynamic',
+  'schedule',
+  'workflow_dispatch',
+  'deployment_status',
+  'issues',
+  'issue_comment',
+]);
+
+function parseTriggerReason(rawBuild: WorkflowRun): TriggerReason {
+  if ((rawBuild.run_attempt ?? 1) > 1) {
+    return 'manual';
+  } else if (setTriggerReasonScm.has(rawBuild.event)) {
+    return 'scm';
+  } else if (setTriggerReasonInternal.has(rawBuild.event)) {
+    return 'internal';
+  }
+  console.log(
+    `[cicd-statistics-module-github]: Found unknown workflow run event: ${rawBuild.event}`,
+  );
+  return 'other';
+}
+
+function parseStatus(
+  status: string,
+  conclusion?: string | null,
+): FilterStatusType {
+  if (!statusMap[status] && !statusMap[conclusion ?? '']) {
+    const con = !conclusion ? '' : ` (conclusion ${conclusion})`;
+    console.log(
+      `[cicd-statistics-module-github]: Found unknown status ${status}${con}`,
+    );
+  }
+  return statusMap[status] ?? statusMap[conclusion ?? ''] ?? 'unknown';
+}
+
+function parseRunStatus(rawBuild: WorkflowRun): FilterStatusType {
+  return parseStatus(rawBuild.status!, rawBuild.conclusion);
+}
+
+function parseBranch(rawBuild: WorkflowRun): FilterBranchType {
+  const branch = rawBuild.head_branch?.toLowerCase();
+  return branch === 'master' || branch === 'main' ? 'master' : 'branch';
+}
+
+function parseDuration(rawBuild: WorkflowRun): number {
+  return (
+    new Date(rawBuild.updated_at ?? undefined).getTime() -
+    new Date(rawBuild.run_started_at ?? rawBuild.created_at).getTime()
+  );
+}
+
+export function parseBuild(rawBuild: WorkflowRun): ParsedBuild {
+  return {
+    raw: rawBuild,
+
+    id: `${rawBuild.id}`,
+    triggeredBy: parseTriggerReason(rawBuild),
+    status: parseRunStatus(rawBuild),
+    branchType: parseBranch(rawBuild),
+    requestedAt: new Date(rawBuild.run_started_at ?? rawBuild.created_at),
+    duration: parseDuration(rawBuild),
+
+    stages: [], // Will be filled in second step when fetching jobs
+  };
+}

--- a/plugins/cicd-statistics-module-github/src/index.ts
+++ b/plugins/cicd-statistics-module-github/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { CicdStatisticsApiGithub } from './apis';

--- a/plugins/github-octokit/.eslintrc.js
+++ b/plugins/github-octokit/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint')],
+};

--- a/plugins/github-octokit/CHANGELOG.md
+++ b/plugins/github-octokit/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @backstage/plugin-github

--- a/plugins/github-octokit/README.md
+++ b/plugins/github-octokit/README.md
@@ -1,0 +1,3 @@
+# GitHub Plugin
+
+This is a plugin for integrating with GitHub (using `@octokit/rest` or `@octokit/graphql`). It is useful for other plugins to use, but is in and of itself not providing and UI.

--- a/plugins/github-octokit/package.json
+++ b/plugins/github-octokit/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@backstage/plugin-github-octokit",
+  "description": "A Backstage plugin that integrates with GitHub",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/github"
+  },
+  "keywords": [
+    "backstage",
+    "github",
+    "octokit"
+  ],
+  "scripts": {
+    "build": "backstage-cli plugin:build",
+    "start": "backstage-cli plugin:serve",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test",
+    "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
+    "clean": "backstage-cli clean"
+  },
+  "dependencies": {
+    "@backstage/catalog-model": "^0.9.10",
+    "@backstage/core-plugin-api": "^0.6.0",
+    "@backstage/errors": "^0.2.0",
+    "@backstage/integration": "^0.7.2",
+    "@backstage/plugin-catalog-react": "^0.6.13-next.1",
+    "octokit": "^1.7.1",
+    "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.13.1-next.1",
+    "@backstage/test-utils": "^0.2.4-next.0",
+    "@types/jest": "^26.0.7"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/github-octokit/src/api/github-credentials-api.ts
+++ b/plugins/github-octokit/src/api/github-credentials-api.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GitHubIntegrationConfig } from '@backstage/integration';
+import { Entity } from '@backstage/catalog-model';
+
+import { OwnerRepo } from '../utils/types';
+
+export type IntegrationInfo = { baseUrl: string; host: string };
+export type CredentialsInfo = IntegrationInfo & { token: string };
+
+export type GithubCredentialsApi = {
+  /**
+   * Get all GitHub integrations
+   */
+  getIntegrations(): GitHubIntegrationConfig[];
+
+  /**
+   * Get the GitHub integration that matches a certain hostname, provided as a
+   * string or a URL object.
+   */
+  getIntegration(hostname: string | URL): IntegrationInfo;
+
+  /**
+   * Get the GitHub integration that matches the source location of an Entity.
+   */
+  getIntegrationForEntity(entity: Entity): IntegrationInfo & OwnerRepo;
+
+  /**
+   * Get the credentials for the GitHub integration that matches a certain
+   * hostname, provided as a string or a URL object.
+   */
+  getCredentials(
+    hostname: string | URL,
+    scopes: string[],
+  ): Promise<CredentialsInfo>;
+
+  /**
+   * Get the credentials for the GitHub integration that matches the source
+   * location of an Entity.
+   */
+  getCredentialsForEntity(
+    entity: Entity,
+    scopes: string[],
+  ): Promise<CredentialsInfo & OwnerRepo>;
+};

--- a/plugins/github-octokit/src/api/github-credentials.ts
+++ b/plugins/github-octokit/src/api/github-credentials.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readGitHubIntegrationConfigs } from '@backstage/integration';
+import { ConfigApi, OAuthApi } from '@backstage/core-plugin-api';
+import { NotFoundError } from '@backstage/errors';
+import { Entity } from '@backstage/catalog-model';
+
+import type { GithubCredentialsApi } from './github-credentials-api';
+import { getEntitySourceLocationInfo } from '../utils';
+
+export class GithubCredentials implements GithubCredentialsApi {
+  private readonly configApi: ConfigApi;
+  private readonly githubAuthApi: OAuthApi;
+
+  constructor(options: { configApi: ConfigApi; githubAuthApi: OAuthApi }) {
+    this.configApi = options.configApi;
+    this.githubAuthApi = options.githubAuthApi;
+  }
+
+  public getIntegrations() {
+    return readGitHubIntegrationConfigs(
+      this.configApi.getOptionalConfigArray('integrations.github') ?? [],
+    );
+  }
+
+  public getIntegration(hostnameOrUrl: string | URL) {
+    const hostname =
+      typeof hostnameOrUrl === 'string'
+        ? hostnameOrUrl
+        : hostnameOrUrl.hostname;
+
+    const integrations = this.getIntegrations();
+    const githubIntegrationConfig = integrations.find(v => v.host === hostname);
+
+    if (!githubIntegrationConfig) {
+      throw new NotFoundError(`Missing integrations with ${hostname}`);
+    }
+
+    const { apiBaseUrl, host } = githubIntegrationConfig;
+
+    if (!apiBaseUrl) {
+      throw new NotFoundError(
+        `Missing 'baseUrl' for integration with ${hostname}`,
+      );
+    }
+
+    return { baseUrl: apiBaseUrl, host };
+  }
+
+  public getIntegrationForEntity(entity: Entity) {
+    const { url, repo, owner } = getEntitySourceLocationInfo(entity);
+
+    const { baseUrl, host } = this.getIntegration(url);
+
+    return { baseUrl, host, repo, owner };
+  }
+
+  public async getCredentials(hostname: string | URL, scopes: string[]) {
+    const { baseUrl, host } = this.getIntegration(hostname);
+
+    // TODO: Get access token for the specified hostname
+    const token = await this.githubAuthApi.getAccessToken(scopes);
+
+    return { baseUrl, host, token };
+  }
+
+  public async getCredentialsForEntity(entity: Entity, scopes: string[]) {
+    const { url, repo, owner } = getEntitySourceLocationInfo(entity);
+
+    const { baseUrl, host, token } = await this.getCredentials(url, scopes);
+
+    return { baseUrl, host, token, repo, owner };
+  }
+}

--- a/plugins/github-octokit/src/api/github-octokit-api.ts
+++ b/plugins/github-octokit/src/api/github-octokit-api.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Octokit } from 'octokit';
+
+import { Entity } from '@backstage/catalog-model';
+
+import { OwnerRepo } from '../utils/types';
+
+export type OctokitWithOwnerRepo = { octokit: Octokit } & OwnerRepo;
+
+export type GithubOctokitApi = {
+  /**
+   * Get an Octokit instance given the hostname to GitHub (or an enterprise
+   * GitHub installation)
+   *
+   * Specify which scopes you need access to (e.g. ['repo'])..
+   */
+  getOctokit(hostname: string | URL, scopes: string[]): Promise<Octokit>;
+
+  /**
+   * Get an Octokit instance given an entity's source url.
+   *
+   * Specify which scopes you need access to (e.g. ['repo'])..
+   *
+   * Also returns the {owner/repo} parts of the entity source url.
+   */
+  getOctokitForEntity(
+    entity: Entity,
+    scopes: string[],
+  ): Promise<OctokitWithOwnerRepo>;
+};

--- a/plugins/github-octokit/src/api/github-octokit.ts
+++ b/plugins/github-octokit/src/api/github-octokit.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Octokit } from 'octokit';
+
+import { Entity } from '@backstage/catalog-model';
+
+import type { GithubCredentialsApi } from './github-credentials-api';
+import type { GithubOctokitApi } from './github-octokit-api';
+import { getEntitySourceLocationInfo } from '../utils';
+
+export class GithubOctokit implements GithubOctokitApi {
+  private readonly githubCredentialsApi: GithubCredentialsApi;
+
+  constructor(options: { githubCredentialsApi: GithubCredentialsApi }) {
+    this.githubCredentialsApi = options.githubCredentialsApi;
+  }
+
+  public async getOctokit(
+    hostname: string | URL,
+    scopes: string[],
+  ): Promise<Octokit> {
+    const { token, baseUrl } = await this.githubCredentialsApi.getCredentials(
+      hostname,
+      scopes,
+    );
+
+    return new Octokit({ auth: token, baseUrl });
+  }
+
+  public async getOctokitForEntity(entity: Entity, scopes: string[]) {
+    const entityInfo = getEntitySourceLocationInfo(entity);
+    const { url, ...ownerRepo } = entityInfo;
+
+    const octokit = await this.getOctokit(url, scopes);
+
+    return { octokit, ...ownerRepo };
+  }
+}

--- a/plugins/github-octokit/src/api/index.ts
+++ b/plugins/github-octokit/src/api/index.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createApiRef } from '@backstage/core-plugin-api';
+
+import type { GithubCredentialsApi } from './github-credentials-api';
+import type { GithubOctokitApi } from './github-octokit-api';
+
+export type { GithubCredentialsApi } from './github-credentials-api';
+export * from './github-credentials';
+
+export type {
+  GithubOctokitApi,
+  OctokitWithOwnerRepo,
+} from './github-octokit-api';
+export * from './github-octokit';
+
+export const githubCredentialsApiRef = createApiRef<GithubCredentialsApi>({
+  id: 'plugin.github.credentials',
+});
+
+export const githubOctokitApiRef = createApiRef<GithubOctokitApi>({
+  id: 'plugin.github.octokit',
+});

--- a/plugins/github-octokit/src/hooks/index.ts
+++ b/plugins/github-octokit/src/hooks/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  useOctokit,
+  useOctokitForCustomEntity,
+  useOctokitForEntity,
+} from './use-octokit';

--- a/plugins/github-octokit/src/hooks/use-octokit.ts
+++ b/plugins/github-octokit/src/hooks/use-octokit.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import { useAsync } from 'react-use';
+import { useApi } from '@backstage/core-plugin-api';
+import { Entity } from '@backstage/catalog-model';
+import { useEntity } from '@backstage/plugin-catalog-react';
+
+import { githubOctokitApiRef } from '../api';
+
+function useMemoizedScopes(scopes: string[]): string[] {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => scopes, [scopes.join('$$')]);
+}
+
+/**
+ * Get an Octokit instance for the provided GitHub hostname
+ *
+ * Specify which scopes you need access to (e.g. ['repo']). This array is
+ * memoized, so it's not necessary to do this by the caller.
+ *
+ * @returns AsyncState<Octokit>
+ */
+export function useOctokit(hostname: string, scopes: string[]) {
+  const githubOctokitApi = useApi(githubOctokitApiRef);
+
+  const authScopes = useMemoizedScopes(scopes);
+
+  return useAsync(
+    () => githubOctokitApi.getOctokit(hostname, authScopes),
+    [githubOctokitApi, hostname, authScopes],
+  );
+}
+
+/**
+ * Get an Octokit instance for the provided entity.
+ *
+ * Specify which scopes you need access to (e.g. ['repo']). This array is
+ * memoized, so it's not necessary to do this by the caller.
+ *
+ * Also return the {owner/repo} parts of the entity source url.
+ *
+ * @returns AsyncState<Octokit & {owner: string; repo: string;}>
+ */
+export function useOctokitForCustomEntity(entity: Entity, scopes: string[]) {
+  const githubOctokitApi = useApi(githubOctokitApiRef);
+
+  const authScopes = useMemoizedScopes(scopes);
+
+  return useAsync(
+    () => githubOctokitApi.getOctokitForEntity(entity, authScopes),
+    [githubOctokitApi, entity, authScopes],
+  );
+}
+
+/**
+ * Get an Octokit instance for the current entity.
+ *
+ * Specify which scopes you need access to (e.g. ['repo']). This array is
+ * memoized, so it's not necessary to do this by the caller.
+ *
+ * Also return the {owner/repo} parts of the entity source url.
+ *
+ * @returns AsyncState<Octokit & {owner: string; repo: string;}>
+ */
+export function useOctokitForEntity(scopes: string[]) {
+  const { entity, loading, error } = useEntity();
+
+  const githubOctokitApi = useApi(githubOctokitApiRef);
+
+  const authScopes = useMemoizedScopes(scopes);
+
+  const asyncState = useAsync(
+    () => githubOctokitApi.getOctokitForEntity(entity, authScopes),
+    [githubOctokitApi, entity, authScopes],
+  );
+
+  if (loading || asyncState.loading) {
+    return { loading: true } as const;
+  }
+  if (error || asyncState.error) {
+    return { error: error ?? asyncState.error! };
+  }
+
+  return { value: asyncState.value! };
+}

--- a/plugins/github-octokit/src/index.ts
+++ b/plugins/github-octokit/src/index.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A Backstage plugin that integrates with GitHub
+ *
+ * @packageDocumentation
+ */
+
+export { githubPlugin } from './plugin';
+export * from './api';
+export * from './hooks';

--- a/plugins/github-octokit/src/plugin.test.ts
+++ b/plugins/github-octokit/src/plugin.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { githubPlugin } from './plugin';
+
+describe('github', () => {
+  it('should export plugin', () => {
+    expect(githubPlugin).toBeDefined();
+  });
+});

--- a/plugins/github-octokit/src/plugin.ts
+++ b/plugins/github-octokit/src/plugin.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  configApiRef,
+  createPlugin,
+  createApiFactory,
+  githubAuthApiRef,
+} from '@backstage/core-plugin-api';
+
+import {
+  githubCredentialsApiRef,
+  GithubCredentials,
+  githubOctokitApiRef,
+  GithubOctokit,
+} from './api';
+
+export const githubPlugin = createPlugin({
+  id: 'github',
+  apis: [
+    createApiFactory({
+      api: githubCredentialsApiRef,
+      deps: { configApi: configApiRef, githubAuthApi: githubAuthApiRef },
+      factory: ({ configApi, githubAuthApi }) =>
+        new GithubCredentials({ configApi, githubAuthApi }),
+    }),
+    createApiFactory({
+      api: githubOctokitApiRef,
+      deps: { githubCredentialsApi: githubCredentialsApiRef },
+      factory: ({ githubCredentialsApi }) =>
+        new GithubOctokit({ githubCredentialsApi }),
+    }),
+  ],
+});

--- a/plugins/github-octokit/src/utils/index.ts
+++ b/plugins/github-octokit/src/utils/index.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NotFoundError, InputError } from '@backstage/errors';
+import { Entity, SOURCE_LOCATION_ANNOTATION } from '@backstage/catalog-model';
+import { OwnerRepo } from './types';
+
+export function getEntitySourceLocationInfo(
+  entity: Entity,
+): { url: URL } & OwnerRepo {
+  const source = entity.metadata.annotations?.[SOURCE_LOCATION_ANNOTATION];
+
+  if (!source) {
+    throw new NotFoundError(`The entity doesn't have a source url`);
+  }
+
+  const sourceUrl = source.startsWith('url:') ? source.slice(4) : source;
+
+  const url = (() => {
+    try {
+      return new URL(sourceUrl);
+    } catch (_err) {
+      throw new InputError(`The entity source isn't a valid url: ${sourceUrl}`);
+    }
+  })();
+
+  const parts = url.pathname.slice(1).split('/');
+
+  if (parts.length < 2) {
+    throw new InputError(
+      `The entity source url doesn't contain owner/repo: ${sourceUrl}`,
+    );
+  }
+
+  const owner = parts[0];
+  const repo = parts[1].endsWith('.git')
+    ? parts[1].slice(0, parts[1].length - 4)
+    : parts[1];
+
+  return {
+    url,
+    owner,
+    repo,
+  };
+}

--- a/plugins/github-octokit/src/utils/types.ts
+++ b/plugins/github-octokit/src/utils/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type OwnerRepo = { owner: string; repo: string };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4047,15 +4047,6 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
-"@octokit/graphql@^4.8.0":
-  version "4.8.0"
-  resolved "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
-  integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
-  dependencies:
-    "@octokit/request" "^5.6.0"
-    "@octokit/types" "^6.0.3"
-    universal-user-agent "^6.0.0"
-
 "@octokit/oauth-app@^3.3.2", "@octokit/oauth-app@^3.5.1":
   version "3.6.0"
   resolved "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-3.6.0.tgz#36f660c7eb6b5a5cd23f6207a8d95e74b6834db0"
@@ -18206,8 +18197,8 @@ octokit-plugin-create-pull-request@^3.10.0:
 
 octokit@^1.7.1:
   version "1.7.1"
-  resolved "https://registry.npmjs.org/octokit/-/octokit-1.7.1.tgz#d86e51c8e0cec65cb64822ca2c9ff1b052593799"
-  integrity sha512-1b7eRgU8uWetHOWr8f9ptnVo2EKbrkOfocMeQdpgCt7tl/LK67HptFsy2Xg4fMjsJ/+onoBJW0hy/fO0In3/uA==
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/octokit/-/octokit-1.7.1.tgz#d86e51c8e0cec65cb64822ca2c9ff1b052593799"
+  integrity sha1-2G5RyODOxly2SCLKLJ/xsFJZN5k=
   dependencies:
     "@octokit/app" "^12.0.4"
     "@octokit/core" "^3.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4047,6 +4047,15 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
+"@octokit/graphql@^4.8.0":
+  version "4.8.0"
+  resolved "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
+  integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
+  dependencies:
+    "@octokit/request" "^5.6.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
 "@octokit/oauth-app@^3.3.2", "@octokit/oauth-app@^3.5.1":
   version "3.6.0"
   resolved "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-3.6.0.tgz#36f660c7eb6b5a5cd23f6207a8d95e74b6834db0"


### PR DESCRIPTION
> This is a cross-branch PR against #8912 hence shouldn't be merged. It will be rebased once that PR is merged to master.

## Hey, I just made a Pull Request!

This is an API implementation for using the CI/CD Statistics against Github Actions.

When making this, I found that several plugins practically do the same thing identifying *integrations* and then fetching *credentials* against Github; `git-release-manager`, `github-actions`, `github-deployments`. This process should also eventually support getting credentials against different Github instances.

It didn't feel right to copy-paste a fourth variant of that logic, so I took the liberty to create a plugin `github` which given a hostname or an Entity (its source location, which also includes owner/repo) manages getting credentials and getting a REST or GraphQL interface back (`@octokit`). That's the first commit. Later, we could cc the authors of those other plugins to start using `github` instead. WDYT? It's pretty thin, but provides helpers so that you don't have to deal with integration configs and credentials handling every time you want to access Github (could extract to separate PR if you want):

```
┌─────────────────────────────────────────────────┐    ┌────────────────────────────────────────────────────┐
│                                                 │    │                                                    │
│  Apis                                           │    │  Hooks                                             │
│                                                 │    │                                                    │
│                                                 │    │                                                    │
│ ┌────────────────────────────────────────────┐  │    │  useOctokitRest(hostname: string)                  │
│ │                                            │  ◄────┤  useOctokitRestForCustomEntity(entity: Entity)     │
│ │  GithubCredentialsApi                      │  │    │  useOctokitRestForEntity()                         │
│ │                                            │  │    │  useOctokitGraphql(hostname: string)               │
│ │  getIntegrations()                         │  │    │  useOctokitGraphqlForCustomEntity(entity: Entity)  │
│ │  getIntegration(hostname: string | URL)    │  │    │  useOctokitGraphqlForEntity()                      │
│ │  getIntegrationForEntity(entity: Entity)   │  │    │                                                    │
│ │  getCredentials(hostname: string | URL)    │  │    └────────────────────────────────────────────────────┘
│ │  getCredentialsForEntity(entity: Entity)   │  │
│ │                                            │  │
│ └────────────────────▲───────────────────────┘  │
│                      │                          │
│                      │                          │
│ ┌────────────────────┴──────────────────┐       │
│ │                                       │       │
│ │  GithubOctokitApi                     │       │
│ │                                       │       │
│ │  getRest(hostname: string | URL)      │       │
│ │  getRestForEntity(entity: Entity)     │       │
│ │  getGraphql(hostname: string | URL)   │       │
│ │  getGraphqlForEntity(entity: Entity)  │       │
│ │                                       │       │
│ └───────────────────────────────────────┘       │
│                                                 │
└─────────────────────────────────────────────────┘
```

The second commit is the Github Actions implementation for the CI/CD Statistics plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
