### PR TITLE
catalog-react: Delete loadIdentityOwnerRefs, deprecate loadCatalogOwn…

### DIFF
--- a/.changeset/moody-elephants-float.md
+++ b/.changeset/moody-elephants-float.md
@@ -2,6 +2,6 @@
 '@backstage/plugin-catalog-react': minor
 ---
 
-Deleted the deprecated `loadIdentityOwnerRefs` function which is replaced by `ownershipEntityRefs` from `identityApi.getBackstageIdentity()`.
+**BREAKING**: Deleted the deprecated `loadIdentityOwnerRefs` function which is replaced by `ownershipEntityRefs` from `identityApi.getBackstageIdentity()`.
 
 Deprecated the `loadCatalogOwnerRefs` hook as membership references should be added as `ent` inside `claims` sections of the `SignInResolver` when issuing tokens. See https://backstage.io/docs/auth/identity-resolver for more details on how to prepare your `SignInResolver` if not done already. Usage of the `loadCatalogOwnerRefs` hook should be replaced by `ownershipEntityRefs` from `identityApi.getBackstageIdentity()` instead.

--- a/.changeset/moody-elephants-float.md
+++ b/.changeset/moody-elephants-float.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Deleted the deprecated `loadIdentityOwnerRefs` function which is replaced by `ownershipEntityRefs` from `identityApi.getBackstageIdentity()`.
+
+Deprecated the `loadCatalogOwnerRefs` hook as membership references should be added as `ent` inside `claims` sections of the `SignInResolver` when issuing tokens. See https://backstage.io/docs/auth/identity-resolver for more details on how to prepare your `SignInResolver` if not done already. Usage of the `loadCatalogOwnerRefs` hook should be replaced by `ownershipEntityRefs` from `identityApi.getBackstageIdentity()` instead.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -16,7 +16,6 @@ import { Entity } from '@backstage/catalog-model';
 import { EntityName } from '@backstage/catalog-model';
 import { GetEntitiesResponse } from '@backstage/catalog-client';
 import { IconButton } from '@material-ui/core';
-import { IdentityApi } from '@backstage/core-plugin-api';
 import { LinkProps } from '@backstage/core-components';
 import { Observable } from '@backstage/types';
 import { Overrides } from '@material-ui/core/styles/overrides';
