### PR TITLE
Enable adding extra setting tabs

### DIFF
--- a/.changeset/three-rivers-remain.md
+++ b/.changeset/three-rivers-remain.md
@@ -1,0 +1,6 @@
+---
+'example-app': minor
+'@backstage/plugin-user-settings': minor
+---
+
+Added the ability to render extra setting tabs

--- a/.changeset/three-rivers-remain.md
+++ b/.changeset/three-rivers-remain.md
@@ -1,5 +1,4 @@
 ---
-'example-app': minor
 '@backstage/plugin-user-settings': minor
 ---
 

--- a/.changeset/three-rivers-remain.md
+++ b/.changeset/three-rivers-remain.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-user-settings': minor
+'@backstage/plugin-user-settings': patch
 ---
 
 Added the ability to render extra setting tabs

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -69,7 +69,8 @@ import {
   techdocsPlugin,
   TechDocsReaderPage,
 } from '@backstage/plugin-techdocs';
-import { UserSettingsPage, SettingsTab } from '@backstage/plugin-user-settings';
+import { UserSettingsPage } from '@backstage/plugin-user-settings';
+import { AdvancedSettings } from './components/advancedSettings';
 import AlarmIcon from '@material-ui/icons/Alarm';
 import React from 'react';
 import { hot } from 'react-hot-loader/root';
@@ -82,7 +83,6 @@ import { LowerCaseValuePickerFieldExtension } from './components/scaffolder/cust
 import { searchPage } from './components/search/SearchPage';
 import { providers } from './identityProviders';
 import * as plugins from './plugins';
-import { AdvancedSettings } from './components/advancedSettings';
 import { techDocsPage } from './components/techdocs/TechDocsPage';
 import { ApacheAirflowPage } from '@backstage/plugin-apache-airflow';
 import { PermissionedRoute } from '@backstage/plugin-permission-react';
