### PR TITLE
catalog-react: restrict type of Permission passed to `useEntityPermission`

### DIFF
--- a/.changeset/clever-donuts-teach.md
+++ b/.changeset/clever-donuts-teach.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Prevent permissions with types other than `CatalogEntityPermission` from being used with the `useEntityPermission` hook.

--- a/.changeset/clever-donuts-teach.md
+++ b/.changeset/clever-donuts-teach.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-Prevent permissions with types other than `CatalogEntityPermission` from being used with the `useEntityPermission` hook.
+Prevent permissions with types other than `ResourcePermission<'catalog-entity'>` from being used with the `useEntityPermission` hook.

--- a/.changeset/rare-waves-hammer.md
+++ b/.changeset/rare-waves-hammer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-common': patch
+---
+
+Add `CatalogEntityPermission` convenience type.

--- a/.changeset/rare-waves-hammer.md
+++ b/.changeset/rare-waves-hammer.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-common': patch
 ---
 
-Add `CatalogEntityPermission` convenience type.
+Add `@alpha` `CatalogEntityPermission` convenience type, available for import from `@backstage/plugin-catalog-common/alpha`.

--- a/plugins/catalog-common/api-report.md
+++ b/plugins/catalog-common/api-report.md
@@ -30,6 +30,11 @@ export interface CatalogEntityDocument extends IndexableDocument {
 }
 
 // @alpha
+export type CatalogEntityPermission = ResourcePermission<
+  typeof RESOURCE_TYPE_CATALOG_ENTITY
+>;
+
+// @alpha
 export const catalogEntityReadPermission: ResourcePermission<'catalog-entity'>;
 
 // @alpha

--- a/plugins/catalog-common/src/index.ts
+++ b/plugins/catalog-common/src/index.ts
@@ -31,5 +31,6 @@ export {
   catalogLocationCreatePermission,
   catalogLocationDeletePermission,
 } from './permissions';
+export type { CatalogEntityPermission } from './permissions';
 
 export * from './search';

--- a/plugins/catalog-common/src/permissions.ts
+++ b/plugins/catalog-common/src/permissions.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { createPermission } from '@backstage/plugin-permission-common';
+import {
+  createPermission,
+  ResourcePermission,
+} from '@backstage/plugin-permission-common';
 
 /**
  * Permission resource type which corresponds to catalog entities.
@@ -23,6 +26,15 @@ import { createPermission } from '@backstage/plugin-permission-common';
  * @alpha
  */
 export const RESOURCE_TYPE_CATALOG_ENTITY = 'catalog-entity';
