### PR TITLE
feat(bitbucket): add support for ETag at `BitbucketUrlReader.readUrl`

### DIFF
--- a/.changeset/metal-glasses-join.md
+++ b/.changeset/metal-glasses-join.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+add support for ETag at `BitbucketUrlReader.readUrl`

--- a/packages/backend-common/src/reading/BitbucketUrlReader.ts
+++ b/packages/backend-common/src/reading/BitbucketUrlReader.ts
@@ -80,15 +80,17 @@ export class BitbucketUrlReader implements UrlReader {
     url: string,
     options?: ReadUrlOptions,
   ): Promise<ReadUrlResponse> {
-    // TODO: etag is not supported yet
-    const { signal } = options ?? {};
+    const { etag, signal } = options ?? {};
     const bitbucketUrl = getBitbucketFileFetchUrl(url, this.integration.config);
     const requestOptions = getBitbucketRequestOptions(this.integration.config);
 
     let response: Response;
     try {
       response = await fetch(bitbucketUrl.toString(), {
-        ...requestOptions,
+        headers: {
+          ...requestOptions.headers,
+          ...(etag && { 'If-None-Match': etag }),
+        },
         // TODO(freben): The signal cast is there because pre-3.x versions of
         // node-fetch have a very slightly deviating AbortSignal type signature.
         // The difference does not affect us in practice however. The cast can be
@@ -101,9 +103,14 @@ export class BitbucketUrlReader implements UrlReader {
       throw new Error(`Unable to read ${url}, ${e}`);
     }
 
+    if (response.status === 304) {
+      throw new NotModifiedError();
+    }
+
     if (response.ok) {
       return {
         buffer: async () => Buffer.from(await response.arrayBuffer()),
+        etag: response.headers.get('ETag') ?? undefined,
       };
     }
 


### PR DESCRIPTION
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
