### PR TITLE
feat: split BitbucketDiscoveryProcessor

### DIFF
--- a/.changeset/real-pots-raise.md
+++ b/.changeset/real-pots-raise.md
@@ -1,0 +1,112 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket': patch
+---
+
+Split `BitbucketDiscoveryProcessor` into `BitbucketCloudDiscoveryProcessor` and `BitbucketServerDiscoveryProcessor`.
+
+Deprecates `BitbucketDiscoveryProcessor` in favor of its two replacements which will
+use both of them under the hood until its removal.
+
+**Migration for Bitbucket Cloud users:**
+
+Previous setup:
+
+```yaml
+catalog:
+  locations:
+    - type: bitbucket-cloud-discovery
+      target: https://bitbucket.org/workspaces/my-workspace
+```
+
+```typescript
+// In packages/backend/src/plugins/catalog.ts
+import { BitbucketDiscoveryProcessor } from '@backstage/plugin-catalog-backend-module-bitbucket';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  const builder = await CatalogBuilder.create(env);
+  builder.addProcessor(
+    BitbucketDiscoveryProcessor.fromConfig(env.config, { logger: env.logger }),
+  );
+  // [...]
+}
+```
+
+New setup:
+
+```yaml
+catalog:
+  locations:
+    - type: bitbucket-cloud-discovery
+      target: https://bitbucket.org/workspaces/my-workspace
+```
+
+```typescript
+// In packages/backend/src/plugins/catalog.ts
+import { BitbucketCloudDiscoveryProcessor } from '@backstage/plugin-catalog-backend-module-bitbucket';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  const builder = await CatalogBuilder.create(env);
+  builder.addProcessor(
+    BitbucketCloudDiscoveryProcessor.fromConfig(env.config, {
+      logger: env.logger,
+    }),
+  );
+  // [...]
+}
+```
+
+**Migration for Bitbucket Server users:**
+
+Previous setup:
+
+```yaml
+catalog:
+  locations:
+    - type: bitbucket-discovery
+      target: https://bitbucket.mycompany.com/projects/my-project/repos/service-*/catalog-info.yaml
+```
+
+```typescript
+// In packages/backend/src/plugins/catalog.ts
+import { BitbucketDiscoveryProcessor } from '@backstage/plugin-catalog-backend-module-bitbucket';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  const builder = await CatalogBuilder.create(env);
+  builder.addProcessor(
+    BitbucketDiscoveryProcessor.fromConfig(env.config, { logger: env.logger }),
+  );
+  // [...]
+}
+```
+
+New setup:
+
+```yaml
+catalog:
+  locations:
+    - type: bitbucket-server-discovery
+      target: https://bitbucket.mycompany.com/projects/my-project/repos/service-*/catalog-info.yaml
+```
+
+```typescript
+// In packages/backend/src/plugins/catalog.ts
+import { BitbucketServerDiscoveryProcessor } from '@backstage/plugin-catalog-backend-module-bitbucket';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  const builder = await CatalogBuilder.create(env);
+  builder.addProcessor(
+    BitbucketServerDiscoveryProcessor.fromConfig(env.config, {
+      logger: env.logger,
+    }),
+  );
+  // [...]
+}
+```

--- a/docs/integrations/bitbucket/discovery.md
+++ b/docs/integrations/bitbucket/discovery.md
@@ -11,7 +11,9 @@ catalog entities located in Bitbucket. The processor will crawl your Bitbucket
 account and register entities matching the configured path. This can be useful
 as an alternative to static locations or manually adding things to the catalog.
 
-## Installation
+## Self-hosted Bitbucket Server
+
+### Installation
 
 You will have to add the processor in the catalog initialization code of your
 backend. The provider is not installed by default, therefore you have to add a
@@ -27,18 +29,18 @@ And then add the processor to your catalog builder:
 
 ```diff
 // In packages/backend/src/plugins/catalog.ts
-+import { BitbucketDiscoveryProcessor } from '@backstage/plugin-catalog-backend-module-bitbucket';
++import { BitbucketServerDiscoveryProcessor } from '@backstage/plugin-catalog-backend-module-bitbucket';
 
  export default async function createPlugin(
    env: PluginEnvironment,
  ): Promise<Router> {
    const builder = await CatalogBuilder.create(env);
 +  builder.addProcessor(
-+    BitbucketDiscoveryProcessor.fromConfig(env.config, { logger: env.logger })
++    BitbucketServerDiscoveryProcessor.fromConfig(env.config, { logger: env.logger })
 +  );
 ```
 
-## Self-hosted Bitbucket Server
+### Configuration
 
 To use the discovery processor with a self-hosted Bitbucket Server, you'll need
 a Bitbucket integration [set up](locations.md) with a `BITBUCKET_TOKEN` and a
@@ -48,11 +50,11 @@ configuration:
 ```yaml
 catalog:
   locations:
-    - type: bitbucket-discovery
+    - type: bitbucket-server-discovery
       target: https://bitbucket.mycompany.com/projects/my-project/repos/service-*/catalog-info.yaml
 ```
 
-Note the `bitbucket-discovery` type, as this is not a regular `url` processor.
+Note the `bitbucket-server-discovery` type, as this is not a regular `url` processor.
 
 The target is composed of four parts:
 
@@ -73,6 +75,35 @@ The target is composed of four parts:
 
 ## Bitbucket Cloud
 
+### Installation
+
+You will have to add the processor in the catalog initialization code of your
+backend. The provider is not installed by default, therefore you have to add a
+dependency to `@backstage/plugin-catalog-backend-module-bitbucket` to your backend
+package.
+
+```bash
+# From your Backstage root directory
+yarn add --cwd packages/backend @backstage/plugin-catalog-backend-module-bitbucket
+```
+
+And then add the processor to your catalog builder:
+
+```diff
+// In packages/backend/src/plugins/catalog.ts
++import { BitbucketCloudDiscoveryProcessor } from '@backstage/plugin-catalog-backend-module-bitbucket';
+
+ export default async function createPlugin(
+   env: PluginEnvironment,
+ ): Promise<Router> {
+   const builder = await CatalogBuilder.create(env);
++  builder.addProcessor(
++    BitbucketCloudDiscoveryProcessor.fromConfig(env.config, { logger: env.logger })
++  );
+```
+
+### Configuration
+
 To use the discovery processor with Bitbucket Cloud, you'll need a Bitbucket
 integration [set up](locations.md) with a `username` and an `appPassword`. Then
 you can add a location target to the catalog configuration:
