### PR TITLE
Trigger upgrade helper release once

### DIFF
--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -56,18 +56,7 @@ jobs:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
           # TODO(Rugvip): Remove the create-app dispatch once we've been on the release version for a while
           script: |
-            console.log('Dispatching upgrade helper sync - release version');
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'backstage',
-              repo: 'upgrade-helper-diff',
-              workflow_id: 'release.yml',
-              ref: 'master',
-              inputs: {
-                version: require('./backstage/package.json').version,
-              },
-            });
-
-            console.log('Dispatching upgrade helper sync - create-app version');
+            console.log('Dispatching upgrade helper sync');
             await github.rest.actions.createWorkflowDispatch({
               owner: 'backstage',
               repo: 'upgrade-helper-diff',
@@ -75,5 +64,6 @@ jobs:
               ref: 'master',
               inputs: {
                 version: require('./backstage/packages/create-app/package.json').version,
+                releaseVersion: require('./backstage/package.json').version
               },
             });


### PR DESCRIPTION
Signed-off-by: Vincenzo Scamporlino <me@vinzscam.dev>

## Hey, I just made a Pull Request!

Trigger the upgrade helper only once, passing the release version as parameter.

Marked as **DO NOT MERGE** since requires some sync between the repos

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist


- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
