### PR TITLE
catalog-model: Deprecate `entity.metadata.generation`

### DIFF
--- a/.changeset/thirty-keys-study.md
+++ b/.changeset/thirty-keys-study.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Deprecated the `entity.metadata.generation` field which has been superseded by `entity.metadata.etag`.

--- a/.changeset/thirty-keys-study.md
+++ b/.changeset/thirty-keys-study.md
@@ -2,4 +2,4 @@
 '@backstage/catalog-model': patch
 ---
 
-Deprecated the `entity.metadata.generation` field which has been superseded by `entity.metadata.etag`.
+Deprecated the `entity.metadata.generation` as the field has never been fully functioning.

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -116,6 +116,7 @@ export type EntityMeta = JsonObject & {
    * This field can not be set by the user at creation time, and the server
    * will reject an attempt to do so. The field will be populated in read
    * operations.
+   * @deprecated replaced by etag.
    */
   generation?: number;
 

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -116,7 +116,7 @@ export type EntityMeta = JsonObject & {
    * This field can not be set by the user at creation time, and the server
    * will reject an attempt to do so. The field will be populated in read
    * operations.
-   * @deprecated replaced by etag.
+   * @deprecated field is not supported.
    */
   generation?: number;
 

--- a/packages/catalog-model/src/schema/EntityMeta.schema.json
+++ b/packages/catalog-model/src/schema/EntityMeta.schema.json
@@ -38,7 +38,8 @@
       "type": "integer",
       "description": "A positive nonzero number that indicates the current generation of data for this entity; the value is incremented each time the spec changes. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.",
       "examples": [1],
-      "minimum": 1
+      "minimum": 1,
+      "deprecated": true
     },
     "name": {
       "type": "string",


### PR DESCRIPTION
Deprecated the `entity.metadata.generation` field which has been superseded by `entity.metadata.etag`.
