### PR TITLE
[TechDocs] Fix HEAD request cache bug

### DIFF
--- a/.changeset/techdocs-head-shoulders-knees-toes.md
+++ b/.changeset/techdocs-head-shoulders-knees-toes.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Fixed a bug affecting those with cache enabled that would result in empty content being cached if the first attempt to load a static asset from storage were made via a `HEAD` request, rather than a `GET` request.

--- a/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
+++ b/plugins/techdocs-backend/src/cache/cacheMiddleware.test.ts
@@ -85,6 +85,15 @@ describe('createCacheMiddleware', () => {
       expect(cache.set).not.toHaveBeenCalled();
     });
 
+    it('checks cache for head requests', async () => {
+      cache.get.mockResolvedValueOnce(getMockHttpResponseFor('xyz'));
+
+      await request(app).head('/static/docs/foo.html').expect(200);
+
+      await waitForSocketClose();
+      expect(cache.set).not.toHaveBeenCalled();
+    });
+
     it('sets cache when content is cacheable', async () => {
       const expectedPath = 'default/api/xyz/index.html';
       await request(app)
@@ -101,6 +110,14 @@ describe('createCacheMiddleware', () => {
 
     it('does not set cache on error', async () => {
       await request(app).get('/static/docs/error.png').expect(500);
+
+      await waitForSocketClose();
+      expect(cache.set).not.toHaveBeenCalled();
+    });
+
+    it('does not set cache on head requests', async () => {
+      const expectedPath = 'default/api/xyz/index.html';
+      await request(app).head(`/static/docs/${expectedPath}`).expect(200);
 
       await waitForSocketClose();
       expect(cache.set).not.toHaveBeenCalled();

--- a/plugins/techdocs-backend/src/cache/cacheMiddleware.ts
+++ b/plugins/techdocs-backend/src/cache/cacheMiddleware.ts
@@ -36,6 +36,7 @@ export const createCacheMiddleware = ({
   cacheMiddleware.use(async (req, res, next) => {
     const socket = res.socket;
     const isCacheable = req.path.startsWith('/static/docs/');
+    const isGetRequest = req.method === 'GET';
 
     // Continue early if this is non-cacheable, or there's no socket.
     if (!isCacheable || !socket) {
@@ -69,7 +70,12 @@ export const createCacheMiddleware = ({
     socket.on('close', async hadError => {
       const content = Buffer.concat(chunks);
       const head = content.toString('utf8', 0, 12);
-      if (writeToCache && !hadError && head.match(/HTTP\/\d\.\d 200/)) {
+      if (
+        isGetRequest &&
+        writeToCache &&
+        !hadError &&
+        head.match(/HTTP\/\d\.\d 200/)
+      ) {
         await cache.set(reqPath, content);
       }
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves a bug that could cause static assets to be cached as empty if the first request to retrieve it were a `HEAD` request.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
