### PR TITLE
`repoUrl` has no protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "**/@roadiehq/**/@backstage/plugin-catalog": "*",
     "**/@roadiehq/**/@backstage/catalog-model": "*"
   },
-  "version": "0.69.1",
+  "version": "0.69.2",
   "dependencies": {
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.15.0",

--- a/plugins/scaffolder-backend/CHANGELOG.md
+++ b/plugins/scaffolder-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-scaffolder-backend
 
+## 0.17.2
+
+### Patch Changes
+
+- `repoUrl` does not have a protocol in `publish:github:pull-request`
+
 ## 0.17.1
 
 ### Patch Changes

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-scaffolder-backend",
   "description": "The Backstage backend plugin that helps you create new things",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -72,7 +72,7 @@ export const defaultClientFactory = async ({
   const octokitOptions = await getOctokitOptions({
     integrations,
     credentialsProvider: githubCredentialsProvider,
-    repoUrl: `https://${encodedHost}?owner=${encodedOwner}&repo=${encodedRepo}`,
+    repoUrl: `${encodedHost}?owner=${encodedOwner}&repo=${encodedRepo}`,
     token: providedToken,
   });
 


### PR DESCRIPTION
`repoUrl` does not have a protocol in `publish:github:pull-request`