### PR TITLE
catalog-common: mark permission-related exports as alpha

### DIFF
--- a/.changeset/chilled-dolls-agree.md
+++ b/.changeset/chilled-dolls-agree.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Mark permission-related exports as alpha. This means that the exports below should now be imported from `@backstage/plugin-catalog-backend/alpha` instead of `@backstage/plugin-catalog-backend`.
+**Breaking**: Mark permission-related exports as alpha. This means that the exports below should now be imported from `@backstage/plugin-catalog-backend/alpha` instead of `@backstage/plugin-catalog-backend`.
 
 - `catalogConditions`
 - `createCatalogPolicyDecision`

--- a/.changeset/gorgeous-actors-shave.md
+++ b/.changeset/gorgeous-actors-shave.md
@@ -1,0 +1,12 @@
+---
+'@backstage/create-app': patch
+---
+
+Update import location of catalogEntityCreatePermission.
+
+To apply this change to an existing app, make the following change to `packages/app/src/App.tsx`:
+
+```diff
+-import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common';
++import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
+```

--- a/.changeset/nice-walls-reply.md
+++ b/.changeset/nice-walls-reply.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-catalog-common': minor
+---
+
+Mark permission-related exports as alpha. This means that the exports below should now be imported from `@backstage/plugin-catalog-common/alpha` instead of `@backstage/plugin-catalog-common`.
+
+- `RESOURCE_TYPE_CATALOG_ENTITY`
+- `catalogEntityReadPermission`
+- `catalogEntityCreatePermission`
+- `catalogEntityDeletePermission`
+- `catalogEntityRefreshPermission`
+- `catalogLocationReadPermission`
+- `catalogLocationCreatePermission`
+- `catalogLocationDeletePermission`

--- a/.changeset/nice-walls-reply.md
+++ b/.changeset/nice-walls-reply.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-catalog-common': minor
 ---
 
-Mark permission-related exports as alpha. This means that the exports below should now be imported from `@backstage/plugin-catalog-common/alpha` instead of `@backstage/plugin-catalog-common`.
+**Breaking**: Mark permission-related exports as alpha. This means that the exports below should now be imported from `@backstage/plugin-catalog-common/alpha` instead of `@backstage/plugin-catalog-common`.
 
 - `RESOURCE_TYPE_CATALOG_ENTITY`
 - `catalogEntityReadPermission`

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -30,7 +30,7 @@ import { createApp } from '@backstage/app-defaults';
 import { FlatRoutes } from '@backstage/core-app-api';
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { PermissionedRoute } from '@backstage/plugin-permission-react';
-import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common';
+import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 
 const app = createApp({
   apis,

--- a/plugins/catalog-common/api-report.md
+++ b/plugins/catalog-common/api-report.md
@@ -5,27 +5,27 @@
 ```ts
 import { Permission } from '@backstage/plugin-permission-common';
 
-// @public
+// @alpha
 export const catalogEntityCreatePermission: Permission;
 
-// @public
+// @alpha
 export const catalogEntityDeletePermission: Permission;
 
-// @public
+// @alpha
 export const catalogEntityReadPermission: Permission;
 
-// @public
+// @alpha
 export const catalogEntityRefreshPermission: Permission;
 
-// @public
+// @alpha
 export const catalogLocationCreatePermission: Permission;
 
-// @public
+// @alpha
 export const catalogLocationDeletePermission: Permission;
 
-// @public
+// @alpha
 export const catalogLocationReadPermission: Permission;
 
-// @public (undocumented)
+// @alpha
 export const RESOURCE_TYPE_CATALOG_ENTITY = 'catalog-entity';
 ```

--- a/plugins/catalog-common/package.json
+++ b/plugins/catalog-common/package.json
@@ -10,7 +10,8 @@
     "access": "public",
     "main": "dist/index.cjs.js",
     "module": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "alphaTypes": "dist/index.alpha.d.ts"
   },
   "backstage": {
     "role": "common-library"
@@ -25,7 +26,7 @@
     "backstage"
   ],
   "scripts": {
-    "build": "backstage-cli package build",
+    "build": "backstage-cli package build --experimental-type-build",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "prepack": "backstage-cli package prepack",
@@ -39,6 +40,7 @@
     "@backstage/cli": "^0.14.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "alpha"
   ]
 }

--- a/plugins/catalog-common/src/permissions.ts
+++ b/plugins/catalog-common/src/permissions.ts
@@ -17,8 +17,10 @@
 import { Permission } from '@backstage/plugin-permission-common';
 
 /**
+ * Permission resource type which corresponds to catalog entities.
+ *
  * {@link https://backstage.io/docs/features/software-catalog/software-catalog-overview}
- * @public
+ * @alpha
  */
 export const RESOURCE_TYPE_CATALOG_ENTITY = 'catalog-entity';
 
@@ -28,7 +30,7 @@ export const RESOURCE_TYPE_CATALOG_ENTITY = 'catalog-entity';
  *
  * If this permission is not authorized, it will appear that the entity does not
  * exist in the catalog — both in the frontend and in API responses.
- * @public
+ * @alpha
  */
 export const catalogEntityReadPermission: Permission = {
   name: 'catalog.entity.read',
@@ -42,7 +44,7 @@ export const catalogEntityReadPermission: Permission = {
  * This permission is used to authorize actions that involve creating a new
  * catalog entity. This includes registering an existing component into the
  * catalog.
- * @public
+ * @alpha
  */
 export const catalogEntityCreatePermission: Permission = {
   name: 'catalog.entity.create',
@@ -55,7 +57,7 @@ export const catalogEntityCreatePermission: Permission = {
 /**
  * This permission is used to designate actions that involve removing one or
  * more entities from the catalog.
- * @public
+ * @alpha
  */
 export const catalogEntityDeletePermission: Permission = {
   name: 'catalog.entity.delete',
@@ -68,7 +70,7 @@ export const catalogEntityDeletePermission: Permission = {
 /**
  * This permission is used to designate refreshing one or more entities from the
  * catalog.
- * @public
+ * @alpha
  */
 export const catalogEntityRefreshPermission: Permission = {
   name: 'catalog.entity.refresh',
@@ -84,7 +86,7 @@ export const catalogEntityRefreshPermission: Permission = {
  *
  * If this permission is not authorized, it will appear that the location does
  * not exist in the catalog — both in the frontend and in API responses.
- * @public
+ * @alpha
  */
 export const catalogLocationReadPermission: Permission = {
   name: 'catalog.location.read',
@@ -96,7 +98,7 @@ export const catalogLocationReadPermission: Permission = {
 /**
  * This permission is used to designate actions that involve creating catalog
  * locations.
- * @public
+ * @alpha
  */
 export const catalogLocationCreatePermission: Permission = {
   name: 'catalog.location.create',
@@ -108,7 +110,7 @@ export const catalogLocationCreatePermission: Permission = {
 /**
  * This permission is used to designate actions that involve deleting locations
  * from the catalog.
- * @public
+ * @alpha
  */
 export const catalogLocationDeletePermission: Permission = {
   name: 'catalog.location.delete',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Marks all permission-related exports in `@backstage/plugin-catalog-common` (which is everything in that package so far) as alpha.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
