### PR TITLE
Add template migration documentation regarding dash-case action ids

### DIFF
--- a/docs/features/software-templates/migrating-from-v1beta2-to-v1beta3.md
+++ b/docs/features/software-templates/migrating-from-v1beta2-to-v1beta3.md
@@ -180,6 +180,35 @@ These should be moved to `links` under the `output` object instead.
 
 ```
 
+## Watch out for `dash-case`
+
+The nunjucks compiler can run into issues if the `id` fields in your template steps use dash characters, since these IDs translate directly to JavaScript object properties when accessed as output. One possible migration path is to use `camelCase` for your action IDs.
+
+```diff
+  steps:
+-   id: my-custom-action
+-   ...
+-
+-   id: publish-pull-request
+-   input:
+-     repoUrl: {{ steps.my-custom-action.output.repoUrl }} # Will not recognize 'my-custom-action' as a JS property since it contains dashes!
+
+  steps:
++   id: myCustomAction
++   ...
++
++   id: publishPullRequest
++   input:
++     repoUrl: ${{ steps.myCustomAction.output.repoUrl }}
+```
+
+Alternatively, it's possible to keep the `dash-case` syntax and use brackets for property access as you would in JavaScript:
+
+```yaml
+input:
+  repoUrl: ${{ steps['my-custom-action'].output.repoUrl }}
+```
+
 ### Summary
 
 Of course, we're always available on [discord](https://discord.gg/MUpMjP2) if


### PR DESCRIPTION
Signed-off-by: daftgopher <daftgopher@users.noreply.github.com>

## Hey, I just made a Pull Request!

I recently ran into an issue when migrating our org's software templates to `scaffolder.backstage.io/v1beta3` that I didn't see covered in the migration guide - the switch over to use nunjucks means that `dash-case` syntax in some templates can behave in unexpected ways that break templates. For example, when accessing a template's `output` property, if the `id` of the step used in the template was written in `dash-case` (e.g. `my-cool-backstage-action`), then accessing that property via the following template syntax now produces an error:

```yaml
# some-template.yaml

steps:
  id: my-cool-backstage-action
  ...

  id: publish-pull-request
  input:
    repoUrl: ${{ steps.my-cool-backstage-action.output.repoUrl }}
``` 

This worked in the previous version of the templates that used handlebars without the `$` syntax, but it appears to have broken in the new version most likely because it's attempting to interpret the dash-case string as a JS object property, where dash-case needs to be wrapped in a bracket with quotes: `steps['my-cool-backstage-action'].output.repoUrl`. I've also confirmed that wrapping the property in that syntax produces the intended result. 

The PR adds documentation around this and suggests two paths to migration, either:

1. Use `camelCase` for action ids
2. Use bracket syntax to access `dash-case` id names as properties in your templates



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
