### PR TITLE
Support creating draft GitHub prs

### DIFF
--- a/.changeset/moody-ducks-return.md
+++ b/.changeset/moody-ducks-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Add new option to create draft GitHub PRs

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -251,6 +251,7 @@ export const createPublishGithubPullRequestAction: ({
   branchName: string;
   description: string;
   repoUrl: string;
+  draft?: boolean | undefined;
   targetPath?: string | undefined;
   sourcePath?: string | undefined;
   token?: string | undefined;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.test.ts
@@ -85,6 +85,7 @@ describe('createPublishGithubPullRequestAction', () => {
         title: 'Create my new app',
         branchName: 'new-app',
         description: 'This PR is really good',
+        draft: true,
       };
 
       mockFs({
@@ -109,6 +110,7 @@ describe('createPublishGithubPullRequestAction', () => {
         title: 'Create my new app',
         head: 'new-app',
         body: 'This PR is really good',
+        draft: true,
         changes: [
           {
             commit: 'Create my new app',

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -114,6 +114,7 @@ export const createPublishGithubPullRequestAction = ({
     title: string;
     branchName: string;
     description: string;
+    draft?: boolean;
     repoUrl: string;
     targetPath?: string;
     sourcePath?: string;
@@ -144,6 +145,11 @@ export const createPublishGithubPullRequestAction = ({
             type: 'string',
             title: 'Pull Request Description',
             description: 'The description of the pull request',
+          },
+          draft: {
+            type: 'boolean',
+            title: 'Create as Draft',
+            description: 'Create a draft pull request',
           },
           sourcePath: {
             type: 'string',
@@ -186,6 +192,7 @@ export const createPublishGithubPullRequestAction = ({
         branchName,
         title,
         description,
+        draft,
         targetPath,
         sourcePath,
         token: providedToken,
@@ -264,6 +271,7 @@ export const createPublishGithubPullRequestAction = ({
           changes,
           body: description,
           head: branchName,
+          draft,
         });
 
         if (!response) {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/githubPullRequest.ts
@@ -114,8 +114,8 @@ export const createPublishGithubPullRequestAction = ({
     title: string;
     branchName: string;
     description: string;
-    draft?: boolean;
     repoUrl: string;
+    draft?: boolean;
     targetPath?: string;
     sourcePath?: string;
     token?: string;


### PR DESCRIPTION
Signed-off-by: Simon Gellis <sgellis@attentivemobile.com>

## Hey, I just made a Pull Request!

Support passing a "draft" flag to this octokit package.

My org is trying to automate service onboarding, but requires a few manual steps for it. We'd like to create draft PRs, with a set of changes needed and instructions on how to perform the manual steps before fully opening them.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
