### PR TITLE
[TechDocs]: Adjust footer copyright

### DIFF
--- a/.changeset/techdocs-cats-whisper.md
+++ b/.changeset/techdocs-cats-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Remove copyright from old footer in documentation generated with previous version of `mkdocs-techdocs-plugin` (`v0.2.2`).

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -410,9 +410,20 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
             .md-nav {
               font-size: calc(var(--md-typeset-font-size) * 0.9);
             }
+            .md-nav__link {
+              display: flex;
+              align-items: center;
+              justify-content: space-between;
+            }
             .md-nav__icon {
-              width: auto !important;
-              height: auto !important;
+              height: 20px !important;
+              width: 20px !important;
+              margin-left:${theme.spacing(1)}px;
+            }
+            .md-nav__icon svg {
+              margin: 0;
+              width: 20px !important;
+              height: 20px !important;
             }
             .md-nav__icon:after {
               width: 20px !important;
@@ -424,9 +435,12 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
             }
             
             .md-sidebar {
+              height: calc(100% - 100px);
               position: fixed;
-              bottom: 100px;
               width: 16rem;
+            }
+            .md-sidebar .md-sidebar__scrollwrap {
+              max-height: calc(100% - 100px);
             }
             .md-sidebar--secondary {
               right: ${theme.spacing(3)}px;
@@ -499,11 +513,14 @@ export const useTechDocsReaderDom = (entityRef: EntityName): Element | null => {
                 display: none;
               }
 
+              .md-sidebar {
+                height: 100%;
+              }
               .md-sidebar--primary {
                 width: 12.1rem !important;
                 z-index: 200;
                 left: ${
-                  isPinned ? 'calc(224px - 12.1rem)' : 'calc(72px - 12.1rem)'
+                  isPinned ? 'calc(-12.1rem + 242px)' : 'calc(-12.1rem + 72px)'
                 } !important;
               }
               .md-sidebar--secondary:not([hidden]) {

--- a/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.test.ts
+++ b/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.test.ts
@@ -30,7 +30,7 @@ describe('simplifyMkdocsFooter', () => {
     expect(shadowDom.querySelector('.md-footer .md-copyright')).toBeTruthy();
   });
 
-  it('does remove mkdocs copyright', async () => {
+  it('does remove new mkdocs copyright', async () => {
     const shadowDom = await createTestShadowDom(
       FIXTURES.FIXTURE_STANDARD_PAGE,
       {
@@ -40,5 +40,17 @@ describe('simplifyMkdocsFooter', () => {
     );
 
     expect(shadowDom.querySelector('.md-footer .md-copyright')).toBeFalsy();
+  });
+
+  it('does remove old mkdocs copyright', async () => {
+    const shadowDom = await createTestShadowDom(
+      FIXTURES.FIXTURE_STANDARD_PAGE,
+      {
+        preTransformers: [simplifyMkdocsFooter()],
+        postTransformers: [],
+      },
+    );
+
+    expect(shadowDom.querySelector('.md-footer-copyright')).toBeFalsy();
   });
 });

--- a/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.ts
+++ b/plugins/techdocs/src/reader/transformers/simplifyMkdocsFooter.ts
@@ -18,9 +18,10 @@ import type { Transformer } from './transformer';
 
 export const simplifyMkdocsFooter = (): Transformer => {
   return dom => {
-    // Remove mkdocs copyright
+    // Remove new mkdocs copyright
     dom.querySelector('.md-footer .md-copyright')?.remove();
-
+    // Remove old mkdocs copyright
+    dom.querySelector('.md-footer-copyright')?.remove();
     return dom;
   };
 };


### PR DESCRIPTION
Signed-off-by: Camila Belo <camilaibs@gmail.com>

## Hey, I just made a Pull Request!

Remove old footer copyright for docs generated with previous `mkdocs-techdocs-plugin` version.

| Before | After |
| --- | --- |
| ![with copyright](https://user-images.githubusercontent.com/6290749/155567655-0995f0a1-bfa2-493e-90c6-6f9352ceaab0.png) | ![without copyright](https://user-images.githubusercontent.com/6290749/155567681-bb0fce19-c718-4d10-9275-ff3776d7c085.png) |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
