### PR TITLE
patch 1.0 - add resolutions for react types to create-app template

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "resolutions": {
     "**/@graphql-codegen/cli/**/ws": "^7.4.6"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "dependencies": {
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.15.0",

--- a/packages/create-app/CHANGELOG.md
+++ b/packages/create-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/create-app
 
+## 0.4.25
+
+### Patch Changes
+
+- Added resolutions for `@types/react` and `@types/react-dom` to make sure that React v17 types are installed.
+
 ## 0.4.24
 
 ### Patch Changes

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/create-app",
   "description": "A CLI that helps you create your own Backstage app",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/create-app/templates/default-app/package.json.hbs
+++ b/packages/create-app/templates/default-app/package.json.hbs
@@ -37,6 +37,10 @@
     "prettier": "^2.3.2",
     "typescript": "~4.5.4"
   },
+  "resolutions": {
+    "@types/react": "^17",
+    "@types/react-dom": "^17"
+  },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [


### PR DESCRIPTION
This release patches the `@backstage/create-app` template to add resolutions for `@types/react` and `@types/react-dom`, making sure that React v17 types are installed.