### PR TITLE
scaffolder-backend: switch bitbucket-demo example template to use fetch:template

### DIFF
--- a/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
+++ b/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template.yaml
@@ -45,20 +45,18 @@ spec:
   steps:
     - id: fetch-base
       name: Fetch Base
-      action: fetch:cookiecutter
+      action: fetch:template
       input:
         url: ./template
         values:
           name: ${{ parameters.name }}
           owner: ${{ parameters.owner }}
-
     - id: fetch-docs
       name: Fetch Docs
       action: fetch:plain
       input:
         targetPath: ./community
         url: https://github.com/backstage/community/tree/main/backstage-community-sessions
-
     - id: publish
       name: Publish
       action: publish:bitbucket
@@ -74,9 +72,9 @@ spec:
         catalogInfoPath: '/catalog-info.yaml'
 
   output:
-    links:	
-      - title: Repository	
+    links:
+      - title: Repository
         url: ${{ steps.publish.output.remoteUrl }}
-      - title: Open in catalog	
+      - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps.register.output.entityRef }}

--- a/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template/catalog-info.yaml
+++ b/plugins/scaffolder-backend/sample-templates/bitbucket-demo/template/catalog-info.yaml
@@ -1,8 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: {{cookiecutter.name | jsonify}}
+  name: ${{values.name | dump}}
 spec:
   type: website
   lifecycle: experimental
-  owner: {{cookiecutter.owner | jsonify}}
+  owner: ${{values.owner | dump}}


### PR DESCRIPTION
Came across this, is this supposed to be the case? 😅 

No changeset since the samples aren't published