### PR TITLE
Override default connection pool settings

### DIFF
--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -56,9 +56,9 @@ directly for development.
 
 The Backstage App is now ready to start up with a PostgreSQL backing database.
 
-### Override default PostgreSQL Database Pool Configuration 
+### Override default PostgreSQL Database Pool Configuration
 
-If you want to override the default connection pool settings then use the below configuration: 
+If you want to override the default connection pool settings then use the below configuration:
 
 ```diff
 backend:
@@ -74,7 +74,7 @@ backend:
 +      password: ${POSTGRES_PASSWORD}
 +    # Refer to Tarn docs for default values on PostgreSQL pool configuration - https://github.com/Vincit/tarn.js
 +    knexConfig:
-+      pool: 
++      pool:
 +        min: 3
 +        max: 12
 +        acquireTimeoutMillis: 60000
@@ -84,10 +84,6 @@ backend:
 +      # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
 +      # ssl:
 +      #   ca: # if you have a CA file and want to verify it you can uncomment this section
-+      #     $file: <file-path>/ca/server.crt      
-<<<<<<< HEAD
++      #     $file: <file-path>/ca/server.crt   
 ```
-=======
-```
-  
->>>>>>> 3e223b4dfb (Moved the reference doc link up,  Signed-off-by: Sharad Pattanshetti <sharad.pattanshetti@gmail.com>)
+

--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -85,4 +85,9 @@ backend:
 +      # ssl:
 +      #   ca: # if you have a CA file and want to verify it you can uncomment this section
 +      #     $file: <file-path>/ca/server.crt      
+<<<<<<< HEAD
 ```
+=======
+```
+  
+>>>>>>> 3e223b4dfb (Moved the reference doc link up,  Signed-off-by: Sharad Pattanshetti <sharad.pattanshetti@gmail.com>)

--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -72,6 +72,7 @@ backend:
 +      port: ${POSTGRES_PORT}
 +      user: ${POSTGRES_USER}
 +      password: ${POSTGRES_PASSWORD}
++    # Refer to Tarn docs for default values on PostgreSQL pool configuration - https://github.com/Vincit/tarn.js
 +    knexConfig:
 +      pool: 
 +        min: 3
@@ -83,8 +84,6 @@ backend:
 +      # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
 +      # ssl:
 +      #   ca: # if you have a CA file and want to verify it you can uncomment this section
-+      #     $file: <file-path>/ca/server.crt
-+      #
-+      # Refer to Tarn docs for default values on PostgreSQL pool configuration - https://github.com/Vincit/tarn.js
++      #     $file: <file-path>/ca/server.crt      
 ```
   

--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -56,9 +56,9 @@ directly for development.
 
 The Backstage App is now ready to start up with a PostgreSQL backing database.
 
-### Override default PostgreSQL Database Pool Configuration 
+### Override default PostgreSQL Database Pool Configuration
 
-If you want to override the default connection pool settings then use the below configuration: 
+If you want to override the default connection pool settings then use the below configuration:
 
 ```diff
 backend:
@@ -74,7 +74,7 @@ backend:
 +      password: ${POSTGRES_PASSWORD}
 +    # Refer to Tarn docs for default values on PostgreSQL pool configuration - https://github.com/Vincit/tarn.js
 +    knexConfig:
-+      pool: 
++      pool:
 +        min: 3
 +        max: 12
 +        acquireTimeoutMillis: 60000
@@ -84,6 +84,5 @@ backend:
 +      # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
 +      # ssl:
 +      #   ca: # if you have a CA file and want to verify it you can uncomment this section
-+      #     $file: <file-path>/ca/server.crt      
++      #     $file: <file-path>/ca/server.crt
 ```
-  

--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -86,4 +86,3 @@ backend:
 +      #   ca: # if you have a CA file and want to verify it you can uncomment this section
 +      #     $file: <file-path>/ca/server.crt      
 ```
-  

--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -56,9 +56,9 @@ directly for development.
 
 The Backstage App is now ready to start up with a PostgreSQL backing database.
 
-### Override default PostgreSQL Database Pool Configuration
+### Override default PostgreSQL Database Pool Configuration 
 
-If you want to override the default connection pool settings then use the below configuration:
+If you want to override the default connection pool settings then use the below configuration: 
 
 ```diff
 backend:
@@ -74,7 +74,7 @@ backend:
 +      password: ${POSTGRES_PASSWORD}
 +    # Refer to Tarn docs for default values on PostgreSQL pool configuration - https://github.com/Vincit/tarn.js
 +    knexConfig:
-+      pool:
++      pool: 
 +        min: 3
 +        max: 12
 +        acquireTimeoutMillis: 60000
@@ -84,5 +84,6 @@ backend:
 +      # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
 +      # ssl:
 +      #   ca: # if you have a CA file and want to verify it you can uncomment this section
-+      #     $file: <file-path>/ca/server.crt
++      #     $file: <file-path>/ca/server.crt      
 ```
+  

--- a/docs/tutorials/switching-sqlite-postgres.md
+++ b/docs/tutorials/switching-sqlite-postgres.md
@@ -55,3 +55,36 @@ launching Backstage, or remove the `${...}` values and simply set actual values
 directly for development.
 
 The Backstage App is now ready to start up with a PostgreSQL backing database.
+
+### Override default PostgreSQL Database Pool Configuration 
+
+If you want to override the default connection pool settings then use the below configuration: 
+
+```diff
+backend:
+  database:
+-    client: better-sqlite3
+-    connection: ':memory:'
++    # config options: https://node-postgres.com/api/client
++    client: pg
++    connection:
++      host: ${POSTGRES_HOST}
++      port: ${POSTGRES_PORT}
++      user: ${POSTGRES_USER}
++      password: ${POSTGRES_PASSWORD}
++    knexConfig:
++      pool: 
++        min: 3
++        max: 12
++        acquireTimeoutMillis: 60000
++        idleTimeoutMillis: 60000
++      # https://node-postgres.com/features/ssl
++      # you can set the sslmode configuration option via the `PGSSLMODE` environment variable
++      # see https://www.postgresql.org/docs/current/libpq-ssl.html Table 33.1. SSL Mode Descriptions (e.g. require)
++      # ssl:
++      #   ca: # if you have a CA file and want to verify it you can uncomment this section
++      #     $file: <file-path>/ca/server.crt
++      #
++      # Refer to Tarn docs for default values on PostgreSQL pool configuration - https://github.com/Vincit/tarn.js
+```
+  


### PR DESCRIPTION
Provided the configuration to override the default pool settings. This is useful when the min or max connections to be changed or avoid 'Connection Terminated Unexpectedly' errors in certain cases.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
