### PR TITLE
feat(core): Added Plugin React context

### DIFF
--- a/packages/core-plugin-api/src/extensions/extensions.tsx
+++ b/packages/core-plugin-api/src/extensions/extensions.tsx
@@ -21,6 +21,7 @@ import { RouteRef, useRouteRef } from '../routing';
 import { attachComponentData } from './componentData';
 import { Extension, BackstagePlugin } from '../plugin/types';
 import { PluginErrorBoundary } from './PluginErrorBoundary';
+import { PluginContextProvider } from '../plugin-context';
 
 /**
  * Lazy or synchronous retrieving of extension components.
@@ -237,17 +238,23 @@ export function createReactExtension<
 
         return (
           <Suspense fallback={<Progress />}>
-            <PluginErrorBoundary app={app} plugin={plugin}>
-              <AnalyticsContext
-                attributes={{
-                  pluginId: plugin.getId(),
-                  ...(name && { extension: name }),
-                  ...(mountPoint && { routeRef: mountPoint.id }),
-                }}
-              >
-                <Component {...props} />
-              </AnalyticsContext>
-            </PluginErrorBoundary>
+            <PluginContextProvider
+              componentName={componentName}
+              plugin={plugin}
+              routeRef={mountPoint?.id}
+            >
+              <PluginErrorBoundary app={app} plugin={plugin}>
+                <AnalyticsContext
+                  attributes={{
+                    pluginId: plugin.getId(),
+                    ...(name && { extension: name }),
+                    ...(mountPoint && { routeRef: mountPoint.id }),
+                  }}
+                >
+                  <Component {...props} />
+                </AnalyticsContext>
+              </PluginErrorBoundary>
+            </PluginContextProvider>
           </Suspense>
         );
       };

--- a/packages/core-plugin-api/src/plugin-context/context.tsx
+++ b/packages/core-plugin-api/src/plugin-context/context.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createVersionedContext,
+  createVersionedValueMap,
+} from '@backstage/version-bridge';
+import React, { PropsWithChildren, useContext } from 'react';
+
+import { PluginContext } from './types';
+
+const PluginReactContext =
+  createVersionedContext<{ 1: PluginContext[] }>('plugin-context');
+
+/**
+ * A hook that gets the plugin context stack in the React component tree.
+ *
+ * @public
+ */
+export const usePluginContextStack = (): PluginContext[] | undefined => {
+  const ctx = useContext(PluginReactContext);
+
+  if (ctx === undefined) {
+    return undefined;
+  }
+
+  const theValue = ctx.atVersion(1);
+  if (theValue === undefined) {
+    throw new Error('No context found for version 1.');
+  }
+
+  return theValue;
+};
+
+/**
+ * Provides components in the child react tree with plugin information.
+ *
+ * @alpha
+ */
+export const PluginContextProvider = (
+  props: PropsWithChildren<PluginContext>,
+) => {
+  const { componentName, plugin, routeRef, children } = props;
+
+  const parent = usePluginContextStack();
+  const value: PluginContext[] = [
+    ...(parent ?? []),
+    { componentName, plugin, routeRef },
+  ];
+
+  const versionedValue = createVersionedValueMap({ 1: value });
+  return (
+    <PluginReactContext.Provider value={versionedValue}>
+      {children}
+    </PluginReactContext.Provider>
+  );
+};

--- a/packages/core-plugin-api/src/plugin-context/index.ts
+++ b/packages/core-plugin-api/src/plugin-context/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,5 @@
  * limitations under the License.
  */
 
-/**
- * Core API used by Backstage plugins
- *
- * @packageDocumentation
- */
-
-export * from './analytics';
-export * from './apis';
-export * from './app';
-export * from './extensions';
-export * from './icons';
-export * from './plugin';
-export * from './plugin-context';
-export * from './routing';
+export * from './context';
+export * from './types';

--- a/packages/core-plugin-api/src/plugin-context/types.ts
+++ b/packages/core-plugin-api/src/plugin-context/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,26 @@
  * limitations under the License.
  */
 
-/**
- * Core API used by Backstage plugins
- *
- * @packageDocumentation
- */
+import { BackstagePlugin } from '../plugin/types';
 
-export * from './analytics';
-export * from './apis';
-export * from './app';
-export * from './extensions';
-export * from './icons';
-export * from './plugin';
-export * from './plugin-context';
-export * from './routing';
+/**
+ * Plugin context captured for each react extension
+ *
+ * @alpha
+ */
+export type PluginContext = {
+  /**
+   * The nearest known parent plugin
+   */
+  plugin: BackstagePlugin<any, any>;
+
+  /**
+   * The ID of the nearest routeRef
+   */
+  routeRef?: string;
+
+  /**
+   * The nearest known component
+   */
+  componentName: string;
+};


### PR DESCRIPTION
Added PluginContextProvider, with hook, to be able to traverse the plugin stack from a React component.

This can eventually be used for the ErrorBoundary and AnalyticsContext.

## usePluginContextStack / PluginContextProvider

This is basically #7624 picked up again. This will be used in a future PR.

Having a react provider for the plugin (and with its metadata available as per #10256), inner components can see the plugin boundary stack from anywhere in the tree.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
