### PR TITLE
add readmes in the original packages and plugins folders

### DIFF
--- a/.changeset/perfect-phones-roll.md
+++ b/.changeset/perfect-phones-roll.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Add helpful README.md files in the original `packages` and `plugins` folders

--- a/packages/create-app/templates/default-app/packages/README.md
+++ b/packages/create-app/templates/default-app/packages/README.md
@@ -1,0 +1,9 @@
+# The Packages Folder
+
+This is where your own applications and centrally managed libraries live, each
+in a separate folder of its own.
+
+From the start there's an `app` folder (for the frontend) and a `backend` folder
+(for the Node backend), but you can also add more modules in here that house
+your core additions and adaptations, such as themes, common React component
+libraries, utilities, and similar.

--- a/packages/create-app/templates/default-app/plugins/README.md
+++ b/packages/create-app/templates/default-app/plugins/README.md
@@ -1,0 +1,7 @@
+# The Plugins Folder
+
+This is where your own plugins and their associated modules live, each in a
+separate folder of its own.
+
+If you want to create a new plugin here, go to your project root directory, run
+the command `yarn backstage-cli create`, and follow the on-screen instructions.


### PR DESCRIPTION
It was a bit confusing that the plugins folder wasn't there after creating a fresh Backstage repo, so I added that and a little bit of a readme in them instead of just a .gitkeep