### PR TITLE
jenkins: make resourceRef required in JenkinsApi#buildProject

### DIFF
--- a/.changeset/yellow-hats-remember.md
+++ b/.changeset/yellow-hats-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-jenkins-backend': patch
+---
+
+Make resourceRef required in JenkinsApi to match usage.

--- a/.changeset/yellow-hats-remember.md
+++ b/.changeset/yellow-hats-remember.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-jenkins-backend': patch
 ---
 
-Make resourceRef required in JenkinsApi to match usage.
+Make `resourceRef` required in `JenkinsApi` to match usage.

--- a/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
@@ -34,6 +34,7 @@ const mockedJenkinsClient = {
 const mockedJenkins = jenkins as jest.Mocked<any>;
 mockedJenkins.mockReturnValue(mockedJenkinsClient);
 
+const resourceRef = 'component:default/example-component';
 const jobFullName = 'example-jobName/foo';
 const buildNumber = 19;
 const jenkinsInfo: JenkinsInfo = {
@@ -413,7 +414,7 @@ describe('JenkinsApi', () => {
     );
   });
   it('buildProject', async () => {
-    await jenkinsApi.buildProject(jenkinsInfo, jobFullName);
+    await jenkinsApi.buildProject(jenkinsInfo, jobFullName, resourceRef);
 
     expect(mockedJenkins).toHaveBeenCalledWith({
       baseUrl: jenkinsInfo.baseUrl,
@@ -431,7 +432,7 @@ describe('JenkinsApi', () => {
     ]);
 
     await expect(() =>
-      jenkinsApi.buildProject(jenkinsInfo, jobFullName),
+      jenkinsApi.buildProject(jenkinsInfo, jobFullName, resourceRef),
     ).rejects.toThrow(NotAllowedError);
   });
 
@@ -442,7 +443,7 @@ describe('JenkinsApi', () => {
       },
     ]);
 
-    await jenkinsApi.buildProject(jenkinsInfo, jobFullName);
+    await jenkinsApi.buildProject(jenkinsInfo, jobFullName, resourceRef);
     expect(mockedJenkins).toHaveBeenCalledWith({
       baseUrl: jenkinsInfo.baseUrl,
       headers: jenkinsInfo.headers,
@@ -453,7 +454,7 @@ describe('JenkinsApi', () => {
 
   it('buildProject with crumbIssuer option', async () => {
     const info: JenkinsInfo = { ...jenkinsInfo, crumbIssuer: true };
-    await jenkinsApi.buildProject(info, jobFullName);
+    await jenkinsApi.buildProject(info, jobFullName, resourceRef);
 
     expect(mockedJenkins).toHaveBeenCalledWith({
       baseUrl: jenkinsInfo.baseUrl,

--- a/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -139,7 +139,7 @@ export class JenkinsApiImpl {
   async buildProject(
     jenkinsInfo: JenkinsInfo,
     jobFullName: string,
-    resourceRef?: string,
+    resourceRef: string,
     options?: { token?: string },
   ) {
     const client = await JenkinsApiImpl.getClient(jenkinsInfo);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This method is only called in one place outside tests, and the resourceRef is guaranteed to be set there, so we can tighten this typing up a bit to make the value mandatory.

This class is not exported by the package, so this can be shipped as a patch change.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
