### PR TITLE
catalog-import: stop trying to register optional locations

### DIFF
--- a/.changeset/yellow-boxes-jump.md
+++ b/.changeset/yellow-boxes-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+No longer attempt to register locations as optional, since it's ignored.

--- a/plugins/catalog-import/src/components/StepReviewLocation/StepReviewLocation.tsx
+++ b/plugins/catalog-import/src/components/StepReviewLocation/StepReviewLocation.tsx
@@ -73,8 +73,6 @@ export const StepReviewLocation = ({
             const result = await catalogApi.addLocation({
               type: 'url',
               target: l.target,
-              presence:
-                prepareResult.type === 'repository' ? 'optional' : 'required',
             });
             return {
               target: result.location.target,


### PR DESCRIPTION
See #9663, as far as I can tell it's ignored by the backend. Am I missing some point where it would be handled? 😅 