### PR TITLE
catalog-react: Remove `useEntityFromUrl`

### DIFF
--- a/.changeset/late-pianos-attend.md
+++ b/.changeset/late-pianos-attend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+**BREAKING**: Removed `useEntityFromUrl`.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -512,9 +512,6 @@ export function useEntity<TEntity extends Entity = Entity>(): {
   refresh?: VoidFunction;
 };
 
-// @public @deprecated (undocumented)
-export const useEntityFromUrl: () => EntityLoadingStatus;
-
 // @public @deprecated
 export function useEntityKinds(): {
   error: Error | undefined;

--- a/plugins/catalog-react/src/hooks/index.ts
+++ b/plugins/catalog-react/src/hooks/index.ts
@@ -15,7 +15,6 @@
  */
 export {
   useEntity,
-  useEntityFromUrl,
   EntityProvider,
   AsyncEntityProvider,
   useAsyncEntity,

--- a/plugins/catalog-react/src/hooks/useEntity.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.tsx
@@ -15,20 +15,11 @@
  */
 import { Entity } from '@backstage/catalog-model';
 import {
-  errorApiRef,
-  useApi,
-  useRouteRefParams,
-} from '@backstage/core-plugin-api';
-import {
   createVersionedContext,
   createVersionedValueMap,
   useVersionedContext,
 } from '@backstage/version-bridge';
-import React, { ReactNode, useEffect } from 'react';
-import { useNavigate } from 'react-router';
-import useAsyncRetry from 'react-use/lib/useAsyncRetry';
-import { catalogApiRef } from '../api';
-import { entityRouteRef } from '../routes';
+import React, { ReactNode } from 'react';
 
 /** @public */
 export type EntityLoadingStatus<TEntity extends Entity = Entity> = {
@@ -103,35 +94,6 @@ export const EntityProvider = ({ entity, children }: EntityProviderProps) => (
     children={children}
   />
 );
-
-/** @public
- * @deprecated will be deleted shortly due to low external usage, re-implement if needed.
- */
-export const useEntityFromUrl = (): EntityLoadingStatus => {
-  const { kind, namespace, name } = useRouteRefParams(entityRouteRef);
-  const navigate = useNavigate();
-  const errorApi = useApi(errorApiRef);
-  const catalogApi = useApi(catalogApiRef);
-
-  const {
-    value: entity,
-    error,
-    loading,
-    retry: refresh,
-  } = useAsyncRetry(
-    () => catalogApi.getEntityByRef({ kind, namespace, name }),
-    [catalogApi, kind, namespace, name],
-  );
-
-  useEffect(() => {
-    if (!name) {
-      errorApi.post(new Error('No name provided!'));
-      navigate('/');
-    }
-  }, [errorApi, navigate, error, loading, entity, name]);
-
-  return { entity, loading, error, refresh };
-};
 
 /**
  * Grab the current entity from the context, throws if the entity has not yet been loaded


### PR DESCRIPTION
Removed `useEntityFromUrl` due to low usage