### PR TITLE
catalog-backend: tell what entity failed validation

### DIFF
--- a/.changeset/large-coins-arrive.md
+++ b/.changeset/large-coins-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Adjust the error messages when entities fail validation, to clearly state what entity that failed it

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -241,7 +241,7 @@ export class DefaultCatalogProcessingOrchestrator
       validateEntity(entity);
     } catch (e) {
       throw new ConflictError(
-        `Entity envelope failed validation after preprocessing`,
+        `Entity envelope for ${context.entityRef} failed validation after preprocessing`,
         e,
       );
     }
@@ -262,7 +262,7 @@ export class DefaultCatalogProcessingOrchestrator
           }
         } catch (e) {
           throw new InputError(
-            `Processor ${processor.constructor.name} threw an error while validating the entity`,
+            `Processor ${processor.constructor.name} threw an error while validating the entity ${context.entityRef}`,
             e,
           );
         }
@@ -271,7 +271,7 @@ export class DefaultCatalogProcessingOrchestrator
 
     if (!foundKind) {
       throw new InputError(
-        'No processor recognized the entity as valid, possibly caused by a foreign kind or apiVersion',
+        `No processor recognized the entity ${context.entityRef} as valid, possibly caused by a foreign kind or apiVersion`,
       );
     }
   }


### PR DESCRIPTION
These messages appear in customer reports every now and then and having the entity ref in there really helps