### PR TITLE
renovate: ignore @elastic/elasticsearch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,8 @@
   labels: ['dependencies'],
   extends: ['config:base', ':disableDependencyDashboard', ':gitSignOff'],
   rangeStrategy: 'update-lockfile',
+  // @elastic/elasticsearch is ignored due to licensing issues. See #10992
+  ignoreDeps: ['@elastic/elasticsearch'],
   packageRules: [
     {
       matchSourceUrlPrefixes: ['https://github.com/spotify/web-scripts'],


### PR DESCRIPTION
ignore renovate updates for package until dependency is replaced or licensing issue is resolved.

context: https://github.com/backstage/backstage/pull/10992#issuecomment-1106500807
