### PR TITLE
Added an ability to use a custom component when an entity is not found

### DIFF
--- a/.changeset/nasty-humans-give.md
+++ b/.changeset/nasty-humans-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Added the prop `NotFoundComponent` to `EntityLayout` which can be used to include a custom component when an entity is not found in the catalog

--- a/plugins/catalog/api-report.md
+++ b/plugins/catalog/api-report.md
@@ -247,6 +247,8 @@ export const EntityLayout: {
 export interface EntityLayoutProps {
   // (undocumented)
   children?: React_2.ReactNode;
+  // (undocumented)
+  NotFoundComponent?: React_2.ReactNode;
   // Warning: (ae-forgotten-export) The symbol "contextMenuOptions" needs to be exported by the entry point index.d.ts
   //
   // (undocumented)

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -106,7 +106,7 @@ describe('EntityLayout', () => {
     expect(rendered.getByText('tabbed-test-content')).toBeInTheDocument();
   });
 
-  it('renders error message when entity is not found', async () => {
+  it('renders default error message when entity is not found', async () => {
     const rendered = await renderInTestApp(
       <ApiProvider apis={mockApis}>
         <AsyncEntityProvider loading={false}>
@@ -125,6 +125,34 @@ describe('EntityLayout', () => {
     );
 
     expect(rendered.getByText('Warning: Entity not found')).toBeInTheDocument();
+    expect(rendered.queryByText('my-entity')).not.toBeInTheDocument();
+    expect(rendered.queryByText('tabbed-test-title')).not.toBeInTheDocument();
+    expect(rendered.queryByText('tabbed-test-content')).not.toBeInTheDocument();
+  });
+
+  it('renders custom message when entity is not found', async () => {
+    const rendered = await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <AsyncEntityProvider loading={false}>
+          <EntityLayout
+            NotFoundComponent={<div>Oppps.. Your entity was not found</div>}
+          >
+            <EntityLayout.Route path="/" title="tabbed-test-title">
+              <div>tabbed-test-content</div>
+            </EntityLayout.Route>
+          </EntityLayout>
+        </AsyncEntityProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    expect(
+      rendered.getByText('Oppps.. Your entity was not found'),
+    ).toBeInTheDocument();
     expect(rendered.queryByText('my-entity')).not.toBeInTheDocument();
     expect(rendered.queryByText('tabbed-test-title')).not.toBeInTheDocument();
     expect(rendered.queryByText('tabbed-test-content')).not.toBeInTheDocument();

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -261,6 +261,12 @@ export const EntityLayout = (props: EntityLayoutProps) => {
 
       {error && (
         <Content>
+          <Alert severity="error">{error.toString()}</Alert>
+        </Content>
+      )}
+
+      {!loading && !error && !entity && (
+        <Content>
           {NotFoundComponent ? (
             NotFoundComponent
           ) : (
@@ -272,18 +278,6 @@ export const EntityLayout = (props: EntityLayoutProps) => {
               .
             </WarningPanel>
           )}
-        </Content>
-      )}
-
-      {!loading && !error && !entity && (
-        <Content>
-          <WarningPanel title="Entity not found">
-            There is no {kind} with the requested{' '}
-            <Link to="https://backstage.io/docs/features/software-catalog/references">
-              kind, namespace, and name
-            </Link>
-            .
-          </WarningPanel>
         </Content>
       )}
 

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -152,6 +152,7 @@ export interface EntityLayoutProps {
   UNSTABLE_extraContextMenuItems?: ExtraContextMenuItem[];
   UNSTABLE_contextMenuOptions?: contextMenuOptions;
   children?: React.ReactNode;
+  NotFoundComponent?: React.ReactNode;
 }
 
 /**
@@ -176,6 +177,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
     UNSTABLE_extraContextMenuItems,
     UNSTABLE_contextMenuOptions,
     children,
+    NotFoundComponent,
   } = props;
   const { kind, namespace, name } = useRouteRefParams(entityRouteRef);
   const { entity, loading, error } = useAsyncEntity();
@@ -259,7 +261,17 @@ export const EntityLayout = (props: EntityLayoutProps) => {
 
       {error && (
         <Content>
-          <Alert severity="error">{error.toString()}</Alert>
+          {NotFoundComponent ? (
+            NotFoundComponent
+          ) : (
+            <WarningPanel title="Entity not found">
+              There is no {kind} with the requested{' '}
+              <Link to="https://backstage.io/docs/features/software-catalog/references">
+                kind, namespace, and name
+              </Link>
+              .
+            </WarningPanel>
+          )}
         </Content>
       )}
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Added an ability to use a custom component when an entity is not found

```
<EntityLayout NotFoundComponent={<div>Oppss...We couldn't find your entity</div>}>
    <EntityLayout.Route path="/" title="Overview">
      {overviewContent}
    </EntityLayout.Route>
</EntityLayout>
```

![image](https://user-images.githubusercontent.com/12017112/164798947-292aba4d-869b-49bc-8f41-99b931f3e4df.png)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
