### PR TITLE
catalog: Deprecate `useEntityFromUrl` and `useEntityCompoundName`

### DIFF
--- a/.changeset/afraid-ravens-beam.md
+++ b/.changeset/afraid-ravens-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Internalize deprecated `useEntityFromUrl` hook

--- a/.changeset/tame-pants-count.md
+++ b/.changeset/tame-pants-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Deprecated `useEntityFromUrl` and the `useEntityCompoundName` hooks as these have very low utility value.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -541,14 +541,14 @@ export function useEntity<T extends Entity = Entity>(): {
   refresh: VoidFunction | undefined;
 };
 
-// @public
+// @public @deprecated
 export const useEntityCompoundName: () => {
   kind: string;
   namespace: string;
   name: string;
 };
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const useEntityFromUrl: () => EntityLoadingStatus;
 
 // @public

--- a/plugins/catalog-react/src/hooks/useEntity.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.tsx
@@ -134,7 +134,9 @@ const CompatibilityProvider = ({
 };
 EntityContext.Provider = CompatibilityProvider as Provider<EntityLoadingStatus>;
 
-/** @public */
+/** @public
+ * @deprecated will be deleted shortly due to low external usage, re-implement if needed.
+ */
 export const useEntityFromUrl = (): EntityLoadingStatus => {
   const { kind, namespace, name } = useEntityCompoundName();
   const navigate = useNavigate();

--- a/plugins/catalog-react/src/hooks/useEntityCompoundName.ts
+++ b/plugins/catalog-react/src/hooks/useEntityCompoundName.ts
@@ -19,6 +19,7 @@ import { useRouteRefParams } from '@backstage/core-plugin-api';
 /**
  * Grabs entity kind, namespace, and name from the location
  * @public
+ * @deprecated use {@link @backstage/core-plugin-api#useRouteRefParams} instead
  */
 export const useEntityCompoundName = () => {
   const { kind, namespace, name } = useRouteRefParams(entityRouteRef);

--- a/plugins/catalog/src/components/CatalogEntityPage/CatalogEntityPage.tsx
+++ b/plugins/catalog/src/components/CatalogEntityPage/CatalogEntityPage.tsx
@@ -16,10 +16,8 @@
 
 import React from 'react';
 import { Outlet } from 'react-router';
-import {
-  useEntityFromUrl,
-  AsyncEntityProvider,
-} from '@backstage/plugin-catalog-react';
+import { AsyncEntityProvider } from '@backstage/plugin-catalog-react';
+import { useEntityFromUrl } from './UseEntityFromUrl';
 
 /** @public */
 export function CatalogEntityPage() {

--- a/plugins/catalog/src/components/CatalogEntityPage/UseEntityFromUrl.ts
+++ b/plugins/catalog/src/components/CatalogEntityPage/UseEntityFromUrl.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  errorApiRef,
+  useApi,
+  useRouteRefParams,
+} from '@backstage/core-plugin-api';
+import {
+  catalogApiRef,
+  EntityLoadingStatus,
+  entityRouteRef,
+} from '@backstage/plugin-catalog-react';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import useAsyncRetry from 'react-use/lib/useAsyncRetry';
+
+export const useEntityFromUrl = (): EntityLoadingStatus => {
+  const { kind, namespace, name } = useRouteRefParams(entityRouteRef);
+  const navigate = useNavigate();
+  const errorApi = useApi(errorApiRef);
+  const catalogApi = useApi(catalogApiRef);
+
+  const {
+    value: entity,
+    error,
+    loading,
+    retry: refresh,
+  } = useAsyncRetry(
+    () => catalogApi.getEntityByName({ kind, namespace, name }),
+    [catalogApi, kind, namespace, name],
+  );
+
+  useEffect(() => {
+    if (!name) {
+      errorApi.post(new Error('No name provided!'));
+      navigate('/');
+    }
+  }, [errorApi, navigate, error, loading, entity, name]);
+
+  return { entity, loading, error, refresh };
+};


### PR DESCRIPTION
🧹 
