### PR TITLE
Use mail prefix to identify user entities

### DIFF
--- a/.changeset/early-knives-perform.md
+++ b/.changeset/early-knives-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': minor
+---
+
+Use mail prefix to identify user entities (instead of using `normalizeEntityName` helper function). It allows to be compatible with Microsoft auth provider, so that entity ownership can be identified correctly for authenticated users.

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
@@ -97,7 +97,7 @@ describe('read microsoft graph', () => {
             annotations: {
               'graph.microsoft.com/user-id': 'userid',
             },
-            name: 'user.name_example.com',
+            name: 'user.name',
           },
           spec: {
             profile: {
@@ -206,7 +206,7 @@ describe('read microsoft graph', () => {
             annotations: {
               'graph.microsoft.com/user-id': 'userid',
             },
-            name: 'user.name_example.com',
+            name: 'user.name',
           },
           spec: {
             profile: {

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
@@ -50,7 +50,7 @@ export async function defaultUserTransformer(
     return undefined;
   }
 
-  const name = normalizeEntityName(user.mail);
+  const name = user.mail.split('@')[0];
   const entity: UserEntity = {
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'User',

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
@@ -33,7 +33,8 @@ import {
 } from '../microsoftGraph';
 
 /**
- * Extracts teams and users out of a the Microsoft Graph API.
+ * Reads user and group entries out of Microsoft Graph, and provides them as
+ * User and Group entities for the catalog.
  *
  * @public
  */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use mail prefix to identify user entities (instead of using `normalizeEntityName` helper function). It allows to be compatible with Microsoft auth provider, so that entity ownership can be identified correctly for authenticated users.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
