### PR TITLE
GerritUrlReader: Implemented "readTree"

### DIFF
--- a/.changeset/cool-ties-share.md
+++ b/.changeset/cool-ties-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Gerrit integration: Added optional `cloneUrl` string to config.

--- a/.changeset/fair-kings-retire.md
+++ b/.changeset/fair-kings-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': minor
+---
+
+Gerrit UrlReader: Implemented `readTree`

--- a/docs/integrations/gerrit/locations.md
+++ b/docs/integrations/gerrit/locations.md
@@ -19,7 +19,8 @@ To use this integration, add at least one Gerrit configuration to your root `app
 integrations:
   gerrit:
     - host: gerrit.company.com
-      apiBaseUrl: https://gerrit.company.com/gerrit
+      baseUrl: https://gerrit.company.com/gerrit
+      cloneUrl: https://gerrit.company.com/clone
       gitilesBaseUrl: https://gerrit.company.com/gitiles
       username: ${GERRIT_USERNAME}
       password: ${GERRIT_PASSWORD}
@@ -27,12 +28,14 @@ integrations:
 
 Directly under the `gerrit` key is a list of provider configurations, where
 you can list the Gerrit instances you want to fetch data from. Each entry is
-a structure with up to four elements:
+a structure with up to six elements:
 
 - `host`: The host of the Gerrit instance, e.g. `gerrit.company.com`.
-- `apiBaseUrl` (optional): Needed if the Gerrit instance is not reachable at
+- `baseUrl` (optional): Needed if the Gerrit instance is not reachable at
   the base of the `host` option (e.g. `https://gerrit.company.com`) set the
   address here. This is the address that you would open in a browser.
