### PR TITLE
catalog-backend: add support for querying facets

### DIFF
--- a/.changeset/dry-ties-collect.md
+++ b/.changeset/dry-ties-collect.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added an `/entity-facets` endpoint, which lets you query the distribution of
+possible values for fields of entities.
+
+This can be useful for example when populating a dropdown in the user interface,
+such as listing all tag values that are actually being used right now in your
+catalog instance, along with putting the most common ones at the top.

--- a/.changeset/lucky-bulldogs-own.md
+++ b/.changeset/lucky-bulldogs-own.md
@@ -8,6 +8,7 @@
 '@backstage/plugin-catalog-react': patch
 '@backstage/plugin-explore': patch
 '@backstage/plugin-fossa': patch
+'@backstage/plugin-scaffolder': patch
 '@backstage/plugin-todo-backend': patch
 ---
 

--- a/.changeset/lucky-bulldogs-own.md
+++ b/.changeset/lucky-bulldogs-own.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-auth-backend': patch
+'@backstage/plugin-badges-backend': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-graph': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-explore': patch
+'@backstage/plugin-fossa': patch
+'@backstage/plugin-todo-backend': patch
+---
+
+Updated according to the new `getEntityFacets` catalog API method

--- a/.changeset/tiny-ads-knock.md
+++ b/.changeset/tiny-ads-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Added `getEntityFacets` to the client

--- a/.changeset/tiny-ads-knock.md
+++ b/.changeset/tiny-ads-knock.md
@@ -2,4 +2,7 @@
 '@backstage/catalog-client': patch
 ---
 
-Added `getEntityFacets` to the client
+Added `CatalogApi.getEntityFacets`. Marking this as a breaking change since it
+is a non-optional addition to the API and depends on the backend being in place.
+If you are mocking this interface in your tests, you will need to add an extra
+`getEntityFacets: jest.fn()` or similar to that interface.

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -43,6 +43,10 @@ export interface CatalogApi {
     name: EntityName,
     options?: CatalogRequestOptions,
   ): Promise<Entity | undefined>;
