### PR TITLE
Added default commit message

### DIFF
--- a/.changeset/angry-pens-begin.md
+++ b/.changeset/angry-pens-begin.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-override default commit message and author details in gitlab action
+Override default commit message and author details in GitLab action

--- a/.changeset/angry-pens-begin.md
+++ b/.changeset/angry-pens-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+override default commit message and author details in gitlab action

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -266,6 +266,9 @@ export function createPublishGitlabAction(options: {
   repoVisibility?: 'internal' | 'private' | 'public' | undefined;
   sourcePath?: string | undefined;
   token?: string | undefined;
+  defaultCommitMessage?: string | undefined;
+  gitAuthorName?: string | undefined;
+  gitAuthorEmail?: string | undefined;
 }>;
 
 // @public

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -266,7 +266,7 @@ export function createPublishGitlabAction(options: {
   repoVisibility?: 'internal' | 'private' | 'public' | undefined;
   sourcePath?: string | undefined;
   token?: string | undefined;
-  defaultCommitMessage?: string | undefined;
+  gitCommitMessage?: string | undefined;
   gitAuthorName?: string | undefined;
   gitAuthorEmail?: string | undefined;
 }>;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
@@ -181,6 +181,7 @@ describe('publish:gitlab', () => {
       remoteUrl: 'http://mockurl.git',
       auth: { username: 'oauth2', password: 'tokenlols' },
       logger: mockContext.logger,
+      commitMessage: 'initial commit',
       gitAuthorInfo: {},
     });
   });
@@ -205,6 +206,7 @@ describe('publish:gitlab', () => {
       remoteUrl: 'http://mockurl.git',
       auth: { username: 'oauth2', password: 'tokenlols' },
       logger: mockContext.logger,
+      commitMessage: 'initial commit',
       gitAuthorInfo: {},
     });
   });
@@ -252,6 +254,7 @@ describe('publish:gitlab', () => {
       auth: { username: 'oauth2', password: 'tokenlols' },
       logger: mockContext.logger,
       defaultBranch: 'master',
+      commitMessage: 'Test commit message',
       gitAuthorInfo: { name: 'Test', email: 'example@example.com' },
     });
   });
@@ -294,10 +297,10 @@ describe('publish:gitlab', () => {
       dir: mockContext.workspacePath,
       remoteUrl: 'http://mockurl.git',
       auth: { username: 'oauth2', password: 'tokenlols' },
-      logger: mockContext.logger,
       defaultBranch: 'master',
       commitMessage: 'Test commit message',
       gitAuthorInfo: { email: undefined, name: undefined },
+      logger: mockContext.logger,
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.test.ts
@@ -254,7 +254,7 @@ describe('publish:gitlab', () => {
       auth: { username: 'oauth2', password: 'tokenlols' },
       logger: mockContext.logger,
       defaultBranch: 'master',
-      commitMessage: 'Test commit message',
+      commitMessage: 'initial commit',
       gitAuthorInfo: { name: 'Test', email: 'example@example.com' },
     });
   });
