### PR TITLE
catalog-backend: fixes for GitLab discovery .updateLastActivity()

### DIFF
--- a/.changeset/red-olives-clap.md
+++ b/.changeset/red-olives-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Made the `GitLabDiscoveryProcessor.updateLastActivity` method private, as it was accidentally exposed. It has also been fixed to properly operate in its own cache namespace to avoid collisions with other processors.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -888,8 +888,6 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
     _optional: boolean,
     emit: CatalogProcessorEmit,
   ): Promise<boolean>;
-  // (undocumented)
-  updateLastActivity(): Promise<string | undefined>;
 }
 
 // Warning: (ae-missing-release-tag) "inputError" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/catalog-backend/src/ingestion/processors/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/GitLabDiscoveryProcessor.ts
@@ -142,9 +142,10 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
     return true;
   }
 
-  async updateLastActivity(): Promise<string | undefined> {
-    const lastActivity = await this.cache.get('last-activity');
-    await this.cache.set('last-activity', new Date().toISOString());
+  private async updateLastActivity(): Promise<string | undefined> {
+    const cacheKey = `processors/${this.getProcessorName()}/last-activity`;
+    const lastActivity = await this.cache.get(cacheKey);
+    await this.cache.set(cacheKey, new Date().toISOString());
     return lastActivity as string | undefined;
   }
 }


### PR DESCRIPTION
This one needs #9615 😅 

As far as I can tell this is the only usage of the shared cache facility from backend-common in processors, so set up a bit of a naming pattern for the keys too.