### PR TITLE
fix(scaffolder,bitbucket): support custom defaultBranch for Bitbucket Cloud

### DIFF
--- a/.changeset/wise-foxes-confess.md
+++ b/.changeset/wise-foxes-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fix the support for custom defaultBranch values for Bitbucket Cloud at the `publish:bitbucket` scaffolder action.

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
@@ -567,4 +567,47 @@ describe('publish:bitbucket', () => {
       'https://bitbucket.org/workspace/repo/src/master',
     );
   });
+
+  it('should call outputs with the correct urls with correct default branch', async () => {
+    server.use(
+      rest.post(
+        'https://api.bitbucket.org/2.0/repositories/workspace/repo',
+        (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.set('Content-Type', 'application/json'),
+            ctx.json({
+              links: {
+                html: {
+                  href: 'https://bitbucket.org/workspace/repo',
+                },
+                clone: [
+                  {
+                    name: 'https',
+                    href: 'https://bitbucket.org/workspace/cloneurl',
+                  },
+                ],
+              },
+            }),
+          ),
+      ),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        defaultBranch: 'main',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://bitbucket.org/workspace/cloneurl',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'repoContentsUrl',
+      'https://bitbucket.org/workspace/repo/src/main',
+    );
+  });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
@@ -31,6 +31,7 @@ const createBitbucketCloudRepository = async (opts: {
   repo: string;
   description?: string;
   repoVisibility: 'private' | 'public';
+  mainBranch: string;
   authorization: string;
 }) => {
   const {
@@ -39,6 +40,7 @@ const createBitbucketCloudRepository = async (opts: {
     repo,
     description,
     repoVisibility,
+    mainBranch,
     authorization,
   } = opts;
 
@@ -82,8 +84,9 @@ const createBitbucketCloudRepository = async (opts: {
     }
   }
 
-  // TODO use the urlReader to get the default branch
-  const repoContentsUrl = `${r.links.html.href}/src/master`;
+  // "mainbranch.name" cannot be set neither at create nor update of the repo
+  // the first pushed branch will be set as "main branch" then
+  const repoContentsUrl = `${r.links.html.href}/src/${mainBranch}`;
   return { remoteUrl, repoContentsUrl };
 };
 
@@ -324,6 +327,7 @@ export function createPublishBitbucketAction(options: {
         project,
         repo,
         repoVisibility,
+        mainBranch: defaultBranch,
         description,
         apiBaseUrl,
       });


### PR DESCRIPTION
Before this change, the returned `repoContentsUrl` of this scaffolder action
was hardcoded to branch `master` which is the default value for `defaultBranch`.

The change will ensure to use the provided value instead.

Closes: #9759

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
