### PR TITLE
backend-common: make backend.auth.keys optional in config schema

### DIFF
--- a/.changeset/brave-crews-move.md
+++ b/.changeset/brave-crews-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Make backend.auth.keys optional in config schema. Previously backend.auth was optional but keys was not, which meant that if another plugin introduced additional properties under backend.auth, it would implicitly make backend.auth.keys mandatory.

--- a/packages/backend-common/config.d.ts
+++ b/packages/backend-common/config.d.ts
@@ -23,7 +23,7 @@ export interface Config {
     /** Backend configuration for when request authentication is enabled */
     auth?: {
       /** Keys shared by all backends for signing and validating backend tokens. */
-      keys: {
+      keys?: {
         /**
          * Secret for generating tokens. Should be a base64 string, recommended
          * length is 24 bytes.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The previous schema meant that if any other plugin introduced something under backend.auth, the keys property would be mandatory, which isn't correct. This commit relaxes the requirement so that backend.auth.keys is always optional, even if backend.auth is configured.

cf. https://github.com/backstage/backstage/issues/9498#issuecomment-1047102627

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
