### PR TITLE
Limit "View graph" depth in the Catalog Graph Card

### DIFF
--- a/.changeset/tame-tips-thank.md
+++ b/.changeset/tame-tips-thank.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Add optional parameter to catalog graph card to limit graph depth when view graph is clicked

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
@@ -126,6 +126,29 @@ describe('<CatalogGraphCard/>', () => {
     );
   });
 
+  test('renders link to standalone viewer with limited depth', async () => {
+    const { findByText, getByText } = await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <EntityProvider entity={entity}>
+          <CatalogGraphCard viewGraphDepth={3}/>
+        </EntityProvider>
+      </ApiProvider>
+      , {
+        mountedRoutes: {
+          '/entity/{kind}/{namespace}/{name}': entityRouteRef,
+          '/catalog-graph': catalogGraphRouteRef,
+        },
+      });
+
+    expect(await findByText('b:d/c')).toBeInTheDocument();
+    const button = getByText('View graph');
+    expect(button).toBeInTheDocument();
+    expect(button.closest('a')).toHaveAttribute(
+      'href',
+      '/catalog-graph?rootEntityRefs%5B%5D=b%3Ad%2Fc&maxDepth=3',
+    );
+  });
+
   test('captures analytics event on click', async () => {
     const analyticsSpy = new MockAnalyticsApi();
     const { findByText } = await renderInTestApp(

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -55,6 +55,7 @@ export const CatalogGraphCard = ({
   variant = 'gridItem',
   relationPairs = ALL_RELATION_PAIRS,
   maxDepth = 1,
+  viewGraphDepth,
   unidirectional = true,
   mergeRelations = true,
   kinds,
@@ -67,6 +68,7 @@ export const CatalogGraphCard = ({
   variant?: InfoCardVariants;
   relationPairs?: RelationPairs;
   maxDepth?: number;
+  viewGraphDepth?: number;
   unidirectional?: boolean;
   mergeRelations?: boolean;
   kinds?: string[];
@@ -103,7 +105,7 @@ export const CatalogGraphCard = ({
   );
 
   const catalogGraphParams = qs.stringify(
-    { rootEntityRefs: [stringifyEntityRef(entity)] },
+    { rootEntityRefs: [stringifyEntityRef(entity)], maxDepth: viewGraphDepth },
     { arrayFormat: 'brackets', addQueryPrefix: true },
   );
   const catalogGraphUrl = `${catalogGraphRoute()}${catalogGraphParams}`;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #10524

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
I added "viewGraphDepth" as an optional prop to [CatalogGraphCard](https://github.com/backstage/backstage/blob/adfe2ea2ad8c84d32dbf8e7ab572ea3882eb1825/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx#L54) which value is then embedded into the query string in the "View graph" buttons destination URL.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
