### PR TITLE
docs: use localhost instead of 127.0.0.1

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -133,9 +133,9 @@ familiar with. For other options, see
 Go to
 [https://github.com/settings/applications/new](https://github.com/settings/applications/new)
 to create your OAuth App. The `Homepage URL` should point to Backstage's
-frontend, in our tutorial it would be `http://127.0.0.1:3000`. The
+frontend, in our tutorial it would be `http://localhost:3000`. The
 `Authorization callback URL` will point to the auth backend, which will most
-likely be `http://127.0.0.1:7007/api/auth/github/handler/frame`.
+likely be `http://localhost:7007/api/auth/github/handler/frame`.
 
 <p align='center'>
   <img src='../assets/getting-started/gh-oauth.png' alt='Screenshot of the GitHub OAuth creation page' />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This is one option for resolving https://github.com/backstage/backstage/issues/10045

The current documentation is causing a "redirect_uri" mismatch error for readers that follow the getting started guide.

By making this change we also ensure that the text is the same as in the screenshot (which is using localhost, see https://backstage.io/docs/getting-started/configuration#setting-up-authentication)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [N/A] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [N/A] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
