### PR TITLE
Fix incorrect knex migration logic

### DIFF
--- a/.changeset/nice-countries-jam.md
+++ b/.changeset/nice-countries-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fix migrations to do the right thing on sqlite databases, and reapply the column type fix for those who are _not_ on sqlite databases.

--- a/plugins/auth-backend/migrations/20210326100300_timestamptz.js
+++ b/plugins/auth-backend/migrations/20210326100300_timestamptz.js
@@ -21,7 +21,7 @@
  */
 exports.up = async function up(knex) {
   // Sqlite does not support alter column.
-  if (knex.client.config.client.includes('sqlite3')) {
+  if (!knex.client.config.client.includes('sqlite3')) {
     await knex.schema.alterTable('signing_keys', table => {
       table
         .timestamp('created_at', { useTz: true, precision: 0 })
@@ -38,7 +38,7 @@ exports.up = async function up(knex) {
  */
 exports.down = async function down(knex) {
   // Sqlite does not support alter column.
-  if (knex.client.config.client.includes('sqlite3')) {
+  if (!knex.client.config.client.includes('sqlite3')) {
     await knex.schema.alterTable('signing_keys', table => {
       table
         .timestamp('created_at', { useTz: false, precision: 0 })

--- a/plugins/auth-backend/migrations/20220321100910_timestamptz_again.js
+++ b/plugins/auth-backend/migrations/20220321100910_timestamptz_again.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+// NOTE: This may look like a plain duplicate of the previous one, but that
+// file had a bug added when improving sqlite driver support:
+// https://github.com/backstage/backstage/pull/10053/files#diff-30bb343265e71ca2f1cdcccd5ac8fdbb2a597507c5531bf26945059783377b15R24
+// Since the old file was released to end users, those who created a new
+// Backstage app specifically for PostgreSQL since the release will be missing
+// this fix on their table. So we re-apply it.
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  // Sqlite does not support alter column.
+  if (!knex.client.config.client.includes('sqlite3')) {
+    await knex.schema.alterTable('signing_keys', table => {
+      table
+        .timestamp('created_at', { useTz: true, precision: 0 })
+        .notNullable()
+        .defaultTo(knex.fn.now())
+        .comment('The creation time of the key')
+        .alter({ alterType: true });
+    });
+  }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  // Sqlite does not support alter column.
+  if (!knex.client.config.client.includes('sqlite3')) {
+    await knex.schema.alterTable('signing_keys', table => {
+      table
+        .timestamp('created_at', { useTz: false, precision: 0 })
+        .notNullable()
+        .defaultTo(knex.fn.now())
+        .comment('The creation time of the key')
+        .alter({ alterType: true });
+    });
+  }
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hopefully this PR is pretty obvious. The comment right above this line clearly indicates that we are NOT supposed to attempt column alternations with sqlite, but instead this logic applies _only_ to sqlite databases.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
