### PR TITLE
catalog-backend: inline and deprecate BitbucketRepositoryParser type

### DIFF
--- a/.changeset/plenty-tables-mix.md
+++ b/.changeset/plenty-tables-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Deprecated the `BitbucketRepositoryParser` type.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -137,14 +137,22 @@ export class AzureDevOpsDiscoveryProcessor implements CatalogProcessor {
 export class BitbucketDiscoveryProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrationRegistry;
-    parser?: BitbucketRepositoryParser;
+    parser?: (options: {
+      integration: BitbucketIntegration;
+      target: string;
+      logger: Logger_2;
+    }) => AsyncIterable<CatalogProcessorResult>;
     logger: Logger_2;
   });
   // (undocumented)
   static fromConfig(
     config: Config,
     options: {
-      parser?: BitbucketRepositoryParser;
+      parser?: (options: {
+        integration: BitbucketIntegration;
+        target: string;
+        logger: Logger_2;
+      }) => AsyncIterable<CatalogProcessorResult>;
       logger: Logger_2;
     },
   ): BitbucketDiscoveryProcessor;
@@ -158,7 +166,7 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
   ): Promise<boolean>;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type BitbucketRepositoryParser = (options: {
   integration: BitbucketIntegration;
   target: string;

--- a/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/BitbucketDiscoveryProcessor.test.ts
@@ -18,7 +18,6 @@ import { BitbucketDiscoveryProcessor } from './BitbucketDiscoveryProcessor';
 import { ConfigReader } from '@backstage/config';
 import {
   BitbucketRepository20,
-  BitbucketRepositoryParser,
   PagedResponse,
   PagedResponse20,
 } from './bitbucket';
@@ -742,15 +741,6 @@ describe('BitbucketDiscoveryProcessor', () => {
   });
 
   describe('Custom repository parser', () => {
-    const customRepositoryParser: BitbucketRepositoryParser =
-      async function* customRepositoryParser({}) {
-        yield results.location({
-          type: 'custom-location-type',
-          target: 'custom-target',
-          presence: 'optional',
-        });
-      };
-
     const processor = BitbucketDiscoveryProcessor.fromConfig(
       new ConfigReader({
         integrations: {
@@ -763,7 +753,16 @@ describe('BitbucketDiscoveryProcessor', () => {
           ],
         },
       }),
-      { parser: customRepositoryParser, logger: getVoidLogger() },
+      {
+        parser: async function* customRepositoryParser({}) {
+          yield results.location({
+            type: 'custom-location-type',
+            target: 'custom-target',
+            presence: 'optional',
+          });
+        },
+        logger: getVoidLogger(),
+      },
     );
 
     it('use custom repository parser', async () => {

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.test.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.test.ts
@@ -15,8 +15,6 @@
  */
 import { defaultRepositoryParser } from './BitbucketRepositoryParser';
 import { results } from '../index';
-import { getVoidLogger } from '@backstage/backend-common';
-import { BitbucketIntegration } from '@backstage/integration';
 
 describe('BitbucketRepositoryParser', () => {
   describe('defaultRepositoryParser', () => {
@@ -32,9 +30,7 @@ describe('BitbucketRepositoryParser', () => {
         }),
       ];
       const actual = await defaultRepositoryParser({
-        integration: {} as BitbucketIntegration,
         target: `${browseUrl}${path}`,
-        logger: getVoidLogger(),
       });
 
       let i = 0;

--- a/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/bitbucket/BitbucketRepositoryParser.ts
@@ -18,21 +18,27 @@ import { results } from '../index';
 import { Logger } from 'winston';
 import { BitbucketIntegration } from '@backstage/integration';
 
-/** @public */
+/**
+ * @public
+ * @deprecated type inlined.
+ */
 export type BitbucketRepositoryParser = (options: {
   integration: BitbucketIntegration;
   target: string;
   logger: Logger;
 }) => AsyncIterable<CatalogProcessorResult>;
 
-export const defaultRepositoryParser: BitbucketRepositoryParser =
-  async function* defaultRepositoryParser({ target }) {
-    yield results.location({
-      type: 'url',
-      target: target,
-      // Not all locations may actually exist, since the user defined them as a wildcard pattern.
-      // Thus, we emit them as optional and let the downstream processor find them while not outputting
-      // an error if it couldn't.
-      presence: 'optional',
-    });
-  };
+export const defaultRepositoryParser = async function* defaultRepositoryParser({
+  target,
+}: {
+  target: string;
+}) {
+  yield results.location({
+    type: 'url',
+    target: target,
+    // Not all locations may actually exist, since the user defined them as a wildcard pattern.
+    // Thus, we emit them as optional and let the downstream processor find them while not outputting
+    // an error if it couldn't.
+    presence: 'optional',
+  });
+};


### PR DESCRIPTION
🧹 

Deprecate and inline the specific but too generic `BitbucketRepositoryParser` type.