### PR TITLE
Adding configuration for multiple newrelic proxies

### DIFF
--- a/.changeset/cyan-hornets-grin.md
+++ b/.changeset/cyan-hornets-grin.md
@@ -1,0 +1,23 @@
+---
+'@backstage/plugin-newrelic-dashboard': minor
+---
+
+Added API Prefix config to allow for multiple API configurations
+
+Added annotation: `newrelic.com/dashboard-api-prefix`
+
+Allows for additional API configurations:
+
+```
+// app-config.yaml - Multiple Accounts
+proxy:
+  '/newrelic/api':
+    target: https://api.newrelic.com
+    headers:
+      X-Api-Key: ${NEW_RELIC_USER_KEY}
+
+  '/<api-prefix>/newrelic/api':
+    target: https://api.newrelic.com
+    headers:
+      X-Api-Key: ${NEW_RELIC_ACCOUNT2_USER_KEY}
+```

--- a/plugins/newrelic-dashboard/README.md
+++ b/plugins/newrelic-dashboard/README.md
@@ -24,6 +24,20 @@ proxy:
       X-Api-Key: ${NEW_RELIC_USER_KEY}
 ```
 
+```
+// app-config.yaml - Multiple Accounts
+proxy:
+  '/newrelic/api':
+    target: https://api.newrelic.com
+    headers:
+      X-Api-Key: ${NEW_RELIC_USER_KEY}
+
+  '/<api-prefix>/newrelic/api':
+    target: https://api.newrelic.com
+    headers:
+      X-Api-Key: ${NEW_RELIC_ACCOUNT2_USER_KEY}
+```
+
 2. Add the following to `EntityPage.tsx` to display New Relic Dashboard Tab
 
 ```
@@ -72,8 +86,12 @@ metadata:
   # ...
   annotations:
     newrelic.com/dashboard-guid: <dashboard_guid>
