### PR TITLE
vocab: removed old code of conduct words

### DIFF
--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -20,7 +20,6 @@ Autoscaling
 autoselect
 Avro
 aws
-backrub
 backported
 backporting
 Bigtable
@@ -39,8 +38,6 @@ Changesets
 chanwit
 Chanwit
 ci
-cisphobia
-cissexist
 classname
 cli
 cloudbuild
@@ -68,7 +65,6 @@ css
 Datadog
 dataflow
 dayjs
-deadnaming
 debounce
 Debounce
 declaratively
@@ -171,7 +167,6 @@ Minikube
 Minio
 misconfiguration
 misconfigured
-misgendering
 mkdocs
 Mkdocs
 monorepo


### PR DESCRIPTION
Never liked that we had `backrub` in the vocab, now that code of conduct is [updated](https://github.com/backstage/backstage/pull/9274) we can remove it x). Also removed the other words that were only present in the old version