### PR TITLE
workflows: more tweaks to the changeset feedback automation

### DIFF
--- a/.github/workflows/automate_changeset_feedback.yml
+++ b/.github/workflows/automate_changeset_feedback.yml
@@ -16,17 +16,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.head_ref }}
+          # Fetch the commit that's merged into the base rather than the target ref
+          # This will let us diff only the contents of the PR, without fetching more history
+          ref: 'refs/pull/${{ github.event.pull_request.number }}/merge'
 
       - name: fetch base
-        run: git fetch origin ${{ github.base_ref }}
+        run: git fetch --depth 1 origin ${{ github.base_ref }}
 
         # We avoid using the in-source script since this workflow has elevated permissions that we don't want to expose
       - name: Generate Feedback
         id: generate-feedback
         run: |
           wget -O generate.js https://raw.githubusercontent.com/backstage/backstage/master/scripts/generate-changeset-feedback.js 1>&2
-          node generate.js origin/${{ github.base_ref }} > feedback.txt
+          node generate.js FETCH_HEAD > feedback.txt
 
       - name: Post Feedback
         uses: actions/github-script@v5

--- a/.github/workflows/automate_changeset_feedback.yml
+++ b/.github/workflows/automate_changeset_feedback.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   feedback:
@@ -33,7 +34,6 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ github.event.pull_request.number }}
         with:
-          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
           script: |
             const owner = "backstage";
             const repo = "backstage";


### PR DESCRIPTION
Couple more tweaks on top of #10391. I'm trying a switch back to the bot account, turns out `pull-requests: write` might've fixed it. Feeling that's better than using the service account for this one.

Also fixed the diff so that it only diffs the actual contents of the PR, rather than PR head vs tip of master. And so that removing changesets doesn't bork the script