### PR TITLE
Fix Catalog page showing all components when owned filter was pre-selected

### DIFF
--- a/.changeset/shy-peaches-begin.md
+++ b/.changeset/shy-peaches-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix CatalogPage showing all components when owned filter was pre-selected

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.test.tsx
@@ -36,6 +36,7 @@ import {
   identityApiRef,
   storageApiRef,
 } from '@backstage/core-plugin-api';
+import { useEntityOwnership } from '../../hooks';
 
 const mockUser: UserEntity = {
   apiVersion: 'backstage.io/v1alpha1',
@@ -81,9 +82,9 @@ jest.mock('../../hooks', () => {
   const actual = jest.requireActual('../../hooks');
   return {
     ...actual,
-    useEntityOwnership: () => ({
+    useEntityOwnership: jest.fn(() => ({
       isOwnedEntity: mockIsOwnedEntity,
-    }),
+    })),
     useStarredEntities: () => ({
       isStarredEntity: mockIsStarredEntity,
     }),
@@ -324,6 +325,19 @@ describe('<UserListPicker />', () => {
             mockIsOwnedEntity,
             mockIsStarredEntity,
           ),
+        });
+      });
+
+      it('does not reset the filter while owned entities are loading', () => {
+        const isOwnedEntity = jest.fn(() => false);
+        (useEntityOwnership as jest.Mock).mockReturnValueOnce({
+          loading: true,
+          isOwnedEntity,
+        });
+
+        render(picker({ loading: false }));
+        expect(updateFilters).not.toHaveBeenCalledWith({
+          user: new UserListFilter('all', isOwnedEntity, mockIsStarredEntity),
         });
       });
 

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -130,8 +130,13 @@ export const UserListPicker = ({
   const classes = useStyles();
   const configApi = useApi(configApiRef);
   const orgName = configApi.getOptionalString('organization.name') ?? 'Company';
-  const { filters, updateFilters, backendEntities, queryParameters, loading } =
-    useEntityListProvider();
+  const {
+    filters,
+    updateFilters,
+    backendEntities,
+    queryParameters,
+    loading: loadingBackendEntities,
+  } = useEntityListProvider();
 
   // Remove group items that aren't in availableFilters and exclude
   // any now-empty groups.
@@ -149,7 +154,10 @@ export const UserListPicker = ({
     .filter(({ items }) => !!items.length);
 
   const { isStarredEntity } = useStarredEntities();
-  const { isOwnedEntity } = useEntityOwnership();
+  const { isOwnedEntity, loading: loadingEntityOwnership } =
+    useEntityOwnership();
+
+  const loading = loadingBackendEntities || loadingEntityOwnership;
 
   // Static filters; used for generating counts of potentially unselected kinds
   const ownedFilter = useMemo(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR closes #8929.
When loading `CatalogPage` with `owned` filter preselected, there is some logic that toggle the filter to `all` in case the user has zero owned components.
In order to do that, we should ensure to wait until both, backend component and owned components are loaded, since they are loaded using two different rest requests.
The bug was caused by `UserListPicker` and it was visible only when `useEntityOwnership` finished fetching results after `useEntityListProvider` was done.

To constantly reproduce it, add a wait of a few seconds here: https://github.com/backstage/backstage/blob/master/plugins/catalog-react/src/hooks/useEntityOwnership.ts#L109

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
