### PR TITLE
Fix issue with stale data when switching between radars

### DIFF
--- a/.changeset/silly-llamas-relax.md
+++ b/.changeset/silly-llamas-relax.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Fix an issue where the Radar is not updated when switching between different radars

--- a/plugins/tech-radar/src/components/RadarComponent.tsx
+++ b/plugins/tech-radar/src/components/RadarComponent.tsx
@@ -28,7 +28,7 @@ const useTechRadarLoader = (id: string | undefined) => {
 
   const { error, value, loading } = useAsync(
     async () => techRadarApi.load(id),
-    [techRadarApi],
+    [techRadarApi, id],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Signed-off-by: Leon <leonvanginneken@gmail.com>

## Hey, I just made a Pull Request!

At our company, we now have two Tech Radars in two separate tabs. We noticed that when switching between these tabs, the data in the Tech Radar is not updated. This small change fixes that.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
