### PR TITLE
[frontend] Log API

### DIFF
--- a/packages/app-defaults/src/defaults/apis.ts
+++ b/packages/app-defaults/src/defaults/apis.ts
@@ -15,6 +15,8 @@
  */
 
 import {
+  DefaultLogApi,
+  DefaultLogStoreApi,
   AlertApiForwarder,
   NoOpAnalyticsApi,
   ErrorApiForwarder,
@@ -36,6 +38,8 @@ import {
 } from '@backstage/core-app-api';
 
 import {
+  logApiRef,
+  logStoreApiRef,
   createApiFactory,
   alertApiRef,
   analyticsApiRef,
@@ -61,6 +65,16 @@ import {
 } from '@backstage/plugin-permission-react';
 
 export const apis = [
+  createApiFactory({
+    api: logStoreApiRef,
+    deps: {},
+    factory: () => DefaultLogStoreApi.create(),
+  }),
+  createApiFactory({
+    api: logApiRef,
+    deps: { logStoreApi: logStoreApiRef },
+    factory: ({ logStoreApi }) => DefaultLogApi.create({ logStoreApi }),
+  }),
   createApiFactory({
     api: discoveryApiRef,
     deps: { configApi: configApiRef },

--- a/packages/core-app-api/src/apis/implementations/LogApi/LogApi.ts
+++ b/packages/core-app-api/src/apis/implementations/LogApi/LogApi.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  FacettedApi,
+  ApiFacetContext,
+  LogApi,
+  LogStoreApi,
+  LogLevel,
+} from '@backstage/core-plugin-api';
+
+export interface LogApiOptions {
+  logStoreApi: LogStoreApi;
+}
+
+interface CompleteLogApiOptions extends LogApiOptions {
+  facetStack: ApiFacetContext[];
+}
+
+export class DefaultLogApi implements FacettedApi<LogApi> {
+  getApiFacet(context: ApiFacetContext): LogApi {
+    return new DefaultLogApi({
+      ...this.options,
+      facetStack: [...this.options.facetStack, context],
+    });
+  }
+
+  static create(options: LogApiOptions): DefaultLogApi {
+    return new DefaultLogApi({ ...options, facetStack: [] });
+  }
+
+  private constructor(private options: CompleteLogApiOptions) {}
+
+  private post(level: LogLevel, args: any[], callStack?: string) {
+    this.options.logStoreApi.post({
+      level,
+      args,
+      contextStack: this.options.facetStack,
+      pathname: window.location.pathname,
+      timestamp: new Date(),
+      ...(callStack && { callStack }),
+    });
+  }
+
+  debug(...args: any) {
+    this.post('debug', args);
+  }
+  info(...args: any) {
+    this.post('info', args);
+  }
+  warn(...args: any) {
+    this.post('warn', args, cleanStack(new Error().stack));
+  }
+  error(...args: any) {
+    this.post('error', args, cleanStack(new Error().stack));
+  }
+}
+
+// Removes the first line, if it's only "Error" (the default for empty errors)
+// and unindents the lines as much as possible, but evenly
+function cleanStack(stack?: string): typeof stack {
+  if (!stack) return stack;
+
+  const lines = stack.split('\n');
+  if (lines[0] === 'Error') lines.shift();
+
+  const indent = lines
+    .map(line => line.match(/( *)/)![1].length)
+    .reduce((prev, cur) => (prev === -1 ? cur : Math.min(prev, cur)), -1);
+
+  return lines.map(line => line.slice(indent)).join('\n');
+}

--- a/packages/core-app-api/src/apis/implementations/LogApi/index.ts
+++ b/packages/core-app-api/src/apis/implementations/LogApi/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DefaultLogApi } from './LogApi';

--- a/packages/core-app-api/src/apis/implementations/LogStoreApi/LogStoreApi.ts
+++ b/packages/core-app-api/src/apis/implementations/LogStoreApi/LogStoreApi.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  LogEntry,
+  StoredLogEntry,
+  StoredLogEntryArgument,
+  LogChange,
+  LogStoreApi,
+} from '@backstage/core-plugin-api';
+import { Observable } from '@backstage/types';
+
+import { PublishSubject } from '../../../lib/subjects';
+
+export interface LogRetentionPolicy {
+  /**
+   * Max number of log entries before removal / allowing GC
+   */
+  maxEntries: number;
+
+  /**
+   * Milliseconds of TTL until removal / allowing GC
+   */
+  ttl: number;
+}
+
+const POLICY_DEFAULT_MAX_ENTRIES = 5000;
+const POLICY_DEFAULT_TTL = 1000 * 60 * 60 * 24; // 24h
+const POLICY_DEFAULT_GC_MAX_ENTRIES = 200;
+const POLICY_DEFAULT_GC_TTL = 1000 * 60 * 60; // 1h
+
+export interface LogStoreApiOptions {
+  /**
+   * The log retention policy before old entries will be removed.
+   */
+  retentionPolicy: Partial<LogRetentionPolicy>;
+
+  /**
+   * The log retention policy before old entries will allowed to be garbage
+   * collected.
+   */
+  garbageCollectionPolicy: Partial<LogRetentionPolicy>;
+}
+
+interface StoredLogEntryImpl extends StoredLogEntry {
+  /*
+   * Whether the value of the arguments might be garbage collected or not.
+   *
+   * Begins as false, but is set to true after garbage collection retention
+   * policy has handled this entry.
+   */
+  retired: boolean;
+}
+
+export class DefaultLogStoreApi implements LogStoreApi {
+  private _retired: number = 0;
+  private _retentionPolicy: LogRetentionPolicy;
+  private _garbageCollectionPolicy: LogRetentionPolicy;
+  private _entries: StoredLogEntryImpl[] = [];
+
+  private readonly subject = new PublishSubject<LogChange>();
+
+  get entries(): ReadonlyArray<StoredLogEntry> {
+    return this._entries;
+  }
+
+  clear() {
+    this._entries.length = 0;
+    this._retired = 0;
+    this.subject.next({ type: 'clear' });
+  }
+
+  post(entry: LogEntry) {
+    const storedEntry = this.makeStored(entry);
+
+    this._entries.push(storedEntry);
+    this.subject.next({ type: 'add', entry: storedEntry });
+
+    this.runCleanupPolicy();
+  }
+
+  entry$(): Observable<LogChange> {
+    return this.subject;
+  }
+
+  static create(options?: Partial<LogStoreApiOptions>): DefaultLogStoreApi {
+    return new DefaultLogStoreApi({ ...options });
+  }
+
+  private constructor(options: Partial<LogStoreApiOptions>) {
+    this._retentionPolicy = {
+      maxEntries:
+        options.garbageCollectionPolicy?.maxEntries ??
+        POLICY_DEFAULT_MAX_ENTRIES,
+      ttl: options.garbageCollectionPolicy?.ttl ?? POLICY_DEFAULT_TTL,
+    };
+    this._garbageCollectionPolicy = {
+      maxEntries:
+        options.garbageCollectionPolicy?.maxEntries ??
+        POLICY_DEFAULT_GC_MAX_ENTRIES,
+      ttl: options.garbageCollectionPolicy?.ttl ?? POLICY_DEFAULT_GC_TTL,
+    };
+  }
+
+  private makeStored(logEntry: LogEntry): StoredLogEntryImpl {
+    return {
+      ...logEntry,
+      retired: false,
+      args: logEntry.args.map(value => ({ value })),
+      key: `${Math.random()}_${logEntry.timestamp.getTime()}`,
+    };
+  }
+
+  private runCleanupPolicy() {
+    // Remove too old entries
+    this.cleanupEntries();
+    // Allow garbage collection of too old entries
+    this.retireEntries();
+  }
+
+  private cleanupEntries() {
+    const count = this.useRetentionPolicy(this._retentionPolicy);
+
+    if (!count) return;
+
+    this._retired -= Math.min(this._retired, count);
+    const removed = this._entries.splice(0, count);
+
+    removed.forEach(entry => this.subject.next({ type: 'remove', entry }));
+  }
+
+  private retireEntries() {
+    const count = this.useRetentionPolicy(
+      this._garbageCollectionPolicy,
+      this._retired,
+    );
+
+    for (let i = 0; i < count; ++i) {
+      this.retireEntry(this._entries[this._retired++]);
+    }
+  }
+
+  private retireEntry(entry: StoredLogEntryImpl) {
+    entry.retired = true;
+    entry.args = entry.args.map(arg => {
+      if (!isObject(arg.value)) {
+        return arg;
+      }
+
+      const weakRef = new WeakRef(arg.value);
+      const typeName = getObjectTypeName(arg.value);
+
+      return Object.defineProperties({} as StoredLogEntryArgument, {
+        value: {
+          enumerable: true,
+          configurable: true,
+          get() {
+            return weakRef.deref() ?? typeName;
+          },
+        },
+        reclaimed: {
+          enumerable: true,
+          configurable: true,
+          get(): boolean {
+            return !weakRef.deref();
+          },
+        },
+      });
+    });
+  }
+
+  /**
+   * Count the number of entries to apply the policy to
+   */
+  private useRetentionPolicy(policy: LogRetentionPolicy, offset = 0) {
+    let count = Math.max(
+      0,
+      this._entries.length - (offset + policy.maxEntries),
+    );
+
+    const now = Date.now();
+
+    const shouldBeRetiredByTTL = (entry: StoredLogEntry) =>
+      entry.timestamp.getTime() + policy.ttl < now;
+
+    while (
+      count < this._entries.length &&
+      shouldBeRetiredByTTL(this._entries[count])
+    ) {
+      ++count;
+    }
+
+    return count;
+  }
+}
+
+function isObject(t: any): t is object | Function {
+  return (!!t && typeof t === 'object') || typeof t === 'function';
+}
+
+function getObjectTypeName(obj: object | Function): string {
+  if (typeof obj === 'function') {
+    return `[Function ${obj.name}]`;
+  } else if (Array.isArray(obj)) {
+    return `[Array(${obj.length})]`;
+  } else if (typeof obj.constructor?.name === 'string') {
+    return `[Object ${obj.constructor.name}]`;
+  }
+  return `[Object]`;
+}

--- a/packages/core-app-api/src/apis/implementations/LogStoreApi/index.ts
+++ b/packages/core-app-api/src/apis/implementations/LogStoreApi/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DefaultLogStoreApi } from './LogStoreApi';

--- a/packages/core-app-api/src/apis/implementations/index.ts
+++ b/packages/core-app-api/src/apis/implementations/index.ts
@@ -28,5 +28,7 @@ export * from './DiscoveryApi';
 export * from './ErrorApi';
 export * from './FeatureFlagsApi';
 export * from './FetchApi';
+export * from './LogApi';
+export * from './LogStoreApi';
 export * from './OAuthRequestApi';
 export * from './StorageApi';

--- a/packages/core-app-api/src/apis/system/ApiResolver.ts
+++ b/packages/core-app-api/src/apis/system/ApiResolver.ts
@@ -19,6 +19,7 @@ import {
   ApiHolder,
   AnyApiRef,
   TypesToApiRefs,
+  getApiFacet,
 } from '@backstage/core-plugin-api';
 import { ApiFactoryHolder } from './types';
 
@@ -85,7 +86,13 @@ export class ApiResolver implements ApiHolder {
     }
 
     const deps = this.loadDeps(ref, factory.deps, [...loading, factory.api]);
-    const api = factory.factory(deps);
+    const facettedDeps = Object.fromEntries(
+      Object.entries(deps).map(([name, api]) => [
+        name,
+        getApiFacet(api, { dependent: ref }),
+      ]),
+    );
+    const api = factory.factory(facettedDeps);
     this.apis.set(ref.id, api);
     return api as T;
   }

