### PR TITLE
permission-react: more restrictive typing for usePermission and PermissionedRoute

### DIFF
--- a/.changeset/blue-beers-kiss.md
+++ b/.changeset/blue-beers-kiss.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-react': minor
+---
+
+**BREAKING**: More restrictive typing for `usePermission` hook and `PermissionedRoute` component. It's no longer possible to pass a `resourceRef` unless the permission is of type `ResourcPermission`.

--- a/.changeset/blue-beers-kiss.md
+++ b/.changeset/blue-beers-kiss.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-permission-react': minor
 ---
 
-**BREAKING**: More restrictive typing for `usePermission` hook and `PermissionedRoute` component. It's no longer possible to pass a `resourceRef` unless the permission is of type `ResourcPermission`.
+**BREAKING**: More restrictive typing for `usePermission` hook and `PermissionedRoute` component. It's no longer possible to pass a `resourceRef` unless the permission is of type `ResourcePermission`.

--- a/.changeset/thin-lizards-battle.md
+++ b/.changeset/thin-lizards-battle.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Update `usePermission` usage.

--- a/plugins/catalog-react/src/hooks/useEntityPermission.ts
+++ b/plugins/catalog-react/src/hooks/useEntityPermission.ts
@@ -48,10 +48,10 @@ export function useEntityPermission(
     allowed,
     loading: loadingPermission,
     error: permissionError,
-  } = usePermission(
+  } = usePermission({
     permission,
-    entity ? stringifyEntityRef(entity) : undefined,
-  );
+    resourceRef: entity ? stringifyEntityRef(entity) : undefined,
+  });
 
   if (loadingEntity || loadingPermission) {
     return { loading: true, allowed: false };

--- a/plugins/permission-react/api-report.md
+++ b/plugins/permission-react/api-report.md
@@ -12,6 +12,7 @@ import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { Permission } from '@backstage/plugin-permission-common';
 import { ReactElement } from 'react';
+import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { Route } from 'react-router';
 
 // @public (undocumented)
@@ -44,17 +45,25 @@ export const permissionApiRef: ApiRef<PermissionApi>;
 // @public
 export const PermissionedRoute: (
   props: ComponentProps<typeof Route> & {
-    permission: Permission;
-    resourceRef?: string;
     errorComponent?: ReactElement | null;
-  },
+  } & (
+      | {
+          permission: Exclude<Permission, ResourcePermission>;
+          resourceRef?: never;
+        }
+      | {
+          permission: ResourcePermission;
+          resourceRef: string | undefined;
+        }
+    ),
 ) => JSX.Element;
 
 // @public
