### PR TITLE
[frontend plugin] DevTools

### DIFF
--- a/packages/app-defaults/src/defaults/apis.ts
+++ b/packages/app-defaults/src/defaults/apis.ts
@@ -15,6 +15,8 @@
  */
 
 import {
+  DefaultLogApi,
+  DefaultLogStoreApi,
   AlertApiForwarder,
   NoOpAnalyticsApi,
   ErrorApiForwarder,
@@ -36,6 +38,8 @@ import {
 } from '@backstage/core-app-api';
 
 import {
+  logApiRef,
+  logStoreApiRef,
   createApiFactory,
   alertApiRef,
   analyticsApiRef,
@@ -61,6 +65,16 @@ import {
 } from '@backstage/plugin-permission-react';
 
 export const apis = [
+  createApiFactory({
+    api: logStoreApiRef,
+    deps: {},
+    factory: () => DefaultLogStoreApi.create(),
+  }),
+  createApiFactory({
+    api: logApiRef,
+    deps: { logStoreApi: logStoreApiRef },
+    factory: ({ logStoreApi }) => DefaultLogApi.create({ logStoreApi }),
+  }),
   createApiFactory({
     api: discoveryApiRef,
     deps: { configApi: configApiRef },

--- a/packages/core-app-api/package.json
+++ b/packages/core-app-api/package.json
@@ -38,6 +38,7 @@
     "@backstage/types": "^0.1.3",
     "@backstage/version-bridge": "^0.1.2",
     "@types/prop-types": "^15.7.3",
+    "minimatch": "5.0.1",
     "prop-types": "^15.7.2",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4",

--- a/packages/core-app-api/src/apis/implementations/LogApi/LogApi.ts
+++ b/packages/core-app-api/src/apis/implementations/LogApi/LogApi.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  FacettedApi,
+  ApiFacetContext,
+  LogApi,
+  LogStoreApi,
+  LogLevel,
+} from '@backstage/core-plugin-api';
+
+export interface LogApiOptions {
+  logStoreApi: LogStoreApi;
+}
+
+interface CompleteLogApiOptions extends LogApiOptions {
+  facetStack: ApiFacetContext[];
+}
+
+export class DefaultLogApi implements FacettedApi<LogApi> {
+  getApiFacet(context: ApiFacetContext): LogApi {
+    return new DefaultLogApi({
+      ...this.options,
+      facetStack: [...this.options.facetStack, context],
+    });
+  }
+
+  static create(options: LogApiOptions): DefaultLogApi {
+    return new DefaultLogApi({ ...options, facetStack: [] });
+  }
+
+  private constructor(private options: CompleteLogApiOptions) {}
+
+  private post(level: LogLevel, args: any[], callStack?: string) {
+    this.options.logStoreApi.post({
+      level,
+      args,
+      contextStack: this.options.facetStack,
+      pathname: window.location.pathname,
+      timestamp: new Date(),
+      ...(callStack && { callStack }),
+    });
+  }
+
+  debug(...args: any) {
+    this.post('debug', args);
+  }
+  info(...args: any) {
+    this.post('info', args);
+  }
+  warn(...args: any) {
+    this.post('warn', args, cleanStack(new Error().stack));
+  }
+  error(...args: any) {
+    this.post('error', args, cleanStack(new Error().stack));
+  }
+}
+
+// Removes the first line, if it's only "Error" (the default for empty errors)
+// and unindents the lines as much as possible, but evenly
+function cleanStack(stack?: string): typeof stack {
+  if (!stack) return stack;
+
+  const lines = stack.split('\n');
+  if (lines[0] === 'Error') lines.shift();
+
+  const indent = lines
+    .map(line => line.match(/( *)/)![1].length)
+    .reduce((prev, cur) => (prev === -1 ? cur : Math.min(prev, cur)), -1);
+
+  return lines.map(line => line.slice(indent)).join('\n');
+}

--- a/packages/core-app-api/src/apis/implementations/LogApi/index.ts
+++ b/packages/core-app-api/src/apis/implementations/LogApi/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DefaultLogApi } from './LogApi';

--- a/packages/core-app-api/src/apis/implementations/LogStoreApi/LogStoreApi.ts
+++ b/packages/core-app-api/src/apis/implementations/LogStoreApi/LogStoreApi.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  LogEntry,
+  StoredLogEntry,
+  StoredLogEntryArgument,
+  LogChange,
+  LogStoreApi,
+} from '@backstage/core-plugin-api';
+import { Observable } from '@backstage/types';
+
+import { PublishSubject } from '../../../lib/subjects';
+
+export interface LogRetentionPolicy {
+  /**
+   * Max number of log entries before removal / allowing GC
+   */
+  maxEntries: number;
+
+  /**
+   * Milliseconds of TTL until removal / allowing GC
+   */
+  ttl: number;
+}
+
+const POLICY_DEFAULT_MAX_ENTRIES = 5000;
+const POLICY_DEFAULT_TTL = 1000 * 60 * 60 * 24; // 24h
+const POLICY_DEFAULT_GC_MAX_ENTRIES = 200;
+const POLICY_DEFAULT_GC_TTL = 1000 * 60 * 60; // 1h
+
+export interface LogStoreApiOptions {
+  /**
+   * The log retention policy before old entries will be removed.
+   */
+  retentionPolicy: Partial<LogRetentionPolicy>;
+
+  /**
+   * The log retention policy before old entries will allowed to be garbage
+   * collected.
+   */
+  garbageCollectionPolicy: Partial<LogRetentionPolicy>;
+}
+
+interface StoredLogEntryImpl extends StoredLogEntry {
+  /*
+   * Whether the value of the arguments might be garbage collected or not.
+   *
+   * Begins as false, but is set to true after garbage collection retention
+   * policy has handled this entry.
+   */
+  retired: boolean;
+}
+
+export class DefaultLogStoreApi implements LogStoreApi {
+  private _retired: number = 0;
+  private _retentionPolicy: LogRetentionPolicy;
+  private _garbageCollectionPolicy: LogRetentionPolicy;
+  private _entries: StoredLogEntryImpl[] = [];
+
+  private readonly subject = new PublishSubject<LogChange>();
+
+  get entries(): ReadonlyArray<StoredLogEntry> {
+    return this._entries;
+  }
+
+  clear() {
+    this._entries.length = 0;
+    this._retired = 0;
+    this.subject.next({ type: 'clear' });
+  }
+
+  post(entry: LogEntry) {
+    const storedEntry = this.makeStored(entry);
+
+    this._entries.push(storedEntry);
+    this.subject.next({ type: 'add', entry: storedEntry });
+
+    this.runCleanupPolicy();
+  }
+
+  entry$(): Observable<LogChange> {
+    return this.subject;
+  }
+
+  static create(options?: Partial<LogStoreApiOptions>): DefaultLogStoreApi {
+    return new DefaultLogStoreApi({ ...options });
+  }
+
+  private constructor(options: Partial<LogStoreApiOptions>) {
+    this._retentionPolicy = {
+      maxEntries:
+        options.garbageCollectionPolicy?.maxEntries ??
+        POLICY_DEFAULT_MAX_ENTRIES,
+      ttl: options.garbageCollectionPolicy?.ttl ?? POLICY_DEFAULT_TTL,
+    };
+    this._garbageCollectionPolicy = {
+      maxEntries:
+        options.garbageCollectionPolicy?.maxEntries ??
+        POLICY_DEFAULT_GC_MAX_ENTRIES,
+      ttl: options.garbageCollectionPolicy?.ttl ?? POLICY_DEFAULT_GC_TTL,
+    };
+  }
+
+  private makeStored(logEntry: LogEntry): StoredLogEntryImpl {
+    return {
+      ...logEntry,
+      retired: false,
+      args: logEntry.args.map(value => ({ value })),
+      key: `${Math.random()}_${logEntry.timestamp.getTime()}`,
+    };
+  }
+
+  private runCleanupPolicy() {
+    // Remove too old entries
+    this.cleanupEntries();
+    // Allow garbage collection of too old entries
+    this.retireEntries();
+  }
+
+  private cleanupEntries() {
+    const count = this.useRetentionPolicy(this._retentionPolicy);
+
+    if (!count) return;
+
+    this._retired -= Math.min(this._retired, count);
+    const removed = this._entries.splice(0, count);
+
+    removed.forEach(entry => this.subject.next({ type: 'remove', entry }));
+  }
+
+  private retireEntries() {
+    const count = this.useRetentionPolicy(
+      this._garbageCollectionPolicy,
+      this._retired,
+    );
+
+    for (let i = 0; i < count; ++i) {
+      this.retireEntry(this._entries[this._retired++]);
+    }
+  }
+
+  private retireEntry(entry: StoredLogEntryImpl) {
+    entry.retired = true;
+    entry.args = entry.args.map(arg => {
+      if (!isObject(arg.value)) {
+        return arg;
+      }
+
+      const weakRef = new WeakRef(arg.value);
+      const typeName = getObjectTypeName(arg.value);
+
+      return Object.defineProperties({} as StoredLogEntryArgument, {
+        value: {
+          enumerable: true,
+          configurable: true,
+          get() {
+            return weakRef.deref() ?? typeName;
+          },
+        },
+        reclaimed: {
+          enumerable: true,
+          configurable: true,
+          get(): boolean {
+            return !weakRef.deref();
+          },
+        },
+      });
+    });
+  }
+
+  /**
+   * Count the number of entries to apply the policy to
+   */
+  private useRetentionPolicy(policy: LogRetentionPolicy, offset = 0) {
+    let count = Math.max(
+      0,
+      this._entries.length - (offset + policy.maxEntries),
+    );
+
+    const now = Date.now();
+
+    const shouldBeRetiredByTTL = (entry: StoredLogEntry) =>
+      entry.timestamp.getTime() + policy.ttl < now;
+
+    while (
+      count < this._entries.length &&
+      shouldBeRetiredByTTL(this._entries[count])
+    ) {
+      ++count;
+    }
+
+    return count;
+  }
+}
+
+function isObject(t: any): t is object | Function {
+  return (!!t && typeof t === 'object') || typeof t === 'function';
+}
+
+function getObjectTypeName(obj: object | Function): string {
+  if (typeof obj === 'function') {
+    return `[Function ${obj.name}]`;
+  } else if (Array.isArray(obj)) {
+    return `[Array(${obj.length})]`;
+  } else if (typeof obj.constructor?.name === 'string') {
+    return `[Object ${obj.constructor.name}]`;
+  }
+  return `[Object]`;
+}

--- a/packages/core-app-api/src/apis/implementations/LogStoreApi/index.ts
+++ b/packages/core-app-api/src/apis/implementations/LogStoreApi/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DefaultLogStoreApi } from './LogStoreApi';

--- a/packages/core-app-api/src/apis/implementations/index.ts
+++ b/packages/core-app-api/src/apis/implementations/index.ts
@@ -28,5 +28,7 @@ export * from './DiscoveryApi';
 export * from './ErrorApi';
 export * from './FeatureFlagsApi';
 export * from './FetchApi';
+export * from './LogApi';
+export * from './LogStoreApi';
 export * from './OAuthRequestApi';
 export * from './StorageApi';

--- a/packages/core-app-api/src/apis/system/ApiResolver.ts
+++ b/packages/core-app-api/src/apis/system/ApiResolver.ts
@@ -19,6 +19,7 @@ import {
   ApiHolder,
   AnyApiRef,
   TypesToApiRefs,
+  getApiFacet,
 } from '@backstage/core-plugin-api';
 import { ApiFactoryHolder } from './types';
 
@@ -85,7 +86,13 @@ export class ApiResolver implements ApiHolder {
     }
 
     const deps = this.loadDeps(ref, factory.deps, [...loading, factory.api]);
-    const api = factory.factory(deps);
+    const facettedDeps = Object.fromEntries(
+      Object.entries(deps).map(([name, api]) => [
+        name,
+        getApiFacet(api, { dependent: ref }),
+      ]),
+    );
+    const api = factory.factory(facettedDeps);
     this.apis.set(ref.id, api);
     return api as T;
   }

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -181,6 +181,10 @@ export class AppManager implements BackstageApp {
     this.apiFactoryRegistry = new ApiFactoryRegistry();
   }
 
+  getApis(): AnyApiFactory[] {
+    return Array.from(this.apis);
+  }
+
   getPlugins(): BackstagePlugin<any, any>[] {
     return Array.from(this.plugins) as BackstagePlugin<any, any>[];
   }

