### PR TITLE
scaffolder: remove unused titleComponent property

### DIFF
--- a/.changeset/good-gorillas-pump.md
+++ b/.changeset/good-gorillas-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+**BREAKING**: Removed the unused `titleComponent` property of `groups` passed to the `ScaffolderPage`. The property was already ignored, but existing usage should migrated to use the `title` property instead, which now accepts any `ReactNode`.

--- a/plugins/scaffolder/api-report.md
+++ b/plugins/scaffolder/api-report.md
@@ -196,8 +196,7 @@ export type RouterProps = {
     TaskPageComponent?: ComponentType<{}>;
   };
   groups?: Array<{
-    title?: string;
-    titleComponent?: React_2.ReactNode;
+    title?: React_2.ReactNode;
     filter: (entity: Entity) => boolean;
   }>;
   defaultPreviewTemplate?: string;

--- a/plugins/scaffolder/src/components/Router.tsx
+++ b/plugins/scaffolder/src/components/Router.tsx
@@ -45,8 +45,7 @@ export type RouterProps = {
     TaskPageComponent?: ComponentType<{}>;
   };
   groups?: Array<{
-    title?: string;
-    titleComponent?: React.ReactNode;
+    title?: React.ReactNode;
     filter: (entity: Entity) => boolean;
   }>;
   defaultPreviewTemplate?: string;

--- a/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
+++ b/plugins/scaffolder/src/components/ScaffolderPage/ScaffolderPage.tsx
@@ -46,8 +46,6 @@ export type ScaffolderPageProps = {
     | undefined;
   groups?: Array<{
     title?: React.ReactNode;
-    /** @deprcated use title instead as it accepts a string and react component */
-    titleComponent?: React.ReactNode;
     filter: (entity: Entity) => boolean;
   }>;
 };


### PR DESCRIPTION
🧹 , `titleComponent` was already ignored https://github.com/backstage/backstage/blob/b1fc1c3c4478fc1ca7fca3f3b541dfaea4c5a22b/plugins/scaffolder/src/components/TemplateList/TemplateList.tsx#L59-L64