### PR TITLE
remove `metadata.generation`

### DIFF
--- a/.changeset/large-bottles-cheer.md
+++ b/.changeset/large-bottles-cheer.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-model': minor
+'@backstage/plugin-catalog-backend': minor
+---
+
+**BREAKING**: Removed the deprecated `metadata.generation` field entirely. It is no longer present in TS types, nor in the REST API output. Entities that have not yet been re-stitched may still have the field present for some time, but it will get phased out gradually by your catalog instance.

--- a/.changeset/rich-bobcats-behave.md
+++ b/.changeset/rich-bobcats-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graphql': patch
+---
+
+Do not use `metadata.generation` from entity data

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -76,7 +76,6 @@ This is the same entity as returned in JSON from the software catalog API:
     },
     "description": "The place to be, for great artists",
     "etag": "ZjU2MWRkZWUtMmMxZS00YTZiLWFmMWMtOTE1NGNiZDdlYzNk",
-    "generation": 1,
     "labels": {
       "example.com/custom": "custom_label_value"
     },

--- a/packages/catalog-model/api-report.md
+++ b/packages/catalog-model/api-report.md
@@ -165,7 +165,6 @@ export type EntityLink = {
 export type EntityMeta = JsonObject & {
   uid?: string;
   etag?: string;
-  generation?: number;
   name: string;
   namespace?: string;
   title?: string;

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -110,17 +110,6 @@ export type EntityMeta = JsonObject & {
   etag?: string;
 
   /**
-   * A positive nonzero number that indicates the current generation of data
-   * for this entity; the value is incremented each time the spec changes.
-   *
-   * This field can not be set by the user at creation time, and the server
-   * will reject an attempt to do so. The field will be populated in read
-   * operations.
-   * @deprecated field is not supported.
-   */
-  generation?: number;
-
-  /**
    * The name of the entity.
    *
    * Must be unique within the catalog at any given point in time, for any

--- a/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.test.ts
+++ b/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.test.ts
@@ -28,7 +28,6 @@ describe('FieldFormatEntityPolicy', () => {
       metadata:
         uid: e01199ab-08cc-44c2-8e19-5c29ded82521
         etag: lsndfkjsndfkjnsdfkjnsd==
-        generation: 13
         name: my-component-yay
         namespace: the-namespace
         labels:

--- a/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.ts
+++ b/packages/catalog-model/src/entity/policies/FieldFormatEntityPolicy.ts
@@ -29,8 +29,7 @@ import { Entity } from '../Entity';
  *
  * @remarks
  *
- * This does not take into account machine generated fields such as uid, etag
- * and generation.
+ * This does not take into account machine generated fields such as uid and etag.
  *
  * @public
  */

--- a/packages/catalog-model/src/entity/policies/NoForeignRootFieldsEntityPolicy.test.ts
+++ b/packages/catalog-model/src/entity/policies/NoForeignRootFieldsEntityPolicy.test.ts
@@ -28,7 +28,6 @@ describe('NoForeignRootFieldsEntityPolicy', () => {
       metadata:
         uid: e01199ab-08cc-44c2-8e19-5c29ded82521
         etag: lsndfkjsndfkjnsdfkjnsd==
-        generation: 13
         name: my-component-yay
         namespace: the-namespace
         labels:

--- a/packages/catalog-model/src/entity/policies/SchemaValidEntityPolicy.test.ts
+++ b/packages/catalog-model/src/entity/policies/SchemaValidEntityPolicy.test.ts
@@ -29,7 +29,6 @@ describe('SchemaValidEntityPolicy', () => {
       metadata:
         uid: e01199ab-08cc-44c2-8e19-5c29ded82521
         etag: lsndfkjsndfkjnsdfkjnsd==
-        generation: 13
         name: my-component-yay
         namespace: the-namespace
         labels:
@@ -125,26 +124,6 @@ describe('SchemaValidEntityPolicy', () => {
   it('rejects empty etag', async () => {
     data.metadata.etag = '';
     await expect(policy.enforce(data)).rejects.toThrow(/etag/);
-  });
-
-  it('accepts missing generation', async () => {
-    delete data.metadata.generation;
-    await expect(policy.enforce(data)).resolves.toBe(data);
-  });
-
-  it('rejects bad generation type', async () => {
-    data.metadata.generation = 'a';
-    await expect(policy.enforce(data)).rejects.toThrow(/generation/);
-  });
-
-  it('rejects zero generation', async () => {
-    data.metadata.generation = 0;
-    await expect(policy.enforce(data)).rejects.toThrow(/generation/);
-  });
-
-  it('rejects non-integer generation', async () => {
-    data.metadata.generation = 1.5;
-    await expect(policy.enforce(data)).rejects.toThrow(/generation/);
   });
 
   it('rejects missing name', async () => {

--- a/packages/catalog-model/src/schema/EntityMeta.schema.json
+++ b/packages/catalog-model/src/schema/EntityMeta.schema.json
@@ -6,7 +6,6 @@
     {
       "uid": "e01199ab-08cc-44c2-8e19-5c29ded82521",
       "etag": "lsndfkjsndfkjnsdfkjnsd==",
-      "generation": 13,
       "name": "my-component-yay",
       "namespace": "the-namespace",
       "labels": {
@@ -33,13 +32,6 @@
       "description": "An opaque string that changes for each update operation to any part of the entity, including metadata. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations. The field can (optionally) be specified when performing update or delete operations, and the server will then reject the operation if it does not match the current stored value.",
       "examples": ["lsndfkjsndfkjnsdfkjnsd=="],
       "minLength": 1
-    },
-    "generation": {
-      "type": "integer",
-      "description": "A positive nonzero number that indicates the current generation of data for this entity; the value is incremented each time the spec changes. This field can not be set by the user at creation time, and the server will reject an attempt to do so. The field will be populated in read operations.",
-      "examples": [1],
-      "minimum": 1,
-      "deprecated": true
     },
     "name": {
       "type": "string",

--- a/packages/catalog-model/src/validation/entityKindSchemaValidator.test.ts
+++ b/packages/catalog-model/src/validation/entityKindSchemaValidator.test.ts
@@ -28,7 +28,6 @@ describe('entityKindSchemaValidator', () => {
       metadata: {
         uid: 'e01199ab-08cc-44c2-8e19-5c29ded82521',
         etag: 'lsndfkjsndfkjnsdfkjnsd==',
-        generation: 13,
         name: 'test',
         namespace: 'ns',
         labels: {

--- a/packages/catalog-model/src/validation/entitySchemaValidator.test.ts
+++ b/packages/catalog-model/src/validation/entitySchemaValidator.test.ts
@@ -27,7 +27,6 @@ describe('entitySchemaValidator', () => {
       metadata: {
         uid: 'e01199ab-08cc-44c2-8e19-5c29ded82521',
         etag: 'lsndfkjsndfkjnsdfkjnsd==',
-        generation: 13,
         name: 'test',
         namespace: 'ns',
         title: 'My Component, Yay',
@@ -152,26 +151,6 @@ describe('entitySchemaValidator', () => {
   it('rejects empty etag', () => {
     entity.metadata.etag = '';
     expect(() => validator(entity)).toThrow(/etag/);
-  });
-
-  it('accepts missing generation', () => {
-    delete entity.metadata.generation;
-    expect(() => validator(entity)).not.toThrow();
-  });
-
-  it('rejects bad generation type', () => {
-    entity.metadata.generation = 'a';
-    expect(() => validator(entity)).toThrow(/generation/);
-  });
-
-  it('rejects zero generation', () => {
-    entity.metadata.generation = 0;
-    expect(() => validator(entity)).toThrow(/generation/);
-  });
-
-  it('rejects non-integer generation', () => {
-    entity.metadata.generation = 1.5;
-    expect(() => validator(entity)).toThrow(/generation/);
   });
 
   it('rejects missing name', () => {

--- a/plugins/catalog-backend/src/stitching/Stitcher.test.ts
+++ b/plugins/catalog-backend/src/stitching/Stitcher.test.ts
@@ -107,7 +107,6 @@ describe('Stitcher', () => {
           name: 'n',
           namespace: 'ns',
           etag: expect.any(String),
-          generation: 1,
           uid: 'my-id',
         },
         spec: {
@@ -183,7 +182,6 @@ describe('Stitcher', () => {
           name: 'n',
           namespace: 'ns',
           etag: expect.any(String),
-          generation: 1,
           uid: 'my-id',
         },
         spec: {

--- a/plugins/catalog-backend/src/stitching/Stitcher.ts
+++ b/plugins/catalog-backend/src/stitching/Stitcher.ts
@@ -205,7 +205,6 @@ export class Stitcher {
     }
 
     entity.metadata.uid = entityId;
-    entity.metadata.generation = 1;
     if (!entity.metadata.etag) {
       // If the original data source did not have its own etag handling,
       // use the hash as a good-quality etag

--- a/plugins/catalog-backend/src/stitching/buildEntitySearch.test.ts
+++ b/plugins/catalog-backend/src/stitching/buildEntitySearch.test.ts
@@ -62,7 +62,6 @@ describe('buildEntitySearch', () => {
           namespace: 'namespace',
           uid: 'uid',
           etag: 'etag',
-          generation: 'generation',
           c: 'c',
         },
         d: 'd',

--- a/plugins/catalog-backend/src/stitching/buildEntitySearch.ts
+++ b/plugins/catalog-backend/src/stitching/buildEntitySearch.ts
@@ -29,7 +29,6 @@ const SPECIAL_KEYS = [
   'metadata.namespace',
   'metadata.uid',
   'metadata.etag',
-  'metadata.generation',
 ];
 
 // The maximum length allowed for search values. These columns are indexed, and

--- a/plugins/catalog-graphql/src/graphql/module.test.ts
+++ b/plugins/catalog-graphql/src/graphql/module.test.ts
@@ -59,7 +59,6 @@ describe('Catalog Module', () => {
           metadata: {
             annotations: {},
             etag: '123',
-            generation: 1,
             labels: {},
             name: 'Ben',
             namespace: 'Blames',
@@ -118,7 +117,6 @@ describe('Catalog Module', () => {
           metadata: {
             annotations: null as any,
             etag: '123',
-            generation: 1,
             labels: {},
             name: 'Ben',
             namespace: 'Blames',
@@ -170,7 +168,6 @@ describe('Catalog Module', () => {
           metadata: {
             annotations: {},
             etag: '123',
-            generation: 1,
             labels: null as any,
             name: 'Ben',
             namespace: 'Blames',
@@ -221,7 +218,6 @@ describe('Catalog Module', () => {
           metadata: {
             annotations: { lob: 'bloben' },
             etag: '123',
-            generation: 1,
             labels: {},
             name: 'Ben',
             namespace: 'Blames',
@@ -272,7 +268,6 @@ describe('Catalog Module', () => {
           metadata: {
             annotations: {},
             etag: '123',
-            generation: 1,
             labels: { lob2: 'bloben' },
             name: 'Ben',
             namespace: 'Blames',

--- a/plugins/catalog-graphql/src/graphql/types.ts
+++ b/plugins/catalog-graphql/src/graphql/types.ts
@@ -70,7 +70,6 @@ export type ComponentMetadata = EntityMetadata & {
   annotation?: Maybe<Scalars['JSON']>;
   annotations: Scalars['JSONObject'];
   etag: Scalars['String'];
-  generation: Scalars['Int'];
   label?: Maybe<Scalars['JSON']>;
   labels: Scalars['JSONObject'];
   name: Scalars['String'];
@@ -91,7 +90,6 @@ export type DefaultEntityMetadata = EntityMetadata & {
   annotation?: Maybe<Scalars['JSON']>;
   annotations: Scalars['JSONObject'];
   etag: Scalars['String'];
-  generation: Scalars['Int'];
   label?: Maybe<Scalars['JSON']>;
   labels: Scalars['JSONObject'];
   name: Scalars['String'];
@@ -115,7 +113,6 @@ export type EntityMetadata = {
   annotation?: Maybe<Scalars['JSON']>;
   annotations: Scalars['JSONObject'];
   etag: Scalars['String'];
-  generation: Scalars['Int'];
   label?: Maybe<Scalars['JSON']>;
   labels: Scalars['JSONObject'];
   name: Scalars['String'];
@@ -153,7 +150,6 @@ export type TemplateMetadata = EntityMetadata & {
   annotation?: Maybe<Scalars['JSON']>;
   annotations: Scalars['JSONObject'];
   etag: Scalars['String'];
-  generation: Scalars['Int'];
   label?: Maybe<Scalars['JSON']>;
   labels: Scalars['JSONObject'];
   name: Scalars['String'];
@@ -386,7 +382,6 @@ export type ComponentMetadataResolvers<
   >;
   annotations?: Resolver<ResolversTypes['JSONObject'], ParentType, ContextType>;
   etag?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  generation?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   label?: Resolver<
     Maybe<ResolversTypes['JSON']>,
     ParentType,
@@ -416,7 +411,6 @@ export type DefaultEntityMetadataResolvers<
   >;
   annotations?: Resolver<ResolversTypes['JSONObject'], ParentType, ContextType>;
   etag?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  generation?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   label?: Resolver<
     Maybe<ResolversTypes['JSON']>,
     ParentType,
@@ -454,7 +448,6 @@ export type EntityMetadataResolvers<
   >;
   annotations?: Resolver<ResolversTypes['JSONObject'], ParentType, ContextType>;
   etag?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  generation?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   label?: Resolver<
     Maybe<ResolversTypes['JSON']>,
     ParentType,
@@ -517,7 +510,6 @@ export type TemplateMetadataResolvers<
   >;
   annotations?: Resolver<ResolversTypes['JSONObject'], ParentType, ContextType>;
   etag?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  generation?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   label?: Resolver<
     Maybe<ResolversTypes['JSON']>,
     ParentType,

--- a/plugins/catalog-graphql/src/schema.js
+++ b/plugins/catalog-graphql/src/schema.js
@@ -26,7 +26,6 @@ const schema = /* GraphQL */ `
     label(name: String!): JSON
     uid: String!
     etag: String!
-    generation: Int!
   }
 
   type DefaultEntityMetadata implements EntityMetadata {
@@ -37,7 +36,6 @@ const schema = /* GraphQL */ `
     label(name: String!): JSON
     uid: String!
     etag: String!
-    generation: Int!
   }
 
   type ComponentMetadata implements EntityMetadata {
@@ -48,7 +46,6 @@ const schema = /* GraphQL */ `
     label(name: String!): JSON
     uid: String!
     etag: String!
-    generation: Int!
     # mock field to prove extensions working
     relationships: String
   }
@@ -61,7 +58,6 @@ const schema = /* GraphQL */ `
     label(name: String!): JSON
     uid: String!
     etag: String!
-    generation: Int!
     # mock field to prove extensions working
     updatedBy: String
   }

--- a/plugins/catalog-graphql/src/service/client.ts
+++ b/plugins/catalog-graphql/src/service/client.ts
@@ -20,7 +20,6 @@ import fetch from 'node-fetch';
 export interface ReaderEntityMeta extends EntityMeta {
   uid: string;
   etag: string;
-  generation: number;
   namespace: string;
   annotations: Record<string, string>;
   labels: Record<string, string>;

--- a/plugins/github-deployments/src/mocks/mocks.ts
+++ b/plugins/github-deployments/src/mocks/mocks.ts
@@ -24,7 +24,6 @@ export const entityStub: { entity: Entity } = {
       name: 'sample-service',
       description: 'Sample service',
       uid: 'g0h33dd9-56h7-835b-b63v-7x5da3j64851',
-      generation: 1,
     },
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'Component',

--- a/scripts/api-extractor.ts
+++ b/scripts/api-extractor.ts
@@ -581,7 +581,7 @@ async function runApiExtraction({
 WARNING: Bring a blanket if you're gonna read the code below
 
 There's some weird shit going on here, and it's because we cba
-forking rushstash to modify the api-documenter markdown generation,
+forking rushstack to modify the api-documenter markdown generation,
 which otherwise is the recommended way to do customizations.
 */
 


### PR DESCRIPTION
was deprecated in the release on 2022-03-03