### PR TITLE
fix(githubPrAction): properly construct repoUrl

### DIFF
--- a/.changeset/smart-items-fry.md
+++ b/.changeset/smart-items-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix broken GitHub PR action due to malformed `repoUrl`

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -72,7 +72,7 @@ export const defaultClientFactory = async ({
   const octokitOptions = await getOctokitOptions({
     integrations,
     credentialsProvider: githubCredentialsProvider,
-    repoUrl: `https://${encodedHost}/${encodedOwner}/${encodedRepo}`,
+    repoUrl: `${encodedHost}?owner=${encodedOwner}&repo=${encodedRepo}`,
     token: providedToken,
   });
 


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

This fixes a bug (due to https://github.com/backstage/backstage/pull/9701) in the GitHub PR action where `getOctokitOptions` expects `repoUrl` to be of the form `<host>?owner=<owner>&repo=<repo>`. Currently `getOctokitOptions` calls [`parseRepoUrl`](https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts#L32) which throws the [error](https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/util.ts#L70): `No matching integration configuration for host 'https' ...`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
