### PR TITLE
Replace PermissionedRoute with RequirePermission

### DIFF
--- a/.changeset/spotty-pumpkins-obey.md
+++ b/.changeset/spotty-pumpkins-obey.md
@@ -1,0 +1,31 @@
+---
+'@backstage/create-app': minor
+---
+
+Replace PermissionedRoute with RequirePermission
+
+`@backstage/plugin-permission-react` has replaced the `PermissionedRoute`
+component with the `RequirePermission` component (see the
+`@backstage/plugin-permission-react` changelog for details). Any
+`PermissionedRoute`s can be replaced with `RequirePermission` as shown below:
+
+```diff
+// packages/app/src/App.tsx
+
+- import { PermissionedRoute } from '@backstage/plugin-permission-react';
++ import { RequirePermission } from '@backstage/plugin-permission-react';
+
+- <PermissionedRoute
+-   path="/catalog-import"
+-   permission={catalogEntityCreatePermission}
+-   element={<CatalogImportPage />}
+- />
++ <Route
++   path="/catalog-import"
++   element={
++     <RequirePermission permission={catalogEntityCreatePermission}>
++       <CatalogImportPage />
++     </RequirePermission>
++   }
++ />
+```

--- a/.changeset/stale-dingos-brake.md
+++ b/.changeset/stale-dingos-brake.md
@@ -1,0 +1,31 @@
+---
+'@backstage/plugin-permission-react': minor
+---
+
+**BREAKING** Replace PermissionedRoute with RequirePermission
+
+Due to React Router no longer rendering non-`Route` children in v6,
+`PermissionedRoute` will no longer function. Thus, we replace
+`PermissionedRoute` with a `RequirePermission` component which can additionally
+be used more broadly to gate any arbitrary children from rendering with an
+authorization check. (This is [the recommended approach by React
+Router](https://github.com/remix-run/react-router/issues/8092).)
+
+```diff
+- import { PermissionedRoute } from '@backstage/plugin-permission-react';
++ import { RequirePermission } from '@backstage/plugin-permission-react';
+
+- <PermissionedRoute
+-   path="/catalog-import"
+-   permission={catalogEntityCreatePermission}
+-   element={<CatalogImportPage />}
+- />
++ <Route
++   path="/catalog-import"
++   element={
++     <RequirePermission permission={catalogEntityCreatePermission}>
++       <CatalogImportPage />
++     </RequirePermission>
++   }
++ />
+```

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -86,7 +86,7 @@ import * as plugins from './plugins';
 
 import { techDocsPage } from './components/techdocs/TechDocsPage';
 import { ApacheAirflowPage } from '@backstage/plugin-apache-airflow';
-import { PermissionedRoute } from '@backstage/plugin-permission-react';
+import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common';
 
 const app = createApp({
@@ -142,10 +142,13 @@ const routes = (
     >
       {entityPage}
     </Route>
-    <PermissionedRoute
+    <Route
       path="/catalog-import"
-      permission={catalogEntityCreatePermission}
-      element={<CatalogImportPage />}
+      element={
+        <RequirePermission permission={catalogEntityCreatePermission}>
+          <CatalogImportPage />
+        </RequirePermission>
+      }
     />
     <Route
       path="/catalog-graph"

--- a/packages/create-app/templates/default-app/packages/app/src/App.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/App.tsx
@@ -29,7 +29,7 @@ import { AlertDisplay, OAuthRequestDialog } from '@backstage/core-components';
 import { createApp } from '@backstage/app-defaults';
 import { FlatRoutes } from '@backstage/core-app-api';
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
-import { PermissionedRoute } from '@backstage/plugin-permission-react';
+import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 
 const app = createApp({
@@ -75,10 +75,13 @@ const routes = (
       path="/tech-radar"
       element={<TechRadarPage width={1500} height={800} />}
     />
-    <PermissionedRoute
+    <Route
       path="/catalog-import"
-      permission={catalogEntityCreatePermission}
-      element={<CatalogImportPage />}
+      element={
+        <RequirePermission permission={catalogEntityCreatePermission}>
+          <CatalogImportPage />
+        </RequirePermission>
+      }
     />
     <Route path="/search" element={<SearchPage />}>
       {searchPage}

--- a/plugins/permission-react/api-report.md
+++ b/plugins/permission-react/api-report.md
@@ -4,7 +4,6 @@
 
 ```ts
 import { ApiRef } from '@backstage/core-plugin-api';
-import { ComponentProps } from 'react';
 import { Config } from '@backstage/config';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { EvaluatePermissionRequest } from '@backstage/plugin-permission-common';
@@ -12,8 +11,8 @@ import { EvaluatePermissionResponse } from '@backstage/plugin-permission-common'
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { Permission } from '@backstage/plugin-permission-common';
 import { ReactElement } from 'react';
+import { ReactNode } from 'react';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
-import { Route } from 'react-router';
 
 // @public (undocumented)
 export type AsyncPermissionResult = {
@@ -47,20 +46,21 @@ export type PermissionApi = {
 export const permissionApiRef: ApiRef<PermissionApi>;
 
 // @public
-export const PermissionedRoute: (
-  props: ComponentProps<typeof Route> & {
-    errorComponent?: ReactElement | null;
+export function RequirePermission(
+  props: {
+    unauthorizedComponent?: ReactElement | null;
+    children: ReactNode;
   } & (
-      | {
-          permission: Exclude<Permission, ResourcePermission>;
-          resourceRef?: never;
-        }
-      | {
-          permission: ResourcePermission;
-          resourceRef: string | undefined;
-        }
-    ),
-) => JSX.Element;
+    | {
+        permission: Exclude<Permission, ResourcePermission>;
+        resourceRef?: never;
+      }
+    | {
+        permission: ResourcePermission;
+        resourceRef: string | undefined;
+      }
+  ),
+): JSX.Element | null;
 
 // @public
 export function usePermission(

--- a/plugins/permission-react/src/components/RequirePermission.test.tsx
+++ b/plugins/permission-react/src/components/RequirePermission.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { PermissionedRoute } from '.';
+import { RequirePermission } from '.';
 import { usePermission } from '../hooks';
 import { renderInTestApp } from '@backstage/test-utils';
 import { createPermission } from '@backstage/plugin-permission-common';
@@ -32,15 +32,12 @@ const permission = createPermission({
   attributes: { action: 'read' },
 });
 
-describe('PermissionedRoute', () => {
+describe('RequirePermission', () => {
   it('Does not render when loading', async () => {
     mockUsePermission.mockReturnValue({ loading: true, allowed: false });
 
     const { queryByText } = await renderInTestApp(
-      <PermissionedRoute
-        permission={permission}
-        element={<div>content</div>}
-      />,
+      <RequirePermission permission={permission}>content</RequirePermission>,
     );
 
     expect(queryByText('content')).not.toBeTruthy();
@@ -50,10 +47,7 @@ describe('PermissionedRoute', () => {
     mockUsePermission.mockReturnValue({ loading: false, allowed: true });
 
     const { getByText } = await renderInTestApp(
-      <PermissionedRoute
-        permission={permission}
-        element={<div>content</div>}
-      />,
+      <RequirePermission permission={permission}>content</RequirePermission>,
     );
 
     expect(getByText('content')).toBeTruthy();
@@ -64,10 +58,7 @@ describe('PermissionedRoute', () => {
 
     await expect(
       renderInTestApp(
-        <PermissionedRoute
-          permission={permission}
-          element={<div>content</div>}
-        />,
+        <RequirePermission permission={permission}>content</RequirePermission>,
       ),
     ).rejects.toThrowError('Reached NotFound Page');
   });
@@ -76,11 +67,12 @@ describe('PermissionedRoute', () => {
     mockUsePermission.mockReturnValue({ loading: false, allowed: false });
 
     const { getByText } = await renderInTestApp(
-      <PermissionedRoute
+      <RequirePermission
         permission={permission}
-        element={<div>content</div>}
-        errorComponent={<h1>Custom Error</h1>}
-      />,
+        unauthorizedComponent={<h1>Custom Error</h1>}
+      >
+        content
+      </RequirePermission>,
     );
 
     expect(getByText('Custom Error')).toBeTruthy();

--- a/plugins/permission-react/src/components/index.ts
+++ b/plugins/permission-react/src/components/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { PermissionedRoute } from './PermissionedRoute';
+export { RequirePermission } from './RequirePermission';


### PR DESCRIPTION
Due to React Router no longer rendering non-`Route` children in v6, `PermissionedRoute` will no longer function. Thus, we replace `PermissionedRoute` with a `RequirePermission` component which can additionally be used more broadly to gate any arbitrary children from rendering with an authorization check. (This is [the recommended approach by React Router](https://github.com/remix-run/react-router/issues/8092).)

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
