### PR TITLE
feat(integration,bitbucket): discover catalog files using Bitbucket Cloud's code search

### DIFF
--- a/.changeset/fair-turtles-fetch.md
+++ b/.changeset/fair-turtles-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+support Bitbucket Cloud's code search to discover catalog files (multiple per repo, Location entities for existing files only)

--- a/docs/integrations/bitbucket/discovery.md
+++ b/docs/integrations/bitbucket/discovery.md
@@ -80,6 +80,18 @@ The target is composed of the following parts:
   reduce the amount of API calls if you have a large workspace.
   [See here for the specification](https://developer.atlassian.com/bitbucket/api/2/reference/meta/filtering)
   for the query argument (will be passed as the `q` query parameter).
+- (Optional) The `search=true` query argument to activate the mode utilizing code search.
+  - Is mutually exclusive to the `q` query argument.
+  - Allows providing values at `catalogPath` for finding catalog files as allowed by the `path` filter/modifier
+    [at Bitbucket Cloud's code search](https://confluence.atlassian.com/bitbucket/code-search-in-bitbucket-873876782.html#Search-Pathmodifier).
+    - `catalogPath=/catalog-info.yaml`
+    - `catalogPath=catalog-info.yaml` (anywhere in the repository)
+    - `catalogPath=/path/catalog-info.yaml`
+    - `catalogPath=path/catalog-info.yaml`
+    - `catalogPath=/path/*/catalog-info.yaml`
+    - `catalogPath=path/*/catalog-info.yaml`
+  - Supports multiple catalog files per repository depending on the `catalogPath` value.
+  - Registers `Location` entities for existing files only vs all matching repositories.
 
 Examples:
 
@@ -95,6 +107,23 @@ Examples:
 - `https://bitbucket.org/workspaces/my-workspace?catalogPath=my/nested/path/catalog.yaml`
   will find all repositories in the `my-workspace` workspace and use the catalog
   file at `my/nested/path/catalog.yaml`.
+- `https://bitbucket.org/workspaces/my-workspace?search=true&catalogPath=/catalog.yaml`
+  will find all `catalog.yaml` files located in the root of repositories in the workspace `my-workspace`.
+- `https://bitbucket.org/workspaces/my-workspace?search=true&catalogPath=catalog.yaml`
+  will find all `catalog.yaml` files located anywhere within repositories in the workspace `my-workspace`.
+- `https://bitbucket.org/workspaces/my-workspace?search=true&catalogPath=/my/nested/path/catalog.yaml`
+  will find all `catalog.yaml` files located within the directory `/my/nested/path/` within
+  repositories in the workspace `my-workspace`.
+- `https://bitbucket.org/workspaces/my-workspace?search=true&catalogPath=my/nested/path/catalog.yaml`
+  will find all `catalog.yaml` files located within the directory `my/nested/path/` located anywhere within
+  repositories in the workspace `my-workspace`.
+- `https://bitbucket.org/workspaces/my-workspace?search=true&catalogPath=/my/*/path/catalog.yaml`
+  will find all `catalog.yaml` files located within a directory `path/` located within any (recursive) directory
+  within the directory `my/` in the root of repositories in the workspace `my-workspace`
+  (`/my/nested/path/catalog.yaml`, `/my/very/nested/path/catalog.yaml`, ...).
+- `https://bitbucket.org/workspaces/my-workspace/projects/apis-*/repos/service-*?search=true&catalogPath=catalog.yaml`
+  will find all `catalog.yaml` files located anywhere within repositories starting with `service-`
+  in projects starting with `api-` in the workspace `my-workspace`.
 
 ## Custom repository processing
 

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -104,6 +104,7 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
     parser?: (options: {
       integration: BitbucketIntegration;
       target: string;
+      presence?: 'optional' | 'required';
       logger: Logger;
     }) => AsyncIterable<CatalogProcessorResult>;
     logger: Logger;
@@ -115,6 +116,7 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
       parser?: (options: {
         integration: BitbucketIntegration;
         target: string;
+        presence?: 'optional' | 'required';
         logger: Logger;
       }) => AsyncIterable<CatalogProcessorResult>;
       logger: Logger;
@@ -134,6 +136,7 @@ export class BitbucketDiscoveryProcessor implements CatalogProcessor {
 export type BitbucketRepositoryParser = (options: {
   integration: BitbucketIntegration;
   target: string;
+  presence?: 'optional' | 'required';
   logger: Logger;
 }) => AsyncIterable<CatalogProcessorResult>;
 

--- a/plugins/catalog-backend/src/modules/bitbucket/lib/BitbucketRepositoryParser.ts
+++ b/plugins/catalog-backend/src/modules/bitbucket/lib/BitbucketRepositoryParser.ts
@@ -25,17 +25,21 @@ import { CatalogProcessorResult, processingResult } from '../../../api';
 export type BitbucketRepositoryParser = (options: {
   integration: BitbucketIntegration;
   target: string;
+  presence?: 'optional' | 'required';
   logger: Logger;
 }) => AsyncIterable<CatalogProcessorResult>;
 
 export const defaultRepositoryParser =
-  async function* defaultRepositoryParser(options: { target: string }) {
+  async function* defaultRepositoryParser(options: {
+    target: string;
+    presence?: 'optional' | 'required';
+  }) {
     yield processingResult.location({
       type: 'url',
       target: options.target,
       // Not all locations may actually exist, since the user defined them as a wildcard pattern.
       // Thus, we emit them as optional and let the downstream processor find them while not outputting
       // an error if it couldn't.
-      presence: 'optional',
+      presence: options.presence ?? 'optional',
     });
   };


### PR DESCRIPTION
Support discovering catalog files using Bitbucket Cloud's code search
which allows finding multiple catalog files per repository (e.g., monorepo)
as well as creating Location entities for existing locations only.
(compared to creating an optional Location per matching repository using the
defined static path for the catalog file).

Closes: #9765
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
