### PR TITLE
catalog-react: Remove useEntityListProvider

### DIFF
--- a/.changeset/quiet-pens-wait.md
+++ b/.changeset/quiet-pens-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+**BREAKING**: Removed `useEntityListProvider` use `useEntityList` instead.

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -544,11 +544,6 @@ export function useEntityList<
   EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
 >(): EntityListContextProps<EntityFilters>;
 
-// @public @deprecated
-export function useEntityListProvider<
-  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
->(): EntityListContextProps<EntityFilters>;
-
 // @public
 export function useEntityOwnership(): {
   loading: boolean;

--- a/plugins/catalog-react/src/hooks/index.ts
+++ b/plugins/catalog-react/src/hooks/index.ts
@@ -29,7 +29,6 @@ export { useEntityCompoundName } from './useEntityCompoundName';
 export {
   EntityListContext,
   EntityListProvider,
-  useEntityListProvider,
   useEntityList,
 } from './useEntityListProvider';
 export type {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -252,20 +252,6 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>({
 /**
  * Hook for interacting with the entity list context provided by the {@link EntityListProvider}.
  * @public
- * @deprecated use {@link useEntityList} instead.
- */
-export function useEntityListProvider<
-  EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,
->(): EntityListContextProps<EntityFilters> {
-  const context = useContext(EntityListContext);
-  if (!context)
-    throw new Error('useEntityList must be used within EntityListProvider');
-  return context;
-}
-
-/**
- * Hook for interacting with the entity list context provided by the {@link EntityListProvider}.
- * @public
  */
 export function useEntityList<
   EntityFilters extends DefaultEntityFilters = DefaultEntityFilters,


### PR DESCRIPTION
Removed `useEntityListProvider` use `useEntityList` instead.