### PR TITLE
Gcp projects use react hookz

### DIFF
--- a/.changeset/weak-timers-punch.md
+++ b/.changeset/weak-timers-punch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-gcp-projects': patch
+---
+
+Switches to use react-hookz in place of react-use.

--- a/plugins/gcp-projects/package.json
+++ b/plugins/gcp-projects/package.json
@@ -38,7 +38,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
     "react-router-dom": "6.0.0-beta.0",
-    "react-use": "^17.2.4"
+    "react-hookz": "^1.0.12"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0"

--- a/plugins/gcp-projects/src/components/ProjectDetailsPage/ProjectDetailsPage.tsx
+++ b/plugins/gcp-projects/src/components/ProjectDetailsPage/ProjectDetailsPage.tsx
@@ -27,7 +27,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import React from 'react';
-import useAsync from 'react-use/lib/useAsync';
+import { useAsync } from 'react-hookz';
 import { gcpApiRef } from '../../api';
 
 import {
@@ -61,9 +61,9 @@ const DetailsPage = () => {
   const classes = useStyles();
 
   const {
-    loading,
+    status,
+    result: details,
     error,
-    value: details,
   } = useAsync(
     async () =>
       api.getProject(
@@ -72,7 +72,7 @@ const DetailsPage = () => {
     [location.search],
   );
 
-  if (loading) {
+  if (status === 'loading') {
     return <LinearProgress />;
   } else if (error) {
     return (

--- a/plugins/gcp-projects/src/components/ProjectListPage/ProjectListPage.tsx
+++ b/plugins/gcp-projects/src/components/ProjectListPage/ProjectListPage.tsx
@@ -18,7 +18,7 @@
 import { Button, LinearProgress, Tooltip, Typography } from '@material-ui/core';
 import React from 'react';
 
-import useAsync from 'react-use/lib/useAsync';
+import { useAsync } from 'reach-hookz';
 import { gcpApiRef, Project } from '../../api';
 
 import {
@@ -58,9 +58,9 @@ const labels = (
 const PageContents = () => {
   const api = useApi(gcpApiRef);
 
-  const { loading, error, value } = useAsync(() => api.listProjects());
+  const { status, result, error } = useAsync(() => api.listProjects());
 
-  if (loading) {
+  if (status === 'loading') {
     return <LinearProgress />;
   } else if (error) {
     return (
@@ -108,7 +108,7 @@ const PageContents = () => {
           },
         ]}
         data={
-          value?.map((project: Project) => ({
+          result?.map((project: Project) => ({
             id: project.projectId,
             name: project.name,
             projectNumber: project?.projectNumber || 'Error',


### PR DESCRIPTION
Switch gcp-projects to use react-hookz in place of react-use

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
