### PR TITLE
feat(catalog-backend-module-gitlab): create url location only if file exists

### DIFF
--- a/.changeset/real-beers-type.md
+++ b/.changeset/real-beers-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+do not creating url location object if file with component definition do not exists in project, that decrease count of request to gitlab with 404 status code

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
@@ -114,6 +114,18 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
         continue;
       }
 
+      const project_branch = branch === '*' ? project.default_branch : branch;
+
+      const projectHasFile: boolean = await client.hasFile(
+        project.path_with_namespace,
+        project_branch,
+        catalogPath,
+      );
+
+      if (!projectHasFile) {
+        continue;
+      }
+
       res.matches.push(project);
     }
 

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -63,6 +63,36 @@ export class GitLabClient {
     return this.pagedRequest(`/projects`, options);
   }
 
+  async hasFile(
+    projectPath: string,
+    branch: string,
+    filePath: string,
+  ): Promise<boolean> {
+    const endpoint: string = `/projects/${encodeURIComponent(
+      projectPath,
+    )}/repository/files/${encodeURIComponent(filePath)}`;
+    const request = new URL(`${this.config.apiBaseUrl}${endpoint}`);
+    request.searchParams.append('ref', branch);
+
+    this.logger.debug(`Fetching: ${request.toString()}`);
+
+    const response = await fetch(request.toString(), {
+      headers: getGitLabRequestOptions(this.config).headers,
+      method: 'HEAD',
+    });
+
+    if (!response.ok) {
+      this.logger.debug(
+        `Unexpected response when fetching ${request.toString()}. Expected 200 but got ${
+          response.status
+        } - ${response.statusText}`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
   /**
    * Performs a request against a given paginated GitLab endpoint.
    *


### PR DESCRIPTION
## Hey, I just made a Pull Request!

gitlab-discovery create many url location objects, even for projects, that do not contains file with component definitions

in this PR added additional checks for file existing, and after that url location if emited

it's decrease number of 404 requests to gitlab server

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
