### PR TITLE
patch CLI release stage resolution and mark GitHub multi org reader as stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "resolutions": {
     "**/@graphql-codegen/cli/**/ws": "^7.4.6"
   },
-  "version": "0.70.0",
+  "version": "0.70.1",
   "dependencies": {
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.15.0",

--- a/packages/backend-common/CHANGELOG.md
+++ b/packages/backend-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/backend-common
 
+## 0.12.1
+
+### Patch Changes
+
+- Fixed runtime resolution of the `/alpha` entry point.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/backend-common",
   "description": "Common functionality library for Backstage backends",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "private": false,
@@ -89,7 +89,7 @@
     }
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/test-utils": "^0.3.0",
     "@types/archiver": "^5.1.0",
     "@types/compression": "^1.7.0",

--- a/packages/catalog-model/CHANGELOG.md
+++ b/packages/catalog-model/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/catalog-model
 
+## 0.12.1
+
+### Patch Changes
+
+- Fixed runtime resolution of the `/alpha` entry point.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/catalog-model/package.json
+++ b/packages/catalog-model/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/catalog-model",
   "description": "Types and validators that help describe the model of a Backstage Catalog",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -43,7 +43,7 @@
     "uuid": "^8.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@types/jest": "^26.0.7",
     "@types/json-schema": "^7.0.5",
     "@types/lodash": "^4.14.151",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/cli
 
