### PR TITLE
fix(docker): add deps for @vscode/sqlite3

### DIFF
--- a/contrib/docker/devops/Dockerfile
+++ b/contrib/docker/devops/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /tmp
 # update package sources
 # `--virtual` is used to enable removal of these dependencies as a named group
 # - python3: required by node-gyp
-# - g++: reuwired to build @vscode/sqlite3
+# - g++: required to build @vscode/sqlite3
 # - pixman: required by node-canvas
 # - pkgconfig: required by pixman
 # --------------------------------------------

--- a/contrib/docker/devops/Dockerfile
+++ b/contrib/docker/devops/Dockerfile
@@ -9,7 +9,8 @@ WORKDIR /tmp
 
 # update package sources
 # `--virtual` is used to enable removal of these dependencies as a named group
-# - python: required by node-gyp
+# - python3: required by node-gyp
+# - g++: reuwired to build @vscode/sqlite3
 # - pixman: required by node-canvas
 # - pkgconfig: required by pixman
 # --------------------------------------------
@@ -32,7 +33,8 @@ WORKDIR /tmp
 RUN apk update \
   && apk add --no-cache \
     --virtual ${APK_VIRTUAL_NAME} \
-    python \
+    python3 \
+    g++ \
     pixman \
     pkgconfig \
     alpine-sdk \
@@ -50,6 +52,10 @@ RUN apk update \
 RUN wget -qO- ${VALE_INSTALL_URL} \
     | tar xvz -C /bin vale \
     && chmod +x /bin/vale
+
+# needed for sqlite3 build that needs python
+RUN ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /usr/bin/pip3 /usr/bin/pip
 
 RUN mkdir /app
 


### PR DESCRIPTION
The change to using @vscode/sqlite3 broke our deployment builds.
Adding the required build tool `g++` and linking `python` to the python3 executable.

```shell
make: Entering directory '/builds/.../node_modules/@vscode/sqlite3/build'
  ACTION deps_sqlite3_gyp_action_before_build_target_unpack_sqlite_dep Release/obj/gen/sqlite-autoconf-3360000/sqlite3.c
/bin/sh: python: not found
```

Technically, the python path can be added to `.nmprc`, but added it to the docker file instead.

Signed-off-by: Andrew Basson <andrew.basson@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
