### PR TITLE
techdocs: restore event-source-polyfill pinning

### DIFF
--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -52,7 +52,7 @@
     "@material-ui/lab": "4.0.0-alpha.57",
     "@material-ui/styles": "^4.10.0",
     "dompurify": "^2.2.9",
-    "event-source-polyfill": "^1.0.25",
+    "event-source-polyfill": "1.0.25",
     "git-url-parse": "^11.6.0",
     "jss": "~10.8.2",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Was removed by mistake in a previous change