### PR TITLE
atlassian: remove option for disabling refresh

### DIFF
--- a/.changeset/early-beds-smoke.md
+++ b/.changeset/early-beds-smoke.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-removes disable refresh option in order to properly handle refresh tokens for atlassian
+Enabled refresh for the Atlassian provider.

--- a/.changeset/early-beds-smoke.md
+++ b/.changeset/early-beds-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+removes disable refresh option in order to properly handle refresh tokens for atlassian

--- a/plugins/auth-backend/src/providers/atlassian/provider.ts
+++ b/plugins/auth-backend/src/providers/atlassian/provider.ts
@@ -231,7 +231,6 @@ export const createAtlassianProvider = (
       });
 
       return OAuthAdapter.fromConfig(globalConfig, provider, {
-        disableRefresh: true,
         providerId,
         tokenIssuer,
         callbackUrl,


### PR DESCRIPTION
Signed-off-by: Daniel Deloff <44780793+rv-ddeloff@users.noreply.github.com>

## Hey, I just made a Pull Request!

The Atlassian auth provider needs to store refresh tokens in order to properly refresh access tokens. Removing option to disable refresh.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
