### PR TITLE
remove react-use from core-plugin-api

### DIFF
--- a/.changeset/strange-taxis-perform.md
+++ b/.changeset/strange-taxis-perform.md
@@ -2,4 +2,4 @@
 '@backstage/core-plugin-api': patch
 ---
 
-Removes unused react-use depdendency.
+Removes unused react-use dependency.

--- a/.changeset/strange-taxis-perform.md
+++ b/.changeset/strange-taxis-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Removes unused react-use depdendency.

--- a/packages/core-plugin-api/package.json
+++ b/packages/core-plugin-api/package.json
@@ -35,7 +35,6 @@
     "history": "^5.0.0",
     "prop-types": "^15.7.2",
     "react-router-dom": "6.0.0-beta.0",
-    "react-use": "^17.2.4",
     "zen-observable": "^0.8.15"
   },
   "peerDependencies": {


### PR DESCRIPTION
remove react-use from core-plugin-api

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
