### PR TITLE
[Search] Task scheduler cleanups

### DIFF
--- a/.changeset/ninety-eggs-argue.md
+++ b/.changeset/ninety-eggs-argue.md
@@ -17,8 +17,8 @@ To make this change to an existing app, make the following changes to `packages/
 /* ... */
 
 +  const schedule = env.scheduler.createScheduledTaskRunner({
-+    frequency: Duration.fromObject({ seconds: 600 }),
-+    timeout: Duration.fromObject({ seconds: 900 }),
++    frequency: Duration.fromObject({ minutes: 10 }),
++    timeout: Duration.fromObject({ minutes: 15 }),
 +    initialDelay: Duration.fromObject({ seconds: 3 }),
 +  });
 

--- a/docs/assets/search/architecture.drawio.svg
+++ b/docs/assets/search/architecture.drawio.svg
@@ -1,20 +1,19 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="789px" height="766px" viewBox="-0.5 -0.5 789 766" content="&lt;mxfile&gt;&lt;diagram id=&quot;AOZgdlUmH_6GT6Gt5u4e&quot; name=&quot;Page-1&quot;&gt;7V1bc+I6Ev41VM08hPJNvjwmJJkzWzN1ssmps2cejRHgGWOxtklgf/1KlmSsC2DABsIkUzWxZcmX/lqt7k8tpWcPZssvWTiffkcjmPQsY7Ts2fc9y/INB/9PCla0wHENWjDJ4hEtMtcFL/H/ICvk1RbxCOZCxQKhpIjnYmGE0hRGhVAWZhl6E6uNUSI+dR5OoFLwEoWJWvqfeFRM2WcBY13+B4wnU/5k02BXhmH0a5KhRcqe17PscflDL89Cfi9WP5+GI/RWK7IfevYgQ6igR7PlACZEtFxstN3jhqvVe2cwLZo0cBlQr2GygPyVyxcrVlwYb9O4gC/zMCLnbxjvnn03LWYJPjPxYZjPKQTjeAnxbe/GcZIMUIKysrltmQPjFuDyvMjQL1i7YhiuC3zSAqVFrRwMyD9crn4N+8BXmBVwWStiX/cFohksshWuwq6CANAmXBODgJ6/rXE1HYbGtI4pLwyZLk2qe6/liQ+YSDeI175y8TrgnOL1TEWacIQ7MjtFWTFFE5SGycO69K7snUSS9wY+W9f5htCcyfwnLIoVs0rhokAiInAZF/+Q5n0PsNMftUv3S3br8mTFTvIizIpbYppwQYpSyMseY/J5tEE64jWiJMzzOKKFrIrZLsg5WmQRk5rH9BS/0ASyaj4tIgLdqgkZTMIifhUtpw5V1vQJxfhNKg1yuVFlGuRZQLwFfSfWaq0bWFLhqlZtTirkm5/jGfJzDEnV6B3Xild9YyNddIKju/pF92yT41Lv2TboqGcv/l7dDqK35cxZGrN/oVXw98/8hqvkNhGLvXuXbU3iSYqPEzguLl3+tuko8seOVkfyB9Z1abMr9f5L0GagEbGbEEUcxa/4cFKU306Lhplcgh8q1LvWjlBBxV0M3+nr0DM1fSHoDDyd3/wBnmrFxG5nq7hZga7XeS0A5xxvw7bIrCZl5s6NwnxaYmZ2HNKI/cHVyNTVjQt2CzJtMALjkHZODqNVEmMlzqzdGjyk6v5tWBVUYfSfiwLfBnI8qE9ugkvTc+CCvm+LuGiAAX7fdlRofHA8Mpaq7bfzOS54wrIs6Y7bHnF53XBGpF9aoWe0KGD56ewF3f8uEDNPOQyzaFovMmACZ0xE3p14p36/X979sSqmhs271xbLOoOlXIgqkUGMdTgsKxAbSMIwjn7N5kX4fSDG845AFUdhcssuzOLRqAz3WFyAHwPueuBe33VFnWGFohHuUHlsydNW9ca2NB3aaqE/WxqCwilZLBycYqUpkZPGsHmymMTpDVWQG1IXx6jtQcqGsfcMqAOcPggEUAONx6LjRdow0hrP8s9iirsJNgYldrkK6qe/YDS9RxG+hO9vDMIiTNCEnjwU0ecPfLe5pI5PuCAFYNAVwO4+3icRRI9w5VwWa5NekdM1K59zNp6XmfXLDRxb+rzf09+VNQOrhi5YsXTBiul5lRYdpR0aJ0206YIF/xiMRQRNCUFLH27qXOw2RmRtuOnYCkonJLr5MWG5jT7nvPU8NxZ8tqoakRPailLl5HzdrjxbE+T7dleBUl8T5nVWvYwZfsEimvYUip0p1ppfN7YpUJ0tBx4tq7PlgLn1LdPle7PcgRiE2F5QV76d9c3AkpS1xoqrrWWO0jUVC0YFp9D3O+9lOZ54ow3zAAdQ9XpGR+XvudN0x11c5j7hg9O5S1dhVGUy2wo0ZLZ3SotqmwrcL2w4NB7SCaEcMMoP2KpgoVNcX1CSsaMwfKFH2LT0P8CWwPaCflD/cQTsPT5y1rG3T4q9GvSq2H/FSEwybKoR6e/fwhUxBR84C51aJHcdD0e9qqMUdAQtV5kT+0Tcv6k8GOYVubsdnEbuSpVdIDhdXgOv6wlmMZYi0asDPapG3g/vvnXvx+vG+1GcBHkcAabXNztKGHBkWo65SpscGLk+YEJp5kopI6QR9Jt5Um05QOC8/UmKF/bqTZvyabTxi7W9K3XUa3h8IPQau5Nes6+i+1LEa7reVkWX6wNvSyaN2lpmSEyjkZqrAYPc3/awBQf0mR+uA1YL9+frm/f9Ba6yQfYrurF1RJzUid5TmoRMfnig6Yguo3jIiK4X8ZXlVbmyhBX56qYF2pgP14qXP+xaxCtrsGk0VGAXyONtezLWzZofws1T9hwLwCC3szdy7u8YvyojneOnNUHajOKuugjQJXFTyefzMBVkzbEiErqhgR+Zdvf61nyJf5cyMkjYeMNCQXK1nMhQYP4HX0kXs2FJQaExeQwPUnGUuUiKvIY/fZEN+L+/MPWx/GnJIhi+oFG+dkwzuopSPQWOk6aoN89QX0e2a+f7h+B7HxXXduRX25rMdbv1aLTxggRwVrT3iXNqcBuuJQZfQeDtAH0D4bDXGgftBMwJ1YTnB557ysYUzBOPCttal6AhO3eOXswdIWNTNhl+KjMODUp4S8efq0FNGvGCvce7AZrNsUakzce1d71yqkrY47gDVxmVXFfjp7otmKmzDkoHTSdLdKvVFtt6tiVXtoYQ4tTqmS2SLa2ZtH2rrl0765uu36oJ89T46QljVeWUpsOc/OJzOHJq0l8wm5GvL2dwMbB4wNIkwNHLxRSm6rVnWCwyYiqfueOt6T3fwiFMetpMpd1+tOyQq351Qm5/V+VF1/SOxYn76CM3AIq5qpZUs3fp1Zcl68yY0Td9xhdW80D07Eiq/8YVbgr6MrWHxuMcHsvq8V7YUmheTSPePn1tGp3zfHmMT5gkMEGTLJwRFah5V8K1mtu1K1WuHPle1oHdRY2Apmxm+KKzelymS3x2W4jLHN3qq3fMmxy40KaNENdzz+lNiEHPoTFPNft06niHqAT7xqA7Z8NxVWfjMsMfwBJzWluWvTlV+iP8Oafxd0Tj7wS+Ls22qwgInJeoEXeOqOzUXrzcLpN1wWwM0LAx7SfQNtaFzQwJ8wF38vumQfq74g1GUzhaJITAv0JXsE2O3jX8vpwWYOuW1LBIVLAHThs6sDMO2D3Ho1OBLyHLIb5H0WJGrbvxmCESkEprsY6cxWvf3FcAK2FsG4jbgYS4yTGor5c1VbhBG3A3yNv4Ldcxk9xdUwznbSfQzsD2fc1KZqBkrR0Ej/9eIopLHmR1q1TcTnx+xakHln4ZSgd5Wfwzjxm9TZ3pfoaTOC8E491ja9mN77AIR2ER4kOMT8KzxP8I0xEe7j/lny/fqLdgLIAvETjYpmt8eN0mRX4LvIOrS13aD/lAB3zJ3RkP6WhO1bPxUtdrwtYJ1PFZs59FR+Ozq2PnWoD23wtYfuRThiKY53E6aQqmmkPTJrkv5d/USCFTs5lMqzirWxXo9sbqahGHuzM17jCgv2JXYPkB9J47oOksdSso63J4j0J5v2mZ69CGU2+L25U2eK2P2/tpw3UMAqfexberEcDbyb7tBW7lrvGC72FabnphMCNQIT1UmlQe3iCDIdkYi7D8z3CGXqvjeULcOZHOoZkD+PYxVqfOnENxnuiiSAOVywF8ceYJwgAeWp6WLGgvv6jxDOB69sBqntW7EV5h++fL2LwCGKIWbd2iWW3tutrWuziHna/hyjdqbyGmt5N23sv4kTnEOIGVTXpYwoju8MfHvDGlnrelRP1OlsuRGAxgadwgTYzrtxDj+ho36KCt925SNIINfJXfZ382OdbRbb6n223kgL3Z8On6r3VQC7D+iyj2w/8B&lt;/diagram&gt;&lt;/mxfile&gt;" style="background-color: rgb(255, 255, 255);">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="764px" height="881px" viewBox="-0.5 -0.5 764 881" content="&lt;mxfile&gt;&lt;diagram id=&quot;AOZgdlUmH_6GT6Gt5u4e&quot; name=&quot;Page-1&quot;&gt;7R1bl5s2+rfsg8+2D+YgQFweZybJNnuabXanp00fGZuxabDxYpzY/fWVQMJI+jBgi7E94+k5jS0LEPruV43sh8X2X1m4mn9Kp1EysszpdmS/G1kW8nBA/qEjOzbiO7gcmWXxlI3tBx7jvyI2aLLRTTyN1sLEPE2TPF6Jg5N0uYwmuTAWZln6XZz2nCbiU1fhLFIGHidhoo7+Hk/zeTnqY3M//lMUz+b8ychkvzyFk6+zLN0s2fNGlv1c/JU/L0J+LzZ/PQ+n6ffakP1+ZD9kaZqXnxbbhyihm8u3rbzuQ8Ov1bqzaJl3usBigPkWJpuIr7lYWb7ju1G8T0SvMEf2/fd5nEePq3BCf/1OEICMzfNFQr4h8jFM4tmSfE6iZ7KC++c4SR7SJM2KW9kWejDvMBlf51n6Nar9Ypqui316RbrMa+P4gf5Hxtk6oyyPto1vi6o9JMgZpYsoz3ZkCrvAwextGV5iDrbveyBbPhub1wHssMGQIdasuvd+c8kHtr/wXntI2dloStCOfU2zfJ7O0mWYvN+P3ot7v5/zc5qu2I7/GeX5jtFQuMlTER7RNs6/0MsND7Ovf9R+erdlty6+7NiXdR5m+R0lJDKwTJcRH/sQ09crL1hO+YxJEq7X8aQcZFPQCUBWIEo2Ld1kE7Zrns1YQpjNIjbNL4fohh7EhCxKwjz+JtI5BFV26ec0JiupMMjlLIBhkMfph9+iXBO7ao8bZKfCXW3aik5YH3pOID3HlFCtvOMe8ap37ISLTtBO9i2ErpuyAaArxN6ZspHtK5SNbDwQZW9+2909TL5vF87WXPw73QW//bkec5S8Fs6qdf9t5LwgZ8XW68Jm1xS5zCVgM6QnuAlFxGn8jXyc5cW7l0NPmTxCHirMe62EgCTQgYQAgS4YDHLODXKdWJgIuLEP6IYBRHOeBsg5p3OwA5tW22amzE3D9bwAGhp2UyWxMMbAprqQWLA1bCokgGUsf4zCbDJXx98vZzHZKRkGxF5b0Y+TXRITtM+sdpx/Kgnk56dqoLIRf9nkCX0KA2CpwiOsgzKY1akHiC42fFsAJHmoAkjsG7ajgtLHp0PSUsnjbrUiA5/JXha2/N2IashuuKC7X8Dyf+kmj4pXZwt0/79JGUNbc6hXQ2aURAu2Rd69eCfDMIq7f6iGS1bovQOHZZwhu5yLKJFFBNbhUzGBck1qtXHo17jkhKwnIvC8p6CKJ2Fyx35YxNNpYR0yM4I8Bt+P8DuY1kWcYYMi2x6QA9gSB0CAzW1bAAuwNHAAy25kAfSVBThxXKA/jEtoUKRC5mpbRxQmBp3C1UNsYoJ8BQZI/GOVbAgDGZeINqZziWlcE6nl4xtk6tEYw+TqNeOLgx1DMn6RCai/EMroEBqQoisCm4F2u/vrBrgDmq8VqJpvZZ9oJ3S3j5LLaH9SbcSevCt3bU00rLl/mo8hgCEc0p9FYn9barWMFsSWNQBzFrSJkIMM19KAHYAmCNI01wtuZN0MPwTCD0FavA7Khm1awH3ZxKT3wvcGVUnKmvs/Ub0HeXfwkhC2kQLhyJhRPfx9Eq7JvnPD7YFaAek6nxHgld9+3iyz8lOUT4ybOi4C3neMoP7nCID3XMBAH0o7hwEPqOwHeDWn7vEinW6SSK9W9jogrirUjufTaKACaG8gQHO9/IUjn0uyzC8jHq0kX2jg0zSwi/nAPvpZfAPDn/vgZj0CKoRWR/u4Krn96FBktXjQ5yiLySZS1GLPGyRO6nvlWD1O6jF6HzpQqoTakWeggYKljuS6JQ+r3651PmYuKjC42vpmlhkY0nuVQFDe64g47R+ug3cb989v371Pj9Eue8i+TsY2ZOz0cxZflomAJB+RXe1om/6BNHAneI9fWYDclbbYUeU8ZJvriG2A+8sf9lr2V8FhpG4wiMEulrmHvj1uDoD084CUPgqyASa9nd3VjXlN8LNcURF2TYAFQRQyGAfCzb7r9Spcjjr4rj3Dos5rs3RjUTV4zFRb+mthxipQ/kJ+WW4WT0Q5scz0mT6GWVpEJVhvEiqIK/CXC9HtxT6b2v2h+NPlN/FFhmCBQs0cSuX2FHi8aLJh91zDRjVdj5I+kG5tAzmICGvPQuycW4rPCu6+BlCJI6ZriSAPAq8F6A3mU69sVTZjn6o6oAkGoQnP9dBsgvW1mng6cpWjf8AIOsJygfw4beKLqSNUOGWzpx+K7BGzdOVJn3+spJok8oLeAu8hXawIRiy7C7a2aMx6VdYkPMdbSl2XpejIiipixnJdKrkuoKe6GoRScyraMQopdwGbd58/dtVJeQIP2cMwSaIknWXhgmoUNZ4i/FZjNm1huALej3t95qLgbkn6CKJJPZ6qkIBxdd9A9ungd6Ac0iu2GY7NGNSh33nu9Qv8ykn70sKe4gR7x2A42e+41yL7bRdJuHdidUlzNsZN9p9T9lsS3C01kD+U7MfntVB6GKTnMSdqbLKyfP8Q2CLMJDuxImQCdgh+oVBQFVOuAiaS/OsdBjohoIJbVdB2rxqUEPqR4On2fhMnU+o40+If1c9LKv+W4mnTwFxcT4qLIVW75LZGnblgDe4P3CEidjWp+1rrL1zTQO4+zUfm/5YCIsc0fCCLH2MtmXjcQ3b5ausFO5UQF9sCN3dfhptjWwyU2F7QiZurNwpc8Ua+WyWltATS+6q7WNZ3mRRoXNrh+Sfrxy4U/OwnhAJICP13ExUgfoyybzHBlu45yRcjmTTwPCewDI6U3NnheEDwZShp5LVWnfRyc1VgFHQNQc14UuYqIN+PfAqX4YwmS5rkRgRN1uqUkKbLmr9nBAvovHfpZLMorSST8FayOwWSMe8bL5V7MWQTrffLkreBiHgYyLOAyuB9HS6h4ByytWuuXHu3kM5emb1RZ3W36jpJ1oGy43rLK1vEooPdP9SrXRe8ur+ENkWN3pVvpC/PzdMbGVBYJpeMPxHOlhzPOqm/KE4KnliyyPfbaLIpmSR/xN0sjJfr/DCXfFM8EZ2PJ/qna1o6C0DHy3TaGQfecn2K0gEFKgGF0rG09A1QmdE9ryESK87X2aQqSFhXdeUG81JddzKU3sZrUqgMqgKvYKc7VuZDccdbcage0aC1IR8YQvWgylAdick8/K1Z6egqWHxIrtxtiAaeEcaQx+lSxZsfflnRH8LkxxYM6m+GXXNmxGlI6JmGg2olcQJKWrYNuA4CTC4BpI9jyDUuRyHmWSy5pghUW5henwV4RNQMjO9Vxt8BS1Ay8Y4qpnJNGLEGtg6RmMljoRZvpjzf7FPuhC3RmqxaLbQYgcCNsBGYjWSGbMX722CnHmFeBmp8SAzY9TO/tLXakro0ncTGZJXZgioYwPQuHSwraJWlRxpapQGt1Xq+TPDJKrKnqkJuMBDwWguFjgQe2SvCCdPsh3WzvvIaYQeVegwGPKhSUQfw3kWTNHuL0APLT4cCH+Ixef2ckypg1AU5Idu4STpzz6syBKTA4WmIgEREAHphIDSQjwLR0spheHAWhUUjxKIhYnbDgjZz0LWrbPezIMLpPQvBDDXOBjpjwMWlp51G3J5c96J6lIdKCEDmWbL1z5TIelKNQN3xwOO7rdmvfW35itnqN+bVdiGSUJEdl13NZ/k+VcM13c1UbHC9jcuy4WXpSpVCyHo7pNMVm7UjqSu1B3GO9PHI9xkIRxuWqw/nIBHcoB9dWzqxVg0ZzquD4rLY1dHmpCpebQrlAbpRt0ogfpeerTUUmznMw6dwTdXt57SuaYlFRXCUT8sKLmo7fg3XX8mvD2maTeOlENPqtScX8TJ3i3Q5Iz//J51GzfVih17j1XdM0erARsE+mlbjLlCTQqzD8EJnaZly5mqzKrhXKtwutlo0brAot7saLvRLKeWsfm1GNvX8Y9UZLGOkdCNd+oyy4MMRPWVd4nwNClBzQOAiWPHHJSGRYsllGuYkXT7Hs01G5W4+B3LRqx5WEQskPRRXldGJsm8wnAM/5U7wIvd9HhZ5nRnwhHC1ytJVFpe+tkL4mzuCZ+rMNJuFS5bh8Y+ecuQmMA53th0Drcmhrns6TttCPK/1TQgM5tXhSfaluPAOu3W6iwXROwPJCnMYWeFpcs/4lugyRnL2siZR4ckHkB6WFPJ07ZJCwwk7Lhi12KzzdDGq0uplJvprFi7XBfcmczpkxfXzbes+fuvEgASxncUknDEvMRMaN1T9fHQnRCPrZbI7zI+LVXkMl2wqvqpEeZ3IoRRXoAAymhAeKlx14JS901Djy+4vnj7yIZyQ/++64sNR6dGVRnRRtO/KHVuA2hlkAgnSlq8lExXZFgDemyuUNkSgZyg0dlYIkBGoPHrY5gqI91y8dVc4Lb4i6aO844Ggj5aEoV0fxbalnNbhOAp6dG+yoB7+gS2DdwfW3WfBDZSnEXnEFt+4xi5Xna6ptjefPF5QValyb1hSIRWK5p6vvZS84g32Ltom11j/0ODHbcubgM35Iax5DDDP0o2q35aXGnI6A5ngcj8zxz7I3+T5tj1qZGwdHjZYDT5yzqI+3GinWfOAGj2Vyfr6iUeOoemiFk/C/pbeS8r8PsQiuUkGPZoJOc6NXC6LXCBFvSyP0E8uUouWseUaRP7U/rpp7L3JyZdknHU4P0+eP2auvI4EJZ3ebluOYfsDktRZmsReHUkdK00wQB7eMOQhHac0xpQ8hqGIQMRwnkbSSBHS/DHuRREO/LRBqOGsPd778OuzUdB6Hk6LW5ovTk6QYeMNFKQkwqUuWuTulMgI6v0LhklSOdXswX6fJmbkasOXDqWm7ylJVZ3U1hzjupCcF7KMeLoJ6aqrM83NqvmQHCGdRs9lUG1OCMQyp7UejmACS0b2Ko6+RfSmz1kRey1SadgT/gk9IszD4o3SIvOmzJhZhKtVcRPaKVJNqhkVbSejLY3O8b6Sxi0L5rQsmAMnets2cMgLdOqclpQY5xpSYgZQ4Aiz8kWp09EqEoMmLfk0J+Ze1qVXALQzYWVR2sWXLyX2jgfKjcGurNkdONYEWKXoPEDWkM4D7m15c4QiqmatBX6wNmoN420DDskYyD7CnmmYIqOWM890EYUtalFj90AGGFBpJZGUg5Q4jU6q4GB5a1RhmGVnY04ZYzLSmol/gSJkoMgOxlghF9/gub66s/FN7wQx4jqiy2xsW1Ve3hAUY71VikFeIFOMfxTFvBzBDOOKdi1kOHKLN1l10UUbUj6a5E5unW/1IiW5Mc+QkueNxj5Nw0Z2b8lzCk3ox38by/nRHTve98Z+Wzqy5jDu2+CiuooRH3jUIJjfnBelvzpZcGI9Z+QayYtlLkIg27/yZU14WcCkdnIjULwVGTOjPr2q/8qi9Sah+xzn0WJ9LsdTVrpdrtrvZJn4oN8JA5nKUPdJLbW7+PQsdPBEper4hgeKqtv8NdaX0K7FMv90VKdhQ32JZSp9W4+D4Hl6Hh9xPuixJ3V27JP8UmnNYFYzHia5qKJPjl9WN4tIuZHlEFzFNaYjnTnpeoY9XBvhqufSJURkW3xgA3fzfikshQ7RvmFpC5aexYt2TN5Ak1vYa3MLXxiWQrx0oH5ylieb+k7HMAVwK49ocPsaJinZy8KeJhQlX7OU6lX76UQlmn9KpxGd8Tc=&lt;/diagram&gt;&lt;/mxfile&gt;" style="background-color: rgb(255, 255, 255);">
     <defs/>
     <g>
-        <rect x="560" y="484" width="140" height="140" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
-        <rect x="420" y="484" width="140" height="140" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
-        <path d="M 664.5 595 L 664.5 705 L 595.54 705" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 590.29 705 L 597.29 701.5 L 595.54 705 L 597.29 708.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="420" y="110" width="135" height="140" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
-        <rect x="420" y="299" width="280" height="140" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
-        <rect x="565" y="110" width="135" height="140" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
-        <rect x="90" y="469.25" width="110" height="90" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <rect x="420" y="600" width="280" height="140" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <path d="M 624 720 L 624 820 L 595.54 820" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 590.29 820 L 597.29 816.5 L 595.54 820 L 597.29 823.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="420" y="238" width="135" height="140" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <rect x="420" y="414" width="280" height="140" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <rect x="565" y="238" width="135" height="140" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <rect x="65" y="414" width="235" height="90" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 108px; height: 1px; padding-top: 514px; margin-left: 92px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 233px; height: 1px; padding-top: 459px; margin-left: 67px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <div>
                                     <br/>
                                 </div>
@@ -22,18 +21,17 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="92" y="518" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
-                    &#xa;
+                <text x="67" y="463" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
                 </text>
             </switch>
         </g>
         <rect x="5" y="20" width="295" height="170" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 293px; height: 1px; padding-top: 105px; margin-left: 7px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <div>
                                     <br/>
                                 </div>
@@ -42,20 +40,38 @@
                     </div>
                 </foreignObject>
                 <text x="7" y="109" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
-                    &#xa;
                 </text>
             </switch>
         </g>
         <rect x="20" y="50" width="260" height="130" fill="none" stroke="#006658" stroke-dasharray="3 3" pointer-events="all"/>
-        <path d="M 530.83 665 C 530.83 656.72 543.89 650 560 650 C 567.74 650 575.16 651.58 580.63 654.39 C 586.1 657.21 589.17 661.02 589.17 665 L 589.17 720 C 589.17 723.98 586.1 727.79 580.63 730.61 C 575.16 733.42 567.74 735 560 735 C 543.89 735 530.83 728.28 530.83 720 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 589.17 665 C 589.17 668.98 586.1 672.79 580.63 675.61 C 575.16 678.42 567.74 680 560 680 C 543.89 680 530.83 673.28 530.83 665" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 530.83 780 C 530.83 771.72 543.89 765 560 765 C 567.74 765 575.16 766.58 580.63 769.39 C 586.1 772.21 589.17 776.02 589.17 780 L 589.17 835 C 589.17 838.98 586.1 842.79 580.63 845.61 C 575.16 848.42 567.74 850 560 850 C 543.89 850 530.83 843.28 530.83 835 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 589.17 780 C 589.17 783.98 586.1 787.79 580.63 790.61 C 575.16 793.42 567.74 795 560 795 C 543.89 795 530.83 788.28 530.83 780" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 56px; height: 1px; padding-top: 808px; margin-left: 532px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <br/>
+                                Search
+                                <br/>
+                                Engine
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="560" y="811" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Search...
+                </text>
+            </switch>
+        </g>
         <rect x="0" y="0" width="320" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 10px; margin-left: 160px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: nowrap;">
                                 App Package: &lt;Route path="/search" element={&lt;... /&gt;} /&gt;
                             </div>
                         </div>
@@ -66,51 +82,51 @@
                 </text>
             </switch>
         </g>
-        <rect x="419.59" y="80" width="140" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="419.59" y="208" width="120" height="30" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 95px; margin-left: 422px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
-                                @backstage/
-                                <br/>
-                                plugin-search-backend
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 223px; margin-left: 422px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <font style="font-size: 10px">
+                                    @backstage/
+                                    <br/>
+                                    plugin-search-backend
+                                </font>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="422" y="99" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
+                <text x="422" y="227" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
                     @backstage/...
                 </text>
             </switch>
         </g>
-        <rect x="90" y="433.75" width="150" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="65" y="394" width="140" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 449px; margin-left: 92px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
-                                Other Plugins
-                                <br/>
-                                (TechDocs, Catalog, Etc)
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 404px; margin-left: 67px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                @backstage/plugin-xyz
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="92" y="452" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
-                    Other Plugins...
+                <text x="67" y="408" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
+                    @backstage/plugin-xyz
                 </text>
             </switch>
         </g>
-        <rect x="90" y="229.25" width="210" height="177.75" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <rect x="65" y="238.38" width="235" height="141.62" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 208px; height: 1px; padding-top: 318px; margin-left: 92px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 233px; height: 1px; padding-top: 309px; margin-left: 67px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <div>
                                     <font color="#ffffff" size="1">
                                         <br/>
@@ -120,94 +136,90 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="92" y="322" fill="#5C5C5C" font-family="Helvetica" font-size="12px"></text>
+                <text x="67" y="313" fill="#5C5C5C" font-family="Helvetica" font-size="12px"></text>
             </switch>
         </g>
-        <rect x="80" y="209.25" width="160" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="65" y="218.38" width="160" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 219px; margin-left: 160px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 228px; margin-left: 67px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: nowrap;">
                                 @backstage/plugin-search
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="160" y="223" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="67" y="232" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
                     @backstage/plugin-search
                 </text>
             </switch>
         </g>
-        <path d="M 636.37 364.25 L 758 364.3 L 758 177.3 L 655.5 177.25" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 631.12 364.25 L 638.12 360.75 L 636.37 364.25 L 638.12 367.75 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="420" y="279" width="270" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="419.59" y="394" width="190" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 289px; margin-left: 555px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
-                                Other Backend Plugin (TechDocs, Catalog, Etc)
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 404px; margin-left: 422px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                @backstage/plugin-xyz-backend
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="555" y="293" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Other Backend Plugin (TechDocs, Catalog, Etc)
+                <text x="422" y="408" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
+                    @backstage/plugin-xyz-backend
                 </text>
             </switch>
         </g>
-        <rect x="445" y="745" width="230" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="450" y="860" width="220" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 755px; margin-left: 560px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
-                                Search Engine (Elastic, Solr, SaaS, etc.)
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 870px; margin-left: 560px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                e.g. ElasticSearch, Postgres, Lunr, etc.
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="560" y="759" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Search Engine (Elastic, Solr, SaaS, et...
+                <text x="560" y="874" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    e.g. ElasticSearch, Postgres, Lunr,...
                 </text>
             </switch>
         </g>
-        <rect x="415" y="459.5" width="190" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="419.59" y="578.75" width="270" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 470px; margin-left: 510px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
-                                Search Engine Integration Layer
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 589px; margin-left: 555px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                @backstage/plugin-search-backend-module-xyz
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="510" y="473" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Search Engine Integration Layer
+                <text x="555" y="592" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    @backstage/plugin-search-backend-module-xyz
                 </text>
             </switch>
         </g>
-        <path d="M 458.13 178.25 L 400 178.3 L 400 559.8 L 443.63 559.77" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 463.38 178.25 L 456.38 181.76 L 458.13 178.25 L 456.38 174.76 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 448.88 559.77 L 441.88 563.27 L 443.63 559.77 L 441.88 556.27 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 655.5 151.75 L 780 151.8 L 780 555 L 690.87 555" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 685.62 555 L 692.62 551.5 L 690.87 555 L 692.62 558.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 439.05 350.62 L 405 350.6 L 405 685.2 L 477.63 685.2" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 444.3 350.62 L 437.3 354.12 L 439.05 350.62 L 437.3 347.12 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 482.88 685.2 L 475.88 688.7 L 477.63 685.2 L 475.88 681.7 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
         <rect x="80" y="60.5" width="190" height="10" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <rect x="30" y="60" width="40" height="70" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <rect x="80" y="90" width="190" height="65.5" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <rect x="229" y="160.5" width="40" height="10" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 38px; height: 1px; padding-top: 166px; margin-left: 230px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <font color="#ffffff">
                                     1 2 3
                                 </font>
@@ -223,10 +235,10 @@
         <rect x="73" y="70.5" width="100" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 81px; margin-left: 123px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #FFFFFF; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: nowrap;">
                                 <span style="font-size: 7.2px ; text-align: left">
                                     X number of search results
                                 </span>
@@ -239,17 +251,17 @@
                 </text>
             </switch>
         </g>
-        <path d="M 220 313.37 L 220 330.63" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 220 308.12 L 223.5 315.12 L 220 313.37 L 216.5 315.12 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 220 335.88 L 216.5 328.88 L 220 330.63 L 223.5 328.88 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 187 257.5 L 36.1 257.5 L 36.12 179.61" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <rect x="187" y="241" width="66" height="66" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <path d="M 113 323.37 L 113 357.4 L 193.19 357.38" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 113 318.12 L 116.5 325.12 L 113 323.37 L 109.5 325.12 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 198.44 357.38 L 191.44 360.88 L 193.19 357.38 L 191.44 353.88 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 80 284 L 80 285 L 36.1 285 L 36.12 179.61" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="80" y="251" width="66" height="66" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 64px; height: 1px; padding-top: 274px; margin-left: 188px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 64px; height: 1px; padding-top: 284px; margin-left: 81px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <span style="color: rgb(255 , 255 , 255) ; font-size: 9px ; text-align: left">
                                     Components
                                 </span>
@@ -257,43 +269,18 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="220" y="278" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="113" y="288" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Components
                 </text>
             </switch>
         </g>
-        <path d="M 276.37 367 L 360 367 L 360 152.8 L 458.13 152.75" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 271.12 367 L 278.12 363.5 L 276.37 367 L 278.12 370.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 463.38 152.75 L 456.38 156.25 L 458.13 152.75 L 456.38 149.25 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 173 304 L 193 265.87 L 293 265.87 L 273 304 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 220px; margin-left: 351px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; background-color: #ffffff; white-space: nowrap; ">
-                                Pass Search
-                                <br/>
-                                Term and Filters
-                                <br/>
-                                and then
-                                <br/>
-                                Return Results
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="351" y="223" fill="#5C5C5C" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    Pass Search...
-                </text>
-            </switch>
-        </g>
-        <path d="M 160 397 L 180 337 L 280 337 L 260 397 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 367px; margin-left: 161px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 285px; margin-left: 174px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <font color="#ffffff">
                                     Search API
                                 </font>
@@ -301,20 +288,20 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="220" y="371" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="233" y="289" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Search API
                 </text>
             </switch>
         </g>
         <rect x="5" y="20" width="295" height="20" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
-        <path d="M 110 516.25 L 36.1 516.3 L 36.12 180" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <rect x="110" y="483.25" width="66" height="66" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <path d="M 86 461 L 36.1 461 L 36.12 180" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="86" y="428" width="66" height="66" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 64px; height: 1px; padding-top: 516px; margin-left: 111px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 64px; height: 1px; padding-top: 461px; margin-left: 87px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <span style="color: rgb(255 , 255 , 255) ; font-size: 9px ; text-align: left">
                                     Components
                                 </span>
@@ -322,232 +309,574 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="143" y="520" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="119" y="465" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Components
                 </text>
             </switch>
         </g>
-        <path d="M 635 198.75 L 630 198.8 L 630 190" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 573.5 239.75 L 593.5 198.75 L 655.5 198.75 L 635.5 239.75 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 665.5 309 L 665.5 317" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="640" y="317" width="51" height="51" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 80px; height: 1px; padding-top: 219px; margin-left: 575px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #FFFFFF; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 49px; height: 1px; padding-top: 343px; margin-left: 641px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 7px">
+                                    IndexBuilder
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="666" y="346" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    IndexBui...
+                </text>
+            </switch>
+        </g>
+        <path d="M 525.16 437 C 525.16 428.72 534.3 422 545.58 422 C 551 422 556.19 423.58 560.02 426.39 C 563.85 429.21 566 433.02 566 437 L 566 462.62 C 566 470.9 556.86 477.62 545.58 477.62 C 534.3 477.62 525.16 470.9 525.16 462.62 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 566 437 C 566 445.28 556.86 452 545.58 452 C 534.3 452 525.16 445.28 525.16 437" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 586 454.13 L 566 454.13" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="457.79" y="247.5" width="51" height="51" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 49px; height: 1px; padding-top: 273px; margin-left: 459px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 9px">
+                                    Query Service
+                                    <br/>
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="483" y="277" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Query Se...
+                </text>
+            </switch>
+        </g>
+        <rect x="564" y="640" width="80" height="80" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 680px; margin-left: 565px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font color="#ffffff">
+                                    <b>
+                                        Indexer
+                                    </b>
+                                    <br/>
+                                    <br/>
+                                    Manages Indices
+                                    <br/>
+                                    and Writes Documents to a Search Engine
+                                    <br/>
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="604" y="683" fill="#5C5C5C" font-family="Helvetica" font-size="9px" text-anchor="middle">
+                    Indexer...
+                </text>
+            </switch>
+        </g>
+        <path d="M 504 726.37 L 504 820 L 524.63 820" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 504 721.12 L 507.5 728.12 L 504 726.37 L 500.5 728.12 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 529.88 820 L 522.88 823.5 L 524.63 820 L 522.88 816.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="484" y="640" width="80" height="80" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 680px; margin-left: 485px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font color="#ffffff">
+                                    <b>
+                                        Query Handler
+                                    </b>
+                                    <br/>
+                                    <br/>
+                                    Compiles and Executes Query Against a Search Engine
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="524" y="683" fill="#5C5C5C" font-family="Helvetica" font-size="9px" text-anchor="middle">
+                    Query Handler...
+                </text>
+            </switch>
+        </g>
+        <rect x="565" y="208" width="140" height="30" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 223px; margin-left: 567px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: nowrap;">
                                 <font style="font-size: 10px">
+                                    @backstage/
+                                    <br/>
+                                    plugin-search-backend-node
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="567" y="227" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
+                    @backstage/...
+                </text>
+            </switch>
+        </g>
+        <rect x="415" y="0" width="230" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 10px; margin-left: 530px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                Backend Package: src/plugins/search.ts
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="530" y="14" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Backend Package: src/plugins/search.ts
+                </text>
+            </switch>
+        </g>
+        <rect x="420" y="20" width="275" height="170" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 273px; height: 1px; padding-top: 105px; margin-left: 422px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <div>
+                                    <font color="#ffffff" size="1">
+                                        <br/>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="422" y="109" fill="#5C5C5C" font-family="Helvetica" font-size="12px"></text>
+            </switch>
+        </g>
+        <path d="M 435.42 367.75 L 455.42 333.5 L 530.83 333.5 L 510.83 367.75 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 93px; height: 1px; padding-top: 351px; margin-left: 436px;">
+                        <div data-drawio-colors="color: #5C5C5C; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(92, 92, 92); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font color="#ffffff">
+                                    <font style="font-size: 8px">
+                                        Authorization
+                                        <br/>
+                                        (Optional)
+                                    </font>
+                                    <br/>
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="483" y="354" fill="#5C5C5C" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Authorization...
+                </text>
+            </switch>
+        </g>
+        <path d="M 483.12 327.13 L 483.1 314 L 483.21 304.87" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 483.12 332.38 L 479.61 325.39 L 483.12 327.13 L 486.61 325.38 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 483.28 299.62 L 486.69 306.66 L 483.21 304.87 L 479.69 306.57 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="565" y="120.5" width="120" height="25" fill="none" stroke="#006658" stroke-dasharray="3 3" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 133px; margin-left: 566px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                IndexBuilder
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="625" y="137" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    IndexBuilder
+                </text>
+            </switch>
+        </g>
+        <rect x="615" y="30" width="69" height="25" fill="none" stroke="#006658" stroke-dasharray="3 3" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 67px; height: 1px; padding-top: 43px; margin-left: 616px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 10px">
+                                    SearchEngine
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="650" y="46" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    SearchEngine
+                </text>
+            </switch>
+        </g>
+        <rect x="615" y="90.5" width="69" height="25" fill="none" stroke="#006658" stroke-dasharray="3 3" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 67px; height: 1px; padding-top: 103px; margin-left: 616px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 10px">
+                                    Collator(s)
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="650" y="107" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Collator(s)
+                </text>
+            </switch>
+        </g>
+        <rect x="615" y="60.5" width="69" height="25" fill="none" stroke="#006658" stroke-dasharray="3 3" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 67px; height: 1px; padding-top: 73px; margin-left: 616px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 10px">
+                                    Decorator(s)
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="650" y="77" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Decorator(s)
+                </text>
+            </switch>
+        </g>
+        <path d="M 575 180 L 595 160 L 685 160 L 665 180 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 170px; margin-left: 576px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 10px">
+                                    Start Schedule
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="630" y="174" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Start Schedule
+                </text>
+            </switch>
+        </g>
+        <path d="M 428.13 180 L 448.13 160 L 538.13 160 L 518.13 180 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 170px; margin-left: 429px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 10px">
+                                    Create Router
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="483" y="174" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Create Router
+                </text>
+            </switch>
+        </g>
+        <rect x="640" y="258" width="51" height="51" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 49px; height: 1px; padding-top: 284px; margin-left: 641px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 7px">
                                     Scheduler
                                 </font>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="615" y="223" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="666" y="287" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Scheduler
                 </text>
             </switch>
         </g>
-        <rect x="604.5" y="139" width="51" height="51" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <path d="M 438.13 170 L 395 170 L 395 260.3 L 457.79 260.25" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 630 146 L 630 160" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 575 262.5 C 575 254.22 583.95 247.5 595 247.5 C 600.3 247.5 605.39 249.08 609.14 251.89 C 612.89 254.71 615 258.52 615 262.5 L 615 289 C 615 297.28 606.05 304 595 304 C 583.95 304 575 297.28 575 289 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 615 262.5 C 615 270.78 606.05 277.5 595 277.5 C 583.95 277.5 575 270.78 575 262.5" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="565" y="294.25" width="70" height="50" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 49px; height: 1px; padding-top: 165px; margin-left: 606px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #FFFFFF; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                <font style="font-size: 7px">
-                                    Gather Documents From Plugins
-                                </font>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 319px; margin-left: 600px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <div style="text-align: left">
+                                    <span style="font-size: 7.2px">
+                                        Database for
+                                    </span>
+                                </div>
+                                <span style="font-size: 7.2px">
+                                    <div style="text-align: left">
+                                        <span style="font-size: 7.2px">
+                                            Task Coordination
+                                        </span>
+                                    </div>
+                                    <div style="text-align: left">
+                                        <span style="font-size: 7.2px">
+                                            Among Nodes
+                                        </span>
+                                    </div>
+                                </span>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="630" y="168" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Gather D...
+                <text x="600" y="323" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Database fo...
                 </text>
             </switch>
         </g>
-        <path d="M 444.17 349.5 C 444.17 341.22 453.31 334.5 464.59 334.5 C 470.01 334.5 475.2 336.08 479.03 338.89 C 482.86 341.71 485.01 345.52 485.01 349.5 L 485.01 379 C 485.01 387.28 475.87 394 464.59 394 C 453.31 394 444.17 387.28 444.17 379 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 485.01 349.5 C 485.01 357.78 475.87 364.5 464.59 364.5 C 453.31 364.5 444.17 357.78 444.17 349.5" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 550 364.25 L 517.5 364.3 L 485.01 364.3" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <rect x="550" y="324.25" width="80" height="80" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <path d="M 640 286 L 640 284.3 L 615 284.34" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="419.59" y="62" width="90" height="90" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 364px; margin-left: 551px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #FFFFFF; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                <font style="font-size: 11px">
-                                    Register Document / Metadata Collation Handler(s)
-                                </font>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 107px; margin-left: 465px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <div style="text-align: left">
+                                    <span style="font-size: 7.2px">
+                                        Install and configure the
+                                        <br/>
+                                        search engine, collators,
+                                        <br/>
+                                        and decorators that are
+                                        <br/>
+                                        appropriate for your
+                                        <br/>
+                                        organization!
+                                    </span>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="590" y="368" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Register Docu...
+                <text x="465" y="111" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Install and con...
                 </text>
             </switch>
         </g>
-        <rect x="464.5" y="140" width="51" height="51" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <path d="M 671.25 173.75 L 715 173.8 L 715 284 L 691 284" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="431.56" y="27" width="66.87" height="30" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 49px; height: 1px; padding-top: 166px; margin-left: 466px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #FFFFFF; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                <font style="font-size: 9px">
-                                    API Endpoint
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 65px; height: 1px; padding-top: 42px; margin-left: 433px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 6px">
+                                    Custom Query
                                     <br/>
+                                    Translator (Optional)
                                 </font>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="490" y="169" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    API Endp...
+                <text x="465" y="46" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Custom Quer...
                 </text>
             </switch>
         </g>
-        <rect x="419.59" y="110" width="90" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <rect x="484" y="619.25" width="150" height="20" fill="none" stroke="none" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 120px; margin-left: 465px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #FFFFFF; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 629px; margin-left: 486px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <font style="font-size: 10px">
+                                    SearchEngine Implementation
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="486" y="633" fill="#ffffff" font-family="Helvetica" font-size="12px">
+                    SearchEngine Implementati...
+                </text>
+            </switch>
+        </g>
+        <rect x="586" y="440" width="105" height="28.25" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 103px; height: 1px; padding-top: 454px; margin-left: 587px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 10px">
+                                    XyzCollatorFactory
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="639" y="458" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    XyzCollatorFactory
+                </text>
+            </switch>
+        </g>
+        <path d="M 523.75 506.93 C 523.75 498.65 532.89 491.93 544.17 491.93 C 549.59 491.93 554.78 493.51 558.61 496.32 C 562.44 499.14 564.59 502.95 564.59 506.93 L 564.59 532.55 C 564.59 540.83 555.45 547.55 544.17 547.55 C 532.89 547.55 523.75 540.83 523.75 532.55 Z" fill="#21c0a5" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 564.59 506.93 C 564.59 515.21 555.45 521.93 544.17 521.93 C 532.89 521.93 523.75 515.21 523.75 506.93" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 584.59 519.74 L 564.59 519.74" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <rect x="584.59" y="505.62" width="105" height="28.25" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 103px; height: 1px; padding-top: 520px; margin-left: 586px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 10px">
+                                    XyzDecoratorFactory
+                                </font>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="637" y="523" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    XyzDecoratorFacto...
+                </text>
+            </switch>
+        </g>
+        <path d="M 691 342.5 L 725 342.5 L 725 133 L 691.37 133" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 686.12 133 L 693.12 129.5 L 691.37 133 L 693.12 136.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 691 454.13 L 735 454.1 L 735 103 L 690.37 103" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 685.12 103 L 692.12 99.5 L 690.37 103 L 692.12 106.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 689.59 519.74 L 745 519.7 L 745 73 L 690.37 73" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 685.12 73 L 692.12 69.5 L 690.37 73 L 692.12 76.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 700 700 L 755 700 L 755 42.5 L 690.37 42.5" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 685.12 42.5 L 692.12 39 L 690.37 42.5 L 692.12 46 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 691 342.5 L 725 342.5 L 725 680 L 650.37 680" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 645.12 680 L 652.12 676.5 L 650.37 680 L 652.12 683.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="420" y="437" width="100" height="90" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 482px; margin-left: 470px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <div style="text-align: left">
+                                    <span style="font-size: 7.2px">
+                                        Individual backend plugins
+                                        <br/>
+                                        define how documents are
+                                        <br/>
+                                        retrieved from the plugin's
+                                        <br/>
+                                        data store and mapped to
+                                        <br/>
+                                        an IndexableDocument.
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="470" y="486" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Individual backe...
+                </text>
+            </switch>
+        </g>
+        <path d="M 615 48.75 L 525 48.8 L 525.04 153.63" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 525.04 158.88 L 521.54 151.88 L 525.04 153.63 L 528.54 151.88 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 498.43 34.5 L 498.4 36.3 L 608.63 36.25" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 613.88 36.25 L 606.88 39.75 L 608.63 36.25 L 606.88 32.75 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 615 48.75 L 572 48.8 L 571.96 113.63" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 571.96 118.88 L 568.46 111.88 L 571.96 113.63 L 575.46 111.88 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 615 73 L 586.5 73 L 586.48 114.13" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 586.48 119.38 L 582.98 112.38 L 586.48 114.13 L 589.98 112.38 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 613 103 L 600.6 103 L 600.57 113.63" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 600.56 118.88 L 597.08 111.87 L 600.57 113.63 L 604.08 111.89 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="171" y="450" width="120" height="50" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-end; width: 1px; height: 1px; padding-top: 475px; margin-left: 289px;">
+                        <div data-drawio-colors="color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: right;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <div>
+                                    <span style="font-size: 7.2px">
+                                        Individual frontend plugins may
+                                        <br/>
+                                        define custom components,
+                                        <br/>
+                                        e.g. custom search result items.
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="289" y="479" fill="#FFFFFF" font-family="Helvetica" font-size="12px" text-anchor="end">
+                    Individual frontend...
+                </text>
+            </switch>
+        </g>
+        <rect x="199.56" y="347" width="66.87" height="20.75" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 65px; height: 1px; padding-top: 357px; margin-left: 201px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <font style="font-size: 9px">
-                                    Query Processing
+                                    Search Context
                                 </font>
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="465" y="123" fill="#FFFFFF" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    Query Processing
+                <text x="233" y="361" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Search Cont...
                 </text>
             </switch>
         </g>
-        <rect x="565" y="110" width="80" height="20" fill="none" stroke="none" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 120px; margin-left: 605px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #FFFFFF; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
-                                <font style="font-size: 9px">
-                                    Index Processing
-                                </font>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="605" y="123" fill="#FFFFFF" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    Index Processi...
-                </text>
-            </switch>
-        </g>
-        <rect x="560" y="484" width="80" height="20" fill="none" stroke="none" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 494px; margin-left: 600px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
-                                <font style="font-size: 9px" color="#ffffff">
-                                    Index Processing
-                                </font>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="600" y="497" fill="#5C5C5C" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    Index Processi...
-                </text>
-            </switch>
-        </g>
-        <rect x="420" y="484" width="90" height="20" fill="none" stroke="none" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 494px; margin-left: 465px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
-                                <font style="font-size: 9px" color="#ffffff">
-                                    Query Processing
-                                </font>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="465" y="497" fill="#5C5C5C" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    Query Processing
-                </text>
-            </switch>
-        </g>
-        <rect x="604.5" y="515" width="80" height="80" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 555px; margin-left: 606px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                <font color="#ffffff">
-                                    <b>
-                                        Manage Index
-                                    </b>
-                                    <br/>
-                                    Create, Remove, Replace Documents and Indices
-                                </font>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="645" y="558" fill="#5C5C5C" font-family="Helvetica" font-size="9px" text-anchor="middle">
-                    Manage Index...
-                </text>
-            </switch>
-        </g>
-        <path d="M 470.25 601.37 L 470.3 705 L 524.63 705" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
-        <path d="M 470.25 596.12 L 473.75 603.12 L 470.25 601.37 L 466.75 603.12 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 529.88 705 L 522.88 708.5 L 524.63 705 L 522.88 701.5 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
-        <rect x="450" y="514" width="81" height="81" fill="#21c0a5" stroke="#006658" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 79px; height: 1px; padding-top: 555px; margin-left: 451px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
-                            <div style="display: inline-block; font-size: 9px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                <font color="#ffffff">
-                                    Compile and Execute Query from Term and Filters
-                                </font>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="491" y="557" fill="#5C5C5C" font-family="Helvetica" font-size="9px" text-anchor="middle">
-                    Compile and Execute...
-                </text>
-            </switch>
-        </g>
-        <rect x="565" y="80" width="170" height="30" fill="none" stroke="none" pointer-events="all"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 95px; margin-left: 567px;">
-                        <div style="box-sizing: border-box; font-size: 0; text-align: left; ">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #5C5C5C; line-height: 1.2; pointer-events: all; white-space: nowrap; ">
-                                @backstage/
-                                <br/>
-                                plugin-search-backend-node
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="567" y="99" fill="#5C5C5C" font-family="Helvetica" font-size="12px">
-                    @backstage/...
-                </text>
-            </switch>
-        </g>
+        <path d="M 233 310.37 L 233 340.63" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 233 305.12 L 236.5 312.12 L 233 310.37 L 229.5 312.12 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 233 345.88 L 229.5 338.88 L 233 340.63 L 236.5 338.88 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 158.37 444.5 L 233 444.5 L 233 374.12" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 153.12 444.5 L 160.12 441 L 158.37 444.5 L 160.12 448 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 233 368.87 L 236.5 375.87 L 233 374.12 L 229.5 375.87 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 289.37 284.93 L 375.4 284.9 L 451.42 285.68" fill="none" stroke="#006658" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 284.12 284.93 L 291.12 281.43 L 289.37 284.93 L 291.12 288.43 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 456.67 285.74 L 449.64 289.17 L 451.42 285.68 L 449.71 282.17 Z" fill="#006658" stroke="#006658" stroke-miterlimit="10" pointer-events="all"/>
     </g>
     <switch>
         <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>

--- a/docs/features/search/getting-started.md
+++ b/docs/features/search/getting-started.md
@@ -163,8 +163,8 @@ export default async function createPlugin(
   });
 
   const every10MinutesSchedule = env.scheduler.createScheduledTaskRunner({
-    frequency: Duration.fromObject({ seconds: 600 }),
-    timeout: Duration.fromObject({ seconds: 900 }),
+    frequency: Duration.fromObject({ minutes: 10 }),
+    timeout: Duration.fromObject({ minutes: 15 }),
     initialDelay: Duration.fromObject({ seconds: 3 }),
   });
 
@@ -299,14 +299,14 @@ import { Duration } from 'luxon';
 const indexBuilder = new IndexBuilder({ logger: env.logger, searchEngine });
 
 const every10MinutesSchedule = env.scheduler.createScheduledTaskRunner({
-  frequency: Duration.fromObject({ seconds: 600 }),
-  timeout: Duration.fromObject({ seconds: 900 }),
+  frequency: Duration.fromObject({ minutes: 10 }),
+  timeout: Duration.fromObject({ minutes: 15 }),
   initialDelay: Duration.fromObject({ seconds: 3 }),
 });
 
 const everyHourSchedule = env.scheduler.createScheduledTaskRunner({
-  frequency: Duration.fromObject({ seconds: 3600 }),
-  timeout: Duration.fromObject({ seconds: 5400 }),
+  frequency: Duration.fromObject({ hours: 1 }),
+  timeout: Duration.fromObject({ minutes: 90 }),
   initialDelay: Duration.fromObject({ seconds: 3 }),
 });
 
@@ -332,8 +332,8 @@ a scheduled `TaskRunner` to pass into the `schedule` value, like this:
 
 ```typescript {3}
 const every10MinutesSchedule = env.scheduler.createScheduledTaskRunner({
-  frequency: Duration.fromObject({ seconds: 600 }),
-  timeout: Duration.fromObject({ seconds: 900 }),
+  frequency: Duration.fromObject({ minutes: 10 }),
+  timeout: Duration.fromObject({ minutes: 15 }),
   initialDelay: Duration.fromObject({ seconds: 3 }),
 });
 

