### PR TITLE
WIP: Make search result list items first-class extensions.

### DIFF
--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -39,7 +39,7 @@ import {
   useSearch,
 } from '@backstage/plugin-search';
 import { TechDocsSearchResultListItem } from '@backstage/plugin-techdocs';
-import { Grid, List, makeStyles, Paper, Theme } from '@material-ui/core';
+import { Grid, makeStyles, Paper, Theme } from '@material-ui/core';
 import React, { useContext } from 'react';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -130,35 +130,9 @@ const SearchPage = () => {
           )}
           <Grid item xs>
             <SearchResult>
-              {({ results }) => (
-                <List>
-                  {results.map(({ type, document }) => {
-                    switch (type) {
-                      case 'software-catalog':
-                        return (
-                          <CatalogSearchResultListItem
-                            key={document.location}
-                            result={document}
-                          />
-                        );
-                      case 'techdocs':
-                        return (
-                          <TechDocsSearchResultListItem
-                            key={document.location}
-                            result={document}
-                          />
-                        );
-                      default:
-                        return (
-                          <DefaultResultListItem
-                            key={document.location}
-                            result={document}
-                          />
-                        );
-                    }
-                  })}
-                </List>
-              )}
+              <CatalogSearchResultListItem />
+              <TechDocsSearchResultListItem />
+              <DefaultResultListItem />
             </SearchResult>
             <SearchResultPager />
           </Grid>

