### PR TITLE
Typo fix for getting started docs

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -276,7 +276,7 @@ otherwise something went terribly wrong.
 
 - Go to `create` and choose to create a website with the `React SSR Template`
 - Type in a name, let's use `tutorial`
-- Select the group `group-a` which will own this new website, and go to the next
+- Select the group `team-a` which will own this new website, and go to the next
   step
 
 <p align='center'>


### PR DESCRIPTION
Signed-off-by: Mihai Tabara <tabara.mihai@gmail.com>

## Hey, I just made a Pull Request!

Tiny typo fix to match the group defined in the pre-loaded catalog entities in [here](https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme/team-a-group.yaml#L4~).