### PR TITLE
Add table pagination to GoCD plugin

### DIFF
--- a/.changeset/swift-fans-shout.md
+++ b/.changeset/swift-fans-shout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-gocd': patch
+---
+
+Add pagination controls to GoCD build table

--- a/plugins/gocd/src/api/gocdApi.client.ts
+++ b/plugins/gocd/src/api/gocdApi.client.ts
@@ -18,6 +18,8 @@ import { GoCdApiError, PipelineHistory } from './gocdApi.model';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 
+const DEFAULT_PAGE_SIZE = 100;
+
 export class GoCdClientApi implements GoCdApi {
   constructor(private readonly discoveryApi: DiscoveryApi) {}
 
@@ -26,7 +28,7 @@ export class GoCdClientApi implements GoCdApi {
   ): Promise<PipelineHistory | GoCdApiError> {
     const baseUrl = await this.discoveryApi.getBaseUrl('proxy');
     const pipelineHistoryResponse = await fetch(
-      `${baseUrl}/gocd/pipelines/${pipelineName}/history`,
+      `${baseUrl}/gocd/pipelines/${pipelineName}/history?page_size=${DEFAULT_PAGE_SIZE}`,
       {
         headers: {
           Accept: 'application/vnd.go.cd+json',

--- a/plugins/gocd/src/components/GoCdBuildsTable/GoCdBuildsTable.tsx
+++ b/plugins/gocd/src/components/GoCdBuildsTable/GoCdBuildsTable.tsx
@@ -244,9 +244,11 @@ export const GoCdBuildsTable = (props: GoCdBuildsProps): JSX.Element => {
             search: true,
             searchAutoFocus: true,
             debounceInterval: 800,
-            paging: false,
+            paging: true,
+            padding: 'dense',
+            pageSizeOptions: [5, 10, 20, 50],
             showFirstLastPageButtons: false,
-            pageSize: 10,
+            pageSize: 20,
           }}
           columns={columns}
           data={


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The default value for the GoCD API is [10 pipelines per page](https://api.gocd.org/current/#get-pipeline-history).
Here we increase the requested page size to the maximum (100 pipelines per page) and add pagination controls to the build tables.

We still don't have _actual request pagination_ implemented, which means we only ever perform a single request - that will come in a future contribution.

Signed-off-by: Julio Zynger <julio.zynger@soundcloud.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
