### PR TITLE
scripts/prepare-release: fix for overriding open version range

### DIFF
--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -95,7 +95,7 @@ async function updatePatchVersions() {
       const deps = packageJson[depType];
       for (const depName of Object.keys(deps ?? {})) {
         const currentRange = deps[depName];
-        if (currentRange === '*') {
+        if (currentRange === '*' || currentRange === '') {
           continue;
         }
 


### PR DESCRIPTION
Should hopefully fix the 1.0 bump of create-app in #9610