### PR TITLE
permission-docs: adjust tutorial structure

### DIFF
--- a/docs/permission/overview.md
+++ b/docs/permission/overview.md
@@ -38,4 +38,4 @@ The permission framework was designed with a few key properties in mind:
 
 See the "[getting started](./getting-started.md)" permission documentation for Backstage integrators.
 
-If you are a plugin author, see the permission [documentation for plugin authors](plugin-authors/setup-for-the-tutorial.md) on how to integrate permissions into your plugin.
+If you are a plugin author, see the permission [documentation for plugin authors](plugin-authors/01-setup.md) on how to integrate permissions into your plugin.

--- a/docs/permission/plugin-authors/01-setup.md
+++ b/docs/permission/plugin-authors/01-setup.md
@@ -1,12 +1,12 @@
 ---
-id: setup-for-the-tutorial
-title: Permission framework for plugin authors
+id: 01-setup
+title: 1. Tutorial setup
 description: How to get started with the permission framework as a plugin author
 ---
 
 The following tutorial is designed to help plugin authors add support for permissions to their plugins. We'll add support for permissions to example `todo-list` and `todo-list-backend` plugins, but the process should be similar for other plugins!
 
-The rest of this page is focused on adding the `todo-list` and `todo-list-backend` plugins to your Backstage instance. If you want to add support for permissions to your own plugin instead, feel free to skip to the [next section](authorize-the-create-endpoint.md).
+The rest of this page is focused on adding the `todo-list` and `todo-list-backend` plugins to your Backstage instance. If you want to add support for permissions to your own plugin instead, feel free to skip to the [next section](./02-adding-a-basic-permission-check.md).
 
 ## Setup for the Tutorial
 

--- a/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
+++ b/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
@@ -1,7 +1,7 @@
 ---
-id: authorize-the-create-endpoint
-title: Authorize the create endpoint
-description: Authorize the create endpoint
+id: 02-adding-a-basic-permission-check
+title: 2. Adding a basic permission check
+description: Explains how to add a basic permission check to a Backstage plugin
 ---
 
 The first step we need to do in order to authorize the create endpoint, is to create a new `permission` inside our backend plugin.

--- a/docs/permission/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permission/plugin-authors/03-adding-a-resource-permission-check.md
@@ -1,7 +1,7 @@
 ---
-id: authorize-the-update-endpoint
-title: Authorize the update endpoint
-description: Authorize the update endpoint
+id: 03-adding-a-resource-permission-check
+title: 3. Adding a resource permission check
+description: Explains how to add a resource permission check to a Backstage plugin
 ---
 
 When performing updates (or other operations) on specific resources, the permissions framework allows for the decision to be based on characteristics of the resource itself. This means that it's possible to write policies that (for example) allow the operation for users that own a resource, and deny the operation otherwise.

--- a/docs/permission/plugin-authors/04-authorizing-access-to-paginated-data.md
+++ b/docs/permission/plugin-authors/04-authorizing-access-to-paginated-data.md
@@ -1,7 +1,7 @@
 ---
-id: authorize-the-read-endpoint
-title: Authorize the read endpoint
-description: Authorize the read endpoint
+id: 04-authorizing-access-to-paginated-data
+title: 4. Authorizing access to paginated data
+description: Explains how to authorize access to paginated data in a Backstage plugin
 ---
 
 Authorizing `GET /todos` is similar to the update endpoint, in that it should be possible to authorize read access to todo entries based on their characteristics. When a `GET /todos` request is received, only the items that the user is permitted to see should be returned.

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -256,12 +256,12 @@
       "permission/concepts",
       {
         "type": "subcategory",
-        "label": "Permission framework for plugin authors",
+        "label": "Tutorial: using Permissions in your plugin",
         "ids": [
-          "permission/plugin-authors/setup-for-the-tutorial",
-          "permission/plugin-authors/authorize-the-create-endpoint",
-          "permission/plugin-authors/authorize-the-update-endpoint",
-          "permission/plugin-authors/authorize-the-read-endpoint"
+          "permission/plugin-authors/01-setup",
+          "permission/plugin-authors/02-adding-a-basic-permission-check",
+          "permission/plugin-authors/03-adding-a-resource-permission-check",
+          "permission/plugin-authors/04-authorizing-access-to-paginated-data"
         ]
       }
     ],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Targets the long-lived `permission-docs` branch.**

Addresses [this comment](https://github.com/backstage/backstage/pull/9702#pullrequestreview-896956359) by adjusting the structure of the plugin author tutorial in the permissions docs. Also adjusts some content in the tutorial docs to match the new titles a bit better, and sneaks in a few other tweaks along the way - see comments inline for details.

Suggest reviewing commit-by-commit so that renames get followed in the diff.

#### Before

![Screenshot 2022-03-14 at 15 23 40](https://user-images.githubusercontent.com/542836/158204830-8eefb61c-e018-4c10-8893-c887afabb918.png)

#### After

![Screenshot 2022-03-14 at 15 21 03](https://user-images.githubusercontent.com/542836/158203950-5ac2191d-9374-438b-8d72-95b940597471.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
