### PR TITLE
catalog-backend: Deprecate runPeriodically function

### DIFF
--- a/.changeset/chilled-glasses-tan.md
+++ b/.changeset/chilled-glasses-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Deprecated the `runPeriodically` function which is no longer in use.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -1133,7 +1133,7 @@ export interface RouterOptions {
 
 // Warning: (ae-missing-release-tag) "runPeriodically" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public
+// @public @deprecated
 export function runPeriodically(fn: () => any, delayMs: number): () => void;
 
 // Warning: (ae-missing-release-tag) "StaticLocationProcessor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/catalog-backend/src/util/runPeriodically.ts
+++ b/plugins/catalog-backend/src/util/runPeriodically.ts
@@ -23,6 +23,7 @@
  * @param delayMs - The delay between a completed function invocation and the
  *                next.
  * @returns A function that, when called, stops the invocation loop.
+ * @deprecated use \@backstage/backend-tasks package instead.
  */
 export function runPeriodically(fn: () => any, delayMs: number): () => void {
   let cancel: () => void;


### PR DESCRIPTION
Deprecated the `runPeriodically` function which is no longer in use.
