### PR TITLE
feat: split `BitbucketClient` into `BitbucketCloudClient`, `BitbucketServerClient`

### DIFF
--- a/.changeset/tasty-beans-clap.md
+++ b/.changeset/tasty-beans-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket': patch
+---
+
+split BitbucketClient into BitbucketCloudClient, BitbucketServerClient

--- a/plugins/catalog-backend-module-bitbucket/src/lib/BitbucketServerClient.ts
+++ b/plugins/catalog-backend-module-bitbucket/src/lib/BitbucketServerClient.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BitbucketIntegrationConfig,
+  getBitbucketRequestOptions,
+} from '@backstage/integration';
+import fetch from 'node-fetch';
+
+export class BitbucketServerClient {
+  private readonly config: BitbucketIntegrationConfig;
+
+  constructor(options: { config: BitbucketIntegrationConfig }) {
+    this.config = options.config;
+  }
+
+  async listProjects(options?: ListOptions): Promise<PagedResponse<any>> {
+    return this.pagedRequest(`${this.config.apiBaseUrl}/projects`, options);
+  }
+
+  async listRepositories(
+    projectKey: string,
+    options?: ListOptions,
+  ): Promise<PagedResponse<any>> {
+    return this.pagedRequest(
+      `${this.config.apiBaseUrl}/projects/${encodeURIComponent(
+        projectKey,
+      )}/repos`,
+      options,
+    );
+  }
+
+  private async pagedRequest(
+    endpoint: string,
+    options?: ListOptions,
+  ): Promise<PagedResponse<any>> {
+    const request = new URL(endpoint);
+    for (const key in options) {
+      if (options[key]) {
+        request.searchParams.append(key, options[key]!.toString());
+      }
+    }
+
+    const response = await fetch(
+      request.toString(),
+      getBitbucketRequestOptions(this.config),
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Unexpected response when fetching ${request.toString()}. Expected 200 but got ${
+          response.status
+        } - ${response.statusText}`,
+      );
+    }
+    return response.json() as Promise<PagedResponse<any>>;
+  }
+}
+
+export type ListOptions = {
+  [key: string]: number | undefined;
+  limit?: number | undefined;
+  start?: number | undefined;
+};
+
+export type PagedResponse<T> = {
+  size: number;
+  limit: number;
+  start: number;
+  isLastPage: boolean;
+  values: T[];
+  nextPageStart: number;
+};
+
+export async function* paginated(
+  request: (options: ListOptions) => Promise<PagedResponse<any>>,
+  options?: ListOptions,
+) {
+  const opts = options || { start: 0 };
+  let res;
+  do {
+    res = await request(opts);
+    opts.start = res.nextPageStart;
+    for (const item of res.values) {
+      yield item;
+    }
+  } while (!res.isLastPage);
+}

--- a/plugins/catalog-backend-module-bitbucket/src/lib/index.ts
+++ b/plugins/catalog-backend-module-bitbucket/src/lib/index.ts
@@ -16,6 +16,8 @@
 
 export { defaultRepositoryParser } from './BitbucketRepositoryParser';
 export type { BitbucketRepositoryParser } from './BitbucketRepositoryParser';
-export { BitbucketClient, paginated, paginated20 } from './client';
-export type { PagedResponse, PagedResponse20 } from './client';
+export { BitbucketCloudClient, paginated20 } from './BitbucketCloudClient';
+export { BitbucketServerClient, paginated } from './BitbucketServerClient';
+export type { PagedResponse20 } from './BitbucketCloudClient';
+export type { PagedResponse } from './BitbucketServerClient';
 export type { BitbucketRepository, BitbucketRepository20 } from './types';


### PR DESCRIPTION
split `BitbucketClient` into `BitbucketCloudClient`, `BitbucketServerClient`

Bitbucket Cloud and Bitbucket Server (fka. Stash) are different product lines at Atlassian
and offer different APIs.

This was also reflected within the client which contained a mix of endpoints for both.

This is a tiny transparent step towards an easier maintainable setup as proposed at #9923.
The change is transparent for users of the processor, contained within the internals of it.

Besides the maintainability as of #9923, this can also enable future enhancements like
handling of rate limits, etc.

Some API interactions are not part of the client but are included in other packages like
`packages/integration` and then e.g. used at the `UrlReader` implementation.
This imposes some challenges towards topics like rate limit handling, etc.
Due to this, it may even make sense to externalize the clients in the future
(or alternative options) and ensure all interactions go through it.

As part of creating entity providers for such processors (#10183), this might be a good candidate
to create separate entity providers instead. It would not impact current users of the processor
(more than one entity provider).

Relates-to: #9923
Relates-to: #10183
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
