### PR TITLE
migrate entity pages to use relative routes for react-router v6 stable compatibility

### DIFF
--- a/.changeset/flat-walls-kiss.md
+++ b/.changeset/flat-walls-kiss.md
@@ -1,0 +1,27 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated the entity page routes to use relative routes rather than absolute ones. This change is required to be able to upgrade to `react-router` v6 stable in the future.
+
+To apply this change to an existing app, update the path prop of `EntityLayout.Route`s to be relative. For example:
+
+```diff
+   <EntityLayoutWrapper>
+-    <EntityLayout.Route path="/" title="Overview">
++    <EntityLayout.Route path="." title="Overview">
+       {overviewContent}
+     </EntityLayout.Route>
+
+-    <EntityLayout.Route path="/ci-cd" title="CI/CD">
++    <EntityLayout.Route path="ci-cd" title="CI/CD">
+       {cicdContent}
+     </EntityLayout.Route>
+
+-    <EntityLayout.Route path="/errors" title="Errors">
++    <EntityLayout.Route path="errors" title="Errors">
+       {errorsContent}
+     </EntityLayout.Route>
+```
+
+This change should also be applied to any other usage of `TabbedLayout`.

--- a/.changeset/good-avocados-grow.md
+++ b/.changeset/good-avocados-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': minor
+---
+
+Updated the routing system to be compatible with `react-router` v6 stable.

--- a/.changeset/itchy-owls-rescue.md
+++ b/.changeset/itchy-owls-rescue.md
@@ -1,0 +1,13 @@
+---
+'@backstage/create-app': patch
+---
+
+Update the setup of the app routes in the template to wrap the `<Navigate .../>` redirect in a `<Route .../>`, as this will be required in `react-router` v6 stable.
+
+To apply this change to an existing app, make the following change to `packages/app/src/App.tsx`:
+
+```diff
+   <FlatRoutes>
+-    <Navigate key="/" to="catalog" />
++    <Route path="/" element={<Navigate to="catalog" />} />
+```

--- a/.changeset/old-lemons-switch.md
+++ b/.changeset/old-lemons-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+The `RoutedTabs` component has been updated to be compatible with `react-router` v6 stable.

--- a/.changeset/tall-trains-remain.md
+++ b/.changeset/tall-trains-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': minor
+---
+
+Updated `FlatRoutes` to be compatible with `react-router` v6 stable.

