### PR TITLE
[TechDocs] Adds a flag to the cli to override the entrypoint of a custom docker image. It could be used to reuse existing images with different entrypoints.

### DIFF
--- a/.changeset/techdocs-fresh-panthers-kick.md
+++ b/.changeset/techdocs-fresh-panthers-kick.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Adds a new flag to override the entrypoint when using a custom docker image. It could be used to reuse existing images with different entrypoints.

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -71,7 +71,7 @@ implementation, which uses the MkDocs preview server as a proxy to fetch the
 generated documentation files and assets.
 
 NOTE: When using a custom `techdocs` docker image, make sure the entry point is
-also `ENTRYPOINT ["mkdocs"]`.
+also `ENTRYPOINT ["mkdocs"]` or override with `--docker-entrypoint`.
 
 Command reference:
 
@@ -81,11 +81,12 @@ Usage: techdocs-cli serve [options]
 Serve a documentation project locally in a Backstage app-like environment
 
 Options:
-  -i, --docker-image <DOCKER_IMAGE>  The mkdocs docker container to use (default: "spotify/techdocs")
-  --no-docker                        Do not use Docker, use MkDocs executable in current user environment.
-  --mkdocs-port <PORT>               Port for MkDocs server to use (default: "8000")
-  -v --verbose                       Enable verbose output. (default: false)
-  -h, --help                         display help for command
+  -i, --docker-image <DOCKER_IMAGE>        The mkdocs docker container to use (default: "spotify/techdocs")
+  --docker-entrypoint <DOCKER_ENTRYPOINT>  Override the image entrypoint
+  --no-docker                              Do not use Docker, use MkDocs executable in current user environment.
+  --mkdocs-port <PORT>                     Port for MkDocs server to use (default: "8000")
+  -v --verbose                             Enable verbose output. (default: false)
+  -h, --help                               display help for command
 ```
 
 ### Generate TechDocs site from a documentation project

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -207,6 +207,10 @@ export function registerCommands(program: CommanderStatic) {
       defaultDockerImage,
     )
     .option(
+      '--docker-entrypoint <DOCKER_ENTRYPOINT>',
+      'Override the image entrypoint',
+    )
+    .option(
       '--no-docker',
       'Do not use Docker, run `mkdocs serve` in current user environment.',
     )
@@ -223,6 +227,10 @@ export function registerCommands(program: CommanderStatic) {
       '-i, --docker-image <DOCKER_IMAGE>',
       'The mkdocs docker container to use',
       defaultDockerImage,
+    )
+    .option(
+      '--docker-entrypoint <DOCKER_ENTRYPOINT>',
+      'Override the image entrypoint',
     )
     .option(
       '--no-docker',

--- a/packages/techdocs-cli/src/commands/serve/mkdocs.ts
+++ b/packages/techdocs-cli/src/commands/serve/mkdocs.ts
@@ -61,6 +61,7 @@ export default async function serveMkdocs(cmd: Command) {
   const childProcess = await runMkdocsServer({
     port: cmd.port,
     dockerImage: cmd.dockerImage,
+    dockerEntrypoint: cmd.dockerEntrypoint,
     useDocker: cmd.docker,
     stdoutLogFunc: logFunc,
     stderrLogFunc: logFunc,

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -90,6 +90,7 @@ export default async function serve(cmd: Command) {
   const mkdocsChildProcess = await runMkdocsServer({
     port: cmd.mkdocsPort,
     dockerImage: cmd.dockerImage,
+    dockerEntrypoint: cmd.dockerEntrypoint,
     useDocker: cmd.docker,
     stdoutLogFunc: mkdocsLogFunc,
     stderrLogFunc: mkdocsLogFunc,

--- a/packages/techdocs-cli/src/lib/mkdocsServer.ts
+++ b/packages/techdocs-cli/src/lib/mkdocsServer.ts
@@ -21,6 +21,7 @@ export const runMkdocsServer = async (options: {
   port?: string;
   useDocker?: boolean;
   dockerImage?: string;
+  dockerEntrypoint?: string;
   stdoutLogFunc?: LogFunc;
   stderrLogFunc?: LogFunc;
 }): Promise<ChildProcess> => {
@@ -41,6 +42,9 @@ export const runMkdocsServer = async (options: {
         '-p',
         `${port}:${port}`,
         '-it',
+        ...(options.dockerEntrypoint
+          ? ['--entrypoint', options.dockerEntrypoint]
+          : []),
         dockerImage,
         'serve',
         '--dev-addr',


### PR DESCRIPTION
Signed-off-by: Carlo Colombo <carlo.colombo@klarna.com>

Adding a custom entrypoint it allow us to reuse our docker images (the one we use to deploy backstage or in the future a jenkins agent) in our documentation for techdocs adoption in the company.

I left out this option from the `generate` command as I think it's usally used locally or with a custom image with `mkdocs` as entrypoint.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
