### PR TITLE
Render markdown for description in software templates

### DIFF
--- a/.changeset/mean-panthers-wonder.md
+++ b/.changeset/mean-panthers-wonder.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder': minor
+'@backstage/plugin-scaffolder': patch
 ---
 
 Render markdown for description in software templates

--- a/.changeset/mean-panthers-wonder.md
+++ b/.changeset/mean-panthers-wonder.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Render markdown for description in software templates

--- a/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
+++ b/plugins/scaffolder/src/components/TemplateCard/TemplateCard.tsx
@@ -45,7 +45,11 @@ import { generatePath } from 'react-router';
 import { rootRouteRef } from '../../routes';
 import { FavouriteTemplate } from '../FavouriteTemplate/FavouriteTemplate';
 
-import { Button, ItemCardHeader } from '@backstage/core-components';
+import {
+  Button,
+  ItemCardHeader,
+  MarkdownContent,
+} from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 
 const useStyles = makeStyles(theme => ({
@@ -175,7 +179,7 @@ export const TemplateCard = ({ template, deprecated }: TemplateCardProps) => {
           <Typography variant="body2" className={classes.label}>
             Description
           </Typography>
-          {templateProps.description}
+          <MarkdownContent content={templateProps.description} />
         </Box>
         <Box className={classes.box}>
           <Typography variant="body2" className={classes.label}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

For issue https://github.com/backstage/backstage/issues/7151 

> The description field in Software Template should be rendered via Markdown.

With test description
```
  description: |
    Select the type of entity to create:
    - Resource (e.g. SQL Database, S3 Bucket, ...)
    - Component (e.g. backend service, data pipeline)
    - API
    Find more details in the [System Model](https://backstage.io/docs/features/software-catalog/system-model) documentation.
```

### Current Behavior
![image](https://user-images.githubusercontent.com/68127026/155819212-14802a04-ff50-452b-bf59-e209c971f4dc.png)

### Updated Behavior
![image](https://user-images.githubusercontent.com/68127026/155819227-ae7e710e-3846-43c0-9905-1c82d05c3644.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
