### PR TITLE
Add package resolution for @types/react

### DIFF
--- a/.changeset/little-moles-pull.md
+++ b/.changeset/little-moles-pull.md
@@ -6,7 +6,7 @@ Add type resolutions for `@types/react` and `types/react-dom`.
 
 The reason for this is the usage of `"@types/react": "*"` as a dependency which is very common practice in react packages. This recently resolves to react 18 which introduces several breaking changes in both internal and external packages.
 
-To apply these changes to your existing installation. Add a resolutions block to your `package.json`
+To apply these changes to your existing installation, add a resolutions block to your `package.json`
 
 ```json
   "resolutions": {

--- a/.changeset/little-moles-pull.md
+++ b/.changeset/little-moles-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Add resolution for version 17 `@types/react` due to breaking changes introduced in version 18.

--- a/.changeset/little-moles-pull.md
+++ b/.changeset/little-moles-pull.md
@@ -2,7 +2,7 @@
 '@backstage/create-app': patch
 ---
 
-Add resolution for version 17 `@types/react` and `types/react-dom` due to breaking changes introduced in version 18.
+Add type resolutions for `@types/react` and `types/react-dom`. This is an
 
 To apply these changes to your existing installation. Add a resolutions block to your `package.json`
 
@@ -13,7 +13,7 @@ To apply these changes to your existing installation. Add a resolutions block to
   },
 ```
 
-If your depending on react 16 in use this resolution block instead.
+If your existing app depend on react 16 use this resolution block instead.
 
 ```json
   "resolutions": {

--- a/.changeset/little-moles-pull.md
+++ b/.changeset/little-moles-pull.md
@@ -2,4 +2,22 @@
 '@backstage/create-app': patch
 ---
 
-Add resolution for version 17 `@types/react` due to breaking changes introduced in version 18.
+Add resolution for version 17 `@types/react` and `types/react-dom` due to breaking changes introduced in version 18.
+
+To apply these changes to your existing installation. Add a resolutions block to your `package.json`
+
+```json
+  "resolutions": {
+    "@types/react": "^17",
+    "@types/react-dom": "^17"
+  },
+```
+
+If your depending on react 16 in use this resolution block instead.
+
+```json
+  "resolutions": {
+    "@types/react": "^16",
+    "@types/react-dom": "^16"
+  },
+```

--- a/.changeset/little-moles-pull.md
+++ b/.changeset/little-moles-pull.md
@@ -2,7 +2,9 @@
 '@backstage/create-app': patch
 ---
 
-Add type resolutions for `@types/react` and `types/react-dom`. This is an
+Add type resolutions for `@types/react` and `types/react-dom`.
+
+The reason for this is the usage of `"@types/react": "*"` as a dependency which is very common practice in react packages. This recently resolves to react 18 which introduces several breaking changes in both internal and external packages.
 
 To apply these changes to your existing installation. Add a resolutions block to your `package.json`
 
@@ -13,7 +15,7 @@ To apply these changes to your existing installation. Add a resolutions block to
   },
 ```
 
-If your existing app depend on react 16 use this resolution block instead.
+If your existing app depends on react 16, use this resolution block instead.
 
 ```json
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   },
   "resolutions": {
     "**/@graphql-codegen/cli/**/ws": "^7.4.6",
-    "@types/react": "^17.0.39"
+    "@types/react": "^17",
+    "@types/react-dom": "^17"
   },
   "version": "1.1.0-next.2",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     ]
   },
   "resolutions": {
-    "**/@graphql-codegen/cli/**/ws": "^7.4.6"
+    "**/@graphql-codegen/cli/**/ws": "^7.4.6",
+    "@types/react": "^17.0.39"
   },
   "version": "1.1.0-next.2",
   "dependencies": {

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -37,6 +37,9 @@
     "prettier": "^2.3.2",
     "typescript": "~4.5.4"
   },
+  "resolutions": {
+    "@types/react": "^17.0.39"
+  },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -38,7 +38,8 @@
     "typescript": "~4.5.4"
   },
   "resolutions": {
-    "@types/react": "^17.0.39"
+    "@types/react": "^17",
+    "@types/react-dom": "^17"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,14 +1478,6 @@
     lodash "^4.17.21"
     uuid "^8.0.0"
 
-"@backstage/config@^0.1.15":
-  version "0.1.15"
-  resolved "https://registry.npmjs.org/@backstage/config/-/config-0.1.15.tgz#4bad122ad861be5bd61a60639f92d2494fa245c5"
-  integrity sha512-eNJEYYSEu9MkrkBYiMpUBWEc3Bu64YgB9pZZGCMW7/9350tV2wbylEdoBJHslilJlJhiUyTXBckn8Ua7DOH7rw==
-  dependencies:
-    "@backstage/types" "^0.1.3"
-    lodash "^4.17.21"
-
 "@backstage/core-components@^0.9.0", "@backstage/core-components@^0.9.2":
   version "0.9.2"
   resolved "https://registry.npmjs.org/@backstage/core-components/-/core-components-0.9.2.tgz#9a3d79a15039256bbc007e5daa08c983050e0238"
@@ -1609,11 +1601,6 @@
     react-router "6.0.0-beta.0"
     react-use "^17.2.4"
     swr "^1.1.2"
-
-"@backstage/types@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.npmjs.org/@backstage/types/-/types-0.1.3.tgz#6613d8cbdf97d42d31cd1e66a833df533e7ccf14"
-  integrity sha512-fJVi4oVrlO+G3PRv1fYSll9/X4pE11HLnkI//Geare9sP6wSfp/2zXpLYfKVsG0e24jOl7Swkc8lwLkQ90zMaQ==
 
 "@balena/dockerignore@^1.0.2":
   version "1.0.2"
@@ -6652,10 +6639,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^16.13.1 || ^17.0.0":
-  version "17.0.43"
-  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
-  integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^17.0.39":
+  version "17.0.44"
+  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
+  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
Add resolution for version 17 `@types/react` due to breaking changes introduced in version 18.