--- a/packages/core-plugin-api/src/apis/definitions/LogApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/LogApi.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiRef, createApiRef } from '../system';
+import { useApi } from '../hooks';
+import { LogLevel } from './LogStoreApi';
+
+/**
+ * A wrapper for the fetch API, that has additional behaviors such as the
+ * ability to automatically inject auth information where necessary.
+ *
+ * @public
+ */
+export type LogApi = {
+  [Level in LogLevel]: (...args: any) => void;
+};
+
+/**
+ * The {@link ApiRef} of {@link LogApi}.
+ *
+ * @public
+ */
+export const logApiRef: ApiRef<LogApi> = createApiRef({
+  id: 'core.log',
+});
+
+/**
+ * Utility wrapper around `useApi(logApiRef)` which decorates logging with the
+ * current plugin stack metadata.
+ */
+export function useLog() {
+  return useApi(logApiRef);
+}

--- a/packages/core-plugin-api/src/apis/definitions/LogStoreApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/LogStoreApi.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Observable } from '@backstage/types';
+
+import { ApiRef, createApiRef } from '../system';
+import { ApiFacetContext } from '../facet';
+
+export type LogChange =
+  | { type: 'add'; entry: StoredLogEntry }
+  | { type: 'remove'; entry: StoredLogEntry }
+  | { type: 'clear' };
+
+/**
+ * A wrapper for the fetch API, that has additional behaviors such as the
+ * ability to automatically inject auth information where necessary.
+ *
+ * @public
+ */
+export type LogStoreApi = {
+  readonly entries: ReadonlyArray<StoredLogEntry>;
+
+  /**
+   * Clear logs
+   */
+  clear(): void;
+
+  /**
+   * Post a log entry to the store
+   */
+  post(entry: LogEntry): void;
+
+  /**
+   * Observe new log entries
+   */
+  entry$(): Observable<LogChange>;
+};
+
+/**
+ * Log levels
+ *
+ * @public
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * A LogEntry is the information around a log entry created from debug(),
+ * info(), warn() or error().
+ *
+ * @public
+ */
+export interface LogEntry {
+  /**
+   * The log level
+   */
+  level: LogLevel;
+
+  /**
+   * The current time when the log was sent
+   */
+  timestamp: Date;
+
+  /**
+   * The current window.location.pathname when the log was sent
+   */
+  pathname: string;
+
+  /**
+   * The stack of ApiFacetContexts containing information about the callsite
+   */
+  contextStack: ApiFacetContext[];
+
+  /**
+   * The callstack of the log (may only exist for certain log levels)
+   */
+  callStack?: string;
+
+  /**
+   * The message arguments
+   */
+  args: unknown[];
+}
+
+/**
+ * A StoredLogEntry is the _stored_ information around a log entry created from
+ * debug(), info(), warn() or error().
+ *
+ * It is almost the same as {@link LogEntry}, but the arguments are possibly
+ * garbage collectable.
+ *
+ * @public
+ */
+export interface StoredLogEntry extends Omit<LogEntry, 'args'> {
+  args: StoredLogEntryArgument[];
+
+  /**
+   * Unique key for this log entry (useful for arrays of components in React
+   * UI's)
+   */
+  key: string;
+}
+
+/**
+ * StoredLogEntryArgument
+ */
+export interface StoredLogEntryArgument {
+  /**
+   * Will be set to true when the value is reclaimed (garbage collected). In
+   * that case, {@link value} is a string describing the reclaimed object.
+   */
+  reclaimed?: boolean;
+
+  value: unknown;
+}
+
+/**
+ * The {@link ApiRef} of {@link LogStoreApi}.
+ *
+ * @public
+ */
+export const logStoreApiRef: ApiRef<LogStoreApi> = createApiRef({
+  id: 'core.log-store',
+});

