### PR TITLE
catalog-react: mark useEntityPermission as alpha

### DIFF
--- a/.changeset/polite-poems-nail.md
+++ b/.changeset/polite-poems-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Marked `useEntityPermission` as alpha since the underlying permission framework is under active development.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -564,7 +564,7 @@ export function useEntityOwnership(): {
   isOwnedEntity: (entity: Entity | EntityName) => boolean;
 };
 
-// @public
+// @alpha
 export function useEntityPermission(permission: Permission): {
   loading: boolean;
   allowed: boolean;

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -9,7 +9,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "alphaTypes": "dist/index.alpha.d.ts"
   },
   "backstage": {
     "role": "web-library"

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -25,7 +25,7 @@
     "backstage"
   ],
   "scripts": {
-    "build": "backstage-cli package build",
+    "build": "backstage-cli package build --experimental-type-build",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
@@ -77,6 +77,7 @@
     "react-test-renderer": "^16.13.1"
   },
   "files": [
-    "dist"
+    "dist",
+    "alpha"
   ]
 }

--- a/plugins/catalog-react/src/hooks/useEntityPermission.ts
+++ b/plugins/catalog-react/src/hooks/useEntityPermission.ts
@@ -28,7 +28,7 @@ import { useEntity } from './useEntity';
  * Note: this hook blocks the permission request until the entity has loaded in
  * context. If you have the entityRef and need concurrent requests, use the
  * `usePermission` hook directly.
- * @public
+ * @alpha
  */
 export function useEntityPermission(permission: Permission): {
   loading: boolean;


### PR DESCRIPTION
Marked `useEntityPermission` as alpha since the underlying permission framework is under active development.
