### PR TITLE
Incl. Authorization Token to New Relic Dashboard Plugin 

### DIFF
--- a/.changeset/pink-mayflies-rhyme.md
+++ b/.changeset/pink-mayflies-rhyme.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-newrelic-dashboard': minor
+'@backstage/plugin-newrelic-dashboard': patch
 ---
 
-Included the Authorization Token to New Relic Dashboard Plugin, so that frontend can send an authenticated call to backend
+Add `FetchApi` and related `fetchApiRef` which implement fetch. in order to included the Authorization Token to New Relic Dashboard Plugin, so that frontend can send an authenticated proxy call to backend

--- a/.changeset/pink-mayflies-rhyme.md
+++ b/.changeset/pink-mayflies-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-newrelic-dashboard': minor
+---
+
+Included the Authorization Token to New Relic Dashboard Plugin, so that frontend can send an authenticated call to backend

--- a/plugins/newrelic-dashboard/src/api/NewRelicDashboardClient.ts
+++ b/plugins/newrelic-dashboard/src/api/NewRelicDashboardClient.ts
@@ -29,10 +29,18 @@ export class NewRelicDashboardClient implements NewRelicDashboardApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly fetchApi: FetchApi;
 
-  constructor(options: { discoveryApi: DiscoveryApi; fetchApi: FetchApi }) {
-    this.discoveryApi = options.discoveryApi;
-    this.fetchApi = options.fetchApi;
+  constructor({
+    discoveryApi,
+    fetchApi,
+  }: {
+    discoveryApi: DiscoveryApi;
+    fetchApi: FetchApi;
+    baseUrl?: string;
+  }) {
+    this.discoveryApi = discoveryApi;
+    this.fetchApi = fetchApi;
   }
+  
 
   private async callApi<T>(
     query: string,

--- a/plugins/newrelic-dashboard/src/api/NewRelicDashboardClient.ts
+++ b/plugins/newrelic-dashboard/src/api/NewRelicDashboardClient.ts
@@ -40,7 +40,6 @@ export class NewRelicDashboardClient implements NewRelicDashboardApi {
     this.discoveryApi = discoveryApi;
     this.fetchApi = fetchApi;
   }
-  
 
   private async callApi<T>(
     query: string,

--- a/plugins/newrelic-dashboard/src/api/NewRelicDashboardClient.ts
+++ b/plugins/newrelic-dashboard/src/api/NewRelicDashboardClient.ts
@@ -18,7 +18,7 @@ import {
   DashboardSnapshotSummary,
   NewRelicDashboardApi,
 } from './NewRelicDashboardApi';
-import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, IdentityApi } from '@backstage/core-plugin-api';
 import { DashboardEntity } from '../types/DashboardEntity';
 import { DashboardSnapshot } from '../types/DashboardSnapshot';
 import { getDashboardParentGuidQuery } from '../queries/getDashboardParentGuidQuery';
@@ -27,21 +27,27 @@ import { ResponseError } from '@backstage/errors';
 
 export class NewRelicDashboardClient implements NewRelicDashboardApi {
   private readonly discoveryApi: DiscoveryApi;
+  private readonly identityApi: IdentityApi;
   constructor({
     discoveryApi,
+    identityApi,
   }: {
     discoveryApi: DiscoveryApi;
+    identityApi: IdentityApi;
     baseUrl?: string;
   }) {
     this.discoveryApi = discoveryApi;
+    this.identityApi =  identityApi;
   }
 
   private async callApi<T>(
     query: string,
     variables: { [key in string]: string | number },
   ): Promise<T | undefined> {
+    const { token } = await this.identityApi.getCredentials();
     const myHeaders = new Headers();
     myHeaders.append('Content-Type', 'application/json');
+    myHeaders.append('Authorization', `Bearer ${token}`); 
     const graphql = JSON.stringify({
       query: query,
       variables: variables,

--- a/plugins/newrelic-dashboard/src/plugin.ts
+++ b/plugins/newrelic-dashboard/src/plugin.ts
@@ -19,7 +19,7 @@ import {
   createApiFactory,
   discoveryApiRef,
   createComponentExtension,
-  identityApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { newRelicDashboardApiRef, NewRelicDashboardClient } from './api';
 import { rootRouteRef } from './routes';
@@ -32,11 +32,15 @@ export const newRelicDashboardPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: newRelicDashboardApiRef,
-      deps: { configApi: configApiRef, discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-      factory: ({ configApi, discoveryApi, identityApi }) =>
+      deps: {
+        configApi: configApiRef,
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ configApi, discoveryApi, fetchApi }) =>
         new NewRelicDashboardClient({
           discoveryApi,
-          identityApi,
+          fetchApi,
           baseUrl: configApi.getOptionalString('newrelicdashboard.baseUrl'),
         }),
     }),

--- a/plugins/newrelic-dashboard/src/plugin.ts
+++ b/plugins/newrelic-dashboard/src/plugin.ts
@@ -19,6 +19,7 @@ import {
   createApiFactory,
   discoveryApiRef,
   createComponentExtension,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 import { newRelicDashboardApiRef, NewRelicDashboardClient } from './api';
 import { rootRouteRef } from './routes';
@@ -31,10 +32,11 @@ export const newRelicDashboardPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: newRelicDashboardApiRef,
-      deps: { configApi: configApiRef, discoveryApi: discoveryApiRef },
-      factory: ({ configApi, discoveryApi }) =>
+      deps: { configApi: configApiRef, discoveryApi: discoveryApiRef, identityApi: identityApiRef },
+      factory: ({ configApi, discoveryApi, identityApi }) =>
         new NewRelicDashboardClient({
           discoveryApi,
+          identityApi,
           baseUrl: configApi.getOptionalString('newrelicdashboard.baseUrl'),
         }),
     }),


### PR DESCRIPTION
## Hey, I just made a Pull Request! 

Authorising the new relic proxy call from frontend to backend by including User Authorization token to New Relic Dashboards Plugin. Appended myHeaders const with Authorization Token [at line 44 ](https://github.com/backstage/backstage/blob/da0675bf9f28ed1460f03635a22d3c26abd14707/plugins/newrelic-dashboard/src/api/NewRelicDashboardClient.ts#L44)from FetchApi + new import cascading changes. 

Discussed over an issue :  https://github.com/backstage/backstage/issues/9889

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. 
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message.
