### PR TITLE
Avoid PermissionEvaluator breaking changes

### DIFF
--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -24,7 +24,10 @@ import {
   UrlReader,
 } from '@backstage/backend-common';
 import { PluginTaskScheduler } from '@backstage/backend-tasks';
-import { PermissionEvaluator } from '@backstage/plugin-permission-common';
+import {
+  PermissionAuthorizer,
+  PermissionEvaluator,
+} from '@backstage/plugin-permission-common';
 
 export type PluginEnvironment = {
   logger: Logger;
@@ -34,6 +37,6 @@ export type PluginEnvironment = {
   reader: UrlReader;
   discovery: PluginEndpointDiscovery;
   tokenManager: TokenManager;
-  permissions: PermissionEvaluator;
+  permissions: PermissionEvaluator | PermissionAuthorizer;
   scheduler: PluginTaskScheduler;
 };

--- a/plugins/catalog-backend/api-report.md
+++ b/plugins/catalog-backend/api-report.md
@@ -18,6 +18,7 @@ import { GetEntitiesRequest } from '@backstage/catalog-client';
 import { JsonValue } from '@backstage/types';
 import { Logger } from 'winston';
 import { Permission } from '@backstage/plugin-permission-common';
+import { PermissionAuthorizer } from '@backstage/plugin-permission-common';
 import { PermissionCondition } from '@backstage/plugin-permission-common';
 import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
@@ -180,7 +181,7 @@ export type CatalogEnvironment = {
   database: PluginDatabaseManager;
   config: Config;
   reader: UrlReader;
-  permissions: PermissionEvaluator;
+  permissions: PermissionEvaluator | PermissionAuthorizer;
 };
 
 // @alpha

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -382,13 +382,13 @@ export class CatalogBuilder {
     const unauthorizedEntitiesCatalog = new DefaultEntitiesCatalog(dbClient);
 
     let permissionEvaluator: PermissionEvaluator;
-    if (!permissions.hasOwnProperty('query')) {
+    if ('query' in permissions) {
+      permissionEvaluator = permissions as PermissionEvaluator;
+    } else {
       logger.warn(
-        'PermissionAuthorizer is deprecated. Please use PermissionEvaluator instead of PermissionAuthorizer in catalog.ts',
+        'PermissionAuthorizer is deprecated. Please use an instance of PermissionEvaluator instead of PermissionAuthorizer in PluginEnvironment#permissions',
       );
       permissionEvaluator = toPermissionEvaluator(permissions);
-    } else {
-      permissionEvaluator = permissions as PermissionEvaluator;
     }
 
     const entitiesCatalog = new AuthorizedEntitiesCatalog(

--- a/plugins/jenkins-backend/api-report.md
+++ b/plugins/jenkins-backend/api-report.md
@@ -8,6 +8,7 @@ import { CompoundEntityRef } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import express from 'express';
 import { Logger } from 'winston';
+import { PermissionAuthorizer } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 
 // Warning: (ae-missing-release-tag) "createRouter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -96,6 +97,6 @@ export interface RouterOptions {
   // (undocumented)
   logger: Logger;
   // (undocumented)
-  permissions?: PermissionEvaluator;
+  permissions?: PermissionEvaluator | PermissionAuthorizer;
 }
 ```

--- a/plugins/jenkins-backend/src/service/router.ts
+++ b/plugins/jenkins-backend/src/service/router.ts
@@ -20,22 +20,38 @@ import Router from 'express-promise-router';
 import { Logger } from 'winston';
 import { JenkinsInfoProvider } from './jenkinsInfoProvider';
 import { JenkinsApiImpl } from './jenkinsApi';
-import { PermissionEvaluator } from '@backstage/plugin-permission-common';
+import {
+  PermissionAuthorizer,
+  PermissionEvaluator,
+  toPermissionEvaluator,
+} from '@backstage/plugin-permission-common';
 import { getBearerTokenFromAuthorizationHeader } from '@backstage/plugin-auth-node';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 
 export interface RouterOptions {
   logger: Logger;
   jenkinsInfoProvider: JenkinsInfoProvider;
-  permissions?: PermissionEvaluator;
+  permissions?: PermissionEvaluator | PermissionAuthorizer;
 }
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { jenkinsInfoProvider } = options;
+  const { jenkinsInfoProvider, permissions, logger } = options;
 
-  const jenkinsApi = new JenkinsApiImpl(options.permissions);
+  let permissionEvaluator: PermissionEvaluator | undefined;
+  if (permissions?.hasOwnProperty('query')) {
+    permissionEvaluator = permissions as PermissionEvaluator;
+  } else {
+    logger.warn(
+      'PermissionAuthorizer is deprecated. Please use PermissionEvaluator instead of PermissionAuthorizer in your jenkins.ts',
+    );
+    permissionEvaluator = permissions
+      ? toPermissionEvaluator(permissions)
+      : undefined;
+  }
+
+  const jenkinsApi = new JenkinsApiImpl(permissionEvaluator);
 
   const router = Router();
   router.use(express.json());

--- a/plugins/jenkins-backend/src/service/router.ts
+++ b/plugins/jenkins-backend/src/service/router.ts
@@ -40,11 +40,11 @@ export async function createRouter(
   const { jenkinsInfoProvider, permissions, logger } = options;
 
   let permissionEvaluator: PermissionEvaluator | undefined;
-  if (permissions?.hasOwnProperty('query')) {
+  if (permissions && 'query' in permissions) {
     permissionEvaluator = permissions as PermissionEvaluator;
   } else {
     logger.warn(
-      'PermissionAuthorizer is deprecated. Please use PermissionEvaluator instead of PermissionAuthorizer in your jenkins.ts',
+      'PermissionAuthorizer is deprecated. Please use an instance of PermissionEvaluator instead of PermissionAuthorizer in PluginEnvironment#permissions',
     );
     permissionEvaluator = permissions
       ? toPermissionEvaluator(permissions)

--- a/plugins/permission-common/api-report.md
+++ b/plugins/permission-common/api-report.md
@@ -225,4 +225,9 @@ export type ResourcePermission<TResourceType extends string = string> =
       resourceType: TResourceType;
     }
   >;
+
+// @public
+export function toPermissionEvaluator(
+  permissionAuthorizer: PermissionAuthorizer,
+): PermissionEvaluator;
 ```

--- a/plugins/permission-common/src/permissions/util.ts
+++ b/plugins/permission-common/src/permissions/util.ts
@@ -14,7 +14,18 @@
  * limitations under the License.
  */
 
-import { Permission, ResourcePermission } from '../types';
+import {
+  AuthorizePermissionRequest,
+  AuthorizePermissionResponse,
+  DefinitivePolicyDecision,
+  EvaluatorRequestOptions,
+  Permission,
+  PermissionAuthorizer,
+  PermissionEvaluator,
+  QueryPermissionRequest,
+  QueryPermissionResponse,
+  ResourcePermission,
+} from '../types';
 
 /**
  * Check if the two parameters are equivalent permissions.
@@ -74,4 +85,27 @@ export function isUpdatePermission(permission: Permission) {
  */
 export function isDeletePermission(permission: Permission) {
   return permission.attributes.action === 'delete';
+}
+
+export function toPermissionEvaluator(
+  permissionAuthorizer: PermissionAuthorizer,
+): PermissionEvaluator {
+  return {
+    authorize: async (
+      requests: AuthorizePermissionRequest[],
+      options?: EvaluatorRequestOptions,
+    ): Promise<AuthorizePermissionResponse[]> => {
+      const response = await permissionAuthorizer.authorize(requests, options);
+
+      return response as DefinitivePolicyDecision[];
+    },
+    query(
+      requests: QueryPermissionRequest[],
+      options?: EvaluatorRequestOptions,
+    ): Promise<QueryPermissionResponse[]> {
+      // @ts-expect-error
+      const parsedRequests: AuthorizePermissionRequest[] = requests;
+      return permissionAuthorizer.authorize(parsedRequests, options);
+    },
+  };
 }

--- a/plugins/permission-common/src/permissions/util.ts
+++ b/plugins/permission-common/src/permissions/util.ts
@@ -87,6 +87,11 @@ export function isDeletePermission(permission: Permission) {
   return permission.attributes.action === 'delete';
 }
 
+/**
+ * Convert {@link PermissionAuthorizer} to {@link PermissionEvaluator}.
+ *
+ * @public
+ */
 export function toPermissionEvaluator(
   permissionAuthorizer: PermissionAuthorizer,
 ): PermissionEvaluator {
@@ -103,8 +108,8 @@ export function toPermissionEvaluator(
       requests: QueryPermissionRequest[],
       options?: EvaluatorRequestOptions,
     ): Promise<QueryPermissionResponse[]> {
-      // @ts-expect-error
-      const parsedRequests: AuthorizePermissionRequest[] = requests;
+      const parsedRequests =
+        requests as unknown as AuthorizePermissionRequest[];
       return permissionAuthorizer.authorize(parsedRequests, options);
     },
   };

--- a/plugins/search-backend/api-report.md
+++ b/plugins/search-backend/api-report.md
@@ -7,6 +7,7 @@ import { Config } from '@backstage/config';
 import { DocumentTypeInfo } from '@backstage/plugin-search-common';
 import express from 'express';
 import { Logger } from 'winston';
+import { PermissionAuthorizer } from '@backstage/plugin-permission-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { SearchEngine } from '@backstage/plugin-search-backend-node';
 
@@ -21,7 +22,7 @@ export function createRouter(options: RouterOptions): Promise<express.Router>;
 export type RouterOptions = {
   engine: SearchEngine;
   types: Record<string, DocumentTypeInfo>;
-  permissions: PermissionEvaluator;
+  permissions: PermissionEvaluator | PermissionAuthorizer;
   config: Config;
   logger: Logger;
 };

--- a/plugins/search-backend/src/service/router.ts
+++ b/plugins/search-backend/src/service/router.ts
@@ -76,13 +76,13 @@ export async function createRouter(
   });
 
   let permissionEvaluator: PermissionEvaluator;
-  if (!permissions.hasOwnProperty('query')) {
+  if ('query' in permissions) {
+    permissionEvaluator = permissions as PermissionEvaluator;
+  } else {
     logger.warn(
-      'PermissionAuthorizer is deprecated. Please use PermissionEvaluator instead of PermissionAuthorizer in search.ts',
+      'PermissionAuthorizer is deprecated. Please use an instance of PermissionEvaluator instead of PermissionAuthorizer in PluginEnvironment#permissions',
     );
     permissionEvaluator = toPermissionEvaluator(permissions);
-  } else {
-    permissionEvaluator = permissions as PermissionEvaluator;
   }
 
   const engine = config.getOptionalBoolean('permission.enabled')


### PR DESCRIPTION
This PR addresses https://github.com/backstage/backstage/pull/10397#discussion_r840701980

All the services using the permission framework now accepts `PermissionEvaluator` or the deprecated `PermissionAuthorizer`. We handle the migration internally. Since the endpoint remains the same, the `authorize` method can be used as an alternative to `query` method. This means the new version of catalog-backend can be used with the older implementation of ServerPermissionClient.