### PR TITLE
docs: update custom field extensions writing guide

### DIFF
--- a/docs/features/software-templates/writing-custom-field-extensions.md
+++ b/docs/features/software-templates/writing-custom-field-extensions.md
@@ -96,7 +96,7 @@ export const MyCustomFieldExtension = plugin.provide(
 ```tsx
 // packages/app/src/scaffolder/MyCustomExtension/index.ts
 
-export { MyCustomFieldExtension } from './extension';
+export { MyCustomFieldExtension } from './extensions';
 ```
 
 Once all these files are in place, you then need to provide your custom
@@ -119,6 +119,8 @@ Should look something like this instead:
 
 ```tsx
 import { MyCustomFieldExtension } from './scaffolder/MyCustomExtension';
+import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder';
+
 const routes = (
   <FlatRoutes>
     ...


### PR DESCRIPTION
This PR does:
- Fix mismatch of `/extension` vs `/extensions` import, should be plural.
- Add missing import for `ScaffolderFieldExtensions` to make it clear where it comes from.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
