### PR TITLE
gcalendar plugin calendar list fix

### DIFF
--- a/.changeset/tasty-goats-shout.md
+++ b/.changeset/tasty-goats-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-gcalendar': patch
+---
+
+Fixed issue when not all calendars were fetched for some accounts

--- a/.changeset/tasty-goats-shout.md
+++ b/.changeset/tasty-goats-shout.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-gcalendar': patch
+'@backstage/plugin-gcalendar': minor
 ---
 
 Fixed issue when not all calendars were fetched for some accounts

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,7 @@
 /plugins/explore                                    @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/explore-react                              @backstage/reviewers @backstage/sda-se-reviewers
 /plugins/fossa                                      @backstage/reviewers @backstage/sda-se-reviewers
+/plugins/gcalendar                                  @backstage/reviewers @szubster @ptychu @kielosz @alexrybch
 /plugins/git-release-manager                        @backstage/reviewers @erikengervall
 /plugins/home                                       @backstage/reviewers @backstage/techdocs-core
 /plugins/ilert                                      @backstage/reviewers @yacut

--- a/plugins/gcalendar/api-report.md
+++ b/plugins/gcalendar/api-report.md
@@ -29,9 +29,7 @@ export class GCalendarApiClient {
   // Warning: (ae-forgotten-export) The symbol "Options" needs to be exported by the entry point index.d.ts
   constructor(options: Options);
   // (undocumented)
-  getCalendars(params?: any): Promise<{
-    items: GCalendar[];
-  }>;
+  getCalendars(params?: any): Promise<gapi.client.calendar.CalendarList>;
   // (undocumented)
   getEvents(
     calendarId: string,
@@ -54,6 +52,11 @@ export type GCalendarEvent = gapi.client.calendar.Event &
   Pick<EventAttendee, 'responseStatus'> & {
     calendarId?: string;
   };
+
+// Warning: (ae-missing-release-tag) "GCalendarList" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type GCalendarList = gapi.client.calendar.CalendarList;
 
 // Warning: (ae-missing-release-tag) "gcalendarPlugin" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/gcalendar/src/api/client.ts
+++ b/plugins/gcalendar/src/api/client.ts
@@ -15,7 +15,7 @@
  */
 import { OAuthApi, createApiRef, FetchApi } from '@backstage/core-plugin-api';
 
-import { GCalendar, GCalendarEvent } from './types';
+import { GCalendarEvent, GCalendarList } from './types';
 import { ResponseError } from '@backstage/errors';
 
 type Options = {
@@ -58,7 +58,7 @@ export class GCalendarApiClient {
   }
 
   public async getCalendars(params?: any) {
-    return this.get<{ items: GCalendar[] }>(
+    return this.get<GCalendarList>(
       '/calendar/v3/users/me/calendarList',
       params,
     );

--- a/plugins/gcalendar/src/api/types.ts
+++ b/plugins/gcalendar/src/api/types.ts
@@ -17,6 +17,8 @@
 /// <reference types="gapi.auth2" />
 /// <reference types="gapi.client.calendar" />
 
+export type GCalendarList = gapi.client.calendar.CalendarList;
+
 export type GCalendar = gapi.client.calendar.CalendarListEntry;
 
 export type EventAttendee = gapi.client.calendar.EventAttendee;

--- a/plugins/gcalendar/src/components/CalendarCard/CalendarCard.tsx
+++ b/plugins/gcalendar/src/components/CalendarCard/CalendarCard.tsx
@@ -15,7 +15,7 @@
  */
 import { sortBy } from 'lodash';
 import { DateTime } from 'luxon';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { InfoCard, Progress } from '@backstage/core-components';
 import { useAnalytics } from '@backstage/core-plugin-api';
@@ -51,10 +51,10 @@ export const CalendarCard = () => {
     signIn(true);
   }, [signIn]);
 
-  const { isLoading: isCalendarLoading, data } = useCalendarsQuery({
-    enabled: isSignedIn,
-  });
-  const calendars = useMemo(() => data?.items || [], [data]);
+  const { isLoading: isCalendarLoading, data: calendars = [] } =
+    useCalendarsQuery({
+      enabled: isSignedIn,
+    });
   const primaryCalendarId = calendars.find(c => c.primary === true)?.id;
   const defaultSelectedCalendars = primaryCalendarId ? [primaryCalendarId] : [];
   const [storedCalendars, setStoredCalendars] = useStoredCalendars(

--- a/plugins/gcalendar/src/hooks/useCalendarsQuery.ts
+++ b/plugins/gcalendar/src/hooks/useCalendarsQuery.ts
@@ -30,10 +30,22 @@ export const useCalendarsQuery = ({ enabled }: Options) => {
 
   return useQuery(
     ['calendars'],
-    async () =>
-      calendarApi.getCalendars({
-        minAccessRole: 'reader',
-      }),
+    async () => {
+      const calendars = [];
+      let token = '';
+      do {
+        const { nextPageToken = '', items = [] } =
+          await calendarApi.getCalendars({
+            maxResults: 100,
+            minAccessRole: 'reader',
+            pageToken: token,
+          });
+        token = nextPageToken;
+        calendars.push(...items);
+      } while (token);
+
+      return calendars;
+    },
     {
       enabled,
       keepPreviousData: true,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Recently we found out that for some accounts google API does not return all the calendars in one request (it returned ~10 though it should return 100 by default), so with this update we now walk through pages collecting all available calendars.

I also added our team as code owners for the plugin, but not sure what's the process is, would be great if you could elaborate on this :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