--- a/packages/core-plugin-api/src/apis/definitions/index.ts
+++ b/packages/core-plugin-api/src/apis/definitions/index.ts
@@ -31,5 +31,7 @@ export * from './ErrorApi';
 export * from './FeatureFlagsApi';
 export * from './FetchApi';
 export * from './IdentityApi';
+export * from './LogApi';
+export * from './LogStoreApi';
 export * from './OAuthRequestApi';
 export * from './StorageApi';

--- a/packages/core-plugin-api/src/apis/facet/getApiFacet.ts
+++ b/packages/core-plugin-api/src/apis/facet/getApiFacet.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-export * from './system';
-export * from './definitions';
-export * from './hooks';
-export * from './facet';
+import { FacettedApi, ApiFacetContext } from './types';
+
+/**
+ * Returns a facet of an api, if the api is facetted, otherwise returns the api
+ * as is.
+ */
+export function getApiFacet<Api>(api: Api, context: ApiFacetContext): Api {
+  if (typeof (api as FacettedApi<typeof api>).getApiFacet === 'function') {
+    return (api as FacettedApi<typeof api>).getApiFacet!(context);
+  }
+  return api;
+}

--- a/packages/core-plugin-api/src/apis/facet/index.ts
+++ b/packages/core-plugin-api/src/apis/facet/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,5 @@
  * limitations under the License.
  */
 
