### PR TITLE
Rolling back the `@date-io/luxon` bump

### DIFF
--- a/.changeset/moody-parrots-listen.md
+++ b/.changeset/moody-parrots-listen.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-bazaar': patch
+'@backstage/plugin-ilert': patch
+---
+
+Rolling back the `@date-io/luxon` bump as this broke both packages, and we need it for `@material-ui/pickers`

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -28,7 +28,7 @@
     "@backstage/core-plugin-api": "^0.6.0",
     "@backstage/plugin-catalog": "^0.7.12-next.0",
     "@backstage/plugin-catalog-react": "^0.6.14-next.0",
-    "@date-io/luxon": "2.x",
+    "@date-io/luxon": "1.x",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",

--- a/plugins/ilert/package.json
+++ b/plugins/ilert/package.json
@@ -27,7 +27,7 @@
     "@backstage/errors": "^0.2.0",
     "@backstage/plugin-catalog-react": "^0.6.14-next.0",
     "@backstage/theme": "^0.2.14",
-    "@date-io/luxon": "2.x",
+    "@date-io/luxon": "1.x",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,11 +1828,6 @@
   resolved "https://registry.npmjs.org/@date-io/core/-/core-2.10.7.tgz#0fe1fa0ef02c827919e23c2802a4b25589ac522d"
   integrity sha512-EG/1qDiQvd12RoNJ6H+sZcHVswC/3uMx/ySvfaJ24vB30rLjkgHggEXbgMbfgki7wMuiQ/zXI8QlmF1k3kWRGQ==
 
-"@date-io/core@^2.13.1":
-  version "2.13.1"
-  resolved "https://registry.npmjs.org/@date-io/core/-/core-2.13.1.tgz#f041765aff5c55fbc7e37fdd75fc1792733426d6"
-  integrity sha512-pVI9nfkf2qClb2Cxdq0Q4zJhdawMG4ybWZUVGifT78FDwzRMX2SwXBb55s5NRJk0HcIicDuxktmCtemZqMH1Zg==
-
 "@date-io/date-fns@^1.3.13":
   version "1.3.13"
   resolved "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-1.3.13.tgz#7798844041640ab393f7e21a7769a65d672f4735"
@@ -1840,12 +1835,12 @@
   dependencies:
     "@date-io/core" "^1.3.13"
 
-"@date-io/luxon@2.x":
-  version "2.13.1"
-  resolved "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.13.1.tgz#3701b3cabfffda5102af302979aa6e58acfda91a"
-  integrity sha512-yG+uM7lXfwLyKKEwjvP8oZ7qblpmfl9gxQYae55ifbwiTs0CoCTkYkxEaQHGkYtTqGTzLqcb0O9Pzx6vgWg+yg==
+"@date-io/luxon@1.x":
+  version "1.3.13"
+  resolved "https://registry.npmjs.org/@date-io/luxon/-/luxon-1.3.13.tgz#68f0134bb38ef486b2ed6df01981f814c633e28a"
+  integrity sha512-9wUrJCNSMZJeYAiH+dbb45oGpnHeFP7TOH/Lt26If47gjFCkjvyINzWx+K5AGsnlP0Qosxc7hkF1yLi6ecutxw==
   dependencies:
-    "@date-io/core" "^2.13.1"
+    "@date-io/core" "^1.3.13"
 
 "@elastic/elasticsearch-mock@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
So it turns out that that the `@material-ui/pickers` library that we use requires `@date-io/luxon@1.x` range as they don't support v2. This broke at least the `bazaar` plugin, but the chances are is that it broke the `ilert` plugin too, and we don't have any tests around this.

We also can't run both these versions together as they need to be the same due to typescript namespacing and non versioned namespaces causing duplicate identifier warnings.

Rolling this back for now, which closes #9307 but, we really should be adding some tests that we can rely on in these plugins so we don't make the same mistakes moving forward with version bumps.