### PR TITLE
Add plugin metadata support

### DIFF
--- a/packages/core-app-api/package.json
+++ b/packages/core-app-api/package.json
@@ -38,6 +38,7 @@
     "@backstage/types": "^0.1.3",
     "@backstage/version-bridge": "^0.1.2",
     "@types/prop-types": "^15.7.3",
+    "minimatch": "5.0.1",
     "prop-types": "^15.7.2",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4",

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -74,17 +74,13 @@ import {
   AppOptions,
   BackstageApp,
   SignInPageProps,
+  CompatiblePlugin,
 } from './types';
 import { AppThemeProvider } from './AppThemeProvider';
 import { defaultConfigLoader } from './defaultConfigLoader';
 import { ApiRegistry } from '../apis/system/ApiRegistry';
 import { resolveRouteBindings } from './resolveRouteBindings';
-
-type CompatiblePlugin =
-  | BackstagePlugin<any, any>
-  | (Omit<BackstagePlugin<any, any>, 'getFeatureFlags'> & {
-      output(): Array<{ type: 'feature-flag'; name: string }>;
-    });
+import { PluginDecoration } from './PluginDecoration';
 
 /**
  * Get the app base path from the configured app baseUrl.
@@ -156,6 +152,7 @@ class AppContextImpl implements AppContext {
 export class AppManager implements BackstageApp {
   private apiHolder?: ApiHolder;
   private configApi?: ConfigApi;
+  private pluginDecoration: PluginDecoration;
 
   private readonly apis: Iterable<AnyApiFactory>;
   private readonly icons: NonNullable<AppOptions['icons']>;
@@ -170,9 +167,14 @@ export class AppManager implements BackstageApp {
   private readonly apiFactoryRegistry: ApiFactoryRegistry;
 
   constructor(options: AppOptions) {
+    this.pluginDecoration = new PluginDecoration(options);
     this.apis = options.apis ?? [];
     this.icons = options.icons;
-    this.plugins = new Set((options.plugins as CompatiblePlugin[]) ?? []);
+    this.plugins = new Set(
+      this.pluginDecoration.decoratePlugins(
+        (options.plugins as CompatiblePlugin[]) ?? [],
+      ),
+    );
     this.components = options.components;
     this.themes = options.themes as AppTheme[];
     this.configLoader = options.configLoader ?? defaultConfigLoader;
@@ -228,7 +230,10 @@ export class AppManager implements BackstageApp {
         //               the app, rather than having to wait for the provider to render.
         //               For now we need to push the additional plugins we find during
         //               collection and then make sure we initialize things afterwards.
-        result.collectedPlugins.forEach(plugin => this.plugins.add(plugin));
+        result.collectedPlugins.forEach(plugin => {
+          this.pluginDecoration.decoratePlugin(plugin);
+          this.plugins.add(plugin);
+        });
         this.verifyPlugins(this.plugins);
 
         // Initialize APIs once all plugins are available

--- a/packages/core-app-api/src/app/PluginDecoration.ts
+++ b/packages/core-app-api/src/app/PluginDecoration.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Minimatch, IMinimatch } from 'minimatch';
+
+import { AppOptions, CompatiblePlugin } from './types';
+
+export type PluginDecorationOptions = Pick<
+  AppOptions,
+  'pluginOwners' | 'pluginInfoDecorator'
+>;
+
+export class PluginDecoration {
+  private readonly matchers: ReadonlyArray<readonly [IMinimatch, string]>;
+  private knownPluginIds = new Set<string>();
+
+  constructor(private options: PluginDecorationOptions) {
+    const { pluginOwners = [] } = this.options;
+
+    this.matchers = pluginOwners.flatMap(rec =>
+      Object.entries(rec).map(
+        ([pkgNamePattern, owner]) =>
+          [new Minimatch(pkgNamePattern), owner] as const,
+      ),
+    );
+  }
+
+  public matchOwner = (pkgName: string): string | undefined => {
+    const match = this.matchers.find(([matcher]) => matcher.match(pkgName));
+    return match?.[1];
+  };
+
+  public decoratePlugin = <Plugin extends CompatiblePlugin>(plugin: Plugin) => {
+    if (this.knownPluginIds.has(plugin.getId())) {
+      return plugin;
+    }
+
+    const { pluginInfoDecorator = () => {} } = this.options;
+
+    if (!plugin.info) {
+      // Plugin with an older core-plugin-api dependency
+      plugin.info = { links: [] };
+    }
+
+    const pkgJson = (plugin.info.packageJson as any) ?? {};
+
+    const pkgName = pkgJson?.name ? `${pkgJson.name}` : undefined;
+    const pkgDescription = pkgJson?.description
+      ? `${pkgJson.description}`
+      : undefined;
+    const pkgVersion = pkgJson?.version ? `${pkgJson.version}` : undefined;
+
+    if (!plugin.info.ownerEntityRef && pkgName) {
+      plugin.info.ownerEntityRef =
+        this.matchOwner(pkgName) ?? pkgJson.backstage?.owner;
+    }
+    if (!plugin.info.description) {
+      plugin.info.description = pkgDescription;
+    }
+    if (!plugin.info.version) {
+      plugin.info.version = pkgVersion;
+    }
+    if (!plugin.info.name && pkgJson.backstage?.name) {
+      plugin.info.name = pkgJson.backstage.name;
+    }
+    if (!plugin.info.role && pkgJson.backstage?.role) {
+      plugin.info.role = pkgJson.backstage.role;
+    }
+    if (typeof pkgJson.homepage === 'string') {
+      plugin.info.links.push({
+        title: 'Package homepage',
+        url: pkgJson.homepage,
+      });
+    }
+    if (typeof pkgJson.repository === 'string') {
+      try {
+        const url = new URL(pkgJson.repository);
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+          url.protocol = 'https:';
+        }
+        plugin.info.links.push({
+          title: 'Package repository',
+          url: url.toString(),
+        });
+      } catch (_err) {
+        // not critical
+      }
+    }
+    if (typeof pkgJson.repository?.url === 'string') {
+      try {
+        const url = new URL(pkgJson.repository?.url);
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+          url.protocol = 'https:';
+        }
+        if (
+          url.hostname.endsWith('github.com') &&
+          typeof pkgJson.repository.directory === 'string'
+        ) {
+          const slash = url.pathname.endsWith('/') ? '' : '/';
+          const { directory } = pkgJson.repository;
+          url.pathname = `${url.pathname}${slash}tree/master/${directory}`;
+        }
+        plugin.info.links.push({
+          title: 'Package repository',
+          url: url.toString(),
+        });
+      } catch (_err) {
+        // not critical
+      }
+    }
+
+    pluginInfoDecorator(plugin.info, plugin.getId());
+
+    this.knownPluginIds.add(plugin.getId());
+
+    return plugin;
+  };
+
+  public decoratePlugins = <Plugin extends CompatiblePlugin>(
+    plugins: Plugin[],
+  ): Plugin[] => {
+    plugins.forEach(plugin => {
+      this.decoratePlugin(plugin);
+    });
+
+    return plugins;
+  };
+}

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -24,6 +24,7 @@ import {
   SubRouteRef,
   ExternalRouteRef,
   IdentityApi,
+  PluginInfo,
 } from '@backstage/core-plugin-api';
 import { AppConfig } from '@backstage/config';
 
@@ -214,6 +215,20 @@ export type AppOptions = {
   >;
 
   /**
+   * A map of plugin package names to internal groups (as entity refs defaulting
+   * to kind Group).
+   *
+   * The package name (key) can contain wildcards and will be matched using
+   * minimatch.
+   */
+  pluginOwners?: Record<string, string>[];
+
+  /**
+   * Decorate the PluginInfo part of a plugin
+   */
+  pluginInfoDecorator?: (plugin: PluginInfo, id: string) => void;
+
+  /**
    * Supply components to the app to override the default ones.
    */
   components: AppComponents;
