### PR TITLE
handle trailing slashes on enterpriseInstanceUrl

### DIFF
--- a/.changeset/rotten-planes-watch.md
+++ b/.changeset/rotten-planes-watch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Handle trailing slashes on GitHub `enterpriseInstanceUrl` settings

--- a/plugins/auth-backend/src/providers/github/provider.ts
+++ b/plugins/auth-backend/src/providers/github/provider.ts
@@ -318,9 +318,9 @@ export const createGithubProvider = (
     OAuthEnvironmentHandler.mapConfig(config, envConfig => {
       const clientId = envConfig.getString('clientId');
       const clientSecret = envConfig.getString('clientSecret');
-      const enterpriseInstanceUrl = envConfig.getOptionalString(
-        'enterpriseInstanceUrl',
-      );
+      const enterpriseInstanceUrl = envConfig
+        .getOptionalString('enterpriseInstanceUrl')
+        ?.replace(/\/$/, '');
       const customCallbackUrl = envConfig.getOptionalString('callbackUrl');
       const authorizationUrl = enterpriseInstanceUrl
         ? `${enterpriseInstanceUrl}/login/oauth/authorize`


### PR DESCRIPTION
As [reported on Discord](https://discord.com/channels/687207715902193673/956612042956099594/956999649766543381)