### PR TITLE
Search: Index group display name in DefaultCatalogCollatorFactory

### DIFF
--- a/.changeset/many-cameras-search.md
+++ b/.changeset/many-cameras-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added `spec.profile.displayName` to search index for Group kinds

--- a/plugins/catalog-backend/src/search/util.test.ts
+++ b/plugins/catalog-backend/src/search/util.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { ComponentEntity, UserEntity } from '@backstage/catalog-model';
+import {
+  ComponentEntity,
+  GroupEntity,
+  UserEntity,
+} from '@backstage/catalog-model';
 import { getDocumentText } from './util';
 
 describe('getDocumentText', () => {
@@ -61,7 +65,54 @@ describe('getDocumentText', () => {
       expect(actual).toEqual('');
     });
   });
+
+  describe('kind is Group', () => {
+    test('contains display name if set', () => {
+      const entity = createGroup();
+      const actual = getDocumentText(entity);
+      expect(actual).toContain(entity.spec.profile?.displayName);
+    });
+
+    test('contains description if set', () => {
+      const entity = createGroup();
+      const actual = getDocumentText(entity);
+      expect(actual).toContain(entity.metadata.description);
+    });
+
+    test('contains both description and display name if both are set', () => {
+      const entity = createGroup();
+      const actual = getDocumentText(entity);
+      expect(actual).toContain(entity.spec.profile?.displayName);
+      expect(actual).toContain(entity.metadata.description);
+    });
+
+    test('is empty if description and display name are not set', () => {
+      const entity = createGroup();
+      delete entity.metadata.description;
+      delete entity.spec.profile?.displayName;
+      const actual = getDocumentText(entity);
+      expect(actual).toEqual('');
+    });
+  });
 });
+
+function createGroup(): GroupEntity {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Group',
+    metadata: {
+      name: 'group-1',
+      description: 'The expected description',
+    },
+    spec: {
+      type: 'team',
+      profile: {
+        displayName: 'Group 1',
+      },
+      children: [],
+    },
+  };
+}
 
 function createUser(): UserEntity {
   return {

--- a/plugins/catalog-backend/src/search/util.test.ts
+++ b/plugins/catalog-backend/src/search/util.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentEntity, UserEntity } from '@backstage/catalog-model';
+import { getDocumentText } from './util';
+
+describe('getDocumentText', () => {
+  describe('kind is not User or Group', () => {
+    test('contains description if set', () => {
+      const entity = createComponent();
+      entity.metadata.description = 'The expected description';
+      const actual = getDocumentText(entity);
+      expect(actual).toContain(entity.metadata.description);
+    });
+
+    test('is empty if description is not set', () => {
+      const entity = createComponent();
+      const actual = getDocumentText(entity);
+      expect(actual).toEqual('');
+    });
+  });
+
+  describe('kind is User', () => {
+    test('contains display name if set', () => {
+      const entity = createUser();
+      const actual = getDocumentText(entity);
+      expect(actual).toContain(entity.spec.profile?.displayName);
+    });
+
+    test('contains description if set', () => {
+      const entity = createUser();
+      const actual = getDocumentText(entity);
+      expect(actual).toContain(entity.metadata.description);
+    });
+
+    test('contains both description and display name if both are set', () => {
+      const entity = createUser();
+      const actual = getDocumentText(entity);
+      expect(actual).toContain(entity.spec.profile?.displayName);
+      expect(actual).toContain(entity.metadata.description);
+    });
+
+    test('is empty if description and display name are not set', () => {
+      const entity = createUser();
+      delete entity.metadata.description;
+      delete entity.spec.profile?.displayName;
+      const actual = getDocumentText(entity);
+      expect(actual).toEqual('');
+    });
+  });
+});
+
+function createUser(): UserEntity {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'User',
+    metadata: {
+      name: 'user-1',
+      description: 'The expected description',
+    },
+    spec: {
+      profile: {
+        displayName: 'User 1',
+      },
+    },
+  };
+}
+
+function createComponent(): ComponentEntity {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name: 'component-1',
+    },
+    spec: {
+      lifecycle: 'experimental',
+      owner: 'someone',
+      type: 'service',
+    },
+  };
+}

--- a/plugins/catalog-backend/src/search/util.ts
+++ b/plugins/catalog-backend/src/search/util.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity, UserEntity } from '@backstage/catalog-model';
+
+function isUserEntity(entity: Entity): entity is UserEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'USER';
+}
+
+export function getDocumentText(entity: Entity): string {
+  let documentText = entity.metadata.description || '';
+  if (isUserEntity(entity)) {
+    if (entity.spec?.profile?.displayName && documentText) {
+      // combine displayName and description
+      const displayName = entity.spec.profile.displayName;
+      documentText = displayName.concat(' : ', documentText);
+    } else {
+      documentText = entity.spec?.profile?.displayName || documentText;
+    }
+  }
+  return documentText;
+}

--- a/plugins/catalog-backend/src/search/util.ts
+++ b/plugins/catalog-backend/src/search/util.ts
@@ -25,15 +25,13 @@ function isGroupEntity(entity: Entity): entity is UserEntity {
 }
 
 export function getDocumentText(entity: Entity): string {
-  let documentText = entity.metadata.description || '';
+  const documentTexts: string[] = [];
+  documentTexts.push(entity.metadata.description || '');
+
   if (isUserEntity(entity) || isGroupEntity(entity)) {
-    if (entity.spec?.profile?.displayName && documentText) {
-      // combine displayName and description
-      const displayName = entity.spec.profile.displayName;
-      documentText = displayName.concat(' : ', documentText);
-    } else {
-      documentText = entity.spec?.profile?.displayName || documentText;
+    if (entity.spec?.profile?.displayName) {
+      documentTexts.push(entity.spec.profile.displayName);
     }
   }
-  return documentText;
+  return documentTexts.join(' : ');
 }

--- a/plugins/catalog-backend/src/search/util.ts
+++ b/plugins/catalog-backend/src/search/util.ts
@@ -20,9 +20,13 @@ function isUserEntity(entity: Entity): entity is UserEntity {
   return entity.kind.toLocaleUpperCase('en-US') === 'USER';
 }
 
+function isGroupEntity(entity: Entity): entity is UserEntity {
+  return entity.kind.toLocaleUpperCase('en-US') === 'GROUP';
+}
+
 export function getDocumentText(entity: Entity): string {
   let documentText = entity.metadata.description || '';
-  if (isUserEntity(entity)) {
+  if (isUserEntity(entity) || isGroupEntity(entity)) {
     if (entity.spec?.profile?.displayName && documentText) {
       // combine displayName and description
       const displayName = entity.spec.profile.displayName;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Added the `spec.profile.displayName` to the search index for Group kinds

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
