### PR TITLE
Update useSearchModal logic

### DIFF
--- a/.changeset/breezy-fireants-invite.md
+++ b/.changeset/breezy-fireants-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Fix bug with useSearchModal toggleModal and setOpen logic.

--- a/plugins/search/src/components/SearchModal/useSearchModal.tsx
+++ b/plugins/search/src/components/SearchModal/useSearchModal.tsx
@@ -32,19 +32,21 @@ export function useSearchModal(initialState = false) {
     open: initialState,
   });
 
+  // Toggle the current state
   const toggleModal = useCallback(
     () =>
       setState(prevState => ({
-        open: true,
+        open: !prevState.open,
         hidden: !prevState.hidden,
       })),
     [],
   );
 
+  // Manually set the current state
   const setOpen = useCallback(
-    (open: boolean) =>
-      setState(prevState => ({
-        open: prevState.open || open,
+    (open: boolean = true) =>
+      setState(() => ({
+        open: open,
         hidden: !open,
       })),
     [],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I noticed that there was an issue with the `useSearchModal` logic.

`toggleModal` was hardcoded to keep the modal open.

`setOpen` would keep the modal open, if it was already open.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
