### PR TITLE
replacing workflow:write scope with workflow, workflow:write is invalid.

### DIFF
--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -364,7 +364,7 @@ spec:
               secretsKey: USER_OAUTH_TOKEN
               additionalScopes:
                 github:
-                  - workflow:write
+                  - workflow
             allowedHosts:
               - github.com
     ...

--- a/packages/integration-react/src/api/ScmAuth.test.ts
+++ b/packages/integration-react/src/api/ScmAuth.test.ts
@@ -153,11 +153,11 @@ describe('ScmAuth', () => {
       githubAuth.getCredentials({
         url: 'http://example.com',
         additionalScope: {
-          customScopes: { github: ['org:read', 'workflow:write'] },
+          customScopes: { github: ['org:read', 'workflow'] },
         },
       }),
     ).resolves.toMatchObject({
-      token: 'repo read:org read:user org:read workflow:write',
+      token: 'repo read:org read:user org:read workflow',
     });
 
     const gitlabAuth = ScmAuth.forGitlab(mockAuthApi);

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -138,7 +138,7 @@ describe('RepoUrlPicker', () => {
                 'ui:options': {
                   requestUserCredentials: {
                     secretsKey: 'testKey',
-                    additionalScopes: { github: ['workflow:write'] },
+                    additionalScopes: { github: ['workflow'] },
                   },
                 },
               }}
@@ -164,7 +164,7 @@ describe('RepoUrlPicker', () => {
         additionalScope: {
           repoWrite: true,
           customScopes: {
-            github: ['workflow:write'],
+            github: ['workflow'],
           },
         },
       });


### PR DESCRIPTION
Signed-off-by: Marco Crivellaro <marco.crive@gmail.com>

## Hey, I just made a Pull Request!

Addresses an issue identified on the documentation: when pushing a repository with github actions workflows the OAuth app needs the `workflow` scope, not the `workflow:write` which is invalid.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
