### PR TITLE
TechDocs: Change catalog access check for /static/docs requests

### DIFF
--- a/.changeset/sharp-jeans-deny.md
+++ b/.changeset/sharp-jeans-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': patch
+---
+
+Changed `@alpha` behavior of when `permission.enabled=true`: The authorization middleware for the assets endpoint (`/static/docs`) will only check for entity access on HTML document requests. Previously, this would verify access on every asset request.

--- a/plugins/techdocs-backend/src/service/router.ts
+++ b/plugins/techdocs-backend/src/service/router.ts
@@ -257,6 +257,11 @@ export async function createRouter(
     router.use(
       '/static/docs/:namespace/:kind/:name',
       async (req, _res, next) => {
+        if (!req.path.endsWith('/') && !req.path.endsWith('/index.html')) {
+          next();
+          return;
+        }
+
         const { kind, namespace, name } = req.params;
         const entityName = { kind, namespace, name };
         const token = getBearerToken(req.headers.authorization);


### PR DESCRIPTION
Signed-off-by: Joe Porpeglia <josephp@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes a bug with catalog access checks for techdocs assets. Not sure if this behavior changed recently, but we can't provide an authorization header when assets requests are issued by the browser instead of `fetch`. This change should at least prevent users from viewing the HTML documents where these asset URLs are defined.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
