### PR TITLE
[TechDocs] Set entity filters as they change in TechDocsSearchBar

### DIFF
--- a/.changeset/techdocs-war-on-war.md
+++ b/.changeset/techdocs-war-on-war.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed a bug that could cause searches in the in-context TechDocs search bar to show results from a different TechDocs site.

--- a/plugins/techdocs/src/reader/components/TechDocsSearch.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsSearch.tsx
@@ -64,6 +64,7 @@ const TechDocsSearchBar = ({
   const {
     term,
     setTerm,
+    setFilters,
     result: { loading, value: searchVal },
   } = useSearch();
   const classes = useStyles();
@@ -86,6 +87,17 @@ const TechDocsSearchBar = ({
   const [value, setValue] = useState<string>(term);
 
   useDebounce(() => setTerm(value), debounceTime, [value]);
+
+  // Update the filter context when the entityId changes, e.g. when the search
+  // bar continues to be rendered, navigating between different TechDocs sites.
+  useEffect(() => {
+    setFilters(prevFilters => {
+      return {
+        ...prevFilters,
+        ...entityId,
+      };
+    });
+  }, [entityId, setFilters]);
 
   const handleQuery = (e: ChangeEvent<HTMLInputElement>) => {
     if (!open) {

--- a/plugins/techdocs/src/reader/components/TechDocsSearch.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsSearch.tsx
@@ -90,14 +90,17 @@ const TechDocsSearchBar = ({
 
   // Update the filter context when the entityId changes, e.g. when the search
   // bar continues to be rendered, navigating between different TechDocs sites.
+  const { kind, name, namespace } = entityId;
   useEffect(() => {
     setFilters(prevFilters => {
       return {
         ...prevFilters,
-        ...entityId,
+        kind,
+        namespace,
+        name,
       };
     });
-  }, [entityId, setFilters]);
+  }, [kind, namespace, name, setFilters]);
 
   const handleQuery = (e: ChangeEvent<HTMLInputElement>) => {
     if (!open) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #9769

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
