### PR TITLE
Remove strict validation from `PermissionCriteria` schemas

### DIFF
--- a/.changeset/curvy-wolves-worry.md
+++ b/.changeset/curvy-wolves-worry.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-permission-common': patch
+'@backstage/plugin-permission-node': patch
+---
+
+Removed [strict](https://github.com/colinhacks/zod#strict) validation from `PermissionCriteria` schemas to support backward-compatible changes.

--- a/plugins/permission-common/src/PermissionClient.ts
+++ b/plugins/permission-common/src/PermissionClient.ts
@@ -43,18 +43,9 @@ const permissionCriteriaSchema: z.ZodSchema<
       resourceType: z.string(),
       params: z.array(z.unknown()),
     })
-    .strict()
-    .or(
-      z
-        .object({ anyOf: z.array(permissionCriteriaSchema).nonempty() })
-        .strict(),
-    )
-    .or(
-      z
-        .object({ allOf: z.array(permissionCriteriaSchema).nonempty() })
-        .strict(),
-    )
-    .or(z.object({ not: permissionCriteriaSchema }).strict()),
+    .or(z.object({ anyOf: z.array(permissionCriteriaSchema).nonempty() }))
+    .or(z.object({ allOf: z.array(permissionCriteriaSchema).nonempty() }))
+    .or(z.object({ not: permissionCriteriaSchema })),
 );
 
 const authorizePermissionResponseSchema: z.ZodSchema<AuthorizePermissionResponse> =

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -38,16 +38,14 @@ const permissionCriteriaSchema: z.ZodSchema<
   PermissionCriteria<PermissionCondition>
 > = z.lazy(() =>
   z.union([
-    z.object({ anyOf: z.array(permissionCriteriaSchema).nonempty() }).strict(),
-    z.object({ allOf: z.array(permissionCriteriaSchema).nonempty() }).strict(),
-    z.object({ not: permissionCriteriaSchema }).strict(),
-    z
-      .object({
-        rule: z.string(),
-        resourceType: z.string(),
-        params: z.array(z.unknown()),
-      })
-      .strict(),
+    z.object({ anyOf: z.array(permissionCriteriaSchema).nonempty() }),
+    z.object({ allOf: z.array(permissionCriteriaSchema).nonempty() }),
+    z.object({ not: permissionCriteriaSchema }),
+    z.object({
+      rule: z.string(),
+      resourceType: z.string(),
+      params: z.array(z.unknown()),
+    }),
   ]),
 );
 


### PR DESCRIPTION
Signed-off-by: Joe Porpeglia <josephp@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This validation was originally added to prevent accidental errors when defining conditional policy decisions (eg. including both `anyOf` and `allOf` as siblings in `PermissionCriteria`). However, this prevents backward compatible changes and requires upgrades to be carefully sequenced across packages that depend on this schema. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
