### PR TITLE
Tech Radar ring names are now coloured by theme (via theme.palette.text.primary)

### DIFF
--- a/.changeset/shaggy-apricots-hug.md
+++ b/.changeset/shaggy-apricots-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Tech Radar Ring names are now coloured from theme via theme.palette.text.primary (instead of a hard coded colour)

--- a/plugins/tech-radar/src/components/RadarGrid/RadarGrid.tsx
+++ b/plugins/tech-radar/src/components/RadarGrid/RadarGrid.tsx
@@ -23,7 +23,7 @@ export type Props = {
   rings: Ring[];
 };
 
-const useStyles = makeStyles<Theme>(() => ({
+const useStyles = makeStyles<Theme>(theme => ({
   ring: {
     fill: 'none',
     stroke: '#bbb',
@@ -37,7 +37,7 @@ const useStyles = makeStyles<Theme>(() => ({
   text: {
     pointerEvents: 'none',
     userSelect: 'none',
-    fill: '#e5e5e5',
+    fill: theme.palette.text.primary,
     fontSize: '25px',
     fontWeight: 800,
   },


### PR DESCRIPTION
Tech Radar ring names (hold, assess, trial, use) are now coloured by theme (via theme.palette.text.primary) instead of a hard coded colour

![tech-radar-ring-names](https://user-images.githubusercontent.com/40145319/156816297-a9bfa719-4ec2-49cf-80c2-e9285f2463ac.PNG)


Signed-off-by: Jonathan Ash <jonathan-ash@users.noreply.github.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
