### PR TITLE
Make User and Group kinds not default allowed by rules

### DIFF
--- a/.changeset/beige-baboons-walk.md
+++ b/.changeset/beige-baboons-walk.md
@@ -1,0 +1,7 @@
+---
+'@backstage/integration': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Clarify that config locations that emit User and Group kinds now need to declare so in the `catalog.locations.[].rules`

--- a/.changeset/clean-lions-taste.md
+++ b/.changeset/clean-lions-taste.md
@@ -1,0 +1,52 @@
+---
+'@backstage/create-app': patch
+---
+
+Made `User` and `Group` entity kinds not permitted by the default
+`catalog.rules` config.
+
+The effect of this is that after creating a new Backstage repository, its
+catalog no longer permits regular users to register `User` or `Group` entities
+using the Backstage interface. Additionally, if you have config locations that
+result in `User` or `Group` entities, you need to add those kinds to its own
+specific rules:
+
+```yaml
+catalog:
+  locations:
+    # This applies for example to url type locations
+    - type: url
+      target: https://example.com/org.yaml
+      rules:
+        allow: [User, Group]
+    # But also note that this applies to ALL org location types!
+    - type: github-org
+      target: https://github.com/my-org-name
+      rules:
+        allow: [User, Group]
+```
+
+This rule change does NOT affect entity providers, only things that are emitted
+by entity processors.
+
+We recommend that this change is applied to your own Backstage repository, since
+it makes it impossible for regular end users to affect your org data through
+e.g. YAML files. To do so, remove the two kinds from the default rules in your config:
+
+```diff
+ catalog:
+   rules:
+-    - allow: [Component, System, API, Group, User, Resource, Location]
++    - allow: [Component, System, API, Resource, Location]
+```
+
+And for any location that in any way results in org data being ingested, add the corresponding rule to it:
+
+```diff
+ catalog:
+   locations:
+     - type: github-org
+       target: https://github.com/my-org-name
++      rules:
++        allow: [User, Group]
+```

--- a/docs/integrations/github/org.md
+++ b/docs/integrations/github/org.md
@@ -31,6 +31,8 @@ catalog:
   locations:
     - type: github-org
       target: https://github.com/my-org-name
+      rules:
+        allow: [User, Group]
 ```
 
 If Backstage is configured to use GitHub Apps authentication you must grant

--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -365,4 +365,6 @@ catalog:
   locations:
     - type: ldap-org
       target: ldaps://ds.example.net
+      rules:
+        allow: [User, Group]
 ```

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -85,7 +85,7 @@ catalog:
     entityFilename: catalog-info.yaml
     pullRequestBranchName: backstage-integration
   rules:
-    - allow: [Component, System, API, Group, User, Resource, Location]
+    - allow: [Component, System, API, Resource, Location]
   locations:
     # Backstage example components
     - type: url

--- a/packages/integration/CHANGELOG.md
+++ b/packages/integration/CHANGELOG.md
@@ -237,6 +237,8 @@
     locations:
       - type: github-multi-org
         target: https://github.myorg.com
+        rules:
+          allow: [User, Group]
 
     processors:
       githubMultiOrg:

--- a/plugins/catalog-backend-module-msgraph/README.md
+++ b/plugins/catalog-backend-module-msgraph/README.md
@@ -141,8 +141,6 @@ catalog:
   locations:
     - type: microsoft-graph-org
       target: https://graph.microsoft.com/v1.0
-      # If you catalog doesn't allow to import Group and User entities by
-      # default, allow them here
       rules:
         - allow: [Group, User]
     …

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -1394,6 +1394,8 @@
     locations:
       - type: github-multi-org
         target: https://github.myorg.com
+        rules:
+          allow: [User, Group]
 
     processors:
       githubMultiOrg:


### PR DESCRIPTION
This retroactively changes two changelogs and has changesets for that ... not sure if that's just silly, let me know what you think :)