### PR TITLE
Wire up OneLogin provider in settings panel

### DIFF
--- a/.changeset/fair-lamps-leave.md
+++ b/.changeset/fair-lamps-leave.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Wired up the OneLogin provider to be visible in the Settings UI when configured correctly.
+
+Previously it wasn't visible at all.

--- a/plugins/user-settings/src/components/AuthProviders/DefaultProviderSettings.tsx
+++ b/plugins/user-settings/src/components/AuthProviders/DefaultProviderSettings.tsx
@@ -24,6 +24,7 @@ import {
   microsoftAuthApiRef,
   bitbucketAuthApiRef,
   atlassianAuthApiRef,
+  oneloginAuthApiRef,
 } from '@backstage/core-plugin-api';
 
 type Props = {
@@ -77,6 +78,14 @@ export const DefaultProviderSettings = ({ configuredProviders }: Props) => (
         title="Bitbucket"
         description="Provides authentication towards Bitbucket APIs"
         apiRef={bitbucketAuthApiRef}
+        icon={Star}
+      />
+    )}
+    {configuredProviders.includes('onelogin') && (
+      <ProviderSettingsItem
+        title="OneLogin"
+        description="Provides authentication towards OneLogin APIs"
+        apiRef={oneloginAuthApiRef}
         icon={Star}
       />
     )}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I was scratching my head on this one thinking that I was doing my OneLogin configuration incorrectly but no, it just turns out that the OneLogin provider was never wired up in the settings UI 😅 

**Before:**
![CleanShot 2022-03-18 at 17 19 46](https://user-images.githubusercontent.com/14816406/158937270-0bd28c85-6eb5-4fb4-8506-3c4d700f5ed9.png)

**After:**
![CleanShot 2022-03-18 at 17 18 39](https://user-images.githubusercontent.com/14816406/158937275-b42bfd17-1ebc-4547-ad32-68ac7e149399.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
