### PR TITLE
Added example of icon for theme

### DIFF
--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -57,6 +57,7 @@ done like this:
 import { createApp } from '@backstage/app-defaults';
 import { ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import LightIcon from '@material-ui/icons/WbSunny';
 
 const app = createApp({
   apis: ...,
@@ -65,6 +66,7 @@ const app = createApp({
     id: 'my-theme',
     title: 'My Custom Theme',
     variant: 'light',
+    icon: <LightIcon />,
     Provider: ({ children }) => (
       <ThemeProvider theme={myTheme}>
         <CssBaseline>{children}</CssBaseline>


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <awanlin@rapidrtc.com>

## Hey, I just made a Pull Request!

Added an example of adding an icon for the theme when passing it into `createApp`. 

If there is no icon provided they default to the same icon as auto which can be confusing.

As I spent a while figuring this out I figured I should update the documentation. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
