### PR TITLE
chore: update the return type guard for `isGroupEntity`

### DIFF
--- a/.changeset/chatty-pears-nail.md
+++ b/.changeset/chatty-pears-nail.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-When retrieving the text of a document also check if the entity is of type group. The function will then also return the display name and the description and not only the description.
+Fix wrong return type of the `isGroupEntity` function.

--- a/.changeset/chatty-pears-nail.md
+++ b/.changeset/chatty-pears-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+When retrieving the text of a document also check if the entity is of type group. The function will then also return the display name and the description and not only the description.

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
@@ -22,7 +22,6 @@ import {
   Entity,
   stringifyEntityRef,
   UserEntity,
-  GroupEntity,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
@@ -98,13 +97,9 @@ export class DefaultCatalogCollator {
     return entity.kind.toLocaleUpperCase('en-US') === 'USER';
   }
 
-  private isGroupEntity(entity: Entity): entity is GroupEntity {
-    return entity.kind.toLocaleUpperCase('en-US') === 'GROUP';
-  }
-
   private getDocumentText(entity: Entity): string {
     let documentText = entity.metadata.description || '';
-    if (this.isUserEntity(entity) || this.isGroupEntity(entity)) {
+    if (this.isUserEntity(entity)) {
       if (entity.spec?.profile?.displayName && documentText) {
         // combine displayName and description
         const displayName = entity.spec?.profile?.displayName;

--- a/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
+++ b/plugins/catalog-backend/src/search/DefaultCatalogCollator.ts
@@ -22,6 +22,7 @@ import {
   Entity,
   stringifyEntityRef,
   UserEntity,
+  GroupEntity,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import {
@@ -97,9 +98,13 @@ export class DefaultCatalogCollator {
     return entity.kind.toLocaleUpperCase('en-US') === 'USER';
   }
 
+  private isGroupEntity(entity: Entity): entity is GroupEntity {
+    return entity.kind.toLocaleUpperCase('en-US') === 'GROUP';
+  }
+
   private getDocumentText(entity: Entity): string {
     let documentText = entity.metadata.description || '';
-    if (this.isUserEntity(entity)) {
+    if (this.isUserEntity(entity) || this.isGroupEntity(entity)) {
       if (entity.spec?.profile?.displayName && documentText) {
         // combine displayName and description
         const displayName = entity.spec?.profile?.displayName;

--- a/plugins/catalog-backend/src/search/util.ts
+++ b/plugins/catalog-backend/src/search/util.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { Entity, UserEntity } from '@backstage/catalog-model';
+import { Entity, UserEntity, GroupEntity } from '@backstage/catalog-model';
 
 function isUserEntity(entity: Entity): entity is UserEntity {
   return entity.kind.toLocaleUpperCase('en-US') === 'USER';
 }
 
-function isGroupEntity(entity: Entity): entity is UserEntity {
+function isGroupEntity(entity: Entity): entity is GroupEntity {
   return entity.kind.toLocaleUpperCase('en-US') === 'GROUP';
 }
 


### PR DESCRIPTION
… if the entity is of type group

Signed-off-by: djamaile <rdjamaile@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Currently when searching, users have their display name under their actual name. I thought it would be nice to also have this automatically for groups. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
