### PR TITLE
Updated gitlab integration to include port

### DIFF
--- a/.changeset/thirty-peas-exist.md
+++ b/.changeset/thirty-peas-exist.md
@@ -2,4 +2,4 @@
 '@backstage/integration': patch
 ---
 
-Fixed bug in integration package where selfhosted gitlab instances with custom ports weren't supported (because of the lack of an option to add the port in the integration configs. Now users can add the port directly in the host)
+Fixed bug in integration package where Self Hosted GitLab instances with custom ports weren't supported (because of the lack of an option to add the port in the integration configs. Now users can add the port directly in the host)

--- a/.changeset/thirty-peas-exist.md
+++ b/.changeset/thirty-peas-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fixed bug in integration package where selfhosted gitlab instances with custom ports weren't supported (because of the lack of an option to add the port in the integration configs. Now users can add the port directly in the host)

--- a/packages/integration/src/gitlab/config.ts
+++ b/packages/integration/src/gitlab/config.ts
@@ -82,11 +82,7 @@ export function readGitLabIntegrationConfig(
     baseUrl = `https://${host}`;
   }
 
-  if (host.includes(':')) {
-    throw new Error(
-      `Invalid GitLab integration config, host '${host}' should just be the host name (e.g. "github.com"), not a URL`,
-    );
-  } else if (!isValidHost(host)) {
+  if (!isValidHost(host)) {
     throw new Error(
       `Invalid GitLab integration config, '${host}' is not a valid host`,
     );

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -138,7 +138,7 @@ export async function getProjectId(
     // Convert
     // to: https://gitlab.com/api/v4/projects/groupA%2Fteams%2FsubgroupA%2FteamA%2Frepo
     const repoIDLookup = new URL(
-      `${url.protocol + url.hostname}/api/v4/projects/${encodeURIComponent(
+      `${url.protocol + url.host}/api/v4/projects/${encodeURIComponent(
         repo.replace(/^\//, ''),
       )}`,
     );

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -138,7 +138,7 @@ export async function getProjectId(
     // Convert
     // to: https://gitlab.com/api/v4/projects/groupA%2Fteams%2FsubgroupA%2FteamA%2Frepo
     const repoIDLookup = new URL(
-      `${url.protocol + url.host}/api/v4/projects/${encodeURIComponent(
+      `${url.origin}/api/v4/projects/${encodeURIComponent(
         repo.replace(/^\//, ''),
       )}`,
     );


### PR DESCRIPTION
Updated integration module to allow for the use of a custom port, which
is often the case in self hosted gitlab instances.

Removed host.includes(':') check in config.ts to allow for users to
include the port in the host
Changed url.hostname to url.host in core.ts to include the port in the
api call (otherwise it'll result in an error when trying to import a new
component)

With this fix, if you're using a self-hosted gitlab instance with a custom port, you can now add the port in the host in the config as such:
![image](https://user-images.githubusercontent.com/23180135/154337124-473c278d-d016-4404-a33c-b63a9350d772.png)

With this fix, we can now import new components stored in our own gitlab instance.

Fixes  #9581

Signed-off-by: Edgar Silva <emda.silva@campus.fct.unl.pt>