### PR TITLE
remove node version from installation instructions

### DIFF
--- a/docs/getting-started/create-an-app.md
+++ b/docs/getting-started/create-an-app.md
@@ -16,8 +16,7 @@ may want to [Run Backstage Locally](./running-backstage-locally.md) instead.
 ## Create an app
 
 To create a Backstage app, you will need to have
-[Node.js](https://nodejs.org/en/download/) Active LTS Release installed
-(currently v14).
+Node.js [Active LTS Release](https://nodejs.org/en/about/releases/) installed.
 
 Backstage provides a utility for creating new apps. It guides you through the
 initial setup of selecting the name of the app and a database for the backend.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -25,7 +25,7 @@ guide to do a repository-based installation.
   [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/)
 - An account with elevated rights to install the dependencies
 - `curl` or `wget` installed
-- [Node.js Active LTS Release](https://nodejs.org/en/about/releases/) installed using one of these
+Node.js [Active LTS Release](https://nodejs.org/en/about/releases/) installed using one of these
   methods:
   - Using `nvm` (recommended)
     - [Installing nvm](https://github.com/nvm-sh/nvm#install--update-script)

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -25,7 +25,7 @@ guide to do a repository-based installation.
   [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/)
 - An account with elevated rights to install the dependencies
 - `curl` or `wget` installed
-- Node.js Active LTS Release installed (currently v14) using one of these
+- [Node.js Active LTS Release](https://nodejs.org/en/about/releases/) installed using one of these
   methods:
   - Using `nvm` (recommended)
     - [Installing nvm](https://github.com/nvm-sh/nvm#install--update-script)

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -25,7 +25,7 @@ guide to do a repository-based installation.
   [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/)
 - An account with elevated rights to install the dependencies
 - `curl` or `wget` installed
-Node.js [Active LTS Release](https://nodejs.org/en/about/releases/) installed using one of these
+- Node.js [Active LTS Release](https://nodejs.org/en/about/releases/) installed using one of these
   methods:
   - Using `nvm` (recommended)
     - [Installing nvm](https://github.com/nvm-sh/nvm#install--update-script)

--- a/docs/getting-started/running-backstage-locally.md
+++ b/docs/getting-started/running-backstage-locally.md
@@ -13,13 +13,14 @@ trying to contribute, follow the instructions to
 
 - Node.js
 
-First make sure you are using Node.js with an Active LTS Release, currently v14.
+First make sure you are using Node.js with an [Active LTS Release](https://nodejs.org/en/about/releases/).
 This is made easy with a version manager such as
 [nvm](https://github.com/nvm-sh/nvm) which allows for version switching.
 
 ```bash
-# Installing a new version
-nvm install 14
+# Installing current LTS release
+nvm install --lts
+> Installing latest LTS version.
 > Downloading and installing node v14.15.1...
 > Now using node v14.15.1 (npm v6.14.8)
 


### PR DESCRIPTION
It's outdated (v16 is the active LTS curently) and IMO it's better to link to the Node docs rather than update it every 6 months.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] Added or updated documentation
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