--- a/packages/core-app-api/src/app/PluginDecoration.ts
+++ b/packages/core-app-api/src/app/PluginDecoration.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Minimatch, IMinimatch } from 'minimatch';
+
+import { AppOptions, CompatiblePlugin } from './types';
+
+export type PluginDecorationOptions = Pick<
+  AppOptions,
+  'pluginOwners' | 'pluginInfoDecorator'
+>;
+
+export class PluginDecoration {
+  private readonly matchers: ReadonlyArray<readonly [IMinimatch, string]>;
+  private knownPluginIds = new Set<string>();
+
+  constructor(private options: PluginDecorationOptions) {
+    const { pluginOwners = [] } = this.options;
+
+    this.matchers = pluginOwners.flatMap(rec =>
+      Object.entries(rec).map(
+        ([pkgNamePattern, owner]) =>
+          [new Minimatch(pkgNamePattern), owner] as const,
+      ),
+    );
+  }
+
+  public matchOwner = (pkgName: string): string | undefined => {
+    const match = this.matchers.find(([matcher]) => matcher.match(pkgName));
+    return match?.[1];
+  };
+
+  public decoratePlugin = <Plugin extends CompatiblePlugin>(plugin: Plugin) => {
+    if (this.knownPluginIds.has(plugin.getId())) {
+      return plugin;
+    }
+
+    const { pluginInfoDecorator = () => {} } = this.options;
+
+    if (!plugin.info) {
+      // Plugin with an older core-plugin-api dependency
+      plugin.info = { links: [] };
+    }
+
+    const pkgJson = (plugin.info.packageJson as any) ?? {};
+
+    const pkgName = pkgJson?.name ? `${pkgJson.name}` : undefined;
+    const pkgDescription = pkgJson?.description
+      ? `${pkgJson.description}`
+      : undefined;
+    const pkgVersion = pkgJson?.version ? `${pkgJson.version}` : undefined;
+
+    if (!plugin.info.ownerEntityRef && pkgName) {
+      plugin.info.ownerEntityRef =
+        this.matchOwner(pkgName) ?? pkgJson.backstage?.owner;
+    }
+    if (!plugin.info.description) {
+      plugin.info.description = pkgDescription;
+    }
+    if (!plugin.info.version) {
+      plugin.info.version = pkgVersion;
+    }
+    if (!plugin.info.name && pkgJson.backstage?.name) {
+      plugin.info.name = pkgJson.backstage.name;
+    }
+    if (!plugin.info.role && pkgJson.backstage?.role) {
+      plugin.info.role = pkgJson.backstage.role;
+    }
+    if (typeof pkgJson.homepage === 'string') {
+      plugin.info.links.push({
+        title: 'Package homepage',
+        url: pkgJson.homepage,
+      });
+    }
+    if (typeof pkgJson.repository === 'string') {
+      try {
+        const url = new URL(pkgJson.repository);
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+          url.protocol = 'https:';
+        }
+        plugin.info.links.push({
+          title: 'Package repository',
+          url: url.toString(),
+        });
+      } catch (_err) {
+        // not critical
+      }
+    }
+    if (typeof pkgJson.repository?.url === 'string') {
+      try {
+        const url = new URL(pkgJson.repository?.url);
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+          url.protocol = 'https:';
+        }
+        if (
+          url.hostname.endsWith('github.com') &&
+          typeof pkgJson.repository.directory === 'string'
+        ) {
+          const slash = url.pathname.endsWith('/') ? '' : '/';
+          const { directory } = pkgJson.repository;
+          url.pathname = `${url.pathname}${slash}tree/master/${directory}`;
+        }
+        plugin.info.links.push({
+          title: 'Package repository',
+          url: url.toString(),
+        });
+      } catch (_err) {
+        // not critical
+      }
+    }
+
+    pluginInfoDecorator(plugin.info, plugin.getId());
+
+    this.knownPluginIds.add(plugin.getId());
+
+    return plugin;
+  };
+
+  public decoratePlugins = <Plugin extends CompatiblePlugin>(
+    plugins: Plugin[],
+  ): Plugin[] => {
+    plugins.forEach(plugin => {
+      this.decoratePlugin(plugin);
+    });
+
+    return plugins;
+  };
+}

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -24,6 +24,7 @@ import {
   SubRouteRef,
   ExternalRouteRef,
   IdentityApi,
+  PluginInfo,
 } from '@backstage/core-plugin-api';
 import { AppConfig } from '@backstage/config';
 
