### PR TITLE
[Catalog View] Add a 'Grid View' as an alternative to the table on the catalog page. (RFC #9947)

### DIFF
--- a/.changeset/itchy-geckos-buy.md
+++ b/.changeset/itchy-geckos-buy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Added Grid/Card view as an alternative to catalog table

--- a/.changeset/itchy-geckos-buy.md
+++ b/.changeset/itchy-geckos-buy.md
@@ -1,5 +1,7 @@
 ---
-'@backstage/plugin-catalog-react': minor
+'@backstage/plugin-catalog': minor
+'@backstage/catalog-model': minor
 ---
 
-Added Grid/Card view as an alternative to catalog table
+- Added Grid/Card view as an alternative to catalog table.
+- Added 'icon' to Entity metadata model.

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -48,7 +48,10 @@ export const CustomCatalogPage = ({
               <EntityTagPicker />
             </FilterContainer>
             <EntityListContainer>
-              <CatalogTable columns={columns} actions={actions} />
+              {mode === ViewMode.MODE_TABLE && (
+                <CatalogTable columns={columns} actions={actions} />
+              )}
+              {mode === ViewMode.MODE_GRID && <CatalogGrid actions={actions} />}
             </EntityListContainer>
           </FilteredEntityLayout>
         </Content>
@@ -160,7 +163,10 @@ export const CustomCatalogPage = ({
               <EntityTagPicker />
             <FilterContainer>
             <EntityListContainer>
-              <CatalogTable columns={columns} actions={actions} />
+              {mode === ViewMode.MODE_TABLE && (
+                <CatalogTable columns={columns} actions={actions} />
+              )}
+              {mode === ViewMode.MODE_GRID && <CatalogGrid actions={actions} />}
             </EntityListContainer>
           </FilteredEntityLayout>
         </EntityListProvider>

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -333,6 +333,14 @@ This field is optional, and currently has no special semantics.
 Each tag must be sequences of `[a-z0-9]` separated by `-`, at most 63 characters
 in total.
 
+### `icon` [optional]
+
+An icon which represents this entity (e.g. a favourites icon for a website, profile picture etc.)
+
+The value should ideally be either a valid URL to an icon, or a key representing a built in icon (e.g. 'dashboard')
+
+This field is optional.
+
 ### `links` [optional]
 
 A list of external hyperlinks related to the entity. Links can provide

--- a/packages/catalog-model/src/entity/Entity.ts
+++ b/packages/catalog-model/src/entity/Entity.ts
@@ -180,6 +180,11 @@ export type EntityMeta = JsonObject & {
   tags?: string[];
 
   /**
+   * An icon (e.g. favicon) which visually represents this entity.
+   */
+  icon?: string;
+
+  /**
    * A list of external hyperlinks related to the entity.
    */
   links?: EntityLink[];

--- a/packages/catalog-model/src/schema/EntityMeta.schema.json
+++ b/packages/catalog-model/src/schema/EntityMeta.schema.json
@@ -92,6 +92,10 @@
         "minLength": 1
       }
     },
+    "icon": {
+      "type": "string",
+      "description": "An icon (e.g. favicon) which visually represents this entity."
+    },
     "links": {
       "type": "array",
       "description": "A list of external hyperlinks related to the entity. Links can provide additional contextual information that may be located outside of Backstage itself. For example, an admin dashboard or external CMS page.",

--- a/plugins/catalog/src/components/CatalogError/CatalogError.tsx
+++ b/plugins/catalog/src/components/CatalogError/CatalogError.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { CodeSnippet, WarningPanel } from '@backstage/core-components';
+
+/**
+ * Props for {@link CatalogError}.
+ *
+ * @public
+ */
+export interface CatalogErrorProps {
+  error: Error;
+}
+
+/** @public */
+export const CatalogError = (props: CatalogErrorProps) => {
+  return (
+    <div>
+      <WarningPanel severity="error" title="Could not fetch catalog entities.">
+        <CodeSnippet language="text" text={props.error.toString()} />
+      </WarningPanel>
+    </div>
+  );
+};

--- a/plugins/catalog/src/components/CatalogError/index.ts
+++ b/plugins/catalog/src/components/CatalogError/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { CatalogError } from './CatalogError';
+export type { CatalogErrorProps } from './CatalogError';

--- a/plugins/catalog/src/components/CatalogGrid/CardIcon.tsx
+++ b/plugins/catalog/src/components/CatalogGrid/CardIcon.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Box, makeStyles } from '@material-ui/core';
+import { Entity } from '@backstage/catalog-model';
+import { IconComponent, useApp } from '@backstage/core-plugin-api';
+import { CardTitleOptions } from './CatalogGrid';
+
+const useCatalogCardIconStyles = makeStyles({
+  imageIcon: {
+    maxWidth: '35px',
+    maxHeight: '35px',
+    borderRadius: '25%',
+  },
+});
+export const CardIcon = ({
+  entity,
+  options,
+}: {
+  entity: Entity;
+  options: CardTitleOptions;
+}) => {
+  const classes = useCatalogCardIconStyles();
+  const app = useApp();
+  const iconResolver = (key?: string): IconComponent =>
+    key ? app.getSystemIcon(key) ?? options?.defaultIcon : options?.defaultIcon;
+  const key = entity.metadata?.icon as string;
+  const image = /^(\w+:)?\/\//.test(key) ? key : null;
+  const Icon = iconResolver(key);
+  if (!image && !Icon) return <></>;
+  return (
+    <Box mr={1}>
+      {image && (
+        <img
+          alt={`${entity?.metadata?.name} Icon`}
+          src={image}
+          aria-hidden="true"
+          className={classes.imageIcon}
+        />
+      )}
+      {!image && Icon && <Icon fontSize="large" />}
+    </Box>
+  );
+};

--- a/plugins/catalog/src/components/CatalogGrid/CardTitle.tsx
+++ b/plugins/catalog/src/components/CatalogGrid/CardTitle.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { EntityRefLink } from '@backstage/plugin-catalog-react';
+import React from 'react';
+import { Box } from '@material-ui/core';
+import { Entity } from '@backstage/catalog-model';
+import { CardIcon } from './CardIcon';
+
+export interface CardTitleOptions {
+  defaultKind?: string;
+  defaultIcon?: any;
+  alwaysShowPagination?: boolean;
+  hideIcons?: boolean;
+}
+
+export interface CardTitleProps {
+  entity: Entity;
+  options?: CardTitleOptions;
+}
+
+export const CardTitle = ({ entity, options }: CardTitleProps) => {
+  const title = entity.metadata.title ?? entity.metadata.name;
+  return (
+    <Box display="flex" alignItems="center">
+      {!options?.hideIcons && <CardIcon entity={entity} options={options} />}
+      <Box>
+        <EntityRefLink
+          entityRef={entity}
+          defaultKind={options?.defaultKind || 'Component'}
+          title={title}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/plugins/catalog/src/components/CatalogGrid/CatalogGrid.test.tsx
+++ b/plugins/catalog/src/components/CatalogGrid/CatalogGrid.test.tsx
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ANNOTATION_EDIT_URL,
+  ANNOTATION_VIEW_URL,
+  Entity,
+} from '@backstage/catalog-model';
+import { ApiProvider } from '@backstage/core-app-api';
+import {
+  entityRouteRef,
+  MockEntityListContextProvider,
+  starredEntitiesApiRef,
+  UserListFilter,
+  MockStarredEntitiesApi,
+} from '@backstage/plugin-catalog-react';
+import { renderInTestApp, TestApiRegistry } from '@backstage/test-utils';
+import { act, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import { CatalogGrid } from './CatalogGrid';
+
+const entities: Entity[] = [
+  {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'component1', title: 'Component One' },
+  },
+  {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'component2' },
+  },
+  {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'component3' },
+  },
+];
+
+// For now just the same tests as the catalog table
+describe('CatalogGrid component', () => {
+  const mockApis = TestApiRegistry.from([
+    starredEntitiesApiRef,
+    new MockStarredEntitiesApi(),
+  ]);
+
+  beforeEach(() => {
+    window.open = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should render error message', async () => {
+    const rendered = await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider value={{ error: new Error('error') }}>
+          <CatalogGrid />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+    const errorMessage = await rendered.findByText(
+      /Could not fetch catalog entities./,
+    );
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it('should display entity names or titles when loading has finished and no error occurred', async () => {
+    const rendered = await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider
+          value={{
+            entities,
+            filters: {
+              user: new UserListFilter(
+                'owned',
+                () => false,
+                () => false,
+              ),
+            },
+          }}
+        >
+          <CatalogGrid />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+    expect(rendered.getByText(/Owned \(3\)/)).toBeInTheDocument();
+    expect(rendered.getByText(/Component One/)).toBeInTheDocument();
+    expect(rendered.getByText(/component2/)).toBeInTheDocument();
+    expect(rendered.getByText(/component3/)).toBeInTheDocument();
+  });
+
+  it('should use specified edit URL if in annotation', async () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'component1',
+        annotations: { [ANNOTATION_EDIT_URL]: 'https://other.place' },
+      },
+    };
+
+    const { getByTitle } = await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider value={{ entities: [entity] }}>
+          <CatalogGrid />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    const editButton = getByTitle('Edit');
+
+    await act(async () => {
+      fireEvent.click(editButton);
+    });
+
+    expect(window.open).toHaveBeenCalledWith('https://other.place', '_blank');
+  });
+
+  it('should use specified view URL if in annotation', async () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'component1',
+        annotations: { [ANNOTATION_VIEW_URL]: 'https://other.place' },
+      },
+    };
+
+    const { getByTitle } = await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider value={{ entities: [entity] }}>
+          <CatalogGrid />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    const viewButton = getByTitle('View');
+
+    await act(async () => {
+      fireEvent.click(viewButton);
+    });
+
+    expect(window.open).toHaveBeenCalledWith('https://other.place', '_blank');
+  });
+
+  it('should show specified icon by URL if in metadata', async () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'component1',
+        icon: 'https://thishorsedoesnotexist.com/',
+      },
+    };
+
+    const { getByAltText } = await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider value={{ entities: [entity] }}>
+          <CatalogGrid />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    const icon = getByAltText('component1 Icon');
+    expect(icon.getAttribute('src')).toBe('https://thishorsedoesnotexist.com/');
+  });
+
+  it('should show tags if in metadata', async () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'component1',
+        tags: ['tag1', 'tag2'],
+      },
+    };
+
+    const { getByText } = await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider value={{ entities: [entity] }}>
+          <CatalogGrid />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(getByText('tag1')).toBeInTheDocument();
+    expect(getByText('tag2')).toBeInTheDocument();
+  });
+
+  it('should show description if in metadata', async () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'component1',
+        description: 'lorem ipsum dolor sit amet consectetur adipiscing elit',
+      },
+    };
+
+    const { getByText } = await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider value={{ entities: [entity] }}>
+          <CatalogGrid />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(
+      getByText('lorem ipsum dolor sit amet consectetur adipiscing elit'),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/catalog/src/components/CatalogGrid/CatalogGrid.tsx
+++ b/plugins/catalog/src/components/CatalogGrid/CatalogGrid.tsx
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  EntityTagFilter,
+  // EntityTextFilter,
+  useEntityList,
+  useStarredEntities,
+} from '@backstage/plugin-catalog-react';
+import { capitalize } from 'lodash';
+import React, { useState } from 'react';
+import { CatalogGridItem } from './types';
+import {
+  ContentHeader,
+  InfoCard,
+  Progress,
+  Content,
+} from '@backstage/core-components';
+import {
+  Grid,
+  Typography,
+  IconButton,
+  TablePagination,
+  makeStyles,
+  Chip,
+  FormControl,
+  InputLabel,
+  Input,
+} from '@material-ui/core';
+import FilterListIcon from '@material-ui/icons/FilterList';
+import { useDefaultCatalogTableActions } from '../defaultActions';
+import { CatalogError } from '../CatalogError';
+import { entityTransformer } from '../CatalogTable/CatalogTable';
+import { Entity } from '@backstage/catalog-model';
+import { CardTitle, CardTitleOptions } from './CardTitle';
+import { CatalogGridAction, GridActions } from './GridActions';
+
+const useCatalogGridStyles = makeStyles({
+  card: {
+    height: '100%',
+  },
+  cardContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+  },
+  description: {
+    minHeight: '3rem',
+  },
+});
+
+export interface CatalogGridProps<T extends CatalogGridItem> {
+  actions?: CatalogGridAction<T>[];
+  options?: CardTitleOptions;
+}
+
+/** @public */
+export function CatalogGrid<T extends CatalogGridItem>(
+  props: CatalogGridProps<T>,
+) {
+  const classes = useCatalogGridStyles();
+  const { actions } = props;
+  const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
+  const { updateFilters, loading, error, entities, filters } = useEntityList();
+  const { defaultActions } = useDefaultCatalogTableActions<CatalogGridItem>({
+    isStarredEntity,
+    toggleStarredEntity,
+  });
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [textFilter, setTextFilter] = useState('');
+  const titlePreamble = capitalize(filters.user?.value ?? 'all');
+
+  if (error) {
+    return <CatalogError error={error} />;
+  }
+  if (loading) {
+    return <Progress />;
+  }
+
+  const textFilteredEntities = entities.filter(
+    entity =>
+      !textFilter ||
+      textFilter === '' ||
+      entity?.metadata?.name
+        ?.toLocaleLowerCase()
+        .includes(textFilter?.toLocaleLowerCase()),
+  );
+
+  const showPagination =
+    props.options?.alwaysShowPagination ||
+    textFilteredEntities.length > rowsPerPage;
+
+  const rows = textFilteredEntities
+    .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+    .map(entityTransformer);
+
+  const handleChangePage = (_: any, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: { target: { value: string } }) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const subheaderForEntity = (entity: Entity) => {
+    if (!entity) return null;
+    const subheading: string[] = [];
+    if (entity.spec) {
+      if (entity.spec.type) subheading.push(entity.spec.type.toString());
+      if (entity.spec.lifecycle) subheading.push(`(${entity.spec.lifecycle})`);
+    }
+    if (!subheading.length) return null;
+    return subheading.filter(it => it && it.length).join(' ');
+  };
+
+  return (
+    <Content className="grid-view">
+      <ContentHeader
+        title={`${titlePreamble} (${textFilteredEntities.length})`}
+      >
+        <Grid container spacing={1} alignItems="flex-end">
+          <Grid item>
+            <FilterListIcon />
+          </Grid>
+          <Grid item>
+            <FormControl>
+              <InputLabel htmlFor="search-filter">Filter</InputLabel>
+              <Input
+                id="search-filter"
+                type="search"
+                value={filters?.text?.value}
+                // onChange={e => updateFilters({ text: new EntityTextFilter(e.target.value) })}
+                onChange={e => setTextFilter(e.target.value)}
+              />
+            </FormControl>
+          </Grid>
+        </Grid>
+      </ContentHeader>
+      <Grid
+        container
+        direction="row"
+        justifyContent="center"
+        alignItems="stretch"
+      >
+        {rows.map((row, i) => (
+          <Grid
+            item
+            xs={12}
+            sm={6}
+            md={4}
+            key={row.entity.metadata.uid ?? `entity-${i}`}
+          >
+            <InfoCard
+              title={<CardTitle entity={row.entity} options={props.options} />}
+              subheader={subheaderForEntity(row.entity)}
+              actions={
+                <GridActions actions={actions || defaultActions} row={row} />
+              }
+              className={classes.card}
+              cardClassName={classes.cardContent}
+            >
+              <Typography className={classes.description}>
+                {row?.entity?.metadata?.description}
+              </Typography>
+
+              {row.entity?.metadata?.tags && (
+                <Grid>
+                  {(row.entity?.metadata?.tags || []).map(t => (
+                    <Chip
+                      key={t}
+                      size="small"
+                      label={t}
+                      onClick={() =>
+                        updateFilters({
+                          tags: new EntityTagFilter([
+                            ...new Set(
+                              filters.tags?.values?.concat([t]) || [t],
+                            ),
+                          ]),
+                        })
+                      }
+                    />
+                  ))}
+                </Grid>
+              )}
+            </InfoCard>
+          </Grid>
+        ))}
+      </Grid>
+      {showPagination && (
+        <TablePagination
+          component="div"
+          count={textFilteredEntities.length}
+          page={page}
+          onPageChange={handleChangePage}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      )}
+    </Content>
+  );
+}