@@ -333,3 +348,12 @@ export type AppContext = {
    */
   getComponents(): AppComponents;
 };
+
+/**
+ * @private
+ */
+export type CompatiblePlugin =
+  | BackstagePlugin<any, any>
+  | (Omit<BackstagePlugin<any, any>, 'getFeatureFlags'> & {
+      output(): Array<{ type: 'feature-flag'; name: string }>;
+    });

--- a/packages/core-plugin-api/src/plugin/Plugin.tsx
+++ b/packages/core-plugin-api/src/plugin/Plugin.tsx
@@ -21,6 +21,7 @@ import {
   AnyRoutes,
   AnyExternalRoutes,
   PluginFeatureFlagConfig,
+  PluginInfo,
 } from './types';
 import { AnyApiFactory } from '../apis';
 
@@ -32,7 +33,11 @@ export class PluginImpl<
   ExternalRoutes extends AnyExternalRoutes,
 > implements BackstagePlugin<Routes, ExternalRoutes>
 {
-  constructor(private readonly config: PluginConfig<Routes, ExternalRoutes>) {}
+  public readonly info: PluginInfo;
+
+  constructor(private readonly config: PluginConfig<Routes, ExternalRoutes>) {
+    this.info = { links: [], ...config.info };
+  }
 
   getId(): string {
     return this.config.id;

--- a/packages/core-plugin-api/src/plugin/index.ts
+++ b/packages/core-plugin-api/src/plugin/index.ts
@@ -23,4 +23,7 @@ export type {
   FeatureFlagsHooks,
   PluginConfig,
   PluginFeatureFlagConfig,
+  PluginConfigInfo,
+  PluginInfo,
+  PluginInfoLink,
 } from './types';

--- a/packages/core-plugin-api/src/plugin/types.ts
+++ b/packages/core-plugin-api/src/plugin/types.ts
@@ -62,6 +62,7 @@ export type BackstagePlugin<
   provide<T>(extension: Extension<T>): T;
   routes: Routes;
   externalRoutes: ExternalRoutes;
+  info: PluginInfo;
 };
 
 /**
@@ -73,6 +74,62 @@ export type PluginFeatureFlagConfig = {
   /** Feature flag name */
   name: string;
 };
