### PR TITLE
Allow definition of required status checks for new github repos

### DIFF
--- a/.changeset/curly-parrots-applaud.md
+++ b/.changeset/curly-parrots-applaud.md
@@ -2,4 +2,5 @@
 '@backstage/plugin-scaffolder-backend': minor
 ---
 
-Update the github:publish action to allow passing required status checks by name.
+Update the `github:publish` action to allow passing required status check
+contexts before merging to the main branch.

--- a/.changeset/curly-parrots-applaud.md
+++ b/.changeset/curly-parrots-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Update the github:publish action to allow passing required status checks by name.

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -230,6 +230,7 @@ export function createPublishGithubAction(options: {
   allowMergeCommit?: boolean | undefined;
   sourcePath?: string | undefined;
   requireCodeOwnerReviews?: boolean | undefined;
+  requiredStatusCheckContexts?: string[] | undefined;
   repoVisibility?: 'internal' | 'private' | 'public' | undefined;
   collaborators?:
     | {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -132,6 +132,7 @@ type BranchProtectionOptions = {
   repoName: string;
   logger: Logger;
   requireCodeOwnerReviews: boolean;
+  requiredStatusChecks: string[];
   defaultBranch?: string;
 };
 
@@ -141,6 +142,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
   owner,
   logger,
   requireCodeOwnerReviews,
+  requiredStatusChecks = [],
   defaultBranch = 'master',
 }: BranchProtectionOptions): Promise<void> => {
   const tryOnce = async () => {
@@ -159,7 +161,10 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
         owner,
         repo: repoName,
         branch: defaultBranch,
-        required_status_checks: { strict: true, contexts: [] },
+        required_status_checks: {
+          strict: true,
+          contexts: requiredStatusChecks,
+        },
         restrictions: null,
         enforce_admins: true,
         required_pull_request_reviews: {

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/helpers.ts
@@ -132,7 +132,7 @@ type BranchProtectionOptions = {
   repoName: string;
   logger: Logger;
   requireCodeOwnerReviews: boolean;
-  requiredStatusChecks: string[];
+  requiredStatusCheckContexts?: string[];
   defaultBranch?: string;
 };
 
@@ -142,7 +142,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
   owner,
   logger,
   requireCodeOwnerReviews,
-  requiredStatusChecks = [],
+  requiredStatusCheckContexts = [],
   defaultBranch = 'master',
 }: BranchProtectionOptions): Promise<void> => {
   const tryOnce = async () => {
@@ -163,7 +163,7 @@ export const enableBranchProtectionOnDefaultRepoBranch = async ({
         branch: defaultBranch,
         required_status_checks: {
           strict: true,
-          contexts: requiredStatusChecks,
+          contexts: requiredStatusCheckContexts,
         },
         restrictions: null,
         enforce_admins: true,

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -625,6 +625,7 @@ describe('publish:github', () => {
       logger: mockContext.logger,
       defaultBranch: 'master',
       requireCodeOwnerReviews: false,
+      requiredStatusChecks: [],
     });
 
     await action.handler({
@@ -642,6 +643,7 @@ describe('publish:github', () => {
       logger: mockContext.logger,
       defaultBranch: 'master',
       requireCodeOwnerReviews: true,
+      requiredStatusChecks: [],
     });
 
     await action.handler({
@@ -659,6 +661,67 @@ describe('publish:github', () => {
       logger: mockContext.logger,
       defaultBranch: 'master',
       requireCodeOwnerReviews: false,
+      requiredStatusChecks: [],
+    });
+  });
+
+  it('should call enableBranchProtectionOnDefaultRepoBranch with the correct values of requireStatusChecks', async () => {
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+
+    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        name: 'repository',
+      },
+    });
+
+    await action.handler(mockContext);
+
+    expect(enableBranchProtectionOnDefaultRepoBranch).toHaveBeenCalledWith({
+      owner: 'owner',
+      client: mockOctokit,
+      repoName: 'repository',
+      logger: mockContext.logger,
+      defaultBranch: 'master',
+      requireCodeOwnerReviews: false,
+      requiredStatusChecks: [],
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        requiredStatusChecks: ['statusCheck'],
+      },
+    });
+
+    expect(enableBranchProtectionOnDefaultRepoBranch).toHaveBeenCalledWith({
+      owner: 'owner',
+      client: mockOctokit,
+      repoName: 'repository',
+      logger: mockContext.logger,
+      defaultBranch: 'master',
+      requireCodeOwnerReviews: false,
+      requiredStatusChecks: ['statusCheck'],
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        requiredStatusChecks: [],
+      },
+    });
+
+    expect(enableBranchProtectionOnDefaultRepoBranch).toHaveBeenCalledWith({
+      owner: 'owner',
+      client: mockOctokit,
+      repoName: 'repository',
+      logger: mockContext.logger,
+      defaultBranch: 'master',
+      requireCodeOwnerReviews: false,
+      requiredStatusChecks: [],
     });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -625,7 +625,7 @@ describe('publish:github', () => {
       logger: mockContext.logger,
       defaultBranch: 'master',
       requireCodeOwnerReviews: false,
-      requiredStatusChecks: [],
+      requiredStatusCheckContexts: [],
     });
 
     await action.handler({
@@ -643,7 +643,7 @@ describe('publish:github', () => {
       logger: mockContext.logger,
       defaultBranch: 'master',
       requireCodeOwnerReviews: true,
-      requiredStatusChecks: [],
+      requiredStatusCheckContexts: [],
     });
 
     await action.handler({
@@ -661,11 +661,11 @@ describe('publish:github', () => {
       logger: mockContext.logger,
       defaultBranch: 'master',
       requireCodeOwnerReviews: false,
-      requiredStatusChecks: [],
+      requiredStatusCheckContexts: [],
     });
   });
 
-  it('should call enableBranchProtectionOnDefaultRepoBranch with the correct values of requireStatusChecks', async () => {
+  it('should call enableBranchProtectionOnDefaultRepoBranch with the correct values of requiredStatusCheckContexts', async () => {
     mockOctokit.rest.users.getByUsername.mockResolvedValue({
       data: { type: 'User' },
     });
@@ -685,14 +685,14 @@ describe('publish:github', () => {
       logger: mockContext.logger,
       defaultBranch: 'master',
       requireCodeOwnerReviews: false,
-      requiredStatusChecks: [],
+      requiredStatusCheckContexts: [],
     });
 
     await action.handler({
       ...mockContext,
       input: {
         ...mockContext.input,
-        requiredStatusChecks: ['statusCheck'],
+        requiredStatusCheckContexts: ['statusCheck'],
       },
     });
 
@@ -703,14 +703,14 @@ describe('publish:github', () => {
       logger: mockContext.logger,
       defaultBranch: 'master',
       requireCodeOwnerReviews: false,
-      requiredStatusChecks: ['statusCheck'],
+      requiredStatusCheckContexts: ['statusCheck'],
     });
 
     await action.handler({
       ...mockContext,
       input: {
         ...mockContext.input,
-        requiredStatusChecks: [],
+        requiredStatusCheckContexts: [],
       },
     });
 
@@ -721,7 +721,7 @@ describe('publish:github', () => {
       logger: mockContext.logger,
       defaultBranch: 'master',
       requireCodeOwnerReviews: false,
-      requiredStatusChecks: [],
+      requiredStatusCheckContexts: [],
     });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -52,7 +52,7 @@ export function createPublishGithubAction(options: {
     allowMergeCommit?: boolean;
     sourcePath?: string;
     requireCodeOwnerReviews?: boolean;
-    requiredStatusChecks?: string[];
+    requiredStatusCheckContexts?: string[];
     repoVisibility?: 'private' | 'internal' | 'public';
     collaborators?: Array<{
       username: string;
@@ -89,8 +89,8 @@ export function createPublishGithubAction(options: {
               'Require an approved review in PR including files with a designated Code Owner',
             type: 'boolean',
           },
-          requiredStatusChecks: {
-            title: 'Required Status Checks',
+          requiredStatusCheckContexts: {
+            title: 'Required Status Check Contexts',
             description:
               'The list of status checks to require in order to merge into this branch',
             type: 'array',
@@ -188,7 +188,7 @@ export function createPublishGithubAction(options: {
         description,
         access,
         requireCodeOwnerReviews = false,
-        requiredStatusChecks = [],
+        requiredStatusCheckContexts = [],
         repoVisibility = 'private',
         defaultBranch = 'master',
         deleteBranchOnMerge = false,
@@ -328,7 +328,7 @@ export function createPublishGithubAction(options: {
           logger: ctx.logger,
           defaultBranch,
           requireCodeOwnerReviews,
-          requiredStatusChecks,
+          requiredStatusCheckContexts,
         });
       } catch (e) {
         assertError(e);

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -52,6 +52,7 @@ export function createPublishGithubAction(options: {
     allowMergeCommit?: boolean;
     sourcePath?: string;
     requireCodeOwnerReviews?: boolean;
+    requiredStatusChecks?: string[];
     repoVisibility?: 'private' | 'internal' | 'public';
     collaborators?: Array<{
       username: string;
@@ -87,6 +88,15 @@ export function createPublishGithubAction(options: {
             description:
               'Require an approved review in PR including files with a designated Code Owner',
             type: 'boolean',
+          },
+          requiredStatusChecks: {
+            title: 'Required Status Checks',
+            description:
+              'The list of status checks to require in order to merge into this branch',
+            type: 'array',
+            items: {
+              type: 'string',
+            },
           },
           repoVisibility: {
             title: 'Repository Visibility',
@@ -178,6 +188,7 @@ export function createPublishGithubAction(options: {
         description,
         access,
         requireCodeOwnerReviews = false,
+        requiredStatusChecks = [],
         repoVisibility = 'private',
         defaultBranch = 'master',
         deleteBranchOnMerge = false,
@@ -317,6 +328,7 @@ export function createPublishGithubAction(options: {
           logger: ctx.logger,
           defaultBranch,
           requireCodeOwnerReviews,
+          requiredStatusChecks,
         });
       } catch (e) {
         assertError(e);


### PR DESCRIPTION
Signed-off-by: Chris Trombley <ctrombley@gmail.com>

## Hey, I just made a Pull Request!

Update the `github:publish` scaffolder action to allow passing required status checks by name.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
