### PR TITLE
cli: introduce new `repo lint` command

### DIFF
--- a/.changeset/angry-bottles-mix.md
+++ b/.changeset/angry-bottles-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Added a new experimental and hidden `backstage-cli repo lint` command that can be used to lint all packages in the project, similar to `lerna run lint`.

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -42,6 +42,17 @@ export function registerRepoCommand(program: CommanderStatic) {
       'Build all packages, including bundled app and backend packages.',
     )
     .action(lazy(() => import('./repo/build').then(m => m.command)));
+
+  command
+    .command('lint')
+    .description('Lint all packages in the project')
+    .option(
+      '--format <format>',
+      'Lint report output format',
+      'eslint-formatter-friendly',
+    )
+    .option('--fix', 'Attempt to automatically fix violations')
+    .action(lazy(() => import('./repo/lint').then(m => m.command)));
 }
 
 export function registerScriptCommand(program: CommanderStatic) {

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -51,6 +51,10 @@ export function registerRepoCommand(program: CommanderStatic) {
       'Lint report output format',
       'eslint-formatter-friendly',
     )
+    .option(
+      '--since <ref>',
+      'Only lint packages that changed since the specified ref',
+    )
     .option('--fix', 'Attempt to automatically fix violations')
     .action(lazy(() => import('./repo/lint').then(m => m.command)));
 }

