### PR TITLE
cli: added experimental test configuration and module loader

### DIFF
--- a/.changeset/fast-cars-rest.md
+++ b/.changeset/fast-cars-rest.md
@@ -1,0 +1,7 @@
+---
+'@backstage/cli': patch
+---
+
+Introduced a new experimental test configuration with a number of changes. It switches the coverage provider from `v8` to the default Babel provider, along with always enabling source maps in the Sucrase transform. It also adds a custom module loader that caches both file transforms and VM script objects across all projects in a test run, which provides a big performance boost when running tests from the project root, increasing speed and reducing memory usage.
+
+This new configuration is not enabled by default. It is enabled by setting the environment variable `BACKSTAGE_NEXT_TESTS` to a non-empty value.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
         if: ${{ steps.yarn-lock.outcome == 'success' }}
         run: yarn lerna -- run test --since origin/master -- --coverage --runInBand
         env:
+          BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres13.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres9.ports[5432] }}
@@ -166,6 +167,7 @@ jobs:
           yarn lerna -- run test -- --coverage --runInBand
           bash <(curl -s https://codecov.io/bash) -N $(git rev-parse FETCH_HEAD)
         env:
+          BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres13.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres9.ports[5432] }}

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -122,6 +122,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -f packages/core-components/coverage/* -F core-components
           bash <(curl -s https://codecov.io/bash) -f packages/core-plugin-api/coverage/* -F core-plugin-api
         env:
+          BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
           BACKSTAGE_TEST_DATABASE_POSTGRES13_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres13.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_POSTGRES9_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres9.ports[5432] }}

--- a/.github/workflows/verify_windows.yml
+++ b/.github/workflows/verify_windows.yml
@@ -58,6 +58,7 @@ jobs:
       - name: test
         run: yarn lerna -- run test
         env:
+          BACKSTAGE_NEXT_TESTS: 1
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
 
       # credit: https://github.com/appleboy/discord-action/issues/3#issuecomment-731426861

--- a/packages/cli/config/jestCachingModuleLoader.js
+++ b/packages/cli/config/jestCachingModuleLoader.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const { default: JestRuntime } = require('jest-runtime');
+
+const fileTransformCache = new Map();
+const scriptTransformCache = new Map();
+
+let runtimeGeneration = 0;
+
+module.exports = class CachingJestRuntime extends JestRuntime {
+  // Each Jest run creates a new runtime, including when rerunning tests in
+  // watch mode. This keeps track of whether we've switched runtime instance.
+  __runtimeGeneration = runtimeGeneration++;
+
+  transformFile(filename, options) {
+    const entry = fileTransformCache.get(filename);
+    if (entry) {
+      // Only check modification time if it's from a different runtime generation
+      if (entry.generation === this.__runtimeGeneration) {
+        return entry.code;
+      }
+
+      // Keep track of the modification time of files so that we can properly
+      // reprocess them in watch mode.
+      const { mtimeMs } = fs.statSync(filename);
+      if (mtimeMs > entry.mtimeMs) {
+        const code = super.transformFile(filename, options);
+        fileTransformCache.set(filename, {
+          code,
+          mtimeMs,
+          generation: this.__runtimeGeneration,
+        });
+        return code;
+      }
+
+      fileTransformCache.set(filename, {
+        ...entry,
+        generation: this.__runtimeGeneration,
+      });
+      return entry.code;
+    }
+
+    const code = super.transformFile(filename, options);
+    fileTransformCache.set(filename, {
+      code,
+      mtimeMs: fs.statSync(filename).mtimeMs,
+      generation: this.__runtimeGeneration,
+    });
+    return code;
+  }
+
+  // This may or may not be a good idea. Theoretically I don't know why this would impact
+  // test correctness and flakiness, but it seems like it may introduce flakiness and strange failures.
+  // It does seem to speed up test execution by a fair amount though.
+  createScriptFromCode(scriptSource, filename) {
+    let script = scriptTransformCache.get(scriptSource);
+    if (!script) {
+      script = super.createScriptFromCode(scriptSource, filename);
+      // Tried to store the script object in a WeakRef here. It starts out at
+      // about 90% hit rate, but eventually drops all the way to 20%, and overall
+      // it seemed to increase memory usage by 20% or so.
+      scriptTransformCache.set(scriptSource, script);
+    }
+    return script;
+  }
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -86,6 +86,7 @@
     "html-webpack-plugin": "^5.3.1",
     "inquirer": "^8.2.0",
     "jest": "^27.5.1",
+    "jest-runtime": "^27.5.1",
     "jest-css-modules": "^2.1.0",
     "jest-transform-yaml": "^1.0.0",
     "json-schema": "^0.4.0",

--- a/packages/cli/src/lib/parallel.ts
+++ b/packages/cli/src/lib/parallel.ts
@@ -213,6 +213,7 @@ export async function runWorkerQueueThreads<TItem, TResult, TData>(
   return results;
 }
 
+/* istanbul ignore next */
 function workerQueueThread(
   workerFuncFactory: (
     data: unknown,
@@ -313,6 +314,7 @@ export async function runWorkerThreads<TResult, TData, TMessage>(
   );
 }
 
+/* istanbul ignore next */
 function workerThread(
   workerFunc: (
     data: unknown,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This introduces a new experimental test configuration that improves performance by a pretty large margin. I want to make sure there's no impact on test correctness or big negative change in coverage accuracy though, so making it an optional flag for now that we try out in our CI.

There are two big changes to the config, the first one being a switch back to the default Jest coverage provider, as it seems to have much better performance. The reason for switching to the `v8` provider to begin with was that the coverage accuracy was very bad with the default provider, but that should be counteracted now that we can provide source maps in the transformer output.

The second change is a bit more out there and experimental and it's a custom module loader, i.e. Jest runtime implementation. It extends the existing one by overriding the file transform and script creation methods and apply caching to these that work across separate Jest projects. Jest already does some very similar caching, but it's per project rather than globally. This change should be the more risky out of the two, and we should keep a close eye on test flakiness if enabling this by default.

Overall these changes seem to cut CI test time almost in half, and for local development I'm able to test the entire project with coverage in just below 1 minute on an M1 Pro/Max, without the Docker tests.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
