### PR TITLE
config-loader,backend-common: do not fail backend startup on config schema errors

### DIFF
--- a/.changeset/heavy-stingrays-talk.md
+++ b/.changeset/heavy-stingrays-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+The backend will no longer fail to start up when configured secrets do not match the configuration schema.

--- a/.changeset/thirty-icons-buy.md
+++ b/.changeset/thirty-icons-buy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': minor
+---
+
+Added `ignoreSchemaErrors` to `schema.process`.

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -41,7 +41,7 @@ const updateRedactionList = (
 ) => {
   const secretAppConfigs = schema.process(configs, {
     visibility: ['secret'],
-    withDeprecatedKeys: true,
+    ignoreSchemaErrors: true,
   });
   const secretConfig = ConfigReader.fromConfigs(secretAppConfigs);
   const values = new Set<string>();

--- a/packages/config-loader/api-report.md
+++ b/packages/config-loader/api-report.md
@@ -19,6 +19,7 @@ export type ConfigSchema = {
 // @public
 export type ConfigSchemaProcessingOptions = {
   visibility?: ConfigVisibility[];
+  ignoreSchemaErrors?: boolean;
   valueTransform?: TransformFunc<any>;
   withFilteredKeys?: boolean;
   withDeprecatedKeys?: boolean;

--- a/packages/config-loader/src/lib/schema/load.test.ts
+++ b/packages/config-loader/src/lib/schema/load.test.ts
@@ -275,5 +275,12 @@ describe('loadConfigSchema', () => {
     ).toThrow(
       "Config must have required property 'x a' { missingProperty=x a } at /other",
     );
+
+    expect(
+      schema.process([{ data: { other: {} }, context: 'test' }], {
+        visibility: ['frontend'],
+        ignoreSchemaErrors: true,
+      }),
+    ).toEqual([{ data: {}, context: 'test' }]);
   });
 });

--- a/packages/config-loader/src/lib/schema/load.ts
+++ b/packages/config-loader/src/lib/schema/load.ts
@@ -82,18 +82,26 @@ export async function loadConfigSchema(
   return {
     process(
       configs: AppConfig[],
-      { visibility, valueTransform, withFilteredKeys, withDeprecatedKeys } = {},
+      {
+        visibility,
+        valueTransform,
+        withFilteredKeys,
+        withDeprecatedKeys,
+        ignoreSchemaErrors,
+      } = {},
     ): AppConfig[] {
       const result = validate(configs);
 
-      const visibleErrors = filterErrorsByVisibility(
-        result.errors,
-        visibility,
-        result.visibilityByDataPath,
-        result.visibilityBySchemaPath,
-      );
-      if (visibleErrors.length > 0) {
-        throw errorsToError(visibleErrors);
+      if (!ignoreSchemaErrors) {
+        const visibleErrors = filterErrorsByVisibility(
+          result.errors,
+          visibility,
+          result.visibilityByDataPath,
+          result.visibilityBySchemaPath,
+        );
+        if (visibleErrors.length > 0) {
+          throw errorsToError(visibleErrors);
+        }
       }
 
       let processedConfigs = configs;

--- a/packages/config-loader/src/lib/schema/types.ts
+++ b/packages/config-loader/src/lib/schema/types.ts
@@ -118,6 +118,11 @@ export type ConfigSchemaProcessingOptions = {
   visibility?: ConfigVisibility[];
 
   /**
+   * When set to `true`, any schema errors in the provided configuration will be ignored.
+   */
+  ignoreSchemaErrors?: boolean;
+
+  /**
    * A transform function that can be used to transform primitive configuration values
    * during validation. The value returned from the transform function will be used
    * instead of the original value. If the transform returns `undefined`, the value


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ran into this in master, which isn't really the desired behavior imo. Another way to go about this is to have all schema errors surfaced instead, but I'm thinking it's best to have either or, rather than only failing when secrets don't conform to the schema.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
