### PR TITLE
catalog-backend: mark permission-related exports as alpha

### DIFF
--- a/.changeset/chilled-dolls-agree.md
+++ b/.changeset/chilled-dolls-agree.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Mark permission-related exports as alpha. This means that the exports below should now be imported from `@backstage/plugin-catalog-backend/alpha` instead of `@backstage/plugin-catalog-backend`.
+
+- `catalogConditions`
+- `createCatalogPolicyDecision`
+- `permissionRules`
+- `createCatalogPermissionRule`

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -213,7 +213,7 @@ export class CatalogBuilder {
   setRefreshIntervalSeconds(seconds: number): CatalogBuilder;
 }
 
-// @public
+// @alpha
 export const catalogConditions: Conditions<{
   hasAnnotation: PermissionRule<
     Entity,
@@ -394,12 +394,12 @@ export class CodeOwnersProcessor implements CatalogProcessor {
   preProcessEntity(entity: Entity, location: LocationSpec): Promise<Entity>;
 }
 
-// @public
+// @alpha
 export const createCatalogPermissionRule: <TParams extends unknown[]>(
   rule: PermissionRule<Entity, EntitiesSearchFilter, TParams>,
 ) => PermissionRule<Entity, EntitiesSearchFilter, TParams>;
 
-// @public
+// @alpha
 export const createCatalogPolicyDecision: (
   conditions: PermissionCriteria<PermissionCondition<unknown[]>>,
 ) => ConditionalPolicyDecision;
@@ -896,7 +896,7 @@ export function parseEntityYaml(
   location: LocationSpec,
 ): Iterable<CatalogProcessorResult>;
 
-// @public
+// @alpha
 export const permissionRules: {
   hasAnnotation: PermissionRule<
     Entity,

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -9,7 +9,8 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "alphaTypes": "dist/index.alpha.d.ts"
   },
   "backstage": {
     "role": "backend-plugin"
@@ -25,7 +26,7 @@
   ],
   "scripts": {
     "start": "backstage-cli package start",
-    "build": "backstage-cli package build",
+    "build": "backstage-cli package build --experimental-type-build",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
@@ -87,6 +88,7 @@
   },
   "files": [
     "dist",
+    "alpha",
     "migrations/**/*.{js,d.ts}",
     "config.d.ts"
   ],

--- a/plugins/catalog-backend/src/permissions/conditionExports.ts
+++ b/plugins/catalog-backend/src/permissions/conditionExports.ts
@@ -27,7 +27,8 @@ const conditionExports = createConditionExports({
 /**
  * These conditions are used when creating conditional decisions that are returned
  * by authorization policies.
- * @public
+ *
+ * @alpha
  */
 export const catalogConditions = conditionExports.conditions;
 
@@ -50,7 +51,8 @@ export const catalogConditions = conditionExports.conditions;
  *   }
  * }
  * ```
- * @public
+ *
+ * @alpha
  */
 export const createCatalogPolicyDecision =
   conditionExports.createPolicyDecision;

--- a/plugins/catalog-backend/src/permissions/rules/index.ts
+++ b/plugins/catalog-backend/src/permissions/rules/index.ts
@@ -24,7 +24,8 @@ import { hasSpec } from './hasSpec';
 /**
  * These permission rules can be used to conditionally filter catalog entities
  * or describe a user's access to the entities.
- * @public
+ *
+ * @alpha
  */
 export const permissionRules = {
   hasAnnotation,

--- a/plugins/catalog-backend/src/permissions/rules/util.ts
+++ b/plugins/catalog-backend/src/permissions/rules/util.ts
@@ -23,7 +23,7 @@ import { EntitiesSearchFilter } from '../../catalog/types';
  * {@link @backstage/plugin-permission-node#PermissionRule}s for the
  * catalog-backend.
  *
- * @public
+ * @alpha
  */
 export const createCatalogPermissionRule = makeCreatePermissionRule<
   Entity,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Marks all strictly permission-related exports in catalog-backend as alpha. There are permission-related properties on other exports, so this doesn't entirely protect us from future breaking changes, but it will certainly reduce the number.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
