### PR TITLE
scripts/api-extractor: remove forced handlebars inclusion

### DIFF
--- a/scripts/api-extractor.ts
+++ b/scripts/api-extractor.ts
@@ -342,7 +342,6 @@ async function createTemporaryTsConfig(includedPackageDirs: string[]) {
     include: [
       // These two contain global definitions that are needed for stable API report generation
       'packages/cli/asset-types/asset-types.d.ts',
-      'node_modules/handlebars/types/index.d.ts',
       ...includedPackageDirs.map(dir => join(dir, 'src')),
     ],
   });


### PR DESCRIPTION
Should get rid of occasional `Logger_2` when running isolated API report builds