### PR TITLE
catalog-model: move EntityRelationSpec to catalog-backend

### DIFF
--- a/.changeset/lovely-chairs-confess.md
+++ b/.changeset/lovely-chairs-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added `EntityRelationSpec`, which was moved over from `@backstage/catalog-model`.

--- a/.changeset/lovely-falcons-hang.md
+++ b/.changeset/lovely-falcons-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+**BREAKING**: Removed `EntityRelationSpec` as it is only used during the catalog during the catalog processing.

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -234,13 +234,6 @@ export type EntityRelation = {
 };
 
 // @public
-export type EntityRelationSpec = {
-  source: EntityName;
-  type: string;
-  target: EntityName;
-};
-
-// @public
 export function entitySchemaValidator<T extends Entity = Entity>(
   schema?: unknown,
 ): (data: unknown) => T;

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -202,28 +202,6 @@ export type EntityRelation = {
 };
 
 /**
- * Holds the relation data for entities.
- *
- * @public
- */
-export type EntityRelationSpec = {
-  /**
-   * The source entity of this relation.
-   */
-  source: EntityName;
-
-  /**
-   * The type of the relation.
-   */
-  type: string;
-
-  /**
-   * The target entity of this relation.
-   */
-  target: EntityName;
-};
-
-/**
  * A link to external information that is related to the entity.
  *
  * @public

--- a/packages/catalog-model/src/entity/index.ts
+++ b/packages/catalog-model/src/entity/index.ts
@@ -29,7 +29,6 @@ export type {
   EntityLink,
   EntityMeta,
   EntityRelation,
-  EntityRelationSpec,
 } from './Entity';
 export type { EntityEnvelope } from './EntityEnvelope';
 export type {

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -13,8 +13,8 @@ import { Conditions } from '@backstage/plugin-permission-node';
 import { Config } from '@backstage/config';
 import { DocumentCollator } from '@backstage/search-common';
 import { Entity } from '@backstage/catalog-model';
+import { EntityName } from '@backstage/catalog-model';
 import { EntityPolicy } from '@backstage/catalog-model';
-import { EntityRelationSpec } from '@backstage/catalog-model';
 import express from 'express';
 import { GetEntitiesRequest } from '@backstage/catalog-client';
 import { GithubCredentialsProvider } from '@backstage/integration';
@@ -736,6 +736,13 @@ export type EntityProviderMutation =
       added: DeferredEntity[];
       removed: DeferredEntity[];
     };
+
+// @public
+export type EntityRelationSpec = {
+  source: EntityName;
+  type: string;
+  target: EntityName;
+};
 
 // Warning: (ae-missing-release-tag) "FileReaderProcessor" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/catalog-backend/src/database/types.ts
+++ b/plugins/catalog-backend/src/database/types.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 import { JsonObject } from '@backstage/types';
 import { DateTime } from 'luxon';
-import { DeferredEntity } from '../processing/types';
+import { DeferredEntity, EntityRelationSpec } from '../processing/types';
 
 /**
  * An abstraction for transactions of the underlying database technology.

--- a/plugins/catalog-backend/src/ingestion/processors/results.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/results.ts
@@ -15,12 +15,9 @@
  */
 
 import { InputError, NotFoundError } from '@backstage/errors';
-import {
-  Entity,
-  EntityRelationSpec,
-  LocationSpec,
-} from '@backstage/catalog-model';
+import { Entity, LocationSpec } from '@backstage/catalog-model';
 import { CatalogProcessorResult } from './types';
+import { EntityRelationSpec } from '../../processing/types';
 
 export function notFoundError(
   atLocation: LocationSpec,

--- a/plugins/catalog-backend/src/ingestion/processors/types.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/types.ts
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-import {
-  Entity,
-  EntityRelationSpec,
-  LocationSpec,
-} from '@backstage/catalog-model';
+import { Entity, LocationSpec } from '@backstage/catalog-model';
 import { JsonValue } from '@backstage/types';
+import { EntityRelationSpec } from '../../processing/types';
 
 export type CatalogProcessor = {
   /**

--- a/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
+++ b/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
@@ -16,7 +16,6 @@
 
 import {
   Entity,
-  EntityRelationSpec,
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
   stringifyLocationRef,
@@ -25,7 +24,7 @@ import { assertError } from '@backstage/errors';
 import { Logger } from 'winston';
 import { CatalogProcessorResult } from '../ingestion';
 import { locationSpecToLocationEntity } from '../util/conversion';
-import { DeferredEntity } from './types';
+import { DeferredEntity, EntityRelationSpec } from './types';
 import {
   getEntityLocationRef,
   getEntityOriginLocationRef,

--- a/plugins/catalog-backend/src/processing/index.ts
+++ b/plugins/catalog-backend/src/processing/index.ts
@@ -19,6 +19,7 @@ export type {
   CatalogProcessingEngine,
   EntityProcessingRequest,
   EntityProcessingResult,
+  EntityRelationSpec,
   DeferredEntity,
 } from './types';
 export { DefaultCatalogProcessingOrchestrator } from './DefaultCatalogProcessingOrchestrator';

--- a/plugins/catalog-backend/src/processing/types.ts
+++ b/plugins/catalog-backend/src/processing/types.ts
@@ -14,8 +14,30 @@
  * limitations under the License.
  */
 
-import { Entity, EntityRelationSpec } from '@backstage/catalog-model';
+import { Entity, EntityName } from '@backstage/catalog-model';
 import { JsonObject } from '@backstage/types';
+
+/**
+ * Holds the relation data for entities.
+ *
+ * @public
+ */
+export type EntityRelationSpec = {
+  /**
+   * The source entity of this relation.
+   */
+  source: EntityName;
+
+  /**
+   * The type of the relation.
+   */
+  type: string;
+
+  /**
+   * The target entity of this relation.
+   */
+  target: EntityName;
+};
 
 export type EntityProcessingRequest = {
   entity: Entity;


### PR DESCRIPTION
Figured this is alright to do without deprecation, seeing as there's not much use for `EntityRelationSpec` outside the the processing engine implementation and processor result emission