### PR TITLE
config-loader: lazy load typescript-json-schema

### DIFF
--- a/.changeset/calm-boxes-smell.md
+++ b/.changeset/calm-boxes-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+The `typescript-json-schema` dependency that is used during schema collection is now lazy loaded, as it eagerly loads in the TypeScript compiler.

--- a/packages/config-loader/src/lib/schema/collect.test.ts
+++ b/packages/config-loader/src/lib/schema/collect.test.ts
@@ -28,6 +28,9 @@ const mockSchema = {
   },
 };
 
+// Gotta make sure this is in the compiler cache before we start mocking the filesystem
+require('typescript-json-schema');
+
 // We need to load in actual TS libraries when using mock-fs.
 // This lookup is to allow the `typescript` dependency to exist either
 // at top level or inside node_modules of typescript-json-schema


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Jest has a hard coded in-memory per-project cache of transformed files. This creates a memory leak during test runs, which we can't do much about. It does have a pretty high impact on test performance though, as even starting up just a couple of test projects at once can easily lead to a GB being stored in this cache.

The overwhelming majority of all the memory in the cache is taken up by transpiled TypeScript compilers, each taking about 20MB. This is because the `config-loader`, which is imported by `backend-common`, eagerly loads in `typescript-json-schema`, which then in turn eagerly loads the compiler. Breaking that chain should lower memory pressure significantly during test runs, and we might even see some speedups :grin:

I'll keep up a separate investigation of whether we can bring in some changes to how jest handles its caching across projects, in a way that somehow makes it possible to share cache instances between test projects.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
