### PR TITLE
cicd-statistics: fix core-plugin-api dependency range

### DIFF
--- a/.changeset/moody-knives-jump.md
+++ b/.changeset/moody-knives-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-cicd-statistics': patch
+---
+
+Updated `@backstage/core-plugin-api` dependency.

--- a/plugins/cicd-statistics/package.json
+++ b/plugins/cicd-statistics/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@backstage/catalog-model": "^0.9.8",
-    "@backstage/core-plugin-api": "^0.4.1",
+    "@backstage/core-plugin-api": "^0.6.0",
     "@backstage/plugin-catalog-react": "^0.6.14",
     "@date-io/luxon": "^1.3.13",
     "@material-ui/core": "^4.9.13",


### PR DESCRIPTION
🧹 