### PR TITLE
Bumped passport-microsoft to 1.0.0 to resolve CVE-2021-41580

### DIFF
--- a/.changeset/soft-cameras-cry.md
+++ b/.changeset/soft-cameras-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Bumped passport-microsoft to resolve CVE-2021-41580

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -66,7 +66,7 @@
     "passport-github2": "^0.1.12",
     "passport-gitlab2": "^5.0.0",
     "passport-google-oauth20": "^2.0.0",
-    "passport-microsoft": "^0.1.0",
+    "passport-microsoft": "^1.0.0",
     "passport-oauth2": "^1.6.1",
     "passport-okta-oauth": "^0.0.1",
     "passport-onelogin-oauth": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19554,13 +19554,13 @@ passport-google-oauth20@^2.0.0:
   dependencies:
     passport-oauth2 "1.x.x"
 
-passport-microsoft@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/passport-microsoft/-/passport-microsoft-0.1.0.tgz#dc72c1a38b294d74f4dc55fe93f52e25cb9aa5b4"
-  integrity sha512-0giBDgE1fnR5X84zJZkQ11hnKVrzEgViwRO6RGsormK9zTxFQmN/UHMTDbIpvhk989VqALewB6Pk1R5vNr3GHw==
+passport-microsoft@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/passport-microsoft/-/passport-microsoft-1.0.0.tgz#78954cf3201fdce61beeb6587a3b158f8e9db86c"
+  integrity sha512-L1JHeCbSObSZZXiG7jU2KoKie6nzZLwGt38HXz1GasKrsCQdOnf5kH8ltV4BWNUfBL2Pt1csWn1iuBSerprrcg==
   dependencies:
-    passport-oauth2 "1.2.0"
-    pkginfo "0.2.x"
+    passport-oauth2 "1.6.1"
+    pkginfo "0.4.x"
 
 passport-oauth1@1.x.x:
   version "1.1.0"
@@ -19571,16 +19571,7 @@ passport-oauth1@1.x.x:
     passport-strategy "1.x.x"
     utils-merge "1.x.x"
 
-passport-oauth2@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.2.0.tgz#49613a3eca85c7a1e65bf1019e2b6b80a10c8ac2"
-  integrity sha1-SWE6PsqFx6HmW/EBnitrgKEMisI=
-  dependencies:
-    oauth "0.9.x"
-    passport-strategy "1.x.x"
-    uid2 "0.0.x"
-
-passport-oauth2@1.x.x, passport-oauth2@^1.1.2, passport-oauth2@^1.4.0, passport-oauth2@^1.6.1:
+passport-oauth2@1.6.1, passport-oauth2@1.x.x, passport-oauth2@^1.1.2, passport-oauth2@^1.4.0, passport-oauth2@^1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.6.1.tgz#c5aee8f849ce8bd436c7f81d904a3cd1666f181b"
   integrity sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==
@@ -19975,6 +19966,11 @@ pkginfo@0.2.x:
   version "0.2.3"
   resolved "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz#7239c42a5ef6c30b8f328439d9b9ff71042490f8"
   integrity sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg=
+
+pkginfo@0.4.x:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
+  integrity sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=
 
 pluralize@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
Signed-off-by: Harry Hogg <hhogg@spotify.com>

## Hey, I just made a Pull Request!

Bumped passport-microsoft to 1.0.0 see https://github.com/seanfisher/passport-microsoft/pull/12 to resolve security vul. CVE-2021-41580. 

I see https://github.com/backstage/backstage/pull/9452 was already done a couple of months ago but I don't think this resolve the vul. because it's still being pulled down as a dep. of passport-microsoft  and is still in the yarn.lock.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
