### PR TITLE
[TechDocs] Restore 404 behavior

### DIFF
--- a/.changeset/techdocs-changeset-not-found.md
+++ b/.changeset/techdocs-changeset-not-found.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed bugs that prevented a 404 error from being shown when it should have been.

--- a/plugins/techdocs/api-report.md
+++ b/plugins/techdocs/api-report.md
@@ -322,7 +322,7 @@ export type TechDocsReaderPageContentProps = {
 // @public
 export const TechDocsReaderPageHeader: (
   props: TechDocsReaderPageHeaderProps,
-) => JSX.Element;
+) => JSX.Element | null;
 
 // @public @deprecated
 export type TechDocsReaderPageHeaderProps = PropsWithChildren<{

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.test.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.test.tsx
@@ -148,6 +148,28 @@ describe('<TechDocsReaderPageHeader />', () => {
     });
   });
 
+  it('should not render a techdocs page header if techdocs metadata is missing', async () => {
+    getTechDocsMetadata.mockResolvedValue(undefined);
+
+    await act(async () => {
+      const rendered = await renderInTestApp(
+        <Wrapper>
+          <TechDocsReaderPageHeader />
+        </Wrapper>,
+        {
+          mountedRoutes: {
+            '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+            '/docs': rootRouteRef,
+          },
+        },
+      );
+
+      await waitFor(() => {
+        expect(rendered.container.innerHTML).not.toContain('header');
+      });
+    });
+  });
+
   it('should render a link back to the component page', async () => {
     getTechDocsMetadata.mockResolvedValue(mockTechDocsMetadata);
 

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -72,7 +72,7 @@ export const TechDocsReaderPageHeader = (
     setSubtitle,
     entityRef,
     metadata: { value: metadata },
-    entityMetadata: { value: entityMetadata },
+    entityMetadata: { value: entityMetadata, loading: entityMetadataLoading },
   } = useTechDocsReaderPage();
 
   useEffect(() => {
@@ -145,6 +145,10 @@ export const TechDocsReaderPageHeader = (
       ) : null}
     </>
   );
+
+  // If there is no entity metadata, there's no reason to show the header.
+  if (entityMetadataLoading === false && entityMetadata === undefined)
+    return null;
 
   return (
     <Header

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -71,7 +71,7 @@ export const TechDocsReaderPageHeader = (
     subtitle,
     setSubtitle,
     entityRef,
-    metadata: { value: metadata },
+    metadata: { value: metadata, loading: metadataLoading },
     entityMetadata: { value: entityMetadata, loading: entityMetadataLoading },
   } = useTechDocsReaderPage();
 
@@ -146,9 +146,11 @@ export const TechDocsReaderPageHeader = (
     </>
   );
 
-  // If there is no entity metadata, there's no reason to show the header.
-  if (entityMetadataLoading === false && entityMetadata === undefined)
-    return null;
+  // If there is no entity or techdocs metadata, there's no reason to show the
+  // header (hides the header on 404 error pages).
+  const noEntMetadata = !entityMetadataLoading && entityMetadata === undefined;
+  const noTdMetadata = !metadataLoading && metadata === undefined;
+  if (noEntMetadata || noTdMetadata) return null;
 
   return (
     <Header

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageSubheader/TechDocsReaderPageSubheader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageSubheader/TechDocsReaderPageSubheader.tsx
@@ -21,6 +21,7 @@ import { Box, makeStyles, Toolbar, ToolbarProps } from '@material-ui/core';
 import {
   TechDocsAddonLocations as locations,
   useTechDocsAddons,
+  useTechDocsReaderPage,
 } from '@backstage/plugin-techdocs-react';
 
 const useStyles = makeStyles(theme => ({
@@ -43,12 +44,18 @@ export const TechDocsReaderPageSubheader = ({
   toolbarProps?: ToolbarProps;
 }) => {
   const classes = useStyles();
+  const {
+    entityMetadata: { value: entityMetadata, loading: entityMetadataLoading },
+  } = useTechDocsReaderPage();
   const addons = useTechDocsAddons();
   const subheaderAddons = addons.renderComponentsByLocation(
     locations.Subheader,
   );
 
   if (!subheaderAddons) return null;
+
+  // No entity metadata = 404. Don't render subheader on 404.
+  if (entityMetadataLoading === false && !entityMetadata) return null;
 
   return (
     <Toolbar classes={classes} {...toolbarProps}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The refactoring of the reader page to support Addons introduced some regressions related to 404 states.  ...This ensures 404 behavior today matches 404 behavior prior to Addon support being added (and adds some regression tests to that end).

| Scenario                         | Before | After |
|----------------------------------|--------|-------|
| Entity Not Found                 | ![bug-404-entity-does-not-exist](https://user-images.githubusercontent.com/3496491/164227667-f6174bb7-e5b8-45e0-82ac-0fa883e09589.png) | ![fixed-404-entity-does-not-exist](https://user-images.githubusercontent.com/3496491/164227709-b6195283-cd4c-4590-afe0-a877ab354114.png) |
| Content Not Found                | ![bug-404-content-not-found](https://user-images.githubusercontent.com/3496491/164227280-37bb14c4-3877-44e4-8d21-6b8954991aaa.png) | ![fixed-404-content-not-found](https://user-images.githubusercontent.com/3496491/164227549-acde492d-a2b8-4822-8e3d-317114f11f7a.png) |
| Content Not Found (Entity Page)  | ![bug-404-entity-page-content-not-found](https://user-images.githubusercontent.com/3496491/164227786-a1c47c5c-67ca-41d5-a465-3d5642f39e99.png) | ![fixed-404-entity-page-content-not-found](https://user-images.githubusercontent.com/3496491/164227825-3c37a0a1-2bce-48df-a589-ec360053466a.png) |








#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
