### PR TITLE
Updated Columns in Catalog Table

### DIFF
--- a/.changeset/poor-knives-boil.md
+++ b/.changeset/poor-knives-boil.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/plugin-catalog': minor
-'@backstage/plugin-catalog-react': minor
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-react': patch
 ---
 
 Columns in CatalogTable now change depending on the entity kind, ensuring only relevant columns are displayed.

--- a/.changeset/poor-knives-boil.md
+++ b/.changeset/poor-knives-boil.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog': minor
+'@backstage/plugin-catalog-react': minor
+---
+
+Columns in CatalogTable now change depending on the entity kind, ensuring only relevant columns are displayed.

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -169,10 +169,6 @@ describe('DefaultCatalogPage', () => {
 
     expect(columnHeaderLabels).toEqual([
       'Name',
-      'System',
-      'Owner',
-      'Type',
-      'Lifecycle',
       'Description',
       'Tags',
       'Actions',

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.test.tsx
@@ -169,6 +169,10 @@ describe('DefaultCatalogPage', () => {
 
     expect(columnHeaderLabels).toEqual([
       'Name',
+      'System',
+      'Owner',
+      'Type',
+      'Lifecycle',
       'Description',
       'Tags',
       'Actions',

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -296,17 +296,6 @@ describe('CatalogTable component', () => {
       );
       const columnHeaderLabels = columnHeader.map(c => c.textContent);
       expect(columnHeaderLabels).toEqual(expectedColumns);
-
-      // expect(columnHeaderLabels).toEqual([
-      //   'Name',
-      //   'System',
-      //   'Owner',
-      //   'Type',
-      //   'Lifecycle',
-      //   'Description',
-      //   'Tags',
-      //   'Actions'
-      // ]);
     },
     20_000,
   );

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.test.tsx
@@ -25,6 +25,7 @@ import {
   MockEntityListContextProvider,
   starredEntitiesApiRef,
   UserListFilter,
+  EntityKindFilter,
   MockStarredEntitiesApi,
 } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiRegistry } from '@backstage/test-utils';
@@ -176,4 +177,137 @@ describe('CatalogTable component', () => {
 
     expect(window.open).toHaveBeenCalledWith('https://other.place', '_blank');
   });
+
+  it.each([
+    {
+      kind: 'api',
+      expectedColumns: [
+        'Name',
+        'System',
+        'Owner',
+        'Type',
+        'Lifecycle',
+        'Description',
+        'Tags',
+        'Actions',
+      ],
+    },
+    {
+      kind: 'component',
+      expectedColumns: [
+        'Name',
+        'System',
+        'Owner',
+        'Type',
+        'Lifecycle',
+        'Description',
+        'Tags',
+        'Actions',
+      ],
+    },
+    {
+      kind: 'domain',
+      expectedColumns: ['Name', 'Owner', 'Description', 'Tags', 'Actions'],
+    },
+    {
+      kind: 'group',
+      expectedColumns: ['Name', 'Type', 'Description', 'Tags', 'Actions'],
+    },
+    {
+      kind: 'location',
+      expectedColumns: ['Name', 'Type', 'Description', 'Tags', 'Actions'],
+    },
+    {
+      kind: 'resource',
+      expectedColumns: [
+        'Name',
+        'System',
+        'Owner',
+        'Type',
+        'Lifecycle',
+        'Description',
+        'Tags',
+        'Actions',
+      ],
+    },
+    {
+      kind: 'system',
+      expectedColumns: ['Name', 'Owner', 'Description', 'Tags', 'Actions'],
+    },
+    {
+      kind: 'template',
+      expectedColumns: ['Name', 'Type', 'Description', 'Tags', 'Actions'],
+    },
+    {
+      kind: 'user',
+      expectedColumns: ['Name', 'Description', 'Tags', 'Actions'],
+    },
+    {
+      kind: 'custom',
+      expectedColumns: [
+        'Name',
+        'System',
+        'Owner',
+        'Type',
+        'Lifecycle',
+        'Description',
+        'Tags',
+        'Actions',
+      ],
+    },
+    {
+      kind: null,
+      expectedColumns: [
+        'Name',
+        'System',
+        'Owner',
+        'Type',
+        'Lifecycle',
+        'Description',
+        'Tags',
+        'Actions',
+      ],
+    },
+  ])(
+    'should render correct columns with kind filter $kind',
+    async ({ kind, expectedColumns }) => {
+      const { getAllByRole } = await renderInTestApp(
+        <ApiProvider apis={mockApis}>
+          <MockEntityListContextProvider
+            value={{
+              entities,
+              filters: {
+                kind: kind ? new EntityKindFilter(kind) : undefined,
+              },
+            }}
+          >
+            <CatalogTable />
+          </MockEntityListContextProvider>
+        </ApiProvider>,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      );
+
+      const columnHeader = getAllByRole('button').filter(
+        c => c.tagName === 'SPAN',
+      );
+      const columnHeaderLabels = columnHeader.map(c => c.textContent);
+      expect(columnHeaderLabels).toEqual(expectedColumns);
+
+      // expect(columnHeaderLabels).toEqual([
+      //   'Name',
+      //   'System',
+      //   'Owner',
+      //   'Type',
+      //   'Lifecycle',
+      //   'Description',
+      //   'Tags',
+      //   'Actions'
+      // ]);
+    },
+    20_000,
+  );
 });

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -64,18 +64,52 @@ export const CatalogTable = (props: CatalogTableProps) => {
   const { isStarredEntity, toggleStarredEntity } = useStarredEntities();
   const { loading, error, entities, filters } = useEntityList();
 
-  const defaultColumns: TableColumn<CatalogTableRow>[] = useMemo(
-    () => [
+  const defaultColumns: TableColumn<CatalogTableRow>[] = useMemo(() => {
+    return [
       columnFactories.createNameColumn({ defaultKind: filters.kind?.value }),
-      columnFactories.createSystemColumn(),
-      columnFactories.createOwnerColumn(),
-      columnFactories.createSpecTypeColumn(),
-      columnFactories.createSpecLifecycleColumn(),
+      ...createEntitySpecificColumns(),
       columnFactories.createMetadataDescriptionColumn(),
       columnFactories.createTagsColumn(),
-    ],
-    [filters.kind?.value],
-  );
+    ];
+
+    function createEntitySpecificColumns(): TableColumn<CatalogTableRow>[] {
+      switch (filters.kind?.value) {
+        case 'api':
+          return [
+            columnFactories.createSystemColumn(),
+            columnFactories.createOwnerColumn(),
+            columnFactories.createSpecTypeColumn(),
+            columnFactories.createSpecLifecycleColumn(),
+          ];
+        case 'component':
+          return [
+            columnFactories.createSystemColumn(),
+            columnFactories.createOwnerColumn(),
+            columnFactories.createSpecTypeColumn(),
+            columnFactories.createSpecLifecycleColumn(),
+          ];
+        case 'domain':
+          return [columnFactories.createOwnerColumn()];
+        case 'group':
+          return [columnFactories.createSpecTypeColumn()];
+        case 'location':
+          return [columnFactories.createSpecTypeColumn()];
+        case 'resource':
+          return [
+            columnFactories.createSystemColumn(),
+            columnFactories.createOwnerColumn(),
+            columnFactories.createSpecTypeColumn(),
+            columnFactories.createSpecLifecycleColumn(),
+          ];
+        case 'system':
+          return [columnFactories.createOwnerColumn()];
+        case 'template':
+          return [columnFactories.createSpecTypeColumn()];
+        default:
+          return [];
+      }
+    }
+  }, [filters.kind?.value]);
 
   const showTypeColumn = filters.type === undefined;
   // TODO(timbonicus): remove the title from the CatalogTable once using EntitySearchBar

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -74,39 +74,22 @@ export const CatalogTable = (props: CatalogTableProps) => {
 
     function createEntitySpecificColumns(): TableColumn<CatalogTableRow>[] {
       switch (filters.kind?.value) {
-        case 'api':
-          return [
-            columnFactories.createSystemColumn(),
-            columnFactories.createOwnerColumn(),
-            columnFactories.createSpecTypeColumn(),
-            columnFactories.createSpecLifecycleColumn(),
-          ];
-        case 'component':
-          return [
-            columnFactories.createSystemColumn(),
-            columnFactories.createOwnerColumn(),
-            columnFactories.createSpecTypeColumn(),
-            columnFactories.createSpecLifecycleColumn(),
-          ];
+        case 'user':
+          return [];
         case 'domain':
-          return [columnFactories.createOwnerColumn()];
-        case 'group':
-          return [columnFactories.createSpecTypeColumn()];
-        case 'location':
-          return [columnFactories.createSpecTypeColumn()];
-        case 'resource':
-          return [
-            columnFactories.createSystemColumn(),
-            columnFactories.createOwnerColumn(),
-            columnFactories.createSpecTypeColumn(),
-            columnFactories.createSpecLifecycleColumn(),
-          ];
         case 'system':
           return [columnFactories.createOwnerColumn()];
+        case 'group':
+        case 'location':
         case 'template':
           return [columnFactories.createSpecTypeColumn()];
         default:
-          return [];
+          return [
+            columnFactories.createSystemColumn(),
+            columnFactories.createOwnerColumn(),
+            columnFactories.createSpecTypeColumn(),
+            columnFactories.createSpecLifecycleColumn(),
+          ];
       }
     }
   }, [filters.kind?.value]);


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Updated columns in the catalogue table view to vary columns based on entity kind. Specifically excluding columns that aren't supported by that entity kind.  Further work could be done on top of this to further tailor columns to each entity kind (e.g. Groups could show parent instead of owner, systems could have a `domain` column)

Fixes #10452

(I am primarily a .Net backend dev, so let me know if there are more idiomatic ways I could implement this.)

Screenshots for each entity kind:
![image](https://user-images.githubusercontent.com/289860/160256111-4be20dfe-e576-4128-a36f-99a1a72f5c41.png)
![image](https://user-images.githubusercontent.com/289860/160256118-d6042d0d-0ae8-43ca-b318-0e0cc95d0037.png)
![image](https://user-images.githubusercontent.com/289860/160256122-81b7aab5-329d-496b-b5b8-26e1880da83d.png)
![image](https://user-images.githubusercontent.com/289860/160256128-a7263872-7fca-48b5-9031-2b71a6077112.png)
![image](https://user-images.githubusercontent.com/289860/160256132-54b6af6a-0e09-4ff2-8f7e-e661ff47e63e.png)
![image](https://user-images.githubusercontent.com/289860/160256137-ba8defa0-c1fe-4c77-b39a-b01352c8e53d.png)
![image](https://user-images.githubusercontent.com/289860/160256144-8ccbbae2-7862-471f-b713-04d86a404e4a.png)
![image](https://user-images.githubusercontent.com/289860/160256148-328c3208-de5a-4f08-ac97-c7592d5c02f2.png)
![image](https://user-images.githubusercontent.com/289860/160256152-2de62900-5802-44cc-86cd-8c53b78f486e.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
