### PR TITLE
option to use org as the namespace for teams

### DIFF
--- a/.changeset/pink-eels-knock.md
+++ b/.changeset/pink-eels-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Add option to allow GitHub teams to the GitHub organization's namespace.

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -765,6 +765,7 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     integrations: ScmIntegrationRegistry;
     logger: Logger_2;
     githubCredentialsProvider?: GithubCredentialsProvider;
+    useOrgAsNamespace?: Boolean;
   });
   // (undocumented)
   static fromConfig(
@@ -772,6 +773,7 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     options: {
       logger: Logger_2;
       githubCredentialsProvider?: GithubCredentialsProvider;
+      useOrgAsNamespace?: Boolean;
     },
   ): GithubOrgReaderProcessor;
   // (undocumented)

--- a/plugins/catalog-backend/src/modules/github/GithubOrgReaderProcessor.ts
+++ b/plugins/catalog-backend/src/modules/github/GithubOrgReaderProcessor.ts
@@ -47,12 +47,14 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
   private readonly integrations: ScmIntegrationRegistry;
   private readonly logger: Logger;
   private readonly githubCredentialsProvider: GithubCredentialsProvider;
+  private readonly useOrgAsNamespace: Boolean | undefined;
 
   static fromConfig(
     config: Config,
     options: {
       logger: Logger;
       githubCredentialsProvider?: GithubCredentialsProvider;
+      useOrgAsNamespace?: Boolean;
     },
   ) {
     const integrations = ScmIntegrations.fromConfig(config);
@@ -67,12 +69,14 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     integrations: ScmIntegrationRegistry;
     logger: Logger;
     githubCredentialsProvider?: GithubCredentialsProvider;
+    useOrgAsNamespace?: Boolean;
   }) {
     this.integrations = options.integrations;
     this.githubCredentialsProvider =
       options.githubCredentialsProvider ||
       DefaultGithubCredentialsProvider.fromIntegrations(this.integrations);
     this.logger = options.logger;
+    this.useOrgAsNamespace = options.useOrgAsNamespace;
   }
   getProcessorName(): string {
     return 'GithubOrgReaderProcessor';
@@ -98,6 +102,7 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     const { groups, groupMemberUsers } = await getOrganizationTeams(
       client,
       org,
+      this.useOrgAsNamespace ? org : 'default',
     );
 
     const duration = ((Date.now() - startTimestamp) / 1000).toFixed(1);

--- a/plugins/catalog-backend/src/modules/github/lib/github.ts
+++ b/plugins/catalog-backend/src/modules/github/lib/github.ts
@@ -145,6 +145,7 @@ export async function getOrganizationUsers(
  *
  * @param client - An octokit graphql client
  * @param org - The slug of the org to read
+ * @param orgNamespace - The namespace to create the team in Backstage
  */
 export async function getOrganizationTeams(
   client: typeof graphql,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds an option to GitHub org processor to allow it to use org as the namespace for teams.

#### :heavy_check_mark: Checklist


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