-export const usePermission: (
-  permission: Permission,
-  resourceRef?: string | undefined,
-) => AsyncPermissionResult;
+export function usePermission(
+  ...[permission, resourceRef]:
+    | [ResourcePermission, string | undefined]
+    | [Exclude<Permission, ResourcePermission>]
+): AsyncPermissionResult;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/permission-react/api-report.md
+++ b/plugins/permission-react/api-report.md
@@ -60,9 +60,15 @@ export const PermissionedRoute: (
 
 // @public
 export function usePermission(
-  ...[permission, resourceRef]:
-    | [ResourcePermission, string | undefined]
-    | [Exclude<Permission, ResourcePermission>]
+  input:
+    | {
+        permission: Exclude<Permission, ResourcePermission>;
+        resourceRef?: never;
+      }
+    | {
+        permission: ResourcePermission;
+        resourceRef: string | undefined;
+      },
 ): AsyncPermissionResult;
 
 // (No @packageDocumentation comment for this package)

--- a/plugins/permission-react/src/components/PermissionedRoute.tsx
+++ b/plugins/permission-react/src/components/PermissionedRoute.tsx
@@ -47,9 +47,9 @@ export const PermissionedRoute = (
   const { permission, resourceRef, errorComponent, ...otherProps } = props;
 
   const permissionResult = usePermission(
-    ...(isResourcePermission(permission)
-      ? [permission, resourceRef]
-      : [permission]),
+    isResourcePermission(permission)
+      ? { permission, resourceRef }
+      : { permission },
   );
   const app = useApp();
   const { NotFoundErrorPage } = app.getComponents();

--- a/plugins/permission-react/src/hooks/usePermission.test.tsx
+++ b/plugins/permission-react/src/hooks/usePermission.test.tsx
@@ -31,7 +31,7 @@ const permission = createPermission({
 });
 
 const TestComponent: FC = () => {
-  const { loading, allowed, error } = usePermission(permission);
+  const { loading, allowed, error } = usePermission({ permission });
   return (
     <div>
       {loading && 'loading'}

--- a/plugins/permission-react/src/hooks/usePermission.ts
+++ b/plugins/permission-react/src/hooks/usePermission.ts
@@ -32,6 +32,17 @@ export type AsyncPermissionResult = {
   error?: Error;
 };
 
+/** @public */
+export type UsePermissionProps =
+  | {
+      permission: Exclude<Permission, ResourcePermission>;
+      resourceRef?: never;
+    }
+  | {
+      permission: ResourcePermission;
+      resourceRef: string | undefined;
+    };
+
 /**
  * React hook utility for authorization. Given either a non-resource
  * {@link @backstage/plugin-permission-common#Permission} or a
@@ -41,7 +52,7 @@ export type AsyncPermissionResult = {
  * {@link @backstage/plugin-permission-common/PermissionClient#authorize} for
  * more details.
  *
- * The resourceRef parameter is optional to allow calling this hook with an
+ * The resourceRef field is optional to allow calling this hook with an
  * entity that might be loading asynchronously, but when resourceRef is not
  * supplied, the value of `allowed` will always be false.
  *
@@ -51,12 +62,10 @@ export type AsyncPermissionResult = {
  * @public
  */
 export function usePermission(
-  ...[permission, resourceRef]:
-    | [ResourcePermission, string | undefined]
-    | [Exclude<Permission, ResourcePermission>]
+  props: UsePermissionProps,
 ): AsyncPermissionResult {
   const permissionApi = useApi(permissionApiRef);
-  const { data, error } = useSWR({ permission, resourceRef }, async args => {
+  const { data, error } = useSWR(props, async (args: UsePermissionProps) => {
     // We could make the resourceRef parameter required to avoid this check, but
     // it would make using this hook difficult in situations where the entity
     // must be asynchronously loaded, so instead we short-circuit to a deny when

--- a/plugins/permission-react/src/hooks/usePermission.ts
+++ b/plugins/permission-react/src/hooks/usePermission.ts
@@ -32,17 +32,6 @@ export type AsyncPermissionResult = {
   error?: Error;
 };
 
-/** @public */
-export type UsePermissionProps =
-  | {
-      permission: Exclude<Permission, ResourcePermission>;
-      resourceRef?: never;
-    }
-  | {
-      permission: ResourcePermission;
-      resourceRef: string | undefined;
-    };
-
 /**
  * React hook utility for authorization. Given either a non-resource
  * {@link @backstage/plugin-permission-common#Permission} or a
@@ -62,10 +51,18 @@ export type UsePermissionProps =
  * @public
  */
 export function usePermission(
-  props: UsePermissionProps,
+  input:
+    | {
+        permission: Exclude<Permission, ResourcePermission>;
+        resourceRef?: never;
+      }
+    | {
+        permission: ResourcePermission;
+        resourceRef: string | undefined;
+      },
 ): AsyncPermissionResult {
   const permissionApi = useApi(permissionApiRef);
-  const { data, error } = useSWR(props, async (args: UsePermissionProps) => {
+  const { data, error } = useSWR(input, async (args: typeof input) => {
     // We could make the resourceRef parameter required to avoid this check, but
     // it would make using this hook difficult in situations where the entity
     // must be asynchronously loaded, so instead we short-circuit to a deny when

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -63,7 +63,9 @@ export const ScaffolderPageContents = ({
     },
   };
 
-  const { allowed } = usePermission(catalogEntityCreatePermission);
+  const { allowed } = usePermission({
+    permission: catalogEntityCreatePermission,
+  });
 
   return (
     <Page themeId="home">

--- a/plugins/scaffolder/src/next/TemplateListPage/RegisterExistingButton.tsx
+++ b/plugins/scaffolder/src/next/TemplateListPage/RegisterExistingButton.tsx
@@ -39,7 +39,9 @@ export type RegisterExistingButtonProps = {
  */
 export const RegisterExistingButton = (props: RegisterExistingButtonProps) => {
   const { title, to } = props;
-  const { allowed } = usePermission(catalogEntityCreatePermission);
+  const { allowed } = usePermission({
+    permission: catalogEntityCreatePermission,
+  });
   const isXSScreen = useMediaQuery<BackstageTheme>(theme =>
     theme.breakpoints.down('xs'),
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Targets branch from #10066.

Restrict types such that the `usePermission` hook and `PermissionedRoute` component to ensure that a `resourceRef` is not passed with a `non-resource `Permission` and vice-verse.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