+
+export type PluginInfoLink = {
+  /**
+   * The url to the external site, document, etc.
+   */
+  url: string;
+
+  /**
+   * An optional descriptive title for the link.
+   */
+  title?: string;
+};
+
+/**
+ * PluginInfo
+ *
+ * @public
+ */
+export type PluginInfo = {
+  packageJson?: unknown;
+
+  /**
+   * Plugin name; defaults to `backstage.name` in package.json
+   */
+  name?: string;
+
+  /**
+   * Plugin description; defaults to `description` in package.json
+   */
+  description?: string;
+
+  /**
+   * Plugin version; defaults to `version` in package.json
+   */
+  version?: string;
+
+  /**
+   * Owner of the plugin. It's a catalog entity ref, defaulting the kind to
+   * Group, so it's either a full entity ref, or just a group name
+   */
+  ownerEntityRef?: string;
+
+  /**
+   * A set of links. Will by default include the `homepage` and `repository`
+   * field in package.json
+   */
+  links: PluginInfoLink[];
+
+  /**
+   * Plugin role; will likely be frontend-plugin, frontend-plugin-module or
+   * common-library
+   */
+  role?: string;
+};
+
+export type PluginConfigInfo = Partial<PluginInfo>;
 
 /**
  * Plugin descriptor type.
@@ -88,6 +145,7 @@ export type PluginConfig<
   routes?: Routes;
   externalRoutes?: ExternalRoutes;
   featureFlags?: PluginFeatureFlagConfig[];
+  info?: PluginConfigInfo;
 };
 
 /**


### PR DESCRIPTION
## Plugin metadata

This PR adds plugin metadata to plugins, in a field called `info`. It allows implementors (and plugin developers) to decorate plugins with:
 * Information about the plugin itself (coming from `package.json`, or totally custom)
 * "Ownership" of a plugin

The metadata (`PluginInfo`) contains name, version, owner, links etc. It will be deduced from `package.json`, and the way to do the decoration is for a plugin to:

```ts
import packageJson from '../package.json';

// ...

export const myPlugin = createPlugin({
  id: 'my-plugin',
  apis: [ /* ... */ ],
  routes: { /* ... */ },
  info: { packageJson }, // <-- add fields here, or just packageJson content
});
```

This means we can use the package.json as the basis for plugin metadata, and plugins can get information from the `package.json` about themselves or other plugins. The idea here is to re-use the `backstage` field for `backstage.name` and `backstage.role` etc.

An implementor can provide a callback `pluginInfoDecorator` to `createApp()` which will be called for each plugin, to allow further decorations of the plugin (extend with links to slack channels or whatnot).

You could argue that adding the package.json to each plugin will grow the webpack bundles. That's true, but it shouldn't be that bad though. A 1.5kB package.json is gzipped down to <600b. Having this would allow other future plugins to inspect this at runtime and indicate package dependency mismatches etc. Could be useful for more than just the metadata explicitly used here.

### Ownership

Alongside the metadata is ownership. It's very useful for implementors to be able to decorate their own _internal_ plugins with owners; what team/group owns a certain plugin. Combined with metadata, this would allow for error boundaries, help/support buttons etc to use that information to provide the user with relevant links to contact the corresponding owner for help / bug reports etc. Implementors can choose their own ownership model (maybe a field in package.json) and use the `pluginInfoDecorator` to decorate that to the `PluginInfo` blob.

This isn't only useful for _internal_ plugins though, but also for those plugins pulled in from this very open source repo (or any other). There's likely several teams being responsible for certain parts of a backstage implementation. You might have a core team being overall responsible for the implementation, maybe a documentation team, CI/CD team etc. This is where the `pluginOwners` option to `createApp()` comes in handy;

An implementor can create a mapping (e.g. in a yaml-file) between package names (npm package names) and internal team names, and these should (preferably) be **catalog groups**, or an entity-ref. With wild-card matching, you could create a mapping like this:

```yaml
# plugin-metadata.yaml
owners:
  - '*techdocs*': the-doc-team
  - '@backstage/plugin-ci*': cicd-team
  - '@backstage/plugin-jenkins*': cicd-team
  - '*': the-core-team # Fallback unless specified above
```

You'd then:

```ts
import pluginMetadata from './plugin-metadata.yaml';

createApp({
  pluginOwners: pluginMetadata.owners,
  // ...
});
```

A follow-up PR will use this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
