### PR TITLE
Change input label for owner field in GitlabRepoPicker

### DIFF
--- a/.changeset/few-hotels-approve.md
+++ b/.changeset/few-hotels-approve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Changed input label for owner field in GitlabRepoPicker

--- a/.changeset/orange-dragons-brake.md
+++ b/.changeset/orange-dragons-brake.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-scaffolder-backend': patch
----
-
-modified input label for owner field in GitlabRepoPicker

--- a/.changeset/orange-dragons-brake.md
+++ b/.changeset/orange-dragons-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+modified input label for owner field in GitlabRepoPicker

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
@@ -65,7 +65,8 @@ export const GitlabRepoPicker = (props: {
           </>
         )}
         <FormHelperText>
-          The organization, user or project that this repo will belong to
+          The organization, groups, subgroups, user, project (also known as
+          namespaces in gitlab), that this repo will belong to
         </FormHelperText>
       </FormControl>
       <FormControl


### PR DESCRIPTION
## Changed input label for owner field in GitlabRepoPicker

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Changed input label for owner field in GitlabRepoPicker, as according to [Gitlab Docs](https://docs.gitlab.com/ee/user/group/#namespaces) the Owner field is to be populated with namespaces. 
Screenshot of Gitlab Docs

![gitlabNamespace](https://user-images.githubusercontent.com/19923220/162734861-2543b9e6-c822-4b23-a952-8da8edb52091.png)

Screenshot of changed input label 

![scrnli_11_04_2022_17-23-30](https://user-images.githubusercontent.com/19923220/162734130-75406c7c-fb5b-4e70-85f5-544f95d3509f.png)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
