### PR TITLE
[Permissions] Improve error message for backend-to-backend authn setup

### DIFF
--- a/.changeset/serious-eyes-fix.md
+++ b/.changeset/serious-eyes-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+Improved error message permissions are enabled without backend-to-backend authentication.

--- a/.changeset/serious-eyes-fix.md
+++ b/.changeset/serious-eyes-fix.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-permission-node': patch
 ---
 
-Improved error message permissions are enabled without backend-to-backend authentication.
+Improved error message shown when permissions are enabled without backend-to-backend authentication.

--- a/plugins/permission-node/src/ServerPermissionClient.test.ts
+++ b/plugins/permission-node/src/ServerPermissionClient.test.ts
@@ -113,7 +113,7 @@ describe('ServerPermissionClient', () => {
         tokenManager: ServerTokenManager.noop(),
       }),
     ).toThrowError(
-      'You must configure at least one key in backend.auth.keys if permissions are enabled.',
+      'Backend-to-backend authentication must be configured before enabling permissions. Read more here https://backstage.io/docs/tutorials/backend-to-backend-auth',
     );
   });
 });

--- a/plugins/permission-node/src/ServerPermissionClient.ts
+++ b/plugins/permission-node/src/ServerPermissionClient.ts
@@ -56,7 +56,7 @@ export class ServerPermissionClient implements PermissionAuthorizer {
       (tokenManager as any).isInsecureServerTokenManager
     ) {
       throw new Error(
-        'You must configure at least one key in backend.auth.keys if permissions are enabled.',
+        'Backend-to-backend authentication must be configured before enabling permissions. Read more here https://backstage.io/docs/tutorials/backend-to-backend-auth',
       );
     }
 


### PR DESCRIPTION
Signed-off-by: Joe Porpeglia <josephp@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This should provide better instructions if the permissions framework is enabled without backend to backend authentication configured. The error message I changed here is already displayed if `ServerTokenManager` is used without setting `backend.auth.keys` (see [`ServerTokenManager`](https://github.com/backstage/backstage/blob/c323b2b6af34c60cb757199f520a1ad291d49ca0/packages/backend-common/src/tokens/ServerTokenManager.ts#L56)). Now `ServerPermissionClient` tells users to set up backend-to-backend authentication and `ServerTokenManager` tells them to set the related config values.

Related to #9498

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
