### PR TITLE
fix(README): do not copy docs/README.md as docs/index.md

### DIFF
--- a/.changeset/swift-weeks-admire.md
+++ b/.changeset/swift-weeks-admire.md
@@ -1,0 +1,13 @@
+---
+'@techdocs/cli': minor
+'@backstage/plugin-techdocs-backend': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+BREAKING: The default Techdocs behavior will no longer attempt to copy `docs/README.md` or `README.md` to `docs/index.md` (if not found). To retain this behavior in your instance, you can set the following config in your `app-config.yaml`:
+
+```yaml
+techdocs:
+  generator:
+    legacyCopyReadmeMdToIndexMd: true
+```

--- a/.changeset/techdocs-swift-weeks-admire.md
+++ b/.changeset/techdocs-swift-weeks-admire.md
@@ -9,5 +9,6 @@ BREAKING: The default Techdocs behavior will no longer attempt to copy `docs/REA
 ```yaml
 techdocs:
   generator:
-    legacyCopyReadmeMdToIndexMd: true
+    mkdocs:
+      legacyCopyReadmeMdToIndexMd: true
 ```

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -132,6 +132,8 @@ Options:
                                   in techdocs_metadata.json.
   --omitTechdocsCoreMkdocsPlugin  An option to disable automatic addition of techdocs-core plugin to the mkdocs.yaml files.
                                   Defaults to false, which means that the techdocs-core plugin is always added to the mkdocs file.
+  --legacyCopyReadmeMdToIndexMd   Attempt to ensure an index.md exists falling back to using <docs-dir>/README.md or README.md
+                                  in case a default <docs-dir>/index.md is not provided. (default: false)
   -v --verbose                    Enable verbose output. (default: false)
   -h, --help                      display help for command
 ```

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -42,12 +42,12 @@ techdocs:
       # Defaults to false, which means that the techdocs-core plugin is always added to the mkdocs file.
       omitTechdocsCorePlugin: false
 
-    # (Optional and not recommended) Configures the techdocs generator to
-    # attempt to ensure an index.md exists falling back to using <docs-dir>/README.md
-    # or README.md in case a default <docs-dir>/index.md is not provided.
-    # Note that https://www.mkdocs.org/user-guide/configuration/#edit_uri behavior
-    # will be broken in these scenarios.
-    legacyCopyReadmeMdToIndexMd: false
+      # (Optional and not recommended) Configures the techdocs generator to
+      # attempt to ensure an index.md exists falling back to using <docs-dir>/README.md
+      # or README.md in case a default <docs-dir>/index.md is not provided.
+      # Note that https://www.mkdocs.org/user-guide/configuration/#edit_uri behavior
+      # will be broken in these scenarios.
+      legacyCopyReadmeMdToIndexMd: false
 
   # techdocs.builder can be either 'local' or 'external.
   # Using the default build strategy, if builder is set to 'local' and you open a TechDocs page,

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -42,6 +42,13 @@ techdocs:
       # Defaults to false, which means that the techdocs-core plugin is always added to the mkdocs file.
       omitTechdocsCorePlugin: false
 
