### PR TITLE
Permission tutorial: update to recent changes

### DIFF
--- a/docs/permission/getting-started.md
+++ b/docs/permission/getting-started.md
@@ -8,6 +8,8 @@ If you prefer to watch a video instead, you can start with this video introducti
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/EQr9tFClgG0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
+> Note: This video was recorded in the January 2022 Contributors Session using `@backstage/create-app@0.4.14`. Some aspects of the demo may have changed in later releases.
+
 Backstage integrators control permissions by writing a policy. In general terms, a policy is simply an async function which receives a request to authorize a specific action for a user and (optional) resource, and returns a decision on whether to authorize that permission. Integrators can implement their own policies from scratch, or adopt reusable policies written by others.
 
 ## Prerequisites

--- a/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
+++ b/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
@@ -131,6 +131,8 @@ In order to test the logic above, the integrators of your backstage instance nee
     PermissionPolicy,
 +   PolicyQuery,
   } from '@backstage/plugin-permission-node';
++ import { isPermission } from '@backstage/plugin-permission-common';
++ import { todosListCreate } from '@internal/plugin-todo-list-backend';
 
   class TestPermissionPolicy implements PermissionPolicy {
 -   async handle(): Promise<PolicyDecision> {
@@ -138,7 +140,7 @@ In order to test the logic above, the integrators of your backstage instance nee
 +     request: PolicyQuery,
 +     user?: BackstageIdentityResponse,
 +   ): Promise<PolicyDecision> {
-+     if (request.permission.name === 'todos.list.create') {
++     if (isPermission(request.permission, todosListCreate)) {
 +       return {
 +         result: AuthorizeResult.DENY,
 +       };

--- a/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
+++ b/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
@@ -132,8 +132,7 @@ In order to test the logic above, the integrators of your backstage instance nee
 +   PolicyQuery,
   } from '@backstage/plugin-permission-node';
 
-- class TestPermissionPolicy implements PermissionPolicy
-+ class TestPermissionPolicy implements PermissionPolicy {
+  class TestPermissionPolicy implements PermissionPolicy {
 -   async handle(): Promise<PolicyDecision> {
 +   async handle(
 +     request: PolicyQuery,

--- a/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
+++ b/docs/permission/plugin-authors/02-adding-a-basic-permission-check.md
@@ -115,7 +115,7 @@ That's it! Now your plugin is fully configured. Let's try to test the logic by d
 
 ## Test the authorized create endpoint
 
-Before running this step, please make sure you followed the steps described in [Getting started](../getting-started) section.
+Before running this step, please make sure you followed the steps described in [Getting started](../getting-started.md) section.
 
 In order to test the logic above, the integrators of your backstage instance need to change their permission policy to return `DENY` for our newly-created permission:
 


### PR DESCRIPTION
Signed-off-by: Vincenzo Scamporlino <me@vinzscam.dev>

## Hey, I just made a Pull Request!

This PR update the permission framework for plugin adopters tutorial, by checking that the following files are up to date with the recent changes:

- permission/overview
- permission/concepts
- permission/getting-started
- permission/writing-a-policy
- permission/plugin-authors/01-setup
- permission/plugin-authors/02-adding-a-basic-permission-check

---

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
