### PR TITLE
feat: allow overriding `getMarkdownCode`

### DIFF
--- a/.changeset/fresh-bulldogs-own.md
+++ b/.changeset/fresh-bulldogs-own.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-badges-backend': patch
+---
+
+allow overriding `DefaultBadgeBuilder.getMarkdownCode`

--- a/plugins/badges-backend/api-report.md
+++ b/plugins/badges-backend/api-report.md
@@ -122,6 +122,8 @@ export class DefaultBadgeBuilder implements BadgeBuilder {
   createBadgeSvg(options: BadgeOptions): Promise<string>;
   // (undocumented)
   getBadges(): Promise<BadgeInfo[]>;
+  // (undocumented)
+  protected getMarkdownCode(params: Badge, badgeUrl: string): string;
 }
 
 // Warning: (ae-missing-release-tag) "RouterOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/badges-backend/src/lib/BadgeBuilder/DefaultBadgeBuilder.ts
+++ b/plugins/badges-backend/src/lib/BadgeBuilder/DefaultBadgeBuilder.ts
@@ -70,7 +70,7 @@ export class DefaultBadgeBuilder implements BadgeBuilder {
     }
   }
 
-  private getMarkdownCode(params: Badge, badgeUrl: string): string {
+  protected getMarkdownCode(params: Badge, badgeUrl: string): string {
     let altText = `${params.label}: ${params.message}`;
     if (params.description && params.description !== params.label) {
       altText = `${params.description}, ${altText}`;


### PR DESCRIPTION
allow overriding `DefaultBadgeBuilder.getMarkdownCode`

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