@@ -479,15 +478,10 @@ export function InspectEntityDialog(props: {
 // @public
 export function isOwnerOf(owner: Entity, owned: Entity): boolean;
 
-// @public
+// @public @deprecated
 export function loadCatalogOwnerRefs(
   catalogApi: CatalogApi,
   identityOwnerRefs: string[],
-): Promise<string[]>;
-
-// @public @deprecated
-export function loadIdentityOwnerRefs(
-  identityApi: IdentityApi,
 ): Promise<string[]>;
 
 // @public (undocumented)

--- a/plugins/catalog-react/src/hooks/index.ts
+++ b/plugins/catalog-react/src/hooks/index.ts
@@ -43,10 +43,6 @@ export { useOwnUser } from './useOwnUser';
 export { useRelatedEntities } from './useRelatedEntities';
 export { useStarredEntities } from './useStarredEntities';
 export { useStarredEntity } from './useStarredEntity';
-export {
-  loadCatalogOwnerRefs,
-  useEntityOwnership,
-  loadIdentityOwnerRefs,
-} from './useEntityOwnership';
+export { loadCatalogOwnerRefs, useEntityOwnership } from './useEntityOwnership';
 export { useOwnedEntities } from './useOwnedEntities';
 export { useEntityPermission } from './useEntityPermission';

--- a/plugins/catalog-react/src/hooks/useEntityOwnership.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityOwnership.test.tsx
@@ -26,11 +26,7 @@ import { TestApiProvider } from '@backstage/test-utils';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 import { catalogApiRef } from '../api';
-import {
-  loadCatalogOwnerRefs,
-  loadIdentityOwnerRefs,
-  useEntityOwnership,
-} from './useEntityOwnership';
+import { loadCatalogOwnerRefs, useEntityOwnership } from './useEntityOwnership';
 
 describe('useEntityOwnership', () => {
   type MockIdentityApi = jest.Mocked<Pick<IdentityApi, 'getBackstageIdentity'>>;
@@ -99,18 +95,6 @@ describe('useEntityOwnership', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
-  });
-
-  describe('loadIdentityOwnerRefs', () => {
-    it('passes through the ownershipEntityRefs', async () => {
-      const refs = new Array<string>();
-      mockIdentityApi.getBackstageIdentity.mockResolvedValueOnce({
-        type: 'user',
-        userEntityRef: 'user:default/guest',
-        ownershipEntityRefs: refs,
-      });
-      await expect(loadIdentityOwnerRefs(identityApi)).resolves.toBe(refs);
-    });
   });
 
   describe('loadCatalogOwnerRefs', () => {

--- a/plugins/catalog-react/src/hooks/useEntityOwnership.ts
+++ b/plugins/catalog-react/src/hooks/useEntityOwnership.ts
@@ -23,33 +23,11 @@ import {
   RELATION_OWNED_BY,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import {
-  IdentityApi,
-  identityApiRef,
-  useApi,
-} from '@backstage/core-plugin-api';
+import { identityApiRef, useApi } from '@backstage/core-plugin-api';
 import { useMemo } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { catalogApiRef } from '../api';
 import { getEntityRelations } from '../utils/getEntityRelations';
-
-/**
- * Takes the relevant parts of the Backstage identity, and translates them into
- * a list of entity refs on string form that represent the user's ownership
- * connections.
- *
- * @public
- * @deprecated Use `ownershipEntityRefs` from `identityApi.getBackstageIdentity()` instead.
- *
- * @param identityApi - The IdentityApi implementation
- * @returns IdentityOwner refs as a string array
- */
-export async function loadIdentityOwnerRefs(
-  identityApi: IdentityApi,
-): Promise<string[]> {
-  const identity = await identityApi.getBackstageIdentity();
-  return identity.ownershipEntityRefs;
-}
 
 /**
  * Takes the relevant parts of the User entity corresponding to the Backstage
@@ -61,6 +39,7 @@ export async function loadIdentityOwnerRefs(
  * @param catalogApi - The Catalog API implementation
  * @param identityOwnerRefs - List of identity owner refs as strings
  * @returns OwnerRefs as a string array
+ * @deprecated Use `ownershipEntityRefs` from `identityApi.getBackstageIdentity()` instead.
  */
 export async function loadCatalogOwnerRefs(
   catalogApi: CatalogApi,

--- a/plugins/catalog-react/src/hooks/useOwnedEntities.ts
+++ b/plugins/catalog-react/src/hooks/useOwnedEntities.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 import { catalogApiRef } from './../api';
-import {
-  loadCatalogOwnerRefs,
-  loadIdentityOwnerRefs,
-} from './useEntityOwnership';
+import { loadCatalogOwnerRefs } from './useEntityOwnership';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
 import { RELATION_OWNED_BY } from '@backstage/catalog-model';
 import { GetEntitiesResponse } from '@backstage/catalog-client';
@@ -41,7 +38,8 @@ export function useOwnedEntities(allowedKinds?: string[]): {
   const catalogApi = useApi(catalogApiRef);
 
   const { loading, value: refs } = useAsync(async () => {
-    const identityRefs = await loadIdentityOwnerRefs(identityApi);
+    const identity = await identityApi.getBackstageIdentity();
+    const identityRefs = identity.ownershipEntityRefs;
     const catalogRefs = await loadCatalogOwnerRefs(catalogApi, identityRefs);
     const catalogs = await catalogApi.getEntities(
       allowedKinds


### PR DESCRIPTION
Deleted the deprecated `loadIdentityOwnerRefs` function which is replaced by `ownershipEntityRefs` from `identityApi.getBackstageIdentity()`.

Deprecated the `loadCatalogOwnerRefs` hook as membership references should be added as `ent` inside `claims` sections of the `SignInResolver` when issuing tokens. See https://backstage.io/docs/auth/identity-resolver for more details on how to prepare your `SignInResolver` if not done already. Usage of the `loadCatalogOwnerRefs` hook should be replaced by `ownershipEntityRefs` from `identityApi.getBackstageIdentity()` instead.