### PR TITLE
workflows: add changeset feedback automation

### DIFF
--- a/.github/workflows/automate_changeset_feedback.yml
+++ b/.github/workflows/automate_changeset_feedback.yml
@@ -1,0 +1,82 @@
+name: Automate Changeset Feedback
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  issues: write
+
+jobs:
+  feedback:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: fetch base
+        run: git fetch origin ${{ github.base_ref }}
+
+      - name: Generate Feedback
+        id: generate-feedback
+        run: |
+          wget -O generate.js https://raw.githubusercontent.com/backstage/backstage/master/scripts/generate-changeset-feedback.js 1>&2
+          node generate.js origin/${{ github.base_ref }} > feedback.txt
+
+      - name: Post Feedback
+        uses: actions/github-script@v5
+        env:
+          ISSUE_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const owner = "backstage";
+            const repo = "backstage";
+            const marker = "<!-- changeset-feedback -->";
+            const feedback = require('fs').readFileSync('feedback.txt', 'utf8');
+            const issue_number = Number(process.env.ISSUE_NUMBER);
+            const body = feedback.trim() ? feedback + marker : undefined
+
+            const existingComments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            });
+
+            const existingComment = existingComments.find((c) =>
+              c.user.login === "github-actions[bot]" &&
+              c.body.includes(marker)
+            );
+
+            if (existingComment) {
+              if (body) {
+                if (existingComment.body !== body) {
+                  console.log(`updating existing comment in #${issue_number}`);
+                  await github.rest.issues.updateComment({
+                    repo,
+                    owner,
+                    comment_id: existingComment.id,
+                    body,
+                  });
+                } else {
+                  console.log(`skipped update of identical comment in #${issue_number}`);
+                }
+              } else {
+                console.log(`removing comment from #${issue_number}`);
+                await github.rest.issues.deleteComment({
+                  repo,
+                  owner,
+                  comment_id: existingComment.id,
+                  body,
+                });
+              }
+            } else if (body) {
+              console.log(`creating comment for #${issue_number}`);
+              await github.rest.issues.createComment({
+                repo,
+                owner,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/automate_changeset_feedback.yml
+++ b/.github/workflows/automate_changeset_feedback.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   feedback:
+    if: github.repository == 'backstage/backstage' # prevent running on forks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,6 +20,7 @@ jobs:
       - name: fetch base
         run: git fetch origin ${{ github.base_ref }}
 
+        # We avoid using the in-source script since this workflow has elevated permissions that we don't want to expose
       - name: Generate Feedback
         id: generate-feedback
         run: |

--- a/scripts/generate-changeset-feedback.js
+++ b/scripts/generate-changeset-feedback.js
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const { execFile: execFileCb } = require('child_process');
+const { promisify } = require('util');
+const {
+  basename,
+  resolve: resolvePath,
+  relative: relativePath,
+} = require('path');
+
+const execFile = promisify(execFileCb);
+
+// Tells whether a path relative to the package directory has an effect
+// on the published package
+function isPublishedPath(path) {
+  if (path.startsWith('dev/')) {
+    return false;
+  }
+  if (path.includes('__mocks__')) {
+    return false;
+  }
+  if (path.includes('__fixtures__')) {
+    return false;
+  }
+  // Don't count manual modifications to the changelog
+  if (path === 'CHANGELOG.md') {
+    return false;
+  }
+  // API report changes by themselves don't count
+  if (path === 'api-report.md') {
+    return false;
+  }
+  // Lint changes don't count
+  if (path === '.eslintrc.js') {
+    return false;
+  }
+
+  const name = basename(path);
+  if (name.startsWith('setupTests.')) {
+    return false;
+  }
+  if (name.includes('.test.')) {
+    return false;
+  }
+  if (name.includes('.stories.')) {
+    return false;
+  }
+  return true;
+}
+
+async function listChangedFiles(ref) {
+  if (!ref) {
+    throw new Error('ref is required');
+  }
+
+  const { stdout } = await execFile('git', ['diff', '--name-only', ref]);
+  return stdout.trim().split(/\r?\n/);
+}
+
+async function listPackages() {
+  const { stdout } = await execFile('yarn', ['-s', 'workspaces', 'info']);
+  return Object.entries(JSON.parse(stdout)).map(([name, info]) => ({
+    name,
+    path: info.location,
+  }));
+}
+
+async function parseChangesets(filePaths) {
+  const changesets = [];
+  for (const filePath of filePaths) {
+    if (!filePath.startsWith('.changeset/') || !filePath.endsWith('.md')) {
+      continue;
+    }
+    const content = await fs.promises.readFile(filePath, 'utf8');
+    let lines = content.split(/\r?\n/);
+
+    lines = lines.slice(lines.findIndex(line => line === '---') + 1);
+    lines = lines.slice(
+      0,
+      lines.findIndex(line => line === '---'),
+    );
+
+    const bumps = new Map();
+    for (const line of lines) {
+      const match = line.match(/^'(.*)': (patch|minor|major)$/);
+      if (!match) {
+        throw new Error(`Invalid changeset line: ${line}`);
+      }
+
+      bumps.set(match[1], match[2]);
+    }
+
+    changesets.push({
+      filePath,
+      bumps,
+    });
+  }
+
+  return changesets;
+}
+
+async function listChangedPackages(changedFiles, packages) {
+  const changedPackageMap = new Map();
+  for (const filePath of changedFiles) {
+    for (const pkg of packages) {
+      if (filePath.startsWith(pkg.path)) {
+        const pkgPath = relativePath(pkg.path, filePath);
+        if (!isPublishedPath(pkgPath)) {
+          break;
+        }
+        const entry = changedPackageMap.get(pkg.name);
+        if (entry) {
+          entry.files.push(pkgPath);
+        } else {
+          const pkgJson = require(resolvePath(pkg.path, 'package.json'));
+
+          changedPackageMap.set(pkg.name, {
+            ...pkg,
+            version: pkgJson.version,
+            isStable: !pkgJson.version.startsWith('0.'),
+            isPrivate: Boolean(pkgJson.private),
+            files: [pkgPath],
+          });
+        }
+        break;
+      }
+    }
+  }
+  return Array.from(changedPackageMap.values());
+}
+
+function formatSection(prefix = [], generator, suffix = ['']) {
+  const lines = Array.from(generator());
+  if (lines.length === 0) {
+    return '';
+  }
+
+  return [...[prefix].flat(), ...lines, ...[suffix].flat(), '', ''].join('\n');
+}
+
+function formatSummary(changedPackages, changesets) {
+  const changedNames = new Set(changedPackages.map(pkg => pkg.name));
+
+  let output = '';
+
+  output += formatSection(
+    `## Missing Changesets
+
+The following package(s) are changed by this PR but do not have a changeset:
+`,
+    function* section() {
+      for (const pkg of changedPackages) {
+        if (changesets.some(c => c.bumps.get(pkg.name))) {
+          continue;
+        }
+        if (pkg.isPrivate) {
+          continue;
+        }
+        yield `- **${pkg.name}**`;
+      }
+    },
+    `
+See [CONTRIBUTION.md](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets) for more information about how to add changesets.
+`,
+  );
+
+  output += formatSection(
+    `## Unexpected Changesets
+
+The following changeset(s) reference packages that have not been changed in this PR:
+`,
+    function* section() {
+      for (const c of changesets) {
+        const missing = Array.from(c.bumps.keys()).filter(
+          b => !changedNames.has(b),
+        );
+        if (missing.length > 0) {
+          yield `- **${c.filePath}**: ${missing.join(', ')}`;
+        }
+      }
+    },
+    `
+Note that only changes that affect the published package require changesets, for example changes to tests and storybook stories do not require changesets.
+`,
+  );
+
+  output += formatSection(
+    `## Unnecessary Changesets
+
+The following package(s) are private and do not need a changeset:
+`,
+    function* section() {
+      for (const pkg of changedPackages) {
+        if (changesets.some(c => c.bumps.get(pkg.name)) && pkg.isPrivate) {
+          yield `- **${pkg.name}**`;
+        }
+      }
+    },
+  );
+
+  output += formatSection(
+    `## Changed Packages
+
+| Package Name | Package Path | Changeset Bump | Current Version |
+|:-------------|:-------------|:--------------:|:----------------|`,
+    function* section() {
+      const bumpMap = {
+        undefined: -1,
+        patch: 0,
+        minor: 1,
+        major: 2,
+      };
+
+      for (const pkg of changedPackages) {
+        const maxBump =
+          changesets
+            .map(c => c.bumps.get(pkg.name))
+            .reduce(
+              (max, bump) => (bumpMap[bump] > bumpMap[max] ? bump : max),
+              undefined,
+            ) ?? 'none';
+        yield `| ${pkg.name} | ${pkg.path} | **${maxBump}** | \`v${pkg.version}\` |`;
+      }
+    },
+  );
+
+  return output;
+}
+
+async function main() {
+  const [diffRef = 'origin/master'] = process.argv.slice(2);
+  const changedFiles = await listChangedFiles(diffRef);
+  const packages = await listPackages();
+
+  const changesets = await parseChangesets(changedFiles);
+  const changedPackages = await listChangedPackages(changedFiles, packages);
+
+  process.stderr.write(
+    JSON.stringify(
+      {
+        changesets,
+        changedPackages,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const summary = formatSummary(changedPackages, changesets);
+  process.stdout.write(summary);
+}
+
+main().catch(error => {
+  console.error(error.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
Proposing this as a replacement for the changeset bot. This gives us a lot more control, and lets us provide a lot more precise feedback. The trigger for adding this was the realization that the existing package version is now going to be an important part of reviewing changeset additions.

Feedback looks something like this:

<img width="920" alt="image" src="https://user-images.githubusercontent.com/4984472/159496941-1dfeb8dc-90cf-444d-93a8-81ae7b53f210.png">

Or with a slightly different PR:

<img width="901" alt="image" src="https://user-images.githubusercontent.com/4984472/159497479-c2aee191-130c-40b3-a3bc-43cbe5424922.png">

Or if there are no changes that need changesets, it won't post anything! :grin: