### PR TITLE
Update code to CatalogPage Customization.

### DIFF
--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -176,9 +176,7 @@ const routes = (
   <FlatRoutes>
     <Navigate key="/" to="catalog" />
 -    <Route path="/catalog" element={<CatalogIndexPage />} />
-+    <Route path="/catalog" element={<CatalogIndexPage />}>
-+      <CustomCatalogPage />
-+    </Route>
++    <Route path="/catalog" element={<CustomCatalogPage />} />
 ```
 
 The same method can be used to customize the _default_ filters with a different


### PR DESCRIPTION
Based on testing, only replacing CatalogIndexPage to CustomCatalogPage could make CustomCatalogPage in use for catalog page customization, otherwise, backstage won't use CustomCatalogPage.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
