### PR TITLE
Correct log message

### DIFF
--- a/.changeset/polite-apples-relax.md
+++ b/.changeset/polite-apples-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed display of the location in the log message that is printed when entity envelope validation fails.

--- a/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
+++ b/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
@@ -72,16 +72,16 @@ export class ProcessorOutputCollector {
 
     if (i.type === 'entity') {
       let entity: Entity;
+      const location = stringifyLocationRef(i.location);
+
       try {
         entity = validateEntityEnvelope(i.entity);
       } catch (e) {
         assertError(e);
-        this.logger.debug(`Envelope validation failed at ${i.location}, ${e}`);
+        this.logger.debug(`Envelope validation failed at ${location}, ${e}`);
         this.errors.push(e);
         return;
       }
-
-      const location = stringifyLocationRef(i.location);
 
       // Note that at this point, we have only validated the envelope part of
       // the entity data. Annotations are not part of that, so we have to be


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Correct log message so we aren't logging an object.

This means that we try to stringify the location before validating the envelope but as the location comes from the CatalogProcessorResult which is created by code, it should be rare that this causes errors (and even if it does this only changes which error is logged between this and the envelope validation).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
