### PR TITLE
workflows: fix nightly releases of techdocs/cli

### DIFF
--- a/.github/workflows/deploy_nightly.yml
+++ b/.github/workflows/deploy_nightly.yml
@@ -58,6 +58,10 @@ jobs:
       - name: build
         run: yarn backstage-cli repo build
 
+      - name: build embedded techdocs app
+        working-directory: packages/techdocs-cli-embedded-app
+        run: yarn build
+
       # Prepares a nightly release version of any package with pending changesets
       # Pre-mode is exited if case we're in it, otherwise it has no effect
       - name: prepare nightly release


### PR DESCRIPTION
Currently the embedded app needs to be built separately, which we're already doing in the main release flow. I intend to get rid of this need, but needs a bit of refactoring so doing this manually for now.