### PR TITLE
create-app: Remove octokit/rest from dependencies section

### DIFF
--- a/.changeset/light-dragons-crash.md
+++ b/.changeset/light-dragons-crash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Remove `@octokit/rest` from dependencies.

--- a/packages/create-app/templates/default-app/packages/backend/package.json.hbs
+++ b/packages/create-app/templates/default-app/packages/backend/package.json.hbs
@@ -36,7 +36,6 @@
     "@backstage/plugin-search-backend-node": "^{{version '@backstage/plugin-search-backend-node'}}",
     "@backstage/plugin-techdocs-backend": "^{{version '@backstage/plugin-techdocs-backend'}}",
     "@gitbeaker/node": "^34.6.0",
-    "@octokit/rest": "^18.5.3",
     "dockerode": "^3.3.1",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",


### PR DESCRIPTION
This dependency should not be needed for a freshly created app.