### PR TITLE
chore: Generate source maps for Type Script in order to be able to debug the code in an easy way

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
   ],
   "compilerOptions": {
     "outDir": "dist-types",
+    "sourceMap": true,
     "rootDir": ".",
     "useUnknownInCatchVariables": false
   }


### PR DESCRIPTION
Currently we have to go in Chrome Developer tool, traverse to node_modules, find a particular module, and investigate in which minimized file the transpiled source is located.

![Screenshot 2022-03-17 at 21 57 22](https://user-images.githubusercontent.com/2265094/158894125-22517131-44d8-46db-8549-7d0eea3e145e.png)

By enabling sourceMap for typescript, it will become way less easier. It is possible just to type the name of the file name and debug typescript code. 

Example:
![Screenshot 2022-03-17 at 21 59 37](https://user-images.githubusercontent.com/2265094/158894283-74da7afb-9d33-4882-9ec6-00f908e4053e.png)


