### PR TITLE
feat(plugin-api): useRouteContext() for introspection

### DIFF
--- a/packages/core-plugin-api/src/routing/useRouteContext.ts
+++ b/packages/core-plugin-api/src/routing/useRouteContext.ts
@@ -14,26 +14,21 @@
  * limitations under the License.
  */
 
-export type {
-  AnyParams,
-  RouteRef,
-  SubRouteRef,
-  ExternalRouteRef,
-  OptionalParams,
-  ParamKeys,
-  RouteFunc,
-  BackstageRouteObject,
-} from './types';
-export { createRouteRef } from './RouteRef';
-export { createSubRouteRef } from './SubRouteRef';
-export type {
-  MakeSubRouteRef,
-  MergeParams,
-  ParamNames,
-  ParamPart,
-  PathParams,
-} from './SubRouteRef';
-export { createExternalRouteRef } from './ExternalRouteRef';
-export { useRouteRef } from './useRouteRef';
-export { useRouteRefParams } from './useRouteRefParams';
-export { useRouteContext } from './useRouteContext';
+import { useVersionedContext } from '@backstage/version-bridge';
+import { RouteResolver } from './useRouteRef';
+
+export function useRouteContext(): RouteResolver | undefined {
+  const versionedContext =
+    useVersionedContext<{ 1: RouteResolver }>('routing-context');
+  if (!versionedContext) {
+    throw new Error('Routing context is not available');
+  }
+
+  const resolver = versionedContext.atVersion(1);
+
+  if (!resolver) {
+    throw new Error('RoutingContext v1 not available');
+  }
+
+  return resolver;
+}


### PR DESCRIPTION
## Expose route context

This adds the hook `useRouteContext()` for plugins to be able to introspect the route table. A follow-up PR will _use_ this.

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
