### PR TITLE
search: check for non-resource permissions when authorizing results

### DIFF
--- a/.changeset/big-mayflies-sin.md
+++ b/.changeset/big-mayflies-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': patch
+---
+
+Check for non-resource permissions when authorizing result-by-result in AuthorizedSearchEngine.

--- a/plugins/search-backend/src/service/AuthorizedSearchEngine.test.ts
+++ b/plugins/search-backend/src/service/AuthorizedSearchEngine.test.ts
@@ -82,24 +82,28 @@ describe('AuthorizedSearchEngine', () => {
       visibilityPermission: createPermission({
         name: 'search.users.read',
         attributes: { action: 'read' },
+        resourceType: 'test-user',
       }),
     },
     [typeTemplates]: {
       visibilityPermission: createPermission({
         name: 'search.templates.read',
         attributes: { action: 'read' },
+        resourceType: 'test-template',
       }),
     },
     [typeServices]: {
       visibilityPermission: createPermission({
         name: 'search.services.read',
         attributes: { action: 'read' },
+        resourceType: 'test-service',
       }),
     },
     [typeGroups]: {
       visibilityPermission: createPermission({
         name: 'search.groups.read',
         attributes: { action: 'read' },
+        resourceType: 'test-group',
       }),
     },
   };

--- a/plugins/search-backend/src/service/AuthorizedSearchEngine.ts
+++ b/plugins/search-backend/src/service/AuthorizedSearchEngine.ts
@@ -21,6 +21,7 @@ import {
   AuthorizeDecision,
   AuthorizeQuery,
   AuthorizeResult,
+  isResourcePermission,
   PermissionAuthorizer,
 } from '@backstage/plugin-permission-common';
 import {
@@ -197,7 +198,11 @@ export class AuthorizedSearchEngine implements SearchEngine {
           const permission = this.types[result.type]?.visibilityPermission;
           const resourceRef = result.document.authorization?.resourceRef;
 
-          if (!permission || !resourceRef) {
+          if (
+            !permission ||
+            !isResourcePermission(permission) ||
+            !resourceRef
+          ) {
             return result;
           }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Targets branch from #10067.

Now that we can differentiate between ResourcePermissions and other kinds of permissions, we can skip authorizing result-by-result when the permission for a given document type is not a ResourcePermission.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
