### PR TITLE
permission-docs: add logical operator support to example plugin filtering

### DIFF
--- a/contrib/plugins/todo-list-backend/package.json
+++ b/contrib/plugins/todo-list-backend/package.json
@@ -20,10 +20,10 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.10.6",
+    "@backstage/backend-common": "^0.10.7",
     "@backstage/config": "^0.1.13",
     "@backstage/errors": "^0.2.0",
-    "@backstage/plugin-auth-node": "^0.1.2",
+    "@backstage/plugin-auth-node": "^0.1.0",
     "@types/express": "*",
     "cross-fetch": "^3.0.6",
     "express": "^4.17.1",
@@ -33,11 +33,11 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.13.1",
+    "@backstage/cli": "^0.13.2",
     "@types/supertest": "^2.0.8",
-    "@types/uuid": "^8.3.4",
+    "@types/uuid": "^8.0.0",
     "msw": "^0.35.0",
-    "supertest": "^4.0.2"
+    "supertest": "^6.1.6"
   },
   "files": [
     "dist"

--- a/contrib/plugins/todo-list-backend/src/service/router.ts
+++ b/contrib/plugins/todo-list-backend/src/service/router.ts
@@ -15,7 +15,6 @@
  */
 
 import { errorHandler } from '@backstage/backend-common';
-import { InputError } from '@backstage/errors';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
@@ -24,6 +23,7 @@ import {
   getBearerTokenFromAuthorizationHeader,
 } from '@backstage/plugin-auth-node';
 import { add, getAll, update } from './todos';
+import { InputError } from '@backstage/errors';
 
 export interface RouterOptions {
   logger: Logger;

--- a/contrib/plugins/todo-list-backend/src/service/standaloneServer.ts
+++ b/contrib/plugins/todo-list-backend/src/service/standaloneServer.ts
@@ -39,7 +39,7 @@ export async function startStandaloneServer(
   const discovery = SingleHostDiscovery.fromConfig(config);
   const router = await createRouter({
     logger,
-    identity: new IdentityClient({
+    identity: IdentityClient.create({
       discovery,
       issuer: await discovery.getExternalBaseUrl('auth'),
     }),

--- a/contrib/plugins/todo-list/package.json
+++ b/contrib/plugins/todo-list/package.json
@@ -21,7 +21,7 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@backstage/core-components": "^0.8.7",
+    "@backstage/core-components": "^0.8.8",
     "@backstage/core-plugin-api": "^0.6.0",
     "@backstage/theme": "^0.2.14",
     "@material-ui/core": "^4.12.2",
@@ -33,9 +33,9 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.13.1",
+    "@backstage/cli": "^0.13.2",
     "@backstage/core-app-api": "^0.5.2",
-    "@backstage/dev-utils": "^0.2.12",
+    "@backstage/dev-utils": "^0.2.21",
     "@backstage/test-utils": "^0.2.4",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^11.2.5",

--- a/docs/permission/plugin-authors/01-setup.md
+++ b/docs/permission/plugin-authors/01-setup.md
@@ -90,7 +90,7 @@ The source code is available here:
       apiRouter.use(notFoundHandler());
     ```
 
-    Apply the following changes to `packages/app/src/App.ts`:
+    Apply the following changes to `packages/app/src/App.tsx`:
 
     ```diff
     + import { TodoListPage } from '@internal/plugin-todo-list';

--- a/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
+++ b/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
@@ -15,7 +15,8 @@ We'll start by creating a new permission, and then we'll use the permission api 
 Install the following module:
 
 ```
-$ yarn workspace @internal/plugin-todo-list-backend add @backstage/plugin-permission-common
+$ yarn workspace @internal/plugin-todo-list-backend \
+    add @backstage/plugin-permission-common
 ```
 
 ## Creating a new permission
@@ -40,11 +41,14 @@ We recommend exporting all permissions from your plugin, so that Backstage integ
 Edit `plugins/todo-list-backend/src/service/router.ts`:
 
 ```diff
+...
+
 - import { InputError } from '@backstage/errors';
 + import { InputError, NotAllowedError } from '@backstage/errors';
-  import { add, getAll, getTodo, Todo, TodoFilter, update } from './todos';
 + import { PermissionAuthorizer, AuthorizeResult } from '@backstage/plugin-permission-common';
 + import { todosListCreate } from './permissions';
+
+...
 
   export interface RouterOptions {
     logger: Logger;

--- a/docs/permission/plugin-authors/04-authorizing-access-to-paginated-data.md
+++ b/docs/permission/plugin-authors/04-authorizing-access-to-paginated-data.md
@@ -77,6 +77,8 @@ export const todosListUpdate: Permission = {
 +   createConditionTransformer,
 +   ConditionTransformer,
 + } from '@backstage/plugin-permission-node';
+- import { add, getAll, getTodo, update } from './todos';
++ import { add, getAll, getTodo, TodoFilter, update } from './todos';
   import {
     todosListCreate,
     todosListUpdate,
@@ -105,10 +107,11 @@ export const todosListUpdate: Permission = {
 +       createConditionTransformer(Object.values(rules));
 +     const filter = conditionTransformer(decision.conditions) as TodoFilter;
 +     res.json(getAll(filter));
-+     return;
++   } else {
++     res.json(getAll());
 +   }
-
-   res.json(getAll());
++ }
+-   res.json(getAll());
   });
 ```
 
@@ -143,7 +146,5 @@ Let's update our permission policy's handler to return a conditional result when
 ```
 
 Once the changes to the permission policy are saved, the UI should should show only the items you have created.
-
-// TODO(vinzscam): add support for boolean operators
 
 // TODO(vinzscam): add frontend documentation


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Update todo-list-backend example plugin, making the filters declarative and allowing them to be combined the same way catalog filters can be.
- Updates the permission docs to reflect the changes, and make a few miscellaneous fixes along the way. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
