### PR TITLE
feat(core): getApis() on BackstageApp

### DIFF
--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -181,6 +181,10 @@ export class AppManager implements BackstageApp {
     this.apiFactoryRegistry = new ApiFactoryRegistry();
   }
 
+  getApis(): AnyApiFactory[] {
+    return Array.from(this.apis);
+  }
+
   getPlugins(): BackstagePlugin<any, any>[] {
     return Array.from(this.plugins) as BackstagePlugin<any, any>[];
   }

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -289,6 +289,11 @@ export type AppOptions = {
  */
 export type BackstageApp = {
   /**
+   * Returns all APIs registered for the app.
+   */
+  getApis(): AnyApiFactory[];
+
+  /**
    * Returns all plugins registered for the app.
    */
   getPlugins(): BackstagePlugin<any, any>[];

--- a/packages/core-app-api/src/routing/RouteResolver.ts
+++ b/packages/core-app-api/src/routing/RouteResolver.ts
@@ -180,14 +180,14 @@ function resolveBasePath(
 
 export class RouteResolver {
   constructor(
-    private readonly routePaths: Map<RouteRef, string>,
-    private readonly routeParents: Map<RouteRef, RouteRef | undefined>,
-    private readonly routeObjects: BackstageRouteObject[],
-    private readonly routeBindings: Map<
+    public readonly routePaths: Map<RouteRef, string>,
+    public readonly routeParents: Map<RouteRef, RouteRef | undefined>,
+    public readonly routeObjects: BackstageRouteObject[],
+    public readonly routeBindings: Map<
       ExternalRouteRef,
       RouteRef | SubRouteRef
     >,
-    private readonly appBasePath: string, // base path without a trailing slash
+    public readonly appBasePath: string, // base path without a trailing slash
   ) {}
 
   resolve<Params extends AnyParams>(

--- a/packages/core-plugin-api/src/routing/useRouteRef.tsx
+++ b/packages/core-plugin-api/src/routing/useRouteRef.tsx
@@ -19,6 +19,7 @@ import { matchRoutes, useLocation } from 'react-router-dom';
 import { useVersionedContext } from '@backstage/version-bridge';
 import {
   AnyParams,
+  BackstageRouteObject,
   ExternalRouteRef,
   RouteFunc,
   RouteRef,
@@ -36,6 +37,12 @@ export interface RouteResolver {
       | ExternalRouteRef<Params, any>,
     sourceLocation: Parameters<typeof matchRoutes>[1],
   ): RouteFunc<Params> | undefined;
+
+  readonly routePaths: Map<RouteRef, string>;
+  readonly routeParents: Map<RouteRef, RouteRef | undefined>;
+  readonly routeObjects: BackstageRouteObject[];
+  readonly routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef>;
+  readonly appBasePath: string; // base path without a trailing slash
 }
 
 /**


### PR DESCRIPTION
Also add missing types to base-type RouteResolver and make them public, for introspection

## Introspection support

This PR adds a function `getApis()` to be able to iterate the apis on a Backstage app. It also exposes more from the app that wasn't on the `BackstageApp` base type before. These aren't useful for most plugins, but for those specifically targeting debug/introspection backstage itself. A follow-up PR will use this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
