### PR TITLE
maybe rename CatalogResultListItem

### DIFF
--- a/.changeset/dry-papayas-melt.md
+++ b/.changeset/dry-papayas-melt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Renamed `CatalogResultListItem` to `CatalogSearchResultListItem` along with its prop type, leaving the old names in place as a deprecations.

--- a/.changeset/gentle-buttons-hunt.md
+++ b/.changeset/gentle-buttons-hunt.md
@@ -1,0 +1,22 @@
+---
+'@backstage/create-app': patch
+---
+
+Update the template to reflect the renaming of `CatalogResultListItem` to `CatalogSearchResultListItem` from `@backstage/plugin-catalog`.
+
+To apply this change to an existing app, make the following change to `packages/app/src/components/search/SearchPage.tsx`:
+
+```diff
+-import { CatalogResultListItem } from '@backstage/plugin-catalog';
++import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';
+```
+
+```diff
+   case 'software-catalog':
+     return (
+-      <CatalogResultListItem
++      <CatalogSearchResultListItem
+         key={document.location}
+         result={document}
+       />
+```

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -24,7 +24,7 @@ import {
   SidebarPinStateContext,
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import { CatalogResultListItem } from '@backstage/plugin-catalog';
+import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';
 import {
   catalogApiRef,
   CATALOG_FILTER_EXISTS,
@@ -136,7 +136,7 @@ const SearchPage = () => {
                     switch (type) {
                       case 'software-catalog':
                         return (
-                          <CatalogResultListItem
+                          <CatalogSearchResultListItem
                             key={document.location}
                             result={document}
                           />

--- a/packages/create-app/templates/default-app/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/search/SearchPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles, Theme, Grid, List, Paper } from '@material-ui/core';
 
-import { CatalogResultListItem } from '@backstage/plugin-catalog';
+import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';
 import {
   catalogApiRef,
   CATALOG_FILTER_EXISTS,
@@ -116,7 +116,7 @@ const SearchPage = () => {
                     switch (type) {
                       case 'software-catalog':
                         return (
-                          <CatalogResultListItem
+                          <CatalogSearchResultListItem
                             key={document.location}
                             result={document}
                           />

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -104,13 +104,19 @@ const catalogPlugin: BackstagePlugin<
 export { catalogPlugin };
 export { catalogPlugin as plugin };
 
+// @public @deprecated (undocumented)
+export const CatalogResultListItem: typeof CatalogSearchResultListItem;
+
+// @public @deprecated (undocumented)
+export type CatalogResultListItemProps = CatalogSearchResultListItemProps;
+
 // @public (undocumented)
-export function CatalogResultListItem(
-  props: CatalogResultListItemProps,
+export function CatalogSearchResultListItem(
+  props: CatalogSearchResultListItemProps,
 ): JSX.Element;
 
 // @public
-export interface CatalogResultListItemProps {
+export interface CatalogSearchResultListItemProps {
   // (undocumented)
   result: IndexableDocument;
 }

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
@@ -38,16 +38,18 @@ const useStyles = makeStyles({
 });
 
 /**
- * Props for {@link CatalogResultListItem}.
+ * Props for {@link CatalogSearchResultListItem}.
  *
  * @public
  */
-export interface CatalogResultListItemProps {
+export interface CatalogSearchResultListItemProps {
   result: IndexableDocument;
 }
 
 /** @public */
-export function CatalogResultListItem(props: CatalogResultListItemProps) {
+export function CatalogSearchResultListItem(
+  props: CatalogSearchResultListItemProps,
+) {
   const result = props.result as any;
 
   const classes = useStyles();
@@ -71,3 +73,15 @@ export function CatalogResultListItem(props: CatalogResultListItemProps) {
     </Link>
   );
 }
+
+/**
+ * @public
+ * @deprecated use {@link CatalogSearchResultListItemProps} instead
+ */
+export type CatalogResultListItemProps = CatalogSearchResultListItemProps;
+
+/**
+ * @public
+ * @deprecated use {@link CatalogSearchResultListItem} instead
+ */
+export const CatalogResultListItem = CatalogSearchResultListItem;

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/index.ts
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/index.ts
@@ -14,5 +14,11 @@
  * limitations under the License.
  */
 
-export { CatalogResultListItem } from './CatalogResultListItem';
-export type { CatalogResultListItemProps } from './CatalogResultListItem';
+export {
+  CatalogSearchResultListItem,
+  CatalogResultListItem,
+} from './CatalogSearchResultListItem';
+export type {
+  CatalogSearchResultListItemProps,
+  CatalogResultListItemProps,
+} from './CatalogSearchResultListItem';

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -22,7 +22,7 @@
 
 export * from './components/AboutCard';
 export * from './components/CatalogKindHeader';
-export * from './components/CatalogResultListItem';
+export * from './components/CatalogSearchResultListItem';
 export * from './components/CatalogTable';
 export * from './components/CatalogTable/columns';
 export * from './components/EntityLayout';


### PR DESCRIPTION
Draft to see what you think @backstage/techdocs-core. It ofc needs changeset if we wanna do this, and we'd do it as a deprecation as well.

What triggered this is that we didn't feel `CatalogResultListItem` gave enough context within the catalog package, as in just looking at the name you're not quite sure what it's for. That's somewhat counteracted if `ResultListItem` is a naming pattern that we settle on to refer to search results, but tbh I'm finding it a bit difficult to motivate why we shouldn't still call them `*SearchResultListItem`s as they're often mixed in with other exports.