### PR TITLE
Change header style word-wrap from break-all to break-word

### DIFF
--- a/.changeset/grumpy-rules-fetch.md
+++ b/.changeset/grumpy-rules-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Change header style `word-wrap` from `break-all` to `break-word`

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -66,7 +66,7 @@ const useStyles = makeStyles<BackstageTheme>(
     },
     title: {
       color: theme.palette.bursts.fontColor,
-      wordBreak: 'break-all',
+      wordBreak: 'break-word',
       fontSize: theme.typography.h3.fontSize,
       marginBottom: 0,
     },


### PR DESCRIPTION
Signed-off-by: KaemonIsland <kaemonlovendahl@outlook.com>

## Hey, I just made a Pull Request!

I have just a small change for the `<Header />` component.

We had an issue where a title was wrapping mid-word and thought that it should just move the word to the next line.

Is there specific functionality or preference for a title to be broken up at any point?

Current Behavior:
![lighthouse-break-all](https://user-images.githubusercontent.com/37159349/157325495-37941d32-4bf3-4c30-bc32-cb16196f702a.png)

New Behavior:
![lighthouse-break-word](https://user-images.githubusercontent.com/37159349/157325514-64da5f33-31bf-4d60-a703-9d59224289f1.png)

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
