### PR TITLE
[TechDocs] [Search] Final release, old common packages

### DIFF
--- a/.changeset/search-pour-one-out-common.md
+++ b/.changeset/search-pour-one-out-common.md
@@ -1,0 +1,5 @@
+---
+'@backstage/search-common': patch
+---
+
+This package is no longer maintained. Use `@backstage/plugin-search-common`, going forward.

--- a/.changeset/techdocs-pour-one-out-common.md
+++ b/.changeset/techdocs-pour-one-out-common.md
@@ -1,0 +1,5 @@
+---
+'@backstage/techdocs-common': patch
+---
+
+This package is no longer maintained. Use `@backstage/plugin-techdocs-node`, going forward.

--- a/packages/search-common/README.md
+++ b/packages/search-common/README.md
@@ -1,7 +1,5 @@
 # @backstage/search-common
 
-**WARNING**: This package is moving to `@backstage/plugin-search-common`.
-Please update any dependencies you may have, as this package will no longer be
-published or updated in the near future.
-
-Common functionalities for Search, to be shared between various search-enabled plugins.
+This package has been moved to `@backstage/plugin-search-common` and is no
+longer maintained. Please update any dependencies you have on this package
+accordingly.

--- a/packages/search-common/package.json
+++ b/packages/search-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/search-common",
-  "description": "Common functionalities for Search, to be shared between various search-enabled plugins",
+  "description": "No longer maintained. Use @backstage/plugin-search-common instead.",
   "version": "0.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -19,10 +19,6 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/search-common"
   },
-  "keywords": [
-    "backstage",
-    "search"
-  ],
   "license": "Apache-2.0",
   "files": [
     "dist"
@@ -39,7 +35,7 @@
     "url": "https://github.com/backstage/backstage/issues"
   },
   "dependencies": {
-    "@backstage/plugin-search-common": "^0.3.1"
+    "@backstage/plugin-search-common": "0.3.1"
   },
   "devDependencies": {},
   "jest": {

--- a/packages/techdocs-common/README.md
+++ b/packages/techdocs-common/README.md
@@ -1,53 +1,5 @@
 # @backstage/techdocs-common
 
-**WARNING**: This package is moving to `@backstage/plugin-techdocs-node`.
-Please update any dependencies you may have, as this package will no longer be
-published or updated in the near future.
-
-Common node.js functionalities for TechDocs, to be shared between techdocs-backend plugin and techdocs-cli
-
-This package is used by `techdocs-backend` to serve docs from different types of publishers (Google GCS, Local, etc.).
-It is also used to build docs and publish them to storage, by both `techdocs-backend` and `techdocs-cli`.
-
-## Usage
-
-Create a preparer instance from the [preparers available](/plugins/techdocs-node/src/stages/prepare) at which takes an Entity instance.
-Run the [docs generator](/plugins/techdocs-node/src/stages/generate) on the prepared directory.
-Publish the generated directory files to a [storage](/plugins/techdocs-node/src/stages/publish) of your choice.
-
-Example:
-
-```js
-async () => {
-  const preparedDir = await preparer.prepare(entity);
-
-  const parsedLocationAnnotation = getLocationForEntity(entity);
-  const { resultDir } = await generator.run({
-    directory: preparedDir,
-    dockerClient: dockerClient,
-    parsedLocationAnnotation,
-  });
-
-  await publisher.publish({
-    entity: entity,
-    directory: resultDir,
-  });
-};
-```
-
-## Features
-
-Currently the build process is split up in these three stages.
-
-- Preparers
-- Generators
-- Publishers
-
-Preparers read your entity data and creates a working directory with your documentation source code. For example if you have set your `backstage.io/techdocs-ref` to `url:https://github.com/backstage/backstage.git` it will clone that repository to a temp folder and pass that on to the generator.
-
-Generators takes the prepared source and runs the `techdocs-container` on it. It then passes on the output folder of that build to the publisher.
-
-Publishers gets a folder path from the generator and publish it to your storage solution. Read documentation to know more about configuring storage solutions.
-http://backstage.io/docs/features/techdocs/configuration
-
-Any of these can be extended. We want to extend our support to most of the storage providers (Publishers) and source code host providers (Preparers).
+This package has been moved to `@backstage/plugin-techdocs-node` and is no
+longer maintained. Please update any dependencies you have on this package
+accordingly.

--- a/packages/techdocs-common/package.json
+++ b/packages/techdocs-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/techdocs-common",
-  "description": "Common node.js functionalities for TechDocs, to be shared between techdocs-backend plugin and techdocs-cli",
+  "description": "No longer maintained. Use @backstage/plugin-techdocs-node instead.",
   "version": "0.11.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -19,10 +19,6 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/techdocs-common"
   },
-  "keywords": [
-    "techdocs",
-    "backstage"
-  ],
   "license": "Apache-2.0",
   "files": [
     "dist"
@@ -40,7 +36,7 @@
     "url": "https://github.com/backstage/backstage/issues"
   },
   "dependencies": {
-    "@backstage/plugin-techdocs-node": "^0.11.12"
+    "@backstage/plugin-techdocs-node": "0.11.12"
   },
   "devDependencies": {},
   "jest": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Last release of the old Search/TechDocs common packages:

- Updates the `README.md`s to indicate deprecation
- Very clearly marks them as deprecated in `package.json` metadata
- Pins the dependency of each to the most recent version.

Once this release is out, one of the maintainers will want to deprecate these packages on NPM as well.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