--- a/packages/create-app/templates/default-app/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/search/SearchPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme, Grid, List, Paper } from '@material-ui/core';
+import { makeStyles, Theme, Grid, Paper } from '@material-ui/core';
 
 import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';
 import {
@@ -110,35 +110,9 @@ const SearchPage = () => {
           </Grid>
           <Grid item xs={9}>
             <SearchResult>
-              {({ results }) => (
-                <List>
-                  {results.map(({ type, document }) => {
-                    switch (type) {
-                      case 'software-catalog':
-                        return (
-                          <CatalogSearchResultListItem
-                            key={document.location}
-                            result={document}
-                          />
-                        );
-                      case 'techdocs':
-                        return (
-                          <TechDocsSearchResultListItem
-                            key={document.location}
-                            result={document}
-                          />
-                        );
-                      default:
-                        return (
-                          <DefaultResultListItem
-                            key={document.location}
-                            result={document}
-                          />
-                        );
-                    }
-                  })}
-                </List>
-              )}
+              <CatalogSearchResultListItem />
+              <TechDocsSearchResultListItem />
+              <DefaultResultListItem />
             </SearchResult>
           </Grid>
         </Grid>

--- a/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
+++ b/plugins/catalog/src/components/CatalogSearchResultListItem/CatalogSearchResultListItem.tsx
@@ -25,6 +25,9 @@ import {
 } from '@material-ui/core';
 import { Link } from '@backstage/core-components';
 import { IndexableDocument } from '@backstage/plugin-search-common';
+import { CatalogEntityDocument } from '@backstage/plugin-catalog-common';
+import { SearchResultItemProps } from '@backstage/plugin-search';
+import { useAnalytics } from '@backstage/core-plugin-api';
 
 const useStyles = makeStyles({
   flexContainer: {
@@ -48,13 +51,17 @@ export interface CatalogSearchResultListItemProps {
 
 /** @public */
 export function CatalogSearchResultListItem(
-  props: CatalogSearchResultListItemProps,
+  props: SearchResultItemProps<CatalogEntityDocument>,
 ) {
-  const result = props.result as any;
-
+  const { rank, result } = props;
+  const analytics = useAnalytics();
+  const trackClick = () => analytics.captureEvent('click', result.title, {
+    attributes: { to: result.location },
+    value: rank,
+  });
   const classes = useStyles();
   return (
-    <Link to={result.location}>
+    <Link to={result.location} noTrack onClick={trackClick}>
       <ListItem alignItems="flex-start" className={classes.flexContainer}>
         <ListItemText
           className={classes.itemText}

--- a/plugins/catalog/src/index.ts
+++ b/plugins/catalog/src/index.ts
@@ -29,7 +29,6 @@ export type {
 } from './components/AboutCard';
 export { AboutContent, AboutField } from './components/AboutCard';
 export * from './components/CatalogKindHeader';
-export * from './components/CatalogSearchResultListItem';
 export * from './components/CatalogTable';
 export * from './components/EntityLayout';
 export * from './components/EntityOrphanWarning';
@@ -41,6 +40,7 @@ export {
   CatalogEntityPage,
   CatalogIndexPage,
   catalogPlugin,
+  CatalogSearchResultListItem,
   EntityAboutCard,
   EntityDependencyOfComponentsCard,
   EntityDependsOnComponentsCard,

--- a/plugins/catalog/src/plugin.ts
+++ b/plugins/catalog/src/plugin.ts
@@ -43,6 +43,9 @@ import { HasSubcomponentsCardProps } from './components/HasSubcomponentsCard';
 import { HasSystemsCardProps } from './components/HasSystemsCard';
 import { RelatedEntitiesCardProps } from './components/RelatedEntitiesCard';
 import { rootRouteRef } from './routes';
+import { createSearchResultExtension } from '@backstage/plugin-search/src/extensions';
+import { CatalogSearchResultListItem as CatalogSearchResultListItemComponent } from './components/CatalogSearchResultListItem';
+import { CatalogEntityDocument } from '@backstage/plugin-catalog-common';
 
 /** @public */
 export const catalogPlugin = createPlugin({
@@ -93,6 +96,15 @@ export const CatalogEntityPage: () => JSX.Element = catalogPlugin.provide(
       import('./components/CatalogEntityPage').then(m => m.CatalogEntityPage),
     mountPoint: entityRouteRef,
   }),
+);
+
+/** @public */
+export const CatalogSearchResultListItem = catalogPlugin.provide(
+  createSearchResultExtension<CatalogEntityDocument>({
+    name: 'CatalogSearchResultListItem',
+    component: CatalogSearchResultListItemComponent,
+    filterPredicate: (result) => result.type === 'software-catalog',
+  })
 );
 
 /** @public */

--- a/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.tsx
+++ b/plugins/search/src/components/DefaultResultListItem/DefaultResultListItem.tsx
@@ -15,7 +15,6 @@
  */
 
 import React, { ReactNode } from 'react';
-import { IndexableDocument } from '@backstage/plugin-search-common';
 import {
   ListItem,
   ListItemIcon,
@@ -24,12 +23,14 @@ import {
   Divider,
 } from '@material-ui/core';
 import { Link } from '@backstage/core-components';
+import { IndexableDocument } from '@backstage/plugin-search-common';
 import TextTruncate from 'react-text-truncate';
+import { SearchResultItemProps } from '../../extensions';
+import { useAnalytics } from '@backstage/core-plugin-api';
 
-type Props = {
+export type DefaultResultListItemProps = {
   icon?: ReactNode;
   secondaryAction?: ReactNode;
-  result: IndexableDocument;
   lineClamp?: number;
 };
 
@@ -38,9 +39,15 @@ export const DefaultResultListItem = ({
   icon,
   secondaryAction,
   lineClamp = 5,
-}: Props) => {
+  rank,
+}: SearchResultItemProps<IndexableDocument, DefaultResultListItemProps>) => {
+  const analytics = useAnalytics();
+  const trackClick = () => analytics.captureEvent('click', result.title, {
+    attributes: { to: result.location },
+    value: rank,
+  });
   return (
-    <Link to={result.location}>
+    <Link to={result.location} noTrack onClick={trackClick}>
       <ListItem alignItems="center">
         {icon && <ListItemIcon>{icon}</ListItemIcon>}
         <ListItemText

--- a/plugins/search/src/components/DefaultResultListItem/index.ts
+++ b/plugins/search/src/components/DefaultResultListItem/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { DefaultResultListItem } from './DefaultResultListItem';
+export type { DefaultResultListItemProps } from './DefaultResultListItem';

--- a/plugins/search/src/components/SearchModal/SearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/SearchModal.tsx
@@ -119,7 +119,7 @@ export const Modal = ({ toggleModal }: SearchModalProps) => {
         <SearchResult>
           {({ results }) => (
             <List>
-              {results.map(({ document }) => (
+              {results.map(({ document }, index) => (
                 <div
                   role="button"
                   tabIndex={0}
@@ -130,6 +130,7 @@ export const Modal = ({ toggleModal }: SearchModalProps) => {
                   <DefaultResultListItem
                     key={document.location}
                     result={document}
+                    rank={index + 1}
                   />
                 </div>
               ))}

--- a/plugins/search/src/extensions.tsx
+++ b/plugins/search/src/extensions.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { createReactExtension, Extension } from '@backstage/core-plugin-api';
+import { IndexableDocument, SearchResult } from '@backstage/plugin-search-common';
+
+export const RESULT_EXTENSION_WRAPPER_KEY = 'search.extensions.result_wrapper.v1';
+export const RESULT_EXTENSION_KEY = 'search.extensions.result.v1';
+
+/**
+ * Represents the component exposed as an extension when a plugin provides a
+ * Search Result extension via the `createSearchResultExtension` function.
+ * 
+ * Note that the props of this component can vary:
+ * 
+ * - The props may only consist of `TComponentProps` when the extension is
+ *   being configured (e.g. within a `<SearchResult>` component).
+ * - The props represent a full `SearchResultItemProps` when the extension is
+ *   actually being rendered.
+ *
+ * @public
+ */
+ export type SearchResultExtensionComponent<TResultType extends IndexableDocument = IndexableDocument, TComponentProps = {}> = (props: (SearchResultItemProps<TResultType, TComponentProps> | TComponentProps)) => JSX.Element | null;
+
+ /**
+  * A type used to represent the props that a search result extension expects
+  * to receive. This covers both any component-specific props (supplied via the
+  * `TComponentProps` generic), as well as the result itself (defaulting to the
+  * generic `IndexableDocument` type, but extendable via the `TResultType`
+  * generic).
+  * 
+  * @public
+  */
+ export type SearchResultItemProps<TResultType extends IndexableDocument = IndexableDocument, TComponentProps = {}> = TComponentProps & {
+   result: TResultType,
+   rank: number;
+ };
+
+/**
+ * Options for creating a Search Result extension. The `component` is what's
+ * rendered for a given search result that matches the given `filterPredicate`.
+ *
+ * @public
+ */
+ export type SearchResultExtensionOptions<TResultType extends IndexableDocument = IndexableDocument, TComponentProps = {}> = {
+   name: string;
+   component: (
+     props: SearchResultItemProps<TResultType, TComponentProps>,
+   ) => JSX.Element | null;
+   filterPredicate: (result: SearchResult) => boolean;
+};
+
+/**
+ * Type guard that helps typescript differentiate between directly rendered
+ * result list item components and those merely representing configuration.
+ */
+const resultIsProvided = (props: SearchResultItemProps | {}): props is SearchResultItemProps => {
+  return props.hasOwnProperty('result');
+}
+
+/**
+ * Creates a Search Result extension.
+ *
+ * @public
+ */
+ export function createSearchResultExtension<TResultType extends IndexableDocument = IndexableDocument, TComponentProps = {}>(
+ options: SearchResultExtensionOptions<TResultType, TComponentProps>,
+): Extension<SearchResultExtensionComponent<TResultType, TComponentProps>> {
+  const { component: Component, filterPredicate, name } = options;
+  const extension = createReactExtension<SearchResultExtensionComponent<TResultType, TComponentProps>>({
+    name,
+    component: {
+      sync: (props) => {
+        // When a result is provided via the props, the component should be
+        // rendered normally. Otherwise, the component represents configuration
+        // and should not be rendered normally.
+        if (resultIsProvided(props)) {
+          return <Component {...props} />;
+        }
+
+        return null;
+      }
+    },
+    data: {
+      [RESULT_EXTENSION_KEY]: {
+        filterPredicate,
+      },
+    },
+  });
+
+  return extension;
+}

--- a/plugins/search/src/index.ts
+++ b/plugins/search/src/index.ts
@@ -64,3 +64,6 @@ export {
   SearchResult,
   SidebarSearchModal,
 } from './plugin';
+
+export { createSearchResultExtension } from './extensions';
+export type { SearchResultItemProps } from './extensions';

--- a/plugins/search/src/plugin.ts
+++ b/plugins/search/src/plugin.ts
@@ -24,6 +24,9 @@ import {
   createComponentExtension,
   identityApiRef,
 } from '@backstage/core-plugin-api';
+import { DefaultResultListItem as DefaultResultListItemComponent, DefaultResultListItemProps } from './components/DefaultResultListItem';
+import { createSearchResultExtension } from './extensions';
+import { IndexableDocument } from '@backstage/plugin-search-common';
 
 export const rootRouteRef = createRouteRef({
   id: 'search',
@@ -133,14 +136,10 @@ export const SidebarSearchModal = searchPlugin.provide(
 );
 
 export const DefaultResultListItem = searchPlugin.provide(
-  createComponentExtension({
+  createSearchResultExtension<IndexableDocument, DefaultResultListItemProps>({
     name: 'DefaultResultListItem',
-    component: {
-      lazy: () =>
-        import('./components/DefaultResultListItem').then(
-          m => m.DefaultResultListItem,
-        ),
-    },
+    component: DefaultResultListItemComponent,
+    filterPredicate: () => true,
   }),
 );
 

--- a/plugins/techdocs/src/index.ts
+++ b/plugins/techdocs/src/index.ts
@@ -32,6 +32,7 @@ export {
   TechDocsIndexPage,
   TechdocsPage,
   TechDocsReaderPage,
+  TechDocsSearchResultListItem,
   techdocsPlugin as plugin,
   techdocsPlugin,
 } from './plugin';

--- a/plugins/techdocs/src/plugin.ts
+++ b/plugins/techdocs/src/plugin.ts
@@ -30,6 +30,12 @@ import {
   fetchApiRef,
   identityApiRef,
 } from '@backstage/core-plugin-api';
+import { createSearchResultExtension } from '@backstage/plugin-search';
+import {
+  TechDocsSearchResultListItemProps,
+  TechDocsSearchResultListItem as TechDocsSearchResultListItemCompoonent,
+} from './search/components/TechDocsSearchResultListItem';
+import { IndexableDocument } from '@backstage/plugin-search-common';
 
 /**
  * The Backstage plugin that renders technical documentation for your components
@@ -149,4 +155,15 @@ export const TechDocsReaderPage = techdocsPlugin.provide(
       ),
     mountPoint: rootDocsRouteRef,
   }),
+);
+
+/**
+ * @public
+ */
+export const TechDocsSearchResultListItem = techdocsPlugin.provide(
+  createSearchResultExtension<IndexableDocument, TechDocsSearchResultListItemProps>({
+    name: 'TechDocsSearchResultListItem',
+    component: TechDocsSearchResultListItemCompoonent,
+    filterPredicate: (result) => result.type === 'techdocs',
+  })
 );

--- a/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
+++ b/plugins/techdocs/src/search/components/TechDocsSearchResultListItem.tsx
@@ -18,6 +18,9 @@ import React, { PropsWithChildren } from 'react';
 import { Divider, ListItem, ListItemText, makeStyles } from '@material-ui/core';
 import { Link } from '@backstage/core-components';
 import TextTruncate from 'react-text-truncate';
+import { SearchResultItemProps } from '@backstage/plugin-search';
+import { useAnalytics } from '@backstage/core-plugin-api';
+import { IndexableDocument } from '@backstage/plugin-search-common';
 
 const useStyles = makeStyles({
   flexContainer: {
@@ -35,7 +38,6 @@ const useStyles = makeStyles({
  * @public
  */
 export type TechDocsSearchResultListItemProps = {
-  result: any;
   lineClamp?: number;
   asListItem?: boolean;
   asLink?: boolean;
@@ -48,7 +50,7 @@ export type TechDocsSearchResultListItemProps = {
  * @public
  */
 export const TechDocsSearchResultListItem = (
-  props: TechDocsSearchResultListItemProps,
+  props: SearchResultItemProps<IndexableDocument, TechDocsSearchResultListItemProps>,
 ) => {
   const {
     result,
@@ -56,8 +58,14 @@ export const TechDocsSearchResultListItem = (
     asListItem = true,
     asLink = true,
     title,
+    rank,
   } = props;
   const classes = useStyles();
+  const analytics = useAnalytics();
+  const trackClick = () => analytics.captureEvent('click', result.title, {
+    attributes: { to: result.location },
+    value: rank,
+  })
   const TextItem = () => (
     <ListItemText
       className={classes.itemText}
@@ -65,7 +73,7 @@ export const TechDocsSearchResultListItem = (
       primary={
         title
           ? title
-          : `${result.title} | ${result.entityTitle ?? result.name} docs`
+          : `${result.title} | ${(result as any).entityTitle ?? (result as any).name} docs`
       }
       secondary={
         <TextTruncate
@@ -79,7 +87,7 @@ export const TechDocsSearchResultListItem = (
   );
 
   const LinkWrapper = ({ children }: PropsWithChildren<{}>) =>
-    asLink ? <Link to={result.location}>{children}</Link> : <>{children}</>;
+    asLink ? <Link to={result.location} noTrack onClick={trackClick}>{children}</Link> : <>{children}</>;
 
   const ListItemWrapper = ({ children }: PropsWithChildren<{}>) =>
     asListItem ? (

--- a/plugins/techdocs/src/search/components/index.ts
+++ b/plugins/techdocs/src/search/components/index.ts
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-export * from './TechDocsSearchResultListItem';
 export * from './TechDocsSearch';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

An exploration of what it might look like to create a first-class search result extension type.\

```tsx
<SearchResult>
  <CatalogSearchResultListItem />
  <TechDocsSearchResultListItem lineClamp={2} />
  <DefaultResultListItem />
</SearchResult>
```

Why?

- Reduce boilerplate in search UI code
- Improve type handling within result components
- Abstract away direct search result rendering from integrators so that we can handle some things on their behalf (notably, capturing search result rank on click)

This (very WIP) PR gets close, but after working through it, I think a slightly different approach might be in order:
- Instead of trying to support both the function-based and the extension-based result rendering...  We might introduce the extension-based rendering as a separate component (e.g. `<SearchResults>` vs. the existing `<SearchResult>`).
- It'd be great to avoid passing down the `rank` to the component and handling click tracking from within the search plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
