### PR TITLE
config-loader: watch any extra files loaded when loading local config

### DIFF
--- a/.changeset/pink-fans-tie.md
+++ b/.changeset/pink-fans-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Include any files included in configuration via $include or $file directives when watching for configuration changes.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Any files included via `$include` or `$file` directives are now watched for changes along with config files themselves.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
