### PR TITLE
auth-backend: remove all default sign-in resolvers

### DIFF
--- a/.changeset/big-teachers-count.md
+++ b/.changeset/big-teachers-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+**DEPRECATION**: The `AuthProviderFactoryOptions` type has been deprecated, as the options are now instead inlined in the `AuthProviderFactory` type. This will make it possible to more easily introduce new options in the future without a possibly breaking change.

--- a/.changeset/four-onions-pretend.md
+++ b/.changeset/four-onions-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+**DEPRECATION**: The `getEntityClaims` helper has been deprecated, with `getDefaultOwnershipEntityRefs` being added to replace it.

--- a/.changeset/loud-bags-run.md
+++ b/.changeset/loud-bags-run.md
@@ -53,7 +53,8 @@ export default async function createPlugin(
       ...defaultAuthProviderFactories,
       google: providers.google.create({
         signIn: {
-          resolver: providers.google.resolvers.lookupEmailAnnotation(),
+          resolver:
+            providers.google.resolvers.emailMatchingUserEntityAnnotation(),
         },
       }),
     },

--- a/.changeset/loud-bags-run.md
+++ b/.changeset/loud-bags-run.md
@@ -1,0 +1,62 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+**DEPRECATION**: All `create<Provider>Provider` and `<provider>*SignInResolver` have been deprecated. Instead, a single `providers` object is exported which contains all built-in auth providers.
+
+If you have a setup that currently looks for example like this:
+
+```ts
+import {
+  createRouter,
+  defaultAuthProviderFactories,
+  createGoogleProvider,
+  googleEmailSignInResolver,
+} from '@backstage/plugin-auth-backend';
+import { Router } from 'express';
+import { PluginEnvironment } from '../types';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    ...env,
+    providerFactories: {
+      ...defaultAuthProviderFactories,
+      google: createGoogleProvider({
+        signIn: {
+          resolver: googleEmailSignInResolver,
+        },
+      }),
+    },
+  });
+}
+```
+
+You would migrate it to something like this:
+
+```ts
+import {
+  createRouter,
+  providers,
+  defaultAuthProviderFactories,
+} from '@backstage/plugin-auth-backend';
+import { Router } from 'express';
+import { PluginEnvironment } from '../types';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  return await createRouter({
+    ...env,
+    providerFactories: {
+      ...defaultAuthProviderFactories,
+      google: providers.google.create({
+        signIn: {
+          resolver: providers.google.resolvers.lookupEmailAnnotation(),
+        },
+      }),
+    },
+  });
+}
+```

--- a/.changeset/neat-countries-hammer.md
+++ b/.changeset/neat-countries-hammer.md
@@ -1,0 +1,58 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+**DEPRECATION** The `AuthResolverContext` has received a number of changes, which is the context used by auth handlers and sign-in resolvers.
+
+The following fields deprecated: `logger`, `tokenIssuer`, `catalogIdentityClient`. If you need to access the `logger`, you can do so through a closure instead. The `tokenIssuer` has been replaced with an `issueToken` method, which is available directory on the context. The `catalogIdentityClient` has been replaced by the `signInWithCatalogUser` method, as well as the lower level `findCatalogUser` method and `getDefaultOwnershipEntityRefs` helper.
+
+It should be possible to migrate most sign-in resolvers to more or less only use `signInWithCatalogUser`, for example an email lookup resolver like this one:
+
+```ts
+async ({ profile }, ctx) => {
+  if (!profile.email) {
+    throw new Error('Profile contained no email');
+  }
+
+  const entity = await ctx.catalogIdentityClient.findUser({
+    annotations: {
+      'acme.org/email': profile.email,
+    },
+  });
+
+  const claims = getEntityClaims(entity);
+  const token = await ctx.tokenIssuer.issueToken({ claims });
+
+  return { id: entity.metadata.name, entity, token };
+};
+```
+
+can be migrated to the following:
+
+```ts
+async ({ profile }, ctx) => {
+  if (!profile.email) {
+    throw new Error('Profile contained no email');
+  }
+
+  return ctx.signInWithCatalogUser({
+    annotations: {
+      'acme.org/email': profile.email,
+    },
+  });
+};
+```
+
+While a direct entity name lookup using a user ID might look like this:
+
+```ts
+async ({ result: { fullProfile } }, ctx) => {
+  return ctx.signInWithCatalogUser({
+    entityRef: {
+      name: fullProfile.userId,
+    },
+  });
+};
+```
+
+If you want more control over the way that users are looked up, ownership is assigned, or tokens are issued, you can use a combination of the `findCatalogUser`, `getDefaultOwnershipEntityRefs`, and `issueToken` instead.

