### PR TITLE
Expose initialFiliter from Catalog Page 

### DIFF
--- a/.changeset/tasty-emus-hunt.md
+++ b/.changeset/tasty-emus-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Expose 'initalFilter' through initialKind prop on Catalog Page.

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -48,10 +48,16 @@ export interface DefaultCatalogPageProps {
   initiallySelectedFilter?: UserListFilterKind;
   columns?: TableColumn<CatalogTableRow>[];
   actions?: TableProps<CatalogTableRow>['actions'];
+  initialKind?: string;
 }
 
 export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
-  const { columns, actions, initiallySelectedFilter = 'owned' } = props;
+  const {
+    columns,
+    actions,
+    initiallySelectedFilter = 'owned',
+    initialKind = 'component',
+  } = props;
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
   const createComponentLink = useRouteRef(createComponentRouteRef);
@@ -60,7 +66,9 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
     <PageWithHeader title={`${orgName} Catalog`} themeId="home">
       <EntityListProvider>
         <Content>
-          <ContentHeader titleComponent={<CatalogKindHeader />}>
+          <ContentHeader
+            titleComponent={<CatalogKindHeader initialFilter={initialKind} />}
+          >
             <CreateButton
               title="Create Component"
               to={createComponentLink && createComponentLink()}


### PR DESCRIPTION
Signed-off-by: irma12 <irma@roadie.io>

## Hey, I just made a Pull Request!
Currently there is no prop being passed from Catalog Page in order to customise default kind displayed in catalog page. My suggestion is to add ability for users to pass this in from there. This way we wouldn't need to add custom catalog page and having it as a prop in CatalogKindHeader makes it natural to also be able to pass it here.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
