### PR TITLE
fix: fix S3 object URL creation at AwsS3EntityProvider

### DIFF
--- a/.changeset/short-dodos-sparkle.md
+++ b/.changeset/short-dodos-sparkle.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+Fix S3 object URL creation at AwsS3EntityProvider by
+
+- handle absence of region config,
+- handle regions with region-less URIs (us-east-1),
+- apply URI encoding,
+- and simplify the logic overall.

--- a/.github/styles/vocab.txt
+++ b/.github/styles/vocab.txt
@@ -339,6 +339,7 @@ untracked
 upsert
 upvote
 url
+URIs
 URLs
 utils
 validator

--- a/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.ts
@@ -57,7 +57,7 @@ export class AwsS3EntityProvider implements EntityProvider {
     // Even though the awsS3 integration allows a config array
     // there is no *real* support for multiple configs.
     // Usually, there will be just the integration for the default host.
-    // In case, a config custom endpoint is used, the host from this endpoint
+    // In case, a custom endpoint is used, the host from this endpoint
     // will be extracted and used as host (e.g., localhost when used with LocalStack)
     // and the default integration will be added as second integration.
     // In this case, we still want the first one though, but have no means to select it
@@ -80,7 +80,7 @@ export class AwsS3EntityProvider implements EntityProvider {
 
   private constructor(
     private readonly config: AwsS3Config,
-    private readonly integration: AwsS3Integration,
+    integration: AwsS3Integration,
     logger: Logger,
     schedule: TaskRunner,
   ) {
@@ -196,16 +196,8 @@ export class AwsS3EntityProvider implements EntityProvider {
 
   private createObjectUrl(key: string): string {
     const bucketName = this.config.bucketName;
-    const endpoint = this.integration.config.endpoint;
+    const endpoint = this.s3.endpoint.href;
 
-    if (endpoint) {
-      if (endpoint.startsWith(`https://${bucketName}.`)) {
-        return `${endpoint}/${key}`;
-      }
-
-      return `${endpoint}/${bucketName}/${key}`;
-    }
-
-    return `https://${bucketName}.s3.${this.config.region}.amazonaws.com/${key}`;
+    return encodeURI(`${endpoint}${bucketName}/${key}`);
   }
 }


### PR DESCRIPTION
Fix S3 object URL creation at AwsS3EntityProvider by

- handle absence of region config,
- handle regions with region-less URIs (us-east-1),
- apply URI encoding,
- and simplify the logic overall.

Signed-off-by: Patrick Jungermann <Patrick.Jungermann@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
