### PR TITLE
Change colors for highlighted code

### DIFF
--- a/.changeset/silly-ghosts-dance.md
+++ b/.changeset/silly-ghosts-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Improve overall appearance of higlighted code in docs.

--- a/.changeset/silly-ghosts-dance.md
+++ b/.changeset/silly-ghosts-dance.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs': patch
 ---
 
-Improve overall appearance of higlighted code in docs.
+Improve overall appearance of highlighted code in docs.

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -142,6 +142,7 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
   const techdocsSanitizer = useApi(configApiRef);
   const { namespace = '', kind = '', name = '' } = entityRef;
   const { state, path, content: rawPage } = useTechDocsReader();
+  const isDarkTheme = theme.palette.type === 'dark';
 
   const [sidebars, setSidebars] = useState<HTMLElement[]>();
   const [dom, setDom] = useState<HTMLElement | null>(null);
@@ -218,6 +219,27 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
             --md-code-bg-color: ${theme.palette.background.paper};
             --md-accent-fg-color: ${theme.palette.primary.main};
             --md-default-fg-color--lightest: ${theme.palette.textVerySubtle};
+          }
+          .codehilite .gd, .highlight .gd { 
+            background-color: ${isDarkTheme ? 'rgba(248,81,73,0.65)' : '#fdd'};
+          }
+          .codehilite .gi, .highlight .gi {
+            background-color: ${isDarkTheme ? 'rgba(46,160,67,0.65)' : '#dfd'};
+          }
+          .highlight .kd {
+            color: ${isDarkTheme ? '#4aaaf7' : '#3b78e7'};
+          }
+           .highlight .k {
+            color: ${isDarkTheme ? '#4aaaf7' : '#3b78e7'};
+          }
+          .highlight .nx {
+            color: ${isDarkTheme ? '#ff53a3' : '#ec407a'};
+          }
+          .highlight .s1 {
+            color: ${isDarkTheme ? '#1cad46' : 'rgb(13, 144, 79)'};
+          }
+          .highlight .kt {
+            color: ${isDarkTheme ? '#4aaaf7' : '#3e61a2'};
           }
           .md-main__inner { margin-top: 0; }
           .md-sidebar {  position: fixed; bottom: 100px; width: 20rem; }
@@ -351,21 +373,22 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
         }),
       ]),
     [
+      techdocsSanitizer,
+      techdocsStorageApi,
       kind,
       name,
       namespace,
       scmIntegrationsApi,
-      techdocsStorageApi,
-      techdocsSanitizer,
-      theme.palette.action.disabledBackground,
-      theme.palette.background.default,
-      theme.palette.background.paper,
-      theme.palette.primary.main,
-      theme.palette.success.main,
-      theme.palette.text.primary,
-      theme.palette.textSubtle,
-      theme.palette.textVerySubtle,
       theme.typography.fontFamily,
+      theme.palette.text.primary,
+      theme.palette.primary.main,
+      theme.palette.background.paper,
+      theme.palette.background.default,
+      theme.palette.textVerySubtle,
+      theme.palette.textSubtle,
+      theme.palette.action.disabledBackground,
+      theme.palette.success.main,
+      isDarkTheme,
       isPinned,
     ],
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As reported in https://github.com/backstage/backstage/issues/9395. it is hard for users to detect text in diff docs. My proposal would be to do something like this which makes it a bit more readable.
<img width="559" alt="Screenshot 2022-02-11 at 09 40 19" src="https://user-images.githubusercontent.com/7230518/153590333-1ce75ea8-606a-4321-8b5c-9e07fd2b54c5.png">
 instead of currently used
<img width="723" alt="Screenshot 2022-02-11 at 09 43 30" src="https://user-images.githubusercontent.com/7230518/153590341-6ceea5bf-bba8-4e92-9f0b-179628cedb76.png">
and 
<img width="568" alt="Screenshot 2022-02-11 at 09 40 32" src="https://user-images.githubusercontent.com/7230518/153590337-600a4ca6-431a-4d3f-900c-daa9bf8cee18.png">
instead of
<img width="724" alt="Screenshot 2022-02-11 at 09 43 40" src="https://user-images.githubusercontent.com/7230518/153590345-65b777de-4c7b-435f-92fd-788edbc4d1c6.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
