### PR TITLE
catalog-backend: Deprecate StaticLocationProcessor

### DIFF
--- a/.changeset/poor-tomatoes-stare.md
+++ b/.changeset/poor-tomatoes-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Deprecated `StaticLocationProcessor` which is unused and replaced by `ConfigLocationEntityProvider`.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -1138,7 +1138,7 @@ export function runPeriodically(fn: () => any, delayMs: number): () => void;
 
 // Warning: (ae-missing-release-tag) "StaticLocationProcessor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class StaticLocationProcessor implements StaticLocationProcessor {
   constructor(staticLocations: LocationSpec[]);
   // (undocumented)

--- a/plugins/catalog-backend/src/ingestion/processors/StaticLocationProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/StaticLocationProcessor.ts
@@ -19,6 +19,9 @@ import { Config } from '@backstage/config';
 import * as result from './results';
 import { CatalogProcessorEmit } from './types';
 
+/**
+ * @deprecated no longer in use, replaced by the ConfigLocationEntityProvider.
+ */
 export class StaticLocationProcessor implements StaticLocationProcessor {
   static fromConfig(config: Config): StaticLocationProcessor {
     const locations: LocationSpec[] = [];


### PR DESCRIPTION
Deprecated `StaticLocationProcessor` which is unused and replaced by `ConfigLocationEntityProvider`.
