### PR TITLE
Fix broken querySelectors on techdocs

### DIFF
--- a/.changeset/silver-panthers-occur.md
+++ b/.changeset/silver-panthers-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fix broken query selectors on techdocs

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -803,7 +803,7 @@ export const useTechDocsReaderDom = (
                 navigate(`${parsedUrl.pathname}${parsedUrl.hash}`);
                 // Scroll to hash if it's on the current page
                 transformedElement
-                  ?.querySelector(`#${parsedUrl.hash.slice(1)}`)
+                  ?.querySelector(`[id='${parsedUrl.hash.slice(1)}']`)
                   ?.scrollIntoView();
               }
             } else {


### PR DESCRIPTION
This change fixes the broken pattern for selecting DOM elements to scroll to.

Previously it had error messages like so:
```
Uncaught DOMException: Failed to execute 'querySelector' on 'Element': '#fn:someidtag' is not a valid selector.
```

This did not bode well with the techdocs integration with footnotes.

The query has now changed to include something that is expected by the DOM queries.

edit: changes were merged during this pr that had similar changes https://github.com/backstage/backstage/pull/10311

Signed-off-by: Nicolas Arnold <nic@roadie.io>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
