### PR TITLE
deprecations: Deprecate the `OctokitProvider` export from `scaffolder-backend`

### DIFF
--- a/.changeset/poor-pens-complain.md
+++ b/.changeset/poor-pens-complain.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+- **DEPRECATED** - `OctokitProvider` has been deprecated and will be removed in upcoming versions
+  This helper doesn't make sense to be export from the `plugin-scaffolder-backend` and possibly will be moved into the `integrations` package at a later date.
+  All implementations have been moved over to a private implementation called `getOctokitOptions` which is then passed to the `Octokit` constructor. If you're using this API you should consider duplicating the logic that lives in `getOctokitOptions` and move away from the deprecated export.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -382,13 +382,15 @@ export function fetchContents({
 
 // Warning: (ae-missing-release-tag) "OctokitProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public
+// @public @deprecated
 export class OctokitProvider {
   constructor(
     integrations: ScmIntegrationRegistry,
     githubCredentialsProvider?: GithubCredentialsProvider,
   );
   // Warning: (ae-forgotten-export) The symbol "OctokitIntegration" needs to be exported by the entry point index.d.ts
+  //
+  // @deprecated
   getOctokit(
     repoUrl: string,
     options?: {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
@@ -34,7 +34,7 @@ export type OctokitIntegration = {
  * OctokitProvider supports GitHub credentials caching out of the box.
  *
  * @deprecated we are no longer providing a way from the scaffolder to generate octokit instances.
- * Implement your own if you're using this method from an external package, or suse the internal `getOctokitOptions` function instead
+ * Implement your own if you're using this method from an external package, or use the internal `getOctokitOptions` function instead
  */
 export class OctokitProvider {
   private readonly integrations: ScmIntegrationRegistry;
@@ -56,7 +56,7 @@ export class OctokitProvider {
    * @param repoUrl - Repository URL
    *
    * @deprecated we are no longer providing a way from the scaffolder to generate octokit instances.
-   * Implement your own if you're using this method from an external package, or suse the internal `getOctokitOptions` function instead
+   * Implement your own if you're using this method from an external package, or use the internal `getOctokitOptions` function instead
    */
   async getOctokit(
     repoUrl: string,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
@@ -33,7 +33,8 @@ export type OctokitIntegration = {
  * OctokitProvider provides Octokit client based on ScmIntegrationsRegistry configuration.
  * OctokitProvider supports GitHub credentials caching out of the box.
  *
- * @deprecated use the internal {@link getOctokitOptions} function instead
+ * @deprecated we are no longer providing a way from the scaffolder to generate octokit instances.
+ * Implement your own if you're using this method from an external package, or suse the internal `getOctokitOptions` function instead
  */
 export class OctokitProvider {
   private readonly integrations: ScmIntegrationRegistry;
@@ -54,7 +55,8 @@ export class OctokitProvider {
    *
    * @param repoUrl - Repository URL
    *
-   * @deprecated use the internal {@link getOctokitOptions} function instead
+   * @deprecated we are no longer providing a way from the scaffolder to generate octokit instances.
+   * Implement your own if you're using this method from an external package, or suse the internal `getOctokitOptions` function instead
    */
   async getOctokit(
     repoUrl: string,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/OctokitProvider.ts
@@ -32,6 +32,8 @@ export type OctokitIntegration = {
 /**
  * OctokitProvider provides Octokit client based on ScmIntegrationsRegistry configuration.
  * OctokitProvider supports GitHub credentials caching out of the box.
+ *
+ * @deprecated use the internal {@link getOctokitOptions} function instead
  */
 export class OctokitProvider {
   private readonly integrations: ScmIntegrationRegistry;
@@ -51,6 +53,8 @@ export class OctokitProvider {
    * gets standard Octokit client based on repository URL.
    *
    * @param repoUrl - Repository URL
+   *
+   * @deprecated use the internal {@link getOctokitOptions} function instead
    */
   async getOctokit(
     repoUrl: string,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubActionsDispatch.ts
@@ -13,24 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { InputError } from '@backstage/errors';
 import {
-  DefaultGithubCredentialsProvider,
   GithubCredentialsProvider,
   ScmIntegrations,
 } from '@backstage/integration';
+import { Octokit } from 'octokit';
 import { createTemplateAction } from '../../createTemplateAction';
-import { OctokitProvider } from './OctokitProvider';
+import { parseRepoUrl } from '../publish/util';
+import { getOctokitOptions } from './helpers';
 
 export function createGithubActionsDispatchAction(options: {
   integrations: ScmIntegrations;
   githubCredentialsProvider?: GithubCredentialsProvider;
 }) {
   const { integrations, githubCredentialsProvider } = options;
-  const octokitProvider = new OctokitProvider(
-    integrations,
-    githubCredentialsProvider ||
-      DefaultGithubCredentialsProvider.fromIntegrations(integrations),
-  );
 
   return createTemplateAction<{
     repoUrl: string;
@@ -90,9 +87,19 @@ export function createGithubActionsDispatchAction(options: {
         `Dispatching workflow ${workflowId} for repo ${repoUrl} on ${branchOrTagName}`,
       );
 
-      const { client, owner, repo } = await octokitProvider.getOctokit(
-        repoUrl,
-        { token: providedToken },
+      const { owner, repo } = parseRepoUrl(repoUrl, integrations);
+
+      if (!owner) {
+        throw new InputError('Invalid repository owner provided in repoUrl');
+      }
+
+      const client = new Octokit(
+        await getOctokitOptions({
+          integrations,
+          repoUrl,
+          credentialsProvider: githubCredentialsProvider,
+          token: providedToken,
+        }),
       );
 
       await client.rest.actions.createWorkflowDispatch({

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
@@ -126,6 +126,10 @@ export function createGithubWebhookAction(options: {
       ctx.logger.info(`Creating webhook ${webhookUrl} for repo ${repoUrl}`);
       const { owner, repo } = parseRepoUrl(repoUrl, integrations);
 
+      if (!owner) {
+        throw new InputError('Invalid repository owner provided in repoUrl');
+      }
+
       const client = new Octokit(
         await getOctokitOptions({
           integrations,
@@ -134,10 +138,6 @@ export function createGithubWebhookAction(options: {
           token: providedToken,
         }),
       );
-
-      if (!owner) {
-        throw new InputError('Invalid repository owner provided in repoUrl');
-      }
 
       try {
         const insecure_ssl = insecureSsl ? '1' : '0';

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/githubWebhook.ts
@@ -19,7 +19,7 @@ import {
 } from '@backstage/integration';
 import { createTemplateAction } from '../../createTemplateAction';
 import { emitterEventNames } from '@octokit/webhooks';
-import { assertError } from '@backstage/errors';
+import { assertError, InputError } from '@backstage/errors';
 import { Octokit } from 'octokit';
 import { getOctokitOptions } from './helpers';
 import { parseRepoUrl } from '../publish/util';
@@ -29,11 +29,8 @@ export function createGithubWebhookAction(options: {
   defaultWebhookSecret?: string;
   githubCredentialsProvider?: GithubCredentialsProvider;
 }) {
-  const {
-    integrations,
-    defaultWebhookSecret,
-    githubCredentialsProvider,
-  } = options;
+  const { integrations, defaultWebhookSecret, githubCredentialsProvider } =
+    options;
 
   const eventNames = emitterEventNames.filter(event => !event.includes('.'));
 
@@ -139,7 +136,7 @@ export function createGithubWebhookAction(options: {
       );
 
       if (!owner) {
-        throw new InputError('Invalid repository owner');
+        throw new InputError('Invalid repository owner provided in repoUrl');
       }
 
       try {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InputError } from '@backstage/errors';
+import {
+  DefaultGithubCredentialsProvider,
+  GithubCredentialsProvider,
+  ScmIntegrationRegistry,
+} from '@backstage/integration';
+import { OctokitOptions } from '@octokit/core/dist-types/types';
+import { parseRepoUrl } from '../publish/util';
+
+interface GetOctokitOptionsInput {
+  integrations: ScmIntegrationRegistry;
+  credentialsProvider?: GithubCredentialsProvider;
+  token?: string;
+  repoUrl: string;
+}
+export const getOctokitOptions = async ({
+  integrations,
+  credentialsProvider,
+  repoUrl,
+  token,
+}: GetOctokitOptionsInput): Promise<OctokitOptions> => {
+  const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
+
+  if (!owner) {
+    throw new InputError(`No owner provided for repo ${repoUrl}`);
+  }
+
+  const integrationConfig = integrations.github.byHost(host)?.config;
+
+  if (!integrationConfig) {
+    throw new InputError(`No integration for host ${host}`);
+  }
+
+  // Short circuit the internal Github Token provider the token provided
+  // by the action or the caller.
+  if (token) {
+    return {
+      auth: token,
+      baseUrl: integrationConfig.apiBaseUrl,
+      previews: ['nebula-preview'],
+    };
+  }
+
+  const githubCredentialsProvider =
+    credentialsProvider ??
+    DefaultGithubCredentialsProvider.fromIntegrations(integrations);
+
+  // TODO(blam): Consider changing this API to have owner, repo interface instead of URL as the it's
+  // needless to create URL and then parse again the other side.
+  const {
+    token: credentialProviderToken,
+  } = await githubCredentialsProvider.getCredentials({
+    url: `https://${host}/${encodeURIComponent(owner)}/${encodeURIComponent(
+      repo,
+    )}`,
+  });
+
+  if (!credentialProviderToken) {
+    throw new InputError(
+      `No token available for host: ${host}, with owner ${owner}, and repo ${repo}`,
+    );
+  }
+
+  return {
+    auth: credentialProviderToken,
+    baseUrl: integrationConfig.apiBaseUrl,
+    previews: ['nebula-preview'],
+  };
+};

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -56,13 +56,12 @@ export async function getOctokitOptions(options: {
 
   // TODO(blam): Consider changing this API to take host and repo instead of repoUrl, as we end up parsing in this function
   // and then parsing in the `getCredentials` function too the other side
-  const {
-    token: credentialProviderToken,
-  } = await githubCredentialsProvider.getCredentials({
-    url: `https://${host}/${encodeURIComponent(owner)}/${encodeURIComponent(
-      repo,
-    )}`,
-  });
+  const { token: credentialProviderToken } =
+    await githubCredentialsProvider.getCredentials({
+      url: `https://${host}/${encodeURIComponent(owner)}/${encodeURIComponent(
+        repo,
+      )}`,
+    });
 
   if (!credentialProviderToken) {
     throw new InputError(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import {
-  DefaultGithubCredentialsProvider,
   GithubCredentialsProvider,
   ScmIntegrationRegistry,
 } from '@backstage/integration';
@@ -22,11 +21,12 @@ import {
   enableBranchProtectionOnDefaultRepoBranch,
   initRepoAndPush,
 } from '../helpers';
-import { getRepoSourceDirectory } from './util';
+import { getRepoSourceDirectory, parseRepoUrl } from './util';
 import { createTemplateAction } from '../../createTemplateAction';
 import { Config } from '@backstage/config';
-import { OctokitProvider } from '../github/OctokitProvider';
-import { assertError } from '@backstage/errors';
+import { assertError, InputError } from '@backstage/errors';
+import { getOctokitOptions } from '../github/helpers';
+import { Octokit } from 'octokit';
 
 export function createPublishGithubAction(options: {
   integrations: ScmIntegrationRegistry;
@@ -34,11 +34,6 @@ export function createPublishGithubAction(options: {
   githubCredentialsProvider?: GithubCredentialsProvider;
 }) {
   const { integrations, config, githubCredentialsProvider } = options;
-  const octokitProvider = new OctokitProvider(
-    integrations,
-    githubCredentialsProvider ||
-      DefaultGithubCredentialsProvider.fromIntegrations(integrations),
-  );
 
   return createTemplateAction<{
     repoUrl: string;
@@ -160,10 +155,20 @@ export function createPublishGithubAction(options: {
         token: providedToken,
       } = ctx.input;
 
-      const { client, token, owner, repo } = await octokitProvider.getOctokit(
+      const { owner, repo } = parseRepoUrl(repoUrl, integrations);
+
+      const octokitOptions = await getOctokitOptions({
+        integrations,
+        credentialsProvider: githubCredentialsProvider,
+        token: providedToken,
         repoUrl,
-        { token: providedToken },
-      );
+      });
+
+      const client = new Octokit(octokitOptions);
+
+      if (!owner) {
+        throw new InputError('Invalid repository owner provided in repoUrl');
+      }
 
       const user = await client.rest.users.getByUsername({
         username: owner,
@@ -253,7 +258,7 @@ export function createPublishGithubAction(options: {
         defaultBranch,
         auth: {
           username: 'x-access-token',
-          password: token,
+          password: octokitOptions.token,
         },
         logger: ctx.logger,
         commitMessage: config.getOptionalString(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -258,7 +258,7 @@ export function createPublishGithubAction(options: {
         defaultBranch,
         auth: {
           username: 'x-access-token',
-          password: octokitOptions.token,
+          password: octokitOptions.auth,
         },
         logger: ctx.logger,
         commitMessage: config.getOptionalString(

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -157,6 +157,10 @@ export function createPublishGithubAction(options: {
 
       const { owner, repo } = parseRepoUrl(repoUrl, integrations);
 
+      if (!owner) {
+        throw new InputError('Invalid repository owner provided in repoUrl');
+      }
+
       const octokitOptions = await getOctokitOptions({
         integrations,
         credentialsProvider: githubCredentialsProvider,
@@ -165,10 +169,6 @@ export function createPublishGithubAction(options: {
       });
 
       const client = new Octokit(octokitOptions);
-
-      if (!owner) {
-        throw new InputError('Invalid repository owner provided in repoUrl');
-      }
 
       const user = await client.rest.users.getByUsername({
         username: owner,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -65,10 +65,14 @@ export const defaultClientFactory = async ({
   host = 'github.com',
   token: providedToken,
 }: ClientFactoryInput): Promise<PullRequestCreator> => {
+  const [encodedHost, encodedOwner, encodedRepo] = [host, owner, repo].map(
+    encodeURIComponent,
+  );
+
   const octokitOptions = await getOctokitOptions({
     integrations,
     credentialsProvider: githubCredentialsProvider,
-    repoUrl: `https://${host}/${owner}/${repo}`,
+    repoUrl: `https://${encodedHost}/${encodedOwner}/${encodedRepo}`,
     token: providedToken,
   });
 


### PR DESCRIPTION
More info in changeset.