### PR TITLE
🧹 Remove `cookiecutter-golang` template

### DIFF
--- a/.changeset/curvy-forks-cross.md
+++ b/.changeset/curvy-forks-cross.md
@@ -1,0 +1,14 @@
+---
+'@backstage/create-app': patch
+---
+
+Removed the `cookiecutter-golang` template from the default `create-app` install as we no longer provide `cookiecutter` action out of the box.
+
+You can remove the template by removing the following lines from your `app-config.yaml` under `catalog.locations`:
+
+```diff
+-    - type: url
+-      target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
+-      rules:
+-        - allow: [Template]
+```

--- a/docs/features/software-templates/adding-templates.md
+++ b/docs/features/software-templates/adding-templates.md
@@ -94,7 +94,7 @@ for example:
 catalog:
   locations:
     - type: url
-      target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
+      target: https://github.com/backstage/software-templates/blob/main/scaffolder-templates/react-ssr-template/template.yaml
       rules:
         - allow: [Template]
 ```

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -117,10 +117,6 @@ catalog:
       rules:
         - allow: [Template]
     - type: url
-      target: https://github.com/spotify/cookiecutter-golang/blob/master/template.yaml
-      rules:
-        - allow: [Template]
-    - type: url
       target: https://github.com/backstage/software-templates/blob/main/scaffolder-templates/docs-template/template.yaml
       rules:
         - allow: [Template]


### PR DESCRIPTION
- chore: remove the golang cookiecutter template as we're no longer providing cookiecutter out of the box
- chore: added changeset

We no longer ship cookiecutter out of the box, so let's remove it from `create-app` default tempaltes


