### PR TITLE
fix(bitbucket): fix line number references

### DIFF
--- a/.changeset/tough-pets-beg.md
+++ b/.changeset/tough-pets-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Fix Bitbucket Cloud and Bitbucket Server line number reference.

--- a/packages/integration/src/bitbucket/BitbucketIntegration.test.ts
+++ b/packages/integration/src/bitbucket/BitbucketIntegration.test.ts
@@ -45,8 +45,10 @@ describe('BitbucketIntegration', () => {
     expect(integration.title).toBe('h.com');
   });
 
-  it('resolves url line number correctly', () => {
-    const integration = new BitbucketIntegration({ host: 'h.com' } as any);
+  it('resolves url line number correctly for Bitbucket Cloud', () => {
+    const integration = new BitbucketIntegration({
+      host: 'bitbucket.org',
+    } as any);
 
     expect(
       integration.resolveUrl({
@@ -55,8 +57,20 @@ describe('BitbucketIntegration', () => {
         lineNumber: 14,
       }),
     ).toBe(
-      'https://bitbucket.org/my-owner/my-project/src/master/a.yaml#a.yaml-14',
+      'https://bitbucket.org/my-owner/my-project/src/master/a.yaml#lines-14',
     );
+  });
+
+  it('resolves url line number correctly for Bitbucket Server', () => {
+    const integration = new BitbucketIntegration({ host: 'h.com' } as any);
+
+    expect(
+      integration.resolveUrl({
+        url: './a.yaml',
+        base: 'https://bitbucket.org/my-owner/my-project/src/master/README.md',
+        lineNumber: 14,
+      }),
+    ).toBe('https://bitbucket.org/my-owner/my-project/src/master/a.yaml#14');
   });
 
   it('resolve edit URL', () => {

--- a/packages/integration/src/bitbucket/BitbucketIntegration.ts
+++ b/packages/integration/src/bitbucket/BitbucketIntegration.ts
@@ -60,17 +60,21 @@ export class BitbucketIntegration implements ScmIntegration {
     lineNumber?: number;
   }): string {
     const resolved = defaultScmResolveUrl(options);
-
-    // Bitbucket line numbers use the syntax #example.txt-42, rather than #L42
-    if (options.lineNumber) {
-      const url = new URL(resolved);
-
-      const filename = url.pathname.split('/').slice(-1)[0];
-      url.hash = `${filename}-${options.lineNumber}`;
-      return url.toString();
+    if (!options.lineNumber) {
+      return resolved;
     }
 
-    return resolved;
+    const url = new URL(resolved);
+
+    if (this.integrationConfig.host === 'bitbucket.org') {
+      // Bitbucket Cloud uses the syntax #lines-{start}[:{end}][,...]
+      url.hash = `lines-${options.lineNumber}`;
+    } else {
+      // Bitbucket Server uses the syntax #{start}[-{end}][,...]
+      url.hash = `${options.lineNumber}`;
+    }
+
+    return url.toString();
   }
 
   resolveEditUrl(url: string): string {


### PR DESCRIPTION
Use the actual line number syntax for Bitbucket Cloud
and Bitbucket Server.

Closes: #9764

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
