### PR TITLE
Add entity sync to Group page

### DIFF
--- a/.changeset/rude-tools-vanish.md
+++ b/.changeset/rude-tools-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Add entity sync button to Group page

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -18,8 +18,11 @@ import {
   GroupEntity,
   RELATION_CHILD_OF,
   RELATION_PARENT_OF,
+  ANNOTATION_LOCATION,
+  stringifyEntityRef,
 } from '@backstage/catalog-model';
 import {
+  catalogApiRef,
   EntityRefLinks,
   getEntityRelations,
   useEntity,
@@ -39,14 +42,16 @@ import AccountTreeIcon from '@material-ui/icons/AccountTree';
 import EmailIcon from '@material-ui/icons/Email';
 import GroupIcon from '@material-ui/icons/Group';
 import EditIcon from '@material-ui/icons/Edit';
+import CachedIcon from '@material-ui/icons/Cached';
 import Alert from '@material-ui/lab/Alert';
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   Avatar,
   InfoCard,
   InfoCardVariants,
   Link,
 } from '@backstage/core-components';
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 
 const CardTitle = ({ title }: { title: string }) => (
   <Box display="flex" alignItems="center">
@@ -60,13 +65,21 @@ export const GroupProfileCard = ({
 }: {
   variant?: InfoCardVariants;
 }) => {
+  const catalogApi = useApi(catalogApiRef);
+  const alertApi = useApi(alertApiRef);
   const { entity: group } = useEntity<GroupEntity>();
+
+  const refreshEntity = useCallback(async () => {
+    await catalogApi.refreshEntity(stringifyEntityRef(group));
+    alertApi.post({ message: 'Refresh scheduled', severity: 'info' });
+  }, [catalogApi, alertApi, group]);
+
   if (!group) {
     return <Alert severity="error">Group not found</Alert>;
   }
 
   const {
-    metadata: { name, description },
+    metadata: { name, description, annotations },
     spec: { profile },
   } = group;
 
@@ -76,6 +89,10 @@ export const GroupProfileCard = ({
   const parentRelations = getEntityRelations(group, RELATION_CHILD_OF, {
     kind: 'group',
   });
+
+  const entityLocation = annotations?.[ANNOTATION_LOCATION];
+  const allowRefresh =
+    entityLocation?.startsWith('url:') || entityLocation?.startsWith('file:');
 
   const entityMetadataEditUrl = getEntityMetadataEditUrl(group);
 
@@ -101,7 +118,20 @@ export const GroupProfileCard = ({
       title={<CardTitle title={displayName} />}
       subheader={description}
       variant={variant}
-      action={infoCardAction}
+      action={
+        <>
+          {allowRefresh && (
+            <IconButton
+              aria-label="Refresh"
+              title="Schedule entity refresh"
+              onClick={refreshEntity}
+            >
+              <CachedIcon />
+            </IconButton>
+          )}
+          {infoCardAction}
+        </>
+      }
     >
       <Grid container spacing={3}>
         <Grid item xs={12} sm={2} xl={1}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Previously this button wasn't exists in Group page, need to add this button for immediate changes without waiting for the ingestion loop
<img width="840" alt="image" src="https://user-images.githubusercontent.com/33563774/155264937-25f47bf0-6ba4-44bc-99c4-44d72b90151c.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
