### PR TITLE
[chore] Adds npm package info for plugin-home.

### DIFF
--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -10,6 +10,16 @@
     "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
+  "homepage": "https://github.com/backstage/backstage/tree/master/plugins/home#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/home"
+  },
+  "keywords": [
+    "backstage",
+    "homepage"
+  ],
   "scripts": {
     "build": "backstage-cli plugin:build",
     "start": "backstage-cli plugin:serve",


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Taking it real easy for my first proposed PR here, thanks for working on Backstage!

[From the NPM docs regarding repository](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository), that field enables `npm docs` command to find this project. The additional fields I add here provide super-convenient links when viewing [the package for this plugin in npmjs](https://www.npmjs.com/package/@backstage/plugin-home).

To better illustrate the utility of the page, if we compare to another `backstage` plugin, graphiql, we see some convenient links from [its npmjs package info](https://github.com/backstage/backstage/blob/v0.67.0/plugins/graphiql/package.json#L12-L19) that takes one directly to the source.

https://www.npmjs.com/package/@backstage/plugin-graphiql
<img width="400" alt="screenshot of the npm page for the graphiql plugin showing the fields from package.json being added as hyperlinks" src="https://user-images.githubusercontent.com/47125187/153552237-773e3fc6-11be-485f-98c1-82acbfff6279.png">

Whereas, before this PR is merged, the current `home` npmjs view shows (note that `repository` and `homepage` are missing:
https://www.npmjs.com/package/@backstage/plugin-home

<img width="400" alt="screenshot of the npm page for the home plugin showing no such links" src="https://user-images.githubusercontent.com/47125187/153552400-049217bf-3ec1-474f-80b0-c6b7e5530a1a.png">



And we certainly don't want the homepage plugin to be missing a homepage, now do we!? :)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets)) -- 
      -- MCV: this is a metadata update, do we require changeset for these or it's OK to leave it out?
- [x] Added or updated documentation - purely updating documentation within the defined parameters of `package.json`.
- [x] ~Tests for new functionality and regression tests for bug fixes~ - N/A
- [x] ~Screenshots attached (for UI changes)~ - N/A
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
