### PR TITLE
Match admonition text size to content text size

### DIFF
--- a/.changeset/eighty-rice-happen.md
+++ b/.changeset/eighty-rice-happen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Match text size of admonitions to main content text size.

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -270,7 +270,7 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
           }
           .md-typeset table:not([class]) th { font-weight: bold; }
           .md-typeset .admonition, .md-typeset details {
-            font-size: 1rem;
+            font-size: inherit;
           }
           
           /* style the checkmarks of the task list */


### PR DESCRIPTION
Admonitions provide an interface for creators of documentation to highlight important information as well as give little hints in addition to existing content.

Currently, the font size (1rem) is slightly larger than the main font size (0.9rem), which works well for important callouts but not so much for minor comments.

Hence this PR lets the admonition font size match the content and let visual cues such as border coloring decide the importance

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
