### PR TITLE
Optionally hide OwnershipCard relation toggle

### DIFF
--- a/.changeset/grumpy-parents-prove.md
+++ b/.changeset/grumpy-parents-prove.md
@@ -2,4 +2,24 @@
 '@backstage/plugin-org': patch
 ---
 
-Provides the ability to hide the relations toggle as well as setting a default relation type
+Provides the ability to hide the relations toggle on the `OwnershipCard` as well as setting a default relation type.
+
+To hide the toggle simply include the `hideRelationsToggle` prop like this:
+
+```tsx
+<EntityOwnershipCard
+  variant="gridItem"
+  entityFilterKind={customEntityFilterKind}
+  hideRelationsToggle
+/>
+```
+
+To set the default relation type, add the `relationsType` prop with a value of direct or aggregated, the default if not provided is direct. Here is an example:
+
+```tsx
+<EntityOwnershipCard
+  variant="gridItem"
+  entityFilterKind={customEntityFilterKind}
+  relationsType="aggregated"
+/>
+```

--- a/.changeset/grumpy-parents-prove.md
+++ b/.changeset/grumpy-parents-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Provides the ability to hide the relations toggle as well as setting a default relation type

--- a/plugins/org/api-report.md
+++ b/plugins/org/api-report.md
@@ -25,6 +25,8 @@ export const EntityMembersListCard: (props: {
 export const EntityOwnershipCard: (props: {
   variant?: InfoCardVariants | undefined;
   entityFilterKind?: string[] | undefined;
+  hideRelationsToggle?: boolean | undefined;
+  relationsType?: string | undefined;
 }) => JSX.Element;
 
 // @public (undocumented)
@@ -64,6 +66,8 @@ export { orgPlugin as plugin };
 export const OwnershipCard: (props: {
   variant?: InfoCardVariants;
   entityFilterKind?: string[];
+  hideRelationsToggle?: boolean;
+  relationsType?: string;
 }) => JSX.Element;
 
 // @public (undocumented)

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -291,4 +291,74 @@ describe('OwnershipCard', () => {
       '/create/?filters%5Bkind%5D=API&filters%5Btype%5D=openapi&filters%5Bowners%5D%5B0%5D=the-user&filters%5Bowners%5D%5B1%5D=my-team&filters%5Buser%5D=all',
     );
   });
+
+  describe('OwnershipCard relations', () => {
+    it('shows relations toggle', async () => {
+      const catalogApi: jest.Mocked<CatalogApi> = {
+        getEntities: jest.fn(),
+      } as any;
+
+      catalogApi.getEntities.mockImplementation(getEntitiesMock);
+
+      const { getByTitle } = await renderInTestApp(
+        <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+          <EntityProvider entity={groupEntity}>
+            <OwnershipCard />
+          </EntityProvider>
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/create': catalogIndexRouteRef,
+          },
+        },
+      );
+
+      expect(getByTitle('Direct Relations')).toBeInTheDocument();
+    });
+
+    it('hides relations toggle', async () => {
+      const catalogApi: jest.Mocked<CatalogApi> = {
+        getEntities: jest.fn(),
+      } as any;
+
+      catalogApi.getEntities.mockImplementation(getEntitiesMock);
+
+      const rendered = await renderInTestApp(
+        <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+          <EntityProvider entity={groupEntity}>
+            <OwnershipCard hideRelationsToggle />
+          </EntityProvider>
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/create': catalogIndexRouteRef,
+          },
+        },
+      );
+
+      expect(rendered.queryByText('Direct Relations')).toBeNull();
+    });
+    it('overrides relation type', async () => {
+      const catalogApi: jest.Mocked<CatalogApi> = {
+        getEntities: jest.fn(),
+      } as any;
+
+      catalogApi.getEntities.mockImplementation(getEntitiesMock);
+
+      const { getByTitle } = await renderInTestApp(
+        <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+          <EntityProvider entity={groupEntity}>
+            <OwnershipCard relationsType="aggregated" />
+          </EntityProvider>
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/create': catalogIndexRouteRef,
+          },
+        },
+      );
+
+      expect(getByTitle('Aggregated Relations')).toBeInTheDocument();
+    });
+  });
 });

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -55,48 +55,58 @@ const useStyles = makeStyles(theme => ({
 export const OwnershipCard = (props: {
   variant?: InfoCardVariants;
   entityFilterKind?: string[];
+  hideRelationsToggle?: boolean;
+  relationsType?: string;
 }) => {
-  const { variant, entityFilterKind } = props;
-
+  const { variant, entityFilterKind, hideRelationsToggle, relationsType } =
+    props;
+  const relationsToggle =
+    hideRelationsToggle === undefined ? false : hideRelationsToggle;
   const classes = useStyles();
   const { entity } = useEntity();
   const isGroup = entity.kind === 'Group';
-  const [relationsType, setRelationsType] = useState('direct');
+  const [getRelationsType, setRelationsType] = useState(
+    relationsType || 'direct',
+  );
 
   return (
     <InfoCard title="Ownership" variant={variant}>
       <List dense>
         <ListItem className={classes.list}>
           <ListItemText className={classes.listItemText} />
-          <ListItemSecondaryAction className={classes.listItemSecondaryAction}>
-            Direct Relations
-            <Tooltip
-              placement="top"
-              arrow
-              title={`${
-                relationsType === 'direct' ? 'Direct' : 'Aggregated'
-              } Relations`}
+          {!relationsToggle && (
+            <ListItemSecondaryAction
+              className={classes.listItemSecondaryAction}
             >
-              <Switch
-                color="primary"
-                checked={relationsType !== 'direct'}
-                onChange={() =>
-                  relationsType === 'direct'
-                    ? setRelationsType('aggregated')
-                    : setRelationsType('direct')
-                }
-                name="pin"
-                inputProps={{ 'aria-label': 'Ownership Type Switch' }}
-                disabled={!isGroup}
-              />
-            </Tooltip>
-            Aggregated Relations
-          </ListItemSecondaryAction>
+              Direct Relations
+              <Tooltip
+                placement="top"
+                arrow
+                title={`${
+                  getRelationsType === 'direct' ? 'Direct' : 'Aggregated'
+                } Relations`}
+              >
+                <Switch
+                  color="primary"
+                  checked={getRelationsType !== 'direct'}
+                  onChange={() =>
+                    getRelationsType === 'direct'
+                      ? setRelationsType('aggregated')
+                      : setRelationsType('direct')
+                  }
+                  name="pin"
+                  inputProps={{ 'aria-label': 'Ownership Type Switch' }}
+                  disabled={!isGroup}
+                />
+              </Tooltip>
+              Aggregated Relations
+            </ListItemSecondaryAction>
+          )}
         </ListItem>
       </List>
       <ComponentsGrid
         entity={entity}
-        relationsType={relationsType}
+        relationsType={getRelationsType}
         isGroup={isGroup}
         entityFilterKind={entityFilterKind}
       />

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.tsx
@@ -71,10 +71,10 @@ export const OwnershipCard = (props: {
 
   return (
     <InfoCard title="Ownership" variant={variant}>
-      <List dense>
-        <ListItem className={classes.list}>
-          <ListItemText className={classes.listItemText} />
-          {!relationsToggle && (
+      {!relationsToggle && (
+        <List dense>
+          <ListItem className={classes.list}>
+            <ListItemText className={classes.listItemText} />
             <ListItemSecondaryAction
               className={classes.listItemSecondaryAction}
             >
@@ -101,9 +101,9 @@ export const OwnershipCard = (props: {
               </Tooltip>
               Aggregated Relations
             </ListItemSecondaryAction>
-          )}
-        </ListItem>
-      </List>
+          </ListItem>
+        </List>
+      )}
       <ComponentsGrid
         entity={entity}
         relationsType={getRelationsType}


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <awanlin@rapidrtc.com>

## Hey, I just made a Pull Request!

Provides the ability to hide the relations toggle on the `OwnershipCard` as well as setting a default relation type

Current State

![current-state](https://user-images.githubusercontent.com/67169551/161447675-a46148d4-c058-473e-9d9e-1e3a058251fa.png)

Hidden Toggle

![hidden-state](https://user-images.githubusercontent.com/67169551/161447684-1de55cc8-a994-4f49-9867-8887f774d796.png)

Relation Type of Aggregated with Toggle Hidden

![hidden-relationstype](https://user-images.githubusercontent.com/67169551/161447962-f2788eff-7140-4c1b-abf1-4daf98a6efd3.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
