### PR TITLE
fix: Stop loading all teams when plugin is initialized

### DIFF
--- a/.changeset/poor-pumpkins-fly.md
+++ b/.changeset/poor-pumpkins-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-azure-devops-backend': patch
+---
+
+Stop loading all teams when plugin is initialized

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -35,16 +35,11 @@ export class PullRequestsDashboardProvider {
     private readonly azureDevOpsApi: AzureDevOpsApi,
   ) {}
 
-  public static async create(
+  public static create(
     logger: Logger,
     azureDevOpsApi: AzureDevOpsApi,
-  ): Promise<PullRequestsDashboardProvider> {
+  ): PullRequestsDashboardProvider {
     const provider = new PullRequestsDashboardProvider(logger, azureDevOpsApi);
-    try {
-      await provider.readTeams();
-    } catch (error) {
-      logger.warn(`Failed to load azure team information, ${error}`);
-    }
     return provider;
   }
 

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -35,10 +35,10 @@ export class PullRequestsDashboardProvider {
     private readonly azureDevOpsApi: AzureDevOpsApi,
   ) {}
 
-  public static create(
+  public static async create(
     logger: Logger,
     azureDevOpsApi: AzureDevOpsApi,
-  ): PullRequestsDashboardProvider {
+  ): Promise<PullRequestsDashboardProvider> {
     const provider = new PullRequestsDashboardProvider(logger, azureDevOpsApi);
     return provider;
   }

--- a/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
+++ b/plugins/azure-devops-backend/src/api/PullRequestsDashboardProvider.ts
@@ -110,6 +110,8 @@ export class PullRequestsDashboardProvider {
     const dashboardPullRequests =
       await this.azureDevOpsApi.getDashboardPullRequests(projectName, options);
 
+    await this.getAllTeams(); // Make sure team members are loaded
+
     return dashboardPullRequests.map(pr => {
       if (pr.createdBy?.id) {
         const teamIds = this.teamMembers.get(pr.createdBy.id)?.memberOf;

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -53,8 +53,10 @@ export async function createRouter(
   const azureDevOpsApi =
     options.azureDevOpsApi || new AzureDevOpsApi(logger, webApi);
 
-  const pullRequestsDashboardProvider =
-    await PullRequestsDashboardProvider.create(logger, azureDevOpsApi);
+  const pullRequestsDashboardProvider = PullRequestsDashboardProvider.create(
+    logger,
+    azureDevOpsApi,
+  );
 
   const router = Router();
   router.use(express.json());

--- a/plugins/azure-devops-backend/src/service/router.ts
+++ b/plugins/azure-devops-backend/src/service/router.ts
@@ -53,10 +53,8 @@ export async function createRouter(
   const azureDevOpsApi =
     options.azureDevOpsApi || new AzureDevOpsApi(logger, webApi);
 
-  const pullRequestsDashboardProvider = PullRequestsDashboardProvider.create(
-    logger,
-    azureDevOpsApi,
-  );
+  const pullRequestsDashboardProvider =
+    await PullRequestsDashboardProvider.create(logger, azureDevOpsApi);
 
   const router = Router();
   router.use(express.json());


### PR DESCRIPTION
Quick fix for #9709

Ideally I think it would be useful to chunk the loading of teams. If anyone has any suggestions on how to best approach this feel free to comment.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
