### PR TITLE
catalog-backend: Require impl of getProcessorName in CatalogProcessor

### DIFF
--- a/.changeset/spicy-cherries-ring.md
+++ b/.changeset/spicy-cherries-ring.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Updated all processors to implement `getProcessorName`.
+
+**BREAKING**: The `CatalogProcessor` interface now require that the `CatalogProcessor` class implements `getProcessorName()`.
+The processor name has previously defaulted processor class name. It's therefore _recommended_ to keep your return the same name as the class name if you did not implement this method previously.
+
+For example:
+
+```ts
+class CustomProcessor implements CatalogProcessor {
+  getProcessorName() {
+    // Use the same name as the class name if this method was not previously implemented.
+    return 'CustomProcessor';
+  }
+}
+```

--- a/.changeset/unlucky-penguins-wonder.md
+++ b/.changeset/unlucky-penguins-wonder.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Implemented required `getProcessorName` method for catalog processor.

--- a/docs/features/software-catalog/external-integrations.md
+++ b/docs/features/software-catalog/external-integrations.md
@@ -472,8 +472,8 @@ type CacheItem = {
 export class SystemXReaderProcessor implements CatalogProcessor {
   constructor(private readonly reader: UrlReader) {}
 
-  // It's recommended to give the processor a unique name.
   getProcessorName() {
+    // The processor name must be unique.
     return 'system-x-processor';
   }
 

--- a/plugins/catalog-backend-module-ldap/api-report.md
+++ b/plugins/catalog-backend-module-ldap/api-report.md
@@ -137,6 +137,8 @@ export class LdapOrgReaderProcessor implements CatalogProcessor {
     },
   ): LdapOrgReaderProcessor;
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   readLocation(
     location: LocationSpec,
     _optional: boolean,

--- a/plugins/catalog-backend-module-ldap/src/processors/LdapOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-ldap/src/processors/LdapOrgReaderProcessor.ts
@@ -69,6 +69,10 @@ export class LdapOrgReaderProcessor implements CatalogProcessor {
     this.userTransformer = options.userTransformer;
   }
 
+  getProcessorName(): string {
+    return 'LdapOrgReaderProcessor';
+  }
+
   async readLocation(
     location: LocationSpec,
     _optional: boolean,

--- a/plugins/catalog-backend-module-msgraph/api-report.md
+++ b/plugins/catalog-backend-module-msgraph/api-report.md
@@ -134,6 +134,8 @@ export class MicrosoftGraphOrgReaderProcessor implements CatalogProcessor {
     },
   ): MicrosoftGraphOrgReaderProcessor;
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   readLocation(
     location: LocationSpec,
     _optional: boolean,

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
@@ -73,6 +73,9 @@ export class MicrosoftGraphOrgReaderProcessor implements CatalogProcessor {
     this.groupTransformer = options.groupTransformer;
     this.organizationTransformer = options.organizationTransformer;
   }
+  getProcessorName(): string {
+    return 'MicrosoftGraphOrgReaderProcessor';
+  }
 
   async readLocation(
     location: LocationSpec,

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -92,6 +92,8 @@ export class AnnotateLocationEntityProcessor implements CatalogProcessor {
   // Warning: (ae-forgotten-export) The symbol "Options" needs to be exported by the entry point index.d.ts
   constructor(options: Options);
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   preProcessEntity(
     entity: Entity,
     location: LocationSpec,
@@ -107,6 +109,8 @@ export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
   constructor(opts: { scmIntegrationRegistry: ScmIntegrationRegistry });
   // (undocumented)
   static fromConfig(config: Config): AnnotateScmSlugEntityProcessor;
+  // (undocumented)
+  getProcessorName(): string;
   // (undocumented)
   preProcessEntity(entity: Entity, location: LocationSpec): Promise<Entity>;
 }
@@ -133,6 +137,8 @@ export class AwsOrganizationCloudAccountProcessor implements CatalogProcessor {
   ): AwsOrganizationCloudAccountProcessor;
   // (undocumented)
   getAwsAccounts(): Promise<Account[]>;
+  // (undocumented)
+  getProcessorName(): string;
   // (undocumented)
   logger: Logger_2;
   // (undocumented)
@@ -164,6 +170,8 @@ export type AwsOrganizationProviderConfig = {
 export class AwsS3DiscoveryProcessor implements CatalogProcessor {
   constructor(reader: UrlReader);
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   readLocation(
     location: LocationSpec,
     optional: boolean,
@@ -187,6 +195,8 @@ export class AzureDevOpsDiscoveryProcessor implements CatalogProcessor {
       logger: Logger_2;
     },
   ): AzureDevOpsDiscoveryProcessor;
+  // (undocumented)
+  getProcessorName(): string;
   // (undocumented)
   readLocation(
     location: LocationSpec,
@@ -213,6 +223,8 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
     },
   ): BitbucketDiscoveryProcessor;
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   readLocation(
     location: LocationSpec,
     _optional: boolean,
@@ -233,6 +245,8 @@ export type BitbucketRepositoryParser = (options: {
 //
 // @public (undocumented)
 export class BuiltinKindsEntityProcessor implements CatalogProcessor {
+  // (undocumented)
+  getProcessorName(): string;
   // (undocumented)
   postProcessEntity(
     entity: Entity,
@@ -352,7 +366,7 @@ export interface CatalogProcessingOrchestrator {
 //
 // @public (undocumented)
 export type CatalogProcessor = {
-  getProcessorName?(): string;
+  getProcessorName(): string;
   readLocation?(
     location: LocationSpec,
     optional: boolean,
@@ -478,6 +492,8 @@ export class CodeOwnersProcessor implements CatalogProcessor {
       reader: UrlReader;
     },
   ): CodeOwnersProcessor;
+  // (undocumented)
+  getProcessorName(): string;
   // (undocumented)
   preProcessEntity(entity: Entity, location: LocationSpec): Promise<Entity>;
 }
@@ -731,6 +747,8 @@ export type EntityProviderMutation =
 // @public (undocumented)
 export class FileReaderProcessor implements CatalogProcessor {
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   readLocation(
     location: LocationSpec,
     optional: boolean,
@@ -765,6 +783,8 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
     },
   ): GithubDiscoveryProcessor;
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   readLocation(
     location: LocationSpec,
     _optional: boolean,
@@ -788,6 +808,8 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
       githubCredentialsProvider?: GithubCredentialsProvider;
     },
   ): GithubMultiOrgReaderProcessor;
+  // (undocumented)
+  getProcessorName(): string;
   // (undocumented)
   readLocation(
     location: LocationSpec,
@@ -843,6 +865,8 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     },
   ): GithubOrgReaderProcessor;
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   readLocation(
     location: LocationSpec,
     _optional: boolean,
@@ -861,6 +885,8 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
       logger: Logger_2;
     },
   ): GitLabDiscoveryProcessor;
+  // (undocumented)
+  getProcessorName(): string;
   // (undocumented)
   readLocation(
     location: LocationSpec,
@@ -901,6 +927,8 @@ export type LocationAnalyzer = {
 // @public (undocumented)
 export class LocationEntityProcessor implements CatalogProcessor {
   constructor(options: LocationEntityProcessorOptions);
+  // (undocumented)
+  getProcessorName(): string;
   // (undocumented)
   postProcessEntity(
     entity: Entity,
@@ -1025,6 +1053,8 @@ export const permissionRules: {
 // @public
 export class PlaceholderProcessor implements CatalogProcessor {
   constructor(options: PlaceholderProcessorOptions);
+  // (undocumented)
+  getProcessorName(): string;
   // (undocumented)
   preProcessEntity(entity: Entity, location: LocationSpec): Promise<Entity>;
 }

--- a/plugins/catalog-backend/src/ingestion/processors/AnnotateLocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AnnotateLocationEntityProcessor.ts
@@ -35,6 +35,10 @@ type Options = {
 export class AnnotateLocationEntityProcessor implements CatalogProcessor {
   constructor(private readonly options: Options) {}
 
+  getProcessorName(): string {
+    return 'AnnotateLocationEntityProcessor';
+  }
+
   async preProcessEntity(
     entity: Entity,
     location: LocationSpec,

--- a/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AnnotateScmSlugEntityProcessor.ts
@@ -30,6 +30,10 @@ export class AnnotateScmSlugEntityProcessor implements CatalogProcessor {
     private readonly opts: { scmIntegrationRegistry: ScmIntegrationRegistry },
   ) {}
 
+  getProcessorName(): string {
+    return 'AnnotateScmSlugEntityProcessor';
+  }
+
   static fromConfig(config: Config): AnnotateScmSlugEntityProcessor {
     return new AnnotateScmSlugEntityProcessor({
       scmIntegrationRegistry: ScmIntegrations.fromConfig(config),

--- a/plugins/catalog-backend/src/ingestion/processors/AwsOrganizationCloudAccountProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AwsOrganizationCloudAccountProcessor.ts
@@ -81,6 +81,9 @@ export class AwsOrganizationCloudAccountProcessor implements CatalogProcessor {
       region: AWS_ORGANIZATION_REGION,
     }); // Only available in us-east-1
   }
+  getProcessorName(): string {
+    return 'AwsOrganizationCloudAccountProcessor';
+  }
 
   normalizeName(name: string): string {
     return name

--- a/plugins/catalog-backend/src/ingestion/processors/AwsS3DiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AwsS3DiscoveryProcessor.ts
@@ -28,6 +28,10 @@ import {
 export class AwsS3DiscoveryProcessor implements CatalogProcessor {
   constructor(private readonly reader: UrlReader) {}
 
+  getProcessorName(): string {
+    return 'AwsS3DiscoveryProcessor';
+  }
+
   async readLocation(
     location: LocationSpec,
     optional: boolean,

--- a/plugins/catalog-backend/src/ingestion/processors/AzureDevOpsDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/AzureDevOpsDiscoveryProcessor.ts
@@ -60,6 +60,10 @@ export class AzureDevOpsDiscoveryProcessor implements CatalogProcessor {
     this.logger = options.logger;
   }
 
+  getProcessorName(): string {
+    return 'AzureDevOpsDiscoveryProcessor';
+  }
+
   async readLocation(
     location: LocationSpec,
     _optional: boolean,

--- a/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.ts
@@ -64,6 +64,10 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
     this.logger = options.logger;
   }
 
+  getProcessorName(): string {
+    return 'BitbucketDiscoveryProcessor';
+  }
+
   async readLocation(
     location: LocationSpec,
     _optional: boolean,

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
@@ -69,6 +69,10 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     domainEntityV1alpha1Validator,
   ];
 
+  getProcessorName(): string {
+    return 'BuiltinKindsEntityProcessor';
+  }
+
   async validateEntityKind(entity: Entity): Promise<boolean> {
     for (const validator of this.validators) {
       const results = await validator.check(entity);

--- a/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/CodeOwnersProcessor.ts
@@ -64,6 +64,10 @@ export class CodeOwnersProcessor implements CatalogProcessor {
     this.reader = options.reader;
   }
 
+  getProcessorName(): string {
+    return 'CodeOwnersProcessor';
+  }
+
   async preProcessEntity(
     entity: Entity,
     location: LocationSpec,

--- a/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/FileReaderProcessor.ts
@@ -29,6 +29,10 @@ import {
 const glob = promisify(g);
 
 export class FileReaderProcessor implements CatalogProcessor {
+  getProcessorName(): string {
+    return 'FileReaderProcessor';
+  }
+
   async readLocation(
     location: LocationSpec,
     optional: boolean,

--- a/plugins/catalog-backend/src/ingestion/processors/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GitLabDiscoveryProcessor.ts
@@ -60,6 +60,10 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
     this.logger = options.logger;
   }
 
+  getProcessorName(): string {
+    return 'GitLabDiscoveryProcessor';
+  }
+
   async readLocation(
     location: LocationSpec,
     _optional: boolean,

--- a/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubDiscoveryProcessor.ts
@@ -73,6 +73,9 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
       options.githubCredentialsProvider ||
       DefaultGithubCredentialsProvider.fromIntegrations(this.integrations);
   }
+  getProcessorName(): string {
+    return 'GithubDiscoveryProcessor';
+  }
 
   async readLocation(
     location: LocationSpec,

--- a/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubMultiOrgReaderProcessor.ts
@@ -78,6 +78,9 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
       options.githubCredentialsProvider ||
       DefaultGithubCredentialsProvider.fromIntegrations(this.integrations);
   }
+  getProcessorName(): string {
+    return 'GithubMultiOrgReaderProcessor';
+  }
 
   async readLocation(
     location: LocationSpec,

--- a/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GithubOrgReaderProcessor.ts
@@ -70,6 +70,9 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
       DefaultGithubCredentialsProvider.fromIntegrations(this.integrations);
     this.logger = options.logger;
   }
+  getProcessorName(): string {
+    return 'GithubOrgReaderProcessor';
+  }
 
   async readLocation(
     location: LocationSpec,

--- a/plugins/catalog-backend/src/ingestion/processors/LocationEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/LocationEntityProcessor.ts
@@ -45,6 +45,10 @@ export type LocationEntityProcessorOptions = {
 export class LocationEntityProcessor implements CatalogProcessor {
   constructor(private readonly options: LocationEntityProcessorOptions) {}
 
+  getProcessorName(): string {
+    return 'LocationEntityProcessor';
+  }
+
   async postProcessEntity(
     entity: Entity,
     location: LocationSpec,

--- a/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.ts
@@ -52,6 +52,10 @@ export type PlaceholderProcessorOptions = {
 export class PlaceholderProcessor implements CatalogProcessor {
   constructor(private readonly options: PlaceholderProcessorOptions) {}
 
+  getProcessorName(): string {
+    return 'PlaceholderProcessor';
+  }
+
   async preProcessEntity(
     entity: Entity,
     location: LocationSpec,

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -24,9 +24,8 @@ import { JsonValue } from '@backstage/types';
 export type CatalogProcessor = {
   /**
    * A unique identifier for the Catalog Processor.
-   * It's strongly recommended to implement getProcessorName as this method will be required in the future.
    */
-  getProcessorName?(): string;
+  getProcessorName(): string;
 
   /**
    * Reads the contents of a location.

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
@@ -208,6 +208,7 @@ describe('DefaultCatalogProcessingOrchestrator', () => {
 
       const integrations = ScmIntegrations.fromConfig(new ConfigReader({}));
       const processor: jest.Mocked<CatalogProcessor> = {
+        getProcessorName: jest.fn(),
         validateEntityKind: jest.fn(async () => true),
         readLocation: jest.fn(async (_l, _o, emit) => {
           emit(results.entity({ type: 't', target: 't' }, entity));

--- a/plugins/catalog-backend/src/processing/ProcessorCacheManager.test.ts
+++ b/plugins/catalog-backend/src/processing/ProcessorCacheManager.test.ts
@@ -21,7 +21,11 @@ class MyProcessor implements CatalogProcessor {
   getProcessorName = () => 'my-processor';
 }
 
-class OtherProcessor implements CatalogProcessor {}
+class OtherProcessor implements CatalogProcessor {
+  getProcessorName(): string {
+    return 'OtherProcessor';
+  }
+}
 
 describe('ProcessorCacheManager', () => {
   const myProcessor = new MyProcessor();

--- a/plugins/catalog-backend/src/processing/ProcessorCacheManager.ts
+++ b/plugins/catalog-backend/src/processing/ProcessorCacheManager.ts
@@ -104,7 +104,7 @@ export class ProcessorCacheManager {
     key?: string,
   ): CatalogProcessorCache {
     // constructor name will be deprecated in the future when we make `getProcessorName` required in the implementation
-    const name = processor.getProcessorName?.() ?? processor.constructor.name;
+    const name = processor.getProcessorName();
     const cache = this.caches.get(name);
     if (cache) {
       return key ? cache.withKey(key) : cache;

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -432,6 +432,8 @@ export const runCommand: ({
 // @public (undocumented)
 export class ScaffolderEntitiesProcessor implements CatalogProcessor {
   // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
   postProcessEntity(
     entity: Entity,
     _location: LocationSpec,

--- a/plugins/scaffolder-backend/src/processor/ScaffolderEntitiesProcessor.ts
+++ b/plugins/scaffolder-backend/src/processor/ScaffolderEntitiesProcessor.ts
@@ -34,6 +34,10 @@ import {
 
 /** @public */
 export class ScaffolderEntitiesProcessor implements CatalogProcessor {
+  getProcessorName(): string {
+    return 'ScaffolderEntitiesProcessor';
+  }
+
   private readonly validators = [templateEntityV1beta3Validator];
 
   async validateEntityKind(entity: Entity): Promise<boolean> {


### PR DESCRIPTION
This method was previously optional to ease adoption to the new catalog. In order to stabilise the API before the 1.0 release of catalog getProcessorName is now required.