### PR TITLE
Permissions: Fix PermissionEvaluator instance checks

### DIFF
--- a/.changeset/sixty-llamas-change.md
+++ b/.changeset/sixty-llamas-change.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-jenkins-backend': patch
+'@backstage/plugin-search-backend': patch
+---
+
+Fixed issue in `PermissionEvaluator` instance check that would cause unexpected "invalid union" errors.

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -382,7 +382,7 @@ export class CatalogBuilder {
     const unauthorizedEntitiesCatalog = new DefaultEntitiesCatalog(dbClient);
 
     let permissionEvaluator: PermissionEvaluator;
-    if ('query' in permissions) {
+    if ('authorizeConditional' in permissions) {
       permissionEvaluator = permissions as PermissionEvaluator;
     } else {
       logger.warn(

--- a/plugins/jenkins-backend/src/service/router.ts
+++ b/plugins/jenkins-backend/src/service/router.ts
@@ -40,7 +40,7 @@ export async function createRouter(
   const { jenkinsInfoProvider, permissions, logger } = options;
 
   let permissionEvaluator: PermissionEvaluator | undefined;
-  if (permissions && 'query' in permissions) {
+  if (permissions && 'authorizeConditional' in permissions) {
     permissionEvaluator = permissions as PermissionEvaluator;
   } else {
     logger.warn(

--- a/plugins/search-backend/src/service/router.ts
+++ b/plugins/search-backend/src/service/router.ts
@@ -76,7 +76,7 @@ export async function createRouter(
   });
 
   let permissionEvaluator: PermissionEvaluator;
-  if ('query' in permissions) {
+  if ('authorizeConditional' in permissions) {
     permissionEvaluator = permissions as PermissionEvaluator;
   } else {
     logger.warn(


### PR DESCRIPTION
Signed-off-by: Joe Porpeglia <josephp@spotify.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes a bug where instances of `PermissionEvaluator` are passed into `toPermissionEvaluator`, resulting in invalid usage of the `authorize` method and "invalid union" errors.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
