### PR TITLE
plugin-kubernetes: fix div by zero pod resources

### DIFF
--- a/.changeset/wicked-beds-return.md
+++ b/.changeset/wicked-beds-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+Fix division by zero in currentToDeclaredResourceToPerc when pod resources weren't set

--- a/plugins/kubernetes/src/utils/pod.tsx
+++ b/plugins/kubernetes/src/utils/pod.tsx
@@ -118,7 +118,7 @@ export const currentToDeclaredResourceToPerc = (
   current: number | string,
   resource: number | string,
 ): string => {
-  if(Number(resource) == 0) return `0%`;
+  if (Number(resource) == 0) return `0%`;
 
   if (typeof current === 'number' && typeof resource === 'number') {
     return `${Math.round((current / resource) * 100)}%`;

--- a/plugins/kubernetes/src/utils/pod.tsx
+++ b/plugins/kubernetes/src/utils/pod.tsx
@@ -118,6 +118,8 @@ export const currentToDeclaredResourceToPerc = (
   current: number | string,
   resource: number | string,
 ): string => {
+  if(Number(resource) == 0) return `0%`;
+
   if (typeof current === 'number' && typeof resource === 'number') {
     return `${Math.round((current / resource) * 100)}%`;
   }

--- a/plugins/kubernetes/src/utils/pod.tsx
+++ b/plugins/kubernetes/src/utils/pod.tsx
@@ -118,7 +118,7 @@ export const currentToDeclaredResourceToPerc = (
   current: number | string,
   resource: number | string,
 ): string => {
-  if (Number(resource) == 0) return `0%`;
+  if (Number(resource) === 0) return `0%`;
 
   if (typeof current === 'number' && typeof resource === 'number') {
     return `${Math.round((current / resource) * 100)}%`;


### PR DESCRIPTION
When pods have no resources set, currentToDeclaredResourceToPerc would
throw div by zero, added check. fixes #8671 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
