### PR TITLE
feat(msgraph): add `groupExpand` config option

### DIFF
--- a/.changeset/fluffy-trees-occur.md
+++ b/.changeset/fluffy-trees-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+add config option `groupExpand` to allow expanding a single relationship

--- a/plugins/catalog-backend-module-msgraph/README.md
+++ b/plugins/catalog-backend-module-msgraph/README.md
@@ -51,6 +51,12 @@ catalog:
           # This and userFilter are mutually exclusive, only one can be specified
           # See https://docs.microsoft.com/en-us/graph/search-query-parameter
           userGroupMemberFilter: "displayName eq 'Backstage Users'"
+          # Optional parameter to include the expanded resource or collection referenced
+          # by a single relationship (navigation property) in your results.
+          # Only one relationship can be expanded in a single request.
+          # See https://docs.microsoft.com/en-us/graph/query-parameters#expand-parameter
+          # Can be combined with userGroupMember[...] instead of userFilter.
+          groupExpand: member
           # Optional search for users, use group membership to get users.
           # (Search for groups and fetch their members.)
           # This and userFilter are mutually exclusive, only one can be specified

--- a/plugins/catalog-backend-module-msgraph/api-report.md
+++ b/plugins/catalog-backend-module-msgraph/api-report.md
@@ -164,6 +164,7 @@ export type MicrosoftGraphProviderConfig = {
   userExpand?: string;
   userGroupMemberFilter?: string;
   userGroupMemberSearch?: string;
+  groupExpand?: string;
   groupFilter?: string;
   groupSearch?: string;
 };
@@ -198,6 +199,7 @@ export function readMicrosoftGraphOrg(
     userFilter?: string;
     userGroupMemberSearch?: string;
     userGroupMemberFilter?: string;
+    groupExpand?: string;
     groupSearch?: string;
     groupFilter?: string;
     userTransformer?: UserTransformer;

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
@@ -55,6 +55,7 @@ describe('readMicrosoftGraphConfig', () => {
           authority: 'https://login.example.com/',
           userExpand: 'manager',
           userFilter: 'accountEnabled eq true',
+          groupExpand: 'member',
           groupFilter: 'securityEnabled eq false',
         },
       ],
@@ -69,6 +70,7 @@ describe('readMicrosoftGraphConfig', () => {
         authority: 'https://login.example.com',
         userExpand: 'manager',
         userFilter: 'accountEnabled eq true',
+        groupExpand: 'member',
         groupFilter: 'securityEnabled eq false',
       },
     ];

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
@@ -71,6 +71,12 @@ export type MicrosoftGraphProviderConfig = {
    */
   userGroupMemberSearch?: string;
   /**
+   * The "expand" argument to apply to groups.
+   *
+   * E.g. "member"
+   */
+  groupExpand?: string;
+  /**
    * The filter to apply to extract groups.
    *
    * E.g. "securityEnabled eq false and mailEnabled eq true"
@@ -115,6 +121,7 @@ export function readMicrosoftGraphConfig(
     const userGroupMemberSearch = providerConfig.getOptionalString(
       'userGroupMemberSearch',
     );
+    const groupExpand = providerConfig.getOptionalString('groupExpand');
     const groupFilter = providerConfig.getOptionalString('groupFilter');
     const groupSearch = providerConfig.getOptionalString('groupSearch');
 
@@ -139,6 +146,7 @@ export function readMicrosoftGraphConfig(
       userFilter,
       userGroupMemberFilter,
       userGroupMemberSearch,
+      groupExpand,
       groupFilter,
       groupSearch,
     });

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
@@ -140,6 +140,7 @@ export async function readMicrosoftGraphUsersInGroups(
     userExpand?: string;
     userGroupMemberSearch?: string;
     userGroupMemberFilter?: string;
+    groupExpand?: string;
     transformer?: UserTransformer;
     logger: Logger;
   },
@@ -150,15 +151,16 @@ export async function readMicrosoftGraphUsersInGroups(
 
   const limiter = limiterFactory(10);
 
-  const transformer = options?.transformer ?? defaultUserTransformer;
+  const transformer = options.transformer ?? defaultUserTransformer;
   const userGroupMemberPromises: Promise<void>[] = [];
   const userPromises: Promise<void>[] = [];
 
   const groupMemberUsers: Set<string> = new Set();
 
   for await (const group of client.getGroups({
-    search: options?.userGroupMemberSearch,
-    filter: options?.userGroupMemberFilter,
+    expand: options.groupExpand,
+    search: options.userGroupMemberSearch,
+    filter: options.userGroupMemberFilter,
   })) {
     // Process all groups in parallel, otherwise it can take quite some time
     userGroupMemberPromises.push(
@@ -329,8 +331,9 @@ export async function readMicrosoftGraphGroups(
   client: MicrosoftGraphClient,
   tenantId: string,
   options?: {
-    groupSearch?: string;
+    groupExpand?: string;
     groupFilter?: string;
+    groupSearch?: string;
     groupTransformer?: GroupTransformer;
     organizationTransformer?: OrganizationTransformer;
   },
@@ -357,6 +360,7 @@ export async function readMicrosoftGraphGroups(
   const promises: Promise<void>[] = [];
 
   for await (const group of client.getGroups({
+    expand: options?.groupExpand,
     search: options?.groupSearch,
     filter: options?.groupFilter,
   })) {
@@ -513,6 +517,7 @@ export async function readMicrosoftGraphOrg(
     userFilter?: string;
     userGroupMemberSearch?: string;
     userGroupMemberFilter?: string;
+    groupExpand?: string;
     groupSearch?: string;
     groupFilter?: string;
     userTransformer?: UserTransformer;

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgReaderProcessor.ts
@@ -109,6 +109,7 @@ export class MicrosoftGraphOrgReaderProcessor implements CatalogProcessor {
         userFilter: provider.userFilter,
         userGroupMemberFilter: provider.userGroupMemberFilter,
         userGroupMemberSearch: provider.userGroupMemberSearch,
+        groupExpand: provider.groupExpand,
         groupFilter: provider.groupFilter,
         groupSearch: provider.groupSearch,
         userTransformer: this.userTransformer,


### PR DESCRIPTION
Add `groupExpand` allowing to use the `$expand`
query parameter by the Microsoft Graph API
to expand a single relationship.

Relates-to: issue #9819
Relates-to: PR #9826
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
