### PR TITLE
catalog-backend: allow json object placeholder values

### DIFF
--- a/.changeset/tasty-seahorses-remain.md
+++ b/.changeset/tasty-seahorses-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Allow for JSON Object placeholder values

--- a/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.ts
+++ b/plugins/catalog-backend/src/ingestion/processors/PlaceholderProcessor.ts
@@ -103,7 +103,7 @@ export class PlaceholderProcessor implements CatalogProcessor {
       const resolverKey = keys[0].substr(1);
       const resolverValue = data[keys[0]];
       const resolver = this.options.resolvers[resolverKey];
-      if (!resolver || typeof resolverValue !== 'string') {
+      if (!resolver) {
         // If there was no such placeholder resolver or if the value was not a
         // string, we err on the side of safety and assume that this is
         // something that's best left alone. For example, if the input contains


### PR DESCRIPTION
Signed-off-by: Mark David Avery <mark@webark.cc>

## Hey, I just made a Pull Request!

Allowing for JSON Objects for placeholder values.
An example usage
```
$myPlaceholder:
  foo: 'foo-value'
  bar: 'bar-value'
```
Our practical usage
```
dependsOn:
  $externallyManagedRelations:
    datadog:
      name: '<datadog-service-name>'
      type: 'calls'
    rawRelations:
      - 'Component:<actual relation>'
```
 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
