### PR TITLE
workflows: tweak e2e test paths

### DIFF
--- a/.github/workflows/verify_e2e-techdocs.yml
+++ b/.github/workflows/verify_e2e-techdocs.yml
@@ -2,14 +2,11 @@ name: E2E Test Techdocs
 on:
   pull_request:
     paths:
+      - 'yarn.lock'
+      - '.github/workflows/verify_e2e-techdocs.yml'
       - 'packages/techdocs-cli/**'
       - 'packages/techdocs-cli-embedded-app/**'
       - 'plugins/techdocs/**'
-    paths-ignore:
-      - '.changeset/**'
-      - 'contrib/**'
-      - 'docs/**'
-      - 'microsite/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/verify_e2e-windows.yml
+++ b/.github/workflows/verify_e2e-windows.yml
@@ -5,6 +5,7 @@ name: E2E Test Windows
 on:
   pull_request:
     paths:
+      - 'yarn.lock'
       - '.github/workflows/verify_e2e-windows.yml'
       - 'packages/cli/**'
       - 'packages/e2e-test/**'


### PR DESCRIPTION
🧹 

Only one of `paths` and `paths-ignore` can be used at a time.

Figured we add `yarn.lock` to all e2e tests as well, to make sure breakages don't sneak in