### PR TITLE
Set timeout for scaffolder octokit client

### DIFF
--- a/.changeset/khaki-socks-wash.md
+++ b/.changeset/khaki-socks-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Set timeout for scaffolder octokit client

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -22,6 +22,8 @@ import {
 import { OctokitOptions } from '@octokit/core/dist-types/types';
 import { parseRepoUrl } from '../publish/util';
 
+const SECOND = 1000;
+
 export async function getOctokitOptions(options: {
   integrations: ScmIntegrationRegistry;
   credentialsProvider?: GithubCredentialsProvider;
@@ -30,6 +32,10 @@ export async function getOctokitOptions(options: {
 }): Promise<OctokitOptions> {
   const { integrations, credentialsProvider, repoUrl, token } = options;
   const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
+  const requestOptions = {
+    // set timeout to 60 seconds
+    timeout: 60 * SECOND,
+  };
 
   if (!owner) {
     throw new InputError(`No owner provided for repo ${repoUrl}`);
@@ -47,6 +53,7 @@ export async function getOctokitOptions(options: {
       auth: token,
       baseUrl: integrationConfig.apiBaseUrl,
       previews: ['nebula-preview'],
+      request: requestOptions,
     };
   }
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -22,6 +22,8 @@ import {
 import { OctokitOptions } from '@octokit/core/dist-types/types';
 import { parseRepoUrl } from '../publish/util';
 
+const DEFAULT_TIMEOUT_MS = 60_000;
+
 export async function getOctokitOptions(options: {
   integrations: ScmIntegrationRegistry;
   credentialsProvider?: GithubCredentialsProvider;
@@ -30,9 +32,10 @@ export async function getOctokitOptions(options: {
 }): Promise<OctokitOptions> {
   const { integrations, credentialsProvider, repoUrl, token } = options;
   const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
+
   const requestOptions = {
     // set timeout to 60 seconds
-    timeout: 60_000,
+    timeout: DEFAULT_TIMEOUT_MS,
   };
 
   if (!owner) {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/github/helpers.ts
@@ -22,8 +22,6 @@ import {
 import { OctokitOptions } from '@octokit/core/dist-types/types';
 import { parseRepoUrl } from '../publish/util';
 
-const SECOND = 1000;
-
 export async function getOctokitOptions(options: {
   integrations: ScmIntegrationRegistry;
   credentialsProvider?: GithubCredentialsProvider;
@@ -34,7 +32,7 @@ export async function getOctokitOptions(options: {
   const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
   const requestOptions = {
     // set timeout to 60 seconds
-    timeout: 60 * SECOND,
+    timeout: 60_000,
   };
 
   if (!owner) {


### PR DESCRIPTION
If a client fails to contact github (or the network connectivity is bad), there is no reasonible timeout for the Octokit client.

This change here adds a default timeout of 60 seconds

Here is a link to the octokit type definition: https://github.com/octokit/types.ts/blob/master/src/RequestRequestOptions.ts

Signed-off-by: Nicolas Arnold <nic@roadie.io>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