@@ -80,11 +111,11 @@ you can add a location target to the catalog configuration:
 ```yaml
 catalog:
   locations:
-    - type: bitbucket-discovery
+    - type: bitbucket-cloud-discovery
       target: https://bitbucket.org/workspaces/my-workspace
 ```
 
-Note the `bitbucket-discovery` type, as this is not a regular `url` processor.
+Note the `bitbucket-cloud-discovery` type, as this is not a regular `url` processor.
 
 The target is composed of the following parts:
 
@@ -154,17 +185,17 @@ Examples:
 
 ## Custom repository processing
 
-The Bitbucket Discovery Processor will by default emit a location for each
+The Bitbucket discovery processors will by default emit a location for each
 matching repository for further processing by other processors. However, it is
 possible to override this functionality and take full control of how each
 matching repository is processed.
 
-`BitbucketDiscoveryProcessor.fromConfig` takes an optional parameter
-`options.parser` where you can set your own parser to be used for each matched
+`BitbucketCloudDiscoveryProcessor.fromConfig` and `BitbucketServerDiscoveryProcessor.fromConfig`
+take an optional parameter `options.parser` where you can set your own parser to be used for each matched
 repository.
 
 ```typescript
-const processor = BitbucketDiscoveryProcessor.fromConfig(env.config, {
+const processor = BitbucketCloudDiscoveryProcessor.fromConfig(env.config, {
   parser: async function* customRepositoryParser({ client, repository }) {
     // Custom logic for interpreting the matching repository.
     // See defaultRepositoryParser for an example

--- a/plugins/catalog-backend-module-bitbucket/api-report.md
+++ b/plugins/catalog-backend-module-bitbucket/api-report.md
@@ -13,6 +13,31 @@ import { Logger } from 'winston';
 import { ScmIntegrationRegistry } from '@backstage/integration';
 
 // @public (undocumented)
+export class BitbucketCloudDiscoveryProcessor implements CatalogProcessor {
+  constructor(options: {
+    integrations: ScmIntegrationRegistry;
+    parser?: BitbucketRepositoryParser;
+    logger: Logger;
+  });
+  // (undocumented)
+  static fromConfig(
+    config: Config,
+    options: {
+      parser?: BitbucketRepositoryParser;
+      logger: Logger;
+    },
+  ): BitbucketCloudDiscoveryProcessor;
+  // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
+  readLocation(
+    location: LocationSpec,
+    _optional: boolean,
+    emit: CatalogProcessorEmit,
+  ): Promise<boolean>;
+}
+
+// @public @deprecated (undocumented)
 export class BitbucketDiscoveryProcessor implements CatalogProcessor {
   constructor(options: {
     integrations: ScmIntegrationRegistry;
@@ -44,4 +69,29 @@ export type BitbucketRepositoryParser = (options: {
   presence?: 'optional' | 'required';
   logger: Logger;
 }) => AsyncIterable<CatalogProcessorResult>;
+
+// @public (undocumented)
+export class BitbucketServerDiscoveryProcessor implements CatalogProcessor {
+  constructor(options: {
+    integrations: ScmIntegrationRegistry;
+    parser?: BitbucketRepositoryParser;
+    logger: Logger;
+  });
+  // (undocumented)
+  static fromConfig(
+    config: Config,
+    options: {
+      parser?: BitbucketRepositoryParser;
+      logger: Logger;
+    },
+  ): BitbucketServerDiscoveryProcessor;
+  // (undocumented)
+  getProcessorName(): string;
+  // (undocumented)
+  readLocation(
+    location: LocationSpec,
+    _optional: boolean,
+    emit: CatalogProcessorEmit,
+  ): Promise<boolean>;
+}
 ```

