### PR TITLE
catalog-backend: Deprecate the durationText function

### DIFF
--- a/.changeset/clean-tools-peel.md
+++ b/.changeset/clean-tools-peel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Deprecated `durationText` as the function does not have external usage.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -582,7 +582,7 @@ export type DeferredEntity = {
 
 // Warning: (ae-missing-release-tag) "durationText" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public
+// @public @deprecated
 export function durationText(startTimestamp: [number, number]): string;
 
 // @public (undocumented)

--- a/plugins/catalog-backend/src/util/timing.ts
+++ b/plugins/catalog-backend/src/util/timing.ts
@@ -20,6 +20,7 @@
  *
  * @param startTimestamp - The timestamp (from process.hrtime()) at the start ot
  *                       the operation
+ * @deprecated use luxon library instead.
  */
 export function durationText(startTimestamp: [number, number]): string {
   const delta = process.hrtime(startTimestamp);


### PR DESCRIPTION
Deprecated `durationText` as the function does not have external usage.
