### PR TITLE
Added default commit msg for Github, Azure, Bitbucket

### DIFF
--- a/.changeset/mean-flowers-change.md
+++ b/.changeset/mean-flowers-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Override default commit message and author details in GitHub, Azure, bitbucket

--- a/plugins/scaffolder-backend/api-report.md
+++ b/plugins/scaffolder-backend/api-report.md
@@ -193,6 +193,9 @@ export function createPublishAzureAction(options: {
   defaultBranch?: string | undefined;
   sourcePath?: string | undefined;
   token?: string | undefined;
+  gitCommitMessage?: string | undefined;
+  gitAuthorName?: string | undefined;
+  gitAuthorEmail?: string | undefined;
 }>;
 
 // @public
@@ -207,6 +210,9 @@ export function createPublishBitbucketAction(options: {
   sourcePath?: string | undefined;
   enableLFS?: boolean | undefined;
   token?: string | undefined;
+  gitCommitMessage?: string | undefined;
+  gitAuthorName?: string | undefined;
+  gitAuthorEmail?: string | undefined;
 }>;
 
 // @public
@@ -225,6 +231,9 @@ export function createPublishGithubAction(options: {
   access?: string | undefined;
   defaultBranch?: string | undefined;
   deleteBranchOnMerge?: boolean | undefined;
+  gitCommitMessage?: string | undefined;
+  gitAuthorName?: string | undefined;
+  gitAuthorEmail?: string | undefined;
   allowRebaseMerge?: boolean | undefined;
   allowSquashMerge?: boolean | undefined;
   allowMergeCommit?: boolean | undefined;

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.test.ts
@@ -192,6 +192,7 @@ describe('publish:azure', () => {
       defaultBranch: 'master',
       auth: { username: 'notempty', password: 'tokenlols' },
       logger: mockContext.logger,
+      commitMessage: 'initial commit',
       gitAuthorInfo: {},
     });
   });
@@ -215,6 +216,7 @@ describe('publish:azure', () => {
       defaultBranch: 'master',
       auth: { username: 'notempty', password: 'tokenlols' },
       logger: mockContext.logger,
+      commitMessage: 'initial commit',
       gitAuthorInfo: {},
     });
   });
@@ -254,6 +256,7 @@ describe('publish:azure', () => {
       auth: { username: 'notempty', password: 'tokenlols' },
       logger: mockContext.logger,
       defaultBranch: 'master',
+      commitMessage: 'initial commit',
       gitAuthorInfo: { name: 'Test', email: 'example@example.com' },
     });
   });
@@ -290,7 +293,7 @@ describe('publish:azure', () => {
       auth: { username: 'notempty', password: 'tokenlols' },
       logger: mockContext.logger,
       defaultBranch: 'master',
-      commitMessage: 'Test commit message',
+      commitMessage: 'initial commit',
       gitAuthorInfo: { email: undefined, name: undefined },
     });
   });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/azure.ts
