### PR TITLE
Add BackstageTab to overridableComponents

### DIFF
--- a/.changeset/few-buttons-breathe.md
+++ b/.changeset/few-buttons-breathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add BackstageTab to overridableComponents so can override styles in a theme

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1286,8 +1286,6 @@ export namespace TabbedLayout {
     Route: (props: SubRoute) => null;
 }
 
-// Warning: (ae-missing-release-tag) "TabClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export type TabClassKey = 'root' | 'selected';
 

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -1286,6 +1286,11 @@ export namespace TabbedLayout {
     Route: (props: SubRoute) => null;
 }
 
+// Warning: (ae-missing-release-tag) "TabClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type TabClassKey = 'root' | 'selected';
+
 // Warning: (ae-missing-release-tag) "TabIconClassKey" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/packages/core-components/src/components/Tabs/Tab.tsx
+++ b/packages/core-components/src/components/Tabs/Tab.tsx
@@ -37,6 +37,7 @@ const tabMarginLeft = (isFirstNav: boolean, isFirstIndex: boolean) => {
   return '40px';
 };
 
+/** @public */
 export type TabClassKey = 'root' | 'selected';
 
 const useStyles = makeStyles<BackstageTheme, StyledTabProps>(

--- a/packages/core-components/src/components/Tabs/Tab.tsx
+++ b/packages/core-components/src/components/Tabs/Tab.tsx
@@ -37,6 +37,8 @@ const tabMarginLeft = (isFirstNav: boolean, isFirstIndex: boolean) => {
   return '40px';
 };
 
+export type TabClassKey = 'root' | 'selected';
+
 const useStyles = makeStyles<BackstageTheme, StyledTabProps>(
   theme => ({
     root: {
@@ -65,5 +67,5 @@ const useStyles = makeStyles<BackstageTheme, StyledTabProps>(
 export const StyledTab = (props: StyledTabProps) => {
   const classes = useStyles(props);
   const { isFirstNav, isFirstIndex, ...rest } = props;
-  return <Tab className={classes.root} disableRipple {...rest} />;
+  return <Tab classes={classes} disableRipple {...rest} />;
 };

--- a/packages/core-components/src/components/Tabs/index.ts
+++ b/packages/core-components/src/components/Tabs/index.ts
@@ -16,6 +16,7 @@
 
 export { Tabs } from './Tabs';
 export type { TabsClassKey } from './Tabs';
+export type { TabClassKey } from './Tab';
 
 export type { TabBarClassKey } from './TabBar';
 export type { TabIconClassKey } from './TabIcon';

--- a/packages/core-components/src/overridableComponents.ts
+++ b/packages/core-components/src/overridableComponents.ts
@@ -63,6 +63,7 @@ import {
   TabBarClassKey,
   TabIconClassKey,
   TabsClassKey,
+  TabClassKey,
   WarningPanelClassKey,
 } from './components';
 
@@ -143,6 +144,7 @@ type BackstageComponentsNameToClassKey = {
   BackstageTabBar: TabBarClassKey;
   BackstageTabIcon: TabIconClassKey;
   BackstageTabs: TabsClassKey;
+  BackstageTab: TabClassKey;
   BackstageWarningPanel: WarningPanelClassKey;
   BackstageBottomLink: BottomLinkClassKey;
   BackstageBreadcrumbsClickableText: BreadcrumbsClickableTextClassKey;


### PR DESCRIPTION
Signed-off-by: sandra-greenhalgh <sandra.greenhalgh@justeattakeaway.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Add `BackstageTab` to `overridableComponents` so its possible to override styles in themes

Its a follow on from https://github.com/backstage/backstage/pull/10554

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
