### PR TITLE
remove duplicate ingress.class annotation

### DIFF
--- a/contrib/chart/backstage/templates/ingress.yaml
+++ b/contrib/chart/backstage/templates/ingress.yaml
@@ -15,7 +15,6 @@ metadata:
     {{- if .Values.issuer.email }}
     cert-manager.io/cluster-issuer: {{ .Values.issuer.clusterIssuer }}
     {{- end }}
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($scheme = https) {


### PR DESCRIPTION
`kubernetes.io/ingress.class` annotation is already rendered on line 23 from `.Values.ingress.annotations`.

This removes the duplicate, allowing Flux to deploy the chart (https://github.com/fluxcd/flux2/issues/1522)