### PR TITLE
Updated Azure discovery docs after move to seperate package

### DIFF
--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -12,6 +12,34 @@ DevOps organization and register entities matching the configured path. This can
 be useful as an alternative to static locations or manually adding things to the
 catalog.
 
+## Installation
+
+You will have to add the processors in the catalog initialization code of your
+backend. They are not installed by default, therefore you have to add a
+dependency to `@backstage/plugin-catalog-backend-module-azure` to your backend
+package.
+
+```bash
+# From your Backstage root directory
+cd packages/backend
+yarn add @backstage/plugin-catalog-backend-module-azure
+```
+
+And then add the processors to your catalog builder:
+
+```diff
+// In packages/backend/src/plugins/catalog.ts
++import { AzureDevOpsDiscoveryProcessor } from '@backstage/plugin-catalog-backend-module-azure';
+
+ export default async function createPlugin(
+   env: PluginEnvironment,
+ ): Promise<Router> {
+   const builder = await CatalogBuilder.create(env);
++  builder.addProcessor(AzureDevOpsDiscoveryProcessor.fromConfig(env.config, { logger: env.logger }));
+```
+
+## Configuration
+
 To use the discovery processor, you'll need a Azure integration
 [set up](locations.md) with a `AZURE_TOKEN`. Then you can add a location target
 to the catalog configuration:


### PR DESCRIPTION
Signed-off-by: Alex Crome <afscrome@users.noreply.github.com>

## Hey, I just made a Pull Request!

Updated the Azure Discovery docs to work with recent package changes to extract `plugin-catalog-backend-module-azure` to it's own package.

This change mostly replicates the change from the github discovery doc, with appropriate changes for Azure.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
