### PR TITLE
SidebarItem: support for external links

### DIFF
--- a/.changeset/big-phones-drop.md
+++ b/.changeset/big-phones-drop.md
@@ -1,0 +1,9 @@
+---
+'@backstage/core-components': patch
+---
+
+SidebarItem: add support for external links
+
+SidebarItem takes an optional href prop which add support for external links.
+
+It is possible to specify either `to` (internal links) or `href` (external links) prop.

--- a/.changeset/wicked-laws-argue.md
+++ b/.changeset/wicked-laws-argue.md
@@ -1,0 +1,9 @@
+---
+'@backstage/core-components': patch
+---
+
+SidebarSubmenuItem: add support for external links
+
+`SidebarSubmenuItemProps` takes an optional `href` prop which add support for external links.
+
+It isn't possible anymore to specify `to` and `dropdownItems` props at the same time.

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -21,6 +21,7 @@ import { default as CSS_2 } from 'csstype';
 import { CSSProperties } from 'react';
 import { ElementType } from 'react';
 import { ErrorInfo } from 'react';
+import { HTMLAttributeAnchorTarget } from 'react';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { LinearProgressProps } from '@material-ui/core/LinearProgress';
@@ -1052,23 +1053,50 @@ export type SidebarSpacerClassKey = 'root';
 export const SidebarSubmenu: (props: SidebarSubmenuProps) => JSX.Element;
 
 // @public
+export type SidebarSubmenuDropdownProps = {
+  title: string;
+  icon?: IconComponent;
+  dropdownItems: SidebarSubmenuItemDropdownItem[];
+  href?: never;
+  target?: never;
+  to?: never;
+};
+
+// @public
+export type SidebarSubmenuExternalLink = {
+  title: string;
+  icon?: IconComponent;
+  href: string;
+  target?: HTMLAttributeAnchorTarget;
+  to?: never;
+  dropdownItems?: never;
+};
+
+// @public
+export type SidebarSubmenuInternalLink = {
+  title: string;
+  icon?: IconComponent;
+  to: string;
+  href?: never;
+  target?: never;
+  dropdownItems?: never;
+};
+
+// @public
 export const SidebarSubmenuItem: (
   props: SidebarSubmenuItemProps,
 ) => JSX.Element;
 
 // @public
-export type SidebarSubmenuItemDropdownItem = {
-  title: string;
-  to: string;
-};
+export type SidebarSubmenuItemDropdownItem =
+  | SidebarSubmenuInternalLink
+  | SidebarSubmenuExternalLink;
 
 // @public
-export type SidebarSubmenuItemProps = {
-  title: string;
-  to: string;
-  icon: IconComponent;
-  dropdownItems?: SidebarSubmenuItemDropdownItem[];
-};
+export type SidebarSubmenuItemProps =
+  | SidebarSubmenuInternalLink
+  | SidebarSubmenuExternalLink
+  | SidebarSubmenuDropdownProps;
 
 // @public
 export type SidebarSubmenuProps = {

--- a/packages/core-components/src/layout/Sidebar/Bar.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.test.tsx
@@ -48,7 +48,6 @@ async function renderScalableSidebar() {
             <SidebarSubmenuItem title="Tools" to="/1" icon={BuildRoundedIcon} />
             <SidebarSubmenuItem
               title="Misc"
-              to="/6"
               icon={AcUnitIcon}
               dropdownItems={[
                 {

--- a/packages/core-components/src/layout/Sidebar/Items.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.test.tsx
@@ -19,6 +19,7 @@ import { renderInTestApp } from '@backstage/test-utils';
 import { createEvent, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import HomeIcon from '@material-ui/icons/Home';
+import LinkIcon from '@material-ui/icons/Link';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import { Sidebar } from './Bar';
 import { SidebarItem, SidebarSearchField, SidebarExpandButton } from './Items';
@@ -38,6 +39,11 @@ async function renderSidebar() {
     <Sidebar>
       <SidebarSearchField onSearch={() => {}} to="/search" />
       <SidebarItem text="Home" icon={HomeIcon} to="./" />
+      <SidebarItem
+        text="External link"
+        icon={LinkIcon}
+        to="https://backstage.io"
+      />
       <SidebarItem
         icon={CreateComponentIcon}
         onClick={() => {}}
@@ -62,7 +68,13 @@ describe('Items', () => {
       ).toBeInTheDocument();
     });
 
-    it('should render a button when `to` prop is not provided', async () => {
+    it('should render a link when `href` prop provided', async () => {
+      expect(
+        await screen.findByRole('link', { name: 'External link' }),
+      ).toBeInTheDocument();
+    });
+
+    it('should render a button when `to` and `href` props are not provided', async () => {
       expect(
         await screen.findByRole('button', { name: /create/i }),
       ).toBeInTheDocument();

--- a/packages/core-components/src/layout/Sidebar/Sidebar.stories.tsx
+++ b/packages/core-components/src/layout/Sidebar/Sidebar.stories.tsx
@@ -19,6 +19,7 @@ import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import HomeOutlinedIcon from '@material-ui/icons/HomeOutlined';
 import MenuIcon from '@material-ui/icons/Menu';
 import BuildRoundedIcon from '@material-ui/icons/BuildRounded';
+import LinkIcon from '@material-ui/icons/Link';
 import MenuBookIcon from '@material-ui/icons/MenuBook';
 import CloudQueueIcon from '@material-ui/icons/CloudQueue';
 import AcUnitIcon from '@material-ui/icons/AcUnit';
@@ -85,7 +86,6 @@ export const SampleScalableSidebar = () => (
             <SidebarSubmenuItem title="Components" to="/3" icon={AppsIcon} />
             <SidebarSubmenuItem
               title="Misc"
-              to="/6"
               icon={AcUnitIcon}
               dropdownItems={[
                 {
@@ -96,12 +96,23 @@ export const SampleScalableSidebar = () => (
                   title: 'Lorem Ipsum',
                   to: '/8',
                 },
+                {
+                  title: 'External link',
+                  href: 'https://backstage.io',
+                  target: '_blank',
+                },
               ]}
             />
           </SidebarSubmenu>
         </SidebarItem>
         <SidebarItem icon={HomeOutlinedIcon} to="#" text="Plugins" />
         <SidebarItem icon={AddCircleOutlineIcon} to="#" text="Create..." />
+        <SidebarSubmenuItem
+          title="External link"
+          href="https://backstage.io"
+          icon={LinkIcon}
+          target="_blank"
+        />
       </SidebarGroup>
       <SidebarDivider />
       <SidebarIntro />

--- a/packages/core-components/src/layout/Sidebar/index.ts
+++ b/packages/core-components/src/layout/Sidebar/index.ts
@@ -25,6 +25,9 @@ export type { SidebarSubmenuProps } from './SidebarSubmenu';
 export type {
   SidebarSubmenuItemProps,
   SidebarSubmenuItemDropdownItem,
+  SidebarSubmenuInternalLink,
+  SidebarSubmenuExternalLink,
+  SidebarSubmenuDropdownProps,
 } from './SidebarSubmenuItem';
 export type { SidebarClassKey, SidebarProps } from './Bar';
 export {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR closes #9293.

`SidebarItem` and `SidebarSubmenuItem` take an option `href` prop for handling external links.

`SidebarSubmenuItemProps` has been improved: it is now possible to specify only one prop between `to`, `href` and `dropdownItems`.


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
