### PR TITLE
Update behavior when unregistering locations from `UnregisterEntityDialog`

### DIFF
--- a/.changeset/proud-teachers-draw.md
+++ b/.changeset/proud-teachers-draw.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Updated the "unregister location" behavior in `UnregisterEntityDialog`. Removed unnecessary entity deletion requests that were sent after successfully deleting a location.

--- a/plugins/catalog-react/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.ts
+++ b/plugins/catalog-react/src/components/UnregisterEntityDialog/useUnregisterEntityDialogState.ts
@@ -95,18 +95,13 @@ export function useUnregisterEntityDialogState(
     );
   }, [catalogApi, entity]);
 
-  // Unregisters the underlying location and removes all of the entities that
-  // are spawned from it. Can only ever be called when the prerequisites have
-  // finished loading successfully, and if there was a matching location.
+  // Unregisters the underlying location which will remove all of the entities that are spawned from
+  // it. Can only ever be called when the prerequisites have finished loading successfully, and if
+  // there was a matching location.
   const unregisterLocation = useCallback(
     async function unregisterLocationFn() {
-      const { location, colocatedEntities } = prerequisites.value!;
+      const { location } = prerequisites.value!;
       await catalogApi.removeLocationById(location!.id);
-      await Promise.allSettled(
-        colocatedEntities.map(e =>
-          catalogApi.removeEntityByUid(e.metadata.uid!),
-        ),
-      );
     },
     [catalogApi, prerequisites],
   );


### PR DESCRIPTION
Signed-off-by: Joe Porpeglia <josephp@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Removes explicit entity deletion requests from the "unregister location" flow.

When clicking the "unregister location" button of the `UnregisterEntityDialog`, the frontend will delete the location from the catalog. Once that succeeds, the frontend will delete each of the colocated entities that originated from the location. However, these entities were likely deleted with the first request (see [Life of an Entity - Implicit Deletion](https://backstage.io/docs/features/software-catalog/life-of-an-entity#implicit-deletion)). If any were not deleted, that would indicate that another catalog location is pointing to them. In either case, explicit entity deletion will not have a permanent effect unless all parent locations are deleted.

Related to #5043

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
