### PR TITLE
fix react testing lib version in gcalendar

### DIFF
--- a/plugins/gcalendar/package.json
+++ b/plugins/gcalendar/package.json
@@ -47,7 +47,7 @@
     "@backstage/dev-utils": "^0.2.25",
     "@backstage/test-utils": "^0.3.0",
     "@testing-library/jest-dom": "^5.10.1",
-    "@testing-library/react": "^11.2.5",
+    "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.1.8",
     "@types/dompurify": "^2.3.3",
     "@types/gapi": "^0.0.41",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12012,6 +12012,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     "@backstage/plugin-code-coverage" "^0.1.29"
     "@backstage/plugin-cost-insights" "^0.11.24"
     "@backstage/plugin-explore" "^0.3.33"
+    "@backstage/plugin-gcalendar" "^0.1.0"
     "@backstage/plugin-gcp-projects" "^0.3.21"
     "@backstage/plugin-github-actions" "^0.5.2"
     "@backstage/plugin-gocd" "^0.1.8"


### PR DESCRIPTION
This fixes a lingering missing yarn.lock change. Skipping changeset since it was merged basically minutes ago