### PR TITLE
Docs fix for tutorial Github repo config

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -218,8 +218,10 @@ for 7 days, it's a lucky number.
   <img src='../assets/getting-started/gh-pat.png' alt='Screenshot of the GitHub Personal Access Token creation page' />
 </p>
 
-Set the scope to your likings. For this tutorial, selecting "repo" should be
-enough.
+Set the scope to your likings. For this tutorial, selecting `workflow` should be
+enough. (Note: using `repo` won't suffice as the Scaffolder template contains
+a Github Action manifest defined in `.github/workflows/build.yml` during the
+initialization of the repo)
 
 In the `app-config.yaml`, search for `integrations:` and add your token, like we
 did in below example:


### PR DESCRIPTION
Signed-off-by: Mihai Tabara <tabara.mihai@gmail.com>

## Hey, I just made a Pull Request!

Tiny docs fix to match the expected role on the Github API side.
If my understanding is correct from the logs, during the initialisation phase in Backstage the following happen:
1) fetch the skeleton + template for the repo - this is public so it doesn't need any special auth permissions
2) publish the website - multiple steps here
* init git repository - for this operation `repo` role suffices as it allows for private repo creation. At this point the repo has no actual code but it's correctly initialised in Github
* add the template files and publish repo - Scaffolder also includes a `.github/workflows/build.yml` to define basic workflow at which point the Backstage Publish step fails due to missing scopes as depicted below

<img width="1046" alt="Screenshot 2022-03-10 at 17 30 44" src="https://user-images.githubusercontent.com/103932/157721190-ff77b147-108e-458b-bce2-7dd56927c231.png">

Once the token is enriched with `workflow` scope, the publishing works as expected and continues to step 3) by Registering the component in the local Backstage instance. (see below)

![Screenshot 2022-03-10 at 17 34 01](https://user-images.githubusercontent.com/103932/157721713-4b57cd87-dc65-4ad2-8e8d-0f00b061435b.png)
