### PR TITLE
catalog-model: deprecate unused exports

### DIFF
--- a/.changeset/stupid-cows-design.md
+++ b/.changeset/stupid-cows-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Deprecates the following exports which all have very limited and internal use. `ENTITY_META_GENERATED_FIELDS`, `entityHasChanges`, `generateEntityEtag`, `generateEntityUid`, `generateUpdatedEntity`, `ENTITY_META_GENERATED_FIELDS`.

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -126,7 +126,7 @@ export type Entity = {
 // @public
 export const ENTITY_DEFAULT_NAMESPACE = 'default';
 
-// @public
+// @public @deprecated
 export const ENTITY_META_GENERATED_FIELDS: readonly [
   'uid',
   'etag',
@@ -148,7 +148,7 @@ export function entityEnvelopeSchemaValidator<
   T extends EntityEnvelope = EntityEnvelope,
 >(schema?: unknown): (data: unknown) => T;
 
-// @public
+// @public @deprecated
 export function entityHasChanges(previous: Entity, next: Entity): boolean;
 
 // @public
@@ -252,13 +252,13 @@ export class FieldFormatEntityPolicy implements EntityPolicy {
   enforce(entity: Entity): Promise<Entity>;
 }
 
-// @public
+// @public @deprecated
 export function generateEntityEtag(): string;
 
-// @public
+// @public @deprecated
 export function generateEntityUid(): string;
 
-// @public
+// @public @deprecated
 export function generateUpdatedEntity(previous: Entity, next: Entity): Entity;
 
 // @public

--- a/packages/catalog-model/src/entity/constants.ts
+++ b/packages/catalog-model/src/entity/constants.ts
@@ -25,6 +25,7 @@ export const ENTITY_DEFAULT_NAMESPACE = 'default';
  * The keys of EntityMeta that are auto-generated.
  *
  * @public
+ * @deprecated will be removed in a future release.
  */
 export const ENTITY_META_GENERATED_FIELDS = [
   'uid',

--- a/packages/catalog-model/src/entity/util.ts
+++ b/packages/catalog-model/src/entity/util.ts
@@ -23,6 +23,7 @@ import { Entity, AlphaEntity } from './Entity';
  *
  * @public
  * @returns A string with enough randomness to uniquely identify an entity
+ * @deprecated use `uuidv4()` instead.
  */
 export function generateEntityUid(): string {
   return uuidv4();
@@ -34,6 +35,7 @@ export function generateEntityUid(): string {
  * @public
  * @returns A string with enough randomness to uniquely identify an entity
  *          revision
+ * @deprecated will be removed in a future release.
  */
 export function generateEntityEtag(): string {
   return Buffer.from(uuidv4(), 'utf8').toString('base64').replace(/[^\w]/g, '');
@@ -55,6 +57,7 @@ export function generateEntityEtag(): string {
  * @public
  * @param previous - The old state of the entity
  * @param next - The new state of the entity
+ * @deprecated will be removed in a future release.
  */
 export function entityHasChanges(previous: Entity, next: Entity): boolean {
   const e1 = lodash.cloneDeep(previous);
@@ -109,6 +112,7 @@ export function entityHasChanges(previous: Entity, next: Entity): boolean {
  * @param previous - The old state of the entity
  * @param next - The new state of the entity
  * @returns An entity with the merged state of both
+ * @deprecated will be removed in a future release.
  */
 export function generateUpdatedEntity(previous: Entity, next: Entity): Entity {
   const { uid, etag, generation } = previous.metadata;


### PR DESCRIPTION
Deprecates the following exports which all have very limited and internal use. `ENTITY_META_GENERATED_FIELDS`, `entityHasChanges`, `generateEntityEtag`, `generateEntityUid`, `generateUpdatedEntity`, `ENTITY_META_GENERATED_FIELDS`.