### PR TITLE
Fix pagePause=true bug

### DIFF
--- a/.changeset/spicy-lies-grin.md
+++ b/.changeset/spicy-lies-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': patch
+---
+
+Fixed bug in Catalog LDAP module to ack page events to continue receiving entries if pagePause=true

--- a/.changeset/spicy-lies-grin.md
+++ b/.changeset/spicy-lies-grin.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-ldap': patch
 ---
 
-Fixed bug in Catalog LDAP module to ack page events to continue receiving entries if pagePause=true
+Fixed bug in Catalog LDAP module to acknowledge page events to continue receiving entries if pagePause=true

--- a/plugins/catalog-backend-module-ldap/src/ldap/client.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/client.ts
@@ -106,7 +106,7 @@ export class LdapClient {
             reject(new Error(errorString(e)));
           });
 
-          res.on('page', (result, cb) => {
+          res.on('page', (_result, cb) => {
             if (cb) {
               cb();
             }

--- a/plugins/catalog-backend-module-ldap/src/ldap/client.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/client.ts
@@ -106,6 +106,12 @@ export class LdapClient {
             reject(new Error(errorString(e)));
           });
 
+          res.on('page', (result, cb) => {
+            if (cb) {
+              cb();
+            }
+          });
+
           res.on('end', r => {
             if (!r) {
               reject(new Error('Null response'));


### PR DESCRIPTION
Signed-off-by: Jen Evans <jenevan@rei.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Add a listener for "page" events and call the callback if provided. If pagePause=true, LDAPJS library waits for the callback to be called before returning more data. Related to https://github.com/backstage/backstage/issues/9527

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
