### PR TITLE
(doc) Use https link for directing users to knexjs

### DIFF
--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -12,7 +12,7 @@ Once you're ready to deploy Backstage in production, or to have a more
 persistent development setup, you can switch the Backstage database to
 PostgreSQL.
 
-Backstage uses the [Knex](http://knexjs.org/) library, making it fairly easy to
+Backstage uses the [Knex](https://knexjs.org/) library, making it fairly easy to
 switch between database backends.
 
 ## Install PostgreSQL


### PR DESCRIPTION
Updated the link for knexjs website to use HTTPS instead of HTTP; in the documentation page for postgres migration.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
