### PR TITLE
[TechDocs addons] reader page tests + layout component refactoring

### DIFF
--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@backstage/catalog-model": "^1.0.1-next.0",
     "@backstage/config": "^1.0.0",
-    "@backstage/core-app-api": "^1.0.0",
+    "@backstage/core-app-api": "^1.0.1-next.0",
     "@backstage/core-components": "^0.9.3-next.0",
     "@backstage/core-plugin-api": "^1.0.0",
     "@backstage/errors": "^1.0.0",
@@ -70,7 +70,6 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.17.0-next.1",
-    "@backstage/core-app-api": "^1.0.1-next.0",
     "@backstage/dev-utils": "^1.0.1-next.0",
     "@backstage/test-utils": "^1.0.1-next.1",
     "@testing-library/jest-dom": "^5.10.1",

--- a/plugins/techdocs/src/EntityPageDocs.tsx
+++ b/plugins/techdocs/src/EntityPageDocs.tsx
@@ -19,7 +19,8 @@ import React from 'react';
 import { Entity, getCompoundEntityRef } from '@backstage/catalog-model';
 
 import { TechDocsReaderPage } from './plugin';
-import { TechDocsReaderLayout } from './reader';
+import { TechDocsReaderPageSubheader } from './reader/components/TechDocsReaderPageSubheader';
+import { TechDocsReaderPageContent } from './reader/components/TechDocsReaderPageContent';
 
 type EntityPageDocsProps = { entity: Entity };
 
@@ -28,7 +29,8 @@ export const EntityPageDocs = ({ entity }: EntityPageDocsProps) => {
 
   return (
     <TechDocsReaderPage entityRef={entityRef}>
-      <TechDocsReaderLayout withHeader={false} />
+      <TechDocsReaderPageSubheader />
+      <TechDocsReaderPageContent withSearch={false} />
     </TechDocsReaderPage>
   );
 };

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.test.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { act } from '@testing-library/react';
+import { ThemeProvider } from '@material-ui/core';
+import { scmIntegrationsApiRef } from '@backstage/integration-react';
+
+import { lightTheme } from '@backstage/theme';
+import { entityRouteRef } from '@backstage/plugin-catalog-react';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+
+import { techdocsApiRef, techdocsStorageApiRef } from '../../../api';
+
+import { rootRouteRef, rootDocsRouteRef } from '../../../routes';
+
+import { TechDocsReaderPage } from './TechDocsReaderPage';
+
+const mockEntityMetadata = {
+  locationMetadata: {
+    type: 'github',
+    target: 'https://example.com/',
+  },
+  apiVersion: 'v1',
+  kind: 'test',
+  metadata: {
+    name: 'test-name',
+    namespace: 'test-namespace',
+  },
+  spec: {
+    owner: 'test',
+  },
+};
+
+const mockTechDocsMetadata = {
+  site_name: 'test-site-name',
+  site_description: 'test-site-desc',
+};
+
+const getEntityMetadata = jest.fn();
+const getTechDocsMetadata = jest.fn();
+
+const techdocsApiMock = {
+  getEntityMetadata,
+  getTechDocsMetadata,
+};
+
+const techdocsStorageApiMock: jest.Mocked<typeof techdocsStorageApiRef.T> = {
+  getApiOrigin: jest.fn(),
+  getBaseUrl: jest.fn(),
+  getBuilder: jest.fn(),
+  getEntityDocs: jest.fn(),
+  getStorageUrl: jest.fn(),
+  syncEntityDocs: jest.fn(),
+};
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <ThemeProvider theme={lightTheme}>
+      <TestApiProvider
+        apis={[
+          [scmIntegrationsApiRef, {}],
+          [techdocsApiRef, techdocsApiMock],
+          [techdocsStorageApiRef, techdocsStorageApiMock],
+        ]}
+      >
+        {children}
+      </TestApiProvider>
+    </ThemeProvider>
+  );
+};
+
+const mountedRoutes = {
+  '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+  '/docs': rootRouteRef,
+  '/docs/:namespace/:kind/:name/*': rootDocsRouteRef,
+};
+
+describe('<TechDocsReaderPage />', () => {
+  beforeEach(() => {
+    getEntityMetadata.mockResolvedValue(mockEntityMetadata);
+    getTechDocsMetadata.mockResolvedValue(mockTechDocsMetadata);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('should render a techdocs reader page without children', async () => {
+    const rendered = await renderInTestApp(
+      <Wrapper>
+        <TechDocsReaderPage
+          entityRef={{
+            name: 'test-name',
+            namespace: 'test-namespace',
+            kind: 'test',
+          }}
+        />
+      </Wrapper>,
+      {
+        mountedRoutes,
+      },
+    );
+
+    // TechDocsReaderPageHeader
+    expect(rendered.container.querySelector('header')).toBeInTheDocument();
+    // TechDocsReaderPageContent
+    expect(rendered.container.querySelector('article')).toBeInTheDocument();
+  });
+
+  it('should render a techdocs reader page with children', async () => {
+    await act(async () => {
+      const rendered = await renderInTestApp(
+        <Wrapper>
+          <TechDocsReaderPage
+            entityRef={{
+              name: 'test-name',
+              namespace: 'test-namespace',
+              kind: 'test',
+            }}
+          >
+            techdocs reader page
+          </TechDocsReaderPage>
+        </Wrapper>,
+        {
+          mountedRoutes,
+        },
+      );
+      expect(
+        rendered.container.querySelector('header'),
+      ).not.toBeInTheDocument();
+      expect(
+        rendered.container.querySelector('article'),
+      ).not.toBeInTheDocument();
+      expect(rendered.getByText('techdocs reader page')).toBeInTheDocument();
+    });
+  });
+});

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPage/TechDocsReaderPage.tsx
@@ -61,11 +61,11 @@ export const TechDocsReaderLayout = ({
   withHeader = true,
 }: TechDocsReaderLayoutProps) => {
   return (
-    <>
+    <Page themeId="documentation">
       {withHeader && <TechDocsReaderPageHeader />}
       <TechDocsReaderPageSubheader />
       <TechDocsReaderPageContent withSearch={withSearch} />
-    </>
+    </Page>
   );
 };
 
@@ -101,9 +101,7 @@ export const TechDocsReaderPage = ({
     return (
       (page as JSX.Element) || (
         <TechDocsReaderPageProvider entityName={entityName}>
-          <Page themeId="documentation">
-            <TechDocsReaderLayout />
-          </Page>
+          <TechDocsReaderLayout />
         </TechDocsReaderPageProvider>
       )
     );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds two basic tests for the TechDocsReaderPage component, with and without children. 
It also refactors the TechDocsReaderLayout so that it contains the page component too. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
