### PR TITLE
remove the `EntityName` codepath from the `useEntityOwnership` hook

### DIFF
--- a/.changeset/strong-suns-hope.md
+++ b/.changeset/strong-suns-hope.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-catalog-react': minor
 ---
 
 Removing the `EntityName` path for the `useEntityOwnership` as it has never worked correctly. Please pass in an entire `Entity` instead.

--- a/.changeset/strong-suns-hope.md
+++ b/.changeset/strong-suns-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Removing the `EntityName` path for the `useEntityOwnership` as it has never worked correctly. Please pass in an entire `Entity` instead.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -544,7 +544,7 @@ export function useEntityListProvider<
 // @public
 export function useEntityOwnership(): {
   loading: boolean;
-  isOwnedEntity: (entity: Entity | EntityName) => boolean;
+  isOwnedEntity: (entity: Entity) => boolean;
 };
 
 // @alpha

--- a/plugins/catalog-react/src/hooks/useEntityOwnership.ts
+++ b/plugins/catalog-react/src/hooks/useEntityOwnership.ts
@@ -17,7 +17,6 @@
 import { CatalogApi } from '@backstage/catalog-client';
 import {
   Entity,
-  EntityName,
   parseEntityRef,
   RELATION_MEMBER_OF,
   RELATION_OWNED_BY,
@@ -77,7 +76,7 @@ export async function loadCatalogOwnerRefs(
  */
 export function useEntityOwnership(): {
   loading: boolean;
-  isOwnedEntity: (entity: Entity | EntityName) => boolean;
+  isOwnedEntity: (entity: Entity) => boolean;
 } {
   const identityApi = useApi(identityApiRef);
   const catalogApi = useApi(catalogApiRef);
@@ -94,12 +93,10 @@ export function useEntityOwnership(): {
 
   const isOwnedEntity = useMemo(() => {
     const myOwnerRefs = new Set(refs ?? []);
-    return (entity: Entity | EntityName) => {
-      const entityOwnerRefs = (
-        'metadata' in entity
-          ? getEntityRelations(entity, RELATION_OWNED_BY)
-          : [entity]
-      ).map(stringifyEntityRef);
+    return (entity: Entity) => {
+      const entityOwnerRefs = getEntityRelations(entity, RELATION_OWNED_BY).map(
+        stringifyEntityRef,
+      );
       for (const ref of entityOwnerRefs) {
         if (myOwnerRefs.has(ref)) {
           return true;


### PR DESCRIPTION
More info in changeset.

Minor change but no deprecation as it never worked anyway.