### PR TITLE
Increase content pane techdocs

### DIFF
--- a/.changeset/mean-jokes-jump.md
+++ b/.changeset/mean-jokes-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Increased width of the content pane when there is no ToC.

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -145,6 +145,7 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
   const isDarkTheme = theme.palette.type === 'dark';
 
   const [sidebars, setSidebars] = useState<HTMLElement[]>();
+  const [tocItems, setHasTocItems] = useState(false);
   const [dom, setDom] = useState<HTMLElement | null>(null);
 
   // sidebar pinned status to be used in computing CSS style injections
@@ -245,9 +246,16 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
           .md-sidebar {  position: fixed; bottom: 100px; width: 20rem; }
           .md-sidebar--secondary { right: 2rem; }
           .md-content { margin-bottom: 50px }
-          .md-footer { position: fixed; bottom: 0px; }
+          .md-footer { 
+            position: fixed;
+            bottom: 0px; 
+            background-color:${theme.palette.background.default}
+          };
           .md-footer-nav__link { width: 20rem;}
-          .md-content { margin-left: 20rem; max-width: calc(100% - 20rem * 2 - 3rem); }
+          .md-content { 
+            margin-left: 20rem; 
+            max-width: ${tocItems ? 'calc(100% - 20rem * 2 - 3rem)' : '100%'}; 
+          }
           .md-typeset { font-size: 1rem; }
           .md-typeset h1, .md-typeset h2, .md-typeset h3 { font-weight: bold; }
           .md-nav { font-size: 1rem; }
@@ -389,6 +397,7 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
       theme.palette.action.disabledBackground,
       theme.palette.success.main,
       isDarkTheme,
+      tocItems,
       isPinned,
     ],
   );
@@ -441,6 +450,10 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
             renderedElement
               .querySelector('.md-nav__title')
               ?.removeAttribute('for');
+            const noTocItems = renderedElement.querySelector(
+              '.md-nav.md-nav--secondary',
+            )?.childElementCount;
+            setHasTocItems(noTocItems && noTocItems > 0 ? true : false);
             setSidebars(
               Array.from(renderedElement.querySelectorAll('.md-sidebar')),
             );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

MkDocs in Tech Docs are rendered with right sidebar which contains ToC. However, in cases when there is no ToC, it seems natural to use full width to show documents, and currently that is not the case. This has been reported as a bug by some users so we thought we might suggest a small change :) 

I have also added background color in footer in order to avoid text overlapping.

Here is the current state:
<img width="1440" alt="Screenshot 2022-02-15 at 22 46 38" src="https://user-images.githubusercontent.com/7230518/154155148-93c16098-ee74-4a89-beea-6694a84cf06b.png">

My suggestion is to have full width in this case
<img width="1440" alt="Screenshot 2022-02-15 at 22 47 16" src="https://user-images.githubusercontent.com/7230518/154155191-f54c406b-9cff-4d46-9ced-9a5c084f4d25.png">

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
