### PR TITLE
Fix ReferenceError: database is not defined after create-app

### DIFF
--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/search.ts.hbs
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/search.ts.hbs
@@ -16,6 +16,9 @@ export default async function createPlugin({
   permissions,
   discovery,
   config,
+  {{#if dbTypePG}}
+  database,
+  {{/if}}
   tokenManager,
 }: PluginEnvironment) {
   // Initialize a connection to a search engine.


### PR DESCRIPTION
Fix create app template.

Backend failed to start up, ReferenceError: database is not defined