### PR TITLE
badges: use useAsyncEntity

### DIFF
--- a/.changeset/quiet-dots-raise.md
+++ b/.changeset/quiet-dots-raise.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-badges': patch
+---
+
+Fixed an error caused by the `EntityBadgesDialog` trying to access the entity before it is loaded.

--- a/plugins/badges/src/components/EntityBadgesDialog.tsx
+++ b/plugins/badges/src/components/EntityBadgesDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEntity } from '@backstage/plugin-catalog-react';
+import { useAsyncEntity } from '@backstage/plugin-catalog-react';
 import {
   Box,
   Button,
@@ -44,7 +44,7 @@ type Props = {
 
 export const EntityBadgesDialog = ({ open, onClose }: Props) => {
   const theme = useTheme();
-  const { entity } = useEntity();
+  const { entity } = useAsyncEntity();
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const badgesApi = useApi(badgesApiRef);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since the `EntityBadgesDialog` is [not rendered within the `EntityLayout`](https://github.com/backstage/backstage/blob/c484c4825fda48b4294d8ae01bbc13ff617c2f91/packages/app/src/components/catalog/EntityPage.tsx#L162) it should instead use `useAsyncEntity`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
