### PR TITLE
Fixes CNCF footer link

### DIFF
--- a/microsite/core/Footer.js
+++ b/microsite/core/Footer.js
@@ -51,7 +51,7 @@ class Footer extends React.Component {
             <a href="https://mailchi.mp/spotify/backstage-community">
               Subscribe to our newsletter
             </a>
-            <a href="https://www.cncf.io/sandbox-projects/">CNCF Incubation</a>
+            <a href="https://www.cncf.io/projects/">CNCF Incubation</a>
           </div>
           <div>
             <h5>More</h5>


### PR DESCRIPTION
@jenjamall noticed on #10376 that the footer
linking to `CNCF` projects was outdated and
pointing to `sandbox` projects instead of the ones
in incubation and graduated.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
