### PR TITLE
fix: forward to wrong service name

### DIFF
--- a/contrib/chart/backstage/templates/ingress.yaml
+++ b/contrib/chart/backstage/templates/ingress.yaml
@@ -74,7 +74,7 @@ spec:
             backend:
               {{- if  .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
-                name: {{ include "frontend.serviceName" . }}
+                name: {{ include "backend.serviceName" . }}
                 port:
                   number: 80
               {{- else -}}


### PR DESCRIPTION
fix: forward to wrong service name in case backend host != frontend host

in case backend host != frontend host, we're forwarding to wrong service name

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
