### PR TITLE
Simplified the `parseEntityRef` function

### DIFF
--- a/.changeset/purple-impalas-listen.md
+++ b/.changeset/purple-impalas-listen.md
@@ -1,0 +1,8 @@
+---
+'@backstage/catalog-model': minor
+---
+
+**BREAKING**: Simplified the `parseEntityRef` function to _always_ either return
+a complete `EntityName`, complete with both kind, namespace and name, or throw
+an error if it for some reason did not have enough information to form that
+result. This makes its usage and its type declaration vastly simpler.

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -417,46 +417,10 @@ export function parseEntityRef(
         name: string;
       },
   context?: {
-    defaultKind: string;
-    defaultNamespace: string;
+    defaultKind?: string;
+    defaultNamespace?: string;
   },
 ): EntityName;
-
-// @public
-export function parseEntityRef(
-  ref:
-    | string
-    | {
-        kind?: string;
-        namespace?: string;
-        name: string;
-      },
-  context?: {
-    defaultKind: string;
-  },
-): {
-  kind: string;
-  namespace?: string;
-  name: string;
-};
-
-// @public
-export function parseEntityRef(
-  ref:
-    | string
-    | {
-        kind?: string;
-        namespace?: string;
-        name: string;
-      },
-  context?: {
-    defaultNamespace: string;
-  },
-): {
-  kind?: string;
-  namespace: string;
-  name: string;
-};
 
 // @public
 export function parseLocationRef(ref: string): {

--- a/packages/catalog-model/src/entity/ref.test.ts
+++ b/packages/catalog-model/src/entity/ref.test.ts
@@ -187,18 +187,8 @@ describe('ref', () => {
         namespace: 'b',
         name: 'c',
       });
-      expect(parseEntityRef('b/c')).toEqual({
-        kind: undefined,
-        namespace: 'b',
-        name: 'c',
-      });
       expect(parseEntityRef('a:c')).toEqual({
         kind: 'a',
-        namespace: 'default',
-        name: 'c',
-      });
-      expect(parseEntityRef('c')).toEqual({
-        kind: undefined,
         namespace: 'default',
         name: 'c',
       });

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.test.ts
@@ -187,7 +187,7 @@ describe('BuiltinKindsEntityProcessor', () => {
       await expect(
         processor.postProcessEntity(entity, location, emit),
       ).rejects.toThrowError(
-        'Entity reference "r" did not specify a kind (e.g. starting with "Component:"), and has no default',
+        'Entity reference "r" had missing or empty kind (e.g. did not start with "component:" or similar)',
       );
     });
 
@@ -360,7 +360,7 @@ describe('BuiltinKindsEntityProcessor', () => {
       await expect(
         processor.postProcessEntity(entity, location, emit),
       ).rejects.toThrowError(
-        'Entity reference "c" did not specify a kind (e.g. starting with "Component:"), and has no default',
+        'Entity reference "c" had missing or empty kind (e.g. did not start with "component:" or similar)',
       );
     });
 

--- a/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BuiltinKindsEntityProcessor.ts
@@ -106,11 +106,6 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
       }
       for (const target of [targets].flat()) {
         const targetRef = parseEntityRef(target, context);
-        if (targetRef.kind === undefined) {
-          throw new Error(
-            `Entity reference "${target}" did not specify a kind (e.g. starting with "Component:"), and has no default`,
-          );
-        }
         emit(
           result.relation({
             source: selfRef,


### PR DESCRIPTION
This reduces the whole confusion of the optional namespaces and kinds and stuff. Now it's a complete data type, always.