### PR TITLE
ci(prettier): ignore `ADOPTERS.md` using `.prettierignore`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         continue-on-error: true
 
       - name: prettier
-        run: yarn prettier:check '!ADOPTERS.md'
+        run: yarn prettier:check
 
       - name: lock
         run: yarn lock:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,6 @@ api-report.md
 plugins/scaffolder-backend/sample-templates
 .vscode
 dist-types
+
+# reduce the barrier for adopters to add themselves
+ADOPTERS.md


### PR DESCRIPTION
Ignore `ADOPTERS.md` using `.prettierignore`
instead of ignoring it at the GitHub action config.

This will cause the same rules to be applied locally as these checks.

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
