### PR TITLE
Fixed bad help link in Entity Inspector

### DIFF
--- a/.changeset/purple-laws-give.md
+++ b/.changeset/purple-laws-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Removed broken link from Labels section of entity inspector.

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
@@ -107,15 +107,7 @@ export function OverviewPage(props: { entity: AlphaEntity }) {
             </List>
           )}
           {!!Object.keys(metadata.labels || {}).length && (
-            <List
-              dense
-              subheader={
-                <ListSubheader>
-                  Labels
-                  <HelpIcon to="https://backstage.io/docs/features/software-catalog/well-known-labels" />
-                </ListSubheader>
-              }
-            >
+            <List dense subheader={<ListSubheader>Labels</ListSubheader>}>
               {Object.entries(metadata.labels!).map(entry => (
                 <KeyValueListItem key={entry[0]} indent entry={entry} />
               ))}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The help link for labels in the entity inspector was 404ing (highlighted in red below), so removed it.
Fixes #10139.

![image](https://user-images.githubusercontent.com/289860/160252593-56ea52fb-c899-4682-914e-a18a1427f92a.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
