### PR TITLE
cli: fix test file matching

### DIFF
--- a/.changeset/great-pots-fetch.md
+++ b/.changeset/great-pots-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': minor
+---
+
+**BREAKING**: The provided Jest configuration now only matches files with a `.test.` infix, rather than any files that is suffixed with `test.<ext>`. In particular this means that files named just `test.ts` will no longer be considered a test file.

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -112,7 +112,7 @@ async function getProjectConfig(targetPath, displayName) {
     },
 
     // A bit more opinionated
-    testMatch: ['**/?(*.)test.{js,jsx,ts,tsx,mjs,cjs}'],
+    testMatch: ['**/*.test.{js,jsx,ts,tsx,mjs,cjs}'],
 
     transformIgnorePatterns: [`/node_modules/(?:${transformIgnorePattern})/`],
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#1655 didn't really ever intend to make it a suffix iirc, so this is really a bugfix. Things like `test.ts` and `my-test.ts` should not be considered tests x) It's been around for a very long time though, so marking it as breaking etc. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