--- a/packages/backend/src/plugins/search.ts
+++ b/packages/backend/src/plugins/search.ts
@@ -57,8 +57,8 @@ export default async function createPlugin(
   });
 
   const schedule = env.scheduler.createScheduledTaskRunner({
-    frequency: Duration.fromObject({ seconds: 600 }),
-    timeout: Duration.fromObject({ seconds: 900 }),
+    frequency: Duration.fromObject({ minutes: 10 }),
+    timeout: Duration.fromObject({ minutes: 15 }),
     // A 3 second delay gives the backend server a chance to initialize before
     // any collators are executed, which may attempt requests against the API.
     initialDelay: Duration.fromObject({ seconds: 3 }),

--- a/packages/create-app/templates/default-app/packages/backend/src/plugins/search.ts.hbs
+++ b/packages/create-app/templates/default-app/packages/backend/src/plugins/search.ts.hbs
@@ -33,8 +33,8 @@ export default async function createPlugin(
   });
 
   const schedule = env.scheduler.createScheduledTaskRunner({
-    frequency: Duration.fromObject({ seconds: 600 }),
-    timeout: Duration.fromObject({ seconds: 900 }),
+    frequency: Duration.fromObject({ minutes: 10 }),
+    timeout: Duration.fromObject({ minutes: 15 }),
     // A 3 second delay gives the backend server a chance to initialize before
     // any collators are executed, which may attempt requests against the API.
     initialDelay: Duration.fromObject({ seconds: 3 }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a mostly-documentation follow-up to #7784:

- Adds the task scheduler DB explicitly to the architecture diagram
- Cleans up the architecture diagram to better match current realities
- Updates duration usage throughout to be a little easier to read.

No changeset because these changes are covered by the existing changeset.

#### Updated Architecture Diagram

![Screenshot 2022-04-08 at 18 17 24](https://user-images.githubusercontent.com/3496491/162482186-b910fd73-0de8-49a7-aa08-a97cd00798f6.png)

#### :heavy_check_mark: Checklist

- [x] Added or updated documentation
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
