### PR TITLE
Add aria landmarks

### DIFF
--- a/.changeset/afraid-insects-do.md
+++ b/.changeset/afraid-insects-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added ARIA landmark <main> to Page component and added ARIA landmark <nav> to DesktopSidebar and Sidebar components

--- a/packages/core-components/src/layout/Page/Page.tsx
+++ b/packages/core-components/src/layout/Page/Page.tsx
@@ -52,7 +52,7 @@ export function Page(props: Props) {
         page: baseTheme.getPageTheme({ themeId }),
       })}
     >
-      <div className={classes.root}>{children}</div>
+      <main className={classes.root}>{children}</main>
     </ThemeProvider>
   );
 }

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -189,7 +189,7 @@ const DesktopSidebar = (props: DesktopSidebarProps) => {
   };
 
   return (
-    <div style={{}}>
+    <nav style={{}}>
       <A11ySkipSidebar />
       <SidebarContext.Provider value={{ isOpen, setOpen }}>
         <div
@@ -209,7 +209,7 @@ const DesktopSidebar = (props: DesktopSidebarProps) => {
           </div>
         </div>
       </SidebarContext.Provider>
-    </div>
+    </nav>
   );
 };
 

--- a/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
+++ b/packages/core-components/src/layout/Sidebar/MobileSidebar.tsx
@@ -140,7 +140,7 @@ const OverlayMenu = ({
           <CloseIcon />
         </IconButton>
       </Box>
-      <Box>{children}</Box>
+      <Box component="nav">{children}</Box>
     </Drawer>
   );
 };
@@ -226,6 +226,7 @@ export const MobileSidebar = (props: MobileSidebarProps) => {
         <BottomNavigation
           className={classes.root}
           data-testid="mobile-sidebar-root"
+          component="nav"
         >
           {sidebarGroups}
         </BottomNavigation>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated `Page` and `Bar` to include the ARIA landmarks `<main>` and `<nav>` respectively. This is a start to address accessibility issues noted in [Issue 7124](https://github.com/backstage/backstage/issues/7124). This not change any functionality or UI, just makes it more accessible to screen readers.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. 
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