--- a/.changeset/six-ravens-behave.md
+++ b/.changeset/six-ravens-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+**BREAKING**: All auth providers have had their default sign-in resolvers removed. This means that if you want to use a particular provider for sign-in, you must provide an explicit sign-in resolver. For more information on how to configure sign-in resolvers, see the [sign-in resolver documentation](https://backstage.io/docs/auth/identity-resolver).

--- a/.changeset/sour-kiwis-impress.md
+++ b/.changeset/sour-kiwis-impress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added exports of the following types: `AuthProviderConfig`, `StateEncoder`, `TokenParams`, `AwsAlbResult`.

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -40,7 +40,7 @@ export default async function createPlugin(
       //       It is here for demo purposes only.
       github: providers.github.create({
         signIn: {
-          resolver: providers.github.resolvers.byUsername(),
+          resolver: providers.github.resolvers.usernameMatchingUserEntityName(),
         },
       }),
       gitlab: providers.gitlab.create({
@@ -56,22 +56,26 @@ export default async function createPlugin(
       }),
       microsoft: providers.microsoft.create({
         signIn: {
-          resolver: providers.microsoft.resolvers.lookupEmailAnnotation(),
+          resolver:
+            providers.microsoft.resolvers.emailMatchingUserEntityAnnotation(),
         },
       }),
       google: providers.google.create({
         signIn: {
-          resolver: providers.google.resolvers.byEmailLocalPart(),
+          resolver:
+            providers.google.resolvers.emailLocalPartMatchingUserEntityName(),
         },
       }),
       okta: providers.okta.create({
         signIn: {
-          resolver: providers.okta.resolvers.lookupEmailAnnotation(),
+          resolver:
+            providers.okta.resolvers.emailMatchingUserEntityAnnotation(),
         },
       }),
       bitbucket: providers.bitbucket.create({
         signIn: {
-          resolver: providers.bitbucket.resolvers.lookupUsernameAnnotation(),
+          resolver:
+            providers.bitbucket.resolvers.usernameMatchingUserEntityAnnotation(),
         },
       }),
       onelogin: providers.onelogin.create({

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -35,7 +35,18 @@ export default async function createPlugin(
       ...defaultAuthProviderFactories,
       google: providers.google.create({
         signIn: {
-          resolver: providers.google.resolvers.byEmailLocalPart(),
+          resolver({ profile }, ctx) {
+            if (!profile.email) {
+              throw new Error(
+                'Login failed, user profile does not contain an email',
+              );
+            }
+            return ctx.signInWithCatalogUser({
+              entityRef: {
+                name: profile.email.split('@')[0],
+              },
+            });
+          },
         },
       }),
     },

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { createRouter } from '@backstage/plugin-auth-backend';
+import {
+  createRouter,
+  providers,
+  defaultAuthProviderFactories,
+} from '@backstage/plugin-auth-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
 
@@ -27,5 +31,13 @@ export default async function createPlugin(
     database: env.database,
     discovery: env.discovery,
     tokenManager: env.tokenManager,
+    providerFactories: {
+      ...defaultAuthProviderFactories,
+      google: providers.google.create({
+        signIn: {
+          resolver: providers.google.resolvers.byEmailLocalPart(),
+        },
+      }),
+    },
   });
 }

--- a/packages/backend/src/plugins/auth.ts
+++ b/packages/backend/src/plugins/auth.ts
@@ -33,17 +33,53 @@ export default async function createPlugin(
     tokenManager: env.tokenManager,
     providerFactories: {
       ...defaultAuthProviderFactories,
-      google: providers.google.create({
+
+      // NOTE: DO NOT add this many resolvers in your own instance!
+      //       It is important that each real user always gets resolved to
+      //       the same sign-in identity. The code below will not do that.
+      //       It is here for demo purposes only.
+      github: providers.github.create({
         signIn: {
-          resolver({ profile }, ctx) {
-            if (!profile.email) {
-              throw new Error(
-                'Login failed, user profile does not contain an email',
-              );
-            }
+          resolver: providers.github.resolvers.byUsername(),
+        },
+      }),
+      gitlab: providers.gitlab.create({
+        signIn: {
+          async resolver({ result: { fullProfile } }, ctx) {
             return ctx.signInWithCatalogUser({
               entityRef: {
-                name: profile.email.split('@')[0],
+                name: fullProfile.id,
+              },
+            });
+          },
+        },
+      }),
+      microsoft: providers.microsoft.create({
+        signIn: {
+          resolver: providers.microsoft.resolvers.lookupEmailAnnotation(),
+        },
+      }),
+      google: providers.google.create({
+        signIn: {
+          resolver: providers.google.resolvers.byEmailLocalPart(),
+        },
+      }),
+      okta: providers.okta.create({
+        signIn: {
+          resolver: providers.okta.resolvers.lookupEmailAnnotation(),
+        },
+      }),
+      bitbucket: providers.bitbucket.create({
+        signIn: {
+          resolver: providers.bitbucket.resolvers.lookupUsernameAnnotation(),
+        },
+      }),
+      onelogin: providers.onelogin.create({
+        signIn: {
+          async resolver({ result: { fullProfile } }, ctx) {
+            return ctx.signInWithCatalogUser({
+              entityRef: {
+                name: fullProfile.id,
               },
             });
           },

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -811,8 +811,8 @@ export const providers: Readonly<{
         | undefined,
     ) => AuthProviderFactory;
     resolvers: Readonly<{
-      lookupUsernameAnnotation(): SignInResolver<OAuthResult>;
-      lookupUserIdAnnotation(): SignInResolver<OAuthResult>;
+      usernameMatchingUserEntityAnnotation(): SignInResolver<OAuthResult>;
+      userIdMatchingUserEntityAnnotation(): SignInResolver<OAuthResult>;
     }>;
   }>;
   gcpIap: Readonly<{
@@ -839,7 +839,7 @@ export const providers: Readonly<{
         | undefined,
     ) => AuthProviderFactory;
     resolvers: Readonly<{
-      byUsername: () => SignInResolver<GithubOAuthResult>;
+      usernameMatchingUserEntityName: () => SignInResolver<GithubOAuthResult>;
     }>;
   }>;
   gitlab: Readonly<{
@@ -871,8 +871,8 @@ export const providers: Readonly<{
         | undefined,
     ) => AuthProviderFactory;
     resolvers: Readonly<{
-      byEmailLocalPart: () => SignInResolver<unknown>;
-      lookupEmailAnnotation(): SignInResolver<OAuthResult>;
+      emailLocalPartMatchingUserEntityName: () => SignInResolver<unknown>;
+      emailMatchingUserEntityAnnotation(): SignInResolver<OAuthResult>;
     }>;
   }>;
   microsoft: Readonly<{
@@ -889,7 +889,7 @@ export const providers: Readonly<{
         | undefined,
     ) => AuthProviderFactory;
     resolvers: Readonly<{
-      lookupEmailAnnotation(): SignInResolver<OAuthResult>;
+      emailMatchingUserEntityAnnotation(): SignInResolver<OAuthResult>;
     }>;
   }>;
   oauth2: Readonly<{
@@ -945,7 +945,7 @@ export const providers: Readonly<{
         | undefined,
     ) => AuthProviderFactory;
     resolvers: Readonly<{
-      lookupEmailAnnotation(): SignInResolver<OAuthResult>;
+      emailMatchingUserEntityAnnotation(): SignInResolver<OAuthResult>;
     }>;
   }>;
   onelogin: Readonly<{
@@ -977,7 +977,7 @@ export const providers: Readonly<{
         | undefined,
     ) => AuthProviderFactory;
     resolvers: Readonly<{
-      byNameId(): SignInResolver<SamlAuthResult>;
+      nameIdMatchingUserEntityName(): SignInResolver<SamlAuthResult>;
     }>;
   }>;
 }>;

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -44,8 +44,6 @@ export class AtlassianAuthProvider implements OAuthHandlers {
   start(req: OAuthStartRequest): Promise<RedirectInfo>;
 }
 
-// Warning: (ae-missing-release-tag) "AtlassianProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type AtlassianProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
@@ -54,8 +52,6 @@ export type AtlassianProviderOptions = {
   };
 };
 
-// Warning: (ae-missing-release-tag) "Auth0ProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type Auth0ProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
@@ -75,8 +71,6 @@ export type AuthHandlerResult = {
   profile: ProfileInfo;
 };
 
-// Warning: (ae-missing-release-tag) "AuthProviderConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type AuthProviderConfig = {
   baseUrl: string;
@@ -124,8 +118,6 @@ export interface AuthProviderRouteHandlers {
   start(req: express.Request, res: express.Response): Promise<void>;
 }
 
-// Warning: (ae-missing-release-tag) "AuthResolverCatalogUserQuery" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export type AuthResolverCatalogUserQuery =
   | {
@@ -160,8 +152,6 @@ export type AuthResolverContext = {
   ): Promise<BackstageSignInResult>;
 };
 
-// Warning: (ae-missing-release-tag) "AuthResponse" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type AuthResponse<ProviderInfo> = {
   providerInfo: ProviderInfo;
@@ -169,14 +159,19 @@ export type AuthResponse<ProviderInfo> = {
   backstageIdentity?: BackstageIdentityResponse;
 };
 
-// Warning: (ae-missing-release-tag) "AwsAlbProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type AwsAlbProviderOptions = {
   authHandler?: AuthHandler<AwsAlbResult>;
   signIn: {
     resolver: SignInResolver<AwsAlbResult>;
   };
+};
+
+// @public (undocumented)
+export type AwsAlbResult = {
+  fullProfile: Profile;
+  expiresInSeconds?: number;
+  accessToken: string;
 };
 
 // Warning: (ae-missing-release-tag) "BitbucketOAuthResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -210,8 +205,6 @@ export type BitbucketPassportProfile = Profile & {
   };
 };
 
-// Warning: (ae-missing-release-tag) "BitbucketProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type BitbucketProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
@@ -262,8 +255,6 @@ export const createAtlassianProvider: (
     | undefined,
 ) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createAuth0Provider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export const createAuth0Provider: (
   options?:
@@ -278,9 +269,7 @@ export const createAuth0Provider: (
     | undefined,
 ) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createAwsAlbProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createAwsAlbProvider: (
   options?:
     | {
@@ -476,8 +465,6 @@ export const encodeState: (state: OAuthState) => string;
 // @public (undocumented)
 export const ensuresXRequestedWith: (req: express.Request) => boolean;
 
-// Warning: (ae-missing-release-tag) "GcpIapProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type GcpIapProviderOptions = {
   authHandler?: AuthHandler<GcpIapResult>;
@@ -520,8 +507,6 @@ export type GithubOAuthResult = {
   refreshToken?: string;
 };
 
-// Warning: (ae-missing-release-tag) "GithubProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type GithubProviderOptions = {
   authHandler?: AuthHandler<GithubOAuthResult>;
@@ -531,8 +516,6 @@ export type GithubProviderOptions = {
   stateEncoder?: StateEncoder;
 };
 
-// Warning: (ae-missing-release-tag) "GitlabProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type GitlabProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
@@ -544,8 +527,6 @@ export type GitlabProviderOptions = {
 // @public @deprecated (undocumented)
 export const googleEmailSignInResolver: SignInResolver<OAuthResult>;
 
-// Warning: (ae-missing-release-tag) "GoogleProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type GoogleProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
@@ -557,8 +538,6 @@ export type GoogleProviderOptions = {
 // @public @deprecated (undocumented)
 export const microsoftEmailSignInResolver: SignInResolver<OAuthResult>;
 
-// Warning: (ae-missing-release-tag) "MicrosoftProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type MicrosoftProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
@@ -567,8 +546,6 @@ export type MicrosoftProviderOptions = {
   };
 };
 
-// Warning: (ae-missing-release-tag) "OAuth2ProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type OAuth2ProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
@@ -577,8 +554,6 @@ export type OAuth2ProviderOptions = {
   };
 };
 
-// Warning: (ae-missing-release-tag) "Oauth2ProxyProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type Oauth2ProxyProviderOptions<JWTPayload> = {
   authHandler: AuthHandler<OAuth2ProxyResult<JWTPayload>>;
@@ -729,8 +704,6 @@ export type OidcAuthResult = {
   userinfo: UserinfoResponse;
 };
 
-// Warning: (ae-missing-release-tag) "OidcProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type OidcProviderOptions = {
   authHandler?: AuthHandler<OidcAuthResult>;
@@ -742,8 +715,6 @@ export type OidcProviderOptions = {
 // @public @deprecated (undocumented)
 export const oktaEmailSignInResolver: SignInResolver<OAuthResult>;
 
-// Warning: (ae-missing-release-tag) "OktaProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type OktaProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
@@ -752,8 +723,6 @@ export type OktaProviderOptions = {
   };
 };
 
-// Warning: (ae-missing-release-tag) "OneLoginProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type OneLoginProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
@@ -783,9 +752,7 @@ export type ProfileInfo = {
   picture?: string;
 };
 
-// Warning: (ae-missing-release-tag) "providers" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public
 export const providers: Readonly<{
   atlassian: Readonly<{
     create: (
@@ -1048,8 +1015,6 @@ export type SamlAuthResult = {
 // @public @deprecated (undocumented)
 export const samlNameIdEntityNameSignInResolver: SignInResolver<SamlAuthResult>;
 
-// Warning: (ae-missing-release-tag) "SamlProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export type SamlProviderOptions = {
   authHandler?: AuthHandler<SamlAuthResult>;
@@ -1070,9 +1035,12 @@ export type SignInResolver<TAuthResult> = (
   context: AuthResolverContext,
 ) => Promise<BackstageSignInResult>;
 
-// Warning: (ae-missing-release-tag) "TokenIssuer" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public
+// @public (undocumented)
+export type StateEncoder = (req: OAuthStartRequest) => Promise<{
+  encodedState: string;
+}>;
+
+// @public @deprecated
 export type TokenIssuer = {
   issueToken(params: TokenParams): Promise<string>;
   listPublicKeys(): Promise<{
@@ -1080,8 +1048,6 @@ export type TokenIssuer = {
   }>;
 };
 
-// Warning: (ae-missing-release-tag) "TokenParams" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public
 export type TokenParams = {
   claims: {
@@ -1110,7 +1076,5 @@ export type WebMessageResponse =
 
 // Warnings were encountered during analysis:
 //
-// src/identity/types.d.ts:31:9 - (ae-forgotten-export) The symbol "AnyJWK" needs to be exported by the entry point index.d.ts
-// src/providers/aws-alb/provider.d.ts:73:5 - (ae-forgotten-export) The symbol "AwsAlbResult" needs to be exported by the entry point index.d.ts
-// src/providers/github/provider.d.ts:175:5 - (ae-forgotten-export) The symbol "StateEncoder" needs to be exported by the entry point index.d.ts
+// src/identity/types.d.ts:38:9 - (ae-forgotten-export) The symbol "AnyJWK" needs to be exported by the entry point index.d.ts
 ```

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -9,7 +9,9 @@ import { BackstageIdentityResponse } from '@backstage/plugin-auth-node';
 import { BackstageSignInResult } from '@backstage/plugin-auth-node';
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
+import { Entity } from '@backstage/catalog-model';
 import express from 'express';
+import { GetEntitiesRequest } from '@backstage/catalog-client';
 import { JsonValue } from '@backstage/types';
 import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
@@ -110,11 +112,40 @@ export interface AuthProviderRouteHandlers {
   start(req: express.Request, res: express.Response): Promise<void>;
 }
 
+// Warning: (ae-missing-release-tag) "AuthResolverCatalogUserQuery" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type AuthResolverCatalogUserQuery =
+  | {
+      entityRef:
+        | string
+        | {
+            kind?: string;
+            namespace?: string;
+            name: string;
+          };
+    }
+  | {
+      annotations: Record<string, string>;
+    }
+  | {
+      filter: Exclude<GetEntitiesRequest['filter'], undefined>;
+    };
+
 // @public
 export type AuthResolverContext = {
+  logger: Logger;
   tokenIssuer: TokenIssuer;
   catalogIdentityClient: CatalogIdentityClient;
-  logger: Logger;
+  issueToken(params: TokenParams): Promise<{
+    token: string;
+  }>;
+  findCatalogUser(query: AuthResolverCatalogUserQuery): Promise<{
+    entity: Entity;
+  }>;
+  signInWithCatalogUser(
+    query: AuthResolverCatalogUserQuery,
+  ): Promise<BackstageSignInResult>;
 };
 
 // Warning: (ae-missing-release-tag) "AuthResponse" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -360,10 +391,12 @@ export type GcpIapTokenInfo = {
   [key: string]: JsonValue;
 };
 
-// Warning: (ae-forgotten-export) The symbol "TokenParams" needs to be exported by the entry point index.d.ts
+// @public
+export function getDefaultOwnershipEntityRefs(entity: Entity): string[];
+
 // Warning: (ae-missing-release-tag) "getEntityClaims" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function getEntityClaims(entity: UserEntity): TokenParams['claims'];
 
 // Warning: (ae-missing-release-tag) "GithubOAuthResult" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -760,5 +793,6 @@ export type WebMessageResponse =
 // src/identity/types.d.ts:31:9 - (ae-forgotten-export) The symbol "AnyJWK" needs to be exported by the entry point index.d.ts
 // src/providers/aws-alb/provider.d.ts:77:5 - (ae-forgotten-export) The symbol "AwsAlbResult" needs to be exported by the entry point index.d.ts
 // src/providers/github/provider.d.ts:97:5 - (ae-forgotten-export) The symbol "StateEncoder" needs to be exported by the entry point index.d.ts
-// src/providers/types.d.ts:131:5 - (ae-forgotten-export) The symbol "AuthProviderConfig" needs to be exported by the entry point index.d.ts
+// src/providers/types.d.ts:50:5 - (ae-forgotten-export) The symbol "TokenParams" needs to be exported by the entry point index.d.ts
+// src/providers/types.d.ts:180:5 - (ae-forgotten-export) The symbol "AuthProviderConfig" needs to be exported by the entry point index.d.ts
 ```

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -74,13 +74,21 @@ export type AuthHandlerResult = {
 // Warning: (ae-missing-release-tag) "AuthProviderFactory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type AuthProviderFactory = (
-  options: AuthProviderFactoryOptions,
-) => AuthProviderRouteHandlers;
+export type AuthProviderFactory = (options: {
+  providerId: string;
+  globalConfig: AuthProviderConfig;
+  config: Config;
+  resolverContext: AuthResolverContext;
+  logger: Logger;
+  tokenManager: TokenManager;
+  tokenIssuer: TokenIssuer;
+  discovery: PluginEndpointDiscovery;
+  catalogApi: CatalogApi;
+}) => AuthProviderRouteHandlers;
 
 // Warning: (ae-missing-release-tag) "AuthProviderFactoryOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type AuthProviderFactoryOptions = {
   providerId: string;
   globalConfig: AuthProviderConfig;
@@ -248,9 +256,18 @@ export const createGitlabProvider: (
 
 // Warning: (ae-missing-release-tag) "createGoogleProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createGoogleProvider: (
-  options?: GoogleProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
 // Warning: (ae-missing-release-tag) "createMicrosoftProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -369,10 +386,15 @@ export type GithubOAuthResult = {
 export type GithubProviderOptions = {
   authHandler?: AuthHandler<GithubOAuthResult>;
   signIn?: {
-    resolver?: SignInResolver<GithubOAuthResult>;
+    resolver: SignInResolver<GithubOAuthResult>;
   };
   stateEncoder?: StateEncoder;
 };
+
+// Warning: (ae-missing-release-tag) "githubUsernameEntityNameSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const githubUsernameEntityNameSignInResolver: SignInResolver<GithubOAuthResult>;
 
 // Warning: (ae-missing-release-tag) "GitlabProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -380,22 +402,22 @@ export type GithubProviderOptions = {
 export type GitlabProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 
 // Warning: (ae-missing-release-tag) "googleEmailSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
-export const googleEmailSignInResolver: SignInResolver<OAuthResult>;
+// @public @deprecated (undocumented)
+export const googleEmailSignInResolver: () => SignInResolver<OAuthResult>;
 
 // Warning: (ae-missing-release-tag) "GoogleProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type GoogleProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 
@@ -410,7 +432,7 @@ export const microsoftEmailSignInResolver: SignInResolver<OAuthResult>;
 export type MicrosoftProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 
@@ -420,7 +442,7 @@ export type MicrosoftProviderOptions = {
 export type OAuth2ProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 
@@ -578,7 +600,7 @@ export type OidcAuthResult = {
 export type OidcProviderOptions = {
   authHandler?: AuthHandler<OidcAuthResult>;
   signIn?: {
-    resolver?: SignInResolver<OidcAuthResult>;
+    resolver: SignInResolver<OidcAuthResult>;
   };
 };
 
@@ -593,7 +615,7 @@ export const oktaEmailSignInResolver: SignInResolver<OAuthResult>;
 export type OktaProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 
@@ -626,6 +648,30 @@ export type ProfileInfo = {
   picture?: string;
 };
 
+// Warning: (ae-missing-release-tag) "providers" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const providers: Readonly<{
+  google: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: Readonly<{
+      byEmailLocalPart: () => SignInResolver<unknown>;
+      lookupEmailAnnotation(): SignInResolver<OAuthResult>;
+    }>;
+  }>;
+}>;
+
 // Warning: (ae-missing-release-tag) "readState" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -656,11 +702,16 @@ export type SamlAuthResult = {
   fullProfile: any;
 };
 
+// Warning: (ae-missing-release-tag) "samlNameIdEntityNameSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const samlNameIdEntityNameSignInResolver: SignInResolver<SamlAuthResult>;
+
 // @public (undocumented)
 export type SamlProviderOptions = {
   authHandler?: AuthHandler<SamlAuthResult>;
   signIn?: {
-    resolver?: SignInResolver<SamlAuthResult>;
+    resolver: SignInResolver<SamlAuthResult>;
   };
 };
 
@@ -709,5 +760,5 @@ export type WebMessageResponse =
 // src/identity/types.d.ts:31:9 - (ae-forgotten-export) The symbol "AnyJWK" needs to be exported by the entry point index.d.ts
 // src/providers/aws-alb/provider.d.ts:77:5 - (ae-forgotten-export) The symbol "AwsAlbResult" needs to be exported by the entry point index.d.ts
 // src/providers/github/provider.d.ts:97:5 - (ae-forgotten-export) The symbol "StateEncoder" needs to be exported by the entry point index.d.ts
-// src/providers/types.d.ts:118:5 - (ae-forgotten-export) The symbol "AuthProviderConfig" needs to be exported by the entry point index.d.ts
+// src/providers/types.d.ts:131:5 - (ae-forgotten-export) The symbol "AuthProviderConfig" needs to be exported by the entry point index.d.ts
 ```

--- a/plugins/auth-backend/api-report.md
+++ b/plugins/auth-backend/api-report.md
@@ -46,7 +46,7 @@ export class AtlassianAuthProvider implements OAuthHandlers {
 
 // Warning: (ae-missing-release-tag) "AtlassianProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type AtlassianProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
@@ -54,7 +54,9 @@ export type AtlassianProviderOptions = {
   };
 };
 
-// @public (undocumented)
+// Warning: (ae-missing-release-tag) "Auth0ProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public @deprecated (undocumented)
 export type Auth0ProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
@@ -73,6 +75,16 @@ export type AuthHandlerResult = {
   profile: ProfileInfo;
 };
 
+// Warning: (ae-missing-release-tag) "AuthProviderConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type AuthProviderConfig = {
+  baseUrl: string;
+  appUrl: string;
+  isOriginAllowed: (origin: string) => boolean;
+  cookieConfigurer?: CookieConfigurer;
+};
+
 // Warning: (ae-missing-release-tag) "AuthProviderFactory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -80,8 +92,8 @@ export type AuthProviderFactory = (options: {
   providerId: string;
   globalConfig: AuthProviderConfig;
   config: Config;
-  resolverContext: AuthResolverContext;
   logger: Logger;
+  resolverContext: AuthResolverContext;
   tokenManager: TokenManager;
   tokenIssuer: TokenIssuer;
   discovery: PluginEndpointDiscovery;
@@ -159,7 +171,7 @@ export type AuthResponse<ProviderInfo> = {
 
 // Warning: (ae-missing-release-tag) "AwsAlbProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type AwsAlbProviderOptions = {
   authHandler?: AuthHandler<AwsAlbResult>;
   signIn: {
@@ -200,7 +212,7 @@ export type BitbucketPassportProfile = Profile & {
 
 // Warning: (ae-missing-release-tag) "BitbucketProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type BitbucketProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
@@ -208,15 +220,11 @@ export type BitbucketProviderOptions = {
   };
 };
 
-// Warning: (ae-missing-release-tag) "bitbucketUserIdSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const bitbucketUserIdSignInResolver: SignInResolver<BitbucketOAuthResult>;
+// @public @deprecated (undocumented)
+export const bitbucketUserIdSignInResolver: SignInResolver<OAuthResult>;
 
-// Warning: (ae-missing-release-tag) "bitbucketUsernameSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const bitbucketUsernameSignInResolver: SignInResolver<BitbucketOAuthResult>;
+// @public @deprecated (undocumented)
+export const bitbucketUsernameSignInResolver: SignInResolver<OAuthResult>;
 
 // Warning: (ae-missing-release-tag) "CatalogIdentityClient" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -240,53 +248,101 @@ export type CookieConfigurer = (ctx: {
   secure: boolean;
 };
 
-// Warning: (ae-missing-release-tag) "createAtlassianProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createAtlassianProvider: (
-  options?: AtlassianProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
-// @public (undocumented)
+// Warning: (ae-missing-release-tag) "createAuth0Provider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public @deprecated (undocumented)
 export const createAuth0Provider: (
-  options?: Auth0ProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
 // Warning: (ae-missing-release-tag) "createAwsAlbProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export const createAwsAlbProvider: (
-  options?: AwsAlbProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<AwsAlbResult> | undefined;
+        signIn: {
+          resolver: SignInResolver<AwsAlbResult>;
+        };
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createBitbucketProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createBitbucketProvider: (
-  options?: BitbucketProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
-// @public
-export function createGcpIapProvider(
-  options: GcpIapProviderOptions,
-): AuthProviderFactory;
+// @public @deprecated (undocumented)
+export const createGcpIapProvider: (options: {
+  authHandler?: AuthHandler<GcpIapResult> | undefined;
+  signIn: {
+    resolver: SignInResolver<GcpIapResult>;
+  };
+}) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createGithubProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createGithubProvider: (
-  options?: GithubProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<GithubOAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<GithubOAuthResult>;
+            }
+          | undefined;
+        stateEncoder?: StateEncoder | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createGitlabProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createGitlabProvider: (
-  options?: GitlabProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createGoogleProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
 export const createGoogleProvider: (
   options?:
@@ -301,42 +357,82 @@ export const createGoogleProvider: (
     | undefined,
 ) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createMicrosoftProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createMicrosoftProvider: (
-  options?: MicrosoftProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createOAuth2Provider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createOAuth2Provider: (
-  options?: OAuth2ProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
-// @public
-export const createOauth2ProxyProvider: <JWTPayload>(
-  options: Oauth2ProxyProviderOptions<JWTPayload>,
-) => AuthProviderFactory;
+// @public @deprecated (undocumented)
+export const createOauth2ProxyProvider: (options: {
+  authHandler: AuthHandler<OAuth2ProxyResult<unknown>>;
+  signIn: {
+    resolver: SignInResolver<OAuth2ProxyResult<unknown>>;
+  };
+}) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createOidcProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createOidcProvider: (
-  options?: OidcProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OidcAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OidcAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
-// Warning: (ae-missing-release-tag) "createOktaProvider" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createOktaProvider: (
-  _options?: OktaProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createOneLoginProvider: (
-  options?: OneLoginProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<OAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<OAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
 // Warning: (ae-missing-release-tag) "createOriginFilter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -349,9 +445,18 @@ export function createOriginFilter(config: Config): (origin: string) => boolean;
 // @public (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const createSamlProvider: (
-  options?: SamlProviderOptions | undefined,
+  options?:
+    | {
+        authHandler?: AuthHandler<SamlAuthResult> | undefined;
+        signIn?:
+          | {
+              resolver: SignInResolver<SamlAuthResult>;
+            }
+          | undefined;
+      }
+    | undefined,
 ) => AuthProviderFactory;
 
 // Warning: (ae-missing-release-tag) "factories" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -371,7 +476,9 @@ export const encodeState: (state: OAuthState) => string;
 // @public (undocumented)
 export const ensuresXRequestedWith: (req: express.Request) => boolean;
 
-// @public
+// Warning: (ae-missing-release-tag) "GcpIapProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public @deprecated (undocumented)
 export type GcpIapProviderOptions = {
   authHandler?: AuthHandler<GcpIapResult>;
   signIn: {
@@ -415,7 +522,7 @@ export type GithubOAuthResult = {
 
 // Warning: (ae-missing-release-tag) "GithubProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type GithubProviderOptions = {
   authHandler?: AuthHandler<GithubOAuthResult>;
   signIn?: {
@@ -424,14 +531,9 @@ export type GithubProviderOptions = {
   stateEncoder?: StateEncoder;
 };
 
-// Warning: (ae-missing-release-tag) "githubUsernameEntityNameSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
-export const githubUsernameEntityNameSignInResolver: SignInResolver<GithubOAuthResult>;
-
 // Warning: (ae-missing-release-tag) "GitlabProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type GitlabProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
@@ -439,10 +541,8 @@ export type GitlabProviderOptions = {
   };
 };
 
-// Warning: (ae-missing-release-tag) "googleEmailSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public @deprecated (undocumented)
-export const googleEmailSignInResolver: () => SignInResolver<OAuthResult>;
+export const googleEmailSignInResolver: SignInResolver<OAuthResult>;
 
 // Warning: (ae-missing-release-tag) "GoogleProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -454,14 +554,12 @@ export type GoogleProviderOptions = {
   };
 };
 
-// Warning: (ae-missing-release-tag) "microsoftEmailSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const microsoftEmailSignInResolver: SignInResolver<OAuthResult>;
 
 // Warning: (ae-missing-release-tag) "MicrosoftProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type MicrosoftProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
@@ -471,7 +569,7 @@ export type MicrosoftProviderOptions = {
 
 // Warning: (ae-missing-release-tag) "OAuth2ProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type OAuth2ProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
@@ -479,7 +577,9 @@ export type OAuth2ProviderOptions = {
   };
 };
 
-// @public
+// Warning: (ae-missing-release-tag) "Oauth2ProxyProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public @deprecated (undocumented)
 export type Oauth2ProxyProviderOptions<JWTPayload> = {
   authHandler: AuthHandler<OAuth2ProxyResult<JWTPayload>>;
   signIn: {
@@ -629,7 +729,9 @@ export type OidcAuthResult = {
   userinfo: UserinfoResponse;
 };
 
-// @public
+// Warning: (ae-missing-release-tag) "OidcProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public @deprecated (undocumented)
 export type OidcProviderOptions = {
   authHandler?: AuthHandler<OidcAuthResult>;
   signIn?: {
@@ -637,14 +739,12 @@ export type OidcProviderOptions = {
   };
 };
 
-// Warning: (ae-missing-release-tag) "oktaEmailSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const oktaEmailSignInResolver: SignInResolver<OAuthResult>;
 
 // Warning: (ae-missing-release-tag) "OktaProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export type OktaProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
@@ -652,7 +752,9 @@ export type OktaProviderOptions = {
   };
 };
 
-// @public (undocumented)
+// Warning: (ae-missing-release-tag) "OneLoginProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public @deprecated (undocumented)
 export type OneLoginProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
   signIn?: {
@@ -685,6 +787,109 @@ export type ProfileInfo = {
 //
 // @public (undocumented)
 export const providers: Readonly<{
+  atlassian: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: never;
+  }>;
+  auth0: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: never;
+  }>;
+  awsAlb: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<AwsAlbResult> | undefined;
+            signIn: {
+              resolver: SignInResolver<AwsAlbResult>;
+            };
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: never;
+  }>;
+  bitbucket: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: Readonly<{
+      lookupUsernameAnnotation(): SignInResolver<OAuthResult>;
+      lookupUserIdAnnotation(): SignInResolver<OAuthResult>;
+    }>;
+  }>;
+  gcpIap: Readonly<{
+    create: (options: {
+      authHandler?: AuthHandler<GcpIapResult> | undefined;
+      signIn: {
+        resolver: SignInResolver<GcpIapResult>;
+      };
+    }) => AuthProviderFactory;
+    resolvers: never;
+  }>;
+  github: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<GithubOAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<GithubOAuthResult>;
+                }
+              | undefined;
+            stateEncoder?: StateEncoder | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: Readonly<{
+      byUsername: () => SignInResolver<GithubOAuthResult>;
+    }>;
+  }>;
+  gitlab: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: never;
+  }>;
   google: Readonly<{
     create: (
       options?:
@@ -701,6 +906,111 @@ export const providers: Readonly<{
     resolvers: Readonly<{
       byEmailLocalPart: () => SignInResolver<unknown>;
       lookupEmailAnnotation(): SignInResolver<OAuthResult>;
+    }>;
+  }>;
+  microsoft: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: Readonly<{
+      lookupEmailAnnotation(): SignInResolver<OAuthResult>;
+    }>;
+  }>;
+  oauth2: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: never;
+  }>;
+  oauth2Proxy: Readonly<{
+    create: (options: {
+      authHandler: AuthHandler<OAuth2ProxyResult<unknown>>;
+      signIn: {
+        resolver: SignInResolver<OAuth2ProxyResult<unknown>>;
+      };
+    }) => AuthProviderFactory;
+    resolvers: never;
+  }>;
+  oidc: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OidcAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OidcAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: never;
+  }>;
+  okta: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: Readonly<{
+      lookupEmailAnnotation(): SignInResolver<OAuthResult>;
+    }>;
+  }>;
+  onelogin: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<OAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<OAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: never;
+  }>;
+  saml: Readonly<{
+    create: (
+      options?:
+        | {
+            authHandler?: AuthHandler<SamlAuthResult> | undefined;
+            signIn?:
+              | {
+                  resolver: SignInResolver<SamlAuthResult>;
+                }
+              | undefined;
+          }
+        | undefined,
+    ) => AuthProviderFactory;
+    resolvers: Readonly<{
+      byNameId(): SignInResolver<SamlAuthResult>;
     }>;
   }>;
 }>;
@@ -735,12 +1045,12 @@ export type SamlAuthResult = {
   fullProfile: any;
 };
 
-// Warning: (ae-missing-release-tag) "samlNameIdEntityNameSignInResolver" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const samlNameIdEntityNameSignInResolver: SignInResolver<SamlAuthResult>;
 
-// @public (undocumented)
+// Warning: (ae-missing-release-tag) "SamlProviderOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public @deprecated (undocumented)
 export type SamlProviderOptions = {
   authHandler?: AuthHandler<SamlAuthResult>;
   signIn?: {
@@ -770,6 +1080,16 @@ export type TokenIssuer = {
   }>;
 };
 
+// Warning: (ae-missing-release-tag) "TokenParams" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type TokenParams = {
+  claims: {
+    sub: string;
+    ent?: string[];
+  };
+};
+
 // Warning: (ae-missing-release-tag) "verifyNonce" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -791,8 +1111,6 @@ export type WebMessageResponse =
 // Warnings were encountered during analysis:
 //
 // src/identity/types.d.ts:31:9 - (ae-forgotten-export) The symbol "AnyJWK" needs to be exported by the entry point index.d.ts
-// src/providers/aws-alb/provider.d.ts:77:5 - (ae-forgotten-export) The symbol "AwsAlbResult" needs to be exported by the entry point index.d.ts
-// src/providers/github/provider.d.ts:97:5 - (ae-forgotten-export) The symbol "StateEncoder" needs to be exported by the entry point index.d.ts
-// src/providers/types.d.ts:50:5 - (ae-forgotten-export) The symbol "TokenParams" needs to be exported by the entry point index.d.ts
-// src/providers/types.d.ts:180:5 - (ae-forgotten-export) The symbol "AuthProviderConfig" needs to be exported by the entry point index.d.ts
+// src/providers/aws-alb/provider.d.ts:73:5 - (ae-forgotten-export) The symbol "AwsAlbResult" needs to be exported by the entry point index.d.ts
+// src/providers/github/provider.d.ts:175:5 - (ae-forgotten-export) The symbol "StateEncoder" needs to be exported by the entry point index.d.ts
 ```

--- a/plugins/auth-backend/src/identity/types.ts
+++ b/plugins/auth-backend/src/identity/types.ts
@@ -22,7 +22,11 @@ export interface AnyJWK extends Record<string, string> {
   kty: string;
 }
 
-/** Parameters used to issue new ID Tokens */
+/**
+ * Parameters used to issue new ID Tokens
+ *
+ * @public
+ */
 export type TokenParams = {
   /** The claims that will be embedded within the token */
   claims: {
@@ -33,8 +37,12 @@ export type TokenParams = {
   };
 };
 
+// TODO(Rugvip): This should at least be made internal
 /**
  * A TokenIssuer is able to issue verifiable ID Tokens on demand.
+ *
+ * @public
+ * @deprecated This interface is deprecated and will be removed in a future release.
  */
 export type TokenIssuer = {
   /**

--- a/plugins/auth-backend/src/index.ts
+++ b/plugins/auth-backend/src/index.ts
@@ -32,3 +32,5 @@ export * from './lib/flow';
 export * from './lib/oauth';
 
 export * from './lib/catalog';
+
+export { getDefaultOwnershipEntityRefs } from './lib/resolvers';

--- a/plugins/auth-backend/src/index.ts
+++ b/plugins/auth-backend/src/index.ts
@@ -21,7 +21,7 @@
  */
 
 export * from './service/router';
-export type { TokenIssuer } from './identity';
+export type { TokenIssuer, TokenParams } from './identity';
 export * from './providers';
 
 // flow package provides 2 functions

--- a/plugins/auth-backend/src/lib/catalog/helpers.ts
+++ b/plugins/auth-backend/src/lib/catalog/helpers.ts
@@ -21,6 +21,9 @@ import {
 } from '@backstage/catalog-model';
 import { TokenParams } from '../../identity';
 
+/**
+ * @deprecated use {@link getDefaultOwnershipEntityRefs} instead
+ */
 export function getEntityClaims(entity: UserEntity): TokenParams['claims'] {
   const userRef = stringifyEntityRef(entity);
 

--- a/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
+++ b/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
@@ -90,7 +90,7 @@ export class CatalogAuthResolverContext implements AuthResolverContext {
 
     if ('entityRef' in query) {
       const entityRef = parseEntityRef(query.entityRef, {
-        defaultKind: 'user',
+        defaultKind: 'User',
         defaultNamespace: DEFAULT_NAMESPACE,
       });
       result = await this.catalogApi.getEntityByRef(entityRef, { token });

--- a/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
+++ b/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
@@ -42,7 +42,9 @@ import { CatalogIdentityClient } from '../catalog';
 export function getDefaultOwnershipEntityRefs(entity: Entity) {
   const membershipRefs =
     entity.relations
-      ?.filter(r => r.type === RELATION_MEMBER_OF)
+      ?.filter(
+        r => r.type === RELATION_MEMBER_OF && r.targetRef.startsWith('group:'),
+      )
       .map(r => r.targetRef) ?? [];
 
   return Array.from(new Set([stringifyEntityRef(entity), ...membershipRefs]));

--- a/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
+++ b/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TokenManager } from '@backstage/backend-common';
+import { CatalogApi } from '@backstage/catalog-client';
+import {
+  DEFAULT_NAMESPACE,
+  Entity,
+  parseEntityRef,
+  RELATION_MEMBER_OF,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
+import { ConflictError, InputError, NotFoundError } from '@backstage/errors';
+import { Logger } from 'winston';
+import { TokenIssuer } from '../..';
+import { TokenParams } from '../../identity';
+import { AuthResolverContext } from '../../providers';
+import { AuthResolverCatalogUserQuery } from '../../providers/types';
+import { CatalogIdentityClient } from '../catalog';
+
+/**
+ * Uses the default ownership resolution logic to return an array
+ * of entity refs that the provided entity claims ownership through.
+ *
+ * A reference to the entity itself will also be included in the returned array.
+ *
+ * @public
+ */
+export function getDefaultOwnershipEntityRefs(entity: Entity) {
+  const membershipRefs =
+    entity.relations
+      ?.filter(r => r.type === RELATION_MEMBER_OF)
+      .map(r => r.targetRef) ?? [];
+
+  return Array.from(new Set([stringifyEntityRef(entity), ...membershipRefs]));
+}
+
+/**
+ * @internal
+ */
+export class CatalogAuthResolverContext implements AuthResolverContext {
+  static create(options: {
+    logger: Logger;
+    catalogApi: CatalogApi;
+    tokenIssuer: TokenIssuer;
+    tokenManager: TokenManager;
+  }): CatalogAuthResolverContext {
+    const catalogIdentityClient = new CatalogIdentityClient({
+      catalogApi: options.catalogApi,
+      tokenManager: options.tokenManager,
+    });
+    return new CatalogAuthResolverContext(
+      options.logger,
+      options.tokenIssuer,
+      catalogIdentityClient,
+      options.catalogApi,
+      options.tokenManager,
+    );
+  }
+
+  private constructor(
+    public readonly logger: Logger,
+    public readonly tokenIssuer: TokenIssuer,
+    public readonly catalogIdentityClient: CatalogIdentityClient,
+    private readonly catalogApi: CatalogApi,
+    private readonly tokenManager: TokenManager,
+  ) {}
+
+  async issueToken(params: TokenParams) {
+    const token = await this.tokenIssuer.issueToken(params);
+    return { token };
+  }
+
+  async findCatalogUser(query: AuthResolverCatalogUserQuery) {
+    let result: Entity[] | Entity | undefined = undefined;
+    const { token } = await this.tokenManager.getToken();
+
+    if ('entityRef' in query) {
+      const entityRef = parseEntityRef(query.entityRef, {
+        defaultKind: 'user',
+        defaultNamespace: DEFAULT_NAMESPACE,
+      });
+      result = await this.catalogApi.getEntityByRef(entityRef, { token });
+    } else if ('annotations' in query) {
+      const filter: Record<string, string> = {
+        kind: 'user',
+      };
+      for (const [key, value] of Object.entries(query.annotations)) {
+        filter[`metadata.annotations.${key}`] = value;
+      }
+      const res = await this.catalogApi.getEntities({ filter }, { token });
+      result = res.items;
+    } else if ('filter' in query) {
+      const res = await this.catalogApi.getEntities(
+        { filter: query.filter },
+        { token },
+      );
+      result = res.items;
+    } else {
+      throw new InputError('Invalid user lookup query');
+    }
+
+    if (Array.isArray(result)) {
+      if (result.length > 1) {
+        throw new ConflictError('User lookup resulted in multiple matches');
+      }
+      result = result[0];
+    }
+    if (!result) {
+      throw new NotFoundError('User not found');
+    }
+
+    return { entity: result };
+  }
+
+  async signInWithCatalogUser(query: AuthResolverCatalogUserQuery) {
+    const { entity } = await this.findCatalogUser(query);
+    const ownershipRefs = getDefaultOwnershipEntityRefs(entity);
+
+    const token = await this.tokenIssuer.issueToken({
+      claims: {
+        sub: stringifyEntityRef(entity),
+        ent: ownershipRefs,
+      },
+    });
+    return { token };
+  }
+  /*
+  async expandCatalogOwnership(query: { entityRefs: string[] }) {
+    const { entityRefs } = query;
+
+    const compoundRefs = entityRefs.map(ref =>
+      parseEntityRef(ref.toLocaleLowerCase('en-US'), {
+        defaultKind: 'user',
+        defaultNamespace: DEFAULT_NAMESPACE,
+      }),
+    );
+    const stringRefs = compoundRefs.map(e => stringifyEntityRef(e));
+
+    const { token } = await this.tokenManager.getToken();
+    const { items: entities } = await this.catalogApi.getEntities(
+      {
+        filter: compoundRefs.map(ref => ({
+          kind: ref.kind,
+          'metadata.namespace': ref.namespace,
+          'metadata.name': ref.name,
+        })),
+      },
+      { token },
+    );
+
+    if (compoundRefs.length !== entities.length) {
+      const found = entities.map(e => stringifyEntityRef(e));
+      const missing = stringRefs.filter(ref => !found.includes(ref));
+      throw new NotFoundError(`Entities not found for refs ${missing.join()}`);
+    }
+
+    const memberOf = entities.flatMap(e => getDefaultOwnershipEntityRefs(e));
+
+    return Array.from(new Set(memberOf));
+  }
+*/
+}

--- a/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
+++ b/plugins/auth-backend/src/lib/resolvers/CatalogAuthResolverContext.ts
@@ -138,39 +138,4 @@ export class CatalogAuthResolverContext implements AuthResolverContext {
     });
     return { token };
   }
-  /*
-  async expandCatalogOwnership(query: { entityRefs: string[] }) {
-    const { entityRefs } = query;
-
-    const compoundRefs = entityRefs.map(ref =>
-      parseEntityRef(ref.toLocaleLowerCase('en-US'), {
-        defaultKind: 'user',
-        defaultNamespace: DEFAULT_NAMESPACE,
-      }),
-    );
-    const stringRefs = compoundRefs.map(e => stringifyEntityRef(e));
-
-    const { token } = await this.tokenManager.getToken();
-    const { items: entities } = await this.catalogApi.getEntities(
-      {
-        filter: compoundRefs.map(ref => ({
-          kind: ref.kind,
-          'metadata.namespace': ref.namespace,
-          'metadata.name': ref.name,
-        })),
-      },
-      { token },
-    );
-
-    if (compoundRefs.length !== entities.length) {
-      const found = entities.map(e => stringifyEntityRef(e));
-      const missing = stringRefs.filter(ref => !found.includes(ref));
-      throw new NotFoundError(`Entities not found for refs ${missing.join()}`);
-    }
-
-    const memberOf = entities.flatMap(e => getDefaultOwnershipEntityRefs(e));
-
-    return Array.from(new Set(memberOf));
-  }
-*/
 }

--- a/plugins/auth-backend/src/lib/resolvers/index.ts
+++ b/plugins/auth-backend/src/lib/resolvers/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  CatalogAuthResolverContext,
+  getDefaultOwnershipEntityRefs,
+} from './CatalogAuthResolverContext';

--- a/plugins/auth-backend/src/providers/atlassian/provider.test.ts
+++ b/plugins/auth-backend/src/providers/atlassian/provider.test.ts
@@ -16,11 +16,9 @@
 
 import { AtlassianAuthProvider } from './provider';
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
-import { getVoidLogger } from '@backstage/backend-common';
-import { TokenIssuer } from '../../identity';
-import { CatalogIdentityClient } from '../../lib/catalog';
 import { OAuthResult } from '../../lib/oauth';
 import { PassportProfile } from '../../lib/passport/types';
+import { AuthResolverContext } from '../types';
 
 const mockFrameHandler = jest.spyOn(
   helpers,
@@ -28,19 +26,8 @@ const mockFrameHandler = jest.spyOn(
 ) as unknown as jest.MockedFunction<() => Promise<{ result: OAuthResult }>>;
 
 describe('createAtlassianProvider', () => {
-  const tokenIssuer = {
-    issueToken: jest.fn(),
-    listPublicKeys: jest.fn(),
-  };
-  const catalogIdentityClient = {
-    findUser: jest.fn(),
-  };
-
   const provider = new AtlassianAuthProvider({
-    logger: getVoidLogger(),
-    catalogIdentityClient:
-      catalogIdentityClient as unknown as CatalogIdentityClient,
-    tokenIssuer: tokenIssuer as unknown as TokenIssuer,
+    resolverContext: {} as AuthResolverContext,
     authHandler: async ({ fullProfile }) => ({
       profile: {
         email: fullProfile.emails![0]!.value,

--- a/plugins/auth-backend/src/providers/atlassian/provider.ts
+++ b/plugins/auth-backend/src/providers/atlassian/provider.ts
@@ -162,6 +162,7 @@ export class AtlassianAuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type AtlassianProviderOptions = {

--- a/plugins/auth-backend/src/providers/atlassian/provider.ts
+++ b/plugins/auth-backend/src/providers/atlassian/provider.ts
@@ -174,6 +174,9 @@ export class AtlassianAuthProvider implements OAuthHandlers {
   }
 }
 
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type AtlassianProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -189,9 +192,20 @@ export type AtlassianProviderOptions = {
   };
 };
 
-export const createAtlassianProvider = (
-  options?: AtlassianProviderOptions,
-): AuthProviderFactory => {
+export const createAtlassianProvider = (options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<OAuthResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  signIn?: {
+    resolver: SignInResolver<OAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -180,7 +180,9 @@ export class Auth0AuthProvider implements OAuthHandlers {
   }
 }
 
-/** @public */
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type Auth0ProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -200,9 +202,23 @@ export type Auth0ProviderOptions = {
 };
 
 /** @public */
-export const createAuth0Provider = (
-  options?: Auth0ProviderOptions,
-): AuthProviderFactory => {
+export const createAuth0Provider = (options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<OAuthResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
+    resolver: SignInResolver<OAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -180,18 +180,6 @@ export class Auth0AuthProvider implements OAuthHandlers {
   }
 }
 
-const defaultSignInResolver: SignInResolver<OAuthResult> = async info => {
-  const { profile } = info;
-
-  if (!profile.email) {
-    throw new Error('Profile does not contain an email');
-  }
-
-  const id = profile.email.split('@')[0];
-
-  return { id, token: '' };
-};
-
 /** @public */
 export type Auth0ProviderOptions = {
   /**
@@ -244,7 +232,7 @@ export const createAuth0Provider = (
             profile: makeProfileInfo(fullProfile, params.id_token),
           });
 
-      const signInResolver = options?.signIn?.resolver ?? defaultSignInResolver;
+      const signInResolver = options?.signIn?.resolver;
 
       const provider = new Auth0AuthProvider({
         clientId,

--- a/plugins/auth-backend/src/providers/auth0/provider.ts
+++ b/plugins/auth-backend/src/providers/auth0/provider.ts
@@ -168,6 +168,7 @@ export class Auth0AuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type Auth0ProviderOptions = {
@@ -249,6 +250,7 @@ export const auth0 = createAuthProviderIntegration({
 });
 
 /**
+ * @public
  * @deprecated Use `providers.auth0.create` instead.
  */
 export const createAuth0Provider = auth0.create;

--- a/plugins/auth-backend/src/providers/aws-alb/index.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { createAwsAlbProvider } from './provider';
-export type { AwsAlbProviderOptions } from './provider';
+export type { AwsAlbProviderOptions, AwsAlbResult } from './provider';

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -220,6 +220,9 @@ export class AwsAlbAuthProvider implements AuthProviderRouteHandlers {
   }
 }
 
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type AwsAlbProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -238,9 +241,23 @@ export type AwsAlbProviderOptions = {
   };
 };
 
-export const createAwsAlbProvider = (
-  options?: AwsAlbProviderOptions,
-): AuthProviderFactory => {
+export const createAwsAlbProvider = (options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<AwsAlbResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  signIn: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
+    resolver: SignInResolver<AwsAlbResult>;
+  };
+}): AuthProviderFactory => {
   return ({ config, tokenIssuer, catalogApi, logger, tokenManager }) => {
     const region = config.getString('region');
     const issuer = config.getOptionalString('iss');

--- a/plugins/auth-backend/src/providers/aws-alb/provider.ts
+++ b/plugins/auth-backend/src/providers/aws-alb/provider.ts
@@ -69,6 +69,7 @@ export type AwsAlbClaims = {
   iss: string;
 };
 
+/** @public */
 export type AwsAlbResult = {
   fullProfile: PassportProfile;
   expiresInSeconds?: number;
@@ -209,6 +210,7 @@ export class AwsAlbAuthProvider implements AuthProviderRouteHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type AwsAlbProviderOptions = {
@@ -279,4 +281,8 @@ export const awsAlb = createAuthProviderIntegration({
   },
 });
 
+/**
+ * @public
+ * @deprecated Use `providers.awsAlb.create` instead
+ */
 export const createAwsAlbProvider = awsAlb.create;

--- a/plugins/auth-backend/src/providers/bitbucket/provider.test.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.test.ts
@@ -16,9 +16,7 @@
 
 import { BitbucketAuthProvider, BitbucketOAuthResult } from './provider';
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
-import { getVoidLogger } from '@backstage/backend-common';
-import { TokenIssuer } from '../../identity/types';
-import { CatalogIdentityClient } from '../../lib/catalog';
+import { AuthResolverContext } from '../types';
 
 const mockFrameHandler = jest.spyOn(
   helpers,
@@ -29,19 +27,8 @@ const mockFrameHandler = jest.spyOn(
 
 describe('createBitbucketProvider', () => {
   it('should auth', async () => {
-    const tokenIssuer = {
-      issueToken: jest.fn(),
-      listPublicKeys: jest.fn(),
-    };
-    const catalogIdentityClient = {
-      findUser: jest.fn(),
-    };
-
     const provider = new BitbucketAuthProvider({
-      logger: getVoidLogger(),
-      catalogIdentityClient:
-        catalogIdentityClient as unknown as CatalogIdentityClient,
-      tokenIssuer: tokenIssuer as unknown as TokenIssuer,
+      resolverContext: {} as AuthResolverContext,
       authHandler: async ({ fullProfile }) => ({
         profile: {
           email: fullProfile.emails![0]!.value,

--- a/plugins/auth-backend/src/providers/bitbucket/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.ts
@@ -193,6 +193,7 @@ export class BitbucketAuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type BitbucketProviderOptions = {

--- a/plugins/auth-backend/src/providers/bitbucket/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.ts
@@ -192,38 +192,6 @@ export class BitbucketAuthProvider implements OAuthHandlers {
   }
 }
 
-export const bitbucketUsernameSignInResolver: SignInResolver<
-  BitbucketOAuthResult
-> = async (info, ctx) => {
-  const { result } = info;
-
-  if (!result.fullProfile.username) {
-    throw new Error('Bitbucket profile contained no Username');
-  }
-
-  return ctx.signInWithCatalogUser({
-    annotations: {
-      'bitbucket.org/username': result.fullProfile.username,
-    },
-  });
-};
-
-export const bitbucketUserIdSignInResolver: SignInResolver<
-  BitbucketOAuthResult
-> = async (info, ctx) => {
-  const { result } = info;
-
-  if (!result.fullProfile.id) {
-    throw new Error('Bitbucket profile contained no User ID');
-  }
-
-  return ctx.signInWithCatalogUser({
-    annotations: {
-      'bitbucket.org/user-id': result.fullProfile.id,
-    },
-  });
-};
-
 /**
  * @deprecated This type has been inlined into the create method and will be removed.
  */
@@ -300,6 +268,44 @@ export const bitbucket = createAuthProviderIntegration({
         });
       });
   },
+  resolvers: {
+    /**
+     * Looks up the user by matching their username to the `bitbucket.org/username` annotation.
+     */
+    lookupUsernameAnnotation(): SignInResolver<OAuthResult> {
+      return async (info, ctx) => {
+        const { result } = info;
+
+        if (!result.fullProfile.username) {
+          throw new Error('Bitbucket profile contained no Username');
+        }
+
+        return ctx.signInWithCatalogUser({
+          annotations: {
+            'bitbucket.org/username': result.fullProfile.username,
+          },
+        });
+      };
+    },
+    /**
+     * Looks up the user by matching their user ID to the `bitbucket.org/user-id` annotation.
+     */
+    lookupUserIdAnnotation(): SignInResolver<OAuthResult> {
+      return async (info, ctx) => {
+        const { result } = info;
+
+        if (!result.fullProfile.id) {
+          throw new Error('Bitbucket profile contained no User ID');
+        }
+
+        return ctx.signInWithCatalogUser({
+          annotations: {
+            'bitbucket.org/user-id': result.fullProfile.id,
+          },
+        });
+      };
+    },
+  },
 });
 
 /**
@@ -307,3 +313,17 @@ export const bitbucket = createAuthProviderIntegration({
  * @deprecated Use `providers.bitbucket.create` instead
  */
 export const createBitbucketProvider = bitbucket.create;
+
+/**
+ * @public
+ * @deprecated Use `providers.bitbucket.resolvers.lookupUsernameAnnotation()` instead.
+ */
+export const bitbucketUsernameSignInResolver =
+  bitbucket.resolvers.lookupUsernameAnnotation();
+
+/**
+ * @public
+ * @deprecated Use `providers.bitbucket.resolvers.lookupUserIdAnnotation()` instead.
+ */
+export const bitbucketUserIdSignInResolver =
+  bitbucket.resolvers.lookupUserIdAnnotation();

--- a/plugins/auth-backend/src/providers/bitbucket/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.ts
@@ -273,7 +273,7 @@ export const bitbucket = createAuthProviderIntegration({
     /**
      * Looks up the user by matching their username to the `bitbucket.org/username` annotation.
      */
-    lookupUsernameAnnotation(): SignInResolver<OAuthResult> {
+    usernameMatchingUserEntityAnnotation(): SignInResolver<OAuthResult> {
       return async (info, ctx) => {
         const { result } = info;
 
@@ -291,7 +291,7 @@ export const bitbucket = createAuthProviderIntegration({
     /**
      * Looks up the user by matching their user ID to the `bitbucket.org/user-id` annotation.
      */
-    lookupUserIdAnnotation(): SignInResolver<OAuthResult> {
+    userIdMatchingUserEntityAnnotation(): SignInResolver<OAuthResult> {
       return async (info, ctx) => {
         const { result } = info;
 
@@ -317,14 +317,14 @@ export const createBitbucketProvider = bitbucket.create;
 
 /**
  * @public
- * @deprecated Use `providers.bitbucket.resolvers.lookupUsernameAnnotation()` instead.
+ * @deprecated Use `providers.bitbucket.resolvers.usernameMatchingUserEntityAnnotation()` instead.
  */
 export const bitbucketUsernameSignInResolver =
-  bitbucket.resolvers.lookupUsernameAnnotation();
+  bitbucket.resolvers.usernameMatchingUserEntityAnnotation();
 
 /**
  * @public
- * @deprecated Use `providers.bitbucket.resolvers.lookupUserIdAnnotation()` instead.
+ * @deprecated Use `providers.bitbucket.resolvers.userIdMatchingUserEntityAnnotation()` instead.
  */
 export const bitbucketUserIdSignInResolver =
-  bitbucket.resolvers.lookupUserIdAnnotation();
+  bitbucket.resolvers.userIdMatchingUserEntityAnnotation();

--- a/plugins/auth-backend/src/providers/bitbucket/provider.ts
+++ b/plugins/auth-backend/src/providers/bitbucket/provider.ts
@@ -247,6 +247,9 @@ export const bitbucketUserIdSignInResolver: SignInResolver<
   return { id: entity.metadata.name, entity, token };
 };
 
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type BitbucketProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -265,9 +268,23 @@ export type BitbucketProviderOptions = {
   };
 };
 
-export const createBitbucketProvider = (
-  options?: BitbucketProviderOptions,
-): AuthProviderFactory => {
+export const createBitbucketProvider = (options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<OAuthResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
+    resolver: SignInResolver<OAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/createAuthProviderIntegration.ts
+++ b/plugins/auth-backend/src/providers/createAuthProviderIntegration.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AuthProviderFactory, SignInResolver } from './types';
+
+/**
+ * Creates a standardized representation of an integration with a third-party
+ * auth provider.
+ *
+ * The returned object facilitates the creation of provider instances, and
+ * supplies built-in sign-in resolvers for the specific provider.
+ */
+export function createAuthProviderIntegration<
+  TCreateOptions extends unknown[],
+  TResolvers extends {
+    [name in string]: (...args: any[]) => SignInResolver<any>;
+  },
+>(config: {
+  create: (...args: TCreateOptions) => AuthProviderFactory;
+  resolvers: TResolvers;
+}): Readonly<{
+  create: (...args: TCreateOptions) => AuthProviderFactory;
+  resolvers: Readonly<TResolvers>;
+}> {
+  return Object.freeze({
+    ...config,
+    resolvers: Object.freeze(config.resolvers),
+  });
+}

--- a/plugins/auth-backend/src/providers/createAuthProviderIntegration.ts
+++ b/plugins/auth-backend/src/providers/createAuthProviderIntegration.ts
@@ -25,18 +25,20 @@ import { AuthProviderFactory, SignInResolver } from './types';
  */
 export function createAuthProviderIntegration<
   TCreateOptions extends unknown[],
-  TResolvers extends {
-    [name in string]: (...args: any[]) => SignInResolver<any>;
-  },
+  TResolvers extends
+    | {
+        [name in string]: (...args: any[]) => SignInResolver<any>;
+      },
 >(config: {
   create: (...args: TCreateOptions) => AuthProviderFactory;
-  resolvers: TResolvers;
+  resolvers?: TResolvers;
 }): Readonly<{
   create: (...args: TCreateOptions) => AuthProviderFactory;
-  resolvers: Readonly<TResolvers>;
+  // If no resolvers are defined, this receives the type `never`
+  resolvers: Readonly<string extends keyof TResolvers ? never : TResolvers>;
 }> {
   return Object.freeze({
     ...config,
-    resolvers: Object.freeze(config.resolvers),
+    resolvers: Object.freeze(config.resolvers ?? ({} as any)),
   });
 }

--- a/plugins/auth-backend/src/providers/gcp-iap/provider.test.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/provider.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { getVoidLogger } from '@backstage/backend-common';
 import express from 'express';
 import request from 'supertest';
+import { AuthResolverContext } from '../types';
 import { GcpIapProvider } from './provider';
 
 beforeEach(() => {
@@ -27,16 +27,13 @@ describe('GcpIapProvider', () => {
   const authHandler = jest.fn();
   const signInResolver = jest.fn();
   const tokenValidator = jest.fn();
-  const logger = getVoidLogger();
 
   it('runs the happy path', async () => {
     const provider = new GcpIapProvider({
       authHandler,
       signInResolver,
       tokenValidator,
-      tokenIssuer: {} as any,
-      catalogIdentityClient: {} as any,
-      logger,
+      resolverContext: {} as AuthResolverContext,
     });
 
     // { "sub": "user:default/me", "ent": ["group:default/home"] }

--- a/plugins/auth-backend/src/providers/gcp-iap/provider.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/provider.ts
@@ -99,9 +99,25 @@ export class GcpIapProvider implements AuthProviderRouteHandlers {
  *
  * @public
  */
-export function createGcpIapProvider(
-  options: GcpIapProviderOptions,
-): AuthProviderFactory {
+export function createGcpIapProvider(options: {
+  /**
+   * The profile transformation function used to verify and convert the auth
+   * response into the profile that will be presented to the user. The default
+   * implementation just provides the authenticated email that the IAP
+   * presented.
+   */
+  authHandler?: AuthHandler<GcpIapResult>;
+
+  /**
+   * Configures sign-in for this provider.
+   */
+  signIn: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
+    resolver: SignInResolver<GcpIapResult>;
+  };
+}): AuthProviderFactory {
   return ({ config, tokenIssuer, catalogApi, logger, tokenManager }) => {
     const audience = config.getString('audience');
 

--- a/plugins/auth-backend/src/providers/gcp-iap/types.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/types.ts
@@ -71,6 +71,7 @@ export type GcpIapProviderInfo = {
 export type GcpIapResponse = AuthResponse<GcpIapProviderInfo>;
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type GcpIapProviderOptions = {

--- a/plugins/auth-backend/src/providers/gcp-iap/types.ts
+++ b/plugins/auth-backend/src/providers/gcp-iap/types.ts
@@ -71,9 +71,7 @@ export type GcpIapProviderInfo = {
 export type GcpIapResponse = AuthResponse<GcpIapProviderInfo>;
 
 /**
- * Options for {@link createGcpIapProvider}.
- *
- * @public
+ * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type GcpIapProviderOptions = {
   /**

--- a/plugins/auth-backend/src/providers/github/index.ts
+++ b/plugins/auth-backend/src/providers/github/index.ts
@@ -14,8 +14,5 @@
  * limitations under the License.
  */
 
-export {
-  createGithubProvider,
-  githubUsernameEntityNameSignInResolver,
-} from './provider';
+export { createGithubProvider } from './provider';
 export type { GithubOAuthResult, GithubProviderOptions } from './provider';

--- a/plugins/auth-backend/src/providers/github/index.ts
+++ b/plugins/auth-backend/src/providers/github/index.ts
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-export { createGithubProvider } from './provider';
+export {
+  createGithubProvider,
+  githubUsernameEntityNameSignInResolver,
+} from './provider';
 export type { GithubOAuthResult, GithubProviderOptions } from './provider';

--- a/plugins/auth-backend/src/providers/github/provider.test.ts
+++ b/plugins/auth-backend/src/providers/github/provider.test.ts
@@ -38,7 +38,7 @@ describe('GithubAuthProvider', () => {
         token: `token-for-user:${entityRef.name}`,
       })),
     } as unknown as AuthResolverContext,
-    signInResolver: github.resolvers.byUsername(),
+    signInResolver: github.resolvers.usernameMatchingUserEntityName(),
     authHandler: async ({ fullProfile }) => ({
       profile: makeProfileInfo(fullProfile),
     }),

--- a/plugins/auth-backend/src/providers/github/provider.test.ts
+++ b/plugins/auth-backend/src/providers/github/provider.test.ts
@@ -15,9 +15,6 @@
  */
 
 import { Profile as PassportProfile } from 'passport';
-import { getVoidLogger } from '@backstage/backend-common';
-import { TokenIssuer } from '../../identity/types';
-import { CatalogIdentityClient } from '../../lib/catalog';
 import {
   GithubAuthProvider,
   GithubOAuthResult,
@@ -26,6 +23,7 @@ import {
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
 import { makeProfileInfo } from '../../lib/passport/PassportStrategyHelper';
 import { OAuthStartRequest, encodeState } from '../../lib/oauth';
+import { AuthResolverContext } from '../types';
 
 const mockFrameHandler = jest.spyOn(
   helpers,
@@ -38,25 +36,12 @@ const mockFrameHandler = jest.spyOn(
 >;
 
 describe('GithubAuthProvider', () => {
-  const tokenIssuer: TokenIssuer = {
-    listPublicKeys: jest.fn(),
-    async issueToken(params) {
-      return `token-for-${params.claims.sub}`;
-    },
-  };
-  const catalogIdentityClient = {
-    findUser: jest.fn(),
-    resolveCatalogMembership: async ({
-      entityRefs,
-    }: {
-      entityRefs: string[];
-    }) => entityRefs,
-  } as unknown as CatalogIdentityClient;
-
   const provider = new GithubAuthProvider({
-    logger: getVoidLogger(),
-    catalogIdentityClient: catalogIdentityClient,
-    tokenIssuer: tokenIssuer as unknown as TokenIssuer,
+    resolverContext: {
+      signInWithCatalogUser: jest.fn(({ entityRef }) => ({
+        token: `token-for-user:${entityRef.name}`,
+      })),
+    } as unknown as AuthResolverContext,
     signInResolver: githubUsernameEntityNameSignInResolver,
     authHandler: async ({ fullProfile }) => ({
       profile: makeProfileInfo(fullProfile),
@@ -96,8 +81,7 @@ describe('GithubAuthProvider', () => {
 
       const expected = {
         backstageIdentity: {
-          id: 'jimmymarkum',
-          token: 'token-for-user:default/jimmymarkum',
+          token: 'token-for-user:jimmymarkum',
         },
         providerInfo: {
           accessToken: '19xasczxcm9n7gacn9jdgm19me',
@@ -142,8 +126,7 @@ describe('GithubAuthProvider', () => {
 
       const expected = {
         backstageIdentity: {
-          id: 'jimmymarkum',
-          token: 'token-for-user:default/jimmymarkum',
+          token: 'token-for-user:jimmymarkum',
         },
         providerInfo: {
           accessToken: '19xasczxcm9n7gacn9jdgm19me',
@@ -186,8 +169,7 @@ describe('GithubAuthProvider', () => {
       };
       const expected = {
         backstageIdentity: {
-          id: 'jimmymarkum',
-          token: 'token-for-user:default/jimmymarkum',
+          token: 'token-for-user:jimmymarkum',
         },
         providerInfo: {
           accessToken: '19xasczxcm9n7gacn9jdgm19me',
@@ -230,8 +212,7 @@ describe('GithubAuthProvider', () => {
 
       const expected = {
         backstageIdentity: {
-          id: 'daveboyle',
-          token: 'token-for-user:default/daveboyle',
+          token: 'token-for-user:daveboyle',
         },
         providerInfo: {
           accessToken:
@@ -276,8 +257,7 @@ describe('GithubAuthProvider', () => {
       expect(response).toEqual({
         response: {
           backstageIdentity: {
-            id: 'daveboyle',
-            token: 'token-for-user:default/daveboyle',
+            token: 'token-for-user:daveboyle',
           },
           providerInfo: {
             accessToken: 'a.b.c',
@@ -352,8 +332,7 @@ describe('GithubAuthProvider', () => {
       expect(result).toEqual({
         response: {
           backstageIdentity: {
-            id: 'mockuser',
-            token: 'token-for-user:default/mockuser',
+            token: 'token-for-user:mockuser',
           },
           profile: {
             displayName: 'Mocked User',
@@ -404,8 +383,7 @@ describe('GithubAuthProvider', () => {
       expect(result).toEqual({
         response: {
           backstageIdentity: {
-            id: 'mockuser',
-            token: 'token-for-user:default/mockuser',
+            token: 'token-for-user:mockuser',
           },
           profile: {
             displayName: 'Mocked User',

--- a/plugins/auth-backend/src/providers/github/provider.test.ts
+++ b/plugins/auth-backend/src/providers/github/provider.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { Profile as PassportProfile } from 'passport';
-import {
-  GithubAuthProvider,
-  GithubOAuthResult,
-  githubUsernameEntityNameSignInResolver,
-} from './provider';
+import { GithubAuthProvider, GithubOAuthResult, github } from './provider';
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
 import { makeProfileInfo } from '../../lib/passport/PassportStrategyHelper';
 import { OAuthStartRequest, encodeState } from '../../lib/oauth';
@@ -42,7 +38,7 @@ describe('GithubAuthProvider', () => {
         token: `token-for-user:${entityRef.name}`,
       })),
     } as unknown as AuthResolverContext,
-    signInResolver: githubUsernameEntityNameSignInResolver,
+    signInResolver: github.resolvers.byUsername(),
     authHandler: async ({ fullProfile }) => ({
       profile: makeProfileInfo(fullProfile),
     }),

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -273,6 +273,9 @@ export const githubUsernameEntityNameSignInResolver: SignInResolver<
   return { id: userId, token };
 };
 
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type GithubProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -309,9 +312,41 @@ export type GithubProviderOptions = {
   stateEncoder?: StateEncoder;
 };
 
-export const createGithubProvider = (
-  options?: GithubProviderOptions,
-): AuthProviderFactory => {
+export const createGithubProvider = (options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<GithubOAuthResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
+    resolver: SignInResolver<GithubOAuthResult>;
+  };
+
+  /**
+   * The state encoder used to encode the 'state' parameter on the OAuth request.
+   *
+   * It should return a string that takes the state params (from the request), url encodes the params
+   * and finally base64 encodes them.
+   *
+   * Providing your own stateEncoder will allow you to add addition parameters to the state field.
+   *
+   * It is typed as follows:
+   *   `export type StateEncoder = (input: OAuthState) => Promise<{encodedState: string}>;`
+   *
+   * Note: the stateEncoder must encode a 'nonce' value and an 'env' value. Without this, the OAuth flow will fail
+   * (These two values will be set by the req.state by default)
+   *
+   * For more information, please see the helper module in ../../oauth/helpers #readState
+   */
+  stateEncoder?: StateEncoder;
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -367,7 +367,7 @@ export const github = createAuthProviderIntegration({
     /**
      * Looks up the user by matching their GitHub username to the entity name.
      */
-    byUsername: (): SignInResolver<GithubOAuthResult> => {
+    usernameMatchingUserEntityName: (): SignInResolver<GithubOAuthResult> => {
       return async (info, ctx) => {
         const { fullProfile } = info.result;
 

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -258,7 +258,7 @@ export type GithubProviderOptions = {
     /**
      * Maps an auth result to a Backstage identity for the user.
      */
-    resolver?: SignInResolver<GithubOAuthResult>;
+    resolver: SignInResolver<GithubOAuthResult>;
   };
 
   /**

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -228,6 +228,7 @@ export class GithubAuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type GithubProviderOptions = {

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -227,19 +227,6 @@ export class GithubAuthProvider implements OAuthHandlers {
   }
 }
 
-export const githubUsernameEntityNameSignInResolver: SignInResolver<
-  GithubOAuthResult
-> = async (info, ctx) => {
-  const { fullProfile } = info.result;
-
-  const userId = fullProfile.username;
-  if (!userId) {
-    throw new Error(`GitHub user profile does not contain a username`);
-  }
-
-  return ctx.signInWithCatalogUser({ entityRef: { name: userId } });
-};
-
 /**
  * @deprecated This type has been inlined into the create method and will be removed.
  */
@@ -374,6 +361,23 @@ export const github = createAuthProviderIntegration({
           callbackUrl,
         });
       });
+  },
+  resolvers: {
+    /**
+     * Looks up the user by matching their GitHub username to the entity name.
+     */
+    byUsername: (): SignInResolver<GithubOAuthResult> => {
+      return async (info, ctx) => {
+        const { fullProfile } = info.result;
+
+        const userId = fullProfile.username;
+        if (!userId) {
+          throw new Error(`GitHub user profile does not contain a username`);
+        }
+
+        return ctx.signInWithCatalogUser({ entityRef: { name: userId } });
+      };
+    },
   },
 });
 

--- a/plugins/auth-backend/src/providers/gitlab/provider.test.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.test.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { GitlabAuthProvider, gitlabDefaultSignInResolver } from './provider';
+import {
+  GitlabAuthProvider,
+  gitlabUsernameEntityNameSignInResolver,
+} from './provider';
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
 import { PassportProfile } from '../../lib/passport/types';
 import { OAuthResult } from '../../lib/oauth';
@@ -34,15 +37,19 @@ describe('GitlabAuthProvider', () => {
   };
   const catalogIdentityClient = {
     findUser: jest.fn(),
-  };
+    resolveCatalogMembership: async ({
+      entityRefs,
+    }: {
+      entityRefs: string[];
+    }) => entityRefs,
+  } as unknown as CatalogIdentityClient;
 
   const provider = new GitlabAuthProvider({
     clientId: 'mock',
     clientSecret: 'mock',
     callbackUrl: 'mock',
     baseUrl: 'mock',
-    catalogIdentityClient:
-      catalogIdentityClient as unknown as CatalogIdentityClient,
+    catalogIdentityClient,
     tokenIssuer: tokenIssuer as unknown as TokenIssuer,
     authHandler: async ({ fullProfile }) => ({
       profile: {
@@ -51,7 +58,7 @@ describe('GitlabAuthProvider', () => {
         picture: 'http://gitlab.com/lols',
       },
     }),
-    signInResolver: gitlabDefaultSignInResolver,
+    signInResolver: gitlabUsernameEntityNameSignInResolver,
     logger: getVoidLogger(),
   });
 

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -62,34 +62,6 @@ export type GitlabAuthProviderOptions = OAuthProviderOptions & {
   logger: Logger;
 };
 
-export const gitlabDefaultSignInResolver: SignInResolver<OAuthResult> = async (
-  info,
-  ctx,
-) => {
-  const { profile, result } = info;
-
-  let id = result.fullProfile.id;
-
-  if (profile.email) {
-    id = profile.email.split('@')[0];
-  }
-
-  const entityRef = stringifyEntityRef({
-    kind: 'User',
-    namespace: DEFAULT_NAMESPACE,
-    name: id,
-  });
-
-  const token = await ctx.tokenIssuer.issueToken({
-    claims: {
-      sub: entityRef,
-      ent: [entityRef],
-    },
-  });
-
-  return { id, token };
-};
-
 export const gitlabDefaultAuthHandler: AuthHandler<OAuthResult> = async ({
   fullProfile,
   params,
@@ -261,23 +233,13 @@ export const createGitlabProvider = (
       const authHandler: AuthHandler<OAuthResult> =
         options?.authHandler ?? gitlabDefaultAuthHandler;
 
-      const signInResolverFn =
-        options?.signIn?.resolver ?? gitlabDefaultSignInResolver;
-
-      const signInResolver: SignInResolver<OAuthResult> = info =>
-        signInResolverFn(info, {
-          catalogIdentityClient,
-          tokenIssuer,
-          logger,
-        });
-
       const provider = new GitlabAuthProvider({
         clientId,
         clientSecret,
         callbackUrl,
         baseUrl,
         authHandler,
-        signInResolver,
+        signInResolver: options?.signIn?.resolver,
         catalogIdentityClient,
         logger,
         tokenIssuer,

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -179,6 +179,7 @@ export class GitlabAuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type GitlabProviderOptions = {

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -211,6 +211,9 @@ export class GitlabAuthProvider implements OAuthHandlers {
   }
 }
 
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type GitlabProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -232,9 +235,26 @@ export type GitlabProviderOptions = {
   };
 };
 
-export const createGitlabProvider = (
-  options?: GitlabProviderOptions,
-): AuthProviderFactory => {
+export const createGitlabProvider = (options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<OAuthResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  /**
+   * Maps an auth result to a Backstage identity for the user.
+   *
+   * Set to `'email'` to use the default email-based sign in resolver, which will search
+   * the catalog for a single user entity that has a matching `microsoft.com/email` annotation.
+   */
+  signIn?: {
+    resolver: SignInResolver<OAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -219,12 +219,6 @@ export const gitlab = createAuthProviderIntegration({
     /**
      * Configure sign-in for this provider, without it the provider can not be used to sign users in.
      */
-    /**
-     * Maps an auth result to a Backstage identity for the user.
-     *
-     * Set to `'email'` to use the default email-based sign in resolver, which will search
-     * the catalog for a single user entity that has a matching `microsoft.com/email` annotation.
-     */
     signIn?: {
       resolver: SignInResolver<OAuthResult>;
     };

--- a/plugins/auth-backend/src/providers/gitlab/provider.ts
+++ b/plugins/auth-backend/src/providers/gitlab/provider.ts
@@ -199,7 +199,7 @@ export type GitlabProviderOptions = {
    * the catalog for a single user entity that has a matching `microsoft.com/email` annotation.
    */
   signIn?: {
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 

--- a/plugins/auth-backend/src/providers/google/provider.test.ts
+++ b/plugins/auth-backend/src/providers/google/provider.test.ts
@@ -39,10 +39,12 @@ describe('createGoogleProvider', () => {
     };
 
     const provider = new GoogleAuthProvider({
-      logger: getVoidLogger(),
-      catalogIdentityClient:
-        catalogIdentityClient as unknown as CatalogIdentityClient,
-      tokenIssuer: tokenIssuer as unknown as TokenIssuer,
+      resolverContext: {
+        logger: getVoidLogger(),
+        catalogIdentityClient:
+          catalogIdentityClient as unknown as CatalogIdentityClient,
+        tokenIssuer: tokenIssuer as unknown as TokenIssuer,
+      },
       authHandler: async ({ fullProfile }) => ({
         profile: {
           email: fullProfile.emails![0]!.value,

--- a/plugins/auth-backend/src/providers/google/provider.test.ts
+++ b/plugins/auth-backend/src/providers/google/provider.test.ts
@@ -17,9 +17,7 @@
 import { GoogleAuthProvider } from './provider';
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
 import { OAuthResult } from '../../lib/oauth';
-import { getVoidLogger } from '@backstage/backend-common';
-import { TokenIssuer } from '../../identity/types';
-import { CatalogIdentityClient } from '../../lib/catalog';
+import { AuthResolverContext } from '../types';
 
 const mockFrameHandler = jest.spyOn(
   helpers,
@@ -30,21 +28,8 @@ const mockFrameHandler = jest.spyOn(
 
 describe('createGoogleProvider', () => {
   it('should auth', async () => {
-    const tokenIssuer = {
-      issueToken: jest.fn(),
-      listPublicKeys: jest.fn(),
-    };
-    const catalogIdentityClient = {
-      findUser: jest.fn(),
-    };
-
     const provider = new GoogleAuthProvider({
-      resolverContext: {
-        logger: getVoidLogger(),
-        catalogIdentityClient:
-          catalogIdentityClient as unknown as CatalogIdentityClient,
-        tokenIssuer: tokenIssuer as unknown as TokenIssuer,
-      },
+      resolverContext: {} as AuthResolverContext,
       authHandler: async ({ fullProfile }) => ({
         profile: {
           email: fullProfile.emails![0]!.value,

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -168,6 +168,7 @@ export class GoogleAuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type GoogleProviderOptions = {

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -215,7 +215,7 @@ export type GoogleProviderOptions = {
     /**
      * Maps an auth result to a Backstage identity for the user.
      */
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 

--- a/plugins/auth-backend/src/providers/google/provider.ts
+++ b/plugins/auth-backend/src/providers/google/provider.ts
@@ -247,11 +247,11 @@ export const google = createAuthProviderIntegration({
     /**
      * Looks up the user by matching their email local part to the entity name.
      */
-    byEmailLocalPart: () => commonByEmailLocalPartResolver,
+    emailLocalPartMatchingUserEntityName: () => commonByEmailLocalPartResolver,
     /**
      * Looks up the user by matching their email to the `google.com/email` annotation.
      */
-    lookupEmailAnnotation(): SignInResolver<OAuthResult> {
+    emailMatchingUserEntityAnnotation(): SignInResolver<OAuthResult> {
       return async (info, ctx) => {
         const { profile } = info;
 
@@ -277,7 +277,7 @@ export const createGoogleProvider = google.create;
 
 /**
  * @public
- * @deprecated Use `providers.google.resolvers.lookupEmailAnnotation()` instead.
+ * @deprecated Use `providers.google.resolvers.emailMatchingUserEntityAnnotation()` instead.
  */
 export const googleEmailSignInResolver =
-  google.resolvers.lookupEmailAnnotation();
+  google.resolvers.emailMatchingUserEntityAnnotation();

--- a/plugins/auth-backend/src/providers/index.ts
+++ b/plugins/auth-backend/src/providers/index.ts
@@ -30,6 +30,8 @@ export * from './onelogin';
 export * from './saml';
 export * from './gcp-iap';
 
+export { providers } from './providers';
+
 export { factories as defaultAuthProviderFactories } from './factories';
 
 // Export the minimal interface required for implementing a

--- a/plugins/auth-backend/src/providers/index.ts
+++ b/plugins/auth-backend/src/providers/index.ts
@@ -34,8 +34,6 @@ export { providers } from './providers';
 
 export { factories as defaultAuthProviderFactories } from './factories';
 
-// Export the minimal interface required for implementing a
-// custom Authorization Handler
 export type {
   AuthProviderConfig,
   AuthProviderRouteHandlers,
@@ -48,10 +46,9 @@ export type {
   SignInResolver,
   SignInInfo,
   CookieConfigurer,
+  StateEncoder,
+  AuthResponse,
+  ProfileInfo,
 } from './types';
-
-// These types are needed for a postMessage from the login pop-up
-// to the frontend
-export type { AuthResponse, ProfileInfo } from './types';
 
 export { prepareBackstageIdentityResponse } from './prepareBackstageIdentityResponse';

--- a/plugins/auth-backend/src/providers/index.ts
+++ b/plugins/auth-backend/src/providers/index.ts
@@ -37,6 +37,7 @@ export { factories as defaultAuthProviderFactories } from './factories';
 // Export the minimal interface required for implementing a
 // custom Authorization Handler
 export type {
+  AuthProviderConfig,
   AuthProviderRouteHandlers,
   AuthProviderFactoryOptions,
   AuthProviderFactory,

--- a/plugins/auth-backend/src/providers/index.ts
+++ b/plugins/auth-backend/src/providers/index.ts
@@ -41,6 +41,7 @@ export type {
   AuthProviderFactoryOptions,
   AuthProviderFactory,
   AuthHandler,
+  AuthResolverCatalogUserQuery,
   AuthResolverContext,
   AuthHandlerResult,
   SignInResolver,

--- a/plugins/auth-backend/src/providers/microsoft/provider.test.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.test.ts
@@ -18,11 +18,10 @@ import { MicrosoftAuthProvider } from './provider';
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
 import { OAuthResult } from '../../lib/oauth';
 import { getVoidLogger } from '@backstage/backend-common';
-import { TokenIssuer } from '../../identity/types';
-import { CatalogIdentityClient } from '../../lib/catalog';
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import { AuthResolverContext } from '../types';
 
 const mockFrameHandler = jest.spyOn(
   helpers,
@@ -87,19 +86,10 @@ const setupHandlers = () => {
 describe('createMicrosoftProvider', () => {
   it('should auth', async () => {
     setupHandlers();
-    const tokenIssuer = {
-      issueToken: jest.fn(),
-      listPublicKeys: jest.fn(),
-    };
-    const catalogIdentityClient = {
-      findUser: jest.fn(),
-    };
 
     const provider = new MicrosoftAuthProvider({
       logger: getVoidLogger(),
-      catalogIdentityClient:
-        catalogIdentityClient as unknown as CatalogIdentityClient,
-      tokenIssuer: tokenIssuer as unknown as TokenIssuer,
+      resolverContext: {} as AuthResolverContext,
       authHandler: async ({ fullProfile }) => ({
         profile: {
           email: fullProfile.emails![0]!.value,
@@ -131,19 +121,9 @@ describe('createMicrosoftProvider', () => {
 
   it('should return the base64 encoded photo data of the profile', async () => {
     setupHandlers();
-    const tokenIssuer = {
-      issueToken: jest.fn(),
-      listPublicKeys: jest.fn(),
-    };
-    const catalogIdentityClient = {
-      findUser: jest.fn(),
-    };
-
     const provider = new MicrosoftAuthProvider({
       logger: getVoidLogger(),
-      catalogIdentityClient:
-        catalogIdentityClient as unknown as CatalogIdentityClient,
-      tokenIssuer: tokenIssuer as unknown as TokenIssuer,
+      resolverContext: {} as AuthResolverContext,
       authHandler: async ({ fullProfile }) => ({
         profile: {
           email: fullProfile.emails![0]!.value,

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -220,6 +220,9 @@ export const microsoftEmailSignInResolver: SignInResolver<OAuthResult> = async (
   return { id: entity.metadata.name, entity, token };
 };
 
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type MicrosoftProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -238,9 +241,23 @@ export type MicrosoftProviderOptions = {
   };
 };
 
-export const createMicrosoftProvider = (
-  options?: MicrosoftProviderOptions,
-): AuthProviderFactory => {
+export const createMicrosoftProvider = (options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<OAuthResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
+    resolver: SignInResolver<OAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -186,23 +186,6 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
   }
 }
 
-export const microsoftEmailSignInResolver: SignInResolver<OAuthResult> = async (
-  info,
-  ctx,
-) => {
-  const { profile } = info;
-
-  if (!profile.email) {
-    throw new Error('Microsoft profile contained no email');
-  }
-
-  return ctx.signInWithCatalogUser({
-    annotations: {
-      'microsoft.com/email': profile.email,
-    },
-  });
-};
-
 /**
  * @deprecated This type has been inlined into the create method and will be removed.
  */
@@ -285,6 +268,26 @@ export const microsoft = createAuthProviderIntegration({
         });
       });
   },
+  resolvers: {
+    /**
+     * Looks up the user by matching their email to the `microsoft.com/email` annotation.
+     */
+    lookupEmailAnnotation(): SignInResolver<OAuthResult> {
+      return async (info, ctx) => {
+        const { profile } = info;
+
+        if (!profile.email) {
+          throw new Error('Microsoft profile contained no email');
+        }
+
+        return ctx.signInWithCatalogUser({
+          annotations: {
+            'microsoft.com/email': profile.email,
+          },
+        });
+      };
+    },
+  },
 });
 
 /**
@@ -292,3 +295,10 @@ export const microsoft = createAuthProviderIntegration({
  * @deprecated Use `providers.microsoft.create` instead
  */
 export const createMicrosoftProvider = microsoft.create;
+
+/**
+ * @public
+ * @deprecated Use `providers.microsoft.resolvers.lookupEmailAnnotation()` instead.
+ */
+export const microsoftEmailSignInResolver =
+  microsoft.resolvers.lookupEmailAnnotation();

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -187,6 +187,7 @@ export class MicrosoftAuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type MicrosoftProviderOptions = {

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -273,7 +273,7 @@ export const microsoft = createAuthProviderIntegration({
     /**
      * Looks up the user by matching their email to the `microsoft.com/email` annotation.
      */
-    lookupEmailAnnotation(): SignInResolver<OAuthResult> {
+    emailMatchingUserEntityAnnotation(): SignInResolver<OAuthResult> {
       return async (info, ctx) => {
         const { profile } = info;
 
@@ -299,7 +299,7 @@ export const createMicrosoftProvider = microsoft.create;
 
 /**
  * @public
- * @deprecated Use `providers.microsoft.resolvers.lookupEmailAnnotation()` instead.
+ * @deprecated Use `providers.microsoft.resolvers.emailMatchingUserEntityAnnotation()` instead.
  */
 export const microsoftEmailSignInResolver =
-  microsoft.resolvers.lookupEmailAnnotation();
+  microsoft.resolvers.emailMatchingUserEntityAnnotation();

--- a/plugins/auth-backend/src/providers/microsoft/provider.ts
+++ b/plugins/auth-backend/src/providers/microsoft/provider.ts
@@ -234,7 +234,7 @@ export type MicrosoftProviderOptions = {
     /**
      * Maps an auth result to a Backstage identity for the user.
      */
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 

--- a/plugins/auth-backend/src/providers/oauth2-proxy/provider.test.ts
+++ b/plugins/auth-backend/src/providers/oauth2-proxy/provider.test.ts
@@ -24,11 +24,7 @@ jest.mock('@backstage/catalog-client');
 import express from 'express';
 import { JWT } from 'jose';
 import { Logger } from 'winston';
-import {
-  AuthHandler,
-  SignInResolver,
-  AuthProviderFactoryOptions,
-} from '../types';
+import { AuthHandler, SignInResolver } from '../types';
 
 import { CatalogIdentityClient } from '../../lib/catalog';
 import { TokenIssuer } from '../../identity/types';
@@ -191,14 +187,13 @@ describe('Oauth2ProxyAuthProvider', () => {
         authHandler,
         signIn: { resolver: signInResolver },
       } as Oauth2ProxyProviderOptions<any>;
-      const factoryOptions = {
+
+      const factory = createOauth2ProxyProvider(providerOptions);
+      const handler = factory({
         logger,
         catalogApi: {},
         tokenIssuer: {},
-      } as unknown as AuthProviderFactoryOptions;
-
-      const factory = createOauth2ProxyProvider(providerOptions);
-      const handler = factory(factoryOptions);
+      } as any);
       await handler.refresh!(mockRequest, mockResponse);
 
       expect(mockRequest.header).toBeCalledWith(OAUTH2_PROXY_JWT_HEADER);

--- a/plugins/auth-backend/src/providers/oauth2-proxy/provider.test.ts
+++ b/plugins/auth-backend/src/providers/oauth2-proxy/provider.test.ts
@@ -21,18 +21,14 @@ jest.mock('jose', () => ({
 }));
 jest.mock('@backstage/catalog-client');
 
+import { AuthenticationError } from '@backstage/errors';
 import express from 'express';
 import { JWT } from 'jose';
 import { Logger } from 'winston';
-import { AuthHandler, SignInResolver } from '../types';
-
-import { CatalogIdentityClient } from '../../lib/catalog';
-import { TokenIssuer } from '../../identity/types';
-
+import { AuthHandler, AuthResolverContext, SignInResolver } from '../types';
 import {
   createOauth2ProxyProvider,
   Oauth2ProxyAuthProvider,
-  Oauth2ProxyProviderOptions,
   OAuth2ProxyResult,
   OAUTH2_PROXY_JWT_HEADER,
 } from './provider';
@@ -72,10 +68,10 @@ describe('Oauth2ProxyAuthProvider', () => {
 
     provider = new Oauth2ProxyAuthProvider<any>({
       authHandler,
-      logger,
       signInResolver,
-      catalogIdentityClient: {} as CatalogIdentityClient,
-      tokenIssuer: {} as TokenIssuer,
+      resolverContext: {
+        _: 'resolver-context',
+      } as unknown as AuthResolverContext,
     });
   });
 
@@ -99,17 +95,17 @@ describe('Oauth2ProxyAuthProvider', () => {
     it('should throw an error when auth header is missing', async () => {
       mockRequest.header.mockReturnValue(undefined);
 
-      await provider.refresh(mockRequest, mockResponse);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(401);
+      await expect(provider.refresh(mockRequest, mockResponse)).rejects.toThrow(
+        AuthenticationError,
+      );
     });
 
     it('should throw an error if the bearer token is invalid', async () => {
       mockRequest.header.mockReturnValue('Basic asdf=');
 
-      await provider.refresh(mockRequest, mockResponse);
-
-      expect(mockResponse.status).toHaveBeenCalledWith(401);
+      await expect(provider.refresh(mockRequest, mockResponse)).rejects.toThrow(
+        AuthenticationError,
+      );
     });
 
     it('should return if auth header is set and valid', async () => {
@@ -152,7 +148,7 @@ describe('Oauth2ProxyAuthProvider', () => {
             fullProfile: decodedToken,
           },
         },
-        { catalogIdentityClient: {}, logger, tokenIssuer: {} },
+        { _: 'resolver-context' },
       );
       expect(mockResponse.json).toHaveBeenCalledWith({
         backstageIdentity: {
@@ -183,12 +179,10 @@ describe('Oauth2ProxyAuthProvider', () => {
     });
 
     it('should create a valid provider', async () => {
-      const providerOptions = {
+      const factory = createOauth2ProxyProvider({
         authHandler,
         signIn: { resolver: signInResolver },
-      } as Oauth2ProxyProviderOptions<any>;
-
-      const factory = createOauth2ProxyProvider(providerOptions);
+      });
       const handler = factory({
         logger,
         catalogApi: {},

--- a/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
@@ -49,6 +49,7 @@ export type OAuth2ProxyResult<JWTPayload> = {
 };
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type Oauth2ProxyProviderOptions<JWTPayload> = {

--- a/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
@@ -20,13 +20,13 @@ import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-no
 import {
   AuthHandler,
   SignInResolver,
-  AuthProviderFactory,
   AuthProviderRouteHandlers,
   AuthResponse,
   AuthResolverContext,
 } from '../types';
 import { JWT } from 'jose';
 import { prepareBackstageIdentityResponse } from '../prepareBackstageIdentityResponse';
+import { createAuthProviderIntegration } from '../createAuthProviderIntegration';
 
 export const OAUTH2_PROXY_JWT_HEADER = 'X-OAUTH2-PROXY-ID-TOKEN';
 
@@ -151,12 +151,12 @@ export class Oauth2ProxyAuthProvider<JWTPayload>
 }
 
 /**
- * Factory function for oauth2-proxy auth provider
+ * Auth provider integration for oauth2-proxy auth
  *
  * @public
  */
-export const createOauth2ProxyProvider =
-  <JWTPayload>(options: {
+export const oauth2Proxy = createAuthProviderIntegration({
+  create<JWTPayload>(options: {
     /**
      * Configure an auth handler to generate a profile for the user.
      */
@@ -171,13 +171,21 @@ export const createOauth2ProxyProvider =
        */
       resolver: SignInResolver<OAuth2ProxyResult<JWTPayload>>;
     };
-  }): AuthProviderFactory =>
-  ({ resolverContext }) => {
-    const signInResolver = options.signIn.resolver;
-    const authHandler = options.authHandler;
-    return new Oauth2ProxyAuthProvider<JWTPayload>({
-      resolverContext,
-      signInResolver,
-      authHandler,
-    });
-  };
+  }) {
+    return ({ resolverContext }) => {
+      const signInResolver = options.signIn.resolver;
+      const authHandler = options.authHandler;
+      return new Oauth2ProxyAuthProvider<JWTPayload>({
+        resolverContext,
+        signInResolver,
+        authHandler,
+      });
+    };
+  },
+});
+
+/**
+ * @public
+ * @deprecated Use `providers.oauth2Proxy.create` instead
+ */
+export const createOauth2ProxyProvider = oauth2Proxy.create;

--- a/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2-proxy/provider.ts
@@ -51,9 +51,7 @@ export type OAuth2ProxyResult<JWTPayload> = {
 };
 
 /**
- * Options for the oauth2-proxy provider factory
- *
- * @public
+ * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type Oauth2ProxyProviderOptions<JWTPayload> = {
   /**
@@ -179,9 +177,22 @@ export class Oauth2ProxyAuthProvider<JWTPayload>
  * @public
  */
 export const createOauth2ProxyProvider =
-  <JWTPayload>(
-    options: Oauth2ProxyProviderOptions<JWTPayload>,
-  ): AuthProviderFactory =>
+  <JWTPayload>(options: {
+    /**
+     * Configure an auth handler to generate a profile for the user.
+     */
+    authHandler: AuthHandler<OAuth2ProxyResult<JWTPayload>>;
+
+    /**
+     * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+     */
+    signIn: {
+      /**
+       * Maps an auth result to a Backstage identity for the user.
+       */
+      resolver: SignInResolver<OAuth2ProxyResult<JWTPayload>>;
+    };
+  }): AuthProviderFactory =>
   ({ catalogApi, logger, tokenIssuer, tokenManager }) => {
     const signInResolver = options.signIn.resolver;
     const authHandler = options.authHandler;

--- a/plugins/auth-backend/src/providers/oauth2/provider.test.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.test.ts
@@ -17,9 +17,7 @@
 import { OAuth2AuthProvider } from './provider';
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
 import { OAuthResult } from '../../lib/oauth';
-import { getVoidLogger } from '@backstage/backend-common';
-import { TokenIssuer } from '../../identity/types';
-import { CatalogIdentityClient } from '../../lib/catalog';
+import { AuthResolverContext } from '../types';
 
 const mockFrameHandler = jest.spyOn(
   helpers,
@@ -30,19 +28,8 @@ const mockFrameHandler = jest.spyOn(
 
 describe('createOAuth2Provider', () => {
   it('should auth', async () => {
-    const tokenIssuer = {
-      issueToken: jest.fn(),
-      listPublicKeys: jest.fn(),
-    };
-    const catalogIdentityClient = {
-      findUser: jest.fn(),
-    };
-
     const provider = new OAuth2AuthProvider({
-      logger: getVoidLogger(),
-      catalogIdentityClient:
-        catalogIdentityClient as unknown as CatalogIdentityClient,
-      tokenIssuer: tokenIssuer as unknown as TokenIssuer,
+      resolverContext: {} as AuthResolverContext,
       authHandler: async ({ fullProfile }) => ({
         profile: {
           email: fullProfile.emails![0]!.value,

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -186,6 +186,7 @@ export class OAuth2AuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type OAuth2ProviderOptions = {

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -202,7 +202,7 @@ export type OAuth2ProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
 
   signIn?: {
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 

--- a/plugins/auth-backend/src/providers/oauth2/provider.ts
+++ b/plugins/auth-backend/src/providers/oauth2/provider.ts
@@ -198,6 +198,9 @@ export class OAuth2AuthProvider implements OAuthHandlers {
   }
 }
 
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type OAuth2ProviderOptions = {
   authHandler?: AuthHandler<OAuthResult>;
 
@@ -206,9 +209,13 @@ export type OAuth2ProviderOptions = {
   };
 };
 
-export const createOAuth2Provider = (
-  options?: OAuth2ProviderOptions,
-): AuthProviderFactory => {
+export const createOAuth2Provider = (options?: {
+  authHandler?: AuthHandler<OAuthResult>;
+
+  signIn?: {
+    resolver: SignInResolver<OAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/oidc/provider.test.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.test.ts
@@ -24,7 +24,7 @@ import { setupServer } from 'msw/node';
 import { ClientMetadata, IssuerMetadata } from 'openid-client';
 import { OAuthAdapter } from '../../lib/oauth';
 import { createOidcProvider, OidcAuthProvider, Options } from './provider';
-import { getVoidLogger } from '@backstage/backend-common';
+import { AuthResolverContext } from '../types';
 
 const issuerMetadata = {
   issuer: 'https://oidc.test',
@@ -42,23 +42,13 @@ const issuerMetadata = {
   request_object_signing_alg_values_supported: ['RS256', 'RS512', 'HS256'],
 };
 
-const catalogIdentityClient = {
-  findUser: jest.fn(),
-};
-const tokenIssuer = {
-  issueToken: jest.fn(),
-  listPublicKeys: jest.fn(),
-};
-
 const clientMetadata: Options = {
   authHandler: async input => ({
     profile: {
       displayName: input.userinfo.email,
     },
   }),
-  catalogIdentityClient: catalogIdentityClient as unknown as any,
-  logger: getVoidLogger(),
-  tokenIssuer: tokenIssuer as unknown as any,
+  resolverContext: {} as AuthResolverContext,
   callbackUrl: 'https://oidc.test/callback',
   clientId: 'testclientid',
   clientSecret: 'testclientsecret',

--- a/plugins/auth-backend/src/providers/oidc/provider.test.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.test.ts
@@ -23,7 +23,6 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { ClientMetadata, IssuerMetadata } from 'openid-client';
 import { OAuthAdapter } from '../../lib/oauth';
-import { AuthProviderFactoryOptions } from '../types';
 import { createOidcProvider, OidcAuthProvider, Options } from './provider';
 import { getVoidLogger } from '@backstage/backend-common';
 
@@ -178,14 +177,13 @@ describe('OidcAuthProvider', () => {
         metadataUrl: 'https://oidc.test/.well-known/openid-configuration',
       },
     } as any);
-    const options = {
+    const provider = createOidcProvider()({
       globalConfig: {
         appUrl: 'https://oidc.test',
         baseUrl: 'https://oidc.test',
       },
       config,
-    } as AuthProviderFactoryOptions;
-    const provider = createOidcProvider()(options) as OAuthAdapter;
+    } as any) as OAuthAdapter;
     expect(provider.start).toBeDefined();
     // Cast provider as any here to be able to inspect private members
     await (provider as any).handlers.get('testEnv').handlers.implementation;

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -227,7 +227,7 @@ export type OidcProviderOptions = {
   authHandler?: AuthHandler<OidcAuthResult>;
 
   signIn?: {
-    resolver?: SignInResolver<OidcAuthResult>;
+    resolver: SignInResolver<OidcAuthResult>;
   };
 };
 

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -212,16 +212,7 @@ export class OidcAuthProvider implements OAuthHandlers {
 }
 
 /**
- * OIDC provider callback options. An auth handler and a sign in resolver
- * can be passed while creating a OIDC provider.
- *
- * authHandler : called after sign in was successful, a new object must be returned which includes a profile
- * signInResolver: called after sign in was successful, expects to return a new {@link @backstage/plugin-auth-node#BackstageSignInResult}
- *
- * Both options are optional. There is fallback for authHandler where the default handler expect an e-mail explicitly
- * otherwise it throws an error
- *
- * @public
+ * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type OidcProviderOptions = {
   authHandler?: AuthHandler<OidcAuthResult>;
@@ -231,9 +222,13 @@ export type OidcProviderOptions = {
   };
 };
 
-export const createOidcProvider = (
-  options?: OidcProviderOptions,
-): AuthProviderFactory => {
+export const createOidcProvider = (options?: {
+  authHandler?: AuthHandler<OidcAuthResult>;
+
+  signIn?: {
+    resolver: SignInResolver<OidcAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/oidc/provider.ts
+++ b/plugins/auth-backend/src/providers/oidc/provider.ts
@@ -199,6 +199,7 @@ export class OidcAuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type OidcProviderOptions = {

--- a/plugins/auth-backend/src/providers/okta/provider.test.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.test.ts
@@ -17,9 +17,7 @@
 import { OktaAuthProvider } from './provider';
 import * as helpers from '../../lib/passport/PassportStrategyHelper';
 import { OAuthResult } from '../../lib/oauth';
-import { getVoidLogger } from '@backstage/backend-common';
-import { TokenIssuer } from '../../identity/types';
-import { CatalogIdentityClient } from '../../lib/catalog';
+import { AuthResolverContext } from '../types';
 
 const mockFrameHandler = jest.spyOn(
   helpers,
@@ -30,19 +28,8 @@ const mockFrameHandler = jest.spyOn(
 
 describe('createOktaProvider', () => {
   it('should auth', async () => {
-    const tokenIssuer = {
-      issueToken: jest.fn(),
-      listPublicKeys: jest.fn(),
-    };
-    const catalogIdentityClient = {
-      findUser: jest.fn(),
-    };
-
     const provider = new OktaAuthProvider({
-      logger: getVoidLogger(),
-      catalogIdentityClient:
-        catalogIdentityClient as unknown as CatalogIdentityClient,
-      tokenIssuer: tokenIssuer as unknown as TokenIssuer,
+      resolverContext: {} as AuthResolverContext,
       authHandler: async ({ fullProfile }) => ({
         profile: {
           email: fullProfile.emails![0]!.value,

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -223,6 +223,9 @@ export const oktaEmailSignInResolver: SignInResolver<OAuthResult> = async (
   return { id: entity.metadata.name, entity, token };
 };
 
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type OktaProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -241,9 +244,23 @@ export type OktaProviderOptions = {
   };
 };
 
-export const createOktaProvider = (
-  _options?: OktaProviderOptions,
-): AuthProviderFactory => {
+export const createOktaProvider = (_options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<OAuthResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
+    resolver: SignInResolver<OAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -41,11 +41,9 @@ import {
   AuthHandler,
   RedirectInfo,
   SignInResolver,
+  AuthResolverContext,
 } from '../types';
 import { StateStore } from 'passport-oauth2';
-import { CatalogIdentityClient, getEntityClaims } from '../../lib/catalog';
-import { TokenIssuer } from '../../identity';
-import { Logger } from 'winston';
 
 type PrivateInfo = {
   refreshToken: string;
@@ -55,18 +53,14 @@ export type OktaAuthProviderOptions = OAuthProviderOptions & {
   audience: string;
   signInResolver?: SignInResolver<OAuthResult>;
   authHandler: AuthHandler<OAuthResult>;
-  tokenIssuer: TokenIssuer;
-  catalogIdentityClient: CatalogIdentityClient;
-  logger: Logger;
+  resolverContext: AuthResolverContext;
 };
 
 export class OktaAuthProvider implements OAuthHandlers {
-  private readonly _strategy: any;
-  private readonly _signInResolver?: SignInResolver<OAuthResult>;
-  private readonly _authHandler: AuthHandler<OAuthResult>;
-  private readonly _tokenIssuer: TokenIssuer;
-  private readonly _catalogIdentityClient: CatalogIdentityClient;
-  private readonly _logger: Logger;
+  private readonly strategy: any;
+  private readonly signInResolver?: SignInResolver<OAuthResult>;
+  private readonly authHandler: AuthHandler<OAuthResult>;
+  private readonly resolverContext: AuthResolverContext;
 
   /**
    * Due to passport-okta-oauth forcing options.state = true,
@@ -76,7 +70,7 @@ export class OktaAuthProvider implements OAuthHandlers {
    * passport-oauth2, which is the StateStore implementation used when options.state = false,
    * allowing us to avoid using express-session in order to integrate with Okta.
    */
-  private _store: StateStore = {
+  private store: StateStore = {
     store(_req: express.Request, cb: any) {
       cb(null, null);
     },
@@ -86,20 +80,18 @@ export class OktaAuthProvider implements OAuthHandlers {
   };
 
   constructor(options: OktaAuthProviderOptions) {
-    this._signInResolver = options.signInResolver;
-    this._authHandler = options.authHandler;
-    this._tokenIssuer = options.tokenIssuer;
-    this._catalogIdentityClient = options.catalogIdentityClient;
-    this._logger = options.logger;
+    this.signInResolver = options.signInResolver;
+    this.authHandler = options.authHandler;
+    this.resolverContext = options.resolverContext;
 
-    this._strategy = new OktaStrategy(
+    this.strategy = new OktaStrategy(
       {
         clientID: options.clientId,
         clientSecret: options.clientSecret,
         callbackURL: options.callbackUrl,
         audience: options.audience,
         passReqToCallback: false as true,
-        store: this._store,
+        store: this.store,
         response_type: 'code',
       },
       (
@@ -126,7 +118,7 @@ export class OktaAuthProvider implements OAuthHandlers {
   }
 
   async start(req: OAuthStartRequest): Promise<RedirectInfo> {
-    return await executeRedirectStrategy(req, this._strategy, {
+    return await executeRedirectStrategy(req, this.strategy, {
       accessType: 'offline',
       prompt: 'consent',
       scope: req.scope,
@@ -138,7 +130,7 @@ export class OktaAuthProvider implements OAuthHandlers {
     const { result, privateInfo } = await executeFrameHandlerStrategy<
       OAuthResult,
       PrivateInfo
-    >(req, this._strategy);
+    >(req, this.strategy);
 
     return {
       response: await this.handleResult(result),
@@ -149,13 +141,13 @@ export class OktaAuthProvider implements OAuthHandlers {
   async refresh(req: OAuthRefreshRequest) {
     const { accessToken, refreshToken, params } =
       await executeRefreshTokenStrategy(
-        this._strategy,
+        this.strategy,
         req.refreshToken,
         req.scope,
       );
 
     const fullProfile = await executeFetchUserProfileStrategy(
-      this._strategy,
+      this.strategy,
       accessToken,
     );
 
@@ -170,12 +162,7 @@ export class OktaAuthProvider implements OAuthHandlers {
   }
 
   private async handleResult(result: OAuthResult) {
-    const context = {
-      logger: this._logger,
-      catalogIdentityClient: this._catalogIdentityClient,
-      tokenIssuer: this._tokenIssuer,
-    };
-    const { profile } = await this._authHandler(result, context);
+    const { profile } = await this.authHandler(result, this.resolverContext);
 
     const response: OAuthResponse = {
       providerInfo: {
@@ -187,13 +174,13 @@ export class OktaAuthProvider implements OAuthHandlers {
       profile,
     };
 
-    if (this._signInResolver) {
-      response.backstageIdentity = await this._signInResolver(
+    if (this.signInResolver) {
+      response.backstageIdentity = await this.signInResolver(
         {
           result,
           profile,
         },
-        context,
+        this.resolverContext,
       );
     }
 
@@ -211,16 +198,11 @@ export const oktaEmailSignInResolver: SignInResolver<OAuthResult> = async (
     throw new Error('Okta profile contained no email');
   }
 
-  const entity = await ctx.catalogIdentityClient.findUser({
+  return ctx.signInWithCatalogUser({
     annotations: {
       'okta.com/email': profile.email,
     },
   });
-
-  const claims = getEntityClaims(entity);
-  const token = await ctx.tokenIssuer.issueToken({ claims });
-
-  return { id: entity.metadata.name, entity, token };
 };
 
 /**
@@ -261,15 +243,7 @@ export const createOktaProvider = (_options?: {
     resolver: SignInResolver<OAuthResult>;
   };
 }): AuthProviderFactory => {
-  return ({
-    providerId,
-    globalConfig,
-    config,
-    tokenIssuer,
-    tokenManager,
-    catalogApi,
-    logger,
-  }) =>
+  return ({ providerId, globalConfig, config, resolverContext }) =>
     OAuthEnvironmentHandler.mapConfig(config, envConfig => {
       const clientId = envConfig.getString('clientId');
       const clientSecret = envConfig.getString('clientSecret');
@@ -286,11 +260,6 @@ export const createOktaProvider = (_options?: {
         throw new Error("URL for 'audience' must start with 'https://'.");
       }
 
-      const catalogIdentityClient = new CatalogIdentityClient({
-        catalogApi,
-        tokenManager,
-      });
-
       const authHandler: AuthHandler<OAuthResult> = _options?.authHandler
         ? _options.authHandler
         : async ({ fullProfile, params }) => ({
@@ -304,15 +273,12 @@ export const createOktaProvider = (_options?: {
         callbackUrl,
         authHandler,
         signInResolver: _options?.signIn?.resolver,
-        tokenIssuer,
-        catalogIdentityClient,
-        logger,
+        resolverContext,
       });
 
       return OAuthAdapter.fromConfig(globalConfig, provider, {
         disableRefresh: false,
         providerId,
-        tokenIssuer,
         callbackUrl,
       });
     });

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -277,7 +277,7 @@ export const okta = createAuthProviderIntegration({
     /**
      * Looks up the user by matching their email to the `okta.com/email` annotation.
      */
-    lookupEmailAnnotation(): SignInResolver<OAuthResult> {
+    emailMatchingUserEntityAnnotation(): SignInResolver<OAuthResult> {
       return async (info, ctx) => {
         const { profile } = info;
 
@@ -303,6 +303,7 @@ export const createOktaProvider = okta.create;
 
 /**
  * @public
- * @deprecated Use `providers.okta.resolvers.lookupEmailAnnotation()` instead.
+ * @deprecated Use `providers.okta.resolvers.emailMatchingUserEntityAnnotation()` instead.
  */
-export const oktaEmailSignInResolver = okta.resolvers.lookupEmailAnnotation();
+export const oktaEmailSignInResolver =
+  okta.resolvers.emailMatchingUserEntityAnnotation();

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -188,23 +188,6 @@ export class OktaAuthProvider implements OAuthHandlers {
   }
 }
 
-export const oktaEmailSignInResolver: SignInResolver<OAuthResult> = async (
-  info,
-  ctx,
-) => {
-  const { profile } = info;
-
-  if (!profile.email) {
-    throw new Error('Okta profile contained no email');
-  }
-
-  return ctx.signInWithCatalogUser({
-    annotations: {
-      'okta.com/email': profile.email,
-    },
-  });
-};
-
 /**
  * @deprecated This type has been inlined into the create method and will be removed.
  */
@@ -289,6 +272,26 @@ export const okta = createAuthProviderIntegration({
         });
       });
   },
+  resolvers: {
+    /**
+     * Looks up the user by matching their email to the `okta.com/email` annotation.
+     */
+    lookupEmailAnnotation(): SignInResolver<OAuthResult> {
+      return async (info, ctx) => {
+        const { profile } = info;
+
+        if (!profile.email) {
+          throw new Error('Okta profile contained no email');
+        }
+
+        return ctx.signInWithCatalogUser({
+          annotations: {
+            'okta.com/email': profile.email,
+          },
+        });
+      };
+    },
+  },
 });
 
 /**
@@ -296,3 +299,9 @@ export const okta = createAuthProviderIntegration({
  * @deprecated Use `providers.okta.create` instead
  */
 export const createOktaProvider = okta.create;
+
+/**
+ * @public
+ * @deprecated Use `providers.okta.resolvers.lookupEmailAnnotation()` instead.
+ */
+export const oktaEmailSignInResolver = okta.resolvers.lookupEmailAnnotation();

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -189,6 +189,7 @@ export class OktaAuthProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type OktaProviderOptions = {

--- a/plugins/auth-backend/src/providers/okta/provider.ts
+++ b/plugins/auth-backend/src/providers/okta/provider.ts
@@ -237,7 +237,7 @@ export type OktaProviderOptions = {
     /**
      * Maps an auth result to a Backstage identity for the user.
      */
-    resolver?: SignInResolver<OAuthResult>;
+    resolver: SignInResolver<OAuthResult>;
   };
 };
 

--- a/plugins/auth-backend/src/providers/onelogin/provider.ts
+++ b/plugins/auth-backend/src/providers/onelogin/provider.ts
@@ -179,7 +179,9 @@ export class OneLoginProvider implements OAuthHandlers {
   }
 }
 
-/** @public */
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type OneLoginProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -199,9 +201,23 @@ export type OneLoginProviderOptions = {
 };
 
 /** @public */
-export const createOneLoginProvider = (
-  options?: OneLoginProviderOptions,
-): AuthProviderFactory => {
+export const createOneLoginProvider = (options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<OAuthResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
+    resolver: SignInResolver<OAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/onelogin/provider.ts
+++ b/plugins/auth-backend/src/providers/onelogin/provider.ts
@@ -179,18 +179,6 @@ export class OneLoginProvider implements OAuthHandlers {
   }
 }
 
-const defaultSignInResolver: SignInResolver<OAuthResult> = async info => {
-  const { profile } = info;
-
-  if (!profile.email) {
-    throw new Error('OIDC profile contained no email');
-  }
-
-  const id = profile.email.split('@')[0];
-
-  return { id, token: '' };
-};
-
 /** @public */
 export type OneLoginProviderOptions = {
   /**
@@ -243,15 +231,13 @@ export const createOneLoginProvider = (
             profile: makeProfileInfo(fullProfile, params.id_token),
           });
 
-      const signInResolver = options?.signIn?.resolver ?? defaultSignInResolver;
-
       const provider = new OneLoginProvider({
         clientId,
         clientSecret,
         callbackUrl,
         issuer,
         authHandler,
-        signInResolver,
+        signInResolver: options?.signIn?.resolver,
         tokenIssuer,
         catalogIdentityClient,
         logger,

--- a/plugins/auth-backend/src/providers/onelogin/provider.ts
+++ b/plugins/auth-backend/src/providers/onelogin/provider.ts
@@ -167,6 +167,7 @@ export class OneLoginProvider implements OAuthHandlers {
 }
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type OneLoginProviderOptions = {

--- a/plugins/auth-backend/src/providers/providers.ts
+++ b/plugins/auth-backend/src/providers/providers.ts
@@ -30,6 +30,11 @@ import { okta } from './okta/provider';
 import { onelogin } from './onelogin/provider';
 import { saml } from './saml/provider';
 
+/**
+ * All built-in auth provider integrations.
+ *
+ * @public
+ */
 export const providers = Object.freeze({
   atlassian,
   auth0,

--- a/plugins/auth-backend/src/providers/providers.ts
+++ b/plugins/auth-backend/src/providers/providers.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { google } from './google/provider';
+
+export const providers = Object.freeze({
+  google,
+});

--- a/plugins/auth-backend/src/providers/providers.ts
+++ b/plugins/auth-backend/src/providers/providers.ts
@@ -14,8 +14,36 @@
  * limitations under the License.
  */
 
+import { atlassian } from './atlassian/provider';
+import { auth0 } from './auth0/provider';
+import { awsAlb } from './aws-alb/provider';
+import { bitbucket } from './bitbucket/provider';
+import { gcpIap } from './gcp-iap/provider';
+import { github } from './github/provider';
+import { gitlab } from './gitlab/provider';
 import { google } from './google/provider';
+import { microsoft } from './microsoft/provider';
+import { oauth2 } from './oauth2/provider';
+import { oauth2Proxy } from './oauth2-proxy/provider';
+import { oidc } from './oidc/provider';
+import { okta } from './okta/provider';
+import { onelogin } from './onelogin/provider';
+import { saml } from './saml/provider';
 
 export const providers = Object.freeze({
+  atlassian,
+  auth0,
+  awsAlb,
+  bitbucket,
+  gcpIap,
+  github,
+  gitlab,
   google,
+  microsoft,
+  oauth2,
+  oauth2Proxy,
+  oidc,
+  okta,
+  onelogin,
+  saml,
 });

--- a/plugins/auth-backend/src/providers/resolvers.ts
+++ b/plugins/auth-backend/src/providers/resolvers.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DEFAULT_NAMESPACE,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
+import { SignInResolver } from './types';
+
+export const commonEmailLocalPartEntityNameSignInResolver: SignInResolver<
+  unknown
+> = async (info, ctx) => {
+  const { profile } = info;
+
+  if (!profile.email) {
+    throw new Error('Login failed, user profile does not contain an email');
+  }
+  const [userId] = profile.email.split('@');
+
+  const entityRef = stringifyEntityRef({
+    kind: 'User',
+    namespace: DEFAULT_NAMESPACE,
+    name: userId,
+  });
+  const ownershipEntityRefs =
+    await ctx.catalogIdentityClient.resolveCatalogMembership({
+      entityRefs: [entityRef],
+    });
+  const token = await ctx.tokenIssuer.issueToken({
+    claims: {
+      sub: entityRef,
+      ent: ownershipEntityRefs,
+    },
+  });
+
+  return { id: userId, token };
+};

--- a/plugins/auth-backend/src/providers/resolvers.ts
+++ b/plugins/auth-backend/src/providers/resolvers.ts
@@ -20,9 +20,10 @@ import {
 } from '@backstage/catalog-model';
 import { SignInResolver } from './types';
 
-export const commonEmailLocalPartEntityNameSignInResolver: SignInResolver<
-  unknown
-> = async (info, ctx) => {
+export const commonByEmailLocalPartResolver: SignInResolver<unknown> = async (
+  info,
+  ctx,
+) => {
   const { profile } = info;
 
   if (!profile.email) {

--- a/plugins/auth-backend/src/providers/saml/index.ts
+++ b/plugins/auth-backend/src/providers/saml/index.ts
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-export { createSamlProvider } from './provider';
+export {
+  createSamlProvider,
+  samlNameIdEntityNameSignInResolver,
+} from './provider';
 export type { SamlProviderOptions, SamlAuthResult } from './provider';

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -148,28 +148,6 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
   }
 }
 
-const samlDefaultSignInResolver: SignInResolver<SamlAuthResult> = async (
-  info,
-  ctx,
-) => {
-  const id = info.result.fullProfile.nameID;
-
-  const entityRef = stringifyEntityRef({
-    kind: 'User',
-    namespace: DEFAULT_NAMESPACE,
-    name: id,
-  });
-
-  const token = await ctx.tokenIssuer.issueToken({
-    claims: {
-      sub: entityRef,
-      ent: [entityRef],
-    },
-  });
-
-  return { id, token };
-};
-
 type SignatureAlgorithm = 'sha1' | 'sha256' | 'sha512';
 
 /** @public */
@@ -218,16 +196,6 @@ export const createSamlProvider = (
           },
         });
 
-    const signInResolverFn =
-      options?.signIn?.resolver ?? samlDefaultSignInResolver;
-
-    const signInResolver: SignInResolver<SamlAuthResult> = info =>
-      signInResolverFn(info, {
-        catalogIdentityClient,
-        tokenIssuer,
-        logger,
-      });
-
     return new SamlAuthProvider({
       callbackUrl: `${globalConfig.baseUrl}/${providerId}/handler/frame`,
       entryPoint: config.getString('entryPoint'),
@@ -248,7 +216,7 @@ export const createSamlProvider = (
       tokenIssuer,
       appUrl: globalConfig.appUrl,
       authHandler,
-      signInResolver,
+      signInResolver: options?.signIn?.resolver,
       logger,
       catalogIdentityClient,
     });

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -174,7 +174,9 @@ export const samlNameIdEntityNameSignInResolver: SignInResolver<
 
 type SignatureAlgorithm = 'sha1' | 'sha256' | 'sha512';
 
-/** @public */
+/**
+ * @deprecated This type has been inlined into the create method and will be removed.
+ */
 export type SamlProviderOptions = {
   /**
    * The profile transformation function used to verify and convert the auth response
@@ -194,9 +196,23 @@ export type SamlProviderOptions = {
 };
 
 /** @public */
-export const createSamlProvider = (
-  options?: SamlProviderOptions,
-): AuthProviderFactory => {
+export const createSamlProvider = (options?: {
+  /**
+   * The profile transformation function used to verify and convert the auth response
+   * into the profile that will be presented to the user.
+   */
+  authHandler?: AuthHandler<SamlAuthResult>;
+
+  /**
+   * Configure sign-in for this provider, without it the provider can not be used to sign users in.
+   */
+  signIn?: {
+    /**
+     * Maps an auth result to a Backstage identity for the user.
+     */
+    resolver: SignInResolver<SamlAuthResult>;
+  };
+}): AuthProviderFactory => {
   return ({
     providerId,
     globalConfig,

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -148,6 +148,30 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
   }
 }
 
+export const samlNameIdEntityNameSignInResolver: SignInResolver<
+  SamlAuthResult
+> = async (info, ctx) => {
+  const id = info.result.fullProfile.nameID;
+
+  const entityRef = stringifyEntityRef({
+    kind: 'User',
+    namespace: DEFAULT_NAMESPACE,
+    name: id,
+  });
+  const ownershipEntityRefs =
+    await ctx.catalogIdentityClient.resolveCatalogMembership({
+      entityRefs: [entityRef],
+    });
+  const token = await ctx.tokenIssuer.issueToken({
+    claims: {
+      sub: entityRef,
+      ent: ownershipEntityRefs,
+    },
+  });
+
+  return { id, token };
+};
+
 type SignatureAlgorithm = 'sha1' | 'sha256' | 'sha512';
 
 /** @public */

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -130,20 +130,6 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
   }
 }
 
-export const samlNameIdEntityNameSignInResolver: SignInResolver<
-  SamlAuthResult
-> = async (info, ctx) => {
-  const id = info.result.fullProfile.nameID;
-
-  if (!id) {
-    throw new AuthenticationError('No nameID found in SAML response');
-  }
-
-  return ctx.signInWithCatalogUser({
-    entityRef: { name: id },
-  });
-};
-
 type SignatureAlgorithm = 'sha1' | 'sha256' | 'sha512';
 
 /**
@@ -224,6 +210,24 @@ export const saml = createAuthProviderIntegration({
       });
     };
   },
+  resolvers: {
+    /**
+     * Looks up the user by matching their nameID to the entity name.
+     */
+    byNameId(): SignInResolver<SamlAuthResult> {
+      return async (info, ctx) => {
+        const id = info.result.fullProfile.nameID;
+
+        if (!id) {
+          throw new AuthenticationError('No nameID found in SAML response');
+        }
+
+        return ctx.signInWithCatalogUser({
+          entityRef: { name: id },
+        });
+      };
+    },
+  },
 });
 
 /**
@@ -231,3 +235,9 @@ export const saml = createAuthProviderIntegration({
  * @deprecated Use `providers.saml.create` instead
  */
 export const createSamlProvider = saml.create;
+
+/**
+ * @public
+ * @deprecated Use `providers.saml.resolvers.byNameId()` instead.
+ */
+export const samlNameIdEntityNameSignInResolver = saml.resolvers.byNameId();

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -165,7 +165,7 @@ export type SamlProviderOptions = {
     /**
      * Maps an auth result to a Backstage identity for the user.
      */
-    resolver?: SignInResolver<SamlAuthResult>;
+    resolver: SignInResolver<SamlAuthResult>;
   };
 };
 

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -215,7 +215,7 @@ export const saml = createAuthProviderIntegration({
     /**
      * Looks up the user by matching their nameID to the entity name.
      */
-    byNameId(): SignInResolver<SamlAuthResult> {
+    nameIdMatchingUserEntityName(): SignInResolver<SamlAuthResult> {
       return async (info, ctx) => {
         const id = info.result.fullProfile.nameID;
 
@@ -239,6 +239,7 @@ export const createSamlProvider = saml.create;
 
 /**
  * @public
- * @deprecated Use `providers.saml.resolvers.byNameId()` instead.
+ * @deprecated Use `providers.saml.resolvers.nameIdMatchingUserEntityName()` instead.
  */
-export const samlNameIdEntityNameSignInResolver = saml.resolvers.byNameId();
+export const samlNameIdEntityNameSignInResolver =
+  saml.resolvers.nameIdMatchingUserEntityName();

--- a/plugins/auth-backend/src/providers/saml/provider.ts
+++ b/plugins/auth-backend/src/providers/saml/provider.ts
@@ -133,6 +133,7 @@ export class SamlAuthProvider implements AuthProviderRouteHandlers {
 type SignatureAlgorithm = 'sha1' | 'sha256' | 'sha512';
 
 /**
+ * @public
  * @deprecated This type has been inlined into the create method and will be removed.
  */
 export type SamlProviderOptions = {

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -219,10 +219,9 @@ export type AuthProviderFactory = (options: {
   providerId: string;
   globalConfig: AuthProviderConfig;
   config: Config;
+  logger: Logger;
   resolverContext: AuthResolverContext;
 
-  /** @deprecated This field has been deprecated and needs to be passed directly to the auth provider instead */
-  logger: Logger;
   /** @deprecated This field has been deprecated and needs to be passed directly to the auth provider instead */
   tokenManager: TokenManager;
   /** @deprecated This field has been deprecated and needs to be passed directly to the auth provider instead */

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -43,6 +43,8 @@ import { Entity } from '@backstage/catalog-model';
  *
  * Regardless of the query method, the query must match exactly one entity
  * in the catalog, or an error will be thrown.
+ *
+ * @public
  */
 export type AuthResolverCatalogUserQuery =
   | {
@@ -112,6 +114,7 @@ export type CookieConfigurer = (ctx: {
   callbackUrl: string;
 }) => { domain: string; path: string; secure: boolean };
 
+/** @public */
 export type AuthProviderConfig = {
   /**
    * The protocol://domain[:port] where the app is hosted. This is used to construct the
@@ -232,6 +235,7 @@ export type AuthProviderFactory = (options: {
   catalogApi: CatalogApi;
 }) => AuthProviderRouteHandlers;
 
+/** @public */
 export type AuthResponse<ProviderInfo> = {
   providerInfo: ProviderInfo;
   profile: ProfileInfo;
@@ -319,6 +323,7 @@ export type AuthHandler<TAuthResult> = (
   context: AuthResolverContext,
 ) => Promise<AuthHandlerResult>;
 
+/** @public */
 export type StateEncoder = (
   req: OAuthStartRequest,
 ) => Promise<{ encodedState: string }>;

--- a/plugins/auth-backend/src/providers/types.ts
+++ b/plugins/auth-backend/src/providers/types.ts
@@ -143,6 +143,9 @@ export interface AuthProviderRouteHandlers {
   logout?(req: express.Request, res: express.Response): Promise<void>;
 }
 
+/**
+ * @deprecated This type is deprecated and will be removed in a future release.
+ */
 export type AuthProviderFactoryOptions = {
   providerId: string;
   globalConfig: AuthProviderConfig;
@@ -154,9 +157,23 @@ export type AuthProviderFactoryOptions = {
   catalogApi: CatalogApi;
 };
 
-export type AuthProviderFactory = (
-  options: AuthProviderFactoryOptions,
-) => AuthProviderRouteHandlers;
+export type AuthProviderFactory = (options: {
+  providerId: string;
+  globalConfig: AuthProviderConfig;
+  config: Config;
+  resolverContext: AuthResolverContext;
+
+  /** @deprecated This field has been deprecated and needs to be passed directly to the auth provider instead */
+  logger: Logger;
+  /** @deprecated This field has been deprecated and needs to be passed directly to the auth provider instead */
+  tokenManager: TokenManager;
+  /** @deprecated This field has been deprecated and needs to be passed directly to the auth provider instead */
+  tokenIssuer: TokenIssuer;
+  /** @deprecated This field has been deprecated and needs to be passed directly to the auth provider instead */
+  discovery: PluginEndpointDiscovery;
+  /** @deprecated This field has been deprecated and needs to be passed directly to the auth provider instead */
+  catalogApi: CatalogApi;
+}) => AuthProviderRouteHandlers;
 
 export type AuthResponse<ProviderInfo> = {
   providerInfo: ProviderInfo;

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -34,7 +34,7 @@ import { createOidcRouter, TokenFactory, KeyStores } from '../identity';
 import session from 'express-session';
 import passport from 'passport';
 import { Minimatch } from 'minimatch';
-import { CatalogIdentityClient } from '../lib/catalog';
+import { CatalogAuthResolverContext } from '../lib/resolvers';
 
 type ProviderFactories = { [s: string]: AuthProviderFactory };
 
@@ -104,11 +104,6 @@ export async function createRouter(
 
   const isOriginAllowed = createOriginFilter(config);
 
-  const catalogIdentityClient = new CatalogIdentityClient({
-    catalogApi,
-    tokenManager,
-  });
-
   for (const [providerId, providerFactory] of Object.entries(
     allProviderFactories,
   )) {
@@ -128,11 +123,12 @@ export async function createRouter(
           tokenIssuer,
           discovery,
           catalogApi,
-          resolverContext: {
+          resolverContext: CatalogAuthResolverContext.create({
             logger,
+            catalogApi,
             tokenIssuer,
-            catalogIdentityClient,
-          },
+            tokenManager,
+          }),
         });
 
         const r = Router();

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -34,6 +34,7 @@ import { createOidcRouter, TokenFactory, KeyStores } from '../identity';
 import session from 'express-session';
 import passport from 'passport';
 import { Minimatch } from 'minimatch';
+import { CatalogIdentityClient } from '../lib/catalog';
 
 type ProviderFactories = { [s: string]: AuthProviderFactory };
 
@@ -103,6 +104,11 @@ export async function createRouter(
 
   const isOriginAllowed = createOriginFilter(config);
 
+  const catalogIdentityClient = new CatalogIdentityClient({
+    catalogApi,
+    tokenManager,
+  });
+
   for (const [providerId, providerFactory] of Object.entries(
     allProviderFactories,
   )) {
@@ -122,6 +128,11 @@ export async function createRouter(
           tokenIssuer,
           discovery,
           catalogApi,
+          resolverContext: {
+            logger,
+            tokenIssuer,
+            catalogIdentityClient,
+          },
         });
 
         const r = Router();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Draft as there's some new design in here I wanna discuss and then apply the same changes to all providers. No changesets, or documentation updates just yet.

The initial chunk of this PR is the removal of all default sign-in resolvers. This means that if you want to sign-in through one of the existing auth providers, you need to add a sign-in resolver to it. This both means there's a clear decision to use a provider for sign-in, and also closes a gap in security.

Another change is to deprecate the `AuthProviderFactoryOptions` type and instead inline it into the `AuthProviderFactory`. That means it's only possible to consume the options, meaning that adding more options is not a breaking change.

Last big change that I want to discuss a bit more is the addition of `createAuthProviderIntegration` and then strive to keep all types and implementations related to each provider within that object. The long-term goal here is to remove most if not all separate auth provider exports, and only export the root `providers` object. You can see what this looks like from the consumers point of view in https://github.com/backstage/backstage/commit/8069b567088998680a80c8d54cea26070d8a4c22

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
