### PR TITLE
Decouple EntityTagPicker from entities

### DIFF
--- a/.changeset/forty-poets-tie.md
+++ b/.changeset/forty-poets-tie.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Decouple tags picker from backend entities
+
+`EntityTagPicker` fetches all the tags independently and it doesn't require all the entities to be available client side.

--- a/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityTagPicker/EntityTagPicker.tsx
@@ -58,10 +58,11 @@ export const EntityTagPicker = () => {
     const facet = 'metadata.tags';
     const { facets } = await catalogApi.getEntityFacets({
       facets: [facet],
+      filter: filters.kind?.getCatalogFilters(),
     });
 
     return facets[facet].map(({ value }) => value);
-  }, []);
+  }, [filters.kind]);
 
   const queryParamTags = useMemo(
     () => [queryParameters.tags].flat().filter(Boolean) as string[],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In `DefaultCatalogPage` some filters require all the entities to be available client side in order to work. Aiming to start leveraging pagination in the CatalogPage, `EntityTagPicker` doesn't require anymore all the entities to be available client side, in order to display all the available tags. All the tags are now fetched using the facets endpoint.

This work, open up some other possible improvements: it is possible to generalize `EntityTagPicker` and `EntityLifecyclePicker` into a unified component, which could also be extended by the adopters to create their own pickers.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
