### PR TITLE
docs: tweak structure of permission framework 

### DIFF
--- a/docs/permission/concepts.md
+++ b/docs/permission/concepts.md
@@ -1,6 +1,6 @@
 ---
 id: concepts
-title: Permission Framework Concepts
+title: Concepts
 description: A list of important permission framework concepts
 ---
 

--- a/docs/permission/overview.md
+++ b/docs/permission/overview.md
@@ -1,6 +1,6 @@
 ---
 id: overview
-title: Permission Framework Overview
+title: Overview
 description: A high level overview of the Backstage permission framework
 ---
 

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -251,9 +251,9 @@
     ],
     "Permissions": [
       "permission/overview",
+      "permission/concepts",
       "permission/getting-started",
       "permission/writing-a-policy",
-      "permission/concepts",
       {
         "type": "subcategory",
         "label": "Permission framework for plugin authors",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Couple tiny tweaks:

1. The repeated "permission framework" felt a bit distracting
2. The "concepts" doc feels like it should appear earlier

### Before

![Screenshot 2022-03-14 at 17 57 01](https://user-images.githubusercontent.com/542836/158232601-1c68b839-3328-4de7-b650-aa1e62fcce4b.png)

### After

![Screenshot 2022-03-14 at 17 55 13](https://user-images.githubusercontent.com/542836/158232328-445861bd-def3-493c-92a5-3b59ee0583ab.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
