### PR TITLE
cli: versions:bump prefer latest manifest when next release is specified

### DIFF
--- a/.changeset/blue-jobs-know.md
+++ b/.changeset/blue-jobs-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The `versions:bump --release next` command is updated to compare the `main` and `next` release manifests and prefer the latest.


### PR DESCRIPTION
The `versions:bump --release next` command is updated to compare the `main` and `next` release manifests and prefer the latest.