--- a/plugins/catalog/src/components/CatalogGrid/GridActions.tsx
+++ b/plugins/catalog/src/components/CatalogGrid/GridActions.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { CatalogGridItem } from './types';
+import { Action } from '@material-table/core/types';
+import { IconButton } from '@material-ui/core';
+
+export type CatalogGridAction<T extends CatalogGridItem> =
+  | Action<T>
+  | ((rowData: T) => Action<T>)
+  | {
+      action: (rowData: T) => Action<T>;
+      position: string;
+    };
+
+export function unpackTableAction<T extends CatalogGridItem>(
+  action: CatalogGridAction<T>,
+  row: CatalogGridItem,
+): Action<CatalogGridItem> | null {
+  if (!action) return null;
+  if (typeof action === 'function')
+    return (action as (rowData: CatalogGridItem) => Action<CatalogGridItem>)(
+      row,
+    );
+  if (action.hasOwnProperty('action')) {
+    return (
+      action as unknown as {
+        action: (rowData: CatalogGridItem) => Action<CatalogGridItem>;
+      }
+    ).action(row);
+  }
+  return action as unknown as Action<CatalogGridItem>;
+}
+
+export interface GridActionsProps<T extends CatalogGridItem> {
+  actions: CatalogGridAction<T>[] | undefined;
+  row: CatalogGridItem;
+}
+
+export function GridActions<T extends CatalogGridItem>({
+  actions,
+  row,
+}: GridActionsProps<T>) {
+  const displayedActions = actions;
+  if (!displayedActions) return null;
+  return (
+    <>
+      {displayedActions.map((action, i) => {
+        const actionProps = unpackTableAction(action, row);
+        if (!actionProps) return null;
+        return (
+          <IconButton
+            key={actionProps.tooltip || `card-action-${i}`}
+            onClick={e => actionProps.onClick(e, row)}
+            title={actionProps.tooltip}
+            disabled={actionProps.disabled}
+          >
+            <actionProps.icon />
+          </IconButton>
+        );
+      })}
+    </>
+  );
+}