@@ -214,6 +215,20 @@ export type AppOptions = {
   >;
 
   /**
+   * A map of plugin package names to internal groups (as entity refs defaulting
+   * to kind Group).
+   *
+   * The package name (key) can contain wildcards and will be matched using
+   * minimatch.
+   */
+  pluginOwners?: Record<string, string>[];
+
+  /**
+   * Decorate the PluginInfo part of a plugin
+   */
+  pluginInfoDecorator?: (plugin: PluginInfo, id: string) => void;
+
+  /**
    * Supply components to the app to override the default ones.
    */
   components: AppComponents;
@@ -338,3 +353,12 @@ export type AppContext = {
    */
   getComponents(): AppComponents;
 };
+
+/**
+ * @private
+ */
+export type CompatiblePlugin =
+  | BackstagePlugin<any, any>
+  | (Omit<BackstagePlugin<any, any>, 'getFeatureFlags'> & {
+      output(): Array<{ type: 'feature-flag'; name: string }>;
+    });

--- a/packages/core-app-api/src/app/types.ts
+++ b/packages/core-app-api/src/app/types.ts
@@ -289,6 +289,11 @@ export type AppOptions = {
  */
 export type BackstageApp = {
   /**
+   * Returns all APIs registered for the app.
+   */
+  getApis(): AnyApiFactory[];
+
+  /**
    * Returns all plugins registered for the app.
    */
   getPlugins(): BackstagePlugin<any, any>[];

--- a/packages/core-app-api/src/routing/RouteResolver.ts
+++ b/packages/core-app-api/src/routing/RouteResolver.ts
@@ -180,14 +180,14 @@ function resolveBasePath(
 
 export class RouteResolver {
   constructor(
-    private readonly routePaths: Map<RouteRef, string>,
-    private readonly routeParents: Map<RouteRef, RouteRef | undefined>,
-    private readonly routeObjects: BackstageRouteObject[],
-    private readonly routeBindings: Map<
+    public readonly routePaths: Map<RouteRef, string>,
+    public readonly routeParents: Map<RouteRef, RouteRef | undefined>,
+    public readonly routeObjects: BackstageRouteObject[],
+    public readonly routeBindings: Map<
       ExternalRouteRef,
       RouteRef | SubRouteRef
     >,
-    private readonly appBasePath: string, // base path without a trailing slash
+    public readonly appBasePath: string, // base path without a trailing slash
   ) {}
 
   resolve<Params extends AnyParams>(

--- a/packages/core-plugin-api/src/apis/definitions/LogApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/LogApi.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiRef, createApiRef } from '../system';
+import { useApi } from '../hooks';
+import { LogLevel } from './LogStoreApi';
+
+/**
+ * A wrapper for the fetch API, that has additional behaviors such as the
+ * ability to automatically inject auth information where necessary.
+ *
+ * @public
+ */
+export type LogApi = {
+  [Level in LogLevel]: (...args: any) => void;
+};
+
+/**
+ * The {@link ApiRef} of {@link LogApi}.
+ *
+ * @public
+ */
+export const logApiRef: ApiRef<LogApi> = createApiRef({
+  id: 'core.log',
+});
+
+/**
+ * Utility wrapper around `useApi(logApiRef)` which decorates logging with the
+ * current plugin stack metadata.
+ */
+export function useLog() {
+  return useApi(logApiRef);
+}

--- a/packages/core-plugin-api/src/apis/definitions/LogStoreApi.ts
+++ b/packages/core-plugin-api/src/apis/definitions/LogStoreApi.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Observable } from '@backstage/types';
+
+import { ApiRef, createApiRef } from '../system';
+import { ApiFacetContext } from '../facet';
+
+export type LogChange =
+  | { type: 'add'; entry: StoredLogEntry }
+  | { type: 'remove'; entry: StoredLogEntry }
+  | { type: 'clear' };
+
+/**
+ * A wrapper for the fetch API, that has additional behaviors such as the
+ * ability to automatically inject auth information where necessary.
+ *
+ * @public
+ */
+export type LogStoreApi = {
+  readonly entries: ReadonlyArray<StoredLogEntry>;
+
+  /**
+   * Clear logs
+   */
+  clear(): void;
+
+  /**
+   * Post a log entry to the store
+   */
+  post(entry: LogEntry): void;
+
+  /**
+   * Observe new log entries
+   */
+  entry$(): Observable<LogChange>;
+};
+
+/**
+ * Log levels
+ *
+ * @public
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * A LogEntry is the information around a log entry created from debug(),
+ * info(), warn() or error().
+ *
+ * @public
+ */
+export interface LogEntry {
+  /**
+   * The log level
+   */
+  level: LogLevel;
+
+  /**
+   * The current time when the log was sent
+   */
+  timestamp: Date;
+
+  /**
+   * The current window.location.pathname when the log was sent
+   */
+  pathname: string;
+
+  /**
+   * The stack of ApiFacetContexts containing information about the callsite
+   */
+  contextStack: ApiFacetContext[];
+
+  /**
+   * The callstack of the log (may only exist for certain log levels)
+   */
+  callStack?: string;
+
+  /**
+   * The message arguments
+   */
+  args: unknown[];
+}
+
+/**
+ * A StoredLogEntry is the _stored_ information around a log entry created from
+ * debug(), info(), warn() or error().
+ *
+ * It is almost the same as {@link LogEntry}, but the arguments are possibly
+ * garbage collectable.
+ *
+ * @public
+ */
+export interface StoredLogEntry extends Omit<LogEntry, 'args'> {
+  args: StoredLogEntryArgument[];
+
+  /**
+   * Unique key for this log entry (useful for arrays of components in React
+   * UI's)
+   */
+  key: string;
+}
+
+/**
+ * StoredLogEntryArgument
+ */
+export interface StoredLogEntryArgument {
+  /**
+   * Will be set to true when the value is reclaimed (garbage collected). In
+   * that case, {@link value} is a string describing the reclaimed object.
+   */
+  reclaimed?: boolean;
+
+  value: unknown;
+}
+
+/**
+ * The {@link ApiRef} of {@link LogStoreApi}.
+ *
+ * @public
+ */
+export const logStoreApiRef: ApiRef<LogStoreApi> = createApiRef({
+  id: 'core.log-store',
+});

--- a/packages/core-plugin-api/src/apis/definitions/index.ts
+++ b/packages/core-plugin-api/src/apis/definitions/index.ts
@@ -31,5 +31,7 @@ export * from './ErrorApi';
 export * from './FeatureFlagsApi';
 export * from './FetchApi';
 export * from './IdentityApi';
+export * from './LogApi';
+export * from './LogStoreApi';
 export * from './OAuthRequestApi';
 export * from './StorageApi';

--- a/packages/core-plugin-api/src/apis/facet/getApiFacet.ts
+++ b/packages/core-plugin-api/src/apis/facet/getApiFacet.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-export * from './system';
-export * from './definitions';
-export * from './hooks';
-export * from './facet';
+import { FacettedApi, ApiFacetContext } from './types';
+
+/**
+ * Returns a facet of an api, if the api is facetted, otherwise returns the api
+ * as is.
+ */
+export function getApiFacet<Api>(api: Api, context: ApiFacetContext): Api {
+  if (typeof (api as FacettedApi<typeof api>).getApiFacet === 'function') {
+    return (api as FacettedApi<typeof api>).getApiFacet!(context);
+  }
+  return api;
+}

--- a/packages/core-plugin-api/src/apis/facet/index.ts
+++ b/packages/core-plugin-api/src/apis/facet/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,5 @@
  * limitations under the License.
  */
 
-export * from './system';
-export * from './definitions';
-export * from './hooks';
-export * from './facet';
+export { getApiFacet } from './getApiFacet';
+export * from './types';

--- a/packages/core-plugin-api/src/apis/facet/types.ts
+++ b/packages/core-plugin-api/src/apis/facet/types.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PluginContext } from '../../plugin-context';
+import { ApiRef } from '../system';
+
+/**
+ * Context for a (possibly) unique facet of an API
+ */
+export interface ApiFacetContext {
+  /**
+   * The API that depends on this API
+   */
+  dependent?: ApiRef<unknown>;
+
+  /**
+   * The plugin that is using the API
+   */
+  pluginStack?: PluginContext[];
+}
+
+/**
+ * An API that is facetted, meaning it can provide unique clones/facets of
+ * itself to dependent APIs.
+ */
+export type FacettedApi<Api> = Api & {
+  getApiFacet?: (context: ApiFacetContext) => FacettedApi<Api>;
+};

--- a/packages/core-plugin-api/src/apis/hooks/index.ts
+++ b/packages/core-plugin-api/src/apis/hooks/index.ts
@@ -14,7 +14,4 @@
  * limitations under the License.
  */
 
-export * from './system';
-export * from './definitions';
-export * from './hooks';
-export * from './facet';
+export { useApi, useApiHolder, withApis } from './useApi';

--- a/packages/core-plugin-api/src/apis/hooks/useApi.test.tsx
+++ b/packages/core-plugin-api/src/apis/hooks/useApi.test.tsx
@@ -16,7 +16,7 @@
 
 import { renderHook } from '@testing-library/react-hooks';
 import { createVersionedContextForTesting } from '@backstage/version-bridge';
-import { createApiRef } from './ApiRef';
+import { createApiRef } from '../system';
 import { useApi } from './useApi';
 
 describe('useApi', () => {

--- a/packages/core-plugin-api/src/apis/system/index.ts
+++ b/packages/core-plugin-api/src/apis/system/index.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-export { useApi, useApiHolder, withApis } from './useApi';
 export { createApiRef } from './ApiRef';
 export type { ApiRefConfig } from './ApiRef';
 export * from './types';

--- a/packages/core-plugin-api/src/extensions/extensions.tsx
+++ b/packages/core-plugin-api/src/extensions/extensions.tsx
@@ -21,6 +21,7 @@ import { RouteRef, useRouteRef } from '../routing';
 import { attachComponentData } from './componentData';
 import { Extension, BackstagePlugin } from '../plugin/types';
 import { PluginErrorBoundary } from './PluginErrorBoundary';
+import { PluginContextProvider } from '../plugin-context';
 
 /**
  * Lazy or synchronous retrieving of extension components.
@@ -237,17 +238,23 @@ export function createReactExtension<
 
         return (
           <Suspense fallback={<Progress />}>
-            <PluginErrorBoundary app={app} plugin={plugin}>
-              <AnalyticsContext
-                attributes={{
-                  pluginId: plugin.getId(),
-                  ...(name && { extension: name }),
-                  ...(mountPoint && { routeRef: mountPoint.id }),
-                }}
-              >
-                <Component {...props} />
-              </AnalyticsContext>
-            </PluginErrorBoundary>
+            <PluginContextProvider
+              componentName={componentName}
+              plugin={plugin}
+              routeRef={mountPoint?.id}
+            >
+              <PluginErrorBoundary app={app} plugin={plugin}>
+                <AnalyticsContext
+                  attributes={{
+                    pluginId: plugin.getId(),
+                    ...(name && { extension: name }),
+                    ...(mountPoint && { routeRef: mountPoint.id }),
+                  }}
+                >
+                  <Component {...props} />
+                </AnalyticsContext>
+              </PluginErrorBoundary>
+            </PluginContextProvider>
           </Suspense>
         );
       };

--- a/packages/core-plugin-api/src/plugin-context/context.tsx
+++ b/packages/core-plugin-api/src/plugin-context/context.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createVersionedContext,
+  createVersionedValueMap,
+} from '@backstage/version-bridge';
+import React, { PropsWithChildren, useContext } from 'react';
+
+import { PluginContext } from './types';
+
+const PluginReactContext =
+  createVersionedContext<{ 1: PluginContext[] }>('plugin-context');
+
+/**
+ * A hook that gets the plugin context stack in the React component tree.
+ *
+ * @public
+ */
+export const usePluginContextStack = (): PluginContext[] | undefined => {
+  const ctx = useContext(PluginReactContext);
+
+  if (ctx === undefined) {
+    return undefined;
+  }
+
+  const theValue = ctx.atVersion(1);
+  if (theValue === undefined) {
+    throw new Error('No context found for version 1.');
+  }
+
+  return theValue;
+};
+
+/**
+ * Provides components in the child react tree with plugin information.
+ *
+ * @alpha
+ */
+export const PluginContextProvider = (
+  props: PropsWithChildren<PluginContext>,
+) => {
+  const { componentName, plugin, routeRef, children } = props;
+
+  const parent = usePluginContextStack();
+  const value: PluginContext[] = [
+    ...(parent ?? []),
+    { componentName, plugin, routeRef },
+  ];
+
+  const versionedValue = createVersionedValueMap({ 1: value });
+  return (
+    <PluginReactContext.Provider value={versionedValue}>
+      {children}
+    </PluginReactContext.Provider>
+  );
+};

--- a/packages/core-plugin-api/src/plugin-context/index.ts
+++ b/packages/core-plugin-api/src/plugin-context/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,5 @@
  * limitations under the License.
  */
 
-/**
- * Core API used by Backstage plugins
- *
- * @packageDocumentation
- */
-
-export * from './analytics';
-export * from './apis';
-export * from './app';
-export * from './extensions';
-export * from './icons';
-export * from './plugin';
-export * from './plugin-context';
-export * from './routing';
+export * from './context';
+export * from './types';

--- a/packages/core-plugin-api/src/plugin-context/types.ts
+++ b/packages/core-plugin-api/src/plugin-context/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,26 @@
  * limitations under the License.
  */
 
-/**
- * Core API used by Backstage plugins
- *
- * @packageDocumentation
- */
+import { BackstagePlugin } from '../plugin/types';
 
-export * from './analytics';
-export * from './apis';
-export * from './app';
-export * from './extensions';
-export * from './icons';
-export * from './plugin';
-export * from './plugin-context';
-export * from './routing';
+/**
+ * Plugin context captured for each react extension
+ *
+ * @alpha
+ */
+export type PluginContext = {
+  /**
+   * The nearest known parent plugin
+   */
+  plugin: BackstagePlugin<any, any>;
+
+  /**
+   * The ID of the nearest routeRef
+   */
+  routeRef?: string;
+
+  /**
+   * The nearest known component
+   */
+  componentName: string;
+};

--- a/packages/core-plugin-api/src/plugin/Plugin.tsx
+++ b/packages/core-plugin-api/src/plugin/Plugin.tsx
@@ -21,6 +21,7 @@ import {
   AnyRoutes,
   AnyExternalRoutes,
   PluginFeatureFlagConfig,
+  PluginInfo,
 } from './types';
 import { AnyApiFactory } from '../apis';
 
@@ -32,7 +33,11 @@ export class PluginImpl<
   ExternalRoutes extends AnyExternalRoutes,
 > implements BackstagePlugin<Routes, ExternalRoutes>
 {
-  constructor(private readonly config: PluginConfig<Routes, ExternalRoutes>) {}
+  public readonly info: PluginInfo;
+
+  constructor(private readonly config: PluginConfig<Routes, ExternalRoutes>) {
+    this.info = { links: [], ...config.info };
+  }
 
   getId(): string {
     return this.config.id;

--- a/packages/core-plugin-api/src/plugin/index.ts
+++ b/packages/core-plugin-api/src/plugin/index.ts
@@ -23,4 +23,7 @@ export type {
   FeatureFlagsHooks,
   PluginConfig,
   PluginFeatureFlagConfig,
+  PluginConfigInfo,
+  PluginInfo,
+  PluginInfoLink,
 } from './types';

--- a/packages/core-plugin-api/src/plugin/types.ts
+++ b/packages/core-plugin-api/src/plugin/types.ts
@@ -62,6 +62,7 @@ export type BackstagePlugin<
   provide<T>(extension: Extension<T>): T;
   routes: Routes;
   externalRoutes: ExternalRoutes;
+  info: PluginInfo;
 };
 
 /**
@@ -73,6 +74,62 @@ export type PluginFeatureFlagConfig = {
   /** Feature flag name */
   name: string;
 };
+
+export type PluginInfoLink = {
+  /**
+   * The url to the external site, document, etc.
+   */
+  url: string;
+
+  /**
+   * An optional descriptive title for the link.
+   */
+  title?: string;
+};
+
+/**
+ * PluginInfo
+ *
+ * @public
+ */
+export type PluginInfo = {
+  packageJson?: unknown;
+
+  /**
+   * Plugin name; defaults to `backstage.name` in package.json
+   */
+  name?: string;
+
+  /**
+   * Plugin description; defaults to `description` in package.json
+   */
+  description?: string;
+
+  /**
+   * Plugin version; defaults to `version` in package.json
+   */
+  version?: string;
+
+  /**
+   * Owner of the plugin. It's a catalog entity ref, defaulting the kind to
+   * Group, so it's either a full entity ref, or just a group name
+   */
+  ownerEntityRef?: string;
+
+  /**
+   * A set of links. Will by default include the `homepage` and `repository`
+   * field in package.json
+   */
+  links: PluginInfoLink[];
+
+  /**
+   * Plugin role; will likely be frontend-plugin, frontend-plugin-module or
+   * common-library
+   */
+  role?: string;
+};
+
+export type PluginConfigInfo = Partial<PluginInfo>;
 
 /**
  * Plugin descriptor type.
@@ -88,6 +145,7 @@ export type PluginConfig<
   routes?: Routes;
   externalRoutes?: ExternalRoutes;
   featureFlags?: PluginFeatureFlagConfig[];
+  info?: PluginConfigInfo;
 };
 
 /**

--- a/packages/core-plugin-api/src/routing/useRouteContext.ts
+++ b/packages/core-plugin-api/src/routing/useRouteContext.ts
@@ -14,26 +14,21 @@
  * limitations under the License.
  */
 
-export type {
-  AnyParams,
-  RouteRef,
-  SubRouteRef,
-  ExternalRouteRef,
-  OptionalParams,
-  ParamKeys,
-  RouteFunc,
-  BackstageRouteObject,
-} from './types';
-export { createRouteRef } from './RouteRef';
-export { createSubRouteRef } from './SubRouteRef';
-export type {
-  MakeSubRouteRef,
-  MergeParams,
-  ParamNames,
-  ParamPart,
-  PathParams,
-} from './SubRouteRef';
-export { createExternalRouteRef } from './ExternalRouteRef';
-export { useRouteRef } from './useRouteRef';
-export { useRouteRefParams } from './useRouteRefParams';
-export { useRouteContext } from './useRouteContext';
+import { useVersionedContext } from '@backstage/version-bridge';
+import { RouteResolver } from './useRouteRef';
+
+export function useRouteContext(): RouteResolver | undefined {
+  const versionedContext =
+    useVersionedContext<{ 1: RouteResolver }>('routing-context');
+  if (!versionedContext) {
+    throw new Error('Routing context is not available');
+  }
+
+  const resolver = versionedContext.atVersion(1);
+
+  if (!resolver) {
+    throw new Error('RoutingContext v1 not available');
+  }
+
+  return resolver;
+}

--- a/packages/core-plugin-api/src/routing/useRouteRef.tsx
+++ b/packages/core-plugin-api/src/routing/useRouteRef.tsx
@@ -19,6 +19,7 @@ import { matchRoutes, useLocation } from 'react-router-dom';
 import { useVersionedContext } from '@backstage/version-bridge';
 import {
   AnyParams,
+  BackstageRouteObject,
   ExternalRouteRef,
   RouteFunc,
   RouteRef,
@@ -36,6 +37,12 @@ export interface RouteResolver {
       | ExternalRouteRef<Params, any>,
     sourceLocation: Parameters<typeof matchRoutes>[1],
   ): RouteFunc<Params> | undefined;
+
+  readonly routePaths: Map<RouteRef, string>;
+  readonly routeParents: Map<RouteRef, RouteRef | undefined>;
+  readonly routeObjects: BackstageRouteObject[];
+  readonly routeBindings: Map<ExternalRouteRef, RouteRef | SubRouteRef>;
+  readonly appBasePath: string; // base path without a trailing slash
 }
 
 /**

--- a/plugins/devtools/.eslintrc.js
+++ b/plugins/devtools/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint')],
+};

--- a/plugins/devtools/README.md
+++ b/plugins/devtools/README.md
@@ -1,0 +1,3 @@
+# DevTools Plugin
+
+Powertools for Backstage developers

--- a/plugins/devtools/package.json
+++ b/plugins/devtools/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@backstage/plugin-devtools",
+  "version": "0.0.0",
+  "description": "Developer power tools for Backstage",
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/devtools"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "name": "DevTools",
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "build": "backstage-cli plugin:build",
+    "start": "backstage-cli plugin:serve",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test",
+    "diff": "backstage-cli plugin:diff",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
+    "clean": "backstage-cli clean"
+  },
+  "dependencies": {
+    "@backstage/catalog-model": "^0.12.0",
+    "@backstage/core-app-api": "^0.6.0",
+    "@backstage/core-components": "^0.9.0",
+    "@backstage/core-plugin-api": "^0.8.0",
+    "@backstage/plugin-catalog-react": "^0.8.0",
+    "@material-ui/core": "^4.9.13",
+    "@material-ui/icons": "^4.9.1",
+    "dagre": "^0.8.5",
+    "react-flow-renderer": "^9.7.4",
+    "react-router": "6.0.0-beta.0"
+  },
+  "peerDependencies": {
+    "@types/react": "^16.13.1 || ^17.0.0",
+    "react": "^16.13.1 || ^17.0.0"
+  },
+  "devDependencies": {
+    "@types/dagre": "^0.7.47",
+    "@types/react-inspector": "^4.0.2"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/devtools/src/components/any-list.tsx
+++ b/plugins/devtools/src/components/any-list.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { PropsWithChildren } from 'react';
+
+import { makeStyles } from '@material-ui/core/styles';
+import ListSubheader from '@material-ui/core/ListSubheader';
+import List from '@material-ui/core/List';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    width: '100%',
+    backgroundColor: theme.palette.background.paper,
+  },
+}));
+
+export interface AnyListProps {
+  subtitle?: string;
+}
+
+export function AnyList(props: PropsWithChildren<AnyListProps>) {
+  const { subtitle, children } = props;
+  const classes = useStyles();
+
+  return (
+    <List
+      component="nav"
+      aria-labelledby="nested-list-subheader"
+      subheader={
+        !subtitle ? undefined : (
+          <ListSubheader component="div" id="nested-list-subheader">
+            {subtitle}
+          </ListSubheader>
+        )
+      }
+      className={classes.root}
+    >
+      {children}
+    </List>
+  );
+}

--- a/plugins/devtools/src/components/api-icon.tsx
+++ b/plugins/devtools/src/components/api-icon.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import {
+  ApiCoreIcon,
+  ApiPluginIcon,
+  ApiInternalIcon,
+  ApiOtherIcon,
+} from '../utils/icons';
+
+export function ApiIcon({ id }: { id: string }) {
+  const prefix = id.split('.')[0];
+
+  if (prefix === 'core') {
+    return <ApiCoreIcon />;
+  }
+  if (prefix === 'plugin') {
+    return <ApiPluginIcon />;
+  }
+  if (prefix === 'internal') {
+    return <ApiInternalIcon />;
+  }
+  return <ApiOtherIcon />;
+}

--- a/plugins/devtools/src/components/api-list-item.tsx
+++ b/plugins/devtools/src/components/api-list-item.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Fragment, PropsWithChildren, useCallback } from 'react';
+
+import { makeStyles } from '@material-ui/core/styles';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+import Collapse from '@material-ui/core/Collapse';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+
+import { ApiIcon } from './api-icon';
+import { PluginLink } from './plugin-link';
+import { DevToolApiWithPlugin } from '../types';
+import { PluginIcon, DependenciesIcon, DependentsIcon } from '../utils/icons';
+
+const useStyles = makeStyles(theme => ({
+  nested: {
+    paddingLeft: theme.spacing(4),
+  },
+  nested2: {
+    paddingLeft: theme.spacing(8),
+  },
+}));
+
+export interface ListItemProps {
+  api: DevToolApiWithPlugin;
+  inPlugin?: boolean;
+}
+
+export function ApiListItem(props: PropsWithChildren<ListItemProps>) {
+  const classes = useStyles();
+
+  const { api, inPlugin, children } = props;
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = useCallback(() => {
+    setOpen(isOpen => !isOpen);
+  }, [setOpen]);
+
+  return (
+    <Fragment>
+      <ListItem button onClick={handleOpen}>
+        <ListItemIcon>
+          <ApiIcon id={api.id} />
+        </ListItemIcon>
+        <ListItemText primary={api.id} />
+        <ListItemAvatar>
+          {open ? <ExpandLess /> : <ExpandMore />}
+        </ListItemAvatar>
+      </ListItem>
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        {children}
+        <List component="div" disablePadding>
+          {!api.plugin || inPlugin ? null : (
+            <ListItem button className={classes.nested}>
+              <ListItemIcon>
+                <PluginIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary={
+                  <>
+                    Provided by <PluginLink pluginId={api.plugin?.id} />
+                  </>
+                }
+              />
+            </ListItem>
+          )}
+          <ListItem button className={classes.nested}>
+            <ListItemIcon>
+              <DependenciesIcon />
+            </ListItemIcon>
+            <ListItemText
+              primary={
+                api.dependencies.length === 0
+                  ? 'No dependencies'
+                  : 'Dependencies:'
+              }
+            />
+          </ListItem>
+          {api.dependencies.map(dep => (
+            <ListItem button className={classes.nested2}>
+              <ListItemIcon>
+                <ApiIcon id={dep.id} />
+              </ListItemIcon>
+              <ListItemText primary={dep.id} />
+            </ListItem>
+          ))}
+          <ListItem button className={classes.nested}>
+            <ListItemIcon>
+              <DependentsIcon />
+            </ListItemIcon>
+            <ListItemText
+              primary={
+                api.dependents.length === 0 ? 'No dependents' : 'Dependents:'
+              }
+            />
+          </ListItem>
+          {api.dependents.map(dep => (
+            <ListItem button className={classes.nested2}>
+              <ListItemIcon>
+                <ApiIcon id={dep.id} />
+              </ListItemIcon>
+              <ListItemText primary={dep.id} />
+            </ListItem>
+          ))}
+        </List>
+      </Collapse>
+    </Fragment>
+  );
+}

--- a/plugins/devtools/src/components/apis-graph.tsx
+++ b/plugins/devtools/src/components/apis-graph.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Edge } from 'react-flow-renderer';
+import { BackstageApp } from '@backstage/core-app-api';
+
+import { useDevToolsApis } from '../hooks-internal/apis';
+import { Graph, UnpositionedNode } from './graph';
+
+export interface ApisGraphProps {
+  app: BackstageApp;
+}
+
+export function ApisGraph(props: ApisGraphProps) {
+  const { app } = props;
+
+  const apis = useDevToolsApis(app);
+
+  const apisWithEdges = apis.filter(
+    api => api.dependents.length > 0 || api.dependencies.length > 0,
+  );
+
+  const nodes: UnpositionedNode[] = apisWithEdges.map(api => ({
+    id: api.id,
+    name: api.id,
+    data: { label: api.id },
+  }));
+  const edges: Edge[] = apisWithEdges.flatMap(api =>
+    api.dependencies.map(
+      (dep): Edge => ({
+        id: `${api.id}---${dep.id}`,
+        source: dep.id,
+        target: api.id,
+        animated: true,
+      }),
+    ),
+  );
+
+  return <Graph nodes={nodes} edges={edges} />;
+}

--- a/plugins/devtools/src/components/graph.tsx
+++ b/plugins/devtools/src/components/graph.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useMemo } from 'react';
+import ReactFlow, { Node, Edge } from 'react-flow-renderer';
+import { Paper } from '@material-ui/core';
+import * as dagre from 'dagre';
+
+export type UnpositionedNode<T = any> = Omit<Node<T>, 'position'>;
+
+export interface GraphProps {
+  nodes: UnpositionedNode[];
+  edges: Edge[];
+}
+
+export function Graph(props: GraphProps) {
+  const elements = useMemo(() => {
+    const graph = new dagre.graphlib.Graph();
+
+    graph.setGraph({ rankdir: 'TB', marginx: 10, ranker: 'tight-tree' });
+    graph.setDefaultEdgeLabel(() => ({}));
+
+    props.nodes.forEach(node => {
+      graph.setNode(node.id, { label: node.data.name, width: 140, height: 50 });
+    });
+    props.edges.forEach(edge => {
+      graph.setEdge(edge.source, edge.target);
+    });
+
+    dagre.layout(graph, { rankdir: 'LR', marginx: 10, ranker: 'tight-tree' });
+
+    const nodes = props.nodes.map((node): Node => {
+      const layouted = graph.node(node.id);
+
+      const isPlugin = node.data.label.startsWith('Plugin ');
+      const isCoreApi = node.id.startsWith('core.');
+      const isInternalApi = node.id.startsWith('internal.');
+      const isPluginApi = node.id.startsWith('plugin.');
+
+      const backgroundColor =
+        // eslint-disable-next-line no-nested-ternary
+        isPlugin
+          ? '#fbfba7'
+          : // eslint-disable-next-line no-nested-ternary
+          isCoreApi
+          ? '#ffd2d2'
+          : // eslint-disable-next-line no-nested-ternary
+          isInternalApi
+          ? '#deffde'
+          : isPluginApi
+          ? '#e1ecff'
+          : 'whitesmoke';
+
+      return {
+        ...node,
+        position: {
+          x: layouted.x,
+          y: layouted.y,
+        },
+        data: {
+          ...node.data,
+          label: <span>{node.data.label}</span>,
+        },
+        style: { backgroundColor },
+      };
+    });
+
+    return [...nodes, ...props.edges];
+  }, [props.nodes, props.edges]);
+
+  return (
+    <Paper style={{ margin: 16 }}>
+      <div style={{ height: 700 }}>
+        <ReactFlow elements={elements} nodesConnectable={false} />
+      </div>
+    </Paper>
+  );
+}

--- a/plugins/devtools/src/components/plugin-card.tsx
+++ b/plugins/devtools/src/components/plugin-card.tsx
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { CSSProperties, PropsWithChildren, useMemo } from 'react';
+
+import { parseEntityRef, DEFAULT_NAMESPACE } from '@backstage/catalog-model';
+import { EntityRefLink } from '@backstage/plugin-catalog-react';
+import { Link } from '@backstage/core-components';
+
+import { makeStyles } from '@material-ui/core';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+
+import { DevToolPlugin } from '../types';
+import { PluginLink } from './plugin-link';
+import { useDevToolsRoutes } from '../hooks/routes';
+import { useDevToolsApis } from '../hooks-internal/apis';
+import { useBackstageApp } from '../hooks-internal/backstage-app';
+import { AnyList } from './any-list';
+import { ApiListItem } from './api-list-item';
+import { RouteListItem } from './route-list-item';
+import { Unknown } from './unknown';
+import { PluginRole } from './role-icon';
+
+const useStyles = makeStyles(theme => ({
+  description: {
+    marginTop: -theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+export interface PluginCardProps {
+  plugin: DevToolPlugin;
+  asPage?: boolean;
+}
+
+export function comparePlugins(a: DevToolPlugin, b: DevToolPlugin) {
+  const _a = (a.plugin.info.name ?? a.plugin.getId()).toLocaleLowerCase(
+    'en-US',
+  );
+  const _b = (b.plugin.info.name ?? b.plugin.getId()).toLocaleLowerCase(
+    'en-US',
+  );
+  return _a.localeCompare(_b);
+}
+
+export function PluginCard({ plugin, asPage }: PluginCardProps) {
+  const classes = useStyles();
+
+  const app = useBackstageApp();
+
+  const { info } = plugin.plugin;
+  const ownerEntity = useMemo(
+    () =>
+      !info.ownerEntityRef
+        ? undefined
+        : parseEntityRef(info.ownerEntityRef, { defaultKind: 'group' }),
+    [info.ownerEntityRef],
+  );
+  const ownerTitle = useMemo(
+    () =>
+      !ownerEntity ||
+      ownerEntity.kind !== 'group' ||
+      ownerEntity.namespace !== DEFAULT_NAMESPACE
+        ? undefined
+        : ownerEntity.name,
+    [ownerEntity],
+  );
+
+  const pluginId = plugin.plugin.getId();
+
+  const routes = useDevToolsRoutes();
+  const providedRoutes = routes.routes.filter(route =>
+    route.refs.some(ref => ref.plugin?.getId() === pluginId),
+  );
+
+  const apis = useDevToolsApis(app);
+  const providedApis = apis.filter(api =>
+    plugin.providedApiIds.includes(api.id),
+  );
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography
+          variant="h5"
+          component="h2"
+          gutterBottom
+          title={info.name ? 'Name' : 'ID'}
+        >
+          <PluginLink pluginId={asPage ? undefined : pluginId}>
+            {info.name ?? pluginId}
+          </PluginLink>
+        </Typography>
+        {!info.description ? null : (
+          <Typography
+            variant="body2"
+            component="p"
+            className={classes.description}
+          >
+            {info.description}
+          </Typography>
+        )}
+        <Grid container spacing={1}>
+          <TableRow title="Name">{info.name}</TableRow>
+
+          <TableRow title="ID">{pluginId}</TableRow>
+
+          <TableRow title="Package">
+            {(info.packageJson as any)?.name ? (
+              (info.packageJson as any).name
+            ) : (
+              <Unknown />
+            )}
+          </TableRow>
+
+          <TableRow title="Version">{info.version}</TableRow>
+
+          <TableRow title="Role">
+            <PluginRole info={info} />
+          </TableRow>
+
+          <TableRow title="Owner">
+            {!ownerEntity ? (
+              <Unknown />
+            ) : (
+              <EntityRefLink entityRef={ownerEntity} title={ownerTitle} />
+            )}
+          </TableRow>
+
+          {!info.links.length ? null : (
+            <TableRow title="Links">
+              {info.links.map((link, i) => (
+                <Typography key={`${i}-${link.url}`} component="p">
+                  <Link to={link.url}>{link.title ?? link.url}</Link>
+                </Typography>
+              ))}
+            </TableRow>
+          )}
+
+          {asPage || providedApis.length === 0 ? null : (
+            <TableRow title="Provided APIs">
+              {providedApis.map(api => (
+                <Typography key={api.id} component="p">
+                  {api.id}
+                </Typography>
+              ))}
+            </TableRow>
+          )}
+
+          {asPage || providedRoutes.length === 0 ? null : (
+            <TableRow title="Provided routes">
+              {providedRoutes.map((route, i) => (
+                <Typography key={`${i}-${route.path}`} component="p">
+                  {route.path}
+                </Typography>
+              ))}
+            </TableRow>
+          )}
+        </Grid>
+        {!asPage || providedApis.length === 0 ? null : (
+          <AnyList subtitle="Provided apis">
+            {providedApis.map(api => (
+              <ApiListItem key={api.id} api={api} inPlugin />
+            ))}
+          </AnyList>
+        )}
+        {!asPage || providedRoutes.length === 0 ? null : (
+          <AnyList subtitle="Routes">
+            {providedRoutes.map((route, i) => (
+              <RouteListItem
+                key={`${i}-${route.path}`}
+                route={route}
+                inPlugin
+              />
+            ))}
+          </AnyList>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+const boldStyle: CSSProperties = { fontWeight: 'bold' };
+function TableRow({ title, children }: PropsWithChildren<{ title: string }>) {
+  return (
+    <>
+      <Grid item sm={4}>
+        <Typography style={boldStyle}>{title}</Typography>
+      </Grid>
+      <Grid item sm={8}>
+        {typeof children === 'string' ? (
+          <Typography variant="body2" component="p">
+            {children}
+          </Typography>
+        ) : (
+          children
+        )}
+      </Grid>
+    </>
+  );
+}

--- a/plugins/devtools/src/components/plugin-link.tsx
+++ b/plugins/devtools/src/components/plugin-link.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { PropsWithChildren, useMemo } from 'react';
+import { Link } from '@backstage/core-components';
+import { useRouteRef } from '@backstage/core-plugin-api';
+
+import { devtoolsRouteRef } from '../route';
+
+export interface PluginLinkProps {
+  pluginId?: string;
+}
+
+export function PluginLink({
+  pluginId,
+  children,
+}: PropsWithChildren<PluginLinkProps>) {
+  const routeFun = useRouteRef(devtoolsRouteRef);
+
+  const urlToPlugin = useMemo(
+    () =>
+      !pluginId
+        ? undefined
+        : `${routeFun()}/plugins/${encodeURIComponent(pluginId)}`,
+    [routeFun, pluginId],
+  );
+
+  return !urlToPlugin ? (
+    <>
+      {!children ? (
+        <span style={{ fontStyle: 'italic' }}>unknown</span>
+      ) : (
+        children
+      )}
+    </>
+  ) : (
+    <Link to={urlToPlugin}>{children ?? pluginId}</Link>
+  );
+}

--- a/plugins/devtools/src/components/plugins-graph.tsx
+++ b/plugins/devtools/src/components/plugins-graph.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Edge } from 'react-flow-renderer';
+import { BackstageApp } from '@backstage/core-app-api';
+
+import { useDevToolsApis } from '../hooks-internal/apis';
+import { useDevToolsPlugins } from '../hooks/plugins';
+import { Graph, UnpositionedNode } from './graph';
+
+export interface PluginsGraphProps {
+  app: BackstageApp;
+}
+
+export function PluginsGraph(props: PluginsGraphProps) {
+  const { app } = props;
+
+  const apis = useDevToolsApis(app);
+  const plugins = useDevToolsPlugins();
+
+  const pluginNodes = plugins.plugins
+    .filter(plugin => plugin.providedApiIds.length > 0)
+    .map((plugin): UnpositionedNode => {
+      return {
+        id: plugin.id,
+        data: { label: `Plugin ${plugin.id}` },
+      };
+    });
+  const pluginEdges = plugins.plugins
+    .filter(plugin => plugin.providedApiIds.length > 0)
+    .flatMap(plugin => {
+      return plugin.providedApiIds.map(
+        (apiId): Edge => ({
+          id: `${plugin.id}===${apiId}`,
+          source: plugin.id,
+          target: apiId,
+          animated: true,
+        }),
+      );
+    });
+
+  const apisWithEdges = apis.filter(
+    api => api.dependents.length > 0 || api.dependencies.length > 0,
+  );
+
+  const nodes: UnpositionedNode[] = apisWithEdges.map(api => ({
+    id: api.id,
+    name: api.id,
+    data: { label: api.id },
+  }));
+  const edges: Edge[] = apisWithEdges.flatMap(api =>
+    api.dependencies.map(
+      (dep): Edge => ({
+        id: `${api.id}---${dep.id}`,
+        source: dep.id,
+        target: api.id,
+        animated: true,
+      }),
+    ),
+  );
+
+  nodes.push(...pluginNodes);
+  edges.push(...pluginEdges);
+
+  return <Graph nodes={nodes} edges={edges} />;
+}

--- a/plugins/devtools/src/components/role-icon.tsx
+++ b/plugins/devtools/src/components/role-icon.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { CSSProperties } from 'react';
+
+import { PluginInfo } from '@backstage/core-plugin-api';
+
+import Typography from '@material-ui/core/Typography';
+import DesktopWindowsIcon from '@material-ui/icons/DesktopWindows';
+import DescriptionIcon from '@material-ui/icons/Description';
+import BurstModeIcon from '@material-ui/icons/BurstMode';
+import NotListedLocationIcon from '@material-ui/icons/NotListedLocation';
+
+import { Unknown } from './unknown';
+
+const roleIconStyle: CSSProperties = {
+  marginRight: 8,
+  verticalAlign: 'middle',
+};
+
+const roleIcon: Record<string, JSX.Element> = {
+  'frontend-plugin': (
+    <DesktopWindowsIcon fontSize="small" style={roleIconStyle} />
+  ),
+  'frontend-plugin-module': (
+    <DescriptionIcon fontSize="small" style={roleIconStyle} />
+  ),
+  'common-library': <BurstModeIcon fontSize="small" style={roleIconStyle} />,
+};
+
+export function PluginRole({ info }: { info: PluginInfo }) {
+  if (!info.role) {
+    return <Unknown />;
+  }
+
+  const icon = roleIcon[info.role] ?? (
+    <NotListedLocationIcon fontSize="small" style={roleIconStyle} />
+  );
+  return (
+    <Typography>
+      {icon}
+      {info.role}
+    </Typography>
+  );
+}

--- a/plugins/devtools/src/components/route-list-item.tsx
+++ b/plugins/devtools/src/components/route-list-item.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Fragment, useCallback, useMemo, CSSProperties } from 'react';
+
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+import Divider from '@material-ui/core/Divider';
+import Collapse from '@material-ui/core/Collapse';
+import TranslateIcon from '@material-ui/icons/Translate';
+import ViewColumnIcon from '@material-ui/icons/ViewColumn';
+import SubdirectoryArrowRightIcon from '@material-ui/icons/SubdirectoryArrowRight';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+
+import { PluginIcon, DependentsIcon } from '../utils/icons';
+import { RouteObjectInfo } from '../hooks/routes';
+import { PluginLink } from './plugin-link';
+
+export interface RouteItemProps {
+  route: RouteObjectInfo;
+  level?: number;
+  inPlugin?: boolean;
+}
+
+export function RouteListItem({ route, level = 2, inPlugin }: RouteItemProps) {
+  const { path, children, refs, caseSensitive } = route;
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = useCallback(() => {
+    setOpen(isOpen => !isOpen);
+  }, [setOpen]);
+
+  const indentStyle = useMemo(
+    (): CSSProperties => ({ paddingLeft: level * 16 }),
+    [level],
+  );
+
+  const singleEnd = getSingleEndedChild(route);
+  const title = useMemo(
+    () => (!singleEnd ? path : `${path} (${singleEnd})`),
+    [path, singleEnd],
+  );
+
+  return (
+    <Fragment>
+      <ListItem style={indentStyle} button onClick={handleOpen}>
+        <ListItemIcon>
+          <SubdirectoryArrowRightIcon />
+        </ListItemIcon>
+        <ListItemText primary={title} />
+        <ListItemAvatar>
+          {open ? <ExpandLess /> : <ExpandMore />}
+        </ListItemAvatar>
+      </ListItem>
+      <Collapse style={indentStyle} in={open} timeout="auto" unmountOnExit>
+        <List component="div" disablePadding>
+          {refs.map((ref, i) => (
+            <Fragment key={i}>
+              <ListItem button>
+                <ListItemIcon>
+                  <PluginIcon />
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    inPlugin ? (
+                      <>Provided as: "{ref.name}"</>
+                    ) : (
+                      <>
+                        Provided by:{' '}
+                        <PluginLink pluginId={ref.plugin?.getId()}>
+                          {ref.plugin?.getId()}
+                        </PluginLink>{' '}
+                        as "{ref.name}"
+                      </>
+                    )
+                  }
+                />
+              </ListItem>
+              {ref.routeRef.params.length === 0 ? null : (
+                <ListItem button>
+                  <ListItemIcon>
+                    <ViewColumnIcon />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={`Params: ${ref.routeRef.params.join(', ')}`}
+                  />
+                </ListItem>
+              )}
+              {refs.length < 2 ? null : <Divider />}
+            </Fragment>
+          ))}
+
+          <ListItem button>
+            <ListItemIcon>
+              <TranslateIcon />
+            </ListItemIcon>
+            <ListItemText
+              primary={`Case ${caseSensitive ? '' : 'in'}sensitive`}
+            />
+          </ListItem>
+
+          {children.length === 0 ? null : (
+            <ChildRoutes routes={children} level={level} />
+          )}
+        </List>
+      </Collapse>
+    </Fragment>
+  );
+}
+
+function getSingleEndedChild(route: RouteObjectInfo) {
+  if (
+    route.children.length === 1 &&
+    route.children[0].refs.length === 0 &&
+    (route.children[0].path === '/' || route.children[0].path === '/*')
+  ) {
+    return route.children[0].path;
+  }
+  return undefined;
+}
+
+interface ChildRoutesProps {
+  routes: RouteObjectInfo[];
+  level: number;
+}
+
+function ChildRoutes({ routes, level }: ChildRoutesProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = useCallback(() => {
+    setOpen(isOpen => !isOpen);
+  }, [setOpen]);
+
+  if (
+    routes.length === 1 &&
+    routes[0].refs.length === 0 &&
+    (routes[0].path === '/' || routes[0].path === '/*')
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      <ListItem button onClick={handleOpen}>
+        <ListItemIcon>
+          <DependentsIcon />
+        </ListItemIcon>
+        <ListItemText primary="Child routes" />
+        <ListItemAvatar>
+          {open ? <ExpandLess /> : <ExpandMore />}
+        </ListItemAvatar>
+      </ListItem>
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        {routes.map((subRoute, i) => (
+          <RouteListItem
+            key={`${i}-${subRoute.path}`}
+            route={subRoute}
+            level={level + 1}
+          />
+        ))}
+      </Collapse>
+    </>
+  );
+}

--- a/plugins/devtools/src/components/unknown.tsx
+++ b/plugins/devtools/src/components/unknown.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { CSSProperties } from 'react';
+
+import Typography from '@material-ui/core/Typography';
+
+const unknownStyle: CSSProperties = {
+  fontStyle: 'italic',
+};
+
+export function Unknown() {
+  return (
+    <Typography style={unknownStyle} color="textSecondary">
+      Unknown
+    </Typography>
+  );
+}

--- a/plugins/devtools/src/hooks-internal/apis.ts
+++ b/plugins/devtools/src/hooks-internal/apis.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import { BackstageApp } from '@backstage/core-app-api';
+
+import { DevToolApiWithPlugin } from '../types';
+import { useMemoArray } from '../hooks/memo-array';
+import { useDevToolsPlugins } from '../hooks/plugins';
+import { parseApis, parseApiGraph, sortCompareApis } from '../utils/api';
+
+export function useDevToolsApis(app: BackstageApp): DevToolApiWithPlugin[] {
+  const { plugins, apiMap } = useDevToolsPlugins();
+
+  const apis = useMemoArray(app.getApis());
+
+  return useMemo(() => {
+    const visitedSet = new Set<string>();
+
+    const parsedApis = parseApiGraph([
+      ...parseApis(apis),
+      ...plugins.flatMap(plugin => plugin.parsedApis),
+    ]);
+
+    // First iterate all known APIs
+    const ret = parsedApis.map((api): DevToolApiWithPlugin => {
+      const plugin = apiMap.get(api.id);
+      const devtoolApi: DevToolApiWithPlugin = {
+        ...api,
+        loaded: true,
+        plugin,
+      };
+      visitedSet.add(devtoolApi.id);
+      return devtoolApi;
+    });
+
+    ret.sort(sortCompareApis);
+
+    // Then iterate all plugins to get their apis, if there such that aren't
+    // loaded into the app
+    // plugins.forEach(plugin => {
+    //   plugin.apis.forEach(api => {
+    //     if (!visitedSet.has(api.id)) {
+    //       ret.push({
+    //         ...api,
+    //         plugin,
+    //         loaded: false,
+    //       });
+    //     }
+    //   });
+    // });
+
+    return ret;
+  }, [plugins, apiMap, apis]);
+}

--- a/plugins/devtools/src/hooks-internal/backstage-app.ts
+++ b/plugins/devtools/src/hooks-internal/backstage-app.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BackstageApp } from '@backstage/core-app-api';
+import { createContext, useContext } from 'react';
+
+const context = createContext<BackstageApp>(undefined as any as BackstageApp);
+
+export function useBackstageApp() {
+  return useContext(context);
+}
+
+export const BackstageAppProvider = context.Provider;

--- a/plugins/devtools/src/hooks-internal/index.ts
+++ b/plugins/devtools/src/hooks-internal/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './apis';
+export * from './backstage-app';

--- a/plugins/devtools/src/hooks/index.ts
+++ b/plugins/devtools/src/hooks/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './memo-array';
+export * from './plugins';
+export * from './routes';

--- a/plugins/devtools/src/hooks/memo-array.ts
+++ b/plugins/devtools/src/hooks/memo-array.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+
+export function useMemoArray<T>(arr: T[]) {
+  const [result, setResult] = useState(() => arr);
+
+  useEffect(() => {
+    if (result.length !== arr.length) {
+      setResult(arr);
+    } else if (arr.some((elem, i) => elem !== result[i])) {
+      setResult(arr);
+    }
+  }, [arr.length, arr, result]);
+
+  return result;
+}

--- a/plugins/devtools/src/hooks/plugins.ts
+++ b/plugins/devtools/src/hooks/plugins.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import { ExternalRouteRef, RouteRef, useApp } from '@backstage/core-plugin-api';
+
+import { useMemoArray } from './memo-array';
+import {
+  DevToolsPluginRouteInfoPlugin,
+  DevToolPlugins,
+  DevToolPlugin,
+} from '../types';
+import { parseApis } from '../utils/api';
+
+export function useDevToolsPlugins(): DevToolPlugins {
+  const rawPlugins = useMemoArray(useApp().getPlugins());
+
+  const plugins = useMemo(
+    () =>
+      rawPlugins.map((plugin): DevToolPlugin => {
+        const pluginApis = [...plugin.getApis()];
+        const providedApiIds = pluginApis.map(api => api.api.id);
+        const parsedApis = parseApis(pluginApis);
+        return {
+          plugin,
+          id: plugin.getId(),
+          featureFlags: [...plugin.getFeatureFlags()].map(({ name }) => ({
+            name,
+          })),
+          providedApiIds,
+          apiIds: parsedApis.map(api => api.id),
+          parsedApis,
+        };
+      }),
+    [rawPlugins],
+  );
+
+  const routeInfo = useMemo(() => {
+    const routeRefMap = new Map<RouteRef, DevToolsPluginRouteInfoPlugin>();
+    const externalRouteRefMap = new Map<
+      ExternalRouteRef,
+      DevToolsPluginRouteInfoPlugin
+    >();
+
+    rawPlugins.map(plugin => {
+      Object.entries(plugin.routes as Record<string, RouteRef>).forEach(
+        ([name, ref]) => {
+          routeRefMap.set(ref, { name, plugin });
+        },
+      );
+
+      Object.entries(
+        plugin.externalRoutes as Record<string, ExternalRouteRef>,
+      ).forEach(([name, ref]) => {
+        externalRouteRefMap.set(ref, { name, plugin });
+      });
+    });
+
+    return { routeRefMap, externalRouteRefMap };
+  }, [rawPlugins]);
+
+  const apiMap = useMemo(
+    () =>
+      new Map<string, DevToolPlugin>(
+        plugins.flatMap(plugin => plugin.apiIds.map(id => [id, plugin])),
+      ),
+    [plugins],
+  );
+
+  return {
+    plugins,
+    ...routeInfo,
+    apiMap,
+  };
+}

--- a/plugins/devtools/src/hooks/routes.ts
+++ b/plugins/devtools/src/hooks/routes.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+
+import {
+  RouteRef,
+  SubRouteRef,
+  BackstageRouteObject,
+  useRouteContext,
+} from '@backstage/core-plugin-api';
+import { useDevToolsPlugins } from './plugins';
+import { DevToolsPluginRouteInfoPlugin } from '../types';
+
+export function useDevToolsRoutes() {
+  const { routeRefMap } = useDevToolsPlugins();
+  const resolver = useRouteContext();
+
+  const bindings = useMemo(
+    () =>
+      [...(resolver?.routeBindings.entries() ?? [])].map(([key, val]) => ({
+        from: {
+          id: (key as any).id,
+          params: key.params,
+          type: key.$$routeRefType,
+          optional: key.optional,
+        },
+        to: routeRefInfo(val),
+      })),
+    [resolver?.routeBindings],
+  );
+
+  const routes = useMemo(
+    () => routeObjectInfo(routeRefMap, resolver?.routeObjects ?? []),
+    [resolver?.routeObjects, routeRefMap],
+  );
+
+  return {
+    bindings,
+    routes,
+  };
+}
+
+export interface RouteRefInfo {
+  id: string;
+  type: string;
+  params: (string | number | symbol)[];
+  path?: string;
+  parent?: RouteRefInfo;
+}
+
+function routeRefInfo(ref: RouteRef | SubRouteRef): RouteRefInfo {
+  return {
+    id: (ref as any).id,
+    type: ref.$$routeRefType,
+    params: ref.params,
+    path: (ref as SubRouteRef).path,
+    parent: (ref as SubRouteRef).parent
+      ? routeRefInfo((ref as SubRouteRef).parent)
+      : undefined,
+  };
+}
+
+export interface RouteObjectInfo {
+  caseSensitive: boolean;
+  children: RouteObjectInfo[];
+  path: string;
+  refs: ({ routeRef: RouteRef } & Partial<DevToolsPluginRouteInfoPlugin>)[];
+}
+
+function routeObjectInfo(
+  routeRefMap: Map<RouteRef, DevToolsPluginRouteInfoPlugin>,
+  objects: BackstageRouteObject[],
+): RouteObjectInfo[] {
+  return objects.map(obj => ({
+    caseSensitive: obj.caseSensitive,
+    children: routeObjectInfo(routeRefMap, obj.children ?? []),
+    path: obj.path,
+    refs: [...obj.routeRefs].map(routeRef => ({
+      routeRef,
+      ...routeRefMap.get(routeRef),
+    })),
+  }));
+}

--- a/plugins/devtools/src/index.ts
+++ b/plugins/devtools/src/index.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createPlugin,
+  createRoutableExtension,
+  createComponentExtension,
+} from '@backstage/core-plugin-api';
+
+import { devtoolsRouteRef } from './route';
+
+import packageJson from '../package.json';
+
+export * from './types';
+export * from './hooks';
+export { PluginLink } from './components/plugin-link';
+
+export { devtoolsRouteRef };
+
+export const devtoolsPlugin = createPlugin({
+  id: 'devtools',
+  apis: [],
+  routes: {
+    root: devtoolsRouteRef,
+  },
+  info: { packageJson },
+});
+
+export const DevToolsPage = devtoolsPlugin.provide(
+  createRoutableExtension({
+    name: 'DevToolsPage',
+    component: () => import('./page-wrapper/root-page').then(m => m.RootPage),
+    mountPoint: devtoolsRouteRef,
+  }),
+);
+
+export const ApiIcon = devtoolsPlugin.provide(
+  createComponentExtension({
+    name: 'ApiIcon',
+    component: {
+      lazy: () => import('./components/api-icon').then(m => m.ApiIcon),
+    },
+  }),
+);

--- a/plugins/devtools/src/page-wrapper/pages.ts
+++ b/plugins/devtools/src/page-wrapper/pages.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const pageNames = ['apis', 'api-graph', 'plugins', 'routes'] as const;
+export type PageName = typeof pageNames[number];
+
+export interface Page {
+  name: PageName;
+  title: string;
+  subtitle: string;
+}
+
+export const pages: Array<Page> = [
+  {
+    name: 'apis',
+    title: 'APIs',
+    subtitle: 'All registered APIs',
+  },
+  {
+    name: 'api-graph',
+    title: 'API graph',
+    subtitle: 'Dependency graph of APIs (and the plugins providing them)',
+  },
+  {
+    name: 'plugins',
+    title: 'Plugins',
+    subtitle: '',
+  },
+  {
+    name: 'routes',
+    title: 'Routes',
+    subtitle: '',
+  },
+];
+
+export const pageMap = Object.fromEntries(
+  pages.map(page => [page.name, page]),
+) as Record<PageName, Page>;

--- a/plugins/devtools/src/page-wrapper/root-page.tsx
+++ b/plugins/devtools/src/page-wrapper/root-page.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Route, Routes, Outlet, useParams, Navigate } from 'react-router';
+
+import { BackstageApp } from '@backstage/core-app-api';
+
+import { PageName, pages } from './pages';
+import { PageWrapper } from './wrapper';
+
+import { BackstageAppProvider } from '../hooks-internal/backstage-app';
+
+import { ApisPage } from '../pages/apis';
+import { ApiGraphPage } from '../pages/api-graph';
+import { PluginsPage } from '../pages/plugins';
+import { PluginPage } from '../pages/plugin';
+import { RoutesPage } from '../pages/routes';
+
+const pageComponents: Record<PageName, React.ComponentType> = {
+  apis: ApisPage,
+  'api-graph': ApiGraphPage,
+  plugins: PluginsPage,
+  routes: RoutesPage,
+};
+
+export interface RootPageProps {
+  app: BackstageApp;
+}
+
+export function RootPage(props: RootPageProps) {
+  return (
+    <BackstageAppProvider value={props.app}>
+      <Routes>
+        <Route path="/*" element={<Wrapper />}>
+          <Route path="/" element={<Navigate replace to="apis" />} />
+          <Route path="/plugins/:pluginId" element={<PluginPage />} />
+          {pages.map(page => {
+            const Component = pageComponents[page.name];
+            return (
+              <Route key={page.name} path={page.name} element={<Component />} />
+            );
+          })}
+        </Route>
+      </Routes>
+    </BackstageAppProvider>
+  );
+}
+
+function Wrapper() {
+  let { '*': pageParam } = useParams();
+
+  if (pageParam.includes('/')) pageParam = pageParam.split('/')[0];
+
+  const page: PageName = pageParam === '' ? 'apis' : (pageParam as PageName);
+
+  return (
+    <PageWrapper page={page as PageName}>
+      <Outlet />
+    </PageWrapper>
+  );
+}

--- a/plugins/devtools/src/page-wrapper/wrapper.tsx
+++ b/plugins/devtools/src/page-wrapper/wrapper.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { PropsWithChildren, useCallback } from 'react';
+import { useNavigate } from 'react-router';
+import { Tabs, Tab, createStyles, makeStyles } from '@material-ui/core';
+import {
+  Header,
+  Page,
+  Content,
+  ContentHeader,
+  HeaderLabel,
+  SupportButton,
+} from '@backstage/core-components';
+import { useRouteRef } from '@backstage/core-plugin-api';
+
+import { PageName, pages, pageMap } from './pages';
+import { devtoolsRouteRef } from '..';
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    wrappedChild: {
+      marginTop: 8,
+    },
+  }),
+);
+
+export interface PageWrapperProps {
+  page: PageName;
+}
+
+export function PageWrapper(props: PropsWithChildren<PageWrapperProps>) {
+  const curPage = pageMap[props.page];
+
+  const rootRoute = useRouteRef(devtoolsRouteRef);
+  const classes = useStyles();
+  const navigate = useNavigate();
+
+  const handleChangeTab = useCallback(
+    (_ev, tab) => {
+      navigate(`${rootRoute()}/${tab}`);
+    },
+    [navigate, rootRoute],
+  );
+
+  return (
+    <Page themeId="tool">
+      <Header title="DevTools" subtitle={curPage.subtitle} />
+      <Content>
+        <Tabs
+          value={props.page}
+          indicatorColor="primary"
+          textColor="primary"
+          onChange={handleChangeTab}
+          aria-label="disabled tabs example"
+        >
+          {pages.map(page => (
+            <Tab key={page.name} value={page.name} label={page.title} />
+          ))}
+        </Tabs>
+        <div className={classes.wrappedChild}>
+          <ContentHeader title={curPage.title}>
+            <SupportButton>{curPage.subtitle}</SupportButton>
+          </ContentHeader>
+        </div>
+        <div className={classes.wrappedChild}>{props.children}</div>
+      </Content>
+    </Page>
+  );
+}

--- a/plugins/devtools/src/pages/api-graph.tsx
+++ b/plugins/devtools/src/pages/api-graph.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { ApisGraph } from '../components/apis-graph';
+import { useBackstageApp } from '../hooks-internal/backstage-app';
+
+export function ApiGraphPage() {
+  const app = useBackstageApp();
+
+  return (
+    <div>
+      <ApisGraph app={app} />
+    </div>
+  );
+}

--- a/plugins/devtools/src/pages/apis.tsx
+++ b/plugins/devtools/src/pages/apis.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { ApiListItem } from '../components/api-list-item';
+import { AnyList } from '../components/any-list';
+import { useDevToolsApis } from '../hooks-internal/apis';
+import { useBackstageApp } from '../hooks-internal/backstage-app';
+
+export function ApisPage() {
+  const app = useBackstageApp();
+
+  const apis = useDevToolsApis(app);
+
+  return (
+    <AnyList subtitle="Registered apis">
+      {apis.map(api => (
+        <ApiListItem key={api.id} api={api} />
+      ))}
+    </AnyList>
+  );
+}

--- a/plugins/devtools/src/pages/plugin.tsx
+++ b/plugins/devtools/src/pages/plugin.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { useDevToolsPlugins } from '../hooks/plugins';
+import { PluginCard } from '../components/plugin-card';
+import { useParams } from 'react-router';
+
+export function PluginPage() {
+  const { pluginId } = useParams();
+
+  const { plugins } = useDevToolsPlugins();
+  const plugin = plugins.find(p => p.id === pluginId);
+
+  return !plugin ? (
+    <div>No such plugin</div>
+  ) : (
+    <PluginCard plugin={plugin} asPage />
+  );
+}

--- a/plugins/devtools/src/pages/plugins.tsx
+++ b/plugins/devtools/src/pages/plugins.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useMemo } from 'react';
+import { Grid } from '@material-ui/core';
+import { useLog } from '@backstage/core-plugin-api';
+
+import { useDevToolsPlugins } from '../hooks/plugins';
+import { PluginCard, comparePlugins } from '../components/plugin-card';
+
+export function PluginsPage() {
+  const { plugins } = useDevToolsPlugins();
+
+  const log = useLog();
+  log.error('foo', 42, 'bar');
+
+  setInterval(() => {
+    makeDoThings(log, plugins)();
+  }, 5000);
+
+  makeDoThings(log, { plugins: 'heh no plugins' })();
+
+  const orderedPlugins = useMemo(
+    () => [...plugins].sort(comparePlugins),
+    [plugins],
+  );
+  log.error('Ordered plugins', orderedPlugins);
+
+  return (
+    <Grid container>
+      {orderedPlugins.map(plugin => (
+        <Grid key={plugin.id} item sm={12} md={6} lg={4} xl={3}>
+          <PluginCard plugin={plugin} />
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+
+function makeDoThings(log: ReturnType<typeof useLog>, plugins: any) {
+  return () => {
+    function Foo() {}
+    const c = new (class Cls {
+      a = 'foo';
+      b = 123;
+    })();
+    log.error(
+      'more',
+      42,
+      ['f', { a: 'b' }],
+      { PluginsPage, plugins },
+      c,
+      Foo,
+      'stuff',
+    );
+  };
+}

--- a/plugins/devtools/src/pages/routes.tsx
+++ b/plugins/devtools/src/pages/routes.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { RouteListItem } from '../components/route-list-item';
+import { AnyList } from '../components/any-list';
+import { useDevToolsRoutes } from '../hooks/routes';
+
+export function RoutesPage() {
+  const routes = useDevToolsRoutes();
+
+  return (
+    <div>
+      <AnyList subtitle="Routes">
+        {routes.routes.map(route => (
+          <RouteListItem key={route.path} route={route} />
+        ))}
+      </AnyList>
+    </div>
+  );
+}

--- a/plugins/devtools/src/route.ts
+++ b/plugins/devtools/src/route.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const devtoolsRouteRef = createRouteRef({ id: 'root' });

--- a/plugins/devtools/src/types.ts
+++ b/plugins/devtools/src/types.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  BackstagePlugin,
+  ExternalRouteRef,
+  RouteRef,
+} from '@backstage/core-plugin-api';
+
+export interface DevToolsPluginRouteInfoPlugin {
+  name: string;
+  plugin: BackstagePlugin;
+}
+
+export interface DevToolsPluginRouteInfo {
+  routeRefMap: Map<RouteRef, DevToolsPluginRouteInfoPlugin>;
+  externalRouteRefMap: Map<ExternalRouteRef, DevToolsPluginRouteInfoPlugin>;
+}
+
+export interface DevToolPlugin {
+  plugin: BackstagePlugin<any, any>;
+  id: string;
+  featureFlags: DevToolFeatureFlag[];
+  providedApiIds: string[];
+  apiIds: string[];
+  parsedApis: DevToolApi[];
+}
+
+export interface DevToolPlugins extends DevToolsPluginRouteInfo {
+  plugins: DevToolPlugin[];
+  apiMap: Map<string, DevToolPlugin>;
+}
+
+export interface DevToolApiDependency {
+  id: string;
+  name: string;
+}
+
+export interface DevToolApi {
+  id: string;
+  dependencies: DevToolApiDependency[];
+  dependents: DevToolApiDependency[];
+}
+
+export interface DevToolApiWithPlugin extends DevToolApi {
+  plugin?: DevToolPlugin;
+  loaded: boolean;
+}
+
+export interface DevToolFeatureFlag {
+  name: string;
+}

--- a/plugins/devtools/src/utils/api.ts
+++ b/plugins/devtools/src/utils/api.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { AnyApiFactory } from '@backstage/core-plugin-api';
+
+import type { DevToolApi, DevToolApiDependency } from '../types';
+
+export function sortCompareApis(a: DevToolApi, b: DevToolApi) {
+  const aPrefix = a.id.split('.')[0];
+  const bPrefix = b.id.split('.')[0];
+
+  if (aPrefix !== bPrefix) {
+    if (aPrefix === 'internal') return -1;
+    else if (bPrefix === 'internal') return 1;
+    else if (aPrefix === 'plugin') return -1;
+    else if (bPrefix === 'plugin') return 1;
+    else if (aPrefix === 'core') return -1;
+    else if (bPrefix === 'core') return 1;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+export function parseApis(apis: Iterable<AnyApiFactory>): DevToolApi[] {
+  const ret = [...apis].map(api => parseApi(api));
+
+  return parseApiGraph(ret);
+}
+
+export function parseApi(api: AnyApiFactory): DevToolApi {
+  return {
+    id: api.api.id,
+    dependencies: Object.entries(api.deps).map(([name, depApi]) => ({
+      id: depApi.id,
+      name,
+    })),
+    dependents: [],
+  };
+}
+
+function uniqDevToolApiDependencies(
+  apis: DevToolApiDependency[],
+): DevToolApiDependency[] {
+  const visited = new Set<string>();
+  return apis.filter(api => {
+    if (visited.has(api.id)) return false;
+    visited.add(api.id);
+    return true;
+  });
+}
+
+// Finds all dependencies/dependents and strips duplicates
+export function parseApiGraph(apis: DevToolApi[]): DevToolApi[] {
+  const condencedMap = new Map<string, DevToolApi>();
+  apis.forEach(api => {
+    const devtoolApi = condencedMap.get(api.id) ?? {
+      id: api.id,
+      dependencies: [],
+      dependents: [],
+    };
+
+    devtoolApi.dependencies = uniqDevToolApiDependencies([
+      ...devtoolApi.dependencies,
+      ...api.dependencies,
+    ]);
+
+    devtoolApi.dependents = uniqDevToolApiDependencies([
+      ...devtoolApi.dependents,
+      ...api.dependents,
+    ]);
+
+    // devtoolApi.dependents.forEach(dep => {
+    //   condencedMap.get(dep.id)
+    // });
+
+    condencedMap.set(api.id, devtoolApi);
+  });
+
+  const condenced = [...condencedMap.values()];
+
+  // Some apis aren't exposed but can be inferred from deps
+  const known = new Set(apis.map(api => api.id));
+  const inferred = new Set<string>();
+
+  condenced.forEach(api => {
+    api.dependencies.forEach(dep => {
+      if (!known.has(dep.id)) {
+        inferred.add(dep.id);
+      }
+    });
+  });
+  const inferredApis = [...inferred].map(
+    (id): DevToolApi => ({ id, dependencies: [], dependents: [] }),
+  );
+  condenced.push(...inferredApis);
+
+  //   const inferredApis = [...inferred].map((id): DevToolApi=>({id, dependencies: [], dependents: []}));
+  //   console.log("KNOWN", [...known], "APIS", [...apis], "INFERRED", inferredApis);
+  //   apis.push(...inferredApis);
+
+  const inverseDepsMap = new Map<string, DevToolApiDependency[]>();
+  condenced.forEach(api => {
+    api.dependencies.forEach(dep => {
+      const list = inverseDepsMap.get(dep.id) ?? [];
+      list.push({ id: api.id, name: dep.name });
+      inverseDepsMap.set(dep.id, list);
+    });
+  });
+
+  return condenced.map(api => ({
+    ...api,
+    dependents: inverseDepsMap.get(api.id) ?? [],
+  }));
+}

--- a/plugins/devtools/src/utils/icons.tsx
+++ b/plugins/devtools/src/utils/icons.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import SettingsInputCompositeIcon from '@material-ui/icons/SettingsInputComposite';
+import SubjectIcon from '@material-ui/icons/Subject';
+import CenterFocusStrongIcon from '@material-ui/icons/CenterFocusStrong';
+import BusinessIcon from '@material-ui/icons/Business';
+import SettingsInputHdmiIcon from '@material-ui/icons/SettingsInputHdmi';
+import MergeTypeIcon from '@material-ui/icons/MergeType';
+import CallSplitIcon from '@material-ui/icons/CallSplit';
+
+export function ApiCoreIcon() {
+  return <CenterFocusStrongIcon />;
+}
+export function ApiPluginIcon() {
+  return <SettingsInputCompositeIcon />;
+}
+export function ApiInternalIcon() {
+  return <BusinessIcon />;
+}
+export function ApiOtherIcon() {
+  return <SubjectIcon />;
+}
+
+export function PluginIcon() {
+  return <SettingsInputHdmiIcon />;
+}
+
+export function DependenciesIcon() {
+  return <MergeTypeIcon />;
+}
+export function DependentsIcon() {
+  return <CallSplitIcon />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,17 +1295,10 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.16.7", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.0", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.2"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.16.7":
-  version "7.17.2"
-  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
-  integrity sha1-ZvaFkWBeWdpHUjxjFBaxhQh3mUE=
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1364,6 +1357,55 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
+
+"@backstage/catalog-client@^0.8.0":
+  version "0.8.0"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@backstage/catalog-client/-/catalog-client-0.8.0.tgz#0ac9c911961643dc0a71539f710f70ed7da7d5ad"
+  integrity sha1-CsnJEZYWQ9wKcVOfcQ9w7X2n1a0=
+  dependencies:
+    "@backstage/catalog-model" "^0.12.0"
+    "@backstage/errors" "^0.2.2"
+    cross-fetch "^3.1.5"
+
+"@backstage/catalog-model@^0.12.0", "@backstage/catalog-model@^0.12.1":
+  version "0.12.1"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@backstage/catalog-model/-/catalog-model-0.12.1.tgz#19c814b0576c0f86ad09fd2e4014246f9731ee3d"
+  integrity sha1-GcgUsFdsD4atCf0uQBQkb5cx7j0=
+  dependencies:
+    "@backstage/config" "^0.1.15"
+    "@backstage/errors" "^0.2.2"
+    "@backstage/types" "^0.1.3"
+    ajv "^7.0.3"
+    json-schema "^0.4.0"
+    lodash "^4.17.21"
+    uuid "^8.0.0"
+
+"@backstage/plugin-catalog-react@^0.8.0":
+  version "0.8.1"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@backstage/plugin-catalog-react/-/plugin-catalog-react-0.8.1.tgz#1fe5a35df6a4e08ab865cd625e7de9ddc7a4bdaa"
+  integrity sha1-H+WjXfak4Iq4Zc1iXn3p3cekvao=
+  dependencies:
+    "@backstage/catalog-client" "^0.8.0"
+    "@backstage/catalog-model" "^0.12.1"
+    "@backstage/core-components" "^0.9.0"
+    "@backstage/core-plugin-api" "^0.8.0"
+    "@backstage/errors" "^0.2.2"
+    "@backstage/integration" "^0.8.0"
+    "@backstage/plugin-permission-common" "^0.5.2"
+    "@backstage/plugin-permission-react" "^0.3.3"
+    "@backstage/types" "^0.1.3"
+    "@backstage/version-bridge" "^0.1.2"
+    "@material-ui/core" "^4.12.2"
+    "@material-ui/icons" "^4.9.1"
+    "@material-ui/lab" "4.0.0-alpha.57"
+    classnames "^2.2.6"
+    jwt-decode "^3.1.0"
+    lodash "^4.17.21"
+    qs "^6.9.4"
+    react-router "6.0.0-beta.0"
+    react-use "^17.2.4"
+    yaml "^1.10.0"
+    zen-observable "^0.8.15"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -5513,15 +5555,10 @@
     "@types/d3-interpolate" "*"
     "@types/d3-selection" "*"
 
-"@types/dagre@^0.7.44":
+"@types/dagre@^0.7.44", "@types/dagre@^0.7.47":
   version "0.7.47"
   resolved "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.47.tgz#1d1b89e1fac36aaf5ef5ed6274bb123073095ac5"
   integrity sha512-oX+3aRf7L6Cqq1MvbWmmD7FpAU/T8URwFFuHBagAiyHILn3i+RNZ35/tvyq28de+lZGY3W19BxJ7FeITQDO7aA==
-
-"@types/dagre@^0.7.47":
-  version "0.7.47"
-  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@types/dagre/-/dagre-0.7.47.tgz#1d1b89e1fac36aaf5ef5ed6274bb123073095ac5"
-  integrity sha1-HRuJ4frDaq9e9e1idLsSMHMJWsU=
 
 "@types/debug@^4.0.0":
   version "4.1.7"
@@ -6144,6 +6181,14 @@
   integrity sha512-/ICuy7OHZxR0YCAZLNg9r7I9aijWUWvxaPR6uTuyxe8tAj5RL4Sw1+R6NhXUtOsarkGYPmaHdBDvuXh2DIN/uA==
   dependencies:
     "@types/react" "*"
+
+"@types/react-inspector@^4.0.2":
+  version "4.0.2"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@types/react-inspector/-/react-inspector-4.0.2.tgz#cf6b4b305f33d7aa5df7d4fb5db2e437b01daf23"
+  integrity sha1-z2tLMF8z16pd99T7XbLkN7AdryM=
+  dependencies:
+    "@types/react" "*"
+    csstype "^3.0.2"
 
 "@types/react-redux@^7.1.16":
   version "7.1.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,6 +1302,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.16.7":
+  version "7.17.2"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha1-ZvaFkWBeWdpHUjxjFBaxhQh3mUE=
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -5511,6 +5518,11 @@
   resolved "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.47.tgz#1d1b89e1fac36aaf5ef5ed6274bb123073095ac5"
   integrity sha512-oX+3aRf7L6Cqq1MvbWmmD7FpAU/T8URwFFuHBagAiyHILn3i+RNZ35/tvyq28de+lZGY3W19BxJ7FeITQDO7aA==
 
+"@types/dagre@^0.7.47":
+  version "0.7.47"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@types/dagre/-/dagre-0.7.47.tgz#1d1b89e1fac36aaf5ef5ed6274bb123073095ac5"
+  integrity sha1-HRuJ4frDaq9e9e1idLsSMHMJWsU=
+
 "@types/debug@^4.0.0":
   version "4.1.7"
   resolved "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
@@ -6137,6 +6149,16 @@
   version "7.1.19"
   resolved "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.19.tgz#477bd0a9b01bae6d6bf809418cdfa7d3c16d4c62"
   integrity sha512-L37dSCT0aoJnCgpR8Iuginlbxoh7qhWOXiaDqEsxVMrER1CmVhFD+63NxgJeT4pkmEM28oX0NH4S4f+sXHTZjA==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react-redux@^7.1.20":
+  version "7.1.22"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/@types/react-redux/-/react-redux-7.1.22.tgz#0eab76a37ef477cc4b53665aeaf29cb60631b72a"
+  integrity sha1-Dqt2o370d8xLU2Za6vKctgYxtyo=
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"
@@ -8807,6 +8829,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classcat@^5.0.3:
+  version "5.0.3"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/classcat/-/classcat-5.0.3.tgz#38eaa0ec6eb1b10faf101bbcef2afb319c23c17b"
+  integrity sha1-OOqg7G6xsQ+vEBu87yr7MZwjwXs=
+
 classnames@*, classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
@@ -8970,7 +8997,7 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
-clsx@^1.0.2, clsx@^1.0.4:
+clsx@^1.0.2, clsx@^1.0.4, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -10272,8 +10299,8 @@ d3-zoom@^3.0.0:
 
 dagre@^0.8.5:
   version "0.8.5"
-  resolved "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz#ba30b0055dac12b6c1fcc247817442777d06afee"
-  integrity sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/dagre/-/dagre-0.8.5.tgz#ba30b0055dac12b6c1fcc247817442777d06afee"
+  integrity sha1-ujCwBV2sErbB/MJHgXRCd30Gr+4=
   dependencies:
     graphlib "^2.1.8"
     lodash "^4.17.15"
@@ -20454,6 +20481,14 @@ react-double-scrollbar@0.0.15:
   resolved "https://registry.npmjs.org/react-double-scrollbar/-/react-double-scrollbar-0.0.15.tgz#e915ab8cb3b959877075f49436debfdb04288fe4"
   integrity sha1-6RWrjLO5WYdwdfSUNt6/2wQoj+Q=
 
+react-draggable@^4.4.4:
+  version "4.4.4"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/react-draggable/-/react-draggable-4.4.4.tgz#5b26d9996be63d32d285a426f41055de87e59b2f"
+  integrity sha1-WybZmWvmPTLShaQm9BBV3oflmy8=
+  dependencies:
+    clsx "^1.1.1"
+    prop-types "^15.6.0"
+
 react-error-boundary@^3.1.0:
   version "3.1.3"
   resolved "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz#276bfa05de8ac17b863587c9e0647522c25e2a0b"
@@ -20470,6 +20505,20 @@ react-fast-compare@^3.1.1:
   version "3.2.0"
   resolved "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-flow-renderer@^9.7.4:
+  version "9.7.4"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/react-flow-renderer/-/react-flow-renderer-9.7.4.tgz#11394c05ca953b650e2017d056c075fd3df9075c"
+  integrity sha1-ETlMBcqVO2UOIBfQVsB1/T35B1w=
+  dependencies:
+    "@babel/runtime" "^7.16.7"
+    classcat "^5.0.3"
+    d3-selection "^3.0.0"
+    d3-zoom "^3.0.0"
+    fast-deep-equal "^3.1.3"
+    react-draggable "^4.4.4"
+    react-redux "^7.2.6"
+    redux "^4.1.2"
 
 react-ga@^3.3.0:
   version "3.3.0"
@@ -20531,7 +20580,7 @@ react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-"react-is@^16.8.0 || ^17.0.0", react-is@^17.0.0, react-is@^17.0.1:
+"react-is@^16.8.0 || ^17.0.0", react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -20581,6 +20630,18 @@ react-redux@^7.1.1, react-redux@^7.2.4:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.13.1"
+
+react-redux@^7.2.6:
+  version "7.2.6"
+  resolved "https://artifactory.spotify.net/artifactory/api/npm/virtual-npm/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
+  integrity sha1-SWM6JP5VK1+cr1j+uKE4k23f6ao=
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-resize-detector@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
> This PR depends on (and currently includes) #10254, #10255, #10256, #10257, #10258, #10259, so shouldn't be merged as is

## DevTools

This PR introduces a new frontend plugin called DevTools. It provides pages/views which can be mounted on e.g. `/devtools`. It allows for introspection of the internals of Backstage, making life easier for integrators and developers.

It also provides a component `PluginLink` for other plugins to use to link to a "plugin page" (below), and hooks: `useDevToolsPlugins` and `useDevToolsRoutes` so that other plugins can perform the same introspection.

## Pages

### APIs

The APIs view shows the registered APIs. Expanding one will show which other APIs it depends on, and what APIs depend on it, and the plugin providing the API (and a link to that plugin, see below).

<img width="1355" alt="Skärmavbild 2022-03-17 kl  10 53 33" src="https://user-images.githubusercontent.com/5362579/158783831-5dda7a15-98a4-4b25-ae8a-978432e21704.png">


### API graph

Since APIs have dependencies on each other, this can be graphed. The API graph tab shows exactly this.

<img width="1351" alt="Skärmavbild 2022-03-14 kl  15 19 55" src="https://user-images.githubusercontent.com/5362579/158783941-51dec617-ac41-4e9b-8d2b-c906fb81a6be.png">


### Plugins

The Plugins tab shows all plugins and their metadata known from #10256, as well as a link to a page for the plugin itself. With the metadata of plugins available, this page is useful to get links to the repo, the owner, the contact information (like slack channels) etc.

<img width="1353" alt="Skärmavbild 2022-03-17 kl  10 58 08" src="https://user-images.githubusercontent.com/5362579/158784845-c5ec140a-26a3-426c-99a9-796e659225be.png">

<img width="859" alt="Skärmavbild 2022-03-17 kl  11 00 32" src="https://user-images.githubusercontent.com/5362579/158785096-3589ad51-4473-4428-98be-28bd8b02e166.png">

### Routes

The last tab shows the route table, although due to how `react-router` is designed, you will never get the "full picture" since sub routes are constructed dynamically. It shows the FlatRoutes though.

<img width="1357" alt="Skärmavbild 2022-03-14 kl  15 40 39" src="https://user-images.githubusercontent.com/5362579/158785546-0e477617-27a1-4fdf-84d0-a49264f453e5.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
