### PR TITLE
backend-tasks: no unnecessary janitor log output on sqlite

### DIFF
--- a/.changeset/nervous-pears-cover.md
+++ b/.changeset/nervous-pears-cover.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+Only output janitor logs when actually timing out tasks


### PR DESCRIPTION
sqlite kept logging "0 tasks timed out and were lost"