--- a/plugins/catalog/src/components/CatalogGrid/index.ts
+++ b/plugins/catalog/src/components/CatalogGrid/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { CatalogGrid } from './CatalogGrid';
+export type { CatalogGridProps } from './CatalogGrid';
+export type { CatalogGridItem } from './types';

--- a/plugins/catalog/src/components/CatalogGrid/types.ts
+++ b/plugins/catalog/src/components/CatalogGrid/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+
+/** @public */
+export interface CatalogGridItem {
+  entity: Entity;
+}

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -47,6 +47,7 @@ import React from 'react';
 import { createComponentRouteRef } from '../../routes';
 import { CatalogTableRow } from '../CatalogTable';
 import { DefaultCatalogPage } from './DefaultCatalogPage';
+import { ViewMode } from './ViewModePicker';
 
 describe('DefaultCatalogPage', () => {
   const origReplaceState = window.history.replaceState;
@@ -161,7 +162,9 @@ describe('DefaultCatalogPage', () => {
   // limit. We should investigate why these timeouts happen.
 
   it('should render the default column of the grid', async () => {
-    const { getAllByRole } = await renderWrapped(<DefaultCatalogPage />);
+    const { getAllByRole } = await renderWrapped(
+      <DefaultCatalogPage viewMode={ViewMode.MODE_TABLE} />,
+    );
 
     const columnHeader = getAllByRole('button').filter(
       c => c.tagName === 'SPAN',
@@ -187,7 +190,7 @@ describe('DefaultCatalogPage', () => {
       { title: 'Baz', field: 'entity.spec.lifecycle' },
     ];
     const { getAllByRole } = await renderWrapped(
-      <DefaultCatalogPage columns={columns} />,
+      <DefaultCatalogPage viewMode={ViewMode.MODE_TABLE} columns={columns} />,
     );
 
     const columnHeader = getAllByRole('button').filter(
@@ -199,7 +202,7 @@ describe('DefaultCatalogPage', () => {
 
   it('should render the default actions of an item in the grid', async () => {
     const { getByTestId, findByTitle, findByText } = await renderWrapped(
-      <DefaultCatalogPage />,
+      <DefaultCatalogPage viewMode={ViewMode.MODE_TABLE} />,
     );
     fireEvent.click(getByTestId('user-picker-owned'));
     expect(await findByText(/Owned \(1\)/)).toBeInTheDocument();
@@ -229,7 +232,7 @@ describe('DefaultCatalogPage', () => {
     ];
 
     const { getByTestId, findByTitle, findByText } = await renderWrapped(
-      <DefaultCatalogPage actions={actions} />,
+      <DefaultCatalogPage viewMode={ViewMode.MODE_TABLE} actions={actions} />,
     );
     fireEvent.click(getByTestId('user-picker-owned'));
     expect(await findByText(/Owned \(1\)/)).toBeInTheDocument();
@@ -243,7 +246,7 @@ describe('DefaultCatalogPage', () => {
   // https://github.com/mbrn/material-table/issues/1293
   it('should render', async () => {
     const { findByText, getByTestId } = await renderWrapped(
-      <DefaultCatalogPage />,
+      <DefaultCatalogPage viewMode={ViewMode.MODE_TABLE} />,
     );
     fireEvent.click(getByTestId('user-picker-owned'));
     await expect(findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
@@ -253,7 +256,10 @@ describe('DefaultCatalogPage', () => {
 
   it('should set initial filter correctly', async () => {
     const { findByText } = await renderWrapped(
-      <DefaultCatalogPage initiallySelectedFilter="all" />,
+      <DefaultCatalogPage
+        viewMode={ViewMode.MODE_TABLE}
+        initiallySelectedFilter="all"
+      />,
     );
     await expect(findByText(/All \(2\)/)).resolves.toBeInTheDocument();
   }, 20_000);
@@ -261,7 +267,9 @@ describe('DefaultCatalogPage', () => {
   // this test is for fixing the bug after favoriting an entity, the matching
   // entities defaulting to "owned" filter and not based on the selected filter
   it('should render the correct entities filtered on the selected filter', async () => {
-    const { getByTestId } = await renderWrapped(<DefaultCatalogPage />);
+    const { getByTestId } = await renderWrapped(
+      <DefaultCatalogPage viewMode={ViewMode.MODE_TABLE} />,
+    );
     fireEvent.click(getByTestId('user-picker-owned'));
     await expect(screen.findByText(/Owned \(1\)/)).resolves.toBeInTheDocument();
     // The "Starred" menu option should initially be disabled, since there
@@ -291,7 +299,9 @@ describe('DefaultCatalogPage', () => {
 
   it('should wrap filter in drawer on smaller screens', async () => {
     mockBreakpoint({ matches: true });
-    const { getByRole } = await renderWrapped(<DefaultCatalogPage />);
+    const { getByRole } = await renderWrapped(
+      <DefaultCatalogPage viewMode={ViewMode.MODE_TABLE} />,
+    );
     const button = getByRole('button', { name: 'Filters' });
     expect(getByRole('presentation', { hidden: true })).toBeInTheDocument();
     fireEvent.click(button);

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -36,12 +36,14 @@ import {
 import React from 'react';
 import { createComponentRouteRef } from '../../routes';
 import { CatalogTable, CatalogTableRow } from '../CatalogTable';
+import { CatalogGrid } from '../CatalogGrid';
 import {
   FilteredEntityLayout,
   EntityListContainer,
   FilterContainer,
 } from '../FilteredEntityLayout';
 import { CatalogKindHeader } from '../CatalogKindHeader';
+import { ViewModePicker, ViewMode } from './ViewModePicker';
 
 /**
  * Props for root catalog pages.
@@ -52,13 +54,21 @@ export interface DefaultCatalogPageProps {
   initiallySelectedFilter?: UserListFilterKind;
   columns?: TableColumn<CatalogTableRow>[];
   actions?: TableProps<CatalogTableRow>['actions'];
+  viewMode?: ViewMode;
 }
 
 export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
-  const { columns, actions, initiallySelectedFilter = 'owned' } = props;
+  const {
+    columns,
+    actions,
+    initiallySelectedFilter = 'owned',
+    viewMode = ViewMode.MODE_TABLE,
+  } = props;
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
   const createComponentLink = useRouteRef(createComponentRouteRef);
+
+  const [mode, setViewMode] = React.useState<ViewMode>(viewMode);
 
   return (
     <PageWithHeader title={`${orgName} Catalog`} themeId="home">
@@ -78,9 +88,16 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
               <EntityOwnerPicker />
               <EntityLifecyclePicker />
               <EntityTagPicker />
+              <ViewModePicker
+                selected={mode}
+                onChange={vm => setViewMode(vm)}
+              />
             </FilterContainer>
             <EntityListContainer>
-              <CatalogTable columns={columns} actions={actions} />
+              {mode === ViewMode.MODE_TABLE && (
+                <CatalogTable columns={columns} actions={actions} />
+              )}
+              {mode === ViewMode.MODE_GRID && <CatalogGrid actions={actions} />}
             </EntityListContainer>
           </FilteredEntityLayout>
         </Content>

--- a/plugins/catalog/src/components/CatalogPage/ViewModePicker.tsx
+++ b/plugins/catalog/src/components/CatalogPage/ViewModePicker.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import {
+  Button,
+  ButtonGroup,
+  Typography,
+  Grid,
+  capitalize,
+  makeStyles,
+} from '@material-ui/core';
+
+export enum ViewMode {
+  MODE_TABLE = 'table',
+  MODE_GRID = 'grid',
+}
+
+const useViewModePickerStyles = makeStyles({
+  title: {
+    paddingBottom: '0 !important',
+  },
+  selector: {
+    paddingTop: '0 !important',
+  },
+});
+
+export interface ViewModePickerProps {
+  selected: ViewMode;
+  onChange: (mode: ViewMode) => void;
+}
+export const ViewModePicker = ({ selected, onChange }: ViewModePickerProps) => {
+  const classes = useViewModePickerStyles();
+  return (
+    <Grid container direction="column">
+      <Grid item className={classes.title}>
+        <Typography variant="button">View Mode</Typography>
+      </Grid>
+      <Grid item className={classes.selector}>
+        <ButtonGroup variant="outlined">
+          {Object.values(ViewMode).map(mode => (
+            <Button
+              key={mode}
+              onClick={() => onChange(mode)}
+              color={mode === selected ? 'primary' : 'default'}
+              variant={mode === selected ? 'contained' : 'outlined'}
+            >
+              {capitalize(mode)}
+            </Button>
+          ))}
+        </ButtonGroup>
+      </Grid>
+    </Grid>
+  );
+};

--- a/plugins/catalog/src/components/defaultActions.tsx
+++ b/plugins/catalog/src/components/defaultActions.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ANNOTATION_EDIT_URL,
+  ANNOTATION_VIEW_URL,
+  CompoundEntityRef,
+  Entity,
+} from '@backstage/catalog-model';
+import Edit from '@material-ui/icons/Edit';
+import OpenInNew from '@material-ui/icons/OpenInNew';
+import React, { useEffect, useState } from 'react';
+import { TableProps } from '@backstage/core-components';
+import StarBorder from '@material-ui/icons/StarBorder';
+import { withStyles } from '@material-ui/core/styles';
+import Star from '@material-ui/icons/Star';
+
+export const YellowStar = withStyles({
+  root: {
+    color: '#f3ba37',
+  },
+})(Star);
+
+export function useDefaultCatalogTableActions<T extends { entity: Entity }>({
+  isStarredEntity,
+  toggleStarredEntity,
+}: {
+  isStarredEntity: (
+    entityOrRef: string | Entity | CompoundEntityRef,
+  ) => boolean;
+  toggleStarredEntity: (
+    entityOrRef: string | Entity | CompoundEntityRef,
+  ) => void;
+}) {
+  const [defaultActions, setDefaultActions] = useState(
+    [] as TableProps<T>['actions'],
+  );
+  useEffect(() => {
+    setDefaultActions([
+      ({ entity }: T) => {
+        const url = entity.metadata.annotations?.[ANNOTATION_VIEW_URL];
+        return {
+          icon: () => <OpenInNew aria-label="View" fontSize="small" />,
+          tooltip: 'View',
+          disabled: !url,
+          onClick: () => {
+            if (!url) return;
+            window.open(url, '_blank');
+          },
+        };
+      },
+      ({ entity }: T) => {
+        const url = entity.metadata.annotations?.[ANNOTATION_EDIT_URL];
+        return {
+          icon: () => <Edit aria-label="Edit" fontSize="small" />,
+          tooltip: 'Edit',
+          disabled: !url,
+          onClick: () => {
+            if (!url) return;
+            window.open(url, '_blank');
+          },
+        };
+      },
+      ({ entity }: T) => {
+        const isStarred = isStarredEntity(entity);
+        return {
+          cellStyle: { paddingLeft: '1em' },
+          icon: () => (isStarred ? <YellowStar /> : <StarBorder />),
+          tooltip: isStarred ? 'Remove from favorites' : 'Add to favorites',
+          onClick: () => toggleStarredEntity(entity),
+        };
+      },
+    ]);
+  }, [isStarredEntity, setDefaultActions, toggleStarredEntity]);
+  return { defaultActions };
+}

--- a/plugins/github-actions/examples/sample.yaml
+++ b/plugins/github-actions/examples/sample.yaml
@@ -3,6 +3,7 @@ kind: Component
 metadata:
   name: backstage
   description: backstage.io
+  icon: https://backstage.io/img/apple-touch-icon.png
   annotations:
     github.com/project-slug: 'backstage/backstage'
     backstage.io/techdocs-ref: url:https://github.com/backstage/backstage

--- a/plugins/techdocs-backend/examples/documented-component/catalog-info.yaml
+++ b/plugins/techdocs-backend/examples/documented-component/catalog-info.yaml
@@ -3,6 +3,7 @@ kind: Component
 metadata:
   name: documented-component
   title: Documented Component
+  icon: kind:component
   description: A Service with TechDocs documentation
   annotations:
     backstage.io/techdocs-ref: dir:.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
* Added a toggle between Grid/Table views (default to the existing Table view)
<img width="200" alt="image" src="https://user-images.githubusercontent.com/8076088/158431691-8b6d59c5-008a-4d77-b643-5376b4398a43.png">

* Added Grid view 
<img width="1696" alt="image" src="https://user-images.githubusercontent.com/8076088/158431810-51eee4a3-c841-45b0-acef-50b4a24a8f42.png">

* Added the ability to search on title/name in the grid view
<img width="1554" alt="image" src="https://user-images.githubusercontent.com/8076088/158431869-1a700834-2aac-47fa-9d45-e8883647941f.png">

* Added the ability to filter on tags from grid view cards
* Added the ability to define icons for cards

<img width="465" alt="Screenshot 2022-03-15 at 17 03 23" src="https://user-images.githubusercontent.com/8076088/158432099-9ffe0221-a77d-497f-b3bd-6047872359e8.png">

* Added some new tests to cover some of the new features (TODO: more to do here)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [~] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
