### PR TITLE
Release 0.71.1 with fix for CLI failing to import */package.json - again

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "resolutions": {
     "**/@graphql-codegen/cli/**/ws": "^7.4.6"
   },
-  "version": "0.71.0",
+  "version": "0.71.1",
   "dependencies": {
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.15.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/cli
 
+## 0.15.3
+
+### Patch Changes
+
+- Fixed an issue where the CLI would try and fail to require the `package.json` of other Backstage packages, like `@backstage/dev-utils/package.json`.
+
 ## 0.15.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/cli",
   "description": "CLI for developing Backstage plugins and apps",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/cli/src/lib/version.ts
+++ b/packages/cli/src/lib/version.ts
@@ -19,7 +19,8 @@ import semver from 'semver';
 import { paths } from './paths';
 import { Lockfile } from './versioning';
 
-/* eslint-disable import/no-extraneous-dependencies,monorepo/no-internal-import */
+/* eslint-disable monorepo/no-relative-import */
+
 /*
 This is a list of all packages used by the templates. If dependencies are added or removed,
 this list should be updated as well.
@@ -33,16 +34,16 @@ Rollup will extract the value of the version field in each package at build time
 leaving any imports in place.
 */
 
-import { version as backendCommon } from '@backstage/backend-common/package.json';
-import { version as cli } from '@backstage/cli/package.json';
-import { version as config } from '@backstage/config/package.json';
-import { version as coreAppApi } from '@backstage/core-app-api/package.json';
-import { version as coreComponents } from '@backstage/core-components/package.json';
-import { version as corePluginApi } from '@backstage/core-plugin-api/package.json';
-import { version as devUtils } from '@backstage/dev-utils/package.json';
-import { version as testUtils } from '@backstage/test-utils/package.json';
-import { version as theme } from '@backstage/theme/package.json';
-import { version as scaffolderBackend } from '@backstage/plugin-scaffolder-backend/package.json';
+import { version as backendCommon } from '../../../../packages/backend-common/package.json';
+import { version as cli } from '../../../../packages/cli/package.json';
+import { version as config } from '../../../../packages/config/package.json';
+import { version as coreAppApi } from '../../../../packages/core-app-api/package.json';
+import { version as coreComponents } from '../../../../packages/core-components/package.json';
+import { version as corePluginApi } from '../../../../packages/core-plugin-api/package.json';
+import { version as devUtils } from '../../../../packages/dev-utils/package.json';
+import { version as testUtils } from '../../../../packages/test-utils/package.json';
+import { version as theme } from '../../../../packages/theme/package.json';
+import { version as scaffolderBackend } from '../../../../plugins/scaffolder-backend/package.json';
 
 export const packageVersions: Record<string, string> = {
   '@backstage/backend-common': backendCommon,

--- a/plugins/airbrake/package.json
+++ b/plugins/airbrake/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@backstage/app-defaults": "^0.2.1",
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/allure/package.json
+++ b/plugins/allure/package.json
@@ -40,7 +40,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/analytics-module-ga/package.json
+++ b/plugins/analytics-module-ga/package.json
@@ -38,7 +38,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/apache-airflow/package.json
+++ b/plugins/apache-airflow/package.json
@@ -36,7 +36,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -56,7 +56,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/azure-devops/package.json
+++ b/plugins/azure-devops/package.json
@@ -49,7 +49,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/badges/package.json
+++ b/plugins/badges/package.json
@@ -46,7 +46,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/bazaar/package.json
+++ b/plugins/bazaar/package.json
@@ -47,7 +47,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/dev-utils": "^0.2.25",
     "@testing-library/jest-dom": "^5.10.1",
     "cross-fetch": "^3.1.5"

--- a/plugins/bitrise/package.json
+++ b/plugins/bitrise/package.json
@@ -43,7 +43,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/catalog-graph/package.json
+++ b/plugins/catalog-graph/package.json
@@ -45,10 +45,10 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
-    "@backstage/plugin-catalog": "^0.10.0",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
+    "@backstage/plugin-catalog": "^0.10.0",
     "@backstage/test-utils": "^0.3.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^11.2.5",

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -60,7 +60,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -60,7 +60,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/plugin-permission-react": "^0.3.3",

--- a/plugins/circleci/package.json
+++ b/plugins/circleci/package.json
@@ -55,7 +55,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/cloudbuild/package.json
+++ b/plugins/cloudbuild/package.json
@@ -52,7 +52,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/code-climate/package.json
+++ b/plugins/code-climate/package.json
@@ -40,7 +40,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/code-coverage/package.json
+++ b/plugins/code-coverage/package.json
@@ -46,7 +46,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/config-schema/package.json
+++ b/plugins/config-schema/package.json
@@ -41,7 +41,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/cost-insights/package.json
+++ b/plugins/cost-insights/package.json
@@ -60,7 +60,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/explore/package.json
+++ b/plugins/explore/package.json
@@ -53,7 +53,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/firehydrant/package.json
+++ b/plugins/firehydrant/package.json
@@ -39,7 +39,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/fossa/package.json
+++ b/plugins/fossa/package.json
@@ -53,7 +53,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/gcp-projects/package.json
+++ b/plugins/gcp-projects/package.json
@@ -47,7 +47,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/git-release-manager/package.json
+++ b/plugins/git-release-manager/package.json
@@ -43,7 +43,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/github-actions/package.json
+++ b/plugins/github-actions/package.json
@@ -55,7 +55,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/github-deployments/package.json
+++ b/plugins/github-deployments/package.json
@@ -43,7 +43,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/gitops-profiles/package.json
+++ b/plugins/gitops-profiles/package.json
@@ -48,7 +48,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/gocd/package.json
+++ b/plugins/gocd/package.json
@@ -49,7 +49,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/graphiql/package.json
+++ b/plugins/graphiql/package.json
@@ -48,7 +48,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -52,7 +52,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/ilert/package.json
+++ b/plugins/ilert/package.json
@@ -43,7 +43,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/jenkins/package.json
+++ b/plugins/jenkins/package.json
@@ -54,7 +54,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/kafka/package.json
+++ b/plugins/kafka/package.json
@@ -39,7 +39,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/kubernetes/package.json
+++ b/plugins/kubernetes/package.json
@@ -56,7 +56,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/lighthouse/package.json
+++ b/plugins/lighthouse/package.json
@@ -51,7 +51,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/newrelic-dashboard/package.json
+++ b/plugins/newrelic-dashboard/package.json
@@ -34,7 +34,7 @@
     "react-use": "^17.2.4"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/dev-utils": "^0.2.25",
     "@testing-library/jest-dom": "^5.10.1",
     "@types/react": "^16.13.1 || ^17.0.0",

--- a/plugins/newrelic/package.json
+++ b/plugins/newrelic/package.json
@@ -47,7 +47,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/org/package.json
+++ b/plugins/org/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@backstage/catalog-client": "^0.9.0",
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/pagerduty/package.json
+++ b/plugins/pagerduty/package.json
@@ -52,7 +52,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/periskop/package.json
+++ b/plugins/periskop/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/rollbar/package.json
+++ b/plugins/rollbar/package.json
@@ -53,7 +53,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -73,7 +73,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/plugin-catalog": "^0.10.0",

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -56,7 +56,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -52,7 +52,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/shortcuts/package.json
+++ b/plugins/shortcuts/package.json
@@ -42,7 +42,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/sonarqube/package.json
+++ b/plugins/sonarqube/package.json
@@ -53,7 +53,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/splunk-on-call/package.json
+++ b/plugins/splunk-on-call/package.json
@@ -51,7 +51,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/tech-insights/package.json
+++ b/plugins/tech-insights/package.json
@@ -42,7 +42,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/tech-radar/package.json
+++ b/plugins/tech-radar/package.json
@@ -49,7 +49,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -65,7 +65,7 @@
     "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/todo/package.json
+++ b/plugins/todo/package.json
@@ -45,7 +45,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",
@@ -55,8 +55,8 @@
     "@types/jest": "^26.0.7",
     "@types/node": "^14.14.32",
     "cross-fetch": "^3.1.5",
-    "react-router": "6.0.0-beta.0",
-    "msw": "^0.35.0"
+    "msw": "^0.35.0",
+    "react-router": "6.0.0-beta.0"
   },
   "files": [
     "dist"

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -47,7 +47,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",

--- a/plugins/xcmetrics/package.json
+++ b/plugins/xcmetrics/package.json
@@ -40,7 +40,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.15.2",
+    "@backstage/cli": "^0.15.3",
     "@backstage/core-app-api": "^0.6.0",
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",


### PR DESCRIPTION
This release fixes an issue where the Backstage CLI would try and fail to require the package.json of other Backstage packages, like @backstage/dev-utils/package.json.