+  getEntityFacets(
+    request: GetEntityFacetsRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<GetEntityFacetsResponse>;
   getLocationById(
     id: string,
     options?: CatalogRequestOptions,
@@ -91,6 +95,10 @@ export class CatalogClient implements CatalogApi {
     compoundName: EntityName,
     options?: CatalogRequestOptions,
   ): Promise<Entity | undefined>;
+  getEntityFacets(
+    request: GetEntityFacetsRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<GetEntityFacetsResponse>;
   // @deprecated (undocumented)
   getLocationByEntity(
     entity: Entity,
@@ -178,6 +186,26 @@ export interface GetEntityAncestorsResponse {
   }>;
   // (undocumented)
   rootEntityRef: string;
+}
+
+// @public
+export interface GetEntityFacetsRequest {
+  facets: string[];
+  filter?:
+    | Record<string, string | symbol | (string | symbol)[]>[]
+    | Record<string, string | symbol | (string | symbol)[]>
+    | undefined;
+}
+
+// @public
+export interface GetEntityFacetsResponse {
+  facets: Record<
+    string,
+    Array<{
+      value: string;
+      count: number;
+    }>
+  >;
 }
 
 // @public

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -143,6 +143,90 @@ export interface GetEntityAncestorsResponse {
 }
 
 /**
+ * The request type for {@link CatalogClient.getEntityFacets}.
+ *
+ * @public
+ */
+export interface GetEntityFacetsRequest {
+  /**
+   * If given, return only entities that match the given patterns.
+   *
+   * @remarks
+   *
+   * If multiple filter sets are given as an array, then there is effectively an
+   * OR between each filter set.
+   *
+   * Within one filter set, there is effectively an AND between the various
+   * keys.
+   *
+   * Within one key, if there are more than one value, then there is effectively
+   * an OR between them.
+   *
+   * Example: For an input of
+   *
+   * ```
+   * [
+   *   { kind: ['API', 'Component'] },
+   *   { 'metadata.name': 'a', 'metadata.namespace': 'b' }
+   * ]
+   * ```
+   *
+   * This effectively means
+   *
+   * ```
+   * (kind = EITHER 'API' OR 'Component')
+   * OR
+   * (metadata.name = 'a' AND metadata.namespace = 'b' )
+   * ```
+   *
+   * Each key is a dot separated path in each object.
+   *
+   * As a value you can also pass in the symbol `CATALOG_FILTER_EXISTS`
+   * (exported from this package), which means that you assert on the existence
+   * of that key, no matter what its value is.
+   */
+  filter?:
+    | Record<string, string | symbol | (string | symbol)[]>[]
+    | Record<string, string | symbol | (string | symbol)[]>
+    | undefined;
+  /**
+   * Dot separated paths for the facets to extract from each entity.
+   *
+   * @remarks
+   *
+   * Example: For an input of `['kind', 'metadata.annotations.backstage.io/orphan']`, then the
+   * response will be shaped like
+   *
+   * ```
+   * {
+   *   "facets": {
+   *     "kind": [
+   *       { "key": "Component", "count": 22 },
+   *       { "key": "API", "count": 13 }
+   *     ],
+   *     "metadata.annotations.backstage.io/orphan": [
+   *       { "key": "true", "count": 2 }
+   *     ]
+   *   }
+   * }
+   * ```
+   */
+  facets: string[];
+}
+
+/**
+ * The response type for {@link CatalogClient.getEntityFacets}.
+ *
+ * @public
+ */
+export interface GetEntityFacetsResponse {
+  /**
+   * The computed facets, one entry per facet in the request.
+   */
+  facets: Record<string, Array<{ value: string; count: number }>>;
+}
+
+/**
  * Options you can pass into a catalog request for additional information.
  *
  * @public
@@ -247,6 +331,17 @@ export interface CatalogApi {
     entityRef: string,
     options?: CatalogRequestOptions,
   ): Promise<void>;
+
+  /**
+   * Gets a summary of field facets of entities in the catalog.
+   *
+   * @param request - Request parameters
+   * @param options - Additional options
+   */
+  getEntityFacets(
+    request: GetEntityFacetsRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<GetEntityFacetsResponse>;
 
   // Locations
 

--- a/packages/catalog-client/src/types/index.ts
+++ b/packages/catalog-client/src/types/index.ts
@@ -25,6 +25,8 @@ export type {
   GetEntityAncestorsRequest,
   GetEntityAncestorsResponse,
   Location,
+  GetEntityFacetsRequest,
+  GetEntityFacetsResponse,
 } from './api';
-export { ENTITY_STATUS_CATALOG_PROCESSING_TYPE } from './status';
 export * from './deprecated';
+export { ENTITY_STATUS_CATALOG_PROCESSING_TYPE } from './status';

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -34,6 +34,7 @@ describe('CatalogIdentityClient', () => {
     removeEntityByUid: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
+    getEntityFacets: jest.fn(),
   };
   const tokenManager: jest.Mocked<TokenManager> = {
     getToken: jest.fn(),

--- a/plugins/badges-backend/src/service/router.test.ts
+++ b/plugins/badges-backend/src/service/router.test.ts
@@ -67,6 +67,7 @@ describe('createRouter', () => {
       removeEntityByUid: jest.fn(),
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
+      getEntityFacets: jest.fn(),
     };
 
     config = new ConfigReader({

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -600,6 +600,7 @@ export type EntitiesCatalog = {
       authorizationToken?: string;
     },
   ): Promise<EntityAncestryResponse>;
+  facets(request: EntityFacetsRequest): Promise<EntityFacetsResponse>;
 };
 
 // Warning: (ae-missing-release-tag) "EntitiesRequest" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -644,6 +645,24 @@ export type EntityAncestryResponse = {
     parentEntityRefs: string[];
   }>;
 };
+
+// @public
+export interface EntityFacetsRequest {
+  authorizationToken?: string;
+  facets: string[];
+  filter?: EntityFilter;
+}
+
+// @public
+export interface EntityFacetsResponse {
+  facets: Record<
+    string,
+    Array<{
+      value: string;
+      count: number;
+    }>
+  >;
+}
 
 // Warning: (ae-missing-release-tag) "EntityFilter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/catalog-backend/src/catalog/index.ts
+++ b/plugins/catalog-backend/src/catalog/index.ts
@@ -18,9 +18,11 @@ export type {
   EntitiesCatalog,
   EntitiesRequest,
   EntitiesResponse,
-  EntityAncestryResponse,
-  PageInfo,
   EntitiesSearchFilter,
+  EntityAncestryResponse,
+  EntityFacetsRequest,
+  EntityFacetsResponse,
   EntityFilter,
   EntityPagination,
+  PageInfo,
 } from './types';

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -87,6 +87,44 @@ export type EntityAncestryResponse = {
   }>;
 };
 
+/**
+ * The request shape for {@link EntitiesCatalog.facets}.
+ *
+ * @public
+ */
+export interface EntityFacetsRequest {
+  /**
+   * A filter to apply on the full list of entities before computing the facets.
+   */
+  filter?: EntityFilter;
+  /**
+   * The facets to compute.
+   *
+   * @remarks
+   *
+   * This is a list of strings corresponding to paths within individual entity
+   * shapes. For example, to compute the facets for all available tags, you
+   * would pass in the string 'metadata.tags'.
+   */
+  facets: string[];
+  /**
+   * The optional token that authorizes the action.
+   */
+  authorizationToken?: string;
+}
+
+/**
+ * The response shape for {@link EntitiesCatalog.facets}.
+ *
+ * @public
+ */
+export interface EntityFacetsResponse {
+  /**
+   * The computed facets, one entry per facet in the request.
+   */
+  facets: Record<string, Array<{ value: string; count: number }>>;
+}
+
 /** @public */
 export type EntitiesCatalog = {
   /**
@@ -115,4 +153,12 @@ export type EntitiesCatalog = {
     entityRef: string,
     options?: { authorizationToken?: string },
   ): Promise<EntityAncestryResponse>;
+
+  /**
+   * Computes facets for a set of entities, e.g. for populating filter lists
+   * or driving insights or similar.
+   *
+   * @param request - Request options
+   */
+  facets(request: EntityFacetsRequest): Promise<EntityFacetsResponse>;
 };

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -40,6 +40,7 @@ describe('createRouter readonly disabled', () => {
       entities: jest.fn(),
       removeEntityByUid: jest.fn(),
       entityAncestry: jest.fn(),
+      facets: jest.fn(),
     };
     locationService = {
       getLocation: jest.fn(),
@@ -394,6 +395,7 @@ describe('createRouter readonly enabled', () => {
       entities: jest.fn(),
       removeEntityByUid: jest.fn(),
       entityAncestry: jest.fn(),
+      facets: jest.fn(),
     };
     locationService = {
       getLocation: jest.fn(),
@@ -578,6 +580,7 @@ describe('NextRouter permissioning', () => {
       entities: jest.fn(),
       removeEntityByUid: jest.fn(),
       entityAncestry: jest.fn(),
+      facets: jest.fn(),
     };
     locationService = {
       getLocation: jest.fn(),

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -37,6 +37,7 @@ import {
 } from './util';
 import { RefreshOptions, LocationService, RefreshService } from './types';
 import { z } from 'zod';
+import { parseEntityFacetParams } from './request/parseEntityFacetParams';
 
 /**
  * Options used by {@link createRouter}.
@@ -160,7 +161,15 @@ export async function createRouter(
           const response = await entitiesCatalog.entityAncestry(entityRef);
           res.status(200).json(response);
         },
-      );
+      )
+      .get('/entity-facets', async (req, res) => {
+        const response = await entitiesCatalog.facets({
+          filter: parseEntityFilterParams(req.query),
+          facets: parseEntityFacetParams(req.query),
+          authorizationToken: getBearerToken(req.header('authorization')),
+        });
+        res.status(200).json(response);
+      });
   }
 
   if (locationService) {

--- a/plugins/catalog-backend/src/service/request/parseEntityFacetParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFacetParams.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+import { parseStringsParam } from './common';
+
+/**
+ * Parses the facets part of a facet query, like
+ * /entity-facets?filter=metadata.namespace=default,kind=Component&facet=metadata.namespace
+ */
+export function parseEntityFacetParams(
+  params: Record<string, unknown>,
+): string[] {
+  // Each facet string is on the form a.b.c
+  const facetStrings = parseStringsParam(params.facet, 'facet');
+  if (facetStrings) {
+    const filtered = facetStrings.filter(Boolean);
+    if (filtered.length) {
+      return filtered;
+    }
+  }
+
+  throw new InputError('Missing facet parameter');
+}

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
@@ -65,6 +65,7 @@ describe('<CatalogGraphCard/>', () => {
       removeLocationById: jest.fn(),
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
+      getEntityFacets: jest.fn(),
     };
     apis = TestApiRegistry.from([catalogApiRef, catalog]);
 

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.test.tsx
@@ -94,6 +94,7 @@ describe('<CatalogGraphPage/>', () => {
       removeLocationById: jest.fn(),
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
+      getEntityFacets: jest.fn(),
     };
 
     wrapper = (

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
@@ -155,6 +155,7 @@ describe('<EntityRelationsGraph/>', () => {
       removeLocationById: jest.fn(),
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
+      getEntityFacets: jest.fn(),
     };
 
     Wrapper = ({ children }) => (

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityStore.test.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityStore.test.ts
@@ -37,6 +37,7 @@ describe('useEntityStore', () => {
       removeLocationById: jest.fn(),
       refreshEntity: jest.fn(),
       getEntityAncestors: jest.fn(),
+      getEntityFacets: jest.fn(),
     };
 
     useApi.mockReturnValue(catalogApi);

--- a/plugins/catalog-import/src/api/CatalogImportClient.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.test.ts
@@ -99,6 +99,7 @@ describe('CatalogImportClient', () => {
     removeEntityByUid: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
+    getEntityFacets: jest.fn(),
   };
 
   let catalogImportClient: CatalogImportClient;

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -45,6 +45,7 @@ describe('<StepPrepareCreatePullRequest />', () => {
     removeEntityByUid: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
+    getEntityFacets: jest.fn(),
   };
 
   const errorApi: jest.Mocked<typeof errorApiRef.T> = {

--- a/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
@@ -26,6 +26,7 @@ import { EntityKindFilter, EntityTypeFilter } from '../../filters';
 import { alertApiRef } from '@backstage/core-plugin-api';
 import { ApiProvider } from '@backstage/core-app-api';
 import { renderWithEffects, TestApiRegistry } from '@backstage/test-utils';
+import { GetEntityFacetsResponse } from '@backstage/catalog-client';
 
 const entities: Entity[] = [
   {
@@ -64,7 +65,14 @@ const apis = TestApiRegistry.from(
   [
     catalogApiRef,
     {
-      getEntities: jest.fn().mockResolvedValue({ items: entities }),
+      getEntityFacets: jest.fn().mockResolvedValue({
+        facets: {
+          'spec.type': entities.map(e => ({
+            value: (e.spec as any).type,
+            count: 1,
+          })),
+        },
+      } as GetEntityFacetsResponse),
     },
   ],
   [

--- a/plugins/catalog-react/src/hooks/useEntityKinds.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityKinds.test.tsx
@@ -16,45 +16,21 @@
 
 import React, { PropsWithChildren } from 'react';
 import { CatalogApi } from '@backstage/catalog-client';
-import { Entity } from '@backstage/catalog-model';
 import { catalogApiRef } from '../api';
 import { renderHook } from '@testing-library/react-hooks';
 import { useEntityKinds } from './useEntityKinds';
 import { TestApiProvider } from '@backstage/test-utils';
 
-const entities: Entity[] = [
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      name: 'component-1',
-    },
-  },
-  {
-    apiVersion: '1',
-    kind: 'Component',
-    metadata: {
-      name: 'component-2',
-    },
-  },
-  {
-    apiVersion: '1',
-    kind: 'Template',
-    metadata: {
-      name: 'template',
-    },
-  },
-  {
-    apiVersion: '1',
-    kind: 'System',
-    metadata: {
-      name: 'system',
-    },
-  },
-];
-
 const mockCatalogApi: Partial<CatalogApi> = {
-  getEntities: jest.fn().mockResolvedValue({ items: entities }),
+  getEntityFacets: jest.fn().mockResolvedValue({
+    facets: {
+      kind: [
+        { value: 'Template', count: 2 },
+        { value: 'System', count: 1 },
+        { value: 'Component', count: 3 },
+      ],
+    },
+  }),
 };
 
 const wrapper = ({ children }: PropsWithChildren<{}>) => {
@@ -66,24 +42,10 @@ const wrapper = ({ children }: PropsWithChildren<{}>) => {
 };
 
 describe('useEntityKinds', () => {
-  it('does not return duplicate kinds', async () => {
+  it('gets entity kinds', async () => {
     const { result, waitForValueToChange } = renderHook(
       () => useEntityKinds(),
-      {
-        wrapper,
-      },
-    );
-    await waitForValueToChange(() => result.current);
-    expect(result.current.kinds).toBeDefined();
-    expect(result.current.kinds!.length).toBe(3);
-  });
-
-  it('sorts entity kinds', async () => {
-    const { result, waitForValueToChange } = renderHook(
-      () => useEntityKinds(),
-      {
-        wrapper,
-      },
+      { wrapper },
     );
     await waitForValueToChange(() => result.current);
     expect(result.current.kinds).toEqual(['Component', 'System', 'Template']);

--- a/plugins/catalog-react/src/hooks/useEntityKinds.ts
+++ b/plugins/catalog-react/src/hooks/useEntityKinds.ts
@@ -27,11 +27,9 @@ export function useEntityKinds() {
     loading,
     value: kinds,
   } = useAsync(async () => {
-    const entities = await catalogApi
-      .getEntities({ fields: ['kind'] })
-      .then(response => response.items);
-
-    return [...new Set(entities.map(e => e.kind))].sort();
+    return await catalogApi
+      .getEntityFacets({ facets: ['kind'] })
+      .then(response => response.facets.kind?.map(f => f.value).sort() || []);
   });
   return { error, loading, kinds };
 }

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import isEqual from 'lodash/isEqual';
+import sortBy from 'lodash/sortBy';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '../api';
 import { useEntityListProvider } from './useEntityListProvider';
@@ -67,51 +68,34 @@ export function useEntityTypeFilter(): EntityTypeReturn {
   const {
     error,
     loading,
-    value: entities,
+    value: facets,
   } = useAsync(async () => {
     if (kind) {
       const items = await catalogApi
-        .getEntities({
+        .getEntityFacets({
           filter: { kind },
-          fields: ['spec.type'],
+          facets: ['spec.type'],
         })
-        .then(response => response.items);
+        .then(response => response.facets['spec.type'] || []);
       return items;
     }
     return [];
   }, [kind, catalogApi]);
 
-  const entitiesRef = useRef(entities);
+  const facetsRef = useRef(facets);
   useEffect(() => {
-    const oldEntities = entitiesRef.current;
-    entitiesRef.current = entities;
-    // Delay processing hook until kind and entity load updates have settled to generate list of types;
-    // This prevents reseting the type filter due to saved type value from query params not matching the
+    const oldFacets = facetsRef.current;
+    facetsRef.current = facets;
+    // Delay processing hook until kind and facets load updates have settled to generate list of types;
+    // This prevents resetting the type filter due to saved type value from query params not matching the
     // empty set of type values while values are still being loaded; also only run this hook on changes
-    // to entities
-    if (loading || !kind || oldEntities === entities) {
+    // to facets
+    if (loading || !kind || oldFacets === facets || !facets) {
       return;
     }
 
-    // Resolve the unique set of types from returned entities; could be optimized by a new endpoint
-    // in the catalog-backend that does this, rather than loading entities with redundant types.
-    if (!entities) return;
-
-    // Sort by entity count descending, so the most common types appear on top
-    const countByType = entities.reduce((acc, entity) => {
-      if (typeof entity.spec?.type !== 'string') return acc;
-
-      const entityType = entity.spec.type.toLocaleLowerCase('en-US');
-      if (!acc[entityType]) {
-        acc[entityType] = 0;
-      }
-      acc[entityType] += 1;
-      return acc;
-    }, {} as Record<string, number>);
-
-    const newTypes = Object.entries(countByType)
-      .sort(([, count1], [, count2]) => count2 - count1)
-      .map(([type]) => type);
+    // Sort by facet count descending, so the most common types appear on top
+    const newTypes = sortBy(facets, f => -f.count).map(f => f.value);
     setAvailableTypes(newTypes);
 
     // Update type filter to only valid values when the list of available types has changed
@@ -121,7 +105,7 @@ export function useEntityTypeFilter(): EntityTypeReturn {
     if (!isEqual(selectedTypes, stillValidTypes)) {
       setSelectedTypes(stillValidTypes);
     }
-  }, [loading, kind, selectedTypes, setSelectedTypes, entities]);
+  }, [loading, kind, selectedTypes, setSelectedTypes, facets]);
 
   useEffect(() => {
     updateFilters({

--- a/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.test.tsx
+++ b/plugins/catalog/src/components/CatalogKindHeader/CatalogKindHeader.test.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
+import { GetEntityFacetsResponse } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import {
   catalogApiRef,
@@ -60,7 +61,15 @@ const entities: Entity[] = [
 const apis = TestApiRegistry.from([
   catalogApiRef,
   {
-    getEntities: jest.fn().mockResolvedValue({ items: entities }),
+    getEntityFacets: jest.fn().mockResolvedValue({
+      facets: {
+        kind: [
+          { value: 'Component', count: 2 },
+          { value: 'Template', count: 1 },
+          { value: 'System', count: 1 },
+        ],
+      },
+    } as GetEntityFacetsResponse),
   },
 ]);
 

--- a/plugins/explore/src/components/DefaultExplorePage/DefaultExplorePage.test.tsx
+++ b/plugins/explore/src/components/DefaultExplorePage/DefaultExplorePage.test.tsx
@@ -31,6 +31,7 @@ describe('<DefaultExplorePage />', () => {
     getEntityByName: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
+    getEntityFacets: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -32,6 +32,7 @@ describe('<DomainExplorerContent />', () => {
     getEntityByName: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
+    getEntityFacets: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
@@ -32,6 +32,7 @@ describe('<GroupsExplorerContent />', () => {
     getEntityByName: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
+    getEntityFacets: jest.fn(),
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (

--- a/plugins/fossa/src/components/FossaPage/FossaPage.test.tsx
+++ b/plugins/fossa/src/components/FossaPage/FossaPage.test.tsx
@@ -36,6 +36,7 @@ describe('<FossaPage />', () => {
     removeLocationById: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
+    getEntityFacets: jest.fn(),
   };
   const fossaApi: jest.Mocked<FossaApi> = {
     getFindingSummary: jest.fn(),

--- a/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.test.tsx
+++ b/plugins/scaffolder/src/components/TemplateTypePicker/TemplateTypePicker.test.tsx
@@ -17,7 +17,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { capitalize } from 'lodash';
-import { CatalogApi } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import { TemplateTypePicker } from './TemplateTypePicker';
 import {
@@ -28,6 +27,7 @@ import {
 import { AlertApi, alertApiRef } from '@backstage/core-plugin-api';
 import { ApiProvider } from '@backstage/core-app-api';
 import { renderWithEffects, TestApiRegistry } from '@backstage/test-utils';
+import { GetEntityFacetsResponse } from '@backstage/catalog-client';
 
 const entities: Entity[] = [
   {
@@ -66,10 +66,15 @@ const apis = TestApiRegistry.from(
   [
     catalogApiRef,
     {
-      getEntities: jest
-        .fn()
-        .mockImplementation(() => Promise.resolve({ items: entities })),
-    } as unknown as CatalogApi,
+      getEntityFacets: jest.fn().mockResolvedValue({
+        facets: {
+          'spec.type': entities.map(e => ({
+            value: (e.spec as any).type,
+            count: 1,
+          })),
+        },
+      } as GetEntityFacetsResponse),
+    },
   ],
   [
     alertApiRef,

--- a/plugins/todo-backend/src/service/TodoReaderService.test.ts
+++ b/plugins/todo-backend/src/service/TodoReaderService.test.ts
@@ -51,6 +51,7 @@ function mockCatalogClient(entity?: Entity): jest.Mocked<CatalogApi> {
     removeEntityByUid: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
+    getEntityFacets: jest.fn(),
   };
   if (entity) {
     mock.getEntityByName.mockReturnValue(entity);


### PR DESCRIPTION
Felt like experimenting a bit.

Closes #9139

Sample response, where the catalog home page asked for `/catalog/entity-facets?filter=kind=component&facet=spec.type`:

![Screen Shot 2022-02-14 at 14 04 04](https://user-images.githubusercontent.com/3097461/153869407-fbe27b89-b234-475e-bc95-815665d476d1.png)

