### PR TITLE
Autoremove containers launched by DockerContainerRunner

### DIFF
--- a/.changeset/grumpy-apes-repeat.md
+++ b/.changeset/grumpy-apes-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+DockerContainerRunner.runContainer now automatically removes the container when its execution terminates

--- a/packages/backend-common/src/util/DockerContainerRunner.test.ts
+++ b/packages/backend-common/src/util/DockerContainerRunner.test.ts
@@ -115,6 +115,7 @@ describe('DockerContainerRunner', () => {
         Env: envVarsArray,
         WorkingDir: workingDir,
         HostConfig: {
+          AutoRemove: true,
           Binds: expect.arrayContaining([
             `${path.join(rootDir, 'input')}:/input`,
             `${path.join(rootDir, 'output')}:/output`,
@@ -207,6 +208,7 @@ describe('DockerContainerRunner', () => {
       logStream,
       expect.objectContaining({
         HostConfig: {
+          AutoRemove: true,
           Binds: [],
         },
         Volumes: {},

--- a/packages/backend-common/src/util/DockerContainerRunner.ts
+++ b/packages/backend-common/src/util/DockerContainerRunner.ts
@@ -105,6 +105,7 @@ export class DockerContainerRunner implements ContainerRunner {
       await this.dockerClient.run(imageName, args, logStream, {
         Volumes,
         HostConfig: {
+          AutoRemove: true,
           Binds,
         },
         ...(workingDir ? { WorkingDir: workingDir } : {}),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`DockerContainerRunner.runContainer` will now set the `HostConfig.AutoRemove` option of the Dockerode client to `true` in order to avoid stopped leftover containers on the machine (see [here](https://github.com/apocas/dockerode#equivalent-of-docker-run-in-dockerode) for more info).

Fixes #9850

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation _(no need to)_
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) _(no need to)_
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