--- a/packages/cli/src/commands/repo/lint.ts
+++ b/packages/cli/src/commands/repo/lint.ts
@@ -22,7 +22,12 @@ import { runWorkerQueueThreads } from '../../lib/parallel';
 import { paths } from '../../lib/paths';
 
 export async function command(cmd: Command): Promise<void> {
-  const packages = await PackageGraph.listTargetPackages();
+  let packages = await PackageGraph.listTargetPackages();
+
+  if (cmd.since) {
+    const graph = PackageGraph.fromPackages(packages);
+    packages = await graph.listChangedPackages({ ref: cmd.since });
+  }
 
   // This formatter uses the cwd to format file paths, so let's have that happen from the root instead
   if (cmd.format === 'eslint-formatter-friendly') {

--- a/packages/cli/src/commands/repo/lint.ts
+++ b/packages/cli/src/commands/repo/lint.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { relative as relativePath } from 'path';
+import { PackageGraph } from '../../lib/monorepo';
+import { runWorkerQueueThreads } from '../../lib/parallel';
+import { paths } from '../../lib/paths';
+
+export async function command(cmd: Command): Promise<void> {
+  const packages = await PackageGraph.listTargetPackages();
+
+  // This formatter uses the cwd to format file paths, so let's have that happen from the root instead
+  if (cmd.format === 'eslint-formatter-friendly') {
+    process.chdir(paths.targetRoot);
+  }
+
+  // Make sure lint output is colored unless the user explicitly disabled it
+  if (!process.env.FORCE_COLOR) {
+    process.env.FORCE_COLOR = '1';
+  }
+
+  const resultsList = await runWorkerQueueThreads({
+    items: packages.map(pkg => ({
+      fullDir: pkg.dir,
+      relativeDir: relativePath(paths.targetRoot, pkg.dir),
+    })),
+    workerData: {
+      fix: Boolean(cmd.fix),
+      format: cmd.format as string | undefined,
+    },
+    workerFactory: async ({ fix, format }) => {
+      const { ESLint } = require('eslint');
+
+      return async ({
+        fullDir,
+        relativeDir,
+      }): Promise<{ relativeDir: string; resultText: string }> => {
+        // Bit of a hack to make file resolutions happen from the correct directory
+        // since some lint rules don't respect the cwd of ESLint
+        process.cwd = () => fullDir;
+
+        const eslint = new ESLint({
+          cwd: fullDir,
+          fix,
+          extensions: ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs'],
+        });
+        const formatter = await eslint.loadFormatter(format);
+
+        const results = await eslint.lintFiles(['.']);
+
+        const count = String(results.length).padStart(3);
+        console.log(`Checked ${count} files in ${relativeDir}`);
+
+        if (fix) {
+          await ESLint.outputFixes(results);
+        }
+
+        const resultText = formatter.format(results);
+
+        return { relativeDir, resultText };
+      };
+    },
+  });
+
+  let failed = false;
+  for (const { relativeDir, resultText } of resultsList) {
+    if (resultText) {
+      console.log();
+      console.log(chalk.red(`Lint failed in ${relativeDir}:`));
+      console.log(resultText.trimLeft());
+
+      failed = true;
+    }
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/repo/lint.ts
+++ b/packages/cli/src/commands/repo/lint.ts
@@ -71,6 +71,7 @@ export async function command(cmd: Command): Promise<void> {
         // since some lint rules don't respect the cwd of ESLint
         process.cwd = () => fullDir;
 
+        const start = Date.now();
         const eslint = new ESLint({
           cwd: fullDir,
           fix,
@@ -81,7 +82,8 @@ export async function command(cmd: Command): Promise<void> {
         const results = await eslint.lintFiles(['.']);
 
         const count = String(results.length).padStart(3);
-        console.log(`Checked ${count} files in ${relativeDir}`);
+        const time = ((Date.now() - start) / 1000).toFixed(2);
+        console.log(`Checked ${count} files in ${relativeDir} ${time}s`);
 
         if (fix) {
           await ESLint.outputFixes(results);

--- a/packages/cli/src/lib/git.test.ts
+++ b/packages/cli/src/lib/git.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { runGit, listChangedFiles } from './git';
+
+describe('runGit', () => {
+  it('runs a git command', async () => {
+    await expect(runGit('log', 'HEAD..HEAD')).resolves.toEqual(['']);
+  });
+
+  it('fails for unknown commands', async () => {
+    await expect(runGit('ryckbegäran')).rejects.toThrow(
+      /^git ryckbegäran failed, git: 'ryckbegäran' is not a git command/,
+    );
+  });
+
+  it('forwards failures', async () => {
+    await expect(
+      runGit(
+        'show',
+        '--quiet',
+        '--pretty=format:%s',
+        '0000000000000000000000000000000000000000',
+      ),
+    ).rejects.toThrow(
+      'git show failed, fatal: bad object 0000000000000000000000000000000000000000',
+    );
+  });
+});
+
+describe('listChangedFiles', () => {
+  it('requires a ref', async () => {
+    await expect(listChangedFiles('')).rejects.toThrow('ref is required');
+  });
+
+  it('should return something', async () => {
+    await expect(listChangedFiles('origin/master')).resolves.toEqual(
+      expect.any(Array),
+    );
+  });
+});

--- a/packages/cli/src/lib/git.test.ts
+++ b/packages/cli/src/lib/git.test.ts
@@ -47,8 +47,6 @@ describe('listChangedFiles', () => {
   });
 
   it('should return something', async () => {
-    await expect(listChangedFiles('origin/master')).resolves.toEqual(
-      expect.any(Array),
-    );
+    await expect(listChangedFiles('HEAD')).resolves.toEqual(expect.any(Array));
   });
 });

--- a/packages/cli/src/lib/git.ts
+++ b/packages/cli/src/lib/git.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assertError, ForwardedError } from '@backstage/errors';
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
+import { paths } from './paths';
+
+const execFile = promisify(execFileCb);
+
+/**
+ * Run a git command, trimming the output splitting it into lines.
+ */
+export async function runGit(...args: string[]) {
+  try {
+    const { stdout } = await execFile('git', args, {
+      shell: true,
+      cwd: paths.targetRoot,
+    });
+    return stdout.trim().split(/\r\n|\r|\n/);
+  } catch (error) {
+    assertError(error);
+    if (error.stderr || typeof error.code === 'number') {
+      const stderr = (error.stderr as undefined | Buffer)?.toString('utf8');
+      const msg = stderr?.trim() ?? `with exit code ${error.code}`;
+      throw new Error(`git ${args[0]} failed, ${msg}`);
+    }
+    throw new ForwardedError('Unknown execution error', error);
+  }
+}
+
+/**
+ * Returns a sorted list of all files that have changed since the merge base
+ * of the provided `ref` and HEAD, as well as all files that are not tracked by git.
+ */
+export async function listChangedFiles(ref: string) {
+  if (!ref) {
+    throw new Error('ref is required');
+  }
+  const [base] = await runGit('merge-base', 'HEAD', ref);
+
+  const tracked = await runGit('diff', '--name-only', base);
+  const untracked = await runGit('ls-files', '--others', '--exclude-standard');
+
+  return Array.from(new Set([...tracked, ...untracked]));
+}

--- a/packages/cli/src/lib/monorepo/index.ts
+++ b/packages/cli/src/lib/monorepo/index.ts
@@ -15,4 +15,8 @@
  */
 
 export { PackageGraph } from './PackageGraph';
-export type { PackageGraphNode } from './PackageGraph';
+export type {
+  PackageGraphNode,
+  ExtendedPackage,
+  ExtendedPackageJSON,
+} from './PackageGraph';

--- a/packages/cli/src/lib/parallel.test.ts
+++ b/packages/cli/src/lib/parallel.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import os from 'os';
 import {
   parseParallelismOption,
   getEnvironmentParallelism,
@@ -22,6 +23,8 @@ import {
   runWorkerThreads,
 } from './parallel';
 
+const defaultParallelism = Math.ceil(os.cpus().length / 2);
+
 describe('parseParallelismOption', () => {
   it('coerces false no parallelism', () => {
     expect(parseParallelismOption(false)).toBe(1);
@@ -29,10 +32,10 @@ describe('parseParallelismOption', () => {
   });
 
   it('coerces true or undefined to default parallelism', () => {
-    expect(parseParallelismOption(true)).toBe(4);
-    expect(parseParallelismOption('true')).toBe(4);
-    expect(parseParallelismOption(undefined)).toBe(4);
-    expect(parseParallelismOption(null)).toBe(4);
+    expect(parseParallelismOption(true)).toBe(defaultParallelism);
+    expect(parseParallelismOption('true')).toBe(defaultParallelism);
+    expect(parseParallelismOption(undefined)).toBe(defaultParallelism);
+    expect(parseParallelismOption(null)).toBe(defaultParallelism);
   });
 
   it('coerces number string to number', () => {
@@ -52,13 +55,13 @@ describe('getEnvironmentParallelism', () => {
     expect(getEnvironmentParallelism()).toBe(2);
 
     process.env.BACKSTAGE_CLI_BUILD_PARALLEL = 'true';
-    expect(getEnvironmentParallelism()).toBe(4);
+    expect(getEnvironmentParallelism()).toBe(defaultParallelism);
 
     process.env.BACKSTAGE_CLI_BUILD_PARALLEL = 'false';
     expect(getEnvironmentParallelism()).toBe(1);
 
     delete process.env.BACKSTAGE_CLI_BUILD_PARALLEL;
-    expect(getEnvironmentParallelism()).toBe(4);
+    expect(getEnvironmentParallelism()).toBe(defaultParallelism);
   });
 });
 
@@ -70,6 +73,7 @@ describe('runParallelWorkers', () => {
 
     const work = runParallelWorkers({
       items: [0, 1, 2, 3, 4],
+      parallelismSetting: 4,
       parallelismFactor: 0.5, // 2 at a time
       worker: async item => {
         started.push(item);

--- a/packages/cli/src/lib/parallel.ts
+++ b/packages/cli/src/lib/parallel.ts
@@ -18,17 +18,17 @@ import os from 'os';
 import { ErrorLike } from '@backstage/errors';
 import { Worker } from 'worker_threads';
 
-export const DEFAULT_PARALLELISM = 4;
+const defaultParallelism = Math.ceil(os.cpus().length / 2);
 
-export const PARALLEL_ENV_VAR = 'BACKSTAGE_CLI_BUILD_PARALLEL';
+const PARALLEL_ENV_VAR = 'BACKSTAGE_CLI_BUILD_PARALLEL';
 
 export type ParallelismOption = boolean | string | number | null | undefined;
 
 export function parseParallelismOption(parallel: ParallelismOption): number {
   if (parallel === undefined || parallel === null) {
-    return DEFAULT_PARALLELISM;
+    return defaultParallelism;
   } else if (typeof parallel === 'boolean') {
-    return parallel ? DEFAULT_PARALLELISM : 1;
+    return parallel ? defaultParallelism : 1;
   } else if (typeof parallel === 'number' && Number.isInteger(parallel)) {
     if (parallel < 1) {
       return 1;

--- a/packages/cli/src/lib/parallel.ts
+++ b/packages/cli/src/lib/parallel.ts
@@ -153,13 +153,14 @@ export type WorkerQueueThreadsOptions<TItem, TResult, TData> = {
 export async function runWorkerQueueThreads<TItem, TResult, TData>(
   options: WorkerQueueThreadsOptions<TItem, TResult, TData>,
 ): Promise<TResult[]> {
+  const items = Array.from(options.items);
   const {
     workerFactory,
     workerData,
-    threadCount = os.cpus().length / 2,
+    threadCount = Math.min(getEnvironmentParallelism(), items.length),
   } = options;
 
-  const iterator = options.items[Symbol.iterator]();
+  const iterator = items[Symbol.iterator]();
   const results = new Array<TResult>();
   let itemIndex = 0;
 

--- a/packages/cli/src/lib/parallel.ts
+++ b/packages/cli/src/lib/parallel.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import os from 'os';
 import { ErrorLike } from '@backstage/errors';
 import { Worker } from 'worker_threads';
 
@@ -137,7 +138,7 @@ export type WorkerQueueThreadsOptions<TItem, TResult, TData> = {
   workerFactory: (data: TData) => (item: TItem) => Promise<TResult>;
   /** Data supplied to each worker factory */
   workerData?: TData;
-  /** Number of threads, defaults to the environment parallelism */
+  /** Number of threads, defaults to half of the number of available CPUs */
   threadCount?: number;
 };
 
@@ -151,7 +152,7 @@ export async function runWorkerQueueThreads<TItem, TResult, TData>(
   const {
     workerFactory,
     workerData,
-    threadCount = getEnvironmentParallelism(),
+    threadCount = os.cpus().length / 2,
   } = options;
 
   const iterator = options.items[Symbol.iterator]();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Similar to the `repo build` command, `repo lint` operates on the entire project and lints all packages at once. It's particularly useful for CI, but can be used during local development too.

This PR also introduces some utilities for change detection in packages, as the new command has a `--since` flag that works similar to `lerna run --since` or `yarn workspaces foreach --since`.

Unlike `repo build`, the `repo lint` command does not check or fall back to executing lint scripts in packages. It assumes that all packages use the common ESLint configuration.

I've ran a couple of tests and running ESLint directly over all packages seems to be about twice as fast executing lint scripts through lerna. The worker queue parallelization that the `repo lint` command uses provides yet another doubling in speed on my 12 core CPU (with HT). On my machine this overall takes a full repo lint down from about 160s to just below 40s, or sometimes closed to 30s.

<img width="553" alt="image" src="https://user-images.githubusercontent.com/4984472/153775806-2db66aeb-7ce2-4161-92c9-cc4b8177611a.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