+- `cloneUrl` (optional): The base url for HTTP clones. Will default to `baseUrl` if
+  not set. The address used to clone a repo is the `cloneUrl` plus the repo name.
 - `gitilesBaseUrl` (optional): This is needed for creating a valid user-friendly url
   that can be used for browsing the content of the provider. If not set a default
   value will be created in the same way as the "baseUrl" option. There is no

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -302,13 +302,19 @@ export type FromReadableArrayOptions = Array<{
 
 // @public
 export class GerritUrlReader implements UrlReader {
-  constructor(integration: GerritIntegration);
+  constructor(
+    integration: GerritIntegration,
+    deps: {
+      treeResponseFactory: ReadTreeResponseFactory;
+    },
+    workDir: string,
+  );
   // (undocumented)
   static factory: ReaderFactory;
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)
-  readTree(): Promise<ReadTreeResponse>;
+  readTree(url: string, options?: ReadTreeOptions): Promise<ReadTreeResponse>;
   // (undocumented)
   readUrl(url: string, options?: ReadUrlOptions): Promise<ReadUrlResponse>;
   // (undocumented)

--- a/packages/backend-common/src/reading/__fixtures__/gerrit/branch-info-response.txt
+++ b/packages/backend-common/src/reading/__fixtures__/gerrit/branch-info-response.txt
@@ -1,0 +1,2 @@
+)]}'
+{"web_links":[{"name":"browse","url":"https://gerrit.googlesource.com/app/web/+/refs/heads/master","target":"_blank"}],"ref":"refs/heads/master","revision":"52432507a70b677b5674b019c9a46b2e9f29d0a1"}

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -195,6 +195,7 @@ export class GerritIntegration implements ScmIntegration {
 export type GerritIntegrationConfig = {
   host: string;
   baseUrl?: string;
+  cloneUrl?: string;
   gitilesBaseUrl?: string;
   username?: string;
   password?: string;
@@ -291,6 +292,18 @@ export function getBitbucketServerRequestOptions(
 ): {
   headers: Record<string, string>;
 };
+
+// @public
+export function getGerritBranchApiUrl(
+  config: GerritIntegrationConfig,
+  url: string,
+): string;
+
+// @public
+export function getGerritCloneRepoUrl(
+  config: GerritIntegrationConfig,
+  url: string,
+): string;
 
 // @public
 export function getGerritFileContentsApiUrl(
@@ -457,6 +470,16 @@ export interface IntegrationsByType {
   // (undocumented)
   gitlab: ScmIntegrationsGroup<GitLabIntegration>;
 }
+
+// @public
+export function parseGerritGitilesUrl(
+  config: GerritIntegrationConfig,
+  url: string,
+): {
+  branch: string;
+  filePath: string;
+  project: string;
+};
 
 // @public
 export function parseGerritJsonResponse(response: Response): Promise<unknown>;

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -109,6 +109,11 @@ export interface Config {
        */
       baseUrl?: string;
       /**
+       * The base url for cloning repos.
+       * @visibility frontend
+       */
+      cloneUrl?: string;
+      /**
        * The username to use for authenticated requests.
        * @visibility secret
        */

--- a/packages/integration/src/gerrit/config.test.ts
+++ b/packages/integration/src/gerrit/config.test.ts
@@ -56,6 +56,7 @@ describe('readGerritIntegrationConfig', () => {
       buildConfig({
         host: 'a.com',
         baseUrl: 'https://a.com/api',
+        cloneUrl: 'https:a.com/clone',
         gitilesBaseUrl: 'https://a.com/git',
         username: 'u',
         password: 'p',
@@ -64,6 +65,7 @@ describe('readGerritIntegrationConfig', () => {
     expect(output).toEqual({
       host: 'a.com',
       baseUrl: 'https://a.com/api',
+      cloneUrl: 'https:a.com/clone',
       gitilesBaseUrl: 'https://a.com/git',
       username: 'u',
       password: 'p',
@@ -79,6 +81,7 @@ describe('readGerritIntegrationConfig', () => {
     expect(output).toEqual({
       host: 'a.com',
       baseUrl: 'https://a.com',
+      cloneUrl: 'https://a.com',
       gitilesBaseUrl: 'https://a.com',
       username: undefined,
       password: undefined,
@@ -110,6 +113,7 @@ describe('readGerritIntegrationConfig', () => {
     ).toEqual({
       host: 'a.com',
       baseUrl: 'https://a.com/gerrit',
+      cloneUrl: 'https://a.com/gerrit',
       gitilesBaseUrl: 'https://a.com',
     });
   });
@@ -139,6 +143,7 @@ describe('readGerritIntegrationConfigs', () => {
       {
         host: 'a.com',
         baseUrl: 'https://a.com/api',
+        cloneUrl: 'https://a.com/api',
         gitilesBaseUrl: 'https://a.com',
         username: 'u',
         password: 'p',
@@ -146,6 +151,7 @@ describe('readGerritIntegrationConfigs', () => {
       {
         host: 'b.com',
         baseUrl: 'https://b.com/api',
+        cloneUrl: 'https://b.com/api',
         gitilesBaseUrl: 'https://b.com',
         username: undefined,
         password: undefined,

--- a/packages/integration/src/gerrit/config.ts
+++ b/packages/integration/src/gerrit/config.ts
@@ -39,6 +39,12 @@ export type GerritIntegrationConfig = {
   baseUrl?: string;
 
   /**
+   * The optional base url to use for cloning a repository. If not set the
+   * baseUrl will be used.
+   */
+  cloneUrl?: string;
+
+  /**
    * Optional base url for Gitiles. This is needed for creating a valid
    * user-friendly url that can be used for browsing the content of the
    * provider. If not set a default value will be created in the same way
@@ -69,6 +75,7 @@ export function readGerritIntegrationConfig(
 ): GerritIntegrationConfig {
   const host = config.getString('host');
   let baseUrl = config.getOptionalString('baseUrl');
+  let cloneUrl = config.getOptionalString('cloneUrl');
   let gitilesBaseUrl = config.getOptionalString('gitilesBaseUrl');
   const username = config.getOptionalString('username');
   const password = config.getOptionalString('password');
@@ -80,6 +87,10 @@ export function readGerritIntegrationConfig(
   } else if (baseUrl && !isValidUrl(baseUrl)) {
     throw new Error(
       `Invalid Gerrit integration config, '${baseUrl}' is not a valid baseUrl`,
+    );
+  } else if (cloneUrl && !isValidUrl(cloneUrl)) {
+    throw new Error(
+      `Invalid Gerrit integration config, '${cloneUrl}' is not a valid cloneUrl`,
     );
   } else if (gitilesBaseUrl && !isValidUrl(gitilesBaseUrl)) {
     throw new Error(
@@ -96,10 +107,16 @@ export function readGerritIntegrationConfig(
   } else {
     gitilesBaseUrl = `https://${host}`;
   }
+  if (cloneUrl) {
+    cloneUrl = trimEnd(cloneUrl, '/');
+  } else {
+    cloneUrl = baseUrl;
+  }
 
   return {
     host,
     baseUrl,
+    cloneUrl,
     gitilesBaseUrl,
     username,
     password,

--- a/packages/integration/src/gerrit/core.test.ts
+++ b/packages/integration/src/gerrit/core.test.ts
@@ -20,9 +20,11 @@ import fetch from 'cross-fetch';
 import { setupRequestMockHandlers } from '@backstage/test-utils';
 import { GerritIntegrationConfig } from './config';
 import {
+  getGerritBranchApiUrl,
+  getGerritCloneRepoUrl,
   getGerritRequestOptions,
   parseGerritJsonResponse,
-  parseGitilesUrl,
+  parseGerritGitilesUrl,
   getGerritFileContentsApiUrl,
 } from './core';
 
@@ -55,7 +57,7 @@ describe('gerrit core', () => {
         host: 'gerrit.com',
         gitilesBaseUrl: 'https://gerrit.com/gitiles',
       };
-      const { branch, filePath, project } = parseGitilesUrl(
+      const { branch, filePath, project } = parseGerritGitilesUrl(
         config,
         'https://gerrit.com/gitiles/web/project/+/refs/heads/master/README.md',
       );
@@ -63,7 +65,7 @@ describe('gerrit core', () => {
       expect(branch).toEqual('master');
       expect(filePath).toEqual('README.md');
 
-      const { filePath: rootPath } = parseGitilesUrl(
+      const { filePath: rootPath } = parseGerritGitilesUrl(
         config,
         'https://gerrit.com/gitiles/web/project/+/refs/heads/master',
       );
@@ -75,17 +77,82 @@ describe('gerrit core', () => {
         gitilesBaseUrl: 'https://gerrit.com',
       };
       expect(() =>
-        parseGitilesUrl(
+        parseGerritGitilesUrl(
           config,
           'https://gerrit.com/+/refs/heads/master/README.md',
         ),
       ).toThrow(/project/);
       expect(() =>
-        parseGitilesUrl(
+        parseGerritGitilesUrl(
           config,
           'https://gerrit.com/web/project/+/refs/changes/1/11/master/README.md',
         ),
       ).toThrow(/branch/);
+    });
+  });
+
+  describe('getGerritBranchApiUrl', () => {
+    it('can create an url for anonymous access.', () => {
+      const config: GerritIntegrationConfig = {
+        host: 'gerrit.com',
+        baseUrl: 'https://gerrit.com',
+        gitilesBaseUrl: 'https://gerrit.com',
+      };
+      const fileContentUrl = getGerritBranchApiUrl(
+        config,
+        'https://gerrit.com/web/project/+/refs/heads/master/README.md',
+      );
+      expect(fileContentUrl).toEqual(
+        'https://gerrit.com/projects/web%2Fproject/branches/master',
+      );
+    });
+    it('can create an url for authenticated access.', () => {
+      const authConfig: GerritIntegrationConfig = {
+        host: 'gerrit.com',
+        baseUrl: 'https://gerrit.com',
+        gitilesBaseUrl: 'https://gerrit.com',
+        username: 'u',
+        password: 'u',
+      };
+      const authFileContentUrl = getGerritBranchApiUrl(
+        authConfig,
+        'https://gerrit.com/web/project/+/refs/heads/master/README.md',
+      );
+      expect(authFileContentUrl).toEqual(
+        'https://gerrit.com/a/projects/web%2Fproject/branches/master',
+      );
+    });
+  });
+
+  describe('getGerritCloneRepoUrl', () => {
+    it('can create an url for anonymous clone.', () => {
+      const config: GerritIntegrationConfig = {
+        host: 'gerrit.com',
+        cloneUrl: 'https://gerrit.com/clone',
+        gitilesBaseUrl: 'https://gerrit.com',
+      };
+      const fileContentUrl = getGerritCloneRepoUrl(
+        config,
+        'https://gerrit.com/web/project/+/refs/heads/master/README.md',
+      );
+      expect(fileContentUrl).toEqual('https://gerrit.com/clone/web/project');
+    });
+    it('can create an url for authenticated clone.', () => {
+      const authConfig: GerritIntegrationConfig = {
+        host: 'gerrit.com',
+        baseUrl: 'https://gerrit.com',
+        cloneUrl: 'https://gerrit.com/clone',
+        gitilesBaseUrl: 'https://gerrit.com',
+        username: 'u',
+        password: 'u',
+      };
+      const authFileContentUrl = getGerritCloneRepoUrl(
+        authConfig,
+        'https://gerrit.com/web/project/+/refs/heads/master/README.md',
+      );
+      expect(authFileContentUrl).toEqual(
+        'https://gerrit.com/clone/a/web/project',
+      );
     });
   });
 

--- a/packages/integration/src/gerrit/index.ts
+++ b/packages/integration/src/gerrit/index.ts
@@ -19,10 +19,13 @@ export {
   readGerritIntegrationConfigs,
 } from './config';
 export {
+  getGerritBranchApiUrl,
+  getGerritCloneRepoUrl,
   getGerritFileContentsApiUrl,
   getGerritProjectsApiUrl,
   getGerritRequestOptions,
   parseGerritJsonResponse,
+  parseGerritGitilesUrl,
 } from './core';
 
 export type { GerritIntegrationConfig } from './config';


### PR DESCRIPTION
"readTree" has been implemented for the "GerritUrlReader". Gerrit have
a REST API's to download repo contents but there are a number of
limitations that makes it unusable.

This implementation works as follows:
* The project and branch is parsed from the url.
* The current revision is fetched from the Gerrit REST API.
* The revision string is used as "etag".
* If the etag has changed a temporary directory is created.
* The project is cloned to the temporary directory.
* The cloned content is read into a "Readable Stream".
* The temporary directory is removed.
* "readTree" returns a response using "fromTarArchive" as read from the
  temporary directory.

Also added an option to specify the base "cloneUrl" has been added to the
gerrit integration config.

Relates: #9896 

Signed-off-by: Niklas Aronsson <niklasar@axis.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
