### PR TITLE
renovate: bump eslint config packages together

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,4 +2,11 @@
   labels: ['dependencies'],
   extends: ['config:base', ':disableDependencyDashboard', ':gitSignOff'],
   rangeStrategy: 'update-lockfile',
+  packageRules: [
+    {
+      matchSourceUrlPrefixes: ['https://github.com/spotify/web-scripts'],
+      groupName: 'Spotify web-scripts monorepo packages',
+      rangeStrategy: 'replace',
+    },
+  ],
 }


### PR DESCRIPTION
Inspired by https://docs.renovatebot.com/configuration-options/#matchsourceurlprefixes
