### PR TITLE
catalog: remove plugin export

### DIFF
--- a/.changeset/thick-tools-tan.md
+++ b/.changeset/thick-tools-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+**BREAKING**: Removed the old `plugin` export, use `catalogPlugin` instead.

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -80,7 +80,7 @@ export interface CatalogKindHeaderProps {
 }
 
 // @public (undocumented)
-const catalogPlugin: BackstagePlugin<
+export const catalogPlugin: BackstagePlugin<
   {
     catalogIndex: RouteRef<undefined>;
     catalogEntity: RouteRef<{
@@ -101,8 +101,6 @@ const catalogPlugin: BackstagePlugin<
     >;
   }
 >;
-export { catalogPlugin };
-export { catalogPlugin as plugin };
 
 // @public (undocumented)
 export function CatalogResultListItem(

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -35,7 +35,6 @@ export {
   CatalogEntityPage,
   CatalogIndexPage,
   catalogPlugin,
-  catalogPlugin as plugin,
   EntityAboutCard,
   EntityDependencyOfComponentsCard,
   EntityDependsOnComponentsCard,


### PR DESCRIPTION
🧹 

`plugin` exports are old and haven't been recommended for a long time, so figured we get rid of it straight away without a deprecation. Migration is very straight-forward too