### PR TITLE
backend-test-utils: avoid cleanup if no databases are supported

### DIFF
--- a/.changeset/pretty-ghosts-scream.md
+++ b/.changeset/pretty-ghosts-scream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+`TestDatabases.create` will no longer set up an `afterAll` test handler if no databases are supported.

--- a/packages/backend-test-utils/src/database/TestDatabases.ts
+++ b/packages/backend-test-utils/src/database/TestDatabases.ts
@@ -91,9 +91,11 @@ export class TestDatabases {
 
     const databases = new TestDatabases(supportedIds);
 
-    afterAll(async () => {
-      await databases.shutdown();
-    });
+    if (supportedIds.length > 0) {
+      afterAll(async () => {
+        await databases.shutdown();
+      });
+    }
 
     return databases;
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Jest complains about `describe` blocks with no tests and an `afterAll` call, which is a situation you can end up in with some test database setups. This fixes that by skipping the `afterAll` call if there are no databases that we support.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
