### PR TITLE
fix(docs): Update Postgres tutorial SSL block to match current Postgres template config

### DIFF
--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -43,9 +43,11 @@ backend:
 +      user: ${POSTGRES_USER}
 +      password: ${POSTGRES_PASSWORD}
 +      # https://node-postgres.com/features/ssl
-+      #ssl: require # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
-+        #ca: # if you have a CA file and want to verify it you can uncomment this section
-+        #$file: <file-path>/ca/server.crt
++      # you can set the sslmode configuration option via the `PGSSLMODE` environment variable
++      # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
++      # ssl:
++      #   ca: # if you have a CA file and want to verify it you can uncomment this section
++      #     $file: <file-path>/ca/server.crt
 ```
 
 If you have an `app-config.local.yaml` for local development, a similar update


### PR DESCRIPTION
Signed-off-by: Marcus Crane <marcus.crane@lightspeedhq.com>

## Hey, I just made a Pull Request!

Currently we're exploring Backstage and it's very neat. Initially I started with sqlite to test out the catalog locally then I converted our production config over to Postgres using [this tutorial](https://backstage.io/docs/tutorials/switching-sqlite-postgres)

I used it as is, with no dice, and discovered that the recommended Postgres configuration (for SSL) had changed in [this PR](https://github.com/backstage/backstage/pull/8199).

Given that I didn't explicitly ask for Postgres when scaffolding my app, I wasn't aware so here's a PR to bring the tutorial up to date with what gets scaffolded when you select pg as a connector.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
