### PR TITLE
feat(home): give star icon yellow color to make it consistent

### DIFF
--- a/.changeset/metal-pants-fly.md
+++ b/.changeset/metal-pants-fly.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/plugin-home': patch
+'example-app': patch
 ---
 
-star icons now have the same yellow color as the other star icons when a entity is favourited
+star icons now have the same yellow color as the other star icons when a entity is favourite

--- a/.changeset/metal-pants-fly.md
+++ b/.changeset/metal-pants-fly.md
@@ -1,6 +1,5 @@
 ---
 '@backstage/plugin-home': patch
-'example-app': patch
 ---
 
 star icons now have the same yellow color as the other star icons when a entity is favourite

--- a/.changeset/metal-pants-fly.md
+++ b/.changeset/metal-pants-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+star icons now have the same yellow color as the other star icons when a entity is favourited

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -22,6 +22,7 @@ import {
   WelcomeTitle,
   HeaderWorldClock,
   ClockConfig,
+  HomePageStarredEntities,
 } from '@backstage/plugin-home';
 import { Content, Header, Page } from '@backstage/core-components';
 import { HomePageSearchBar } from '@backstage/plugin-search';
@@ -103,6 +104,9 @@ export const homePage = (
         </Grid>
         <Grid item xs={12} md={4}>
           <HomePageCalendar />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <HomePageStarredEntities />
         </Grid>
       </Grid>
     </Content>

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -38,7 +38,6 @@ import React from 'react';
  *
  * @public
  */
-
 export const Content = () => {
   const catalogEntityRoute = useRouteRef(entityRouteRef);
   const { starredEntities, toggleStarredEntity } = useStarredEntities();
@@ -64,7 +63,7 @@ export const Content = () => {
                 aria-label="unstar"
                 onClick={() => toggleStarredEntity(entity)}
               >
-                <StarIcon />
+                <StarIcon style={{ color: '#f3ba37' }} />
               </IconButton>
             </Tooltip>
           </ListItemSecondaryAction>


### PR DESCRIPTION
Signed-off-by: djamaile <rdjamaile@gmail.com>

## Hey, I just made a Pull Request!

Made the color of the icon yellow instead of grey. Because in other places the star is yellow as well when something is favourited. Also, added the `HomePageStarredEntities` component to the home page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ x] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<img width="1792" alt="Screenshot 2022-04-12 at 13 54 56" src="https://user-images.githubusercontent.com/15789670/162956932-c3361748-063c-4ae4-b10a-ca8ba24ed6a6.png">

