### PR TITLE
Missing async from `getCollator` causes type mismatch

### DIFF
--- a/docs/features/search/how-to-guides.md
+++ b/docs/features/search/how-to-guides.md
@@ -219,7 +219,7 @@ export class YourCollatorFactory implements DocumentCollatorFactory {
       };
     }
   }
-  getCollator() {
+  async getCollator() {
     return Readable.from(this.execute());
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I'm upgrading Search from alpha to beta following the upgrade guide.

In the process, I discovered that the example causes type mismatch because it's missing `async` which provides the promiss wrapper. The type is correct but example is missing `async`.

<img width="498" alt="image" src="https://user-images.githubusercontent.com/74687/156663384-01cf8e81-6da3-4f5f-a6c5-ae8644888b20.png">

<img width="439" alt="image" src="https://user-images.githubusercontent.com/74687/156663405-8cd9a0db-4ba1-4134-b7b4-2886b1054f71.png">

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
