### PR TITLE
fix: remove page element

### DIFF
--- a/.changeset/cool-mice-sit.md
+++ b/.changeset/cool-mice-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-insights': patch
+---
+
+Add new component `EntityTechInsightsScorecardCard`, which can be used in the overview of the `EntityPage` page or display multiple individual `EntityTechInsightsScorecardCard` in `EntityLayout.Route`.

--- a/plugins/tech-insights/README.md
+++ b/plugins/tech-insights/README.md
@@ -38,10 +38,6 @@ const serviceEntityPage = (
         title="Customized title for the scorecard"
         description="Small description about scorecards"
       />
-      <EntityTechInsightsScorecardContent
-        title="Show only simpleTestCheck in this card"
-        checksId={['simpleTestCheck']}
-      />
     </EntityLayout.Route>
     ...
   </EntityLayoutWrapper>
@@ -50,7 +46,44 @@ const serviceEntityPage = (
 
 It is not obligatory to pass title and description props to `EntityTechInsightsScorecardContent`. If those are left out, default values from `defaultCheckResultRenderers` in `CheckResultRenderer` will be taken, hence `Boolean scorecard` and `This card represents an overview of default boolean Backstage checks`.
 
+If you like to display multiple cards in a `EntityLayout.Route` use `EntityTechInsightsScorecardCard`.
+
 You can pass an array `checksId` as a prop with the [Fact Retrievers ids](../tech-insights-backend#creating-fact-retrievers) to limit which checks you want to show in this card, If you don't pass, the default value is show all checks.
+
+```tsx
+<EntityTechInsightsScorecardContent
+  title="Show only simpleTestCheck in this card"
+  checksId={['simpleTestCheck']}
+/>
+```
+
+If you want to show checks in the overview of an entity use `EntityTechInsightsScorecardCard`.
+
+```tsx
+// packages/app/src/components/catalog/EntityPage.tsx
+
+import { EntityTechInsightsScorecardCard } from '@backstage/plugin-tech-insights';
+
+const overviewContent = (
+  <Grid container spacing={3} alignItems="stretch">
+    {entityWarningContent}
+    <Grid item md={6} xs={12}>
+      <EntityAboutCard variant="gridItem" />
+    </Grid>
+    <Grid item md={6} xs={12}>
+      <EntityCatalogGraphCard variant="gridItem" height={400} />
+    </Grid>
+    ...
+    <Grid item md={8} xs={12}>
+      <EntityTechInsightsScorecardCard
+        title="Customized title for the scorecard"
+        description="Small description about scorecards"
+        checksId={['simpleTestCheck']}
+      />
+    </Grid>
+  </Grid>
+);
+```
 
 ## Boolean Scorecard Example
 

--- a/plugins/tech-insights/api-report.md
+++ b/plugins/tech-insights/api-report.md
@@ -31,6 +31,17 @@ export type CheckResultRenderer = {
 };
 
 // @public (undocumented)
+export const EntityTechInsightsScorecardCard: ({
+  title,
+  description,
+  checksId,
+}: {
+  title?: string | undefined;
+  description?: string | undefined;
+  checksId?: string[] | undefined;
+}) => JSX.Element;
+
+// @public (undocumented)
 export const EntityTechInsightsScorecardContent: ({
   title,
   description,

--- a/plugins/tech-insights/src/components/ScorecardsCard/ScorecardsCard.tsx
+++ b/plugins/tech-insights/src/components/ScorecardsCard/ScorecardsCard.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import useAsync from 'react-use/lib/useAsync';
+import { Progress } from '@backstage/core-components';
+import { useApi } from '@backstage/core-plugin-api';
+import { ScorecardInfo } from '../ScorecardsInfo';
+import Alert from '@material-ui/lab/Alert';
+import { techInsightsApiRef } from '../../api/TechInsightsApi';
+
+export const ScorecardsCard = ({
+  title,
+  description,
+  checksId,
+}: {
+  title?: string;
+  description?: string;
+  checksId?: string[];
+}) => {
+  const api = useApi(techInsightsApiRef);
+  const { namespace, kind, name } = useParams();
+  const { value, loading, error } = useAsync(
+    async () => await api.runChecks({ namespace, kind, name }, checksId),
+  );
+
+  if (loading) {
+    return <Progress />;
+  } else if (error) {
+    return <Alert severity="error">{error.message}</Alert>;
+  }
+
+  return (
+    <ScorecardInfo
+      title={title}
+      description={description}
+      checks={value || []}
+    />
+  );
+};

--- a/plugins/tech-insights/src/components/ScorecardsCard/index.ts
+++ b/plugins/tech-insights/src/components/ScorecardsCard/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { ScorecardsOverview } from './ScorecardsOverview';
+export { ScorecardsCard } from './ScorecardsCard';

--- a/plugins/tech-insights/src/components/ScorecardsContent/ScorecardContent.tsx
+++ b/plugins/tech-insights/src/components/ScorecardsContent/ScorecardContent.tsx
@@ -17,13 +17,21 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import useAsync from 'react-use/lib/useAsync';
-import { Progress } from '@backstage/core-components';
+import { Content, Page, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import { ChecksOverview } from './ChecksOverview';
+import { ScorecardInfo } from '../ScorecardsInfo';
 import Alert from '@material-ui/lab/Alert';
 import { techInsightsApiRef } from '../../api/TechInsightsApi';
+import { makeStyles } from '@material-ui/core';
 
-export const ScorecardsOverview = ({
+const useStyles = makeStyles(() => ({
+  contentScorecards: {
+    paddingLeft: 0,
+    paddingRight: 0,
+  },
+}));
+
+export const ScorecardsContent = ({
   title,
   description,
   checksId,
@@ -32,6 +40,7 @@ export const ScorecardsOverview = ({
   description?: string;
   checksId?: string[];
 }) => {
+  const classes = useStyles();
   const api = useApi(techInsightsApiRef);
   const { namespace, kind, name } = useParams();
   const { value, loading, error } = useAsync(
@@ -45,10 +54,14 @@ export const ScorecardsOverview = ({
   }
 
   return (
-    <ChecksOverview
-      title={title}
-      description={description}
-      checks={value || []}
-    />
+    <Page themeId="home">
+      <Content className={classes.contentScorecards}>
+        <ScorecardInfo
+          title={title}
+          description={description}
+          checks={value || []}
+        />
+      </Content>
+    </Page>
   );
 };

--- a/plugins/tech-insights/src/components/ScorecardsContent/index.ts
+++ b/plugins/tech-insights/src/components/ScorecardsContent/index.ts
@@ -13,13 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export {
-  techInsightsPlugin,
-  EntityTechInsightsScorecardContent,
-  EntityTechInsightsScorecardCard,
-} from './plugin';
 
-export { techInsightsApiRef } from './api/TechInsightsApi';
-export type { TechInsightsApi } from './api/TechInsightsApi';
-export type { Check } from './api/types';
-export type { CheckResultRenderer } from './components/CheckResultRenderer';
+export { ScorecardsContent } from './ScorecardContent';

--- a/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
+++ b/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
@@ -17,17 +17,13 @@
 import React from 'react';
 import { makeStyles, Grid, Typography } from '@material-ui/core';
 import { useApi } from '@backstage/core-plugin-api';
-import { Content, Page, InfoCard } from '@backstage/core-components';
+import { InfoCard } from '@backstage/core-components';
 import { CheckResult } from '@backstage/plugin-tech-insights-common';
 import { techInsightsApiRef } from '../../api/TechInsightsApi';
 import { BackstageTheme } from '@backstage/theme';
 import { Alert } from '@material-ui/lab';
 
 const useStyles = makeStyles((theme: BackstageTheme) => ({
-  contentScorecards: {
-    paddingLeft: 0,
-    paddingRight: 0,
-  },
   subheader: {
     fontWeight: 'bold',
     paddingLeft: theme.spacing(0.5),
@@ -40,12 +36,37 @@ type Checks = {
   description?: string;
 };
 
-export const ChecksOverview = ({ checks, title, description }: Checks) => {
+const infoCard = (
+  title: Checks['title'],
+  description: Checks['description'],
+  className: string,
+  element: JSX.Element,
+) => (
+  <Grid item xs={12}>
+    <InfoCard title={title}>
+      <Typography className={className} variant="body1" gutterBottom>
+        {description}
+      </Typography>
+      <Grid item xs={12}>
+        {element}
+      </Grid>
+    </InfoCard>
+  </Grid>
+);
+
+export const ScorecardInfo = ({ checks, title, description }: Checks) => {
   const classes = useStyles();
   const api = useApi(techInsightsApiRef);
+
   if (!checks.length) {
-    return <Alert severity="warning">No checks have any data yet.</Alert>;
+    return infoCard(
+      title,
+      description,
+      classes.subheader,
+      <Alert severity="warning">No checks have any data yet.</Alert>,
+    );
   }
+
   const checkRenderType = api.getScorecardsDefinition(
     checks[0].check.type,
     checks,
@@ -54,21 +75,11 @@ export const ChecksOverview = ({ checks, title, description }: Checks) => {
   );
 
   if (checkRenderType) {
-    return (
-      <Page themeId="home">
-        <Content className={classes.contentScorecards}>
-          <Grid item xs={12}>
-            <InfoCard title={checkRenderType.title}>
-              <Typography className={classes.subheader} variant="body1">
-                {checkRenderType.description}
-              </Typography>
-              <Grid item xs={11}>
-                {checkRenderType.component}
-              </Grid>
-            </InfoCard>
-          </Grid>
-        </Content>
-      </Page>
+    return infoCard(
+      checkRenderType.title,
+      checkRenderType.description,
+      classes.subheader,
+      checkRenderType.component,
     );
   }
 

--- a/plugins/tech-insights/src/components/ScorecardsInfo/index.ts
+++ b/plugins/tech-insights/src/components/ScorecardsInfo/index.ts
@@ -13,13 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export {
-  techInsightsPlugin,
-  EntityTechInsightsScorecardContent,
-  EntityTechInsightsScorecardCard,
-} from './plugin';
 
-export { techInsightsApiRef } from './api/TechInsightsApi';
-export type { TechInsightsApi } from './api/TechInsightsApi';
-export type { Check } from './api/types';
-export type { CheckResultRenderer } from './components/CheckResultRenderer';
+export { ScorecardInfo } from './ScorecardInfo';

--- a/plugins/tech-insights/src/plugin.ts
+++ b/plugins/tech-insights/src/plugin.ts
@@ -49,7 +49,19 @@ export const EntityTechInsightsScorecardContent = techInsightsPlugin.provide(
   createRoutableExtension({
     name: 'EntityTechInsightsScorecardContent',
     component: () =>
-      import('./components/ScorecardsOverview').then(m => m.ScorecardsOverview),
+      import('./components/ScorecardsContent').then(m => m.ScorecardsContent),
+    mountPoint: rootRouteRef,
+  }),
+);
+
+/**
+ * @public
+ */
+export const EntityTechInsightsScorecardCard = techInsightsPlugin.provide(
+  createRoutableExtension({
+    name: 'EntityTechInsightsScorecardCard',
+    component: () =>
+      import('./components/ScorecardsCard').then(m => m.ScorecardsCard),
     mountPoint: rootRouteRef,
   }),
 );


### PR DESCRIPTION
to display multiple EntityTechInsightsScorecardContent on one route

Signed-off-by: David Weber <david.weber@w3tec.ch>

## Hey, I just made a Pull Request!
If one likes to display multiple score cards on one page like:
```
<EntityLayout.Route path="/tech-insights" title="Scorecards">
      <>
           <EntityTechInsightsScorecardContent
              title="My awesome first scorecard"
              description="Small description about scorecards"
            /> 
           <EntityTechInsightsScorecardContent
              title="My awesome second scorecard"
              description="Small description about scorecards"
            /> 
      </>
</EntityLayout.Route>
```
it will result in
<img width="2423" alt="before" src="https://user-images.githubusercontent.com/1021324/164324916-839cdb64-52c9-40d5-9d7b-5cf780f8ec59.png">

after this change in
<img width="2410" alt="after" src="https://user-images.githubusercontent.com/1021324/164324826-84c8fd2f-9ff0-4a3d-9633-268717f7a4d4.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info]
(https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))