### PR TITLE
api-extractor: add doc transforms for arrow components and func decls

### DIFF
--- a/scripts/api-extractor.ts
+++ b/scripts/api-extractor.ts
@@ -821,9 +821,9 @@ async function main() {
   const selectedPackageDirs = await findSpecificPackageDirs(
     process.argv.slice(2).filter(arg => !arg.startsWith('--')),
   );
-  if (selectedPackageDirs && (isCiBuild || isDocsBuild)) {
+  if (selectedPackageDirs && isCiBuild) {
     throw new Error(
-      'Package path arguments are not supported for the --ci and --docs flags',
+      'Package path arguments are not supported together with the --ci flag',
     );
   }
   if (!selectedPackageDirs && !isCiBuild && !isDocsBuild) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Piling onto the huge mess that is the API Extractor script :grin:

This introduces doc transforms for the API Reference. This most important one being a transform from arrow function into regular function declaration for components. Bit of a best effort thing for now but want to explore how effective it can be.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
