### PR TITLE
scripts: Update list-deprecations script to use new release tags

### DIFF
--- a/scripts/list-deprecations.js
+++ b/scripts/list-deprecations.js
@@ -57,9 +57,7 @@ class ReleaseProvider {
       );
 
       // Filter out just the releases
-      const releases = tagOutput
-        .split('\n')
-        .filter(l => l.startsWith('release-'));
+      const releases = tagOutput.split('\n').filter(l => l.startsWith('v'));
 
       // Then find the earliest release that affected our package
       for (const release of releases) {


### PR DESCRIPTION
Now produces this output and correctly identify released deprecations.

```
### v0.64.0
3d870192 1/14/2022   Patrik Oldsberg   plugins/catalog-react/src/routes.ts:23
3d870192 1/14/2022   Patrik Oldsberg   plugins/catalog-react/src/routes.ts:31
3d870192 1/14/2022   Patrik Oldsberg   plugins/catalog-react/src/routes.ts:56

### v0.66.0
40775bd2 2/1/2022    Patrik Oldsberg   packages/core-app-api/src/apis/implementations/auth/github/GithubAuth.ts:52

### v0.68.0
ac0d932b 2/17/2022   Fredrik Adelöw    plugins/catalog/src/components/AboutCard/AboutCard.tsx:85
```