### PR TITLE
RequestInit instead of Request in PluginProtocolResolverFetchMiddleware

### DIFF
--- a/packages/core-app-api/src/apis/implementations/FetchApi/PluginProtocolResolverFetchMiddleware.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/PluginProtocolResolverFetchMiddleware.ts
@@ -55,7 +55,7 @@ export class PluginProtocolResolverFetchMiddleware implements FetchMiddleware {
       }
 
       const target = `${join(base, pathname)}${search}${hash}`;
-      return next(target, request);
+      return next(target, init);
     };
   }
 }


### PR DESCRIPTION
Signed-off-by: Alex Rybchenko <arybchenko@box.com>

## Hey, I just made a Pull Request!
Today I found out that body is not sent when using "plugin://" prefix for POST requests using FetchAPI. 
I haven't looked into a lot, this can be related to https://bugs.chromium.org/p/chromium/issues/detail?id=969843 , https://bugs.chromium.org/p/chromium/issues/detail?id=688906.
For now I suggest an easy fix :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