+## 0.15.1
+
+### Patch Changes
+
+- Fixed an issue where the release stage entry point of packages were not resolved correctly.
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": false,
   "publishConfig": {
     "access": "public"
@@ -122,7 +122,7 @@
     "zod": "^3.11.6"
   },
   "devDependencies": {
-    "@backstage/backend-common": "^0.12.0",
+    "@backstage/backend-common": "^0.12.1",
     "@backstage/config": "^0.1.15",
     "@backstage/core-components": "^0.9.0",
     "@backstage/core-plugin-api": "^0.8.0",

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -23,6 +23,11 @@ const SKIPPED_KEYS = ['access', 'registry', 'tag', 'alphaTypes', 'betaTypes'];
 const PKG_PATH = 'package.json';
 const PKG_BACKUP_PATH = 'package.json-prepack';
 
+function resolveEntrypoint(pkg: any, name: string) {
+  const targetEntry = pkg.publishConfig[name] || pkg[name];
+  return targetEntry && joinPath('..', targetEntry);
+}
+
 // Writes e.g. alpha/package.json
 async function writeReleaseStageEntrypoint(pkg: any, stage: 'alpha' | 'beta') {
   await fs.ensureDir(paths.resolveTarget(stage));
@@ -31,9 +36,9 @@ async function writeReleaseStageEntrypoint(pkg: any, stage: 'alpha' | 'beta') {
     {
       name: pkg.name,
       version: pkg.version,
-      main: (pkg.publishConfig.main || pkg.main) && '..',
-      module: (pkg.publishConfig.module || pkg.module) && '..',
-      browser: (pkg.publishConfig.browser || pkg.browser) && '..',
+      main: resolveEntrypoint(pkg, 'main'),
+      module: resolveEntrypoint(pkg, 'module'),
+      browser: resolveEntrypoint(pkg, 'browser'),
       types: joinPath('..', pkg.publishConfig[`${stage}Types`]),
     },
     { encoding: 'utf8', spaces: 2 },

--- a/packages/cli/src/lib/packager/copyPackageDist.ts
+++ b/packages/cli/src/lib/packager/copyPackageDist.ts
@@ -20,6 +20,11 @@ import { join as joinPath, resolve as resolvePath } from 'path';
 
 const SKIPPED_KEYS = ['access', 'registry', 'tag', 'alphaTypes', 'betaTypes'];
 
+function resolveEntrypoint(pkg: any, name: string) {
+  const targetEntry = pkg.publishConfig[name] || pkg[name];
+  return targetEntry && joinPath('..', targetEntry);
+}
+
 // Writes e.g. alpha/package.json
 async function writeReleaseStageEntrypoint(
   pkg: any,
@@ -32,9 +37,9 @@ async function writeReleaseStageEntrypoint(
     {
       name: pkg.name,
       version: pkg.version,
-      main: (pkg.publishConfig.main || pkg.main) && '..',
-      module: (pkg.publishConfig.module || pkg.module) && '..',
-      browser: (pkg.publishConfig.browser || pkg.browser) && '..',
+      main: resolveEntrypoint(pkg, 'main'),
+      module: resolveEntrypoint(pkg, 'module'),
+      browser: resolveEntrypoint(pkg, 'browser'),
       types: joinPath('..', pkg.publishConfig[`${stage}Types`]),
     },
     { encoding: 'utf8', spaces: 2 },

--- a/plugins/airbrake/package.json
+++ b/plugins/airbrake/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@backstage/app-defaults": "^0.2.0",
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/allure/package.json
+++ b/plugins/allure/package.json
@@ -40,7 +40,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/analytics-module-ga/package.json
+++ b/plugins/analytics-module-ga/package.json
@@ -38,7 +38,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/apache-airflow/package.json
+++ b/plugins/apache-airflow/package.json
@@ -36,7 +36,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -56,7 +56,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/azure-devops/package.json
+++ b/plugins/azure-devops/package.json
@@ -49,7 +49,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/badges/package.json
+++ b/plugins/badges/package.json
@@ -46,7 +46,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -47,7 +47,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/dev-utils": "^0.2.24",
     "@testing-library/jest-dom": "^5.10.1",
     "cross-fetch": "^3.1.5"

--- a/plugins/bitrise/package.json
+++ b/plugins/bitrise/package.json
@@ -43,7 +43,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage/plugin-catalog-backend
 
+## 0.23.1
+
+### Patch Changes
+
+- Marked `GithubMultiOrgReaderProcessor` as stable, as it was moved to `/alpha` by mistake.
+- Fixed runtime resolution of the `/alpha` entry point.
+- Updated dependencies
+  - @backstage/backend-common@0.12.1
+  - @backstage/catalog-model@0.12.1
+  - @backstage/plugin-catalog-common@0.2.1
+
 ## 0.23.0
 
 ### Minor Changes

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -706,7 +706,7 @@ export type GithubMultiOrgConfig = Array<{
   userNamespace: string | undefined;
 }>;
 
-// @alpha
+// @public
 export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrationRegistry;

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend",
   "description": "The Backstage backend plugin that provides the Backstage catalog",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -34,13 +34,13 @@
     "clean": "backstage-cli package clean"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.12.0",
+    "@backstage/backend-common": "^0.12.1",
     "@backstage/catalog-client": "^0.8.0",
-    "@backstage/catalog-model": "^0.12.0",
+    "@backstage/catalog-model": "^0.12.1",
     "@backstage/config": "^0.1.15",
     "@backstage/errors": "^0.2.2",
     "@backstage/integration": "^0.8.0",
-    "@backstage/plugin-catalog-common": "^0.2.0",
+    "@backstage/plugin-catalog-common": "^0.2.1",
     "@backstage/plugin-permission-common": "^0.5.2",
     "@backstage/plugin-permission-node": "^0.5.3",
     "@backstage/plugin-scaffolder-common": "^0.2.3",
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^0.1.20",
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/plugin-permission-common": "^0.5.2",
     "@backstage/plugin-search-backend-node": "0.5.0",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/catalog-backend/src/modules/github/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/github/GithubMultiOrgReaderProcessor.ts
@@ -40,10 +40,11 @@ import {
 import { buildOrgHierarchy } from '../util/org';
 
 /**
- * @alpha
  * Extracts teams and users out of a multiple GitHub orgs namespaced per org.
  *
  * Be aware that this processor may not be compatible with future org structures in the catalog.
+ *
+ * @public
  */
 export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
   private readonly integrations: ScmIntegrationRegistry;

--- a/plugins/catalog-common/CHANGELOG.md
+++ b/plugins/catalog-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-catalog-common
 
+## 0.2.1
+
+### Patch Changes
+
+- Fixed runtime resolution of the `/alpha` entry point.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/plugins/catalog-common/package.json
+++ b/plugins/catalog-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-common",
   "description": "Common functionalities for the catalog plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -38,7 +38,7 @@
     "@backstage/search-common": "^0.3.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0"
+    "@backstage/cli": "^0.15.1"
   },
   "files": [
     "dist",

--- a/plugins/catalog-graph/package.json
+++ b/plugins/catalog-graph/package.json
@@ -45,10 +45,10 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
-    "@backstage/plugin-catalog": "^0.9.1",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
+    "@backstage/plugin-catalog": "^0.9.1",
     "@backstage/test-utils": "^0.3.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^11.2.5",

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -60,7 +60,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/catalog-react/CHANGELOG.md
+++ b/plugins/catalog-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-catalog-react
 
+## 0.8.1
+
+### Patch Changes
+
+- Fixed runtime resolution of the `/alpha` entry point.
+- Updated dependencies
+  - @backstage/catalog-model@0.12.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-react",
   "description": "A frontend library that helps other Backstage plugins interact with the catalog",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@backstage/catalog-client": "^0.8.0",
-    "@backstage/catalog-model": "^0.12.0",
+    "@backstage/catalog-model": "^0.12.1",
     "@backstage/core-components": "^0.9.0",
     "@backstage/core-plugin-api": "^0.8.0",
     "@backstage/errors": "^0.2.2",
@@ -61,9 +61,9 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
-    "@backstage/plugin-catalog-common": "^0.2.0",
+    "@backstage/plugin-catalog-common": "^0.2.1",
     "@backstage/plugin-scaffolder-common": "^0.2.3",
     "@backstage/test-utils": "^0.3.0",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -60,7 +60,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/plugin-permission-react": "^0.3.3",

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -55,7 +55,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/cloudbuild/package.json
+++ b/plugins/cloudbuild/package.json
@@ -52,7 +52,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/code-climate/package.json
+++ b/plugins/code-climate/package.json
@@ -37,7 +37,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/code-coverage/package.json
+++ b/plugins/code-coverage/package.json
@@ -46,7 +46,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/config-schema/package.json
+++ b/plugins/config-schema/package.json
@@ -41,7 +41,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -60,7 +60,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -53,7 +53,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/firehydrant/package.json
+++ b/plugins/firehydrant/package.json
@@ -39,7 +39,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/fossa/package.json
+++ b/plugins/fossa/package.json
@@ -53,7 +53,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/gcp-projects/package.json
+++ b/plugins/gcp-projects/package.json
@@ -47,7 +47,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/git-release-manager/package.json
+++ b/plugins/git-release-manager/package.json
@@ -43,7 +43,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/github-actions/package.json
+++ b/plugins/github-actions/package.json
@@ -55,7 +55,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/github-deployments/package.json
+++ b/plugins/github-deployments/package.json
@@ -43,7 +43,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/gitops-profiles/package.json
+++ b/plugins/gitops-profiles/package.json
@@ -48,7 +48,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/gocd/package.json
+++ b/plugins/gocd/package.json
@@ -49,7 +49,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/graphiql/package.json
+++ b/plugins/graphiql/package.json
@@ -48,7 +48,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -52,7 +52,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/ilert/package.json
+++ b/plugins/ilert/package.json
@@ -43,7 +43,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/jenkins/package.json
+++ b/plugins/jenkins/package.json
@@ -54,7 +54,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/kafka/package.json
+++ b/plugins/kafka/package.json
@@ -39,7 +39,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -56,7 +56,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -51,7 +51,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/newrelic-dashboard/package.json
+++ b/plugins/newrelic-dashboard/package.json
@@ -34,7 +34,7 @@
     "react-use": "^17.2.4"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/dev-utils": "^0.2.24",
     "@testing-library/jest-dom": "^5.10.1",
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/plugins/newrelic/package.json
+++ b/plugins/newrelic/package.json
@@ -47,7 +47,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@backstage/catalog-client": "^0.8.0",
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/pagerduty/package.json
+++ b/plugins/pagerduty/package.json
@@ -52,7 +52,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/rollbar/package.json
+++ b/plugins/rollbar/package.json
@@ -53,7 +53,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -73,7 +73,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/plugin-catalog": "^0.9.1",

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -56,7 +56,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -52,7 +52,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/shortcuts/package.json
+++ b/plugins/shortcuts/package.json
@@ -42,7 +42,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -53,7 +53,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/splunk-on-call/package.json
+++ b/plugins/splunk-on-call/package.json
@@ -51,7 +51,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/tech-insights/package.json
+++ b/plugins/tech-insights/package.json
@@ -42,7 +42,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -49,7 +49,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -65,7 +65,7 @@
     "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/todo/package.json
+++ b/plugins/todo/package.json
@@ -45,7 +45,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",
@@ -55,8 +55,8 @@
     "@types/jest": "^26.0.7",
     "@types/node": "^14.14.32",
     "cross-fetch": "^3.1.5",
-    "react-router": "6.0.0-beta.0",
-    "msw": "^0.35.0"
+    "msw": "^0.35.0",
+    "react-router": "6.0.0-beta.0"
   },
   "files": [
     "dist"

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -47,7 +47,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/xcmetrics/package.json
+++ b/plugins/xcmetrics/package.json
@@ -40,7 +40,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.0",
+    "@backstage/cli": "^0.15.1",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.24",
     "@backstage/test-utils": "^0.3.0",


### PR DESCRIPTION
This release fixes an issue where package `/alpha` entry points did not resolve correctly at runtime. This applies to the following packages:

- `@backstage/plugin-catalog-backend`
- `@backstage/backend-common`
- `@backstage/catalog-model`
- `@backstage/plugin-catalog-common`
- `@backstage/plugin-catalog-react`

The `GithubMultiOrgReaderProcessor` was also marked as stable, as it had previously been marked as alpha and was therefore inadvertently moved to the `/alpha` entry point when it was introduced.
