### PR TITLE
plugin-auth-backend: Added validation to ensure any custom auth resol…

### DIFF
--- a/.changeset/tasty-poems-raise.md
+++ b/.changeset/tasty-poems-raise.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend': minor
 ---
 
-Added validation to TokenFactory.issueToken that ensure any sub claim given is a valid entityRef. This will affect any custom resolver functions given to auth providers.
+**BREAKING**: The `TokenFactory.issueToken` used by custom sign-in resolvers now ensures that the sub claim given is a full entity reference of the format `<kind>:<namespace>/<name>`. Any existing custom sign-in resolver functions that do not supply a full entity reference must be updated.

--- a/.changeset/tasty-poems-raise.md
+++ b/.changeset/tasty-poems-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Added validation to TokenFactory.issueToken that ensure any sub claim given is a valid entityRef. This will affect any custom resolver functions given to auth providers.

--- a/plugins/auth-backend/src/identity/TokenFactory.ts
+++ b/plugins/auth-backend/src/identity/TokenFactory.ts
@@ -19,6 +19,7 @@ import { JSONWebKey, JWK, JWS } from 'jose';
 import { Logger } from 'winston';
 import { v4 as uuid } from 'uuid';
 import { DateTime } from 'luxon';
+import { parseEntityRef } from '@backstage/catalog-model';
 
 const MS_IN_S = 1000;
 
@@ -71,6 +72,15 @@ export class TokenFactory implements TokenIssuer {
     const aud = 'backstage';
     const iat = Math.floor(Date.now() / MS_IN_S);
     const exp = iat + this.keyDurationSeconds;
+
+    // Validate that the subject claim is a valid EntityRef
+    try {
+      parseEntityRef(sub);
+    } catch (error) {
+      throw new Error(
+        '"sub" claim provided by the auth resolver is not a valid EntityRef.',
+      );
+    }
 
     this.logger.info(`Issuing token for ${sub}, with entities ${ent ?? []}`);
 


### PR DESCRIPTION
…vers are using EntityRefs for subject claims

Signed-off-by: Harry Hogg <hhogg@spotify.com>

## Hey, I just made a Pull Request!

Added in validation to the TokenFactory that ensures the given subject claims are valid entity Refs. This is likely to affect custom resolvers on auth providers. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
