### PR TITLE
[TechDocs] Added configuration for local publishing target

### DIFF
--- a/.changeset/calm-experts-buy.md
+++ b/.changeset/calm-experts-buy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': minor
+---
+
+Added local publishing target directory `config`: `techdocs.publisher.local.publishDirectory`

--- a/.changeset/weak-llamas-repeat.md
+++ b/.changeset/weak-llamas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+---
+
+Added local publishing target directory `config`: `techdocs.publisher.local.publishDirectory`

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -74,6 +74,12 @@ techdocs:
 
     type: 'local'
 
+    # Optional when techdocs.publisher.type is set to 'local'.
+
+    local:
+      # (Optional). Set this to specify where the generated documentation is stored.
+      publishDirectory: '/path/to/local/directory'
+
     # Required when techdocs.publisher.type is set to 'googleGcs'. Skip otherwise.
 
     googleGcs:

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -66,6 +66,13 @@ export interface Config {
     publisher?:
       | {
           type: 'local';
+
+          local?: {
+            /**
+             * Directory to store generated static files.
+             */
+            publishDirectory?: string;
+          };
         }
       | {
           type: 'awsS3';

--- a/plugins/techdocs-node/src/stages/publish/local.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/local.test.ts
@@ -236,5 +236,32 @@ describe('local publisher', () => {
       );
       expect(response.status).toBe(404);
     });
+
+    it('should work with a configured directory', async () => {
+      const customConfig = new ConfigReader({
+        techdocs: {
+          publisher: {
+            local: {
+              publishDirectory: tmpDir,
+            },
+          },
+        },
+      });
+      mockFs({
+        [tmpDir]: {
+          'index.html': 'found it',
+        },
+      });
+      const legacyPublisher = LocalPublish.fromConfig(
+        customConfig,
+        logger,
+        testDiscovery,
+      );
+      app = express().use(legacyPublisher.docsRouter());
+
+      const response = await request(app).get('/index.html');
+      expect(response.status).toBe(200);
+      expect(response.text).toEqual('found it');
+    });
   });
 });


### PR DESCRIPTION
This patch adds a configuration option for setting the "local"
techdocs target directory. The target directory can be set using
the "techdocs.publisher.local.publishDirectory".

This fixes two "TODOs" in the "plugins/techdocs-node/src/stages
/publish/local.ts" file:

*  Use a more persistent storage than node_modules or /tmp directory.
   Make it configurable with techdocs.publisher.local.publishDirectory
*  Move the logic of setting staticDocsDir based on config over to
   fromConfig, and set the value as a class parameter.

Signed-off-by: Niklas Aronsson <niklasar@axis.com>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
