### PR TITLE
backend: removed airbrake plugin dep

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -33,7 +33,6 @@
     "@backstage/catalog-model": "^0.9.10",
     "@backstage/config": "^0.1.13",
     "@backstage/integration": "^0.7.2",
-    "@backstage/plugin-airbrake-backend": "^0.0.0",
     "@backstage/plugin-app-backend": "^0.3.24",
     "@backstage/plugin-auth-backend": "^0.10.0",
     "@backstage/plugin-auth-node": "^0.1.0",


### PR DESCRIPTION
Followup for #9390

Realized the backend plugin wasn't actually installed, so no breakage at startup 😅