--- a/plugins/catalog-backend-module-bitbucket/src/BitbucketCloudDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-bitbucket/src/BitbucketCloudDiscoveryProcessor.test.ts
@@ -1,0 +1,737 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
+import {
+  LocationSpec,
+  processingResult,
+} from '@backstage/plugin-catalog-backend';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { BitbucketCloudDiscoveryProcessor } from './BitbucketCloudDiscoveryProcessor';
+import { BitbucketRepository20, PagedResponse20 } from './lib';
+
+const server = setupServer();
+
+function setupBitbucketCloudStubs(
+  workspace: string,
+  repositories: Pick<BitbucketRepository20, 'slug' | 'project'>[],
+) {
+  const stubCallerFn = jest.fn();
+  function pagedResponse(values: any): PagedResponse20<any> {
+    return {
+      values: values,
+      page: 1,
+    } as PagedResponse20<any>;
+  }
+
+  server.use(
+    rest.get(
+      `https://api.bitbucket.org/2.0/repositories/${workspace}`,
+      (req, res, ctx) => {
+        stubCallerFn(req);
+        return res(
+          ctx.json(
+            pagedResponse(
+              repositories.map(r => ({
+                ...r,
+                links: {
+                  html: {
+                    href: `https://bitbucket.org/${workspace}/${r.slug}`,
+                  },
+                },
+              })),
+            ),
+          ),
+        );
+      },
+    ),
+  );
+  return stubCallerFn;
+}
+
+function setupBitbucketCloudSearchStubs(
+  workspace: string,
+  repositories: Pick<BitbucketRepository20, 'slug' | 'project'>[],
+  catalogPath: string,
+) {
+  const stubCallerFn = jest.fn();
+  function pagedResponse(values: any): PagedResponse20<any> {
+    return {
+      values: values,
+      page: 1,
+    } as PagedResponse20<any>;
+  }
+
+  server.use(
+    rest.get(
+      `https://api.bitbucket.org/2.0/workspaces/${workspace}/search/code`,
+      (req, res, ctx) => {
+        stubCallerFn(req);
+        return res(
+          ctx.json(
+            pagedResponse(
+              repositories.map(r => ({
+                type: 'code_search_result',
+                content_match_count: 0,
+                content_matches: [],
+                path_matches: [
+                  catalogPath
+                    .split('/')
+                    .flatMap(seg => [{ text: '/' }, { text: seg, match: true }])
+                    .slice(1),
+                ],
+                file: {
+                  commit: {
+                    repository: {
+                      ...r,
+                      links: {
+                        html: {
+                          href: `https://bitbucket.org/${workspace}/${r.slug}`,
+                        },
+                      },
+                    },
+                  },
+                  path: catalogPath,
+                },
+              })),
+            ),
+          ),
+        );
+      },
+    ),
+  );
+  return stubCallerFn;
+}
+
+describe('BitbucketCloudDiscoveryProcessor', () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  afterEach(() => jest.resetAllMocks());
+
+  describe('reject unrelated entries', () => {
+    it('rejects unknown types', async () => {
+      const processor = BitbucketCloudDiscoveryProcessor.fromConfig(
+        new ConfigReader({
+          integrations: {
+            bitbucket: [
+              {
+                host: 'bitbucket.org',
+                username: 'myuser',
+                appPassword: 'blob',
+              },
+            ],
+          },
+        }),
+        { logger: getVoidLogger() },
+      );
+      const location: LocationSpec = {
+        type: 'not-bitbucket-cloud-discovery',
+        target: 'https://bitbucket.org',
+      };
+      await expect(
+        processor.readLocation(location, false, () => {}),
+      ).resolves.toBeFalsy();
+    });
+
+    it('rejects unknown targets', async () => {
+      const processor = BitbucketCloudDiscoveryProcessor.fromConfig(
+        new ConfigReader({
+          integrations: {
+            bitbucket: [
+              {
+                host: 'bitbucket.org',
+                username: 'myuser',
+                appPassword: 'blob',
+              },
+              { host: 'bitbucket.mycompany.com', token: 'blob' },
+            ],
+          },
+        }),
+        { logger: getVoidLogger() },
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target: 'https://not.bitbucket.org/foobar',
+      };
+      await expect(
+        processor.readLocation(location, false, () => {}),
+      ).rejects.toThrow(
+        /There is no Bitbucket integration that matches https:\/\/not.bitbucket.org\/foobar/,
+      );
+    });
+  });
+
+  describe('handles cloud repositories', () => {
+    const processor = BitbucketCloudDiscoveryProcessor.fromConfig(
+      new ConfigReader({
+        integrations: {
+          bitbucket: [
+            {
+              host: 'bitbucket.org',
+              username: 'myuser',
+              appPassword: 'blob',
+            },
+          ],
+        },
+      }),
+      { logger: getVoidLogger() },
+    );
+
+    it('output all repositories by default', async () => {
+      setupBitbucketCloudStubs('myworkspace', [
+        { project: { key: 'prj-one' }, slug: 'repository-one' },
+        { project: { key: 'prj-two' }, slug: 'repository-two' },
+      ]);
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target: 'https://bitbucket.org/workspaces/myworkspace',
+      };
+
+      const emitter = jest.fn();
+
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(2);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/catalog-info.yaml',
+          presence: 'optional',
+        },
+      });
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-two/src/master/catalog-info.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('uses provided catalog path', async () => {
+      setupBitbucketCloudStubs('myworkspace', [
+        { project: { key: 'prj-one' }, slug: 'repository-one' },
+        { project: { key: 'prj-two' }, slug: 'repository-two' },
+      ]);
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace?catalogPath=my/nested/path/catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(2);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/my/nested/path/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-two/src/master/my/nested/path/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('output all repositories', async () => {
+      setupBitbucketCloudStubs('myworkspace', [
+        { project: { key: 'prj-one' }, slug: 'repository-one' },
+        { project: { key: 'prj-two' }, slug: 'repository-two' },
+      ]);
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace/projects/*/repos/*?catalogPath=catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(2);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-two/src/master/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('output repositories with wildcards', async () => {
+      setupBitbucketCloudStubs('myworkspace', [
+        { project: { key: 'prj-one' }, slug: 'repository-one' },
+        { project: { key: 'prj-two' }, slug: 'repository-two' },
+      ]);
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/*?catalogPath=catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('filter unrelated repositories', async () => {
+      setupBitbucketCloudStubs('myworkspace', [
+        { project: { key: 'prj-one' }, slug: 'repository-one' },
+        { project: { key: 'prj-one' }, slug: 'repository-two' },
+        { project: { key: 'prj-one' }, slug: 'repository-three' },
+      ]);
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/repository-three?catalogPath=catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-three/src/master/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('submits query', async () => {
+      const mockCall = setupBitbucketCloudStubs('myworkspace', [
+        { project: { key: 'prj-one' }, slug: 'repository-one' },
+      ]);
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace?q=project.key ~ "prj-one"',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/catalog-info.yaml',
+          presence: 'optional',
+        },
+      });
+      expect(mockCall).toBeCalledTimes(1);
+      // it should be possible to do this via an `expect.objectContaining` check but seems to fail with some encoding issue.
+      expect(mockCall.mock.calls[0][0].url).toMatchInlineSnapshot(
+        `"https://api.bitbucket.org/2.0/repositories/myworkspace?page=1&pagelen=100&q=project.key+%7E+%22prj-one%22"`,
+      );
+    });
+
+    it.each`
+      target
+      ${'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/*'}
+      ${'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/*/'}
+      ${'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/repository-*/'}
+    `("target '$target' adds default path to catalog", async ({ target }) => {
+      setupBitbucketCloudStubs('myworkspace', [
+        { project: { key: 'prj-one' }, slug: 'repository-one' },
+      ]);
+
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target: target,
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/catalog-info.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it.each`
+      target
+      ${'https://bitbucket.org/test'}
+    `("target '$target' is rejected", async ({ target }) => {
+      setupBitbucketCloudStubs('myworkspace', [
+        { project: { key: 'prj-one' }, slug: 'repository-one' },
+      ]);
+
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target: target,
+      };
+
+      const emitter = jest.fn();
+      await expect(
+        processor.readLocation(location, false, emitter),
+      ).rejects.toThrow(/Failed to parse /);
+    });
+  });
+
+  describe('handles cloud repositories using code search', () => {
+    const processor = BitbucketCloudDiscoveryProcessor.fromConfig(
+      new ConfigReader({
+        integrations: {
+          bitbucket: [
+            {
+              host: 'bitbucket.org',
+              username: 'myuser',
+              appPassword: 'blob',
+            },
+          ],
+        },
+      }),
+      { logger: getVoidLogger() },
+    );
+
+    it('output all repositories by default', async () => {
+      setupBitbucketCloudSearchStubs(
+        'myworkspace',
+        [
+          { project: { key: 'prj-one' }, slug: 'repository-one' },
+          { project: { key: 'prj-two' }, slug: 'repository-two' },
+        ],
+        'catalog-info.yaml',
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target: 'https://bitbucket.org/workspaces/myworkspace?search=true',
+      };
+
+      const emitter = jest.fn();
+
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(2);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/catalog-info.yaml',
+          presence: 'required',
+        },
+      });
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-two/src/master/catalog-info.yaml',
+          presence: 'required',
+        },
+      });
+    });
+
+    it('uses provided catalog path', async () => {
+      setupBitbucketCloudSearchStubs(
+        'myworkspace',
+        [
+          { project: { key: 'prj-one' }, slug: 'repository-one' },
+          { project: { key: 'prj-two' }, slug: 'repository-two' },
+        ],
+        'my/nested/path/catalog.yaml',
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace?search=true&catalogPath=my/nested/path/catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(2);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/my/nested/path/catalog.yaml',
+          presence: 'required',
+        },
+      });
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-two/src/master/my/nested/path/catalog.yaml',
+          presence: 'required',
+        },
+      });
+    });
+
+    it('output all repositories', async () => {
+      setupBitbucketCloudSearchStubs(
+        'myworkspace',
+        [
+          { project: { key: 'prj-one' }, slug: 'repository-one' },
+          { project: { key: 'prj-two' }, slug: 'repository-two' },
+        ],
+        'catalog.yaml',
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace/projects/*/repos/*?search=true&catalogPath=catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(2);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/catalog.yaml',
+          presence: 'required',
+        },
+      });
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-two/src/master/catalog.yaml',
+          presence: 'required',
+        },
+      });
+    });
+
+    it('output repositories with wildcards', async () => {
+      setupBitbucketCloudSearchStubs(
+        'myworkspace',
+        [
+          { project: { key: 'prj-one' }, slug: 'repository-one' },
+          { project: { key: 'prj-two' }, slug: 'repository-two' },
+        ],
+        'catalog.yaml',
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/*?search=true&catalogPath=catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/catalog.yaml',
+          presence: 'required',
+        },
+      });
+    });
+
+    it('filter unrelated repositories', async () => {
+      setupBitbucketCloudSearchStubs(
+        'myworkspace',
+        [
+          { project: { key: 'prj-one' }, slug: 'repository-one' },
+          { project: { key: 'prj-one' }, slug: 'repository-two' },
+          { project: { key: 'prj-one' }, slug: 'repository-three' },
+        ],
+        'catalog.yaml',
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/repository-three?search=true&catalogPath=catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toBeCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-three/src/master/catalog.yaml',
+          presence: 'required',
+        },
+      });
+    });
+
+    it.each`
+      target
+      ${'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/*?search=true'}
+      ${'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/*/?search=true'}
+      ${'https://bitbucket.org/workspaces/myworkspace/projects/prj-one/repos/repository-*/?search=true'}
+    `("target '$target' adds default path to catalog", async ({ target }) => {
+      setupBitbucketCloudSearchStubs(
+        'myworkspace',
+        [{ project: { key: 'prj-one' }, slug: 'repository-one' }],
+        'catalog-info.yaml',
+      );
+
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target: target,
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.org/myworkspace/repository-one/src/master/catalog-info.yaml',
+          presence: 'required',
+        },
+      });
+    });
+
+    it.each`
+      target
+      ${'https://bitbucket.org/test?search=true'}
+    `("target '$target' is rejected", async ({ target }) => {
+      setupBitbucketCloudSearchStubs(
+        'myworkspace',
+        [{ project: { key: 'prj-one' }, slug: 'repository-one' }],
+        'catalog-info.yaml',
+      );
+
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target: target,
+      };
+
+      const emitter = jest.fn();
+      await expect(
+        processor.readLocation(location, false, emitter),
+      ).rejects.toThrow(/Failed to parse /);
+    });
+  });
+
+  describe('Custom repository parser', () => {
+    const processor = BitbucketCloudDiscoveryProcessor.fromConfig(
+      new ConfigReader({
+        integrations: {
+          bitbucket: [
+            {
+              host: 'bitbucket.org',
+              username: 'myuser',
+              appPassword: 'blob',
+            },
+          ],
+        },
+      }),
+      {
+        parser: async function* customRepositoryParser({}) {
+          yield processingResult.location({
+            type: 'custom-location-type',
+            target: 'custom-target',
+            presence: 'optional',
+          });
+        },
+        logger: getVoidLogger(),
+      },
+    );
+
+    it('use custom repository parser', async () => {
+      setupBitbucketCloudStubs('myworkspace', [
+        { project: { key: 'prj-one' }, slug: 'repository-one' },
+      ]);
+
+      const location: LocationSpec = {
+        type: 'bitbucket-cloud-discovery',
+        target:
+          'https://bitbucket.org/workspaces/myworkspace/repos/repository-one',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'custom-location-type',
+          target: 'custom-target',
+          presence: 'optional',
+        },
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend-module-bitbucket/src/BitbucketCloudDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-bitbucket/src/BitbucketCloudDiscoveryProcessor.ts
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Config } from '@backstage/config';
+import {
+  BitbucketIntegration,
+  ScmIntegrationRegistry,
+  ScmIntegrations,
+} from '@backstage/integration';
+import {
+  CatalogProcessor,
+  CatalogProcessorEmit,
+  LocationSpec,
+} from '@backstage/plugin-catalog-backend';
+import { Logger } from 'winston';
+import {
+  BitbucketCloudClient,
+  BitbucketRepository20,
+  BitbucketRepositoryParser,
+  defaultRepositoryParser,
+  paginated20,
+} from './lib';
+
+const DEFAULT_BRANCH = 'master';
+const DEFAULT_CATALOG_LOCATION = '/catalog-info.yaml';
+
+/** @public */
+export class BitbucketCloudDiscoveryProcessor implements CatalogProcessor {
+  private readonly integrations: ScmIntegrationRegistry;
+  private readonly parser: BitbucketRepositoryParser;
+  private readonly logger: Logger;
+
+  static fromConfig(
+    config: Config,
+    options: {
+      parser?: BitbucketRepositoryParser;
+      logger: Logger;
+    },
+  ) {
+    const integrations = ScmIntegrations.fromConfig(config);
+
+    return new BitbucketCloudDiscoveryProcessor({
+      ...options,
+      integrations,
+    });
+  }
+
+  constructor(options: {
+    integrations: ScmIntegrationRegistry;
+    parser?: BitbucketRepositoryParser;
+    logger: Logger;
+  }) {
+    this.integrations = options.integrations;
+    this.parser = options.parser || defaultRepositoryParser;
+    this.logger = options.logger;
+  }
+
+  getProcessorName(): string {
+    return 'BitbucketCloudDiscoveryProcessor';
+  }
+
+  async readLocation(
+    location: LocationSpec,
+    _optional: boolean,
+    emit: CatalogProcessorEmit,
+  ): Promise<boolean> {
+    if (location.type !== 'bitbucket-cloud-discovery') {
+      return false;
+    }
+
+    const integration = this.integrations.bitbucket.byUrl(location.target);
+    if (!integration) {
+      throw new Error(
+        `There is no Bitbucket integration that matches ${location.target}. Please add a configuration entry for it under integrations.bitbucket`,
+      );
+    }
+
+    const startTimestamp = Date.now();
+    this.logger.info(
+      `Reading ${integration.config.host} repositories from ${location.target}`,
+    );
+
+    const processOptions: ProcessOptions = {
+      emit,
+      integration,
+      location,
+    };
+
+    const { scanned, matches } = await this.processCloudRepositories(
+      processOptions,
+    );
+
+    const duration = ((Date.now() - startTimestamp) / 1000).toFixed(1);
+    this.logger.debug(
+      `Read ${scanned} ${integration.config.host} repositories (${matches} matching the pattern) in ${duration} seconds`,
+    );
+
+    return true;
+  }
+
+  private async processCloudRepositories(
+    options: ProcessOptions,
+  ): Promise<ResultSummary> {
+    const { location, integration, emit } = options;
+    const client = new BitbucketCloudClient({
+      config: integration.config,
+    });
+
+    const { searchEnabled } = parseBitbucketCloudUrl(location.target);
+
+    const result = searchEnabled
+      ? await searchBitbucketCloudLocations(client, location.target)
+      : await readBitbucketCloudLocations(client, location.target);
+
+    for (const locationTarget of result.matches) {
+      for await (const entity of this.parser({
+        integration,
+        target: locationTarget,
+        presence: searchEnabled ? 'required' : 'optional',
+        logger: this.logger,
+      })) {
+        emit(entity);
+      }
+    }
+    return {
+      matches: result.matches.length,
+      scanned: result.scanned,
+    };
+  }
+}
+
+export async function searchBitbucketCloudLocations(
+  client: BitbucketCloudClient,
+  target: string,
+): Promise<Result<string>> {
+  const {
+    workspacePath,
+    catalogPath: requestedCatalogPath,
+    projectSearchPath,
+    repoSearchPath,
+  } = parseBitbucketCloudUrl(target);
+
+  const result: Result<string> = {
+    scanned: 0,
+    matches: [],
+  };
+
+  const catalogPath = requestedCatalogPath
+    ? requestedCatalogPath
+    : DEFAULT_CATALOG_LOCATION;
+  const catalogFilename = catalogPath.substring(
+    catalogPath.lastIndexOf('/') + 1,
+  );
+
+  const searchResults = paginated20(options =>
+    client.searchCode(
+      workspacePath,
+      `"${catalogFilename}" path:${catalogPath}`,
+      options,
+    ),
+  );
+
+  for await (const searchResult of searchResults) {
+    // not a file match, but a code match
+    if (searchResult.path_matches.length === 0) {
+      continue;
+    }
+
+    const repository = searchResult.file.commit.repository;
+    if (!matchesPostFilters(repository, projectSearchPath, repoSearchPath)) {
+      continue;
+    }
+
+    const repoUrl = repository.links.html.href;
+    const branch = repository.mainbranch?.name ?? DEFAULT_BRANCH;
+    const filePath = searchResult.file.path;
+    const location = `${repoUrl}/src/${branch}/${filePath}`;
+
+    result.matches.push(location);
+  }
+
+  return result;
+}
+
+export async function readBitbucketCloudLocations(
+  client: BitbucketCloudClient,
+  target: string,
+): Promise<Result<string>> {
+  const { catalogPath: requestedCatalogPath } = parseBitbucketCloudUrl(target);
+  const catalogPath = requestedCatalogPath
+    ? `/${requestedCatalogPath}`
+    : DEFAULT_CATALOG_LOCATION;
+
+  return readBitbucketCloud(client, target).then(result => {
+    const matches = result.matches.map(repository => {
+      const branch = repository.mainbranch?.name ?? DEFAULT_BRANCH;
+      return `${repository.links.html.href}/src/${branch}${catalogPath}`;
+    });
+
+    return {
+      scanned: result.scanned,
+      matches,
+    };
+  });
+}
+
+export async function readBitbucketCloud(
+  client: BitbucketCloudClient,
+  target: string,
+): Promise<Result<BitbucketRepository20>> {
+  const {
+    workspacePath,
+    queryParam: q,
+    projectSearchPath,
+    repoSearchPath,
+  } = parseBitbucketCloudUrl(target);
+
+  const repositories = paginated20(
+    options => client.listRepositoriesByWorkspace(workspacePath, options),
+    {
+      q,
+    },
+  );
+  const result: Result<BitbucketRepository20> = {
+    scanned: 0,
+    matches: [],
+  };
+
+  for await (const repository of repositories) {
+    result.scanned++;
+    if (matchesPostFilters(repository, projectSearchPath, repoSearchPath)) {
+      result.matches.push(repository);
+    }
+  }
+  return result;
+}
+
+function matchesPostFilters(
+  repository: BitbucketRepository20,
+  projectSearchPath: RegExp | undefined,
+  repoSearchPath: RegExp | undefined,
+): boolean {
+  return (
+    (!projectSearchPath || projectSearchPath.test(repository.project.key)) &&
+    (!repoSearchPath || repoSearchPath.test(repository.slug))
+  );
+}
+
+function readPathParameters(pathParts: string[]): Map<string, string> {
+  const vals: Record<string, any> = {};
+  for (let i = 0; i + 1 < pathParts.length; i += 2) {
+    vals[pathParts[i]] = decodeURIComponent(pathParts[i + 1]);
+  }
+  return new Map<string, string>(Object.entries(vals));
+}
+
+function parseBitbucketCloudUrl(urlString: string): {
+  workspacePath: string;
+  catalogPath?: string;
+  projectSearchPath?: RegExp;
+  repoSearchPath?: RegExp;
+  queryParam?: string;
+  searchEnabled: boolean;
+} {
+  const url = new URL(urlString);
+  const pathMap = readPathParameters(url.pathname.substring(1).split('/'));
+  const query = url.searchParams;
+
+  if (!pathMap.has('workspaces')) {
+    throw new Error(`Failed to parse workspace from ${urlString}`);
+  }
+
+  return {
+    workspacePath: pathMap.get('workspaces')!,
+    projectSearchPath: pathMap.has('projects')
+      ? escapeRegExp(pathMap.get('projects')!)
+      : undefined,
+    repoSearchPath: pathMap.has('repos')
+      ? escapeRegExp(pathMap.get('repos')!)
+      : undefined,
+    catalogPath: query.get('catalogPath') || undefined,
+    queryParam: query.get('q') || undefined,
+    searchEnabled: query.get('search')?.toLowerCase() === 'true',
+  };
+}
+
+function escapeRegExp(str: string): RegExp {
+  return new RegExp(`^${str.replace(/\*/g, '.*')}$`);
+}
+
+type ProcessOptions = {
+  integration: BitbucketIntegration;
+  location: LocationSpec;
+  emit: CatalogProcessorEmit;
+};
+
+type Result<T> = {
+  scanned: number;
+  matches: T[];
+};
+
+type ResultSummary = {
+  scanned: number;
+  matches: number;
+};

--- a/plugins/catalog-backend-module-bitbucket/src/BitbucketServerDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-bitbucket/src/BitbucketServerDiscoveryProcessor.test.ts
@@ -1,0 +1,497 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
+import {
+  LocationSpec,
+  processingResult,
+} from '@backstage/plugin-catalog-backend';
+import { RequestHandler, rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { BitbucketServerDiscoveryProcessor } from './BitbucketServerDiscoveryProcessor';
+import { PagedResponse } from './lib';
+
+const server = setupServer();
+
+function setupStubs(
+  projects: any[],
+  bitbucketBaseUrl = `https://bitbucket.mycompany.com`,
+) {
+  function pagedResponse(values: any): PagedResponse<any> {
+    return {
+      values: values,
+      isLastPage: true,
+    } as PagedResponse<any>;
+  }
+
+  function stubbedProject(
+    project: string,
+    repos: string[],
+  ): RequestHandler<any, any> {
+    return rest.get(
+      `${bitbucketBaseUrl}/api/rest/1.0/projects/${project}/repos`,
+      (_, res, ctx) => {
+        const response = [];
+        for (const repo of repos) {
+          response.push({
+            slug: repo,
+            links: {
+              self: [
+                {
+                  href: `${bitbucketBaseUrl}/projects/${project}/repos/${repo}/browse`,
+                },
+              ],
+            },
+          });
+        }
+        return res(ctx.json(pagedResponse(response)));
+      },
+    );
+  }
+
+  server.use(
+    rest.get(`${bitbucketBaseUrl}/api/rest/1.0/projects`, (_, res, ctx) => {
+      return res(
+        ctx.json(
+          pagedResponse(
+            projects.map(p => {
+              return { key: p.key };
+            }),
+          ),
+        ),
+      );
+    }),
+  );
+
+  for (const project of projects) {
+    server.use(stubbedProject(project.key, project.repos));
+  }
+}
+
+describe('BitbucketServerDiscoveryProcessor', () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  afterEach(() => jest.resetAllMocks());
+
+  describe('reject unrelated entries', () => {
+    it('rejects unknown types', async () => {
+      const processor = BitbucketServerDiscoveryProcessor.fromConfig(
+        new ConfigReader({
+          integrations: {
+            bitbucket: [{ host: 'bitbucket.mycompany.com', token: 'blob' }],
+          },
+        }),
+        { logger: getVoidLogger() },
+      );
+      const location: LocationSpec = {
+        type: 'not-bitbucket-server-discovery',
+        target: 'https://bitbucket.mycompany.com',
+      };
+      await expect(
+        processor.readLocation(location, false, () => {}),
+      ).resolves.toBeFalsy();
+    });
+
+    it('rejects unknown targets', async () => {
+      const processor = BitbucketServerDiscoveryProcessor.fromConfig(
+        new ConfigReader({
+          integrations: {
+            bitbucket: [
+              { host: 'bitbucket.org', token: 'blob' },
+              { host: 'bitbucket.mycompany.com', token: 'blob' },
+            ],
+          },
+        }),
+        { logger: getVoidLogger() },
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target: 'https://not.bitbucket.mycompany.com/foobar',
+      };
+      await expect(
+        processor.readLocation(location, false, () => {}),
+      ).rejects.toThrow(
+        /There is no Bitbucket integration that matches https:\/\/not.bitbucket.mycompany.com\/foobar/,
+      );
+    });
+  });
+
+  describe('handles organisation repositories', () => {
+    const processor = BitbucketServerDiscoveryProcessor.fromConfig(
+      new ConfigReader({
+        integrations: {
+          bitbucket: [
+            {
+              host: 'bitbucket.mycompany.com',
+              token: 'blob',
+              apiBaseUrl: 'https://bitbucket.mycompany.com/api/rest/1.0',
+            },
+          ],
+        },
+      }),
+      { logger: getVoidLogger() },
+    );
+
+    it('output all repositories', async () => {
+      setupStubs([
+        { key: 'backstage', repos: ['backstage'] },
+        { key: 'demo', repos: ['demo'] },
+      ]);
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target:
+          'https://bitbucket.mycompany.com/projects/*/repos/*/catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/projects/backstage/repos/backstage/browse/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/projects/demo/repos/demo/browse/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('output repositories with wildcards', async () => {
+      setupStubs([
+        { key: 'backstage', repos: ['backstage', 'techdocs-cli'] },
+        { key: 'demo', repos: ['demo'] },
+      ]);
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target:
+          'https://bitbucket.mycompany.com/projects/backstage/repos/techdocs-*/catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/projects/backstage/repos/techdocs-cli/browse/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('output repositories by target search ref', async () => {
+      setupStubs([{ key: 'demo', repos: ['demo'] }]);
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target:
+          'https://bitbucket.mycompany.com/projects/demo/repos/demo/catalog.yaml?ref=branch-name',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/projects/demo/repos/demo/browse/catalog.yaml?ref=branch-name',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('filter unrelated repositories', async () => {
+      setupStubs([{ key: 'backstage', repos: ['test', 'abctest', 'testxyz'] }]);
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target:
+          'https://bitbucket.mycompany.com/projects/backstage/repos/test/catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/projects/backstage/repos/test/browse/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it.each`
+      target
+      ${'https://bitbucket.mycompany.com/projects/backstage/repos/*'}
+      ${'https://bitbucket.mycompany.com/projects/backstage/repos/*/'}
+      ${'https://bitbucket.mycompany.com/projects/backstage/repos/techdocs-*/'}
+    `("target '$target' adds default path to catalog", async ({ target }) => {
+      setupStubs([{ key: 'backstage', repos: ['techdocs-cli'] }]);
+
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target: target,
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/projects/backstage/repos/techdocs-cli/browse/catalog-info.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+  });
+
+  describe('handles organisation repositories with a custom baseURL', () => {
+    const processor = BitbucketServerDiscoveryProcessor.fromConfig(
+      new ConfigReader({
+        integrations: {
+          bitbucket: [
+            {
+              host: 'bitbucket.mycompany.com',
+              token: 'blob',
+              apiBaseUrl:
+                'https://bitbucket.mycompany.com/custom-path/api/rest/1.0',
+            },
+          ],
+        },
+      }),
+      { logger: getVoidLogger() },
+    );
+
+    it('output all repositories', async () => {
+      setupStubs(
+        [
+          { key: 'backstage', repos: ['backstage'] },
+          { key: 'demo', repos: ['demo'] },
+        ],
+        'https://bitbucket.mycompany.com/custom-path',
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target:
+          'https://bitbucket.mycompany.com/custom-path/projects/*/repos/*/catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/custom-path/projects/backstage/repos/backstage/browse/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/custom-path/projects/demo/repos/demo/browse/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('output repositories with wildcards', async () => {
+      setupStubs(
+        [
+          { key: 'backstage', repos: ['backstage', 'techdocs-cli'] },
+          { key: 'demo', repos: ['demo'] },
+        ],
+        'https://bitbucket.mycompany.com/custom-path',
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target:
+          'https://bitbucket.mycompany.com/custom-path/projects/backstage/repos/techdocs-*/catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/custom-path/projects/backstage/repos/techdocs-cli/browse/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('output repositories by target search ref', async () => {
+      setupStubs(
+        [{ key: 'demo', repos: ['demo'] }],
+        'https://bitbucket.mycompany.com/custom-path',
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target:
+          'https://bitbucket.mycompany.com/custom-path/projects/demo/repos/demo/catalog.yaml?ref=branch-name',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/custom-path/projects/demo/repos/demo/browse/catalog.yaml?ref=branch-name',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it('filter unrelated repositories', async () => {
+      setupStubs(
+        [{ key: 'backstage', repos: ['test', 'abctest', 'testxyz'] }],
+        'https://bitbucket.mycompany.com/custom-path',
+      );
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target:
+          'https://bitbucket.mycompany.com/custom-path/projects/backstage/repos/test/catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/custom-path/projects/backstage/repos/test/browse/catalog.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+
+    it.each`
+      target
+      ${'https://bitbucket.mycompany.com/custom-path/projects/backstage/repos/*'}
+      ${'https://bitbucket.mycompany.com/custom-path/projects/backstage/repos/*/'}
+      ${'https://bitbucket.mycompany.com/custom-path/projects/backstage/repos/techdocs-*/'}
+    `("target '$target' adds default path to catalog", async ({ target }) => {
+      setupStubs(
+        [{ key: 'backstage', repos: ['techdocs-cli'] }],
+        'https://bitbucket.mycompany.com/custom-path',
+      );
+
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target: target,
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'url',
+          target:
+            'https://bitbucket.mycompany.com/custom-path/projects/backstage/repos/techdocs-cli/browse/catalog-info.yaml',
+          presence: 'optional',
+        },
+      });
+    });
+  });
+
+  describe('Custom repository parser', () => {
+    const processor = BitbucketServerDiscoveryProcessor.fromConfig(
+      new ConfigReader({
+        integrations: {
+          bitbucket: [
+            {
+              host: 'bitbucket.mycompany.com',
+              token: 'blob',
+              apiBaseUrl: 'https://bitbucket.mycompany.com/api/rest/1.0',
+            },
+          ],
+        },
+      }),
+      {
+        parser: async function* customRepositoryParser({}) {
+          yield processingResult.location({
+            type: 'custom-location-type',
+            target: 'custom-target',
+            presence: 'optional',
+          });
+        },
+        logger: getVoidLogger(),
+      },
+    );
+
+    it('use custom repository parser', async () => {
+      setupStubs([{ key: 'backstage', repos: ['test'] }]);
+
+      const location: LocationSpec = {
+        type: 'bitbucket-server-discovery',
+        target:
+          'https://bitbucket.mycompany.com/projects/backstage/repos/test/catalog.yaml',
+      };
+
+      const emitter = jest.fn();
+      await processor.readLocation(location, false, emitter);
+
+      expect(emitter).toHaveBeenCalledTimes(1);
+      expect(emitter).toHaveBeenCalledWith({
+        type: 'location',
+        location: {
+          type: 'custom-location-type',
+          target: 'custom-target',
+          presence: 'optional',
+        },
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend-module-bitbucket/src/BitbucketServerDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-bitbucket/src/BitbucketServerDiscoveryProcessor.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Config } from '@backstage/config';
+import {
+  BitbucketIntegration,
+  ScmIntegrationRegistry,
+  ScmIntegrations,
+} from '@backstage/integration';
+import {
+  CatalogProcessor,
+  CatalogProcessorEmit,
+  LocationSpec,
+} from '@backstage/plugin-catalog-backend';
+import { Logger } from 'winston';
+import {
+  BitbucketRepository,
+  BitbucketRepositoryParser,
+  BitbucketServerClient,
+  defaultRepositoryParser,
+  paginated,
+} from './lib';
+
+const DEFAULT_CATALOG_LOCATION = '/catalog-info.yaml';
+
+/** @public */
+export class BitbucketServerDiscoveryProcessor implements CatalogProcessor {
+  private readonly integrations: ScmIntegrationRegistry;
+  private readonly parser: BitbucketRepositoryParser;
+  private readonly logger: Logger;
+
+  static fromConfig(
+    config: Config,
+    options: {
+      parser?: BitbucketRepositoryParser;
+      logger: Logger;
+    },
+  ) {
+    const integrations = ScmIntegrations.fromConfig(config);
+
+    return new BitbucketServerDiscoveryProcessor({
+      ...options,
+      integrations,
+    });
+  }
+
+  constructor(options: {
+    integrations: ScmIntegrationRegistry;
+    parser?: BitbucketRepositoryParser;
+    logger: Logger;
+  }) {
+    this.integrations = options.integrations;
+    this.parser = options.parser || defaultRepositoryParser;
+    this.logger = options.logger;
+  }
+
+  getProcessorName(): string {
+    return 'BitbucketServerDiscoveryProcessor';
+  }
+
+  async readLocation(
+    location: LocationSpec,
+    _optional: boolean,
+    emit: CatalogProcessorEmit,
+  ): Promise<boolean> {
+    if (location.type !== 'bitbucket-server-discovery') {
+      return false;
+    }
+
+    const integration = this.integrations.bitbucket.byUrl(location.target);
+    if (!integration) {
+      throw new Error(
+        `There is no Bitbucket integration that matches ${location.target}. Please add a configuration entry for it under integrations.bitbucket`,
+      );
+    }
+
+    const startTimestamp = Date.now();
+    this.logger.info(
+      `Reading ${integration.config.host} repositories from ${location.target}`,
+    );
+
+    const processOptions: ProcessOptions = {
+      emit,
+      integration,
+      location,
+    };
+
+    const { scanned, matches } = await this.processOrganizationRepositories(
+      processOptions,
+    );
+
+    const duration = ((Date.now() - startTimestamp) / 1000).toFixed(1);
+    this.logger.debug(
+      `Read ${scanned} ${integration.config.host} repositories (${matches} matching the pattern) in ${duration} seconds`,
+    );
+
+    return true;
+  }
+
+  private async processOrganizationRepositories(
+    options: ProcessOptions,
+  ): Promise<ResultSummary> {
+    const { location, integration, emit } = options;
+    const { catalogPath: requestedCatalogPath } = parseUrl(location.target);
+    const catalogPath = requestedCatalogPath
+      ? `/${requestedCatalogPath}`
+      : DEFAULT_CATALOG_LOCATION;
+
+    const client = new BitbucketServerClient({
+      config: integration.config,
+    });
+
+    const result = await readBitbucketOrg(client, location.target);
+    for (const repository of result.matches) {
+      for await (const entity of this.parser({
+        integration,
+        target: `${repository.links.self[0].href}${catalogPath}`,
+        logger: this.logger,
+      })) {
+        emit(entity);
+      }
+    }
+    return {
+      matches: result.matches.length,
+      scanned: result.scanned,
+    };
+  }
+}
+
+export async function readBitbucketOrg(
+  client: BitbucketServerClient,
+  target: string,
+): Promise<Result<BitbucketRepository>> {
+  const { projectSearchPath, repoSearchPath } = parseUrl(target);
+  const projects = paginated(options => client.listProjects(options));
+  const result: Result<BitbucketRepository> = {
+    scanned: 0,
+    matches: [],
+  };
+
+  for await (const project of projects) {
+    if (!projectSearchPath.test(project.key)) {
+      continue;
+    }
+    const repositories = paginated(options =>
+      client.listRepositories(project.key, options),
+    );
+    for await (const repository of repositories) {
+      result.scanned++;
+      if (repoSearchPath.test(repository.slug)) {
+        result.matches.push(repository);
+      }
+    }
+  }
+  return result;
+}
+
+function parseUrl(urlString: string): {
+  projectSearchPath: RegExp;
+  repoSearchPath: RegExp;
+  catalogPath: string;
+} {
+  const url = new URL(urlString);
+  const indexOfProjectSegment =
+    url.pathname.toLowerCase().indexOf('/projects/') + 1;
+  const path = url.pathname.substr(indexOfProjectSegment).split('/');
+
+  // /projects/backstage/repos/techdocs-*/catalog-info.yaml
+  if (path.length > 3 && path[1].length && path[3].length) {
+    return {
+      projectSearchPath: escapeRegExp(decodeURIComponent(path[1])),
+      repoSearchPath: escapeRegExp(decodeURIComponent(path[3])),
+      catalogPath: decodeURIComponent(path.slice(4).join('/') + url.search),
+    };
+  }
+
+  throw new Error(`Failed to parse ${urlString}`);
+}
+
+function escapeRegExp(str: string): RegExp {
+  return new RegExp(`^${str.replace(/\*/g, '.*')}$`);
+}
+
+type ProcessOptions = {
+  integration: BitbucketIntegration;
+  location: LocationSpec;
+  emit: CatalogProcessorEmit;
+};
+
+type Result<T> = {
+  scanned: number;
+  matches: T[];
+};
+
+type ResultSummary = {
+  scanned: number;
+  matches: number;
+};

--- a/plugins/catalog-backend-module-bitbucket/src/index.ts
+++ b/plugins/catalog-backend-module-bitbucket/src/index.ts
@@ -20,5 +20,7 @@
  * @packageDocumentation
  */
 
+export { BitbucketCloudDiscoveryProcessor } from './BitbucketCloudDiscoveryProcessor';
 export { BitbucketDiscoveryProcessor } from './BitbucketDiscoveryProcessor';
+export { BitbucketServerDiscoveryProcessor } from './BitbucketServerDiscoveryProcessor';
 export type { BitbucketRepositoryParser } from './lib/BitbucketRepositoryParser';


### PR DESCRIPTION
Split `BitbucketDiscoveryProcessor` into `BitbucketCloudDiscoveryProcessor`
and `BitbucketServerDiscoveryProcessor`.

Deprecates `BitbucketDiscoveryProcessor`.

Relates-to: #9923
Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
