### PR TITLE
catalog: remove columnFactories export

### DIFF
--- a/.changeset/fair-otters-happen.md
+++ b/.changeset/fair-otters-happen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Removed `columnFactories`, which was accidentally exported on the previous release.

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -160,23 +160,6 @@ export interface CatalogTableRow {
   };
 }
 
-// @public (undocumented)
-export const columnFactories: Readonly<{
-  createNameColumn(
-    options?:
-      | {
-          defaultKind?: string | undefined;
-        }
-      | undefined,
-  ): TableColumn<CatalogTableRow>;
-  createSystemColumn(): TableColumn<CatalogTableRow>;
-  createOwnerColumn(): TableColumn<CatalogTableRow>;
-  createSpecTypeColumn(): TableColumn<CatalogTableRow>;
-  createSpecLifecycleColumn(): TableColumn<CatalogTableRow>;
-  createMetadataDescriptionColumn(): TableColumn<CatalogTableRow>;
-  createTagsColumn(): TableColumn<CatalogTableRow>;
-}>;
-
 // @public
 export interface DefaultCatalogPageProps {
   // (undocumented)

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -24,7 +24,6 @@ export * from './components/AboutCard';
 export * from './components/CatalogKindHeader';
 export * from './components/CatalogSearchResultListItem';
 export * from './components/CatalogTable';
-export * from './components/CatalogTable/columns';
 export * from './components/EntityLayout';
 export * from './components/EntityOrphanWarning';
 export * from './components/EntityProcessingErrorsPanel';


### PR DESCRIPTION
🧹 

Not marked as breaking or elaborating more since the changeset from the release correctly highlights `CatalogTable.columns` as the new way to consume these.