+
+/**
+ * Convenience type for catalog entity
+ * {@link @backstage/plugin-permission-common#ResourcePermission}s.
+ * @alpha
+ */
+export type CatalogEntityPermission = ResourcePermission<
+  typeof RESOURCE_TYPE_CATALOG_ENTITY
+>;
 
 /**
  * This permission is used to authorize actions that involve reading one or more

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -8,6 +8,7 @@
 import { ApiRef } from '@backstage/core-plugin-api';
 import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
 import { CatalogApi } from '@backstage/catalog-client';
+import { CatalogEntityPermission } from '@backstage/plugin-catalog-common';
 import { ComponentEntity } from '@backstage/catalog-model';
 import { ComponentProps } from 'react';
 import { CompoundEntityRef } from '@backstage/catalog-model';
@@ -16,7 +17,6 @@ import { IconButton } from '@material-ui/core';
 import { LinkProps } from '@backstage/core-components';
 import { Observable } from '@backstage/types';
 import { Overrides } from '@material-ui/core/styles/overrides';
-import { Permission } from '@backstage/plugin-permission-common';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
@@ -489,7 +489,7 @@ export function useEntityOwnership(): {
 };
 
 // @alpha
-export function useEntityPermission(permission: Permission): {
+export function useEntityPermission(permission: CatalogEntityPermission): {
   loading: boolean;
   allowed: boolean;
   error?: Error;

--- a/plugins/catalog-react/api-report.md
+++ b/plugins/catalog-react/api-report.md
@@ -8,7 +8,6 @@
 import { ApiRef } from '@backstage/core-plugin-api';
 import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
 import { CatalogApi } from '@backstage/catalog-client';
-import { CatalogEntityPermission } from '@backstage/plugin-catalog-common';
 import { ComponentEntity } from '@backstage/catalog-model';
 import { ComponentProps } from 'react';
 import { CompoundEntityRef } from '@backstage/catalog-model';
@@ -20,6 +19,7 @@ import { Overrides } from '@material-ui/core/styles/overrides';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
+import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 import { StyleRules } from '@material-ui/core/styles/withStyles';
@@ -489,7 +489,9 @@ export function useEntityOwnership(): {
 };
 
 // @alpha
-export function useEntityPermission(permission: CatalogEntityPermission): {
+export function useEntityPermission(
+  permission: ResourcePermission<'catalog-entity'>,
+): {
   loading: boolean;
   allowed: boolean;
   error?: Error;

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -40,6 +40,7 @@
     "@backstage/core-plugin-api": "^1.0.0",
     "@backstage/errors": "^1.0.0",
     "@backstage/integration": "^1.0.1-next.0",
+    "@backstage/plugin-catalog-common": "^1.0.1-next.0",
     "@backstage/plugin-permission-common": "^0.5.3",
     "@backstage/plugin-permission-react": "^0.3.4",
     "@backstage/theme": "^0.2.15",

--- a/plugins/catalog-react/src/hooks/useEntityPermission.ts
+++ b/plugins/catalog-react/src/hooks/useEntityPermission.ts
@@ -15,7 +15,7 @@
  */
 
 import { stringifyEntityRef } from '@backstage/catalog-model';
-import { Permission } from '@backstage/plugin-permission-common';
+import { CatalogEntityPermission } from '@backstage/plugin-catalog-common';
 import { usePermission } from '@backstage/plugin-permission-react';
 import { useAsyncEntity } from './useEntity';
 
@@ -23,14 +23,14 @@ import { useAsyncEntity } from './useEntity';
  * A thin wrapper around the
  * {@link @backstage/plugin-permission-react#usePermission} hook which uses the
  * current entity in context to make an authorization request for the given
- * permission.
+ * {@link @backstage/plugin-catalog-common#CatalogEntityPermission}.
  *
  * Note: this hook blocks the permission request until the entity has loaded in
  * context. If you have the entityRef and need concurrent requests, use the
  * `usePermission` hook directly.
  * @alpha
  */
-export function useEntityPermission(permission: Permission): {
+export function useEntityPermission(permission: CatalogEntityPermission): {
   loading: boolean;
   allowed: boolean;
   error?: Error;

--- a/plugins/catalog-react/src/hooks/useEntityPermission.ts
+++ b/plugins/catalog-react/src/hooks/useEntityPermission.ts
@@ -31,6 +31,8 @@ import { useAsyncEntity } from './useEntity';
  * @alpha
  */
 export function useEntityPermission(
+  // TODO(joeporpeglia) Replace with `CatalogEntityPermission` when the issue described in
+  // https://github.com/backstage/backstage/pull/10128 is fixed.
   permission: ResourcePermission<'catalog-entity'>,
 ): {
   loading: boolean;

--- a/plugins/catalog-react/src/hooks/useEntityPermission.ts
+++ b/plugins/catalog-react/src/hooks/useEntityPermission.ts
@@ -15,7 +15,7 @@
  */
 
 import { stringifyEntityRef } from '@backstage/catalog-model';
-import { CatalogEntityPermission } from '@backstage/plugin-catalog-common';
+import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { usePermission } from '@backstage/plugin-permission-react';
 import { useAsyncEntity } from './useEntity';
 
@@ -30,7 +30,9 @@ import { useAsyncEntity } from './useEntity';
  * `usePermission` hook directly.
  * @alpha
  */
-export function useEntityPermission(permission: CatalogEntityPermission): {
+export function useEntityPermission(
+  permission: ResourcePermission<'catalog-entity'>,
+): {
   loading: boolean;
   allowed: boolean;
   error?: Error;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Now that we have typed permissions, we can restrict the `useEntityPermission` hook to only accept permissions with the appropriate `resourceType`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
