### PR TITLE
Add name for BackstageTab styles

### DIFF
--- a/.changeset/sharp-terms-tap.md
+++ b/.changeset/sharp-terms-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Adding a name to the core-components Tab styles so can customise in the theme settings

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,4 @@
 {
   labels: ['dependencies'],
   extends: ['config:base', ':disableDependencyDashboard', ':gitSignOff'],
-  rangeStrategy: 'update-lockfile',
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,5 @@
 {
   labels: ['dependencies'],
   extends: ['config:base', ':disableDependencyDashboard', ':gitSignOff'],
+  rangeStrategy: 'update-lockfile',
 }

--- a/packages/core-components/src/components/Tabs/Tab.tsx
+++ b/packages/core-components/src/components/Tabs/Tab.tsx
@@ -37,24 +37,27 @@ const tabMarginLeft = (isFirstNav: boolean, isFirstIndex: boolean) => {
   return '40px';
 };
 
-const useStyles = makeStyles<BackstageTheme, StyledTabProps>(theme => ({
-  root: {
-    textTransform: 'none',
-    height: '64px',
-    fontWeight: theme.typography.fontWeightBold,
-    fontSize: theme.typography.pxToRem(13),
-    color: theme.palette.textSubtle,
-    marginLeft: props =>
-      tabMarginLeft(props.isFirstNav as boolean, props.isFirstIndex as boolean),
-    width: '130px',
-    minWidth: '130px',
-    '&:hover': {
-      outline: 'none',
-      backgroundColor: 'transparent',
+const useStyles = makeStyles<BackstageTheme, StyledTabProps>(
+  theme => ({
+    root: {
+      textTransform: 'none',
+      height: '64px',
+      fontWeight: theme.typography.fontWeightBold,
+      fontSize: theme.typography.pxToRem(13),
       color: theme.palette.textSubtle,
+      marginLeft: props =>
+        tabMarginLeft(props.isFirstNav as boolean, props.isFirstIndex as boolean),
+      width: '130px',
+      minWidth: '130px',
+      '&:hover': {
+        outline: 'none',
+        backgroundColor: 'transparent',
+        color: theme.palette.textSubtle,
+      },
     },
-  },
-}));
+  }),
+  { name: 'BackstageTab' },
+);
 
 export const StyledTab = (props: StyledTabProps) => {
   const classes = useStyles(props);

--- a/packages/core-components/src/components/Tabs/Tab.tsx
+++ b/packages/core-components/src/components/Tabs/Tab.tsx
@@ -46,7 +46,10 @@ const useStyles = makeStyles<BackstageTheme, StyledTabProps>(
       fontSize: theme.typography.pxToRem(13),
       color: theme.palette.textSubtle,
       marginLeft: props =>
-        tabMarginLeft(props.isFirstNav as boolean, props.isFirstIndex as boolean),
+        tabMarginLeft(
+          props.isFirstNav as boolean,
+          props.isFirstIndex as boolean,
+        ),
       width: '130px',
       minWidth: '130px',
       '&:hover': {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a name to core component Tab.tsx styles so can override the css globally for the theme as per 
https://backstage.io/docs/getting-started/app-custom-theme#overriding-backstage-and-material-ui-components-styles

From discord conversation at https://discord.com/channels/687207715902193673/959109962888515664

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
