### PR TITLE
Bump passport-oauth2 to version 1.6.1

### DIFF
--- a/.changeset/fast-lizards-fly.md
+++ b/.changeset/fast-lizards-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Bump `passport-oauth2` to version 1.6.1

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -65,7 +65,7 @@
     "passport-gitlab2": "^5.0.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-microsoft": "^0.1.0",
-    "passport-oauth2": "^1.5.0",
+    "passport-oauth2": "^1.6.1",
     "passport-okta-oauth": "^0.0.1",
     "passport-onelogin-oauth": "^0.0.1",
     "passport-saml": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18893,7 +18893,7 @@ passport-oauth2@1.2.0:
     passport-strategy "1.x.x"
     uid2 "0.0.x"
 
-passport-oauth2@1.x.x, passport-oauth2@^1.1.2, passport-oauth2@^1.4.0, passport-oauth2@^1.5.0:
+passport-oauth2@1.x.x, passport-oauth2@^1.1.2, passport-oauth2@^1.4.0, passport-oauth2@^1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz#c5aee8f849ce8bd436c7f81d904a3cd1666f181b"
   integrity sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==


### PR DESCRIPTION
Because of CVE-2021-41580, but `passport-microsoft` still pulls in the old one and doesn't seem to be maintained :/ https://github.com/seanfisher/passport-microsoft/issues/14