### PR TITLE
patch/v1.1.0: Release fix for PermissionEvaluator checks (#10849)

### DIFF
--- a/.changeset/sixty-llamas-change.md
+++ b/.changeset/sixty-llamas-change.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-jenkins-backend': patch
+'@backstage/plugin-search-backend': patch
+---
+
+Fixed issue in `PermissionEvaluator` instance check that would cause unexpected "invalid union" errors.

--- a/.changeset/sixty-llamas-change.md
+++ b/.changeset/sixty-llamas-change.md
@@ -1,7 +1,0 @@
----
-'@backstage/plugin-catalog-backend': patch
-'@backstage/plugin-jenkins-backend': patch
-'@backstage/plugin-search-backend': patch
----
-
-Fixed issue in `PermissionEvaluator` instance check that would cause unexpected "invalid union" errors.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/react": "^17",
     "@types/react-dom": "^17"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": {
     "@manypkg/get-packages": "^1.1.3",
     "@microsoft/api-documenter": "^7.17.5",

--- a/plugins/catalog-backend/CHANGELOG.md
+++ b/plugins/catalog-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-catalog-backend
 
+## 1.1.1
+
+### Patch Changes
+
+- 777f2125ac: Fixed issue in `PermissionEvaluator` instance check that would cause unexpected "invalid union" errors.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-catalog-backend",
   "description": "The Backstage backend plugin that provides the Backstage catalog",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -382,7 +382,7 @@ export class CatalogBuilder {
     const unauthorizedEntitiesCatalog = new DefaultEntitiesCatalog(dbClient);
 
     let permissionEvaluator: PermissionEvaluator;
-    if ('query' in permissions) {
+    if ('authorizeConditional' in permissions) {
       permissionEvaluator = permissions as PermissionEvaluator;
     } else {
       logger.warn(

--- a/plugins/jenkins-backend/CHANGELOG.md
+++ b/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-jenkins-backend
 
+## 0.1.21
+
+### Patch Changes
+
+- 777f2125ac: Fixed issue in `PermissionEvaluator` instance check that would cause unexpected "invalid union" errors.
+
 ## 0.1.20
 
 ### Patch Changes

--- a/plugins/jenkins-backend/package.json
+++ b/plugins/jenkins-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-jenkins-backend",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/jenkins-backend/src/service/router.ts
+++ b/plugins/jenkins-backend/src/service/router.ts
@@ -40,7 +40,7 @@ export async function createRouter(
   const { jenkinsInfoProvider, permissions, logger } = options;
 
   let permissionEvaluator: PermissionEvaluator | undefined;
-  if (permissions && 'query' in permissions) {
+  if (permissions && 'authorizeConditional' in permissions) {
     permissionEvaluator = permissions as PermissionEvaluator;
   } else {
     logger.warn(

--- a/plugins/search-backend/CHANGELOG.md
+++ b/plugins/search-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/plugin-search-backend
 
+## 0.5.1
+
+### Patch Changes
+
+- 777f2125ac: Fixed issue in `PermissionEvaluator` instance check that would cause unexpected "invalid union" errors.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/plugins/search-backend/package.json
+++ b/plugins/search-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage/plugin-search-backend",
   "description": "The Backstage backend plugin that provides your backstage app with search",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/search-backend/src/service/router.ts
+++ b/plugins/search-backend/src/service/router.ts
@@ -76,7 +76,7 @@ export async function createRouter(
   });
 
   let permissionEvaluator: PermissionEvaluator;
-  if ('query' in permissions) {
+  if ('authorizeConditional' in permissions) {
     permissionEvaluator = permissions as PermissionEvaluator;
   } else {
     logger.warn(


### PR DESCRIPTION
This release patches the Catalog, Jenkins, and Search backend plugins to fix a breakage when passing in a `PermissionEvaluator`.