### PR TITLE
core: simplify route collection logic + replace PermissionedRoute

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -86,7 +86,7 @@ import * as plugins from './plugins';
 
 import { techDocsPage } from './components/techdocs/TechDocsPage';
 import { ApacheAirflowPage } from '@backstage/plugin-apache-airflow';
-import { PermissionedRoute } from '@backstage/plugin-permission-react';
+import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common';
 
 const app = createApp({
@@ -142,10 +142,13 @@ const routes = (
     >
       {entityPage}
     </Route>
-    <PermissionedRoute
+    <Route
       path="/catalog-import"
-      permission={catalogEntityCreatePermission}
-      element={<CatalogImportPage />}
+      element={
+        <RequirePermission permission={catalogEntityCreatePermission}>
+          <CatalogImportPage />
+        </RequirePermission>
+      }
     />
     <Route
       path="/catalog-graph"

--- a/packages/core-app-api/src/app/AppManager.tsx
+++ b/packages/core-app-api/src/app/AppManager.tsx
@@ -55,9 +55,7 @@ import {
 import { pluginCollector } from '../plugins/collectors';
 import {
   featureFlagCollector,
-  routeObjectCollector,
-  routeParentCollector,
-  routePathCollector,
+  routingV1Collector,
 } from '../routing/collectors';
 import { RoutingProvider } from '../routing/RoutingProvider';
 import { RouteTracker } from '../routing/RouteTracker';
@@ -205,20 +203,12 @@ export class AppManager implements BackstageApp {
         [],
       );
 
-      const {
-        routePaths,
-        routeParents,
-        routeObjects,
-        featureFlags,
-        routeBindings,
-      } = useMemo(() => {
+      const { routing, featureFlags, routeBindings } = useMemo(() => {
         const result = traverseElementTree({
           root: children,
           discoverers: [childDiscoverer, routeElementDiscoverer],
           collectors: {
-            routePaths: routePathCollector,
-            routeParents: routeParentCollector,
-            routeObjects: routeObjectCollector,
+            routing: routingV1Collector,
             collectedPlugins: pluginCollector,
             featureFlags: featureFlagCollector,
           },
@@ -241,7 +231,7 @@ export class AppManager implements BackstageApp {
 
       if (!routesHaveBeenValidated) {
         routesHaveBeenValidated = true;
-        validateRouteParameters(routePaths, routeParents);
+        validateRouteParameters(routing.paths, routing.parents);
         validateRouteBindings(
           routeBindings,
           this.plugins as Iterable<BackstagePlugin<any, any>>,
@@ -304,9 +294,9 @@ export class AppManager implements BackstageApp {
           <AppContextProvider appContext={appContext}>
             <ThemeProvider>
               <RoutingProvider
-                routePaths={routePaths}
-                routeParents={routeParents}
-                routeObjects={routeObjects}
+                routePaths={routing.paths}
+                routeParents={routing.parents}
+                routeObjects={routing.objects}
                 routeBindings={routeBindings}
                 basePath={getBasePath(loadedConfig.api)}
               >

--- a/packages/core-app-api/src/routing/RouteTracker.tsx
+++ b/packages/core-app-api/src/routing/RouteTracker.tsx
@@ -22,7 +22,7 @@ import {
   CommonAnalyticsContext,
   RouteRef,
 } from '@backstage/core-plugin-api';
-import { routeObjectCollector } from './collectors';
+import { routingV1Collector } from './collectors';
 import {
   childDiscoverer,
   routeElementDiscoverer,
@@ -101,18 +101,20 @@ export const RouteTracker = ({ tree }: { tree: React.ReactNode }) => {
   const { pathname, search, hash } = useLocation();
   // todo(iamEAP): Work this into the existing traversal and make the data
   // available on the provider. Then grab from app instance on the router.
-  const { routeObjects } = useMemo(() => {
+  const { routing } = useMemo(() => {
     return traverseElementTree({
       root: tree,
       discoverers: [childDiscoverer, routeElementDiscoverer],
       collectors: {
-        routeObjects: routeObjectCollector,
+        routing: routingV1Collector,
       },
     });
   }, [tree]);
 
   return (
-    <AnalyticsContext attributes={getExtensionContext(pathname, routeObjects)}>
+    <AnalyticsContext
+      attributes={getExtensionContext(pathname, routing.objects)}
+    >
       <TrackNavigation pathname={pathname} search={search} hash={hash} />
     </AnalyticsContext>
   );

--- a/packages/core-app-api/src/routing/RouteTracker.tsx
+++ b/packages/core-app-api/src/routing/RouteTracker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { matchRoutes, useLocation } from 'react-router-dom';
 import {
   useAnalytics,
@@ -22,12 +22,6 @@ import {
   CommonAnalyticsContext,
   RouteRef,
 } from '@backstage/core-plugin-api';
-import { routingV1Collector } from './collectors';
-import {
-  childDiscoverer,
-  routeElementDiscoverer,
-  traverseElementTree,
-} from '../extensions/traversal';
 import { BackstageRouteObject } from './types';
 
 /**
@@ -97,24 +91,15 @@ const TrackNavigation = ({
  * Logs a "navigate" event with appropriate plugin-level analytics context
  * attributes each time the user navigates to a page.
  */
-export const RouteTracker = ({ tree }: { tree: React.ReactNode }) => {
+export const RouteTracker = ({
+  routeObjects,
+}: {
+  routeObjects: BackstageRouteObject[];
+}) => {
   const { pathname, search, hash } = useLocation();
-  // todo(iamEAP): Work this into the existing traversal and make the data
-  // available on the provider. Then grab from app instance on the router.
-  const { routing } = useMemo(() => {
-    return traverseElementTree({
-      root: tree,
-      discoverers: [childDiscoverer, routeElementDiscoverer],
-      collectors: {
-        routing: routingV1Collector,
-      },
-    });
-  }, [tree]);
 
   return (
-    <AnalyticsContext
-      attributes={getExtensionContext(pathname, routing.objects)}
-    >
+    <AnalyticsContext attributes={getExtensionContext(pathname, routeObjects)}>
       <TrackNavigation pathname={pathname} search={search} hash={hash} />
     </AnalyticsContext>
   );

--- a/packages/core-app-api/src/routing/RoutingProvider.test.tsx
+++ b/packages/core-app-api/src/routing/RoutingProvider.test.tsx
@@ -34,11 +34,7 @@ import {
   ExternalRouteRef,
 } from '@backstage/core-plugin-api';
 import { RoutingProvider } from './RoutingProvider';
-import {
-  routePathCollector,
-  routeParentCollector,
-  routeObjectCollector,
-} from './collectors';
+import { routingV1Collector } from './collectors';
 import { validateRouteParameters } from './validation';
 import { RouteResolver } from './RouteResolver';
 import { AnyRouteRef, RouteFunc } from './types';
@@ -135,21 +131,19 @@ function withRoutingProvider(
   root: ReactElement,
   routeBindings: [ExternalRouteRef, RouteRef][] = [],
 ) {
-  const { routePaths, routeParents, routeObjects } = traverseElementTree({
+  const { routing } = traverseElementTree({
     root,
     discoverers: [childDiscoverer, routeElementDiscoverer],
     collectors: {
-      routePaths: routePathCollector,
-      routeParents: routeParentCollector,
-      routeObjects: routeObjectCollector,
+      routing: routingV1Collector,
     },
   });
 
   return (
     <RoutingProvider
-      routePaths={routePaths}
-      routeParents={routeParents}
-      routeObjects={routeObjects}
+      routePaths={routing.paths}
+      routeParents={routing.parents}
+      routeObjects={routing.objects}
       routeBindings={new Map(routeBindings)}
       basePath=""
     >
@@ -314,18 +308,17 @@ describe('discovery', () => {
       </MemoryRouter>
     );
 
-    const { routePaths, routeParents } = traverseElementTree({
+    const { routing } = traverseElementTree({
       root,
       discoverers: [childDiscoverer, routeElementDiscoverer],
       collectors: {
-        routePaths: routePathCollector,
-        routeParents: routeParentCollector,
+        routing: routingV1Collector,
       },
     });
 
-    expect(() => validateRouteParameters(routePaths, routeParents)).toThrow(
-      'Parameter :id is duplicated in path /foo/:id/bar/:id',
-    );
+    expect(() =>
+      validateRouteParameters(routing.paths, routing.parents),
+    ).toThrow('Parameter :id is duplicated in path /foo/:id/bar/:id');
   });
 });
 

--- a/packages/core-app-api/src/routing/collectors.test.tsx
+++ b/packages/core-app-api/src/routing/collectors.test.tsx
@@ -15,11 +15,7 @@
  */
 
 import React, { PropsWithChildren } from 'react';
-import {
-  routePathCollector,
-  routeParentCollector,
-  routeObjectCollector,
-} from './collectors';
+import { routingV1Collector } from './collectors';
 
 import {
   traverseElementTree,
@@ -162,30 +158,28 @@ describe('discovery', () => {
       </MemoryRouter>
     );
 
-    const { routes, routeParents, routeObjects } = traverseElementTree({
+    const { routing } = traverseElementTree({
       root,
       discoverers: [childDiscoverer, routeElementDiscoverer],
       collectors: {
-        routes: routePathCollector,
-        routeParents: routeParentCollector,
-        routeObjects: routeObjectCollector,
+        routing: routingV1Collector,
       },
     });
-    expect(sortedEntries(routes)).toEqual([
+    expect(sortedEntries(routing.paths)).toEqual([
       [ref1, '/foo'],
       [ref2, '/bar/:id'],
       [ref3, '/baz'],
       [ref4, '/divsoup'],
       [ref5, '/blop'],
     ]);
-    expect(sortedEntries(routeParents)).toEqual([
+    expect(sortedEntries(routing.parents)).toEqual([
       [ref1, undefined],
       [ref2, ref1],
       [ref3, ref2],
       [ref4, undefined],
       [ref5, ref1],
     ]);
-    expect(routeObjects).toEqual([
+    expect(routing.objects).toEqual([
       routeObj(
         '/foo',
         [ref1],
@@ -220,22 +214,21 @@ describe('discovery', () => {
       </MemoryRouter>
     );
 
-    const { routes, routeParents } = traverseElementTree({
+    const { routing } = traverseElementTree({
       root,
       discoverers: [childDiscoverer, routeElementDiscoverer],
       collectors: {
-        routes: routePathCollector,
-        routeParents: routeParentCollector,
+        routing: routingV1Collector,
       },
     });
-    expect(sortedEntries(routes)).toEqual([
+    expect(sortedEntries(routing.paths)).toEqual([
       [ref1, '/foo'],
       [ref2, '/bar/:id'],
       [ref3, '/baz'],
       [ref4, '/divsoup'],
       [ref5, '/blop'],
     ]);
-    expect(sortedEntries(routeParents)).toEqual([
+    expect(sortedEntries(routing.parents)).toEqual([
       [ref1, undefined],
       [ref2, ref1],
       [ref3, undefined],
@@ -266,30 +259,28 @@ describe('discovery', () => {
       </MemoryRouter>
     );
 
-    const { routes, routeParents, routeObjects } = traverseElementTree({
+    const { routing } = traverseElementTree({
       root,
       discoverers: [childDiscoverer, routeElementDiscoverer],
       collectors: {
-        routes: routePathCollector,
-        routeParents: routeParentCollector,
-        routeObjects: routeObjectCollector,
+        routing: routingV1Collector,
       },
     });
-    expect(sortedEntries(routes)).toEqual([
+    expect(sortedEntries(routing.paths)).toEqual([
       [ref1, '/foo'],
       [ref2, '/foo'],
       [ref3, '/bar'],
       [ref4, '/baz'],
       [ref5, '/baz'],
     ]);
-    expect(sortedEntries(routeParents)).toEqual([
+    expect(sortedEntries(routing.parents)).toEqual([
       [ref1, undefined],
       [ref2, undefined],
       [ref3, undefined],
       [ref4, ref3],
       [ref5, ref3],
     ]);
-    expect(routeObjects).toEqual([
+    expect(routing.objects).toEqual([
       routeObj('/foo', [ref1, ref2], [], 'gathered'),
       routeObj(
         '/bar',
@@ -317,30 +308,28 @@ describe('discovery', () => {
       </MemoryRouter>
     );
 
-    const { routes, routeParents, routeObjects } = traverseElementTree({
+    const { routing } = traverseElementTree({
       root,
       discoverers: [childDiscoverer, routeElementDiscoverer],
       collectors: {
-        routes: routePathCollector,
-        routeParents: routeParentCollector,
-        routeObjects: routeObjectCollector,
+        routing: routingV1Collector,
       },
     });
-    expect(sortedEntries(routes)).toEqual([
+    expect(sortedEntries(routing.paths)).toEqual([
       [ref1, '/foo'],
       [ref2, '/bar'],
       [ref3, '/baz'],
       [ref4, '/blop'],
       [ref5, '/bar'],
     ]);
-    expect(sortedEntries(routeParents)).toEqual([
+    expect(sortedEntries(routing.parents)).toEqual([
       [ref1, undefined],
       [ref2, ref1],
       [ref3, ref1],
       [ref4, ref3],
       [ref5, ref1],
     ]);
-    expect(routeObjects).toEqual([
+    expect(routing.objects).toEqual([
       routeObj(
         '/foo',
         [ref1],
@@ -376,8 +365,7 @@ describe('discovery', () => {
         root,
         discoverers: [childDiscoverer, routeElementDiscoverer],
         collectors: {
-          routes: routePathCollector,
-          routeParents: routeParentCollector,
+          routing: routingV1Collector,
         },
       });
     }).toThrow('Mounted routable extension must have a path');

--- a/packages/core-app-api/src/routing/collectors.test.tsx
+++ b/packages/core-app-api/src/routing/collectors.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { PropsWithChildren } from 'react';
-import { routingV1Collector } from './collectors';
+import { routingV1Collector, routingV2Collector } from './collectors';
 
 import {
   traverseElementTree,
@@ -120,7 +120,7 @@ function routeObj(
   };
 }
 
-describe('discovery', () => {
+describe('routingV1Collector', () => {
   it('should collect routes', () => {
     const list = [
       <div key={0} />,
@@ -369,5 +369,435 @@ describe('discovery', () => {
         },
       });
     }).toThrow('Mounted routable extension must have a path');
+  });
+});
+
+describe('routingV2Collector', () => {
+  function routeRoot(element: JSX.Element) {
+    return (
+      <MemoryRouter>
+        <Routes>{element}</Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('should associate path with extension in element prop', () => {
+    const { routing } = traverseElementTree({
+      root: routeRoot(<Route path="/foo" element={<Extension1 />} />),
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+
+    expect(sortedEntries(routing.paths)).toEqual([[ref1, '/foo']]);
+    expect(sortedEntries(routing.parents)).toEqual([[ref1, undefined]]);
+    expect(routing.objects).toEqual([
+      routeObj('/foo', [ref1], [], undefined, plugin),
+    ]);
+  });
+
+  it('should not allow multiple extensions within the same element prop', () => {
+    expect(() =>
+      traverseElementTree({
+        root: routeRoot(
+          <Route
+            path="/foo"
+            element={
+              <>
+                <Extension1 />
+                <Extension2 />
+              </>
+            }
+          />,
+        ),
+        discoverers: [childDiscoverer, routeElementDiscoverer],
+        collectors: {
+          routing: routingV2Collector,
+        },
+      }),
+    ).toThrow('Route element may not contain multiple routable extensions');
+  });
+
+  it('should not support inline path', () => {
+    expect(() =>
+      traverseElementTree({
+        root: routeRoot(<Extension1 path="/foo" />),
+        discoverers: [childDiscoverer, routeElementDiscoverer],
+        collectors: {
+          routing: routingV2Collector,
+        },
+      }),
+    ).toThrow('Path property may not be set directly on a routable extension');
+  });
+
+  it('should associate the path with extensions deep in the element prop', () => {
+    const { routing } = traverseElementTree({
+      root: routeRoot(
+        <Route
+          path="/foo"
+          element={
+            <>
+              <div>
+                <span />
+                {[
+                  undefined,
+                  null,
+                  <main>
+                    <Extension1 />
+                  </main>,
+                ]}
+              </div>
+            </>
+          }
+        />,
+      ),
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+
+    expect(sortedEntries(routing.paths)).toEqual([[ref1, '/foo']]);
+    expect(sortedEntries(routing.parents)).toEqual([[ref1, undefined]]);
+    expect(routing.objects).toEqual([
+      routeObj('/foo', [ref1], [], undefined, plugin),
+    ]);
+  });
+
+  it('should not associate path with extension in children prop', () => {
+    expect(() =>
+      traverseElementTree({
+        root: routeRoot(
+          <Route path="/foo">
+            <Extension1 />
+          </Route>,
+        ),
+        discoverers: [childDiscoverer, routeElementDiscoverer],
+        collectors: {
+          routing: routingV2Collector,
+        },
+      }),
+    ).toThrow('Routable extension must be assigned a path');
+  });
+
+  it('should assign parent for extension in element prop', () => {
+    const { routing } = traverseElementTree({
+      root: routeRoot(
+        <Route path="/foo" element={<Extension1 />}>
+          <Route path="/bar" element={<Extension2 />} />
+        </Route>,
+      ),
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+
+    expect(sortedEntries(routing.paths)).toEqual([
+      [ref1, '/foo'],
+      [ref2, '/bar'],
+    ]);
+    expect(sortedEntries(routing.parents)).toEqual([
+      [ref1, undefined],
+      [ref2, ref1],
+    ]);
+    expect(routing.objects).toEqual([
+      routeObj(
+        '/foo',
+        [ref1],
+        [routeObj('/bar', [ref2], [], undefined, plugin)],
+        undefined,
+        plugin,
+      ),
+    ]);
+  });
+
+  it('should not allow paths within element props', () => {
+    expect(() => {
+      traverseElementTree({
+        root: routeRoot(
+          <Route
+            path="."
+            element={<Route path="/foo" element={<Extension1 />} />}
+          />,
+        ),
+        discoverers: [childDiscoverer, routeElementDiscoverer],
+        collectors: {
+          routing: routingV2Collector,
+        },
+      });
+    }).toThrow('Elements within the element prop tree may not contain paths');
+  });
+
+  it('should not allow extensions within the element prop to have path props either', () => {
+    expect(() => {
+      traverseElementTree({
+        root: routeRoot(
+          <Route path="." element={<Extension1 path="/foo" />} />,
+        ),
+        discoverers: [childDiscoverer, routeElementDiscoverer],
+        collectors: {
+          routing: routingV2Collector,
+        },
+      });
+    }).toThrow('Elements within the element prop tree may not contain paths');
+  });
+
+  it('should gather extension', () => {
+    const { routing } = traverseElementTree({
+      root: routeRoot(
+        <AggregationComponent path="/foo">
+          <Extension1 />
+        </AggregationComponent>,
+      ),
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+
+    expect(sortedEntries(routing.paths)).toEqual([[ref1, '/foo']]);
+    expect(sortedEntries(routing.parents)).toEqual([[ref1, undefined]]);
+    expect(routing.objects).toEqual([routeObj('/foo', [ref1], [], 'gathered')]);
+  });
+
+  it('should reset gathering if path prop is encountered', () => {
+    const { routing } = traverseElementTree({
+      root: routeRoot(
+        <AggregationComponent path="/foo">
+          <Extension1>
+            <Route path="/bar" element={<Extension2 />} />
+          </Extension1>
+        </AggregationComponent>,
+      ),
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+
+    expect(sortedEntries(routing.paths)).toEqual([
+      [ref1, '/foo'],
+      [ref2, '/bar'],
+    ]);
+    expect(sortedEntries(routing.parents)).toEqual([
+      [ref1, undefined],
+      [ref2, ref1],
+    ]);
+    expect(routing.objects).toEqual([
+      routeObj(
+        '/foo',
+        [ref1],
+        [routeObj('/bar', [ref2], [], undefined, plugin)],
+        'gathered',
+      ),
+    ]);
+  });
+
+  it('should collect routes defined with different patterns', () => {
+    const list = [
+      <div key={0} />,
+      <div key={1} />,
+      <div key={3}>
+        <Route path="/blop" element={<Extension5 />} />
+      </div>,
+    ];
+
+    const { routing } = traverseElementTree({
+      root: routeRoot(
+        <>
+          <Route path="/foo" element={<Extension1 />}>
+            <div>
+              <Route path="/bar/:id" element={<Extension2 />}>
+                <div>
+                  <div />
+                  Some text here shouldn't be a problem
+                  <div />
+                  {null}
+                  <div />
+                  <Route path="/baz" element={<Extension3 />} />
+                </div>
+              </Route>
+              {false}
+              {list}
+              {true}
+              {0}
+            </div>
+          </Route>
+          <div>
+            <Route path="/divsoup" element={<Extension4 />} />
+          </div>
+        </>,
+      ),
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+    expect(sortedEntries(routing.paths)).toEqual([
+      [ref1, '/foo'],
+      [ref2, '/bar/:id'],
+      [ref3, '/baz'],
+      [ref4, '/divsoup'],
+      [ref5, '/blop'],
+    ]);
+    expect(sortedEntries(routing.parents)).toEqual([
+      [ref1, undefined],
+      [ref2, ref1],
+      [ref3, ref2],
+      [ref4, undefined],
+      [ref5, ref1],
+    ]);
+    expect(routing.objects).toEqual([
+      routeObj(
+        '/foo',
+        [ref1],
+        [
+          routeObj(
+            '/bar/:id',
+            [ref2],
+            [routeObj('/baz', [ref3], [], undefined, plugin)],
+            undefined,
+            plugin,
+          ),
+          routeObj('/blop', [ref5], [], undefined, plugin),
+        ],
+        undefined,
+        plugin,
+      ),
+      routeObj('/divsoup', [ref4], undefined, undefined, plugin),
+    ]);
+  });
+
+  it('should handle a subset of react router Route patterns', () => {
+    const { routing } = traverseElementTree({
+      root: routeRoot(
+        <>
+          <Route path="/foo" element={<Extension1 />} />
+          <Route
+            path="/baz"
+            element={
+              <div>
+                <Extension2 />
+              </div>
+            }
+          >
+            <Route path="/child" element={<Extension3 />} />
+            <AggregationComponent path="/collected">
+              <Extension4 />
+            </AggregationComponent>
+          </Route>
+        </>,
+      ),
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+    expect(sortedEntries(routing.paths)).toEqual([
+      [ref1, '/foo'],
+      [ref2, '/baz'],
+      [ref3, '/child'],
+      [ref4, '/collected'],
+    ]);
+    expect(sortedEntries(routing.parents)).toEqual([
+      [ref1, undefined],
+      [ref2, undefined],
+      [ref3, ref2],
+      [ref4, ref2],
+    ]);
+  });
+
+  it('should bind child routes to the same path with a gatherer flag', () => {
+    const { routing } = traverseElementTree({
+      root: routeRoot(
+        <>
+          <AggregationComponent path="/foo">
+            <Extension1 />
+            <div>
+              <Extension2 />
+            </div>
+            HELLO
+          </AggregationComponent>
+        </>,
+      ),
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+    expect(sortedEntries(routing.paths)).toEqual([
+      [ref1, '/foo'],
+      [ref2, '/foo'],
+    ]);
+    expect(sortedEntries(routing.parents)).toEqual([
+      [ref1, undefined],
+      [ref2, undefined],
+    ]);
+    expect(routing.objects).toEqual([
+      routeObj('/foo', [ref1, ref2], [], 'gathered'),
+    ]);
+  });
+
+  it('should gather routes but stop when encountering explicit path', () => {
+    const { routing } = traverseElementTree({
+      root: routeRoot(
+        <Route path="/foo" element={<Extension1 />}>
+          <AggregationComponent path="/bar">
+            <Extension2>
+              <Route path="/baz" element={<Extension3 />}>
+                <AggregationComponent path="/blop">
+                  <Extension4 />
+                </AggregationComponent>
+              </Route>
+              <Extension5 />
+            </Extension2>
+          </AggregationComponent>
+        </Route>,
+      ),
+      discoverers: [childDiscoverer, routeElementDiscoverer],
+      collectors: {
+        routing: routingV2Collector,
+      },
+    });
+    expect(sortedEntries(routing.paths)).toEqual([
+      [ref1, '/foo'],
+      [ref2, '/bar'],
+      [ref3, '/baz'],
+      [ref4, '/blop'],
+      [ref5, '/bar'],
+    ]);
+    expect(sortedEntries(routing.parents)).toEqual([
+      [ref1, undefined],
+      [ref2, ref1],
+      [ref3, ref2],
+      [ref4, ref3],
+      [ref5, ref1],
+    ]);
+    expect(routing.objects).toEqual([
+      routeObj(
+        '/foo',
+        [ref1],
+        [
+          routeObj(
+            '/bar',
+            [ref2, ref5],
+            [
+              routeObj(
+                '/baz',
+                [ref3],
+                [routeObj('/blop', [ref4], [], 'gathered')],
+                undefined,
+                plugin,
+              ),
+            ],
+            'gathered',
+          ),
+        ],
+        undefined,
+        plugin,
+      ),
+    ]);
   });
 });

--- a/packages/core-app-api/src/routing/collectors.tsx
+++ b/packages/core-app-api/src/routing/collectors.tsx
@@ -19,6 +19,7 @@ import {
   getComponentData,
   BackstagePlugin,
 } from '@backstage/core-plugin-api';
+import { isValidElement } from 'react';
 import { BackstageRouteObject } from './types';
 import { createCollector } from '../extensions/traversal';
 import { FeatureFlagged, FeatureFlaggedProps } from './FeatureFlagged';
@@ -102,5 +103,156 @@ export const featureFlagCollector = createCollector(
       const props = node.props as FeatureFlaggedProps;
       acc.add('with' in props ? props.with : props.without);
     }
+  },
+);
+
+interface RoutingV1CollectorContext {
+  path?: string;
+  routeRef?: RouteRef;
+  obj?: BackstageRouteObject;
+  sticky?: boolean;
+}
+
+/**
+ * This is the old V1 logic for collecting the routing model.
+ * It is being replaced by a new collector because this collection
+ * logic does not work well beyond react-router v6 beta.
+ *
+ * The breaking change is that react-router now requires route
+ * elements to be `Route` components, and directly renders the
+ * element prop rather than the `Route` itself. This means it is
+ * no longer possible to create utility route components. In order
+ * to fill this gap and in general simplify the route collection
+ * logic, a new route collection logic is created.
+ *
+ * @internal
+ */
+export const routingV1Collector = createCollector(
+  () => ({
+    paths: new Map<RouteRef, string>(),
+    parents: new Map<RouteRef, RouteRef | undefined>(),
+    objects: new Array<BackstageRouteObject>(),
+  }),
+  (acc, node, parent, ctx?: RoutingV1CollectorContext) => {
+    // Ignore the top-level element within element props, since it's already been collected.
+    if (parent?.props.element === node) {
+      return ctx;
+    }
+
+    let currentObj = ctx?.obj;
+    let currentParentRouteRef = ctx?.routeRef;
+    let sticky = ctx?.sticky;
+
+    const path: string | undefined = node.props?.path;
+    const parentChildren = currentObj?.children ?? acc.objects;
+    const caseSensitive: boolean = Boolean(node.props?.caseSensitive);
+
+    // The context path is used during mount point gathering to assign the same path
+    // to all discovered mount points
+    let currentCtxPath = ctx?.path;
+
+    // Start gathering mount points when we encounter a mount point gathering flag
+    if (getComponentData<boolean>(node, 'core.gatherMountPoints')) {
+      if (!path) {
+        throw new Error('Mount point gatherer must have a path');
+      }
+      currentCtxPath = path;
+    }
+
+    // Route refs are discovered on the element itself, and on the top-level
+    // element within the element prop if it exists.
+    const element = node.props?.element;
+    let routeRef = getComponentData<RouteRef>(node, 'core.mountPoint');
+    if (!routeRef && isValidElement(element)) {
+      routeRef = getComponentData<RouteRef>(element, 'core.mountPoint');
+    }
+
+    if (routeRef) {
+      // First the path gathering
+
+      let routePath: string | undefined = path;
+      // If we're gathering mount points we use the context path as out path, unless
+      // the element has its own path, in which case we use that instead and stop gathering
+      if (currentCtxPath) {
+        if (routePath) {
+          currentCtxPath = undefined;
+        } else {
+          routePath = currentCtxPath;
+        }
+      }
+      if (!routePath) {
+        throw new Error('Mounted routable extension must have a path');
+      }
+      acc.paths.set(routeRef, routePath);
+
+      // Then the parent gathering
+
+      // "sticky" route ref is when we've encountered a mount point gatherer, and we want a
+      // mount points beneath it to have the same parent, regardless of internal structure
+      if (currentParentRouteRef && sticky) {
+        acc.parents.set(routeRef, currentParentRouteRef);
+
+        // When we encounter a mount point with an explicit path, we stop gathering
+        // mount points within the children and remove the sticky state
+        if (path) {
+          currentParentRouteRef = routeRef;
+          sticky = false;
+        }
+      } else {
+        acc.parents.set(routeRef, currentParentRouteRef);
+        currentParentRouteRef = routeRef;
+      }
+
+      // Then construct the objects
+
+      if (path) {
+        currentObj = {
+          caseSensitive,
+          path,
+          element: 'mounted',
+          routeRefs: new Set([routeRef]),
+          children: [MATCH_ALL_ROUTE],
+          plugin: getComponentData<BackstagePlugin>(
+            node.props.element,
+            'core.plugin',
+          ),
+        };
+        parentChildren.push(currentObj);
+      } else {
+        currentObj?.routeRefs.add(routeRef);
+      }
+    }
+
+    if (getComponentData<boolean>(node, 'core.gatherMountPoints')) {
+      sticky = true;
+    }
+
+    const isGatherer = getComponentData<boolean>(
+      node,
+      'core.gatherMountPoints',
+    );
+    if (isGatherer) {
+      if (!path) {
+        throw new Error('Mount point gatherer must have a path');
+      }
+      if (!routeRef) {
+        currentObj = {
+          caseSensitive,
+          path,
+          element: 'gathered',
+          routeRefs: new Set(),
+          children: [MATCH_ALL_ROUTE],
+          plugin: ctx?.obj?.plugin,
+        };
+        parentChildren.push(currentObj);
+      }
+    }
+
+    return {
+      obj: currentObj,
+      path: currentCtxPath,
+      routeRef: currentParentRouteRef,
+      sticky,
+    };
   },
 );

--- a/packages/core-app-api/src/routing/collectors.tsx
+++ b/packages/core-app-api/src/routing/collectors.tsx
@@ -88,7 +88,7 @@ export const routeObjectCollector = createCollector(
 
     const routeRef = getComponentData<RouteRef>(node, 'core.mountPoint');
     if (routeRef) {
-      parentObj?.routeRefs.add(routeRef);
+      currentObj?.routeRefs.add(routeRef);
     }
 
     return currentObj;

--- a/packages/core-app-api/src/routing/collectors.tsx
+++ b/packages/core-app-api/src/routing/collectors.tsx
@@ -19,7 +19,7 @@ import {
   getComponentData,
   BackstagePlugin,
 } from '@backstage/core-plugin-api';
-import { isValidElement } from 'react';
+import { isValidElement, ReactNode, Children } from 'react';
 import { BackstageRouteObject } from './types';
 import { createCollector } from '../extensions/traversal';
 import { FeatureFlagged, FeatureFlaggedProps } from './FeatureFlagged';
@@ -35,58 +35,148 @@ export const MATCH_ALL_ROUTE: BackstageRouteObject = {
   routeRefs: new Set(),
 };
 
-interface RoutingCollectorParentContext {
-  path?: string;
+interface RoutingV2CollectorContext {
   routeRef?: RouteRef;
+  gatherPath?: string;
+  gatherRouteRef?: RouteRef;
   obj?: BackstageRouteObject;
   isElementAncestor?: boolean;
 }
 
-export const routingCollector = createCollector(
+function collectSubTree(
+  node: ReactNode,
+  entries = new Array<{ routeRef: RouteRef; plugin?: BackstagePlugin }>(),
+) {
+  Children.forEach(node, element => {
+    if (!isValidElement(element)) {
+      return;
+    }
+
+    if (element.props.path) {
+      throw new Error(
+        'Elements within the element prop tree may not contain paths',
+      );
+    }
+
+    const routeRef = getComponentData<RouteRef>(element, 'core.mountPoint');
+    if (routeRef) {
+      const plugin = getComponentData<BackstagePlugin>(element, 'core.plugin');
+      entries.push({ routeRef, plugin });
+    }
+
+    collectSubTree(element.props.children, entries);
+  });
+
+  return entries;
+}
+
+export const routingV2Collector = createCollector(
   () => ({
     paths: new Map<RouteRef, string>(),
     parents: new Map<RouteRef, RouteRef | undefined>(),
     objects: new Array<BackstageRouteObject>(),
   }),
-  (acc, node, parentElement, parent?: RoutingCollectorParentContext) => {
-    let currentObj = parent?.obj;
-    const isElement = parentElement?.props.element === node;
-    const isElementAncestor = parent?.isElementAncestor || isElement;
-    const parentChildren = currentObj?.children ?? acc.objects;
-
+  (acc, node, parent, ctx?: RoutingV2CollectorContext) => {
     const path: string | undefined = node.props?.path;
-    if (path && !isElementAncestor) {
-      currentObj = {
-        path,
-        element: 'mounted',
-        routeRefs: new Set(),
-        caseSensitive: Boolean(node.props?.caseSensitive),
-        children: [MATCH_ALL_ROUTE],
-        // TODO(Rugvip): This is borked
-        plugin: getComponentData<BackstagePlugin>(
-          node.props.element,
-          'core.plugin',
-        ),
-      };
-      parentChildren.push(currentObj);
+
+    const mountPoint = getComponentData<RouteRef>(node, 'core.mountPoint');
+    if (mountPoint) {
+      if (path) {
+        throw new Error(
+          'Path property may not be set directly on a routable extension',
+        );
+      }
     }
 
-    const routeRef = getComponentData<RouteRef>(node, 'core.mountPoint');
-    if (routeRef) {
-      currentObj?.routeRefs.add(routeRef);
-      acc.parents.set(routeRef, parent?.routeRef);
+    // If we're in an element prop, ignore everything
+    if (ctx?.isElementAncestor) {
+      return ctx;
+    }
+    // Start ignoring everything if we enter an element prop
+    if (parent?.props.element === node) {
+      return { ...ctx, isElementAncestor: true };
+    }
 
-      if (!parent?.path) {
-        throw new Error('Mounted routable extension must have a path');
+    let currentObj = ctx?.obj;
+    const parentChildren = currentObj?.children ?? acc.objects;
+
+    if (path) {
+      const elementProp = node.props.element;
+
+      if (getComponentData<boolean>(node, 'core.gatherMountPoints')) {
+        if (elementProp) {
+          throw new Error('Mount point gatherers may not have an element prop');
+        }
+
+        currentObj = {
+          path,
+          element: 'gathered',
+          routeRefs: new Set(),
+          caseSensitive: Boolean(node.props?.caseSensitive),
+          children: [MATCH_ALL_ROUTE],
+          plugin: undefined,
+        };
+        parentChildren.push(currentObj);
+
+        return {
+          obj: currentObj,
+          gatherPath: path,
+          routeRef: ctx?.routeRef,
+          gatherRouteRef: ctx?.routeRef,
+        };
       }
-      acc.paths.set(routeRef, isElement ? parent?.path : path ?? parent?.path);
+
+      if (elementProp) {
+        const [{ routeRef, plugin }, ...others] = collectSubTree(elementProp);
+        if (others.length > 0) {
+          throw new Error(
+            'Route element may not contain multiple routable extensions',
+          );
+        }
+
+        currentObj = {
+          path,
+          element: 'mounted',
+          routeRefs: new Set([routeRef]),
+          caseSensitive: Boolean(node.props?.caseSensitive),
+          children: [MATCH_ALL_ROUTE],
+          plugin,
+        };
+        parentChildren.push(currentObj);
+        acc.parents.set(routeRef, ctx?.routeRef);
+        acc.paths.set(routeRef, path);
+
+        return {
+          obj: currentObj,
+          routeRef: routeRef ?? ctx?.routeRef,
+          gatherPath: path,
+          gatherRouteRef: ctx?.gatherRouteRef,
+        };
+      }
+    }
+
+    if (mountPoint) {
+      if (!ctx?.gatherPath) {
+        throw new Error('Routable extension must be assigned a path');
+      }
+
+      ctx?.obj?.routeRefs.add(mountPoint);
+      acc.parents.set(mountPoint, ctx?.gatherRouteRef);
+      acc.paths.set(mountPoint, ctx.gatherPath);
+
+      return {
+        obj: currentObj,
+        routeRef: mountPoint,
+        gatherPath: ctx?.gatherPath,
+        gatherRouteRef: ctx?.gatherRouteRef,
+      };
     }
 
     return {
       obj: currentObj,
-      path: path ?? parent?.path,
-      routeRef: routeRef ?? parent?.routeRef,
-      isElementAncestor,
+      routeRef: ctx?.routeRef,
+      gatherPath: ctx?.gatherPath,
+      gatherRouteRef: ctx?.gatherRouteRef,
     };
   },
 );

--- a/plugins/permission-react/api-report.md
+++ b/plugins/permission-react/api-report.md
@@ -12,6 +12,7 @@ import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { Permission } from '@backstage/plugin-permission-common';
 import { ReactElement } from 'react';
+import { ReactNode } from 'react';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { Route } from 'react-router';
 
@@ -42,9 +43,9 @@ export type PermissionApi = {
 // @public
 export const permissionApiRef: ApiRef<PermissionApi>;
 
-// @public
+// @public @deprecated
 export const PermissionedRoute: (
-  props: ComponentProps<typeof Route> & {
+  _props: ComponentProps<typeof Route> & {
     errorComponent?: ReactElement | null;
   } & (
       | {
@@ -56,7 +57,27 @@ export const PermissionedRoute: (
           resourceRef: string | undefined;
         }
     ),
-) => JSX.Element;
+) => never;
+
+// @public
+export function RequirePermission(
+  props: RequirePermissionProps,
+): JSX.Element | null;
+
+// @public
+export type RequirePermissionProps = (
+  | {
+      permission: Exclude<Permission, ResourcePermission>;
+      resourceRef?: never;
+    }
+  | {
+      permission: ResourcePermission;
+      resourceRef: string | undefined;
+    }
+) & {
+  errorPage?: ReactNode;
+  children: ReactNode;
+};
 
 // @public
 export function usePermission(

--- a/plugins/permission-react/src/components/PermissionedRoute.tsx
+++ b/plugins/permission-react/src/components/PermissionedRoute.tsx
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-import React, { ComponentProps, ReactElement } from 'react';
+import { ComponentProps, ReactElement } from 'react';
 import { Route } from 'react-router';
-import { useApp } from '@backstage/core-plugin-api';
-import { usePermission } from '../hooks';
 import {
-  isResourcePermission,
   Permission,
   ResourcePermission,
 } from '@backstage/plugin-permission-common';
@@ -29,9 +26,10 @@ import {
  * NotFoundErrorPage (see {@link @backstage/core-app-api#AppComponents}).
  *
  * @public
+ * @deprecated This component no longer works with the most recent version of `@backstage/core-app-api` and react-router v6, use {@link RequirePermission} instead.
  */
 export const PermissionedRoute = (
-  props: ComponentProps<typeof Route> & {
+  _props: ComponentProps<typeof Route> & {
     errorComponent?: ReactElement | null;
   } & (
       | {
@@ -44,24 +42,7 @@ export const PermissionedRoute = (
         }
     ),
 ) => {
-  const { permission, resourceRef, errorComponent, ...otherProps } = props;
-
-  const permissionResult = usePermission(
-    isResourcePermission(permission)
-      ? { permission, resourceRef }
-      : { permission },
+  throw new Error(
+    'PermissionedRoute is no longer supported, switch to using <RequirePermission> instead: <Route path="/" element={<RequirePermission permission={...}>...<RequirePermission/>}/>',
   );
-  const app = useApp();
-  const { NotFoundErrorPage } = app.getComponents();
-
-  let shownElement: ReactElement | null | undefined =
-    errorComponent === undefined ? <NotFoundErrorPage /> : errorComponent;
-
-  if (permissionResult.loading) {
-    shownElement = null;
-  } else if (permissionResult.allowed) {
-    shownElement = props.element;
-  }
-
-  return <Route {...otherProps} element={shownElement} />;
 };

--- a/plugins/permission-react/src/components/RequirePermission.test.tsx
+++ b/plugins/permission-react/src/components/RequirePermission.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { PermissionedRoute } from '.';
+import { RequirePermission } from './RequirePermission';
 import { usePermission } from '../hooks';
 import { renderInTestApp } from '@backstage/test-utils';
 import { createPermission } from '@backstage/plugin-permission-common';
@@ -32,14 +32,14 @@ const permission = createPermission({
   attributes: { action: 'read' },
 });
 
-describe('PermissionedRoute', () => {
+describe('RequirePermission', () => {
   it('Does not render when loading', async () => {
     mockUsePermission.mockReturnValue({ loading: true, allowed: false });
 
     const { queryByText } = await renderInTestApp(
-      <PermissionedRoute
+      <RequirePermission
         permission={permission}
-        element={<div>content</div>}
+        children={<div>content</div>}
       />,
     );
 
@@ -50,9 +50,9 @@ describe('PermissionedRoute', () => {
     mockUsePermission.mockReturnValue({ loading: false, allowed: true });
 
     const { getByText } = await renderInTestApp(
-      <PermissionedRoute
+      <RequirePermission
         permission={permission}
-        element={<div>content</div>}
+        children={<div>content</div>}
       />,
     );
 
@@ -64,9 +64,9 @@ describe('PermissionedRoute', () => {
 
     await expect(
       renderInTestApp(
-        <PermissionedRoute
+        <RequirePermission
           permission={permission}
-          element={<div>content</div>}
+          children={<div>content</div>}
         />,
       ),
     ).rejects.toThrowError('Reached NotFound Page');
@@ -76,10 +76,10 @@ describe('PermissionedRoute', () => {
     mockUsePermission.mockReturnValue({ loading: false, allowed: false });
 
     const { getByText } = await renderInTestApp(
-      <PermissionedRoute
+      <RequirePermission
         permission={permission}
-        element={<div>content</div>}
-        errorComponent={<h1>Custom Error</h1>}
+        children={<div>content</div>}
+        errorPage={<h1>Custom Error</h1>}
       />,
     );
 

--- a/plugins/permission-react/src/components/RequirePermission.tsx
+++ b/plugins/permission-react/src/components/RequirePermission.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+import { useApp } from '@backstage/core-plugin-api';
+import { usePermission } from '../hooks';
+import {
+  isResourcePermission,
+  Permission,
+  ResourcePermission,
+} from '@backstage/plugin-permission-common';
+
+/**
+ * Properties for {@link RequirePermission}
+ *
+ * @public
+ */
+export type RequirePermissionProps = (
+  | {
+      permission: Exclude<Permission, ResourcePermission>;
+      resourceRef?: never;
+    }
+  | {
+      permission: ResourcePermission;
+      resourceRef: string | undefined;
+    }
+) & {
+  /**
+   * The error page to be displayed if the user is not allowed access.
+   *
+   * Defaults to the `NotFoundErrorPage` app component.
+   */
+  errorPage?: ReactNode;
+  children: ReactNode;
+};
+
+/**
+ * A boundary that only renders its child elements if the user has the specified permission.
+ *
+ * While loading, nothing will be rendered. If the user does not have
+ * permission, the `errorPage` element will be rendered, falling back
+ * to the `NotFoundErrorPage` app component if no `errorPage` is provider.
+ *
+ * @public
+ */
+export function RequirePermission(
+  props: RequirePermissionProps,
+): JSX.Element | null {
+  const { permission, resourceRef } = props;
+  const permissionResult = usePermission(
+    isResourcePermission(permission)
+      ? { permission, resourceRef }
+      : { permission },
+  );
+  const app = useApp();
+
+  if (permissionResult.loading) {
+    return null;
+  } else if (permissionResult.allowed) {
+    return <>{props.children}</>;
+  }
+
+  if (props.errorPage) {
+    return <>{props.errorPage}</>;
+  }
+  // If no explicit error element is provided, the not found page is used as fallback.
+  const { NotFoundErrorPage } = app.getComponents();
+  return <NotFoundErrorPage />;
+}

--- a/plugins/permission-react/src/components/index.ts
+++ b/plugins/permission-react/src/components/index.ts
@@ -15,3 +15,5 @@
  */
 
 export { PermissionedRoute } from './PermissionedRoute';
+export { RequirePermission } from './RequirePermission';
+export type { RequirePermissionProps } from './RequirePermission';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

See https://github.com/backstage/backstage/pull/10450#issuecomment-1081752655 for more context

The implementation here is more or less complete, except for the plugin collection for analytics. Still a draft though because I wanna discuss ALL the changes in this PR <img src="https://user-images.githubusercontent.com/4984472/160602940-227713de-6e6b-4463-a2fe-b756eeb95e24.png" width="30px">

The main think to discuss though is the changes to the route collection. Previously, all routable extensions had to be placed either directly within the `element` prop of a route, or placed somewhere beneath a route that was marked with the special `core.gatherMountPoints` component data flag. What that flag does is to switch the collection so that any of the elements found underneath a route are considered to be mounted at that route. This was introduced to make entity pages simpler to construct.

The change in this PR essentially removes `core.gatherMountPoints` and makes it the default, allowing things like this:

```tsx
<Route path="my-plugin" element={
  <MyFancyWrapper>
    <MyPluginPage />
  </MyFancyWrapper>
}/>
```

The downside of this is potential confusion, where you might by mistake place routable extensions deeper within a page, without realizing that they'll get bound.

Overall I think this is actually an improvement to the routing system, and as is evident in this PR it simplifies the implementation a lot. Still want to be very careful and evaluate eventual pitfalls though.

This should not be a breaking change, since we're expanding what's possible. I don't think there's any reasonable code that could have its behavior changed as a result of this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
