### PR TITLE
scaffolder-backend: fix error behaviour in runCommand helper

### DIFF
--- a/.changeset/brown-impalas-greet.md
+++ b/.changeset/brown-impalas-greet.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix error handling of the `runCommand` helper to return `Error`
+instance.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -58,7 +58,9 @@ export const runCommand = async ({
 
     process.on('close', code => {
       if (code !== 0) {
-        return reject(`Command ${command} failed, exit code: ${code}`);
+        return reject(
+          new Error(`Command ${command} failed, exit code: ${code}`),
+        );
       }
       return resolve();
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes error-handling behaviour in `helpers.ts` `runCommand()` function.

### Issue:

Raising non-`Error` objects from `runCommand` helper in `plugin-scaffolder-backend` failed `@backstage/errors` `assertError()` checks, which causes `UnhandledPromiseRejection` when a Scaffolder worker process failed. This in-turn causes the task runner in question to fail and is only recoverable by restarting the backend server completely. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
