### PR TITLE
catalog-react: Deprecate getEntityMetadataViewUrl and getEntityMetadataEditUrl

### DIFF
--- a/.changeset/spicy-doors-relax.md
+++ b/.changeset/spicy-doors-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Deprecated `getEntityMetadataEditUrl` and `getEntityMetadataViewUrl` as these just return one annotation from the entity passed in.

--- a/.changeset/two-forks-tell.md
+++ b/.changeset/two-forks-tell.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-org': patch
+---
+
+Removed usage of deprecated `getEntityMetadataViewUrl` and `getEntityMetadataEditUrl` helpers.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -443,10 +443,10 @@ export function formatEntityRefTitle(
   },
 ): string;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function getEntityMetadataEditUrl(entity: Entity): string | undefined;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function getEntityMetadataViewUrl(entity: Entity): string | undefined;
 
 // @public

--- a/plugins/catalog-react/src/utils/getEntityMetadataUrl.ts
+++ b/plugins/catalog-react/src/utils/getEntityMetadataUrl.ts
@@ -20,12 +20,17 @@ import {
   Entity,
 } from '@backstage/catalog-model';
 
-/** @public */
+/**
+ * @public
+ * @deprecated use entity.metadata.annotations?.[ANNOTATION_VIEW_URL] instead. */
 export function getEntityMetadataViewUrl(entity: Entity): string | undefined {
   return entity.metadata.annotations?.[ANNOTATION_VIEW_URL];
 }
 
-/** @public */
+/**
+ * @public
+ * @deprecated use entity.metadata.annotations?.[ANNOTATION_EDIT_URL] instead.
+ */
 export function getEntityMetadataEditUrl(entity: Entity): string | undefined {
   return entity.metadata.annotations?.[ANNOTATION_EDIT_URL];
 }

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -15,6 +15,7 @@
  */
 
 import {
+  ANNOTATION_EDIT_URL,
   ANNOTATION_LOCATION,
   DEFAULT_NAMESPACE,
   stringifyEntityRef,
@@ -32,7 +33,6 @@ import {
 } from '@backstage/integration-react';
 import {
   catalogApiRef,
-  getEntityMetadataEditUrl,
   getEntitySourceLocation,
   useEntity,
 } from '@backstage/plugin-catalog-react';
@@ -97,7 +97,8 @@ export function AboutCard(props: AboutCardProps) {
     entity,
     scmIntegrationsApi,
   );
-  const entityMetadataEditUrl = getEntityMetadataEditUrl(entity);
+  const entityMetadataEditUrl =
+    entity.metadata.annotations?.[ANNOTATION_EDIT_URL];
 
   const viewInSource: IconLinkVerticalProps = {
     label: 'View Source',

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { RELATION_OWNED_BY, RELATION_PART_OF } from '@backstage/catalog-model';
+import {
+  ANNOTATION_EDIT_URL,
+  ANNOTATION_VIEW_URL,
+  RELATION_OWNED_BY,
+  RELATION_PART_OF,
+} from '@backstage/catalog-model';
 import {
   favoriteEntityIcon,
   favoriteEntityTooltip,
   formatEntityRefTitle,
-  getEntityMetadataEditUrl,
-  getEntityMetadataViewUrl,
   getEntityRelations,
   useEntityList,
   useStarredEntities,
@@ -86,7 +89,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
 
   const defaultActions: TableProps<CatalogTableRow>['actions'] = [
     ({ entity }) => {
-      const url = getEntityMetadataViewUrl(entity);
+      const url = entity.metadata.annotations?.[ANNOTATION_VIEW_URL];
       return {
         icon: () => <OpenInNew aria-label="View" fontSize="small" />,
         tooltip: 'View',
@@ -98,7 +101,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
       };
     },
     ({ entity }) => {
-      const url = getEntityMetadataEditUrl(entity);
+      const url = entity.metadata.annotations?.[ANNOTATION_EDIT_URL];
       return {
         icon: () => <Edit aria-label="Edit" fontSize="small" />,
         tooltip: 'Edit',

--- a/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
+++ b/plugins/org/src/components/Cards/Group/GroupProfile/GroupProfileCard.tsx
@@ -20,13 +20,13 @@ import {
   RELATION_PARENT_OF,
   ANNOTATION_LOCATION,
   stringifyEntityRef,
+  ANNOTATION_EDIT_URL,
 } from '@backstage/catalog-model';
 import {
   catalogApiRef,
   EntityRefLinks,
   getEntityRelations,
   useEntity,
-  getEntityMetadataEditUrl,
 } from '@backstage/plugin-catalog-react';
 import {
   Box,
@@ -94,7 +94,8 @@ export const GroupProfileCard = ({
   const allowRefresh =
     entityLocation?.startsWith('url:') || entityLocation?.startsWith('file:');
 
-  const entityMetadataEditUrl = getEntityMetadataEditUrl(group);
+  const entityMetadataEditUrl =
+    group.metadata.annotations?.[ANNOTATION_EDIT_URL];
 
   const displayName = profile?.displayName ?? name;
   const emailHref = profile?.email ? `mailto:${profile.email}` : '#';


### PR DESCRIPTION
🧹 