@@ -40,6 +40,9 @@ export function createPublishAzureAction(options: {
     defaultBranch?: string;
     sourcePath?: string;
     token?: string;
+    gitCommitMessage?: string;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
   }>({
     id: 'publish:azure',
     description:
@@ -61,6 +64,21 @@ export function createPublishAzureAction(options: {
             title: 'Default Branch',
             type: 'string',
             description: `Sets the default branch on the repository. The default value is 'master'`,
+          },
+          gitCommitMessage: {
+            title: 'Git Commit Message',
+            type: 'string',
+            description: `Sets the commit message on the repository. The default value is 'initial commit'`,
+          },
+          gitAuthorName: {
+            title: 'Default Author Name',
+            type: 'string',
+            description: `Sets the default author name for the commit. The default value is 'Scaffolder'`,
+          },
+          gitAuthorEmail: {
+            title: 'Default Author Email',
+            type: 'string',
+            description: `Sets the default author email for the commit.`,
           },
           sourcePath: {
             title: 'Source Path',
@@ -90,7 +108,13 @@ export function createPublishAzureAction(options: {
       },
     },
     async handler(ctx) {
-      const { repoUrl, defaultBranch = 'master' } = ctx.input;
+      const {
+        repoUrl,
+        defaultBranch = 'master',
+        gitCommitMessage = 'initial commit',
+        gitAuthorName,
+        gitAuthorEmail,
+      } = ctx.input;
 
       const { owner, repo, host, organization } = parseRepoUrl(
         repoUrl,
@@ -142,8 +166,12 @@ export function createPublishAzureAction(options: {
       const repoContentsUrl = remoteUrl;
 
       const gitAuthorInfo = {
-        name: config.getOptionalString('scaffolder.defaultAuthor.name'),
-        email: config.getOptionalString('scaffolder.defaultAuthor.email'),
+        name: gitAuthorName
+          ? gitAuthorName
+          : config.getOptionalString('scaffolder.defaultAuthor.name'),
+        email: gitAuthorEmail
+          ? gitAuthorEmail
+          : config.getOptionalString('scaffolder.defaultAuthor.email'),
       };
 
       await initRepoAndPush({
@@ -155,9 +183,9 @@ export function createPublishAzureAction(options: {
           password: token,
         },
         logger: ctx.logger,
-        commitMessage: config.getOptionalString(
-          'scaffolder.defaultCommitMessage',
-        ),
+        commitMessage: gitCommitMessage
+          ? gitCommitMessage
+          : config.getOptionalString('scaffolder.defaultCommitMessage'),
         gitAuthorInfo,
       });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.test.ts
@@ -348,6 +348,7 @@ describe('publish:bitbucket', () => {
       defaultBranch: 'master',
       auth: { username: 'x-token-auth', password: 'tokenlols' },
       logger: mockContext.logger,
+      commitMessage: 'initial commit',
       gitAuthorInfo: {},
     });
   });
@@ -391,6 +392,7 @@ describe('publish:bitbucket', () => {
       defaultBranch: 'main',
       auth: { username: 'x-token-auth', password: 'tokenlols' },
       logger: mockContext.logger,
+      commitMessage: 'initial commit',
       gitAuthorInfo: {},
     });
   });
@@ -460,6 +462,7 @@ describe('publish:bitbucket', () => {
       auth: { username: 'x-token-auth', password: 'tokenlols' },
       logger: mockContext.logger,
       defaultBranch: 'master',
+      commitMessage: 'initial commit',
       gitAuthorInfo: { name: 'Test', email: 'example@example.com' },
     });
   });
@@ -526,7 +529,7 @@ describe('publish:bitbucket', () => {
       auth: { username: 'x-token-auth', password: 'tokenlols' },
       logger: mockContext.logger,
       defaultBranch: 'master',
-      commitMessage: 'Test commit message',
+      commitMessage: 'initial commit',
       gitAuthorInfo: { email: undefined, name: undefined },
     });
   });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/bitbucket.ts
@@ -213,6 +213,9 @@ export function createPublishBitbucketAction(options: {
     sourcePath?: string;
     enableLFS?: boolean;
     token?: string;
+    gitCommitMessage?: string;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
   }>({
     id: 'publish:bitbucket',
     description:
@@ -257,6 +260,21 @@ export function createPublishBitbucketAction(options: {
             type: 'string',
             description: 'The token to use for authorization to BitBucket',
           },
+          gitCommitMessage: {
+            title: 'Git Commit Message',
+            type: 'string',
+            description: `Sets the commit message on the repository. The default value is 'initial commit'`,
+          },
+          gitAuthorName: {
+            title: 'Default Author Name',
+            type: 'string',
+            description: `Sets the default author name for the commit. The default value is 'Scaffolder'`,
+          },
+          gitAuthorEmail: {
+            title: 'Default Author Email',
+            type: 'string',
+            description: `Sets the default author email for the commit.`,
+          },
         },
       },
       output: {
@@ -280,6 +298,9 @@ export function createPublishBitbucketAction(options: {
         defaultBranch = 'master',
         repoVisibility = 'private',
         enableLFS = false,
+        gitCommitMessage = 'initial commit',
+        gitAuthorName,
+        gitAuthorEmail,
       } = ctx.input;
 
       const { workspace, project, repo, host } = parseRepoUrl(
@@ -340,8 +361,12 @@ export function createPublishBitbucketAction(options: {
       });
 
       const gitAuthorInfo = {
-        name: config.getOptionalString('scaffolder.defaultAuthor.name'),
-        email: config.getOptionalString('scaffolder.defaultAuthor.email'),
+        name: gitAuthorName
+          ? gitAuthorName
+          : config.getOptionalString('scaffolder.defaultAuthor.name'),
+        email: gitAuthorEmail
+          ? gitAuthorEmail
+          : config.getOptionalString('scaffolder.defaultAuthor.email'),
       };
 
       let auth;
@@ -368,9 +393,9 @@ export function createPublishBitbucketAction(options: {
         auth,
         defaultBranch,
         logger: ctx.logger,
-        commitMessage: config.getOptionalString(
-          'scaffolder.defaultCommitMessage',
-        ),
+        commitMessage: gitCommitMessage
+          ? gitCommitMessage
+          : config.getOptionalString('scaffolder.defaultCommitMessage'),
         gitAuthorInfo,
       });
 

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.test.ts
@@ -198,6 +198,7 @@ describe('publish:github', () => {
       defaultBranch: 'master',
       auth: { username: 'x-access-token', password: 'tokenlols' },
       logger: mockContext.logger,
+      commitMessage: 'initial commit',
       gitAuthorInfo: {},
     });
   });
@@ -228,6 +229,7 @@ describe('publish:github', () => {
       defaultBranch: 'main',
       auth: { username: 'x-access-token', password: 'tokenlols' },
       logger: mockContext.logger,
+      commitMessage: 'initial commit',
       gitAuthorInfo: {},
     });
   });
@@ -275,6 +277,7 @@ describe('publish:github', () => {
       defaultBranch: 'master',
       auth: { username: 'x-access-token', password: 'tokenlols' },
       logger: mockContext.logger,
+      commitMessage: 'initial commit',
       gitAuthorInfo: { name: 'Test', email: 'example@example.com' },
     });
   });
@@ -319,7 +322,7 @@ describe('publish:github', () => {
       defaultBranch: 'master',
       auth: { username: 'x-access-token', password: 'tokenlols' },
       logger: mockContext.logger,
-      commitMessage: 'Test commit message',
+      commitMessage: 'initial commit',
       gitAuthorInfo: { email: undefined, name: undefined },
     });
   });

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/publish/github.ts
@@ -47,6 +47,9 @@ export function createPublishGithubAction(options: {
     access?: string;
     defaultBranch?: string;
     deleteBranchOnMerge?: boolean;
+    gitCommitMessage?: string;
+    gitAuthorName?: string;
+    gitAuthorEmail?: string;
     allowRebaseMerge?: boolean;
     allowSquashMerge?: boolean;
     allowMergeCommit?: boolean;
@@ -102,6 +105,21 @@ export function createPublishGithubAction(options: {
             title: 'Delete Branch On Merge',
             type: 'boolean',
             description: `Delete the branch after merging the PR. The default value is 'false'`,
+          },
+          gitCommitMessage: {
+            title: 'Git Commit Message',
+            type: 'string',
+            description: `Sets the commit message on the repository. The default value is 'initial commit'`,
+          },
+          gitAuthorName: {
+            title: 'Default Author Name',
+            type: 'string',
+            description: `Sets the default author name for the commit. The default value is 'Scaffolder'`,
+          },
+          gitAuthorEmail: {
+            title: 'Default Author Email',
+            type: 'string',
+            description: `Sets the default author email for the commit.`,
           },
           allowMergeCommit: {
             title: 'Allow Merge Commits',
@@ -181,6 +199,9 @@ export function createPublishGithubAction(options: {
         repoVisibility = 'private',
         defaultBranch = 'master',
         deleteBranchOnMerge = false,
+        gitCommitMessage = 'initial commit',
+        gitAuthorName,
+        gitAuthorEmail,
         allowMergeCommit = true,
         allowSquashMerge = true,
         allowRebaseMerge = true,
@@ -290,8 +311,12 @@ export function createPublishGithubAction(options: {
       const repoContentsUrl = `${newRepo.html_url}/blob/${defaultBranch}`;
 
       const gitAuthorInfo = {
-        name: config.getOptionalString('scaffolder.defaultAuthor.name'),
-        email: config.getOptionalString('scaffolder.defaultAuthor.email'),
+        name: gitAuthorName
+          ? gitAuthorName
+          : config.getOptionalString('scaffolder.defaultAuthor.name'),
+        email: gitAuthorEmail
+          ? gitAuthorEmail
+          : config.getOptionalString('scaffolder.defaultAuthor.email'),
       };
 
       await initRepoAndPush({
@@ -303,9 +328,9 @@ export function createPublishGithubAction(options: {
           password: octokitOptions.auth,
         },
         logger: ctx.logger,
-        commitMessage: config.getOptionalString(
-          'scaffolder.defaultCommitMessage',
-        ),
+        commitMessage: gitCommitMessage
+          ? gitCommitMessage
+          : config.getOptionalString('scaffolder.defaultCommitMessage'),
         gitAuthorInfo,
       });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Currently, we have the following default author and commit message for Scaffolder, so changes are made in order to override the default commit message and author details for multiple teams in the organization, different teams might have their own regex patterns for commit messages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