@@ -298,7 +298,7 @@ describe('publish:gitlab', () => {
       remoteUrl: 'http://mockurl.git',
       auth: { username: 'oauth2', password: 'tokenlols' },
       defaultBranch: 'master',
-      commitMessage: 'Test commit message',
+      commitMessage: 'initial commit',
       gitAuthorInfo: { email: undefined, name: undefined },
       logger: mockContext.logger,
     });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -40,7 +40,7 @@ export function createPublishGitlabAction(options: {
     repoVisibility?: 'private' | 'internal' | 'public';
     sourcePath?: string;
     token?: string;
-    defaultCommitMessage?: string;
+    gitCommitMessage?: string;
     gitAuthorName?: string;
     gitAuthorEmail?: string;
   }>({
@@ -66,10 +66,10 @@ export function createPublishGitlabAction(options: {
             type: 'string',
             description: `Sets the default branch on the repository. The default value is 'master'`,
           },
-          defaultCommitMessage: {
-            title: 'Default Commit Message',
+          gitCommitMessage: {
+            title: 'Git Commit Message',
             type: 'string',
-            description: `Sets the default commit message on the repository. The default value is 'initial commit'`,
+            description: `Sets the commit message on the repository. The default value is 'initial commit'`,
           },
           gitAuthorName: {
             title: 'Default Author Name',
@@ -113,7 +113,7 @@ export function createPublishGitlabAction(options: {
         repoUrl,
         repoVisibility = 'private',
         defaultBranch = 'master',
-        defaultCommitMessage = 'initial commit',
+        gitCommitMessage = 'initial commit',
         gitAuthorName,
         gitAuthorEmail,
       } = ctx.input;
@@ -182,8 +182,8 @@ export function createPublishGitlabAction(options: {
           password: token,
         },
         logger: ctx.logger,
-        commitMessage: defaultCommitMessage
-          ? defaultCommitMessage
+        commitMessage: gitCommitMessage
+          ? gitCommitMessage
           : config.getOptionalString('scaffolder.defaultCommitMessage'),
         gitAuthorInfo,
       });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/gitlab.ts
@@ -40,6 +40,9 @@ export function createPublishGitlabAction(options: {
     repoVisibility?: 'private' | 'internal' | 'public';
     sourcePath?: string;
     token?: string;
+    defaultCommitMessage?: string;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
   }>({
     id: 'publish:gitlab',
     description:
@@ -62,6 +65,21 @@ export function createPublishGitlabAction(options: {
             title: 'Default Branch',
             type: 'string',
             description: `Sets the default branch on the repository. The default value is 'master'`,
+          },
+          defaultCommitMessage: {
+            title: 'Default Commit Message',
+            type: 'string',
+            description: `Sets the default commit message on the repository. The default value is 'initial commit'`,
+          },
+          gitAuthorName: {
+            title: 'Default Author Name',
+            type: 'string',
+            description: `Sets the default author name for the commit. The default value is 'Scaffolder'`,
+          },
+          gitAuthorEmail: {
+            title: 'Default Author Email',
+            type: 'string',
+            description: `Sets the default author email for the commit.`,
           },
           sourcePath: {
             title: 'Source Path',
@@ -95,8 +113,10 @@ export function createPublishGitlabAction(options: {
         repoUrl,
         repoVisibility = 'private',
         defaultBranch = 'master',
+        defaultCommitMessage = 'initial commit',
+        gitAuthorName,
+        gitAuthorEmail,
       } = ctx.input;
-
       const { owner, repo, host } = parseRepoUrl(repoUrl, integrations);
 
       if (!owner) {
@@ -146,10 +166,13 @@ export function createPublishGitlabAction(options: {
       const repoContentsUrl = `${remoteUrl}/-/blob/${defaultBranch}`;
 
       const gitAuthorInfo = {
-        name: config.getOptionalString('scaffolder.defaultAuthor.name'),
-        email: config.getOptionalString('scaffolder.defaultAuthor.email'),
+        name: gitAuthorName
+          ? gitAuthorName
+          : config.getOptionalString('scaffolder.defaultAuthor.name'),
+        email: gitAuthorEmail
+          ? gitAuthorEmail
+          : config.getOptionalString('scaffolder.defaultAuthor.email'),
       };
-
       await initRepoAndPush({
         dir: getRepoSourceDirectory(ctx.workspacePath, ctx.input.sourcePath),
         remoteUrl: http_url_to_repo as string,
@@ -159,9 +182,9 @@ export function createPublishGitlabAction(options: {
           password: token,
         },
         logger: ctx.logger,
-        commitMessage: config.getOptionalString(
-          'scaffolder.defaultCommitMessage',
-        ),
+        commitMessage: defaultCommitMessage
+          ? defaultCommitMessage
+          : config.getOptionalString('scaffolder.defaultCommitMessage'),
         gitAuthorInfo,
       });
 


### PR DESCRIPTION

Signed-off-by: Shivam bisht <shvmbisht@gmail.com>

## Hey, I just made a Pull Request!
Currently, we have the following default author and commit message for Scaffolder, so changes are made in order to override default commit message and author details for multiple teams in the organization, different teams might have their own regex patterns for commit messages.
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
## Screenshots
![scrnli_01_03_2022_02-30-18](https://user-images.githubusercontent.com/19923220/156057931-6c309c22-bca1-458a-8bc4-87ecb700e625.png)

![scrnli_01_03_2022_02-23-02](https://user-images.githubusercontent.com/19923220/156056882-cdcfa7d4-fe84-4f4f-a53e-e01302f4af6c.png)