+    # (Optional and not recommended) Configures the techdocs generator to
+    # attempt to ensure an index.md exists falling back to using <docs-dir>/README.md
+    # or README.md in case a default <docs-dir>/index.md is not provided.
+    # Note that https://www.mkdocs.org/user-guide/configuration/#edit_uri behavior
+    # will be broken in these scenarios.
+    legacyCopyReadmeMdToIndexMd: false
+
   # techdocs.builder can be either 'local' or 'external.
   # Using the default build strategy, if builder is set to 'local' and you open a TechDocs page,
   # techdocs-backend will try to generate the docs, publish to storage and show the generated docs afterwords.

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -42,6 +42,7 @@ export default async function generate(cmd: Command) {
   const omitTechdocsCorePlugin = cmd.omitTechdocsCoreMkdocsPlugin;
   const dockerImage = cmd.dockerImage;
   const pullImage = cmd.pull;
+  const legacyCopyReadmeMdToIndexMd = cmd.legacyCopyReadmeMdToIndexMd;
 
   logger.info(`Using source dir ${sourceDir}`);
   logger.info(`Will output generated files in ${outputDir}`);
@@ -56,6 +57,7 @@ export default async function generate(cmd: Command) {
         runIn: cmd.docker ? 'docker' : 'local',
         dockerImage,
         pullImage,
+        legacyCopyReadmeMdToIndexMd,
         mkdocs: {
           omitTechdocsCorePlugin,
         },

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -59,6 +59,11 @@ export function registerCommands(program: CommanderStatic) {
       "Don't patch MkDocs file automatically with techdocs-core plugin.",
       false,
     )
+    .option(
+      '--legacyCopyReadmeMdToIndexMd',
+      'Attempt to ensure an index.md exists falling back to using <docs-dir>/README.md or README.md in case a default <docs-dir>/index.md is not provided.',
+      false,
+    )
     .alias('build')
     .action(lazy(() => import('./generate/generate').then(m => m.default)));
 

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -44,6 +44,15 @@ export interface Config {
        * Pull the latest docker image
        */
       pullImage?: boolean;
+
+      /**
+       * (Optional and not recommended) Configures the techdocs generator to
+       * attempt to ensure an index.md exists falling back to using <docs-dir>/README.md
+       * or README.md in case a default <docs-dir>/index.md is not provided.
+       * Note that https://www.mkdocs.org/user-guide/configuration/#edit_uri behavior
+       * will be broken in these scenarios.
+       */
+      legacyCopyReadmeMdToIndexMd?: boolean;
     };
 
     /**

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -46,13 +46,18 @@ export interface Config {
       pullImage?: boolean;
 
       /**
-       * (Optional and not recommended) Configures the techdocs generator to
-       * attempt to ensure an index.md exists falling back to using <docs-dir>/README.md
-       * or README.md in case a default <docs-dir>/index.md is not provided.
-       * Note that https://www.mkdocs.org/user-guide/configuration/#edit_uri behavior
-       * will be broken in these scenarios.
+       * Override behavior specific to mkdocs.
        */
-      legacyCopyReadmeMdToIndexMd?: boolean;
+      mkdocs?: {
+        /**
+         * (Optional and not recommended) Configures the techdocs generator to
+         * attempt to ensure an index.md exists falling back to using <docs-dir>/README.md
+         * or README.md in case a default <docs-dir>/index.md is not provided.
+         * Note that https://www.mkdocs.org/user-guide/configuration/#edit_uri behavior
+         * will be broken in these scenarios.
+         */
+        legacyCopyReadmeMdToIndexMd?: boolean;
+      };
     };
 
     /**

--- a/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
@@ -145,7 +145,7 @@ describe('readGeneratorConfig', () => {
           runIn: 'docker',
           dockerImage: 'my-org/techdocs',
           pullImage: false,
-          legacyCopyReadmeMdToIndexMd: true,
+          mkdocs: { legacyCopyReadmeMdToIndexMd: true },
         },
       },
     });

--- a/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
@@ -137,4 +137,24 @@ describe('readGeneratorConfig', () => {
       );
     });
   });
+
+  it('should read legacyCopyReadmeMdToIndexMd config', () => {
+    const config = new ConfigReader({
+      techdocs: {
+        generator: {
+          runIn: 'docker',
+          dockerImage: 'my-org/techdocs',
+          pullImage: false,
+          legacyCopyReadmeMdToIndexMd: true,
+        },
+      },
+    });
+
+    expect(readGeneratorConfig(config, logger)).toEqual({
+      runIn: 'docker',
+      dockerImage: 'my-org/techdocs',
+      pullImage: false,
+      legacyCopyReadmeMdToIndexMd: true,
+    });
+  });
 });

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -222,7 +222,7 @@ export function readGeneratorConfig(
       'techdocs.generator.mkdocs.omitTechdocsCorePlugin',
     ),
     legacyCopyReadmeMdToIndexMd: config.getOptionalBoolean(
-      'techdocs.generator.legacyCopyReadmeMdToIndexMd',
+      'techdocs.generator.mkdocs.legacyCopyReadmeMdToIndexMd',
     ),
   };
 }

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -111,7 +111,10 @@ export class TechdocsGenerator implements GeneratorBase {
         parsedLocationAnnotation,
         this.scmIntegrations,
       );
-      await patchIndexPreBuild({ inputDir, logger: childLogger, docsDir });
+
+      if (this.options.legacyCopyReadmeMdToIndexMd) {
+        await patchIndexPreBuild({ inputDir, logger: childLogger, docsDir });
+      }
     }
 
     if (!this.options.omitTechdocsCoreMkdocsPlugin) {
@@ -217,6 +220,9 @@ export function readGeneratorConfig(
     pullImage: config.getOptionalBoolean('techdocs.generator.pullImage'),
     omitTechdocsCoreMkdocsPlugin: config.getOptionalBoolean(
       'techdocs.generator.mkdocs.omitTechdocsCorePlugin',
+    ),
+    legacyCopyReadmeMdToIndexMd: config.getOptionalBoolean(
+      'techdocs.generator.legacyCopyReadmeMdToIndexMd',
     ),
   };
 }

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -40,6 +40,7 @@ export type GeneratorConfig = {
   dockerImage?: string;
   pullImage?: boolean;
   omitTechdocsCoreMkdocsPlugin?: boolean;
+  legacyCopyReadmeMdToIndexMd?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Reviving the abandoned change from https://github.com/backstage/backstage/pull/8541 (cc: @ryanmrodriguez).

I believe the original fix from that change is correct (though unfortunate that it is breaking behavior). My thinking here is that though ensuring `index.md` exists by copying it from root is useful, it is currently not a fully functional feature since we found that mkdocs [edit_uri](https://www.mkdocs.org/user-guide/configuration/#edit_uri) is broken in these scenarios since it will point to a non-existent file. By relying on the native support for `docs/README.md`, mkdocs will instrument edit links correctly. 

Alternatively, if we don't want to go with a breaking change, perhaps the solution should be to expose an option for Backstage integrators to enable/disable this functionality (eg. an option in `app-config.yaml`) since potentially configuring `mkdocs.yml` to rely on essentially a techdocs "hack" doesn't feel correct. 

~Also snuck in a small change to render entity titles in the UI if defined :)~ 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