@@ -126,10 +126,6 @@ const app = createApp({
 
 const AppProvider = app.getProvider();
 const AppRouter = app.getRouter();
-
-const extraSettingTabs: SettingsTab[] = [
-  { title: 'Advanced', content: <AdvancedSettings /> },
-];
 
 const routes = (
   <FlatRoutes>
@@ -219,10 +215,11 @@ const routes = (
       path="/cost-insights/labeling-jobs"
       element={<CostInsightsLabelDataflowInstructionsPage />}
     />
-    <Route
-      path="/settings"
-      element={<UserSettingsPage tabs={extraSettingTabs} />}
-    />
+    <Route path="/settings" element={<UserSettingsPage />}>
+      <Route path="/advanced" element={<AdvancedSettings />}>
+        Advanced
+      </Route>
+    </Route>
     <Route path="/azure-pull-requests" element={<AzurePullRequestsPage />} />
     <Route path="/apache-airflow" element={<ApacheAirflowPage />} />
   </FlatRoutes>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -69,7 +69,10 @@ import {
   techdocsPlugin,
   TechDocsReaderPage,
 } from '@backstage/plugin-techdocs';
-import { UserSettingsPage } from '@backstage/plugin-user-settings';
+import {
+  UserSettingsPage,
+  UserSettingsTab,
+} from '@backstage/plugin-user-settings';
 import { AdvancedSettings } from './components/advancedSettings';
 import AlarmIcon from '@material-ui/icons/Alarm';
 import React from 'react';
@@ -216,9 +219,9 @@ const routes = (
       element={<CostInsightsLabelDataflowInstructionsPage />}
     />
     <Route path="/settings" element={<UserSettingsPage />}>
-      <Route path="/advanced" element={<AdvancedSettings />}>
-        Advanced
-      </Route>
+      <UserSettingsTab path="/advanced" title="Advanced">
+        <AdvancedSettings />
+      </UserSettingsTab>
     </Route>
     <Route path="/azure-pull-requests" element={<AzurePullRequestsPage />} />
     <Route path="/apache-airflow" element={<ApacheAirflowPage />} />

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -69,7 +69,7 @@ import {
   techdocsPlugin,
   TechDocsReaderPage,
 } from '@backstage/plugin-techdocs';
-import { UserSettingsPage } from '@backstage/plugin-user-settings';
+import { UserSettingsPage, SettingsTab } from '@backstage/plugin-user-settings';
 import AlarmIcon from '@material-ui/icons/Alarm';
 import React from 'react';
 import { hot } from 'react-hot-loader/root';
@@ -82,7 +82,7 @@ import { LowerCaseValuePickerFieldExtension } from './components/scaffolder/cust
 import { searchPage } from './components/search/SearchPage';
 import { providers } from './identityProviders';
 import * as plugins from './plugins';
-
+import { AdvancedSettings } from './components/advancedSettings';
 import { techDocsPage } from './components/techdocs/TechDocsPage';
 import { ApacheAirflowPage } from '@backstage/plugin-apache-airflow';
 import { PermissionedRoute } from '@backstage/plugin-permission-react';
@@ -126,6 +126,10 @@ const app = createApp({
 
 const AppProvider = app.getProvider();
 const AppRouter = app.getRouter();
+
+const extraSettingTabs: SettingsTab[] = [
+  { title: 'Advanced', content: <AdvancedSettings /> },
+];
 
 const routes = (
   <FlatRoutes>
@@ -215,7 +219,10 @@ const routes = (
       path="/cost-insights/labeling-jobs"
       element={<CostInsightsLabelDataflowInstructionsPage />}
     />
-    <Route path="/settings" element={<UserSettingsPage />} />
+    <Route
+      path="/settings"
+      element={<UserSettingsPage tabs={extraSettingTabs} />}
+    />
     <Route path="/azure-pull-requests" element={<AzurePullRequestsPage />} />
     <Route path="/apache-airflow" element={<ApacheAirflowPage />} />
   </FlatRoutes>

--- a/packages/app/src/components/advancedSettings/AdvancedSettings.tsx
+++ b/packages/app/src/components/advancedSettings/AdvancedSettings.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { InfoCard } from '@backstage/core-components';
+import {
+  List,
+  Grid,
+  ListItem,
+  ListItemText,
+  ListItemSecondaryAction,
+  Switch,
+} from '@material-ui/core';
+import { useLocalStorage } from 'react-use';
+
+export function AdvancedSettings() {
+  const [value, setValue] = useLocalStorage<'on' | 'off'>(
+    'advanced-option',
+    'off',
+  );
+
+  const toggleValue = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(ev.currentTarget.checked ? 'on' : 'off');
+  };
+
+  return (
+    <Grid container direction="row" spacing={3}>
+      <Grid item xs={12} md={6}>
+        <InfoCard title="Advanced settings" variant="gridItem">
+          <List>
+            <ListItem>
+              <ListItemText
+                primary="Advanced user option"
+                secondary="An extra settings tab to further customize the experience"
+              />
+              <ListItemSecondaryAction>
+                <Switch
+                  color="primary"
+                  value={value}
+                  onChange={toggleValue}
+                  name="advanced"
+                />
+              </ListItemSecondaryAction>
+            </ListItem>
+          </List>
+        </InfoCard>
+      </Grid>
+    </Grid>
+  );
+}

--- a/packages/app/src/components/advancedSettings/AdvancedSettings.tsx
+++ b/packages/app/src/components/advancedSettings/AdvancedSettings.tsx
@@ -24,7 +24,7 @@ import {
   ListItemSecondaryAction,
   Switch,
 } from '@material-ui/core';
-import { useLocalStorage } from 'react-use';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
 
 export function AdvancedSettings() {
   const [value, setValue] = useLocalStorage<'on' | 'off'>(

--- a/packages/app/src/components/advancedSettings/index.ts
+++ b/packages/app/src/components/advancedSettings/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { Settings } from './Settings';
-export { SettingsPage as Router } from './SettingsPage';
-export type { SettingsTab } from './SettingsPage';
-export * from './AuthProviders';
-export * from './General';
-export * from './FeatureFlags';
-export { useUserProfile } from './useUserProfileInfo';
+
+export * from './AdvancedSettings';

--- a/plugins/user-settings/README.md
+++ b/plugins/user-settings/README.md
@@ -68,23 +68,18 @@ const AppRoutes = () => (
 
 By default, the plugin renders 3 tabs of settings; GENERAL, AUTHENTICATION PROVIDERS, and FEATURE FLAGS.
 
-If you want to add more options for your users, use the `tabs` prop:
+If you want to add more options for your users,
+just pass the extra tabs as children of the `UserSettingsPage` route
+where the children of that route represents the title of the tab.
+The path is in this case a child of the settings path,
+in the example below it would be `/settings/advanced` so that you can easily link to it.
 
 ```tsx
-import { UserSettingsPage, SettingsTab } from '@backstage/plugin-user-settings';
-
-const extraSettingTabs: SettingsTab[] = [
-  { title: 'Advanced', content: <AdvancedSettings /> },
-];
-
-const AppRoutes = () => (
-  <Routes>
-    <Route
-      path="/settings"
-      element={<SettingsRouter tabs={extraSettingTabs} />}
-    />
-  </Routes>
-);
+<Route path="/settings" element={<UserSettingsPage />}>
+  <Route path="/advanced" element={<AdvancedSettings />}>
+    Advanced
+  </Route>
+</Route>
 ```
 
 To standardize the UI of all setting tabs,

--- a/plugins/user-settings/README.md
+++ b/plugins/user-settings/README.md
@@ -63,3 +63,31 @@ const AppRoutes = () => (
 ```
 
 > **Note that the list of providers expects to be rendered within a MUI [`<List>`](https://material-ui.com/components/lists/)**
+
+**Tabs**
+By default, the plugin renders 3 tabs of settings; GENERAL, AUTHENTICATION PROVIDERS, and FEATURE FLAGS.
+
+If you want to add more options for your users, use the `tabs` prop:
+
+```tsx
+import { UserSettingsPage, SettingsTab } from '@backstage/plugin-user-settings';
+
+const extraSettingTabs: SettingsTab[] = [
+  { title: 'Advanced', content: <AdvancedSettings /> },
+];
+
+const AppRoutes = () => (
+  <Routes>
+    <Route
+      path="/settings"
+      element={<SettingsRouter tabs={extraSettingTabs} />}
+    />
+  </Routes>
+);
+```
+
+To standardize the UI of all setting tabs,
+make sure you use a similar component structure as the other tabs.
+You can take a look at
+[the example extra tab](https://github.com/backstage/backstage/blob/master/packages/app/src/components/advancedSettings/AdvancedSettings.tsx)
+we have created in Backstage's demo app.

--- a/plugins/user-settings/README.md
+++ b/plugins/user-settings/README.md
@@ -69,17 +69,21 @@ const AppRoutes = () => (
 By default, the plugin renders 3 tabs of settings; GENERAL, AUTHENTICATION PROVIDERS, and FEATURE FLAGS.
 
 If you want to add more options for your users,
-just pass the extra tabs as children of the `UserSettingsPage` route
-where the children of that route represents the title of the tab.
+just pass the extra tabs using `UserSettingsTab` components as children of the `UserSettingsPage` route.
 The path is in this case a child of the settings path,
 in the example below it would be `/settings/advanced` so that you can easily link to it.
 
 ```tsx
+import {
+  UserSettingsPage,
+  UserSettingsTab,
+} from '@backstage/plugin-user-settings';
+
 <Route path="/settings" element={<UserSettingsPage />}>
-  <Route path="/advanced" element={<AdvancedSettings />}>
-    Advanced
-  </Route>
-</Route>
+  <UserSettingsTab path="/advanced" title="Advanced">
+    <AdvancedSettings />
+  </UserSettingsTab>
+</Route>;
 ```
 
 To standardize the UI of all setting tabs,

--- a/plugins/user-settings/README.md
+++ b/plugins/user-settings/README.md
@@ -65,6 +65,7 @@ const AppRoutes = () => (
 > **Note that the list of providers expects to be rendered within a MUI [`<List>`](https://material-ui.com/components/lists/)**
 
 **Tabs**
+
 By default, the plugin renders 3 tabs of settings; GENERAL, AUTHENTICATION PROVIDERS, and FEATURE FLAGS.
 
 If you want to add more options for your users, use the `tabs` prop:

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -136,8 +136,4 @@ export const useUserProfile: () => {
   displayName: string;
   loading: boolean;
 };
-
-// Warnings were encountered during analysis:
-//
-// src/components/UserSettingsTab/UserSettingsTab.d.ts:7:17 - (tsdoc-code-span-missing-delimiter) The code span is missing its closing backtick
 ```

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -9,6 +9,7 @@ import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { ProfileInfo } from '@backstage/core-plugin-api';
+import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { SessionApi } from '@backstage/core-plugin-api';
 
@@ -107,6 +108,12 @@ export const UserSettingsProfileCard: () => JSX.Element;
 //
 // @public (undocumented)
 export const UserSettingsSignInAvatar: ({ size }: Props_5) => JSX.Element;
+
+// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "UserSettingsTab" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const UserSettingsTab: React_2.FC<Props_6>;
 
 // Warning: (ae-missing-release-tag) "UserSettingsThemeToggle" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -9,7 +9,6 @@ import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { ProfileInfo } from '@backstage/core-plugin-api';
-import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { SessionApi } from '@backstage/core-plugin-api';
 
@@ -36,23 +35,13 @@ export const ProviderSettingsItem: ({
 // Warning: (ae-missing-release-tag) "SettingsPage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const Router: ({ providerSettings, tabs }: Props) => JSX.Element;
+export const Router: ({ providerSettings }: Props) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "SettingsProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Settings" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const Settings: (props: SettingsProps) => JSX.Element;
-
-// Warning: (ae-missing-release-tag) "SettingsTab" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export interface SettingsTab {
-  // (undocumented)
-  content: React_2.ReactElement;
-  // (undocumented)
-  title: string;
-}
 
 // Warning: (ae-missing-release-tag) "UserSettingsAppearanceCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -87,10 +76,8 @@ export const UserSettingsMenu: () => JSX.Element;
 // @public (undocumented)
 export const UserSettingsPage: ({
   providerSettings,
-  tabs,
 }: {
   providerSettings?: JSX.Element | undefined;
-  tabs?: SettingsTab[] | undefined;
 }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "UserSettingsPinToggle" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -115,8 +115,6 @@ export const UserSettingsSignInAvatar: ({ size }: Props_5) => JSX.Element;
 // @public
 export const UserSettingsTab: (props: UserSettingsTabProps) => JSX.Element;
 
-// Warning: (ae-missing-release-tag) "UserSettingsTabProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type UserSettingsTabProps = PropsWithChildren<{
   path: string;

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -9,6 +9,7 @@ import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { ProfileInfo } from '@backstage/core-plugin-api';
+import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { SessionApi } from '@backstage/core-plugin-api';
 
@@ -35,13 +36,23 @@ export const ProviderSettingsItem: ({
 // Warning: (ae-missing-release-tag) "SettingsPage" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const Router: ({ providerSettings }: Props) => JSX.Element;
+export const Router: ({ providerSettings, tabs }: Props) => JSX.Element;
 
 // Warning: (ae-forgotten-export) The symbol "SettingsProps" needs to be exported by the entry point index.d.ts
 // Warning: (ae-missing-release-tag) "Settings" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const Settings: (props: SettingsProps) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "SettingsTab" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface SettingsTab {
+  // (undocumented)
+  content: React_2.ReactElement;
+  // (undocumented)
+  title: string;
+}
 
 // Warning: (ae-missing-release-tag) "UserSettingsAppearanceCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -76,8 +87,10 @@ export const UserSettingsMenu: () => JSX.Element;
 // @public (undocumented)
 export const UserSettingsPage: ({
   providerSettings,
+  tabs,
 }: {
   providerSettings?: JSX.Element | undefined;
+  tabs?: SettingsTab[] | undefined;
 }) => JSX.Element;
 
 // Warning: (ae-missing-release-tag) "UserSettingsPinToggle" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -9,7 +9,7 @@ import { ApiRef } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { ProfileInfo } from '@backstage/core-plugin-api';
-import { default as React_2 } from 'react';
+import { PropsWithChildren } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { SessionApi } from '@backstage/core-plugin-api';
 
@@ -43,6 +43,11 @@ export const Router: ({ providerSettings }: Props) => JSX.Element;
 //
 // @public (undocumented)
 export const Settings: (props: SettingsProps) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "USER_SETTINGS_TAB_KEY" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const USER_SETTINGS_TAB_KEY = 'user-settings.tab';
 
 // Warning: (ae-missing-release-tag) "UserSettingsAppearanceCard" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -109,11 +114,16 @@ export const UserSettingsProfileCard: () => JSX.Element;
 // @public (undocumented)
 export const UserSettingsSignInAvatar: ({ size }: Props_5) => JSX.Element;
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "UserSettingsTab" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+// @public
+export const UserSettingsTab: (props: UserSettingsTabProps) => JSX.Element;
+
+// Warning: (ae-missing-release-tag) "UserSettingsTabProps" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export const UserSettingsTab: React_2.FC<Props_6>;
+export type UserSettingsTabProps = PropsWithChildren<{
+  path: string;
+  title: string;
+}>;
 
 // Warning: (ae-missing-release-tag) "UserSettingsThemeToggle" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -128,4 +138,8 @@ export const useUserProfile: () => {
   displayName: string;
   loading: boolean;
 };
+
+// Warnings were encountered during analysis:
+//
+// src/components/UserSettingsTab/UserSettingsTab.d.ts:6:17 - (tsdoc-code-span-missing-delimiter) The code span is missing its closing backtick
 ```

--- a/plugins/user-settings/api-report.md
+++ b/plugins/user-settings/api-report.md
@@ -44,8 +44,6 @@ export const Router: ({ providerSettings }: Props) => JSX.Element;
 // @public (undocumented)
 export const Settings: (props: SettingsProps) => JSX.Element;
 
-// Warning: (ae-missing-release-tag) "USER_SETTINGS_TAB_KEY" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export const USER_SETTINGS_TAB_KEY = 'user-settings.tab';
 
@@ -141,5 +139,5 @@ export const useUserProfile: () => {
 
 // Warnings were encountered during analysis:
 //
-// src/components/UserSettingsTab/UserSettingsTab.d.ts:6:17 - (tsdoc-code-span-missing-delimiter) The code span is missing its closing backtick
+// src/components/UserSettingsTab/UserSettingsTab.d.ts:7:17 - (tsdoc-code-span-missing-delimiter) The code span is missing its closing backtick
 ```

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -40,6 +40,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
+    "@types/react": "^16.13.1 || ^17.0.0",
     "react-router": "6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
@@ -56,7 +57,6 @@
     "@testing-library/user-event": "^13.1.8",
     "@types/jest": "^26.0.7",
     "@types/node": "^14.14.32",
-    "@types/react": "^16.13.1 || ^17.0.0",
     "cross-fetch": "^3.1.5",
     "msw": "^0.35.0"
   },

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -56,6 +56,7 @@
     "@testing-library/user-event": "^13.1.8",
     "@types/jest": "^26.0.7",
     "@types/node": "^14.14.32",
+    "@types/react": "^16.13.1 || ^17.0.0",
     "cross-fetch": "^3.1.5",
     "msw": "^0.35.0"
   },

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -40,7 +40,6 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
-    "@types/react": "^16.13.1 || ^17.0.0",
     "react-router": "6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
@@ -57,6 +56,7 @@
     "@testing-library/user-event": "^13.1.8",
     "@types/jest": "^26.0.7",
     "@types/node": "^14.14.32",
+    "@types/react": "^16.13.1 || ^17.0.0",
     "cross-fetch": "^3.1.5",
     "msw": "^0.35.0"
   },

--- a/plugins/user-settings/src/components/SettingsPage.test.tsx
+++ b/plugins/user-settings/src/components/SettingsPage.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { renderWithEffects, wrapInTestApp } from '@backstage/test-utils';
+import { SettingsPage, SettingsTab } from './SettingsPage';
+
+describe('<SettingsPage />', () => {
+  it('should render the settings page with 3 tabs', async () => {
+    const { container } = await renderWithEffects(
+      wrapInTestApp(<SettingsPage />),
+    );
+
+    const tabs = container.querySelectorAll('[class*=MuiTabs-root] button');
+    expect(tabs).toHaveLength(3);
+  });
+
+  it('should render the settings page with 4 tabs when extra tabs are provided', async () => {
+    const extraTabs: SettingsTab[] = [
+      { title: 'Advanced', content: <div>advanced content</div> },
+    ];
+    const { container } = await renderWithEffects(
+      wrapInTestApp(<SettingsPage tabs={extraTabs} />),
+    );
+
+    const tabs = container.querySelectorAll('[class*=MuiTabs-root] button');
+    expect(tabs).toHaveLength(4);
+    expect(tabs[3].textContent).toEqual(extraTabs[0].title);
+  });
+});

--- a/plugins/user-settings/src/components/SettingsPage.test.tsx
+++ b/plugins/user-settings/src/components/SettingsPage.test.tsx
@@ -27,6 +27,10 @@ jest.mock('react-router', () => ({
 import { useOutlet } from 'react-router';
 
 describe('<SettingsPage />', () => {
+  beforeEach(() => {
+    (useOutlet as jest.Mock).mockReset();
+  });
+
   it('should render the settings page with 3 tabs', async () => {
     const { container } = await renderWithEffects(
       wrapInTestApp(<SettingsPage />),
@@ -38,13 +42,11 @@ describe('<SettingsPage />', () => {
 
   it('should render the settings page with 4 tabs when extra tabs are provided', async () => {
     const advancedTabRoute = (
-      <>
-        <UserSettingsTab path="/advanced" title="Advanced">
-          <div>Advanced settings</div>
-        </UserSettingsTab>
-      </>
+      <UserSettingsTab path="/advanced" title="Advanced">
+        <div>Advanced settings</div>
+      </UserSettingsTab>
     );
-    (useOutlet as jest.Mock).mockReturnValueOnce(advancedTabRoute);
+    (useOutlet as jest.Mock).mockReturnValue(advancedTabRoute);
     const { container } = await renderWithEffects(
       wrapInTestApp(<SettingsPage />),
     );
@@ -52,26 +54,5 @@ describe('<SettingsPage />', () => {
     const tabs = container.querySelectorAll('[class*=MuiTabs-root] button');
     expect(tabs).toHaveLength(4);
     expect(tabs[3].textContent).toEqual('Advanced');
-  });
-
-  it('should throw error if non compliant route is passed to settings routes', async () => {
-    const advancedTabRoute = (
-      <>
-        <UserSettingsTab path="/advanced" title="Advanced">
-          <div>Advanced settings</div>
-        </UserSettingsTab>
-        <div>Non compliant element</div>
-      </>
-    );
-    (useOutlet as jest.Mock).mockReturnValueOnce(advancedTabRoute);
-    let error: Error;
-    try {
-      await renderWithEffects(wrapInTestApp(<SettingsPage />));
-    } catch (err) {
-      error = err;
-    }
-    expect(error!.message).toEqual(
-      expect.stringContaining('Invalid element passed'),
-    );
   });
 });

--- a/plugins/user-settings/src/components/SettingsPage.test.tsx
+++ b/plugins/user-settings/src/components/SettingsPage.test.tsx
@@ -17,13 +17,14 @@
 import React from 'react';
 import { renderWithEffects, wrapInTestApp } from '@backstage/test-utils';
 import { SettingsPage } from './SettingsPage';
+import { UserSettingsTab } from './UserSettingsTab';
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useOutlet: jest.fn().mockReturnValue(undefined),
 }));
 
-import { useOutlet, Route } from 'react-router';
+import { useOutlet } from 'react-router';
 
 describe('<SettingsPage />', () => {
   it('should render the settings page with 3 tabs', async () => {
@@ -38,9 +39,9 @@ describe('<SettingsPage />', () => {
   it('should render the settings page with 4 tabs when extra tabs are provided', async () => {
     const advancedTabRoute = (
       <>
-        <Route path="/advanced" element={<div>Advanced settings</div>}>
-          Advanced
-        </Route>
+        <UserSettingsTab path="/advanced" title="Advanced">
+          <div>Advanced settings</div>
+        </UserSettingsTab>
       </>
     );
     (useOutlet as jest.Mock).mockReturnValueOnce(advancedTabRoute);
@@ -56,9 +57,9 @@ describe('<SettingsPage />', () => {
   it('should throw error if non compliant route is passed to settings routes', async () => {
     const advancedTabRoute = (
       <>
-        <Route path="/advanced" element={<div>Advanced settings</div>}>
-          Advanced
-        </Route>
+        <UserSettingsTab path="/advanced" title="Advanced">
+          <div>Advanced settings</div>
+        </UserSettingsTab>
         <div>Non compliant element</div>
       </>
     );

--- a/plugins/user-settings/src/components/SettingsPage.tsx
+++ b/plugins/user-settings/src/components/SettingsPage.tsx
@@ -37,11 +37,11 @@ export const SettingsPage = ({ providerSettings }: Props) => {
   const extraTabs = (React.Children.toArray(outlet?.props?.children) ||
     []) as Array<ReactElement>;
   const notCompliantTab = Array.from(extraTabs).some(
-    child => (child.type as any)?.displayName !== 'Route',
+    child => (child.type as any)?.displayName !== 'UserSettingsTab',
   );
   if (notCompliantTab) {
     throw new Error(
-      'Invalid element passed to SettingsPage Outlet. You may only pass children of type Route.',
+      'Invalid element passed to SettingsPage Outlet. You may only pass children of type UserSettingsTab.',
     );
   }
 
@@ -64,7 +64,7 @@ export const SettingsPage = ({ providerSettings }: Props) => {
 
         {extraTabs.map((child, i) => {
           const path: string = child.props.path;
-          const title: string = child.props.children;
+          const title: string = child.props.title;
 
           return (
             <TabbedLayout.Route key={i} path={path} title={title}>

--- a/plugins/user-settings/src/components/SettingsPage.tsx
+++ b/plugins/user-settings/src/components/SettingsPage.tsx
@@ -25,11 +25,17 @@ import { UserSettingsAuthProviders } from './AuthProviders';
 import { UserSettingsFeatureFlags } from './FeatureFlags';
 import { UserSettingsGeneral } from './General';
 
+export interface SettingsTab {
+  title: string;
+  content: React.ReactElement;
+}
+
 type Props = {
   providerSettings?: JSX.Element;
+  tabs?: SettingsTab[];
 };
 
-export const SettingsPage = ({ providerSettings }: Props) => {
+export const SettingsPage = ({ providerSettings, tabs }: Props) => {
   const { isMobile } = useContext(SidebarPinStateContext);
 
   return (
@@ -48,6 +54,15 @@ export const SettingsPage = ({ providerSettings }: Props) => {
         <TabbedLayout.Route path="feature-flags" title="Feature Flags">
           <UserSettingsFeatureFlags />
         </TabbedLayout.Route>
+        {tabs?.map(({ title, content }) => {
+          // Hyphenated the title
+          const path = title.toLocaleLowerCase().replace(/\s/, '-');
+          return (
+            <TabbedLayout.Route key={path} path={path} title={title}>
+              {content}
+            </TabbedLayout.Route>
+          );
+        })}
       </TabbedLayout>
     </Page>
   );

--- a/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
+++ b/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
@@ -13,15 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
+import { attachComponentData } from '@backstage/core-plugin-api';
 
-interface Props {
+export const USER_SETTINGS_TAB_KEY = 'user-settings.tab';
+
+export type UserSettingsTabProps = PropsWithChildren<{
+  /**
+   * The path to the tab in the settings route
+   * @example `/settings/advanced
+   */
   path: string;
-  title: React.ReactNode;
-}
+  /** The title of the tab. It will also reflect in the document title when the tab is active */
+  title: string;
+}>;
 
-export const UserSettingsTab: React.FC<Props> = ({ children }) => {
-  return <>{children}</>;
+/**
+ * Renders a tab inside the settings page
+ * @param props - Component props
+ * @public
+ */
+export const UserSettingsTab = (props: UserSettingsTabProps) => {
+  return <>{props.children}</>;
 };
 
-UserSettingsTab.displayName = 'UserSettingsTab';
+attachComponentData(UserSettingsTab, USER_SETTINGS_TAB_KEY, 'UserSettingsTab');

--- a/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
+++ b/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { Settings } from './Settings';
-export { SettingsPage as Router } from './SettingsPage';
-export * from './AuthProviders';
-export * from './General';
-export * from './FeatureFlags';
-export { useUserProfile } from './useUserProfileInfo';
-export * from './UserSettingsTab';
+import React from 'react';
+
+interface Props {
+  path: string;
+  title: React.ReactNode;
+}
+
+export const UserSettingsTab: React.FC<Props> = ({ children }) => {
+  return <>{children}</>;
+};
+
+UserSettingsTab.displayName = 'UserSettingsTab';

--- a/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
+++ b/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
@@ -19,6 +19,7 @@ import { attachComponentData } from '@backstage/core-plugin-api';
 /** @public */
 export const USER_SETTINGS_TAB_KEY = 'user-settings.tab';
 
+/** @public */
 export type UserSettingsTabProps = PropsWithChildren<{
   /**
    * The path to the tab in the settings route

--- a/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
+++ b/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
@@ -22,7 +22,7 @@ export const USER_SETTINGS_TAB_KEY = 'user-settings.tab';
 export type UserSettingsTabProps = PropsWithChildren<{
   /**
    * The path to the tab in the settings route
-   * @example `/settings/advanced
+   * @example `/settings/advanced`
    */
   path: string;
   /** The title of the tab. It will also reflect in the document title when the tab is active */

--- a/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
+++ b/plugins/user-settings/src/components/UserSettingsTab/UserSettingsTab.tsx
@@ -16,6 +16,7 @@
 import React, { PropsWithChildren } from 'react';
 import { attachComponentData } from '@backstage/core-plugin-api';
 
+/** @public */
 export const USER_SETTINGS_TAB_KEY = 'user-settings.tab';
 
 export type UserSettingsTabProps = PropsWithChildren<{

--- a/plugins/user-settings/src/components/UserSettingsTab/index.ts
+++ b/plugins/user-settings/src/components/UserSettingsTab/index.ts
@@ -13,10 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { Settings } from './Settings';
-export { SettingsPage as Router } from './SettingsPage';
-export * from './AuthProviders';
-export * from './General';
-export * from './FeatureFlags';
-export { useUserProfile } from './useUserProfileInfo';
 export * from './UserSettingsTab';

--- a/plugins/user-settings/src/components/index.ts
+++ b/plugins/user-settings/src/components/index.ts
@@ -15,7 +15,6 @@
  */
 export { Settings } from './Settings';
 export { SettingsPage as Router } from './SettingsPage';
-export type { SettingsTab } from './SettingsPage';
 export * from './AuthProviders';
 export * from './General';
 export * from './FeatureFlags';


### PR DESCRIPTION
## Hey, I just made a Pull Request!
closes #9805

This PR introduces the ability to add extra setting tabs to the user settings page. By the default it will not constrain how the users want to create the content of these tabs, however, the README of the `@backstage/plugin-user-settings` has been updated to suggest using a similar layout to standardise the look and feel across all setting tabs.

![Screenshot 2022-03-07 at 18 35 54](https://user-images.githubusercontent.com/10633734/157087458-9653fc78-6b05-437e-b1fb-a302025fecec.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
