### PR TITLE
techdocs-cli: tweak e2e test setup

### DIFF
--- a/packages/techdocs-cli/e2e-test.config.js
+++ b/packages/techdocs-cli/e2e-test.config.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+
+module.exports = require('@backstage/cli/config/jest').then(baseConfig => ({
+  ...baseConfig,
+  rootDir: path.resolve(__dirname, 'e2e-tests'),
+}));

--- a/packages/techdocs-cli/e2e-tests/techdocs-cli.test.ts
+++ b/packages/techdocs-cli/e2e-tests/techdocs-cli.test.ts
@@ -58,7 +58,7 @@ const timeout = 25000;
 jest.setTimeout(timeout * 2);
 
 describe('end-to-end', () => {
-  const cwd = path.resolve(__dirname, 'example-docs');
+  const cwd = path.resolve(__dirname, '../src/example-docs');
 
   afterEach(async () => {
     // On Windows the pid of a spawned process may be wrong

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -27,9 +27,9 @@
     "build": "backstage-cli package build",
     "clean": "backstage-cli package clean",
     "lint": "backstage-cli package lint",
-    "test": "backstage-cli package test --testPathIgnorePatterns=src/e2e.test.ts",
-    "test:e2e": "backstage-cli test src/e2e.test.ts",
-    "test:e2e:ci": "backstage-cli test --watchAll=false --ci src/e2e.test.ts",
+    "test": "backstage-cli package test",
+    "test:e2e": "backstage-cli test --config e2e-test.config.js",
+    "test:e2e:ci": "backstage-cli test --config e2e-test.config.js --watchAll=false --ci",
     "test:cypress": "cypress open",
     "prepack": "./scripts/prepack.sh"
   },


### PR DESCRIPTION
Came up with a slightly tweaked setup for separate e2e tests that still build on the test infra in the Backstage CLI. Feel like it's better to have the e2e tests a bit more separated out with their own config, so that they're not too mixed in the regular tests.