### PR TITLE
plugin-auth-backend: fix microsoft default signin resolver to claim user's groups

### DIFF
--- a/.changeset/fluffy-jeans-repair.md
+++ b/.changeset/fluffy-jeans-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Updated microsoft provider's microsoftDefaultSignInResolver to claim a logged-in user's ownership of the groups that the user is a member of.

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -241,10 +241,15 @@ export const microsoftDefaultSignInResolver: SignInResolver<
     name: userId,
   });
 
+  const fullEnt = await ctx.catalogIdentityClient.resolveCatalogMembership({
+    entityRefs: [entityRef],
+    logger: ctx.logger
+  });
+
   const token = await ctx.tokenIssuer.issueToken({
     claims: {
       sub: entityRef,
-      ent: [entityRef],
+      ent: fullEnt,
     },
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The [microsoftDefaultSignInResolver](https://github.com/backstage/backstage/blob/83072184fdb530369d296b1ae356fd913cca49ed/plugins/auth-backend/src/providers/microsoft/provider.ts#L236-L249) currently doesn't resolve a user's group memberships.

Several threads on discord about this:
- https://discord.com/channels/687207715902193673/951870094336733244/951878496676880488
- https://discord.com/channels/687207715902193673/952927683250098186
- https://discord.com/channels/687207715902193673/923144214580191282/953957959602413632

Added the suggested solution to be the default behaviour:
```typescript
const fullEnt = await ctx.catalogIdentityClient.resolveCatalogMembership({
    entityRefs: [entityRef],
    logger: ctx.logger
  });

  const token = await ctx.tokenIssuer.issueToken({
    claims: {
      sub: entityRef,
      ent: fullEnt,
    },
  });
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
