### PR TITLE
create-app: remove references to remove-plugin

### DIFF
--- a/.changeset/fifty-books-watch.md
+++ b/.changeset/fifty-books-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Removed remove-plugin from package.json scripts when creating a new app. The remove-plugin command has been removed from backstage-cli and resulted in an error when called.

--- a/docs/local-dev/cli-commands.md
+++ b/docs/local-dev/cli-commands.md
@@ -43,7 +43,6 @@ clean                    Delete cache directories
 
 create                   Open up an interactive guide to creating new things in your app
 create-plugin            Creates a new plugin in the current repository
-remove-plugin            Removes plugin in the current repository
 
 config:docs              Browse the configuration reference documentation
 config:print             Print the app configuration for the current package
@@ -304,23 +303,6 @@ Options:
   --npm-registry &lt;URL&gt;  npm registry URL
   --no-private          Public npm package
   -h, --help            display help for command
-```
-
-## remove-plugin
-
-Scope: `root`
-
-A utility to remove a plugin from a repo, essentially undoing everything that
-was done by `create-plugin`.
-
-This is primarily intended as a utility for manual tests and end to end testing
-scripts.
-
-```text
-Usage: backstage-cli remove-plugin [options]
-
-Options:
-  -h, --help  display help for command
 ```
 
 ## plugin:build

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -20,8 +20,7 @@
     "lint": "lerna run lint --since origin/master --",
     "lint:all": "lerna run lint --",
     "prettier:check": "prettier --check .",
-    "create-plugin": "backstage-cli create-plugin --scope internal",
-    "remove-plugin": "backstage-cli remove-plugin"
+    "create-plugin": "backstage-cli create-plugin --scope internal"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR resolves https://github.com/backstage/backstage/issues/10072 by removing the script in `package.json` that calls `remove-plugin`. 

It also removes the documentation for `remove-plugin`. I believe that the documentation is not versioned, so if you prefer to keep the docs around for users of older versions, but mark it as deprecated, I could change that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [N/A] Tests for new functionality and regression tests for bug fixes
I didn't come across any tests for the code generation in create-plugin that covers package.json 
- [N/A] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
