### PR TITLE
feat: export `locationSpecToLocationEntity`

### DIFF
--- a/.changeset/short-knives-wave.md
+++ b/.changeset/short-knives-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+export `locationSpecToLocationEntity`

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -16,6 +16,7 @@ import { Entity } from '@backstage/catalog-model';
 import { EntityPolicy } from '@backstage/catalog-model';
 import { GetEntitiesRequest } from '@backstage/catalog-client';
 import { JsonValue } from '@backstage/types';
+import { LocationEntityV1alpha1 } from '@backstage/catalog-model';
 import { Logger } from 'winston';
 import { Permission } from '@backstage/plugin-permission-common';
 import { PermissionAuthorizer } from '@backstage/plugin-permission-common';
@@ -457,6 +458,12 @@ export type LocationSpec = {
   target: string;
   presence?: 'optional' | 'required';
 };
+
+// @public (undocumented)
+export function locationSpecToLocationEntity(opts: {
+  location: LocationSpec;
+  parentEntity?: Entity;
+}): LocationEntityV1alpha1;
 
 // @public (undocumented)
 export function parseEntityYaml(

--- a/plugins/catalog-backend/src/modules/core/ConfigLocationEntityProvider.ts
+++ b/plugins/catalog-backend/src/modules/core/ConfigLocationEntityProvider.ts
@@ -60,8 +60,10 @@ export class ConfigLocationEntityProvider implements EntityProvider {
       const type = location.getString('type');
       const target = location.getString('target');
       const entity = locationSpecToLocationEntity({
-        type,
-        target: type === 'file' ? path.resolve(target) : target,
+        location: {
+          type,
+          target: type === 'file' ? path.resolve(target) : target,
+        },
       });
       const locationKey = getEntityLocationRef(entity);
       return { entity, locationKey };

--- a/plugins/catalog-backend/src/modules/core/DefaultLocationStore.ts
+++ b/plugins/catalog-backend/src/modules/core/DefaultLocationStore.ts
@@ -58,7 +58,7 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
 
       return inner;
     });
-    const entity = locationSpecToLocationEntity(location);
+    const entity = locationSpecToLocationEntity({ location });
     await this.connection.applyMutation({
       type: 'delta',
       added: [{ entity, locationKey: getEntityLocationRef(entity) }],
@@ -100,7 +100,7 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
       await tx<DbLocationsRow>('locations').where({ id }).del();
       return location;
     });
-    const entity = locationSpecToLocationEntity(deleted);
+    const entity = locationSpecToLocationEntity({ location: deleted });
     await this.connection.applyMutation({
       type: 'delta',
       added: [],
@@ -122,7 +122,7 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
     const locations = await this.locations();
 
     const entities = locations.map(location => {
-      const entity = locationSpecToLocationEntity(location);
+      const entity = locationSpecToLocationEntity({ location });
       return { entity, locationKey: getEntityLocationRef(entity) };
     });
 

--- a/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
+++ b/plugins/catalog-backend/src/processing/ProcessorOutputCollector.ts
@@ -106,10 +106,10 @@ export class ProcessorOutputCollector {
 
       this.deferredEntities.push({ entity, locationKey: location });
     } else if (i.type === 'location') {
-      const entity = locationSpecToLocationEntity(
-        i.location,
-        this.parentEntity,
-      );
+      const entity = locationSpecToLocationEntity({
+        location: i.location,
+        parentEntity: this.parentEntity,
+      });
       const locationKey = getEntityLocationRef(entity);
       this.deferredEntities.push({ entity, locationKey });
     } else if (i.type === 'relation') {

--- a/plugins/catalog-backend/src/util/conversion.ts
+++ b/plugins/catalog-backend/src/util/conversion.ts
@@ -32,10 +32,14 @@ export function locationSpecToMetadataName(location: LocationSpec) {
   return `generated-${hash}`;
 }
 
-export function locationSpecToLocationEntity(
-  location: LocationSpec,
-  parentEntity?: Entity,
-): LocationEntityV1alpha1 {
+/** @public */
+export function locationSpecToLocationEntity(opts: {
+  location: LocationSpec;
+  parentEntity?: Entity;
+}): LocationEntityV1alpha1 {
+  const location = opts.location;
+  const parentEntity = opts.parentEntity;
+
   let ownLocation: string;
   let originLocation: string;
   if (parentEntity) {

--- a/plugins/catalog-backend/src/util/index.ts
+++ b/plugins/catalog-backend/src/util/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2022 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,4 @@
  * limitations under the License.
  */
 
-/**
- * The Backstage backend plugin that provides the Backstage catalog
- *
- * @packageDocumentation
- */
-
-export * from './api';
-export * from './catalog';
-export * from './ingestion';
-export * from './modules';
-export * from './permissions';
-export * from './processing';
-export * from './search';
-export * from './service';
-export * from './util';
+export { locationSpecToLocationEntity } from './conversion';


### PR DESCRIPTION
Export function `locationSpecToLocationEntity`
which helps with converting `LocationSpec` to `LocationEntityV1alpha1`
and hereby, make it usable in other  packages/plugins.

Change signature to be easier to extend in  the future.

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
