### PR TITLE
Remove obsolete permission docs

### DIFF
--- a/docs/plugins/permissions/index.md
+++ b/docs/plugins/permissions/index.md
@@ -1,5 +1,0 @@
----
-id: index
-title: Integrating Permissions into Plugins
-description: Learn how to integrate permissions into a Backstage plugin by following along with this Todo Plugin tutorial.
----

--- a/microsite/sidebars.json
+++ b/microsite/sidebars.json
@@ -214,11 +214,6 @@
           "plugins/add-to-marketplace",
           "plugins/observability"
         ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Permissions",
-        "ids": ["plugins/permissions/index"]
       }
     ],
     "Configuration": [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is an older structure that we decided not to pursue, and we just never removed the placeholders. The permission docs for plugin authors now live under the "Permissions" top level docs section as a separate subcategory.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
