### PR TITLE
scaffolder: mark TemplateList as internal + removed unused prop

### DIFF
--- a/plugins/scaffolder/src/components/TemplateList/TemplateList.tsx
+++ b/plugins/scaffolder/src/components/TemplateList/TemplateList.tsx
@@ -30,7 +30,7 @@ import { Typography } from '@material-ui/core';
 import { TemplateCard } from '../TemplateCard';
 
 /**
- * @deprecated this type is deprecated and will be removed in a future releases, please use the TemplateCard to render your own list.
+ * @internal
  */
 export type TemplateListProps = {
   TemplateCardComponent?:
@@ -38,14 +38,12 @@ export type TemplateListProps = {
     | undefined;
   group?: {
     title?: React.ReactNode;
-    /** @deprecated use title instead, can be a string or a react component */
-    titleComponent?: React.ReactNode;
     filter: (entity: Entity) => boolean;
   };
 };
 
 /**
- * @deprecated this component is deprecated and will be removed in a future releases, please use the TemplateCard to render your own list.
+ * @internal
  */
 export const TemplateList = ({
   TemplateCardComponent,
@@ -58,13 +56,6 @@ export const TemplateList = ({
     : entities;
 
   const titleComponent: React.ReactNode = (() => {
-    if (group?.titleComponent) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'DEPRECATED: group.titleComponent is now deprecated. Use group.title instead, it can be a string or a react component',
-      );
-      return group?.titleComponent;
-    }
     if (group && group.title) {
       if (typeof group.title === 'string') {
         return <ContentHeader title={group.title} />;


### PR DESCRIPTION
:broom:

No changeset needed for this one since it's not public API anymore. (except for the removed prop, but I don't think it's worth the noise)