### PR TITLE
Updated documentation to rename plugin

### DIFF
--- a/docs/features/software-templates/writing-custom-field-extensions.md
+++ b/docs/features/software-templates/writing-custom-field-extensions.md
@@ -74,17 +74,17 @@ export const myCustomValidation = (
   This is where the magic happens and creates the custom field extension.
 
   Note that if you're writing extensions part of a separate plugin,
-  then please use `plugin.provide` from there instead and export it part of your `plugin.ts` rather than re-using the `scaffolder.plugin`.
+  then please use `scaffolderPlugin.provide` from there instead and export it part of your `plugin.ts` rather than re-using the `scaffolder.plugin`.
 */
 
 import {
-  plugin,
+  scaffolderPlugin,
   createScaffolderFieldExtension,
 } from '@backstage/plugin-scaffolder';
 import { MyCustomExtension } from './MyCustomExtension';
 import { myCustomValidation } from './validation';
 
-export const MyCustomFieldExtension = plugin.provide(
+export const MyCustomFieldExtension = scaffolderPlugin.provide(
   createScaffolderFieldExtension({
     name: 'MyCustomExtension',
     component: MyCustomExtension,


### PR DESCRIPTION
Documentation was not up to date with master codebase where plugin has been renamed to scaffolderPlugin

## Hey, I just made a Pull Request!

Minor update to documentation

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
