### PR TITLE
[Search] search bar base to not use search context

### DIFF
--- a/.changeset/search-modern-mangos-poke.md
+++ b/.changeset/search-modern-mangos-poke.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-search': minor
+---
+
+The `TrackSearch` component responsible for tracking events now takes in a term property instead of relying on the search context. The reason for this is so that the `TrackSearch` component can be used both for `SearchBar` which is recommended to use when you use the `SearchContextProvider` and for `SearchBarBase` which is recommended to use if you don't use SearchContextProvider.
+
+```diff
+- <TrackSearch>
++ <TrackSearch term={value}>
+    <SearchBarBase />
+</TrackSearch>
+```

--- a/plugins/search/src/components/SearchBar/SearchBar.tsx
+++ b/plugins/search/src/components/SearchBar/SearchBar.tsx
@@ -32,10 +32,7 @@ import {
 import SearchIcon from '@material-ui/icons/Search';
 import ClearButton from '@material-ui/icons/Clear';
 
-import {
-  SearchContextProvider,
-  useSearch,
-} from '@backstage/plugin-search-react';
+import { useSearch } from '@backstage/plugin-search-react';
 import { TrackSearch } from '../SearchTracker';
 
 /**
@@ -54,7 +51,7 @@ export type SearchBarBaseProps = Omit<InputBaseProps, 'onChange'> & {
 /**
  * All search boxes exported by the search plugin are based on the <SearchBarBase />,
  * and this one is based on the <InputBase /> component from Material UI.
- * Recommended if you don't use Search Provider or Search Context.
+ * Recommended if you don't use SearchContextProvider.
  *
  * @public
  */
@@ -72,7 +69,6 @@ export const SearchBarBase = ({
 }: SearchBarBaseProps) => {
   const configApi = useApi(configApiRef);
   const [value, setValue] = useState<string>(defaultValue as string);
-  const hasSearchContext = useSearch();
 
   useEffect(() => {
     setValue(prevValue =>
@@ -123,8 +119,8 @@ export const SearchBarBase = ({
     </InputAdornment>
   );
 
-  const searchBar = (
-    <TrackSearch>
+  return (
+    <TrackSearch term={value}>
       <InputBase
         data-testid="search-bar-next"
         value={value}
@@ -139,12 +135,6 @@ export const SearchBarBase = ({
       />
     </TrackSearch>
   );
-
-  return hasSearchContext ? (
-    searchBar
-  ) : (
-    <SearchContextProvider>{searchBar}</SearchContextProvider>
-  );
 };
 
 /**
@@ -155,7 +145,7 @@ export const SearchBarBase = ({
 export type SearchBarProps = Partial<SearchBarBaseProps>;
 
 /**
- * Recommended search bar when you use the Search Provider or Search Context.
+ * Recommended search bar when you use the SearchContextProvider
  *
  * @public
  */

--- a/plugins/search/src/components/SearchTracker/SearchTracker.tsx
+++ b/plugins/search/src/components/SearchTracker/SearchTracker.tsx
@@ -16,14 +16,18 @@
 
 import React, { useEffect } from 'react';
 import { useAnalytics } from '@backstage/core-plugin-api';
-import { useSearch } from '@backstage/plugin-search-react';
 
 /**
  * Capture search event on term change.
  */
-export const TrackSearch = ({ children }: { children: React.ReactChild }) => {
+export const TrackSearch = ({
+  term,
+  children,
+}: {
+  term: string;
+  children: React.ReactChild;
+}) => {
   const analytics = useAnalytics();
-  const { term } = useSearch();
 
   useEffect(() => {
     if (term) {


### PR DESCRIPTION
Signed-off-by: Emma Indal <emma.indahl@gmail.com>

## Hey, I just made a Pull Request!

This PR fixes a bug reported on Discord (https://discord.com/channels/687207715902193673/965983677630791740) where the `HomePageSearchBar` did not properly render and instead gave the error

`Reached ErrorBoundaryFallback Page with error, Error: useSearch must be used within a SearchContextProvider`. This was introduced as a part of removing the export of the SearchContext and the check in that component if the context was available or not. 

The `TrackSearch` component responsible for tracking events now takes in a term property instead of relying on the search context. The reason for this is so that the `TrackSearch` component can be used both for `SearchBar` which is recommended to use when you use the `SearchContextProvider` and for `SearchBarBase` which is recommended to use if you don't use `SearchContextProvider`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