+
+    # optional, used if you have multiple api proxies for multiple accounts
+    # Or if you wanted to use something other than the default
+    newrelic.com/dashboard-api-prefix: <api-prefix>
 spec:
   type: service
 ```
 
-All set , you will be able to see the plugin in action!
+All set, you will be able to see the plugin in action!

--- a/plugins/newrelic-dashboard/src/api/NewRelicDashboardApi.ts
+++ b/plugins/newrelic-dashboard/src/api/NewRelicDashboardApi.ts
@@ -34,9 +34,13 @@ export const newRelicDashboardApiRef = createApiRef<NewRelicDashboardApi>({
 });
 
 export type NewRelicDashboardApi = {
-  getDashboardEntity(guid: string): Promise<DashboardEntitySummary | undefined>;
+  getDashboardEntity(
+    guid: string,
+    apiPrefix: string,
+  ): Promise<DashboardEntitySummary | undefined>;
   getDashboardSnapshot(
     guid: string,
     duration: number,
+    apiPrefix: string,
   ): Promise<DashboardSnapshotSummary | undefined>;
 };

--- a/plugins/newrelic-dashboard/src/components/NewRelicDashboard/DashboardEntityList.tsx
+++ b/plugins/newrelic-dashboard/src/components/NewRelicDashboard/DashboardEntityList.tsx
@@ -28,7 +28,10 @@ import DesktopMac from '@material-ui/icons/DesktopMac';
 import { DashboardEntitySummary } from '../../api/NewRelicDashboardApi';
 import { ResultEntity } from '../../types/DashboardEntity';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { NEWRELIC_GUID_ANNOTATION } from './../../constants';
+import {
+  NEWRELIC_GUID_ANNOTATION,
+  NEWRELIC_API_PREFIX_ANNOTATION,
+} from './../../constants';
 
 const useStyles = makeStyles({
   svgIcon: {
@@ -50,9 +53,13 @@ export const DashboardEntityList = () => {
     const dashboardObject: Promise<DashboardEntitySummary | undefined> =
       newRelicDashboardAPI.getDashboardEntity(
         String(entity.metadata.annotations?.[NEWRELIC_GUID_ANNOTATION]),
+        String(entity.metadata.annotations?.[NEWRELIC_API_PREFIX_ANNOTATION]),
       );
     return dashboardObject;
-  }, [entity.metadata.annotations?.[NEWRELIC_GUID_ANNOTATION]]);
+  }, [
+    entity.metadata.annotations?.[NEWRELIC_GUID_ANNOTATION],
+    entity.metadata.annotations?.[NEWRELIC_API_PREFIX_ANNOTATION],
+  ]);
   if (loading) {
     return <Progress />;
   }

--- a/plugins/newrelic-dashboard/src/components/NewRelicDashboard/DashboardSnapshotList/DashboardSnapshot.tsx
+++ b/plugins/newrelic-dashboard/src/components/NewRelicDashboard/DashboardSnapshotList/DashboardSnapshot.tsx
@@ -31,6 +31,7 @@ type Props = {
   name: string;
   permalink: string;
   duration: number;
+  apiPrefix: string;
 };
 
 export const DashboardSnapshot = ({
@@ -38,15 +39,16 @@ export const DashboardSnapshot = ({
   name,
   permalink,
   duration,
+  apiPrefix,
 }: Props) => {
   const newRelicDashboardAPI = useApi(newRelicDashboardApiRef);
   const { value, loading, error } = useAsync(async (): Promise<
     DashboardSnapshotSummary | undefined
   > => {
     const dashboardObject: Promise<DashboardSnapshotSummary | undefined> =
-      newRelicDashboardAPI.getDashboardSnapshot(guid, duration);
+      newRelicDashboardAPI.getDashboardSnapshot(guid, duration, apiPrefix);
     return dashboardObject;
-  }, [guid, duration]);
+  }, [guid, duration, apiPrefix]);
   if (loading) {
     return <Progress />;
   }

--- a/plugins/newrelic-dashboard/src/components/NewRelicDashboard/DashboardSnapshotList/DashboardSnapshotList.tsx
+++ b/plugins/newrelic-dashboard/src/components/NewRelicDashboard/DashboardSnapshotList/DashboardSnapshotList.tsx
@@ -52,6 +52,7 @@ function a11yProps(index: number) {
 }
 type Props = {
   guid: string;
+  apiPrefix: string;
 };
 const useStyles = makeStyles(
   theme => ({
@@ -79,16 +80,16 @@ const useStyles = makeStyles(
   }),
   { name: 'DashboardHeaderTabs' },
 );
-export const DashboardSnapshotList = ({ guid }: Props) => {
+export const DashboardSnapshotList = ({ guid, apiPrefix }: Props) => {
   const styles = useStyles();
   const newRelicDashboardAPI = useApi(newRelicDashboardApiRef);
   const { value, loading, error } = useAsync(async (): Promise<
     DashboardEntitySummary | undefined
   > => {
     const dashboardObject: Promise<DashboardEntitySummary | undefined> =
-      newRelicDashboardAPI.getDashboardEntity(guid);
+      newRelicDashboardAPI.getDashboardEntity(guid, apiPrefix);
     return dashboardObject;
-  }, [guid]);
+  }, [guid, apiPrefix]);
   const [value1, setValue1] = useState<number>(0);
   const handleChange = ({}: React.ChangeEvent<{}>, newValue: number) => {
     setValue1(newValue);
@@ -137,6 +138,7 @@ export const DashboardSnapshotList = ({ guid }: Props) => {
                 name={Entity.name}
                 permalink={Entity.permalink}
                 guid={Entity.guid}
+                apiPrefix={Entity.apiPrefix}
                 duration={26297430000}
               />
             </TabPanel>

--- a/plugins/newrelic-dashboard/src/components/NewRelicDashboard/NewRelicDashboard.tsx
+++ b/plugins/newrelic-dashboard/src/components/NewRelicDashboard/NewRelicDashboard.tsx
@@ -19,7 +19,10 @@ import { Page, Content } from '@backstage/core-components';
 import { DashboardEntityList } from './DashboardEntityList';
 import { DashboardSnapshotList } from './DashboardSnapshotList';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { NEWRELIC_GUID_ANNOTATION } from '../../constants';
+import {
+  NEWRELIC_GUID_ANNOTATION,
+  NEWRELIC_API_PREFIX_ANNOTATION,
+} from '../../constants';
 
 export const NewRelicDashboard = () => {
   const { entity } = useEntity();
@@ -34,6 +37,9 @@ export const NewRelicDashboard = () => {
             <DashboardSnapshotList
               guid={String(
                 entity.metadata.annotations?.[NEWRELIC_GUID_ANNOTATION],
+              )}
+              apiPrefix={String(
+                entity.metadata.annotations?.[NEWRELIC_API_PREFIX_ANNOTATION],
               )}
             />
           </Grid>

--- a/plugins/newrelic-dashboard/src/constants.ts
+++ b/plugins/newrelic-dashboard/src/constants.ts
@@ -14,3 +14,5 @@
  * limitations under the License.
  */
 export const NEWRELIC_GUID_ANNOTATION = 'newrelic.com/dashboard-guid';
+export const NEWRELIC_API_PREFIX_ANNOTATION =
+  'newrelic.com/dashboard-api-prefix';

--- a/plugins/newrelic-dashboard/src/types/DashboardEntity.ts
+++ b/plugins/newrelic-dashboard/src/types/DashboardEntity.ts
@@ -31,4 +31,5 @@ export type ResultEntity = {
   guid: string;
   permalink: string;
   name: string;
+  apiPrefix: string;
 };


### PR DESCRIPTION
## Support multiple NewRelic Dashboard account proxies

We have about 15 NR accounts in total and needed to be able to pull dashboards from a few of them. 

This adds the ability to configure a prefix for the newrelic-dashboard plugins proxy configuration in the app-config.yaml.  

Added annotation to configure the prefix: `newrelic.com/dashboard-api-prefix` which allows for:
```
proxy:
  '/newrelic/api':
    target: https://api.newrelic.com
    headers:
      X-Api-Key: ${NEW_RELIC_USER_KEY}
  '/<api-prefix>/newrelic/api':
    target: https://api.newrelic.com
    headers:
      X-Api-Key: ${NEW_RELIC_ACCOUNT2_USER_KEY}
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
