### PR TITLE
Fix a path mismatch between techdocs embedded app and serve command

### DIFF
--- a/.changeset/slow-ads-sit.md
+++ b/.changeset/slow-ads-sit.md
@@ -1,0 +1,13 @@
+---
+'@techdocs/cli': patch
+---
+
+Fixed a path mismatch between the techdocs-cli-embedded-app and the `serve` command.
+
+[This commit](https://github.com/backstage/backstage/commit/b44692890b1c6ca1df55313612a1d28e3c61ea8a)
+removed logic that caused the techdocs-cli-embedded-app to resolve the the techdocs API origin to
+`http://localhost:3000/api`.
+After that commit, the techdocs API origin resolved to `http://localhost:3000/api/techdocs`.
+Without this corresponding change in the techdocs-cli, the browser requests for techdocs
+page content are sent to the mkdocs container with the `/techdocs/` prefix, which results in
+404 errors.

--- a/.changeset/slow-ads-sit.md
+++ b/.changeset/slow-ads-sit.md
@@ -5,7 +5,7 @@
 Fixed a path mismatch between the techdocs-cli-embedded-app and the `serve` command.
 
 [This commit](https://github.com/backstage/backstage/commit/b44692890b1c6ca1df55313612a1d28e3c61ea8a)
-removed logic that caused the techdocs-cli-embedded-app to resolve the the techdocs API origin to
+removed logic that caused the techdocs-cli-embedded-app to resolve the techdocs API origin to
 `http://localhost:3000/api`.
 After that commit, the techdocs API origin resolved to `http://localhost:3000/api/techdocs`.
 Without this corresponding change in the techdocs-cli, the browser requests for techdocs

--- a/packages/techdocs-cli/src/lib/httpServer.ts
+++ b/packages/techdocs-cli/src/lib/httpServer.ts
@@ -32,7 +32,7 @@ export default class HTTPServer {
     mkdocsPort: number,
     verbose: boolean,
   ) {
-    this.proxyEndpoint = '/api/';
+    this.proxyEndpoint = '/api/techdocs';
     this.backstageBundleDir = backstageBundleDir;
     this.backstagePort = backstagePort;
     this.mkdocsPort = mkdocsPort;
@@ -46,9 +46,9 @@ export default class HTTPServer {
     });
 
     return (request: http.IncomingMessage): [httpProxy, string] => {
-      // If the request goes to /api/ we want to remove /api/ from the prefix of the request URL.
-      // e.g. ['/', 'api', pathChunks]
-      const [, , ...pathChunks] = request.url?.split('/') ?? [];
+      // If the request goes to /api/techdocs we want to remove /api/techdocs from the prefix of the request URL.
+      // e.g. ['/', 'api', 'techdocs', pathChunks]
+      const [, , , ...pathChunks] = request.url?.split('/') ?? [];
       const forwardPath = pathChunks.join('/');
 
       return [proxy, forwardPath];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue introduced in
b44692890b1c6ca1df55313612a1d28e3c61ea8a.

An override of the path to the techdocs API was removed, without the
corresponding change in the Techdocs CLI. This resulted in traffic for
the techdocs API having an extra `techdocs` in the path, causing the
mkdocs server to 404.

Closes #10362 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
