### PR TITLE
export FetchUrlReader

### DIFF
--- a/.changeset/olive-glasses-approve.md
+++ b/.changeset/olive-glasses-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Export FetchUrlReader to facilitate more flexible configuration of the backend.

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -235,6 +235,21 @@ export type ErrorHandlerOptions = {
 };
 
 // @public
+export class FetchUrlReader implements UrlReader {
+  static factory: ReaderFactory;
+  // (undocumented)
+  read(url: string): Promise<Buffer>;
+  // (undocumented)
+  readTree(): Promise<ReadTreeResponse>;
+  // (undocumented)
+  readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
+  // (undocumented)
+  search(): Promise<SearchResponse>;
+  // (undocumented)
+  toString(): string;
+}
+
+// @public
 export type FromReadableArrayOptions = Array<{
   data: Readable;
   path: string;

--- a/packages/backend-common/src/reading/index.ts
+++ b/packages/backend-common/src/reading/index.ts
@@ -19,6 +19,7 @@ export { BitbucketUrlReader } from './BitbucketUrlReader';
 export { GithubUrlReader } from './GithubUrlReader';
 export { GitlabUrlReader } from './GitlabUrlReader';
 export { AwsS3UrlReader } from './AwsS3UrlReader';
+export { FetchUrlReader } from './FetchUrlReader';
 export type {
   FromReadableArrayOptions,
   ReaderFactory,


### PR DESCRIPTION
Signed-off-by: Brian Fletcher <brian@roadie.io>

## Hey, I just made a Pull Request!

The FetchUrlReader needs to be exported so that backends that are maintaining a custom list of readers can also use this reader.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
