### PR TITLE
Corrected replacements for depreciated items

### DIFF
--- a/.changeset/eleven-pens-collect.md
+++ b/.changeset/eleven-pens-collect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Corrected replacements for depreciated FilteredEntityLayout items

--- a/plugins/catalog/src/components/FilteredEntityLayout/index.ts
+++ b/plugins/catalog/src/components/FilteredEntityLayout/index.ts
@@ -18,7 +18,7 @@ import { CatalogFilterLayout } from '@backstage/plugin-catalog-react';
 
 /**
  * @public
- * @deprecated Use `FilteredCatalogLayout` from `@backstage/plugin-catalog-react` instead.
+ * @deprecated Use `CatalogFilterLayout` from `@backstage/plugin-catalog-react` instead.
  */
 export const FilteredEntityLayout = CatalogFilterLayout as (props: {
   children: React.ReactNode;
@@ -26,12 +26,12 @@ export const FilteredEntityLayout = CatalogFilterLayout as (props: {
 
 /**
  * @public
- * @deprecated Use `FilteredCatalogLayout.Filters` from `@backstage/plugin-catalog-react` instead.
+ * @deprecated Use `CatalogFilterLayout.Filters` from `@backstage/plugin-catalog-react` instead.
  */
 export const FilterContainer = CatalogFilterLayout.Filters;
 
 /**
  * @public
- * @deprecated Use `FilteredCatalogLayout.Content` from `@backstage/plugin-catalog-react` instead.
+ * @deprecated Use `CatalogFilterLayout.Content` from `@backstage/plugin-catalog-react` instead.
  */
 export const EntityListContainer = CatalogFilterLayout.Content;


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <awanlin@rapidrtc.com>

## Hey, I just made a Pull Request!

While upgrading to the 1.0.0 release I noticed we were using some depreciated code. I tried to use what was suggested in VS Code but that wasn't working. Upon further investigation the comments for the depreciation were wrong. This PR fixes them to match what was in the CHANGELOG - https://github.com/backstage/backstage/blob/master/plugins/catalog-react/CHANGELOG.md#patch-changes

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