-export * from './system';
-export * from './definitions';
-export * from './hooks';
-export * from './facet';
+export { getApiFacet } from './getApiFacet';
+export * from './types';

--- a/packages/core-plugin-api/src/apis/facet/types.ts
+++ b/packages/core-plugin-api/src/apis/facet/types.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PluginContext } from '../../plugin-context';
+import { ApiRef } from '../system';
+
+/**
+ * Context for a (possibly) unique facet of an API
+ */
+export interface ApiFacetContext {
+  /**
+   * The API that depends on this API
+   */
+  dependent?: ApiRef<unknown>;
+
+  /**
+   * The plugin that is using the API
+   */
+  pluginStack?: PluginContext[];
+}
+
+/**
+ * An API that is facetted, meaning it can provide unique clones/facets of
+ * itself to dependent APIs.
+ */
+export type FacettedApi<Api> = Api & {
+  getApiFacet?: (context: ApiFacetContext) => FacettedApi<Api>;
+};

--- a/packages/core-plugin-api/src/apis/hooks/index.ts
+++ b/packages/core-plugin-api/src/apis/hooks/index.ts
@@ -14,7 +14,4 @@
  * limitations under the License.
  */
 
-export * from './system';
-export * from './definitions';
-export * from './hooks';
-export * from './facet';
+export { useApi, useApiHolder, withApis } from './useApi';

