### PR TITLE
cli: always use main entry point in packages for backend development

### DIFF
--- a/.changeset/spotty-swans-run.md
+++ b/.changeset/spotty-swans-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The backend development setup now ignores the `"browser"` and `"module"` entry points in `package.json`, and instead always uses `"main"`.

--- a/packages/cli/src/lib/bundler/config.ts
+++ b/packages/cli/src/lib/bundler/config.ts
@@ -272,7 +272,7 @@ export async function createBackendConfig(
     ],
     resolve: {
       extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx'],
-      mainFields: ['browser', 'module', 'main'],
+      mainFields: ['main'],
       modules: [paths.rootNodeModules, ...moduleDirs],
       plugins: [
         new LinkedPackageResolvePlugin(paths.rootNodeModules, externalPkgs),


### PR DESCRIPTION
Fixes #9959, we should not be resolving `browser` and `module` entry points in the backend setup.