### PR TITLE
[Plugin] expose 'read only' configuration option in Splunk On-Call plugin

### DIFF
--- a/.changeset/spicy-elephants-decide.md
+++ b/.changeset/spicy-elephants-decide.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-splunk-on-call': patch
 ---
 
-Splunk OnCall plugin now supports a "read only" mode configuration option for optionally suppressing the rendering of incident trigger-acknowledge-resolve controls from the Backstage UI.
+The Splunk On-Call plugin now supports an optional `readOnly` property (`<SplunkOnCallEntityCard readOnly />`) for suppressing the rendering of incident trigger-acknowledge-resolve controls from the Backstage UI.

--- a/.changeset/spicy-elephants-decide.md
+++ b/.changeset/spicy-elephants-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-splunk-on-call': patch
+---
+
+Splunk OnCall plugin now supports a "read only" mode configuration option for optionally suppressing the rendering of incident trigger-acknowledge-resolve controls from the Backstage UI.

--- a/plugins/splunk-on-call/README.md
+++ b/plugins/splunk-on-call/README.md
@@ -45,6 +45,14 @@ const overviewContent = (
     </EntitySwitch>
 ```
 
+### `readOnly` mode
+
+To suppress the rendering of the actionable create-acknowledge-resolve incident buttons and UI controls, the `EntitySplunkOnCallCard` can also be instantiated in `readOnly` mode:
+
+```ts
+<EntitySplunkOnCallCard readOnly />
+```
+
 ## Client configuration
 
 In order to be able to perform certain actions (create-acknowledge-resolve an action), you need to provide a REST Endpoint.
@@ -74,17 +82,9 @@ proxy:
 
 In addition, to make certain API calls (trigger-resolve-acknowledge an incident) you need to add the `PATCH` method to the backend `cors` methods list: `[GET, POST, PUT, DELETE, PATCH]`.
 
-**WARNING**: In current implementation, the Splunk OnCall plugin requires the `/splunk-on-call` proxy endpoint be exposed by the Backstage backend as an unprotected endpoint, in effect enabling Splunk OnCall API access using the configured `SPLUNK_ON_CALL_API_KEY` for any user or process with access to the `/splunk-on-call` Backstage backend endpoint. See below for further configuration options enabling protection of this endpoint.
-
-### Read Only mode
-
-The Splunk OnCall plugin also supports a "read only" mode if you wish to suppress the rendering of UI controls to trigger-resolve-acknowledge incidents.
+**WARNING**: In current implementation, the Splunk OnCall plugin requires the `/splunk-on-call` proxy endpoint be exposed by the Backstage backend as an unprotected endpoint, in effect enabling Splunk OnCall API access using the configured `SPLUNK_ON_CALL_API_KEY` for any user or process with access to the `/splunk-on-call` Backstage backend endpoint. See below for further configuration options enabling protection of this endpoint. If you regard this as problematic, consider using the plugin in `readOnly` mode (`<EntitySplunkOnCallCard readOnly />`) using the following proxy configuration:
 
 ```yaml
-# enable readOnly mode
-splunkOnCall:
-  readOnly: true
-
 proxy:
   '/splunk-on-call':
     target: https://api.victorops.com/api-public

--- a/plugins/splunk-on-call/README.md
+++ b/plugins/splunk-on-call/README.md
@@ -74,6 +74,28 @@ proxy:
 
 In addition, to make certain API calls (trigger-resolve-acknowledge an incident) you need to add the `PATCH` method to the backend `cors` methods list: `[GET, POST, PUT, DELETE, PATCH]`.
 
+**WARNING**: In current implementation, the Splunk OnCall plugin requires the `/splunk-on-call` proxy endpoint be exposed by the Backstage backend as an unprotected endpoint, in effect enabling Splunk OnCall API access using the configured `SPLUNK_ON_CALL_API_KEY` for any user or process with access to the `/splunk-on-call` Backstage backend endpoint. See below for further configuration options enabling protection of this endpoint.
+
+### Read Only mode
+
+The Splunk OnCall plugin also supports a "read only" mode if you wish to suppress the rendering of UI controls to trigger-resolve-acknowledge incidents.
+
+```yaml
+# enable readOnly mode
+splunkOnCall:
+  readOnly: true
+
+proxy:
+  # ...
+  '/splunk-on-call':
+    target: https://api.victorops.com/api-public
+    headers:
+      X-VO-Api-Id: ${SPLUNK_ON_CALL_API_ID}
+      X-VO-Api-Key: ${SPLUNK_ON_CALL_API_KEY}
+    # prohibit non-GET requests from the /splunk-on-call proxy
+    allowedMethods: ['GET']
+```
+
 ### Adding your team name to the entity annotation
 
 The information displayed for each entity is based on either an associated team name or an associated routing key.

--- a/plugins/splunk-on-call/README.md
+++ b/plugins/splunk-on-call/README.md
@@ -86,13 +86,12 @@ splunkOnCall:
   readOnly: true
 
 proxy:
-  # ...
   '/splunk-on-call':
     target: https://api.victorops.com/api-public
     headers:
       X-VO-Api-Id: ${SPLUNK_ON_CALL_API_ID}
       X-VO-Api-Key: ${SPLUNK_ON_CALL_API_KEY}
-    # prohibit non-GET requests from the /splunk-on-call proxy
+    # prohibit the `/splunk-on-call` proxy endpoint from servicing non-GET requests
     allowedMethods: ['GET']
 ```
 

--- a/plugins/splunk-on-call/api-report.md
+++ b/plugins/splunk-on-call/api-report.md
@@ -12,14 +12,13 @@ import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { RouteRef } from '@backstage/core-plugin-api';
 
+// Warning: (ae-forgotten-export) The symbol "EntitySplunkOnCallCardProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "EntitySplunkOnCallCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const EntitySplunkOnCallCard: ({
-  readOnly,
-}: {
-  readOnly?: boolean | undefined;
-}) => JSX.Element;
+export const EntitySplunkOnCallCard: (
+  props: EntitySplunkOnCallCardProps,
+) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "isSplunkOnCallAvailable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/splunk-on-call/api-report.md
+++ b/plugins/splunk-on-call/api-report.md
@@ -15,7 +15,11 @@ import { RouteRef } from '@backstage/core-plugin-api';
 // Warning: (ae-missing-release-tag) "EntitySplunkOnCallCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const EntitySplunkOnCallCard: () => JSX.Element;
+export const EntitySplunkOnCallCard: ({
+  readOnly,
+}: {
+  readOnly?: boolean | undefined;
+}) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "isSplunkOnCallAvailable" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.test.tsx
@@ -53,26 +53,12 @@ const mockSplunkOnCallApi: Partial<SplunkOnCallClient> = {
 const configApi: ConfigApi = new ConfigReader({
   splunkOnCall: {
     eventsRestEndpoint: 'EXAMPLE_REST_ENDPOINT',
-    readOnly: false,
-  },
-});
-
-const readOnlyConfigApi: ConfigApi = new ConfigReader({
-  splunkOnCall: {
-    eventsRestEndpoint: 'EXAMPLE_REST_ENDPOINT',
-    readOnly: true,
   },
 });
 
 const apis = TestApiRegistry.from(
   [splunkOnCallApiRef, mockSplunkOnCallApi],
   [configApiRef, configApi],
-  [alertApiRef, {}],
-);
-
-const readOnlyApis = TestApiRegistry.from(
-  [splunkOnCallApiRef, mockSplunkOnCallApi],
-  [configApiRef, readOnlyConfigApi],
   [alertApiRef, {}],
 );
 
@@ -155,9 +141,9 @@ describe('SplunkOnCallCard', () => {
 
     const { getByText, queryByTestId } = render(
       wrapInTestApp(
-        <ApiProvider apis={readOnlyApis}>
+        <ApiProvider apis={apis}>
           <EntityProvider entity={mockEntityNoIncidents}>
-            <EntitySplunkOnCallCard />
+            <EntitySplunkOnCallCard readOnly />
           </EntityProvider>
         </ApiProvider>,
       ),

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -109,7 +109,12 @@ const useStyles = makeStyles({
   },
 });
 
-export const EntitySplunkOnCallCard = () => {
+type Props = {
+  readOnly?: boolean;
+};
+
+export const EntitySplunkOnCallCard = ({ readOnly }: Props) => {
+  const readOnlyMode = readOnly || false;
   const classes = useStyles();
   const config = useApi(configApiRef);
   const api = useApi(splunkOnCallApiRef);
@@ -125,8 +130,6 @@ export const EntitySplunkOnCallCard = () => {
 
   const eventsRestEndpoint =
     config.getOptionalString('splunkOnCall.eventsRestEndpoint') || true;
-
-  const readOnly = config.getOptionalBoolean('splunkOnCall.readOnly') || false;
 
   const handleRefresh = useCallback(() => {
     setRefreshIncidents(x => !x);
@@ -221,7 +224,7 @@ export const EntitySplunkOnCallCard = () => {
     return (
       <>
         <Incidents
-          readOnly={readOnly}
+          readOnly={readOnlyMode}
           team={teamName}
           refreshIncidents={refreshIncidents}
         />

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -124,7 +124,9 @@ export const EntitySplunkOnCallCard = () => {
     : undefined;
 
   const eventsRestEndpoint =
-    config.getOptionalString('splunkOnCall.eventsRestEndpoint') || null;
+    config.getOptionalString('splunkOnCall.eventsRestEndpoint') || true;
+
+  const readOnly = config.getOptionalBoolean('splunkOnCall.readOnly') || false;
 
   const handleRefresh = useCallback(() => {
     setRefreshIncidents(x => !x);
@@ -218,7 +220,11 @@ export const EntitySplunkOnCallCard = () => {
 
     return (
       <>
-        <Incidents team={teamName} refreshIncidents={refreshIncidents} />
+        <Incidents
+          readOnly={readOnly}
+          team={teamName}
+          refreshIncidents={refreshIncidents}
+        />
         {usersHashMap && team && (
           <EscalationPolicy team={teamName} users={usersHashMap} />
         )}
@@ -259,7 +265,7 @@ export const EntitySplunkOnCallCard = () => {
               </Typography>,
               <HeaderIconLinkRow
                 key="incident_trigger"
-                links={[serviceLink, triggerLink]}
+                links={!readOnly ? [serviceLink, triggerLink] : [serviceLink]}
               />,
             ]}
           />

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -129,7 +129,7 @@ export const EntitySplunkOnCallCard = ({ readOnly }: Props) => {
     : undefined;
 
   const eventsRestEndpoint =
-    config.getOptionalString('splunkOnCall.eventsRestEndpoint') || true;
+    config.getOptionalString('splunkOnCall.eventsRestEndpoint') || null;
 
   const handleRefresh = useCallback(() => {
     setRefreshIncidents(x => !x);

--- a/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
+++ b/plugins/splunk-on-call/src/components/EntitySplunkOnCallCard.tsx
@@ -109,12 +109,14 @@ const useStyles = makeStyles({
   },
 });
 
-type Props = {
+/** @public */
+export type EntitySplunkOnCallCardProps = {
   readOnly?: boolean;
 };
 
-export const EntitySplunkOnCallCard = ({ readOnly }: Props) => {
-  const readOnlyMode = readOnly || false;
+/** @public */
+export const EntitySplunkOnCallCard = (props: EntitySplunkOnCallCardProps) => {
+  const { readOnly } = props;
   const classes = useStyles();
   const config = useApi(configApiRef);
   const api = useApi(splunkOnCallApiRef);
@@ -224,7 +226,7 @@ export const EntitySplunkOnCallCard = ({ readOnly }: Props) => {
     return (
       <>
         <Incidents
-          readOnly={readOnlyMode}
+          readOnly={readOnly || false}
           team={teamName}
           refreshIncidents={refreshIncidents}
         />

--- a/plugins/splunk-on-call/src/components/Incident/IncidentListItem.tsx
+++ b/plugins/splunk-on-call/src/components/Incident/IncidentListItem.tsx
@@ -243,15 +243,13 @@ export const IncidentListItem = ({
 
       {incident.incidentLink && incident.incidentNumber && (
         <ListItemSecondaryAction>
-          {!readOnly ? (
+          {!readOnly && (
             <IncidentAction
               currentPhase={incident.currentPhase || ''}
               incidentId={incident.entityId}
               resolveAction={handleResolveIncident}
               acknowledgeAction={handleAcknowledgeIncident}
             />
-          ) : (
-            ''
           )}
           <Tooltip title="View in Splunk On-Call" placement="top">
             <IconButton

--- a/plugins/splunk-on-call/src/components/Incident/IncidentListItem.tsx
+++ b/plugins/splunk-on-call/src/components/Incident/IncidentListItem.tsx
@@ -64,6 +64,7 @@ type Props = {
   team: string;
   incident: Incident;
   onIncidentAction: () => void;
+  readOnly: boolean;
 };
 
 const IncidentPhaseStatus = ({
@@ -135,6 +136,7 @@ const IncidentAction = ({
 
 export const IncidentListItem = ({
   incident,
+  readOnly,
   onIncidentAction,
   team,
 }: Props) => {
@@ -241,12 +243,16 @@ export const IncidentListItem = ({
 
       {incident.incidentLink && incident.incidentNumber && (
         <ListItemSecondaryAction>
-          <IncidentAction
-            currentPhase={incident.currentPhase || ''}
-            incidentId={incident.entityId}
-            resolveAction={handleResolveIncident}
-            acknowledgeAction={handleAcknowledgeIncident}
-          />
+          {!readOnly ? (
+            <IncidentAction
+              currentPhase={incident.currentPhase || ''}
+              incidentId={incident.entityId}
+              resolveAction={handleResolveIncident}
+              acknowledgeAction={handleAcknowledgeIncident}
+            />
+          ) : (
+            ''
+          )}
           <Tooltip title="View in Splunk On-Call" placement="top">
             <IconButton
               href={incident.incidentLink}

--- a/plugins/splunk-on-call/src/components/Incident/Incidents.test.tsx
+++ b/plugins/splunk-on-call/src/components/Incident/Incidents.test.tsx
@@ -44,7 +44,7 @@ describe('Incidents', () => {
     const { getByText, queryByTestId } = render(
       wrapInTestApp(
         <ApiProvider apis={apis}>
-          <Incidents refreshIncidents={false} team="test" />
+          <Incidents readOnly={false} refreshIncidents={false} team="test" />
         </ApiProvider>,
       ),
     );
@@ -68,7 +68,7 @@ describe('Incidents', () => {
     } = render(
       wrapInTestApp(
         <ApiProvider apis={apis}>
-          <Incidents team="test" refreshIncidents={false} />
+          <Incidents readOnly={false} team="test" refreshIncidents={false} />
         </ApiProvider>,
       ),
     );
@@ -94,13 +94,7 @@ describe('Incidents', () => {
     mockSplunkOnCallApi.getIncidents.mockResolvedValue([MOCK_INCIDENT]);
     mockSplunkOnCallApi.getTeams.mockResolvedValue([MOCK_TEAM]);
 
-    const {
-      getByText,
-      getByTitle,
-      getAllByTitle,
-      getByLabelText,
-      queryByTestId,
-    } = render(
+    const { getByText, getAllByTitle, getByLabelText, queryByTestId } = render(
       wrapInTestApp(
         <ApiProvider apis={apis}>
           <Incidents readOnly team="test" refreshIncidents={false} />
@@ -139,7 +133,7 @@ describe('Incidents', () => {
     const { getByText, queryByTestId } = render(
       wrapInTestApp(
         <ApiProvider apis={apis}>
-          <Incidents team="test" refreshIncidents={false} />
+          <Incidents readOnly={false} team="test" refreshIncidents={false} />
         </ApiProvider>,
       ),
     );

--- a/plugins/splunk-on-call/src/components/Incident/Incidents.tsx
+++ b/plugins/splunk-on-call/src/components/Incident/Incidents.tsx
@@ -49,9 +49,10 @@ const useStyles = makeStyles((theme: Theme) =>
 type Props = {
   refreshIncidents: boolean;
   team: string;
+  readOnly: boolean;
 };
 
-export const Incidents = ({ refreshIncidents, team }: Props) => {
+export const Incidents = ({ readOnly, refreshIncidents, team }: Props) => {
   const classes = useStyles();
   const api = useApi(splunkOnCallApiRef);
 
@@ -108,6 +109,7 @@ export const Incidents = ({ refreshIncidents, team }: Props) => {
             key={index}
             team={team}
             incident={incident}
+            readOnly={readOnly}
           />
         ))
       )}


### PR DESCRIPTION
This PR ~creates a `splunkOnCall.readOnly` configuration option~ adds a `readOnly` property to the `SplunkOnCallEntityCard` component to address issue #9634.

By default, the plugin continues to render as represented in the screenshot below, displaying a "Create incident" link, as well as acknowledge/resolve controls in association with each incident...

![splunk_on_call_read_only_false](https://user-images.githubusercontent.com/184109/154574575-f0ebf1c0-dd6f-4f1f-a407-ab75ed90afa4.png)

However, when `readOnly` is configured (`<SplunkOnCallEntityCard readOnly />`, the plugin does not render the "Create incident" link, nor the acknowledge/resolve controls in association with each incident as demonstrated in the following screenshot...

![splunk_on_call_read_only_true](https://user-images.githubusercontent.com/184109/154574819-2a4362c7-366d-4761-9e47-b948ab47db92.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
