### PR TITLE
[search-react] versioned context

### DIFF
--- a/.changeset/search-spicy-pots-bow.md
+++ b/.changeset/search-spicy-pots-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': patch
+---
+
+Context managed through version-bridge

--- a/.changeset/search-spicy-pots-bow.md
+++ b/.changeset/search-spicy-pots-bow.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-search-react': patch
 ---
 
-Context managed through version-bridge
+Versioned search context managed through version-bridge

--- a/plugins/search-react/package.json
+++ b/plugins/search-react/package.json
@@ -34,6 +34,7 @@
     "@backstage/plugin-search-common": "^0.3.3-next.1",
     "@backstage/core-plugin-api": "^1.0.1-next.0",
     "@backstage/core-app-api": "^1.0.1-next.1",
+    "@backstage/version-bridge": "^1.0.0",
     "react-use": "^17.3.2",
     "@backstage/types": "^1.0.0"
   },

--- a/plugins/search-react/src/context/SearchContext.tsx
+++ b/plugins/search-react/src/context/SearchContext.tsx
@@ -53,11 +53,7 @@ export type SearchContextState = {
   pageCursor?: string;
 };
 
-// TODO(@backstage/techdocs-core): stop export this publicly when deprecating the context in @backstage/plugin-techdocs.
-/**
- * @public
- */
-export const SearchContext = createVersionedContext<{
+const SearchContext = createVersionedContext<{
   1: SearchContextValue;
 }>('search-context');
 
@@ -72,7 +68,7 @@ export const useSearch = () => {
 
   const value = context.atVersion(1);
   if (!value) {
-    throw new Error('No context for version 1 found');
+    throw new Error('No SearchContext v1 found');
   }
   return value;
 };

--- a/plugins/search-react/src/context/index.tsx
+++ b/plugins/search-react/src/context/index.tsx
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-export {
-  SearchContextProvider,
-  SearchContext,
-  useSearch,
-} from './SearchContext';
+export { SearchContextProvider, useSearch } from './SearchContext';
 export type { SearchContextState } from './SearchContext';
 export {
   SearchContextProvider as SearchContextProviderForStorybook,


### PR DESCRIPTION
Signed-off-by: Emma Indal <emma.indahl@gmail.com>

## Hey, I just made a Pull Request!

The context exported from the new search package (search-react) is now versioned using version bridge.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
