### PR TITLE
catalog-graph: move SVG mocks to test setup

### DIFF
--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
@@ -39,13 +39,6 @@ describe('<CatalogGraphCard/>', () => {
   let catalog: jest.Mocked<CatalogApi>;
   let apis: TestApiRegistry;
 
-  beforeAll(() => {
-    Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
-      value: () => ({ width: 100, height: 100 }),
-      configurable: true,
-    });
-  });
-
   beforeEach(() => {
     entity = {
       apiVersion: 'a',

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.test.tsx
@@ -40,21 +40,6 @@ describe('<CatalogGraphPage/>', () => {
   let wrapper: JSX.Element;
   let catalog: jest.Mocked<CatalogApi>;
 
-  beforeAll(() => {
-    Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
-      value: () => ({ width: 100, height: 100 }),
-      configurable: true,
-    });
-    Object.defineProperty(window.SVGElement.prototype, 'viewBox', {
-      value: { baseVal: { x: 0, y: 0, width: 100, height: 100 } },
-      configurable: true,
-    });
-    Object.defineProperty(window.MouseEvent.prototype, 'view', {
-      value: window,
-      configurable: true,
-    });
-  });
-
   beforeEach(() => {
     const entityC = {
       apiVersion: 'a',

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.test.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/CustomNode.test.tsx
@@ -19,13 +19,6 @@ import { CustomNode } from './CustomNode';
 import userEvent from '@testing-library/user-event';
 
 describe('<CustomNode />', () => {
-  beforeAll(() => {
-    Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
-      value: () => ({ width: 100, height: 100 }),
-      configurable: true,
-    });
-  });
-
   test('renders node', async () => {
     const { getByText } = await renderInTestApp(
       <svg xmlns="http://www.w3.org/2000/svg">

--- a/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
+++ b/plugins/catalog-graph/src/components/EntityRelationsGraph/EntityRelationsGraph.test.tsx
@@ -33,13 +33,6 @@ describe('<EntityRelationsGraph/>', () => {
   let catalog: jest.Mocked<CatalogApi>;
   const CUSTOM_TEST_ID = 'custom-test-id';
 
-  beforeAll(() => {
-    Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
-      value: () => ({ width: 100, height: 100 }),
-      configurable: true,
-    });
-  });
-
   beforeEach(() => {
     const entities: { [ref: string]: Entity } = {
       'b:d/c': {

--- a/plugins/catalog-graph/src/setupTests.ts
+++ b/plugins/catalog-graph/src/setupTests.ts
@@ -14,3 +14,17 @@
  * limitations under the License.
  */
 import '@testing-library/jest-dom';
+
+// Common mocks needed for SVG and D3 rendering
+Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
+  value: () => ({ width: 100, height: 100 }),
+  configurable: true,
+});
+Object.defineProperty(window.SVGElement.prototype, 'viewBox', {
+  value: { baseVal: { x: 0, y: 0, width: 100, height: 100 } },
+  configurable: true,
+});
+Object.defineProperty(window.MouseEvent.prototype, 'view', {
+  value: window,
+  configurable: true,
+});


### PR DESCRIPTION
🧹 

Should get rid of the existing test flakiness

Figured its best to move to a common mock for `catalog-graph`, then we'll keep some 👀 on it to see if we need to do more