### PR TITLE
Added IdentityProviders to exports from SignInPage

### DIFF
--- a/.changeset/selfish-actors-walk.md
+++ b/.changeset/selfish-actors-walk.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Exported IdentityProviders
+Exported `IdentityProviders` type.

--- a/.changeset/selfish-actors-walk.md
+++ b/.changeset/selfish-actors-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Exported IdentityProviders

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -510,6 +510,11 @@ export type IconLinkVerticalProps = {
   title?: string;
 };
 
+// Warning: (ae-missing-release-tag) "IdentityProviders" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type IdentityProviders = ('guest' | 'custom' | SignInProviderConfig)[];
+
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
 //
 // @public

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -510,8 +510,6 @@ export type IconLinkVerticalProps = {
   title?: string;
 };
 
-// Warning: (ae-missing-release-tag) "IdentityProviders" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type IdentityProviders = ('guest' | 'custom' | SignInProviderConfig)[];
 

--- a/packages/core-components/src/layout/SignInPage/index.ts
+++ b/packages/core-components/src/layout/SignInPage/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export type { SignInProviderConfig } from './types';
+export type { IdentityProviders, SignInProviderConfig } from './types';
 export { SignInPage } from './SignInPage';
 export type { SignInPageClassKey } from './styles';
 export type { CustomProviderClassKey } from './customProvider';

--- a/packages/core-components/src/layout/SignInPage/types.ts
+++ b/packages/core-components/src/layout/SignInPage/types.ts
@@ -32,6 +32,7 @@ export type SignInProviderConfig = {
   apiRef: ApiRef<ProfileInfoApi & BackstageIdentityApi & SessionApi>;
 };
 
+/** @public **/
 export type IdentityProviders = ('guest' | 'custom' | SignInProviderConfig)[];
 
 export type ProviderComponent = ComponentType<


### PR DESCRIPTION
Signed-off-by: Liam Mackie <liam.mackie@octopus.com>

## Hey, I just made a Pull Request!

When using the SignInPage component, the `IdentityProviders` type is passed in, but not exported. This ended up meaning when we were introducing logic to pass through the `guest` provider in our development environments based on environment variables, I needed to introduce an inline type. 

This PR exports the `IdentityProviders` type so that it can be used.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
