### PR TITLE
Fix route ref issue for catalog entity

### DIFF
--- a/plugins/catalog-graph/dev/index.tsx
+++ b/plugins/catalog-graph/dev/index.tsx
@@ -42,6 +42,7 @@ import {
   catalogGraphPlugin,
   EntityCatalogGraphCard,
 } from '../src';
+import { CatalogEntityPage } from '@backstage/plugin-catalog';
 
 type DataRelation = [string, string, string];
 type DataEntity = [string, string, DataRelation[]];
@@ -167,6 +168,12 @@ createDevApp()
     ),
   })
   .addPage({
+    path: '/catalog-graph',
     element: <CatalogGraphPage />,
+  })
+  .addPage({
+    path: '/catalog/:kind/:namespace/:name',
+    element: <CatalogEntityPage />,
+    title: 'MockComponent',
   })
   .render();

--- a/plugins/catalog-graph/package.json
+++ b/plugins/catalog-graph/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.14.1",
+    "@backstage/plugin-catalog": "^0.9.0",
     "@backstage/core-app-api": "^0.5.4",
     "@backstage/dev-utils": "^0.2.23",
     "@backstage/test-utils": "^0.2.6",


### PR DESCRIPTION
Signed-off-by: Niall McCullagh <niallmccullagh@users.noreply.github.com>

## Hey, I just made a Pull Request!

Running yarn start within the `plugins/catalog-graph` directory launch the browser but the component throws a `No path for routeRef{type=absolute,id=catalog:entity}` error. The dev test page is missing the catalog entity page. This change adds it so the page renders successfully.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