--- a/.changeset/violet-steaks-knock.md
+++ b/.changeset/violet-steaks-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Added missing `Routes` element to wrap the `Route` elements of the test app wrapping.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -130,7 +130,7 @@ const AppRouter = app.getRouter();
 
 const routes = (
   <FlatRoutes>
-    <Navigate key="/" to="catalog" />
+    <Route path="/" element={<Navigate to="catalog" />} />
     {/* TODO(rubenl): Move this to / once its more mature and components exist */}
     <Route path="/home" element={<HomepageCompositionRoot />}>
       {homePage}

--- a/packages/app/src/components/catalog/EntityPage.test.tsx
+++ b/packages/app/src/components/catalog/EntityPage.test.tsx
@@ -64,7 +64,7 @@ describe('EntityPage Test', () => {
         >
           <EntityProvider entity={entity}>
             <EntityLayout>
-              <EntityLayout.Route path="/ci-cd" title="CI-CD">
+              <EntityLayout.Route path="ci-cd" title="CI-CD">
                 {cicdContent}
               </EntityLayout.Route>
             </EntityLayout>

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -362,19 +362,19 @@ const overviewContent = (
 
 const serviceEntityPage = (
   <EntityLayoutWrapper>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       {overviewContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/ci-cd" title="CI/CD">
+    <EntityLayout.Route path="ci-cd" title="CI/CD">
       {cicdContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/errors" title="Errors">
+    <EntityLayout.Route path="errors" title="Errors">
       {errorsContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/api" title="API">
+    <EntityLayout.Route path="api" title="API">
       <Grid container spacing={3} alignItems="stretch">
         <Grid item xs={12} md={6}>
           <EntityProvidedApisCard />
@@ -385,7 +385,7 @@ const serviceEntityPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/dependencies" title="Dependencies">
+    <EntityLayout.Route path="dependencies" title="Dependencies">
       <Grid container spacing={3} alignItems="stretch">
         <Grid item xs={12} md={6}>
           <EntityDependsOnComponentsCard variant="gridItem" />
@@ -396,39 +396,39 @@ const serviceEntityPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs">
+    <EntityLayout.Route path="docs" title="Docs">
       <EntityTechdocsContent />
     </EntityLayout.Route>
 
     <EntityLayout.Route
       if={isNewRelicDashboardAvailable}
-      path="/newrelic-dashboard"
+      path="newrelic-dashboard"
       title="New Relic Dashboard"
     >
       <EntityNewRelicDashboardContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/kubernetes" title="Kubernetes">
+    <EntityLayout.Route path="kubernetes" title="Kubernetes">
       <EntityKubernetesContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/pull-requests" title="Pull Requests">
+    <EntityLayout.Route path="pull-requests" title="Pull Requests">
       {pullRequestsContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/code-insights" title="Code Insights">
+    <EntityLayout.Route path="code-insights" title="Code Insights">
       <EntityGithubInsightsContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/code-coverage" title="Code Coverage">
+    <EntityLayout.Route path="code-coverage" title="Code Coverage">
       <EntityCodeCoverageContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/kafka" title="Kafka">
+    <EntityLayout.Route path="kafka" title="Kafka">
       <EntityKafkaContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/todos" title="TODOs">
+    <EntityLayout.Route path="todos" title="TODOs">
       <EntityTodoContent />
     </EntityLayout.Route>
   </EntityLayoutWrapper>
@@ -436,23 +436,23 @@ const serviceEntityPage = (
 
 const websiteEntityPage = (
   <EntityLayoutWrapper>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       {overviewContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/ci-cd" title="CI/CD">
+    <EntityLayout.Route path="ci-cd" title="CI/CD">
       {cicdContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/lighthouse" title="Lighthouse">
+    <EntityLayout.Route path="lighthouse" title="Lighthouse">
       <EntityLighthouseContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/errors" title="Errors">
+    <EntityLayout.Route path="errors" title="Errors">
       {errorsContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/dependencies" title="Dependencies">
+    <EntityLayout.Route path="dependencies" title="Dependencies">
       <Grid container spacing={3} alignItems="stretch">
         <Grid item md={6}>
           <EntityDependsOnComponentsCard variant="gridItem" />
@@ -463,34 +463,34 @@ const websiteEntityPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs">
+    <EntityLayout.Route path="docs" title="Docs">
       <EntityTechdocsContent />
     </EntityLayout.Route>
     <EntityLayout.Route
       if={isNewRelicDashboardAvailable}
-      path="/newrelic-dashboard"
+      path="newrelic-dashboard"
       title="New Relic Dashboard"
     >
       <EntityNewRelicDashboardContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/kubernetes" title="Kubernetes">
+    <EntityLayout.Route path="kubernetes" title="Kubernetes">
       <EntityKubernetesContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/pull-requests" title="Pull Requests">
+    <EntityLayout.Route path="pull-requests" title="Pull Requests">
       {pullRequestsContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/code-insights" title="Code Insights">
+    <EntityLayout.Route path="code-insights" title="Code Insights">
       <EntityGithubInsightsContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/code-coverage" title="Code Coverage">
+    <EntityLayout.Route path="code-coverage" title="Code Coverage">
       <EntityCodeCoverageContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/todos" title="TODOs">
+    <EntityLayout.Route path="todos" title="TODOs">
       <EntityTodoContent />
     </EntityLayout.Route>
   </EntityLayoutWrapper>
@@ -498,15 +498,15 @@ const websiteEntityPage = (
 
 const defaultEntityPage = (
   <EntityLayoutWrapper>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       {overviewContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs">
+    <EntityLayout.Route path="docs" title="Docs">
       <EntityTechdocsContent />
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/todos" title="TODOs">
+    <EntityLayout.Route path="todos" title="TODOs">
       <EntityTodoContent />
     </EntityLayout.Route>
   </EntityLayoutWrapper>
@@ -528,7 +528,7 @@ const componentPage = (
 
 const apiPage = (
   <EntityLayoutWrapper>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3}>
         {entityWarningContent}
         <Grid item md={6} xs={12}>
@@ -550,7 +550,7 @@ const apiPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/definition" title="Definition">
+    <EntityLayout.Route path="definition" title="Definition">
       <Grid container spacing={3}>
         <Grid item xs={12}>
           <EntityApiDefinitionCard />
@@ -562,7 +562,7 @@ const apiPage = (
 
 const userPage = (
   <EntityLayoutWrapper>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3}>
         {entityWarningContent}
         <Grid item xs={12} md={6}>
@@ -581,7 +581,7 @@ const userPage = (
 
 const groupPage = (
   <EntityLayoutWrapper>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3}>
         {entityWarningContent}
         <Grid item xs={12} md={6}>
@@ -603,7 +603,7 @@ const groupPage = (
 
 const systemPage = (
   <EntityLayoutWrapper>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3} alignItems="stretch">
         {entityWarningContent}
         <Grid item md={6}>
@@ -623,7 +623,7 @@ const systemPage = (
         </Grid>
       </Grid>
     </EntityLayout.Route>
-    <EntityLayout.Route path="/diagram" title="Diagram">
+    <EntityLayout.Route path="diagram" title="Diagram">
       <EntityCatalogGraphCard
         variant="gridItem"
         direction={Direction.TOP_BOTTOM}
@@ -647,7 +647,7 @@ const systemPage = (
 
 const domainPage = (
   <EntityLayoutWrapper>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3} alignItems="stretch">
         {entityWarningContent}
         <Grid item md={6}>

--- a/packages/core-app-api/src/routing/FlatRoutes.tsx
+++ b/packages/core-app-api/src/routing/FlatRoutes.tsx
@@ -18,6 +18,8 @@ import React, { ReactNode } from 'react';
 import { useRoutes } from 'react-router-dom';
 import { useApp, useElementFilter } from '@backstage/core-plugin-api';
 
+let warned = false;
+
 type RouteObject = {
   path: string;
   element: ReactNode;
@@ -49,7 +51,11 @@ export const FlatRoutes = (props: FlatRoutesProps): JSX.Element | null => {
   const { NotFoundErrorPage } = app.getComponents();
   const routes = useElementFilter(props.children, elements =>
     elements
-      .getElements<{ path?: string; children: ReactNode }>()
+      .getElements<{
+        path?: string;
+        element?: ReactNode;
+        children?: ReactNode;
+      }>()
       .flatMap<RouteObject>(child => {
         let path = child.props.path;
 
@@ -59,16 +65,30 @@ export const FlatRoutes = (props: FlatRoutesProps): JSX.Element | null => {
         }
         path = path?.replace(/\/\*$/, '') ?? '/';
 
+        let element = child.props.element;
+        if (!element) {
+          element = child;
+          if (!warned && process.env.NODE_ENV !== 'test') {
+            // eslint-disable-next-line no-console
+            console.warn(
+              'DEPRECATION WARNING: All elements within <FlatRoutes> must be of type <Route> with an element prop. ' +
+                'Existing usages of <Navigate key=[path] to=[to] /> should be replaced with <Route path=[path] element=<Navigate to=[to] /> />',
+            );
+            warned = true;
+          }
+        }
+
         return [
           {
+            // Each route matches any sub route, except for the explicit root path
             path,
-            element: child,
+            element,
             children: child.props.children
               ? [
                   // These are the children of each route, which we all add in under a catch-all
                   // subroute in order to make them available to `useOutlet`
                   {
-                    path: path === '/' ? '/' : '/*', // The root path must require an exact match
+                    path: path === '/' ? '/' : '*', // The root path must require an exact match
                     element: child.props.children,
                   },
                 ]
@@ -77,19 +97,19 @@ export const FlatRoutes = (props: FlatRoutesProps): JSX.Element | null => {
         ];
       })
       // Routes are sorted to work around a bug where prefixes are unexpectedly matched
+      // TODO(Rugvip): This can be removed once react-router v6 beta is no longer supported
       .sort((a, b) => b.path.localeCompare(a.path))
-      // We make sure all routes have '/*' appended, except '/'
-      .map(obj => {
-        obj.path = obj.path === '/' ? '/' : `${obj.path}/*`;
-        return obj;
-      }),
+      .map(obj => ({ ...obj, path: obj.path === '/' ? '/' : `${obj.path}/*` })),
   );
 
   // TODO(Rugvip): Possibly add a way to skip this, like a noNotFoundPage prop
-  routes.push({
-    element: <NotFoundErrorPage />,
-    path: '/*',
-  });
+  const withNotFound = [
+    ...routes,
+    {
+      path: '/*',
+      element: <NotFoundErrorPage />,
+    },
+  ];
 
-  return useRoutes(routes);
+  return useRoutes(withNotFound);
 };

--- a/packages/core-app-api/src/routing/collectors.test.tsx
+++ b/packages/core-app-api/src/routing/collectors.test.tsx
@@ -113,7 +113,7 @@ function routeObj(
     routeRefs: new Set(refs),
     children: [
       {
-        path: '/*',
+        path: '*',
         caseSensitive: false,
         element: 'match-all',
         routeRefs: new Set(),

--- a/packages/core-app-api/src/routing/collectors.tsx
+++ b/packages/core-app-api/src/routing/collectors.tsx
@@ -120,7 +120,7 @@ export const routeParentCollector = createCollector(
 // mount points that are as deep in the routing tree as possible.
 export const MATCH_ALL_ROUTE: BackstageRouteObject = {
   caseSensitive: false,
-  path: '/*',
+  path: '*',
   element: 'match-all', // These elements aren't used, so we add in a bit of debug information
   routeRefs: new Set(),
 };

--- a/packages/core-components/src/components/TabbedLayout/RoutedTabs.test.tsx
+++ b/packages/core-components/src/components/TabbedLayout/RoutedTabs.test.tsx
@@ -32,7 +32,7 @@ const testRoute2 = {
 
 const testRoute3 = {
   title: 'tabbed-test-title-3',
-  path: '/some-other-path-similar',
+  path: 'some-other-path-similar',
   children: <div>tabbed-test-content-3</div>,
 };
 

--- a/packages/core-components/src/components/TabbedLayout/RoutedTabs.tsx
+++ b/packages/core-components/src/components/TabbedLayout/RoutedTabs.tsx
@@ -41,7 +41,15 @@ export function useSelectedSubRoute(subRoutes: SubRoute[]): {
 
   const element = useRoutes(sortedRoutes) ?? subRoutes[0].children;
 
-  const [matchedRoute] = matchRoutes(sortedRoutes, `/${params['*']}`) ?? [];
+  // TODO(Rugvip): Once we only support v6 stable we can always prefix
+  // This avoids having a double / prefix for react-router v6 beta, which in turn breaks
+  // the tab highlighting when using relative paths for the tabs.
+  let currentRoute = params['*'] ?? '';
+  if (!currentRoute.startsWith('/')) {
+    currentRoute = `/${currentRoute}`;
+  }
+
+  const [matchedRoute] = matchRoutes(sortedRoutes, currentRoute) ?? [];
   const foundIndex = matchedRoute
     ? subRoutes.findIndex(t => `${t.path}/*` === matchedRoute.route.path)
     : 0;

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -56,7 +56,7 @@ const AppRouter = app.getRouter();
 
 const routes = (
   <FlatRoutes>
-    <Navigate key="/" to="catalog" />
+    <Route path="/" element={<Navigate to="catalog" />} />
     <Route path="/catalog" element={<CatalogIndexPage />} />
     <Route
       path="/catalog/:namespace/:kind/:name"

--- a/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/components/catalog/EntityPage.tsx
@@ -136,15 +136,15 @@ const overviewContent = (
 
 const serviceEntityPage = (
   <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       {overviewContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/ci-cd" title="CI/CD">
+    <EntityLayout.Route path="ci-cd" title="CI/CD">
       {cicdContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/api" title="API">
+    <EntityLayout.Route path="api" title="API">
       <Grid container spacing={3} alignItems="stretch">
         <Grid item md={6}>
           <EntityProvidedApisCard />
@@ -155,7 +155,7 @@ const serviceEntityPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/dependencies" title="Dependencies">
+    <EntityLayout.Route path="dependencies" title="Dependencies">
       <Grid container spacing={3} alignItems="stretch">
         <Grid item md={6}>
           <EntityDependsOnComponentsCard variant="gridItem" />
@@ -166,7 +166,7 @@ const serviceEntityPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs">
+    <EntityLayout.Route path="docs" title="Docs">
       <EntityTechdocsContent />
     </EntityLayout.Route>
   </EntityLayout>
@@ -174,15 +174,15 @@ const serviceEntityPage = (
 
 const websiteEntityPage = (
   <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       {overviewContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/ci-cd" title="CI/CD">
+    <EntityLayout.Route path="ci-cd" title="CI/CD">
       {cicdContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/dependencies" title="Dependencies">
+    <EntityLayout.Route path="dependencies" title="Dependencies">
       <Grid container spacing={3} alignItems="stretch">
         <Grid item md={6}>
           <EntityDependsOnComponentsCard variant="gridItem" />
@@ -193,7 +193,7 @@ const websiteEntityPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs">
+    <EntityLayout.Route path="docs" title="Docs">
       <EntityTechdocsContent />
     </EntityLayout.Route>
   </EntityLayout>
@@ -208,11 +208,11 @@ const websiteEntityPage = (
 
 const defaultEntityPage = (
   <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       {overviewContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/docs" title="Docs">
+    <EntityLayout.Route path="docs" title="Docs">
       <EntityTechdocsContent />
     </EntityLayout.Route>
   </EntityLayout>
@@ -234,7 +234,7 @@ const componentPage = (
 
 const apiPage = (
   <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3}>
         {entityWarningContent}
         <Grid item md={6}>
@@ -257,7 +257,7 @@ const apiPage = (
       </Grid>
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/definition" title="Definition">
+    <EntityLayout.Route path="definition" title="Definition">
       <Grid container spacing={3}>
         <Grid item xs={12}>
           <EntityApiDefinitionCard />
@@ -269,7 +269,7 @@ const apiPage = (
 
 const userPage = (
   <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3}>
         {entityWarningContent}
         <Grid item xs={12} md={6}>
@@ -285,7 +285,7 @@ const userPage = (
 
 const groupPage = (
   <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3}>
         {entityWarningContent}
         <Grid item xs={12} md={6}>
@@ -304,7 +304,7 @@ const groupPage = (
 
 const systemPage = (
   <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3} alignItems="stretch">
         {entityWarningContent}
         <Grid item md={6}>
@@ -324,7 +324,7 @@ const systemPage = (
         </Grid>
       </Grid>
     </EntityLayout.Route>
-    <EntityLayout.Route path="/diagram" title="Diagram">
+    <EntityLayout.Route path="diagram" title="Diagram">
       <EntityCatalogGraphCard
         variant="gridItem"
         direction={Direction.TOP_BOTTOM}
@@ -348,7 +348,7 @@ const systemPage = (
 
 const domainPage = (
   <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
+    <EntityLayout.Route path="." title="Overview">
       <Grid container spacing={3} alignItems="stretch">
         {entityWarningContent}
         <Grid item md={6}>

--- a/packages/test-utils/src/testUtils/appWrappers.tsx
+++ b/packages/test-utils/src/testUtils/appWrappers.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { ComponentType, ReactNode, ReactElement } from 'react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Routes } from 'react-router';
 import { Route } from 'react-router-dom';
 import { lightTheme } from '@backstage/theme';
 import { ThemeProvider } from '@material-ui/core/styles';
@@ -69,6 +69,8 @@ const BootErrorPage = ({ step, error }: BootErrorPageProps) => {
   throw new Error(`Reached BootError Page at step ${step} with error ${error}`);
 };
 const Progress = () => <div data-testid="progress" />;
+
+const NoRender = (_props: { children: ReactNode }) => null;
 
 /**
  * Options to customize the behavior of the test app wrapper.
@@ -190,10 +192,12 @@ export function wrapInTestApp(
   return (
     <AppProvider>
       <AppRouter>
-        {routeElements}
+        <NoRender>{routeElements}</NoRender>
         {/* The path of * here is needed to be set as a catch all, so it will render the wrapper element
          *  and work with nested routes if they exist too */}
-        <Route path="*" element={wrappedElement} />
+        <Routes>
+          <Route path="/*" element={wrappedElement} />
+        </Routes>
       </AppRouter>
     </AppProvider>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

More work towards #9913, on top of #10450

This migrates the absolute entity paths to be relative, which we'll for react-router v6 stable

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
