### PR TITLE
catalog-backend: add gitlab to AnnotateScmSlugEntityProcessor

### DIFF
--- a/.changeset/tidy-emus-stare.md
+++ b/.changeset/tidy-emus-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+add gitlab to AnnotateScmSlugEntityProcessor


### PR DESCRIPTION
The plugin-catalog-backend has a core module to annotate a Component with an appropriate project-slug from its location, but only supports github for now. I've added logic and tests to do the same gitlab projects.

_If this should rather get split out into respective catalog-backend-modules, I'd be happy to help_

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
