### PR TITLE
docs: update github discovery processing example

### DIFF
--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -108,7 +108,7 @@ the catalog in your `packages/backend/src/plugins/catalog.ts` file:
 const builder = await CatalogBuilder.create(env);
 
 // For example, to refresh every 5 minutes (300 seconds).
-builder.setRefreshIntervalSeconds(300);
+builder.setProcessingIntervalSeconds(300);
 ```
 
 Alternatively, or additionally, you can configure [github-apps] authentication


### PR DESCRIPTION
## Hey, I just made a Pull Request!

docs on github discovery uses deprecated `setRefreshIntervalSeconds` instead of `setProcessingIntervalSeconds`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
