### PR TITLE
cli: repo backend build

### DIFF
--- a/.changeset/thick-brooms-teach.md
+++ b/.changeset/thick-brooms-teach.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fix building of backends with `repo build --all`, where it would previously only work if the build was executed within the backend package.

--- a/packages/cli/src/commands/build/buildBackend.ts
+++ b/packages/cli/src/commands/build/buildBackend.ts
@@ -35,7 +35,10 @@ export async function buildBackend(options: BuildBackendOptions) {
   const pkg = await fs.readJson(resolvePath(targetDir, 'package.json'));
 
   // We build the target package without generating type declarations.
-  await buildPackage({ outputs: new Set([Output.cjs]) });
+  await buildPackage({
+    targetDir: options.targetDir,
+    outputs: new Set([Output.cjs]),
+  });
 
   const tmpDir = await fs.mkdtemp(resolvePath(os.tmpdir(), 'backstage-bundle'));
   try {


### PR DESCRIPTION
It was trying to build the package in cwd instead 😅. It's usually correct, but not with `backstage-cli repo build --all`