### PR TITLE
catalog: Move Location type from catalog-model to catalog-client

### DIFF
--- a/.changeset/cyan-oranges-sit.md
+++ b/.changeset/cyan-oranges-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Deprecates the `Location` type export from this package. Imports of the `Location` type should now be done from the `@backstage/catalog-client` package instead.

--- a/.changeset/fast-stingrays-hope.md
+++ b/.changeset/fast-stingrays-hope.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-catalog-backend-module-ldap': patch
+---
+
+Import `Location` from the `@backstage/catalog-client` package.

--- a/.changeset/purple-files-hang.md
+++ b/.changeset/purple-files-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Export the `Location` type that was previously exported by the `@backstage/catalog-model` package.

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -5,7 +5,7 @@
 ```ts
 import { Entity } from '@backstage/catalog-model';
 import { EntityName } from '@backstage/catalog-model';
-import { Location as Location_2 } from '@backstage/catalog-model';
+import { LocationSpec } from '@backstage/catalog-model';
 
 // @public
 export type AddLocationRequest = {
@@ -177,4 +177,10 @@ export interface GetEntityAncestorsResponse {
   // (undocumented)
   rootEntityRef: string;
 }
+
+// @public
+type Location_2 = {
+  id: string;
+} & LocationSpec;
+export { Location_2 as Location };
 ```

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -17,7 +17,6 @@
 import {
   Entity,
   EntityName,
-  Location,
   LOCATION_ANNOTATION,
   ORIGIN_LOCATION_ANNOTATION,
   parseEntityRef,
@@ -36,6 +35,7 @@ import {
   CatalogRequestOptions,
   GetEntityAncestorsRequest,
   GetEntityAncestorsResponse,
+  Location,
 } from './types/api';
 import { DiscoveryApi } from './types/discovery';
 import { FetchApi } from './types/fetch';

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity, EntityName, Location } from '@backstage/catalog-model';
+import { Entity, EntityName, LocationSpec } from '@backstage/catalog-model';
 
 /**
  * This symbol can be used in place of a value when passed to filters in e.g.
@@ -150,6 +150,15 @@ export interface GetEntityAncestorsResponse {
 export interface CatalogRequestOptions {
   token?: string;
 }
+
+/**
+ * Entity location for a specific entity.
+ *
+ * @public
+ */
+export type Location = {
+  id: string;
+} & LocationSpec;
 
 /**
  * The request type for {@link CatalogClient.addLocation}.

--- a/packages/catalog-client/src/types/index.ts
+++ b/packages/catalog-client/src/types/index.ts
@@ -24,6 +24,7 @@ export type {
   GetEntitiesResponse,
   GetEntityAncestorsRequest,
   GetEntityAncestorsResponse,
+  Location,
 } from './api';
 export { ENTITY_STATUS_CATALOG_PROCESSING_TYPE } from './status';
 export * from './deprecated';

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -319,7 +319,7 @@ export class KubernetesValidatorFunctions {
   static isValidObjectName(value: unknown): boolean;
 }
 
-// @public
+// @public @deprecated
 type Location_2 = {
   id: string;
 } & LocationSpec;

--- a/packages/catalog-model/src/location/types.ts
+++ b/packages/catalog-model/src/location/types.ts
@@ -35,6 +35,7 @@ export type LocationSpec = {
  * Entity location for a specific entity.
  *
  * @public
+ * @deprecated import from {@link @backstage/catalog-client#Location} instead.
  */
 export type Location = {
   id: string;

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -22,7 +22,7 @@ import { GitHubIntegrationConfig } from '@backstage/integration';
 import { IndexableDocument } from '@backstage/search-common';
 import { JsonObject } from '@backstage/types';
 import { JsonValue } from '@backstage/types';
-import { Location as Location_2 } from '@backstage/catalog-model';
+import { Location as Location_2 } from '@backstage/catalog-client';
 import { LocationSpec } from '@backstage/catalog-model';
 import { Logger as Logger_2 } from 'winston';
 import { Organizations } from 'aws-sdk';

--- a/plugins/catalog-backend/src/providers/DefaultLocationStore.ts
+++ b/plugins/catalog-backend/src/providers/DefaultLocationStore.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Location, LocationSpec } from '@backstage/catalog-model';
+import { LocationSpec } from '@backstage/catalog-model';
+import { Location } from '@backstage/catalog-client';
 import { ConflictError, NotFoundError } from '@backstage/errors';
 import { Knex } from 'knex';
 import { v4 as uuid } from 'uuid';

--- a/plugins/catalog-backend/src/service/AuthorizedLocationService.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedLocationService.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { LocationSpec, Location, Entity } from '@backstage/catalog-model';
+import { Location } from '@backstage/catalog-client';
+import { LocationSpec, Entity } from '@backstage/catalog-model';
 import { NotAllowedError, NotFoundError } from '@backstage/errors';
 import {
   catalogLocationCreatePermission,

--- a/plugins/catalog-backend/src/service/DefaultLocationService.ts
+++ b/plugins/catalog-backend/src/service/DefaultLocationService.ts
@@ -15,12 +15,12 @@
  */
 import {
   Entity,
-  Location,
   LocationSpec,
   LOCATION_ANNOTATION,
   ORIGIN_LOCATION_ANNOTATION,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
+import { Location } from '@backstage/catalog-client';
 import {
   CatalogProcessingOrchestrator,
   DeferredEntity,

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -17,7 +17,8 @@
 import { getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { NotFoundError } from '@backstage/errors';
-import type { Entity, LocationSpec, Location } from '@backstage/catalog-model';
+import type { Location } from '@backstage/catalog-client';
+import type { Entity, LocationSpec } from '@backstage/catalog-model';
 import express from 'express';
 import request from 'supertest';
 import { EntitiesCatalog } from '../catalog';

--- a/plugins/catalog-backend/src/service/types.ts
+++ b/plugins/catalog-backend/src/service/types.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Entity, LocationSpec, Location } from '@backstage/catalog-model';
+import { Entity, LocationSpec } from '@backstage/catalog-model';
+import { Location } from '@backstage/catalog-client';
 
 export interface LocationService {
   createLocation(

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.test.tsx
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.test.tsx
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-import {
-  Entity,
-  Location,
-  ORIGIN_LOCATION_ANNOTATION,
-} from '@backstage/catalog-model';
-import { CatalogApi } from '@backstage/catalog-client';
+import { Entity, ORIGIN_LOCATION_ANNOTATION } from '@backstage/catalog-model';
+import { CatalogApi, Location } from '@backstage/catalog-client';
 import { catalogApiRef } from '../../api';
 import {
   act,

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -22,7 +22,7 @@ import { GetEntityAncestorsResponse } from '@backstage/catalog-client';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
-import { Location as Location_2 } from '@backstage/catalog-model';
+import { Location as Location_2 } from '@backstage/catalog-client';
 import { Overrides } from '@material-ui/core/styles/overrides';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';

--- a/plugins/catalog/src/CatalogClientWrapper.ts
+++ b/plugins/catalog/src/CatalogClientWrapper.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity, EntityName, Location } from '@backstage/catalog-model';
+import { Entity, EntityName } from '@backstage/catalog-model';
 import {
   AddLocationRequest,
   AddLocationResponse,
@@ -25,6 +25,7 @@ import {
   CatalogRequestOptions,
   GetEntityAncestorsRequest,
   GetEntityAncestorsResponse,
+  Location,
 } from '@backstage/catalog-client';
 import { IdentityApi } from '@backstage/core-plugin-api';
 


### PR DESCRIPTION
Location with an `id` is not part of the model but rather the API surface and is therefore moved to the catalog-client.

