### PR TITLE
Updated openid-client from 4.1.2 to 5.1.3

### DIFF
--- a/.changeset/blue-geese-work.md
+++ b/.changeset/blue-geese-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Updated openid-client from 4.1.2 to 5.1.3

--- a/.changeset/blue-geese-work.md
+++ b/.changeset/blue-geese-work.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-auth-backend': minor
+'@backstage/plugin-auth-backend': patch
 ---
 
 Updated openid-client from 4.1.2 to 5.1.3

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -60,7 +60,7 @@
     "morgan": "^1.10.0",
     "node-fetch": "^2.6.7",
     "node-cache": "^5.1.2",
-    "openid-client": "^4.2.1",
+    "openid-client": "^5.1.3",
     "passport": "^0.5.2",
     "passport-bitbucket-oauth2": "^0.1.2",
     "passport-github2": "^0.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15769,6 +15769,11 @@ jose@^2.0.5:
   dependencies:
     "@panva/asn1.js" "^1.0.0"
 
+jose@^4.1.4:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/jose/-/jose-4.5.0.tgz#92829d8cf846351eb55aaaf94f252fb1d191f2d5"
+  integrity sha512-GFcVFQwYQKbQTUOo2JlpFGXTkgBw26uzDsRMD2q1WgSKNSnpKS9Ug7bdQ8dS+p4sZHNH6iRPu6WK2jLIjspaMA==
+
 joycon@^3.0.1:
   version "3.1.0"
   resolved "https://registry.npmjs.org/joycon/-/joycon-3.1.0.tgz#33bb2b6b5a6849a1e251bed623bdf610f477d49f"
@@ -18999,7 +19004,7 @@ openapi-sampler@^1.1.0:
     "@types/json-schema" "^7.0.7"
     json-pointer "^0.6.1"
 
-openid-client@^4.1.1, openid-client@^4.2.1:
+openid-client@^4.1.1:
   version "4.9.0"
   resolved "https://registry.npmjs.org/openid-client/-/openid-client-4.9.0.tgz#bdfc9194435316df419f759ce177635146b43074"
   integrity sha512-ThBbvRUUZwxUKBVK2UpDNIZ3eJkvtqWI8s5Dm+naV+gJdL+yRhT+8ywqct1gy5uL+xVS5+A/nhFcpJIisH2x6Q==
@@ -19009,6 +19014,16 @@ openid-client@^4.1.1, openid-client@^4.2.1:
     jose "^2.0.5"
     lru-cache "^6.0.0"
     make-error "^1.3.6"
+    object-hash "^2.0.1"
+    oidc-token-hash "^5.0.1"
+
+openid-client@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.npmjs.org/openid-client/-/openid-client-5.1.3.tgz#25ef0e48929f33462028001fd4077a7ae5b3ad4d"
+  integrity sha512-i5quCXurPkN50ndRLE2D3Q6khz6AieJ0gTKOmsl3G4ZIP/Udf5Qw5CMRdhMvbFvfKRrkcCWPFXmduFUFYTC0xw==
+  dependencies:
+    jose "^4.1.4"
+    lru-cache "^6.0.0"
     object-hash "^2.0.1"
     oidc-token-hash "^5.0.1"
 


### PR DESCRIPTION
Updated the openid-client from 4.1.2 to 5.1.3 the breaking changes listed do not affect the code written in the provider.ts and the tests pass successfully.

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
