### PR TITLE
workflows: switch to tweaked changeset action

### DIFF
--- a/.github/workflows/sync_version-packages.yml
+++ b/.github/workflows/sync_version-packages.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile
       - name: Create Release Pull Request
-        uses: changesets/action@master
+        uses: backstage/changesets-action@v2
         with:
           # Calls out to `changeset version`, but also runs prettier
           version: yarn release


### PR DESCRIPTION
We hit the max character limit for GitHub Release notes, so switching things up to put the release changelog in a file instead