### PR TITLE
test-utils: add missing Routes element wrapping

### DIFF
--- a/.changeset/violet-steaks-knock.md
+++ b/.changeset/violet-steaks-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Added missing `Routes` element to wrap the `Route` elements of the test app wrapping.

--- a/.changeset/wise-emus-wait.md
+++ b/.changeset/wise-emus-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+The internal elements created as part of the `mountedRoutes` implementation are now hidden during rendering.

--- a/packages/test-utils/src/testUtils/appWrappers.test.tsx
+++ b/packages/test-utils/src/testUtils/appWrappers.test.tsx
@@ -159,4 +159,17 @@ describe('wrapInTestApp', () => {
     expect(rendered.getByText('Link S: /my-b-path/y/p')).toBeInTheDocument();
     expect(rendered.getByText('Link E: /my-e-path/z')).toBeInTheDocument();
   });
+
+  it('should not make route mounting elements visible during tests', async () => {
+    const routeRef = createRouteRef({ id: 'foo' });
+
+    const rendered = await renderInTestApp(<span>foo</span>, {
+      mountedRoutes: { '/foo': routeRef },
+    });
+
+    const [root] = rendered.baseElement.children;
+    expect(root).toBeInTheDocument();
+    expect(root.children.length).toBe(1);
+    expect(root.children[0].textContent).toBe('foo');
+  });
 });

--- a/packages/test-utils/src/testUtils/appWrappers.tsx
+++ b/packages/test-utils/src/testUtils/appWrappers.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { ComponentType, ReactNode, ReactElement } from 'react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Routes } from 'react-router';
 import { Route } from 'react-router-dom';
 import { lightTheme } from '@backstage/theme';
 import { ThemeProvider } from '@material-ui/core/styles';
@@ -69,6 +69,8 @@ const BootErrorPage = ({ step, error }: BootErrorPageProps) => {
   throw new Error(`Reached BootError Page at step ${step} with error ${error}`);
 };
 const Progress = () => <div data-testid="progress" />;
+
+const NoRender = (_props: { children: ReactNode }) => null;
 
 /**
  * Options to customize the behavior of the test app wrapper.
@@ -190,10 +192,12 @@ export function wrapInTestApp(
   return (
     <AppProvider>
       <AppRouter>
-        {routeElements}
+        <NoRender>{routeElements}</NoRender>
         {/* The path of * here is needed to be set as a catch all, so it will render the wrapper element
          *  and work with nested routes if they exist too */}
-        <Route path="*" element={wrappedElement} />
+        <Routes>
+          <Route path="/*" element={wrappedElement} />
+        </Routes>
       </AppRouter>
     </AppProvider>
   );

--- a/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.test.tsx
+++ b/plugins/org/src/components/MyGroupsSidebarItem/MyGroupsSidebarItem.test.tsx
@@ -58,9 +58,7 @@ describe('MyGroupsSidebarItem Test', () => {
           },
         },
       );
-      expect(
-        rendered.getByText('Mounted at /catalog/:namespace/:kind/:name'),
-      ).toBeInTheDocument();
+      expect(rendered.container).toBeEmptyDOMElement();
     });
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Extracted from #10450 to keep that PR slim. These fixes are needed for `reacte-router` v6 stable, but make sense by themselves either way.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
