### PR TITLE
catalog-common: remove resourceType from catalogEntityCreatePermission

### DIFF
--- a/.changeset/giant-taxis-drop.md
+++ b/.changeset/giant-taxis-drop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-common': minor
+---
+
+Remove resourceType property from catalogEntityCreatePermission. Resource type refers to the type of resources whose resourceRefs should be passed along with authorize requests, to allow conditional responses for that resource type. Since creation does not correspond to an entity (as the entity does not exist at the time of authorization), the resourceRef should not be included on the permission.

--- a/plugins/catalog-common/src/permissions.ts
+++ b/plugins/catalog-common/src/permissions.ts
@@ -49,7 +49,6 @@ export const catalogEntityCreatePermission: Permission = {
   attributes: {
     action: 'create',
   },
-  resourceType: RESOURCE_TYPE_CATALOG_ENTITY,
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The resourceType on permissions refers to the resource whose ref is expected to be passed along with the permission during authorization. This allows the permission-backend to make the decision based on characteristics of the resource.

Since the entity being created by definition doesn't yet exist, it's not correct for this permission to include a resourceType.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
