### PR TITLE
remove `CatalogApi.getEntityByName`

### DIFF
--- a/.changeset/olive-emus-speak.md
+++ b/.changeset/olive-emus-speak.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-auth-backend': patch
+'@backstage/plugin-badges-backend': patch
+'@backstage/plugin-catalog-graph': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-explore': patch
+'@backstage/plugin-fossa': patch
+---
+
+Remove usages of now-removed `CatalogApi.getEntityByName`

--- a/.changeset/thick-gifts-cheat.md
+++ b/.changeset/thick-gifts-cheat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': minor
+---
+
+**BREAKING**: Removed previously deprecated `CatalogApi.getEntityByName`, please use `getEntityByRef` instead.

--- a/packages/catalog-client/api-report.md
+++ b/packages/catalog-client/api-report.md
@@ -38,11 +38,6 @@ export interface CatalogApi {
     request: GetEntityAncestorsRequest,
     options?: CatalogRequestOptions,
   ): Promise<GetEntityAncestorsResponse>;
-  // @deprecated
-  getEntityByName(
-    name: CompoundEntityRef,
-    options?: CatalogRequestOptions,
-  ): Promise<Entity | undefined>;
   getEntityByRef(
     entityRef: string | CompoundEntityRef,
     options?: CatalogRequestOptions,
@@ -95,6 +90,7 @@ export class CatalogClient implements CatalogApi {
     request: GetEntityAncestorsRequest,
     options?: CatalogRequestOptions,
   ): Promise<GetEntityAncestorsResponse>;
+  // @deprecated (undocumented)
   getEntityByName(
     compoundName: CompoundEntityRef,
     options?: CatalogRequestOptions,

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -190,7 +190,7 @@ export class CatalogClient implements CatalogApi {
   // longer, to minimize the risk for breakages. Suggested date for removal:
   // August 2022
   /**
-   * {@inheritdoc CatalogApi.getEntityByName}
+   * @deprecated Use getEntityByRef instead
    */
   async getEntityByName(
     compoundName: CompoundEntityRef,

--- a/packages/catalog-client/src/types/api.ts
+++ b/packages/catalog-client/src/types/api.ts
@@ -316,19 +316,6 @@ export interface CatalogApi {
   ): Promise<Entity | undefined>;
 
   /**
-   * Gets a single entity from the catalog by its ref (kind, namespace, name)
-   * triplet.
-   *
-   * @deprecated Use getEntityRef instead
-   * @param name - A complete entity ref
-   * @param options - Additional options
-   */
-  getEntityByName(
-    name: CompoundEntityRef,
-    options?: CatalogRequestOptions,
-  ): Promise<Entity | undefined>;
-
-  /**
    * Removes a single entity from the catalog by entity UID.
    *
    * @param uid - An entity UID

--- a/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
+++ b/plugins/auth-backend/src/lib/catalog/CatalogIdentityClient.test.ts
@@ -27,7 +27,6 @@ describe('CatalogIdentityClient', () => {
   const catalogApi: jest.Mocked<CatalogApi> = {
     getLocationById: jest.fn(),
     getEntityByRef: jest.fn(),
-    getEntityByName: jest.fn(),
     getEntities: jest.fn(),
     addLocation: jest.fn(),
     removeLocationById: jest.fn(),

--- a/plugins/badges-backend/src/service/router.test.ts
+++ b/plugins/badges-backend/src/service/router.test.ts
@@ -61,7 +61,6 @@ describe('createRouter', () => {
       addLocation: jest.fn(),
       getEntities: jest.fn(),
       getEntityByRef: jest.fn(),
-      getEntityByName: jest.fn(),
       getLocationByRef: jest.fn(),
       getLocationById: jest.fn(),
       removeLocationById: jest.fn(),

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
@@ -58,7 +58,6 @@ describe('<CatalogGraphCard/>', () => {
     catalog = {
       getEntities: jest.fn(),
       getEntityByRef: jest.fn(async _ => ({ ...entity, relations: [] })),
-      getEntityByName: jest.fn(),
       removeEntityByUid: jest.fn(),
       getLocationById: jest.fn(),
       getLocationByRef: jest.fn(),

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.test.tsx
@@ -91,7 +91,6 @@ describe('<CatalogGraphPage/>', () => {
       getEntityByRef: jest.fn(async (n: any) =>
         n === 'b:d/e' ? entityE : entityC,
       ),
-      getEntityByName: jest.fn(),
       removeEntityByUid: jest.fn(),
       getLocationById: jest.fn(),
       getLocationByRef: jest.fn(),

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
@@ -156,7 +156,6 @@ describe('<EntityRelationsGraph/>', () => {
     catalog = {
       getEntities: jest.fn(),
       getEntityByRef: jest.fn(async n => entities[n as string]),
-      getEntityByName: jest.fn(),
       removeEntityByUid: jest.fn(),
       getLocationById: jest.fn(),
       getLocationByRef: jest.fn(),

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityStore.test.ts
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/useEntityStore.test.ts
@@ -30,7 +30,6 @@ describe('useEntityStore', () => {
     catalogApi = {
       getEntities: jest.fn(),
       getEntityByRef: jest.fn(),
-      getEntityByName: jest.fn(),
       removeEntityByUid: jest.fn(),
       getLocationById: jest.fn(),
       getLocationByRef: jest.fn(),

--- a/plugins/catalog-import/src/api/CatalogImportClient.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.test.ts
@@ -94,7 +94,6 @@ describe('CatalogImportClient', () => {
     addLocation: jest.fn(),
     removeLocationById: jest.fn(),
     getEntityByRef: jest.fn(),
-    getEntityByName: jest.fn(),
     getLocationByRef: jest.fn(),
     getLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -39,7 +39,6 @@ describe('<StepPrepareCreatePullRequest />', () => {
     getEntities: jest.fn(),
     addLocation: jest.fn(),
     getEntityByRef: jest.fn(),
-    getEntityByName: jest.fn(),
     getLocationByRef: jest.fn(),
     getLocationById: jest.fn(),
     removeLocationById: jest.fn(),

--- a/plugins/explore/src/components/DefaultExplorePage/DefaultExplorePage.test.tsx
+++ b/plugins/explore/src/components/DefaultExplorePage/DefaultExplorePage.test.tsx
@@ -29,7 +29,6 @@ describe('<DefaultExplorePage />', () => {
     removeLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
     getEntityByRef: jest.fn(),
-    getEntityByName: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),

--- a/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
+++ b/plugins/explore/src/components/DomainExplorerContent/DomainExplorerContent.test.tsx
@@ -30,7 +30,6 @@ describe('<DomainExplorerContent />', () => {
     removeLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
     getEntityByRef: jest.fn(),
-    getEntityByName: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),

--- a/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
+++ b/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.test.tsx
@@ -30,7 +30,6 @@ describe('<GroupsExplorerContent />', () => {
     removeLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),
     getEntityByRef: jest.fn(),
-    getEntityByName: jest.fn(),
     refreshEntity: jest.fn(),
     getEntityAncestors: jest.fn(),
     getEntityFacets: jest.fn(),

--- a/plugins/fossa/src/components/FossaPage/FossaPage.test.tsx
+++ b/plugins/fossa/src/components/FossaPage/FossaPage.test.tsx
@@ -30,7 +30,6 @@ describe('<FossaPage />', () => {
     addLocation: jest.fn(),
     getEntities: jest.fn(),
     getEntityByRef: jest.fn(),
-    getEntityByName: jest.fn(),
     getLocationByRef: jest.fn(),
     getLocationById: jest.fn(),
     removeEntityByUid: jest.fn(),


### PR DESCRIPTION
The implementation in `CatalogClient` still remains.