### PR TITLE
Add pointer to custom theme on demo site

### DIFF
--- a/docs/getting-started/app-custom-theme.md
+++ b/docs/getting-started/app-custom-theme.md
@@ -149,6 +149,11 @@ const myTheme = createTheme({
 });
 ```
 
+For a more complete example of a custom theme including Backstage and
+Material-UI component overrides, see the [Aperture
+theme](https://github.com/backstage/demo/blob/master/packages/app/src/theme/aperture.ts)
+from the [Backstage demo site](https://demo.backstage.io).
+
 ## Overriding Backstage and Material UI components styles
 
 When creating a custom theme you would be applying different values to


### PR DESCRIPTION
Adds a documentation pointer to a new theme on demo.backstage.io that's fairly extensive, as a working example of more in-depth theming.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
