### PR TITLE
add dedicated grpc api widget

### DIFF
--- a/.changeset/slimy-horses-do.md
+++ b/.changeset/slimy-horses-do.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-api-docs': patch
 ---
 
-Add dedicated grpc api definition widget
+Add dedicated gRPC api definition widget

--- a/.changeset/slimy-horses-do.md
+++ b/.changeset/slimy-horses-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Add dedicated grpc api definition widget

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionWidget.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import { AsyncApiDefinitionWidget } from '../AsyncApiDefinitionWidget';
 import { GraphQlDefinitionWidget } from '../GraphQlDefinitionWidget';
 import { OpenApiDefinitionWidget } from '../OpenApiDefinitionWidget';
+import { GrpcApiDefinitionWidget } from '../GrpcApiDefinitionWidget';
 
 export type ApiDefinitionWidget = {
   type: string;
@@ -49,6 +50,13 @@ export function defaultDefinitionWidgets(): ApiDefinitionWidget[] {
       rawLanguage: 'graphql',
       component: definition => (
         <GraphQlDefinitionWidget definition={definition} />
+      ),
+    },
+    {
+      type: 'grpc',
+      title: 'gRPC',
+      component: definition => (
+        <GrpcApiDefinitionWidget definition={definition} />
       ),
     },
   ];

--- a/plugins/api-docs/src/components/GrpcApiDefinitionWidget/GrpcApiDefinitionWidget.test.tsx
+++ b/plugins/api-docs/src/components/GrpcApiDefinitionWidget/GrpcApiDefinitionWidget.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderInTestApp } from '@backstage/test-utils';
+import React from 'react';
+import { GrpcApiDefinitionWidget } from './GrpcApiDefinitionWidget';
+
+describe('<GrpcApiDefinitionWidget />', () => {
+  it('renders plain text', async () => {
+    const { getAllByText } = await renderInTestApp(
+      <GrpcApiDefinitionWidget definition="Hello World" />,
+    );
+
+    expect(
+      getAllByText((_text, element) => element?.textContent === 'Hello World')
+        .length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/plugins/api-docs/src/components/GrpcApiDefinitionWidget/GrpcApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/GrpcApiDefinitionWidget/GrpcApiDefinitionWidget.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { CodeSnippet } from '@backstage/core-components';
+import { useTheme } from '@material-ui/core/styles';
+import { BackstageTheme } from '@backstage/theme';
+
+export type GrpcApiDefinitionWidgetProps = {
+  definition: any;
+};
+
+export const GrpcApiDefinitionWidget = (
+  props: GrpcApiDefinitionWidgetProps,
+) => {
+  const theme = useTheme<BackstageTheme>();
+  return (
+    <CodeSnippet
+      customStyle={{ backgroundColor: theme.palette.background.default }}
+      text={props.definition}
+      language="protobuf"
+      showCopyCodeButton
+    />
+  );
+};

--- a/plugins/api-docs/src/components/GrpcApiDefinitionWidget/GrpcApiDefinitionWidget.tsx
+++ b/plugins/api-docs/src/components/GrpcApiDefinitionWidget/GrpcApiDefinitionWidget.tsx
@@ -20,7 +20,7 @@ import { useTheme } from '@material-ui/core/styles';
 import { BackstageTheme } from '@backstage/theme';
 
 export type GrpcApiDefinitionWidgetProps = {
-  definition: any;
+  definition: string;
 };
 
 export const GrpcApiDefinitionWidget = (

--- a/plugins/api-docs/src/components/GrpcApiDefinitionWidget/index.ts
+++ b/plugins/api-docs/src/components/GrpcApiDefinitionWidget/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { GrpcApiDefinitionWidget } from './GrpcApiDefinitionWidget';
+export type { GrpcApiDefinitionWidgetProps } from './GrpcApiDefinitionWidget';


### PR DESCRIPTION
Signed-off-by: Kiss Miklos <miklos@roadie.io>

## Hey, I just made a Pull Request!


The official docs states the support for `grpc` in the api view. However there are no dedicated component and it uses the `<PlainApiDefinitionWidget />`, this widget is a wrapper around the `<CodeSnippet />` componenet which uses directly the `<LigthAsync />` component from the `react-syntac-highlighter` package. 
The issue is that the api definitions type is directly passed into the react-syntax-highlighter and the package does not contain syntax highlighting for a language called `grpc` because actually a grpc definitions are the `.proto` files. So we'd need to use the language `protobuf` to get syntax highlighting. 
I created a dedicated widget for the grpc api definitions just to map the `grpc` type to `protobuf` so we could get syntax highlighting for the definitions without the need to change the type from `grpc` to `protobuf`
     
Before: 
![image](https://user-images.githubusercontent.com/24729496/162420413-c096507a-e75a-4f74-a254-c6f79a632268.png)
After:
![image](https://user-images.githubusercontent.com/24729496/162420475-a8aee36c-65e0-4570-80c7-e07f08986612.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