--- a/packages/core-plugin-api/src/apis/hooks/useApi.test.tsx
+++ b/packages/core-plugin-api/src/apis/hooks/useApi.test.tsx
@@ -16,7 +16,7 @@
 
 import { renderHook } from '@testing-library/react-hooks';
 import { createVersionedContextForTesting } from '@backstage/version-bridge';
-import { createApiRef } from './ApiRef';
+import { createApiRef } from '../system';
 import { useApi } from './useApi';
 
 describe('useApi', () => {

--- a/packages/core-plugin-api/src/apis/system/index.ts
+++ b/packages/core-plugin-api/src/apis/system/index.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-export { useApi, useApiHolder, withApis } from './useApi';
 export { createApiRef } from './ApiRef';
 export type { ApiRefConfig } from './ApiRef';
 export * from './types';

--- a/packages/core-plugin-api/src/extensions/extensions.tsx
+++ b/packages/core-plugin-api/src/extensions/extensions.tsx
@@ -21,6 +21,7 @@ import { RouteRef, useRouteRef } from '../routing';
 import { attachComponentData } from './componentData';
 import { Extension, BackstagePlugin } from '../plugin/types';
 import { PluginErrorBoundary } from './PluginErrorBoundary';
+import { PluginContextProvider } from '../plugin-context';
 
 /**
  * Lazy or synchronous retrieving of extension components.
@@ -237,17 +238,23 @@ export function createReactExtension<
 
         return (
           <Suspense fallback={<Progress />}>
-            <PluginErrorBoundary app={app} plugin={plugin}>
-              <AnalyticsContext
-                attributes={{
-                  pluginId: plugin.getId(),
-                  ...(name && { extension: name }),
-                  ...(mountPoint && { routeRef: mountPoint.id }),
-                }}
-              >
-                <Component {...props} />
-              </AnalyticsContext>
-            </PluginErrorBoundary>
+            <PluginContextProvider
+              componentName={componentName}
+              plugin={plugin}
+              routeRef={mountPoint?.id}
+            >
+              <PluginErrorBoundary app={app} plugin={plugin}>
+                <AnalyticsContext
+                  attributes={{
+                    pluginId: plugin.getId(),
+                    ...(name && { extension: name }),
+                    ...(mountPoint && { routeRef: mountPoint.id }),
+                  }}
+                >
+                  <Component {...props} />
+                </AnalyticsContext>
+              </PluginErrorBoundary>
+            </PluginContextProvider>
           </Suspense>
         );
       };

--- a/packages/core-plugin-api/src/plugin-context/context.tsx
+++ b/packages/core-plugin-api/src/plugin-context/context.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createVersionedContext,
+  createVersionedValueMap,
+} from '@backstage/version-bridge';
+import React, { PropsWithChildren, useContext } from 'react';
+
+import { PluginContext } from './types';
+
+const PluginReactContext =
+  createVersionedContext<{ 1: PluginContext[] }>('plugin-context');
+
+/**
+ * A hook that gets the plugin context stack in the React component tree.
+ *
+ * @public
+ */
+export const usePluginContextStack = (): PluginContext[] | undefined => {
+  const ctx = useContext(PluginReactContext);
+
+  if (ctx === undefined) {
+    return undefined;
+  }
+
+  const theValue = ctx.atVersion(1);
+  if (theValue === undefined) {
+    throw new Error('No context found for version 1.');
+  }
+
+  return theValue;
+};
+
+/**
+ * Provides components in the child react tree with plugin information.
+ *
+ * @alpha
+ */
+export const PluginContextProvider = (
+  props: PropsWithChildren<PluginContext>,
+) => {
+  const { componentName, plugin, routeRef, children } = props;
+
+  const parent = usePluginContextStack();
+  const value: PluginContext[] = [
+    ...(parent ?? []),
+    { componentName, plugin, routeRef },
+  ];
+
+  const versionedValue = createVersionedValueMap({ 1: value });
+  return (
+    <PluginReactContext.Provider value={versionedValue}>
+      {children}
+    </PluginReactContext.Provider>
+  );
+};

--- a/packages/core-plugin-api/src/plugin-context/index.ts
+++ b/packages/core-plugin-api/src/plugin-context/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,5 @@
  * limitations under the License.
  */
 
-/**
- * Core API used by Backstage plugins
- *
- * @packageDocumentation
- */
-
-export * from './analytics';
-export * from './apis';
-export * from './app';
-export * from './extensions';
-export * from './icons';
-export * from './plugin';
-export * from './plugin-context';
-export * from './routing';
+export * from './context';
+export * from './types';

--- a/packages/core-plugin-api/src/plugin-context/types.ts
+++ b/packages/core-plugin-api/src/plugin-context/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,26 @@
  * limitations under the License.
  */
 
-/**
- * Core API used by Backstage plugins
- *
- * @packageDocumentation
- */
+import { BackstagePlugin } from '../plugin/types';
 
-export * from './analytics';
-export * from './apis';
-export * from './app';
-export * from './extensions';
-export * from './icons';
-export * from './plugin';
-export * from './plugin-context';
-export * from './routing';
+/**
+ * Plugin context captured for each react extension
+ *
+ * @alpha
+ */
+export type PluginContext = {
+  /**
+   * The nearest known parent plugin
+   */
+  plugin: BackstagePlugin<any, any>;
+
+  /**
+   * The ID of the nearest routeRef
+   */
+  routeRef?: string;
+
+  /**
+   * The nearest known component
+   */
+  componentName: string;
+};


### PR DESCRIPTION
> This PR depends on (and currently includes) #10257 and #10258, so shouldn't be merged as is

## Core Log and LogStore API

This PR introduces a logging API to use for _writing_ logs from anywhere, and a LogStore API for storing the logs. Both are api refs and can be overridable.

There is currently no logging for the frontend apart from `console.log` which is discouraged. This PR changes that.

### Log API

The Log API can be used from other APIs (as an api ref dependency, like usual), and it can be used from React using `useLog()`. The default log api implementation uses API facets (from #10258) and therefore knows the context of where it is being used (the API, hence plugin; React hence component/plugin stack using #10257).

Having the context of where the log was written will make debugging a lot easier. Often, production builds of the app won't have source maps, so errors (and other logs) in the UI are often hard to analyse. A future PR will add a log viewer which shows the usefulness of having this context.

It's currently pretty minimalistic and has 4 log levels (`debug`, `info`, `warn`, `error`), the arguments are arbitrary just like `console.log|warn|error`.

The Log API depends on a LogStore API into which the Log API pushes logs.

### LogStore API

The LogStore API stores logs. It has a retention policy (number of entries and TTL) until it starts removing old logs, and a garbage retention policy until it starts allowing arguments in a log entry to be garbage collectable by the browser (it does this by transforming object arguments into `WeakRef`'s, and replaces the argument with a string representation if the object is garbage collected, when being read/viewed).

The LogStore API also provides an observable on which one can listen to LogStore changes (new entries, removed, cleared). Other (future) plugins can use this to e.g. push certain logs (say, only `error` entries) to a log server.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
