### PR TITLE
[AlertDisplay] Added props to alert display

### DIFF
--- a/.changeset/lovely-houses-argue.md
+++ b/.changeset/lovely-houses-argue.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Added optional vertical and horizontal alignment props to AlertDisplay
+Added optional anchorOrigin alignment prop to AlertDisplay

--- a/.changeset/lovely-houses-argue.md
+++ b/.changeset/lovely-houses-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added optional vertical and horizontal alignment props to AlertDisplay

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -51,13 +51,10 @@ import { Theme } from '@material-ui/core/styles';
 import { TooltipProps } from '@material-ui/core/Tooltip';
 import { WithStyles } from '@material-ui/core/styles';
 
-// @public
-export type AlertDisplayProps = {
-  vertical?: 'top' | 'bottom';
-  horizontal?: 'left' | 'center' | 'right';
-};
-
-// @public
+// Warning: (ae-forgotten-export) The symbol "AlertDisplayProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-missing-release-tag) "AlertDisplay" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
 export function AlertDisplay(props: AlertDisplayProps): JSX.Element | null;
 
 // @public

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -52,7 +52,13 @@ import { TooltipProps } from '@material-ui/core/Tooltip';
 import { WithStyles } from '@material-ui/core/styles';
 
 // @public
-export function AlertDisplay(_props: {}): JSX.Element | null;
+export type AlertDisplayProps = {
+  vertical?: 'top' | 'bottom';
+  horizontal?: 'left' | 'center' | 'right';
+};
+
+// @public
+export function AlertDisplay(props: AlertDisplayProps): JSX.Element | null;
 
 // @public
 enum Alignment {

--- a/packages/core-components/api-report.md
+++ b/packages/core-components/api-report.md
@@ -51,11 +51,16 @@ import { Theme } from '@material-ui/core/styles';
 import { TooltipProps } from '@material-ui/core/Tooltip';
 import { WithStyles } from '@material-ui/core/styles';
 
-// Warning: (ae-forgotten-export) The symbol "AlertDisplayProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-missing-release-tag) "AlertDisplay" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
-//
 // @public (undocumented)
 export function AlertDisplay(props: AlertDisplayProps): JSX.Element | null;
+
+// @public
+export type AlertDisplayProps = {
+  anchorOrigin?: {
+    vertical: 'top' | 'bottom';
+    horizontal: 'left' | 'center' | 'right';
+  };
+};
 
 // @public
 enum Alignment {

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -34,15 +34,18 @@ import pluralize from 'pluralize';
 // TODO: improve on this and promote to a shared component for use by all apps.
 
 export type AlertDisplayProps = {
-  vertical?: 'top' | 'bottom';
-  horizontal?: 'left' | 'center' | 'right';
+  anchorOrigin?: {
+    vertical: 'top' | 'bottom';
+    horizontal: 'left' | 'center' | 'right';
+  };
 };
 
+/** @public */
 export function AlertDisplay(props: AlertDisplayProps) {
   const [messages, setMessages] = useState<Array<AlertMessage>>([]);
   const alertApi = useApi(alertApiRef);
 
-  const { vertical = 'top', horizontal = 'center' } = props;
+  const { anchorOrigin = { vertical: 'top', horizontal: 'center' } } = props;
 
   useEffect(() => {
     const subscription = alertApi
@@ -65,7 +68,7 @@ export function AlertDisplay(props: AlertDisplayProps) {
   };
 
   return (
-    <Snackbar open anchorOrigin={{ vertical, horizontal }}>
+    <Snackbar open anchorOrigin={anchorOrigin}>
       <Alert
         action={
           <IconButton

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -31,9 +31,17 @@ import pluralize from 'pluralize';
  * Shown as SnackBar at the top of the page
  */
 // TODO: improve on this and promote to a shared component for use by all apps.
-export function AlertDisplay(_props: {}) {
+
+type Props = {
+  vertical?: 'top' | 'bottom';
+  horizontal?: 'left' | 'center' | 'right';
+}
+
+export function AlertDisplay(props: Props) {
   const [messages, setMessages] = useState<Array<AlertMessage>>([]);
   const alertApi = useApi(alertApiRef);
+
+  const { vertical = 'top', horizontal = 'center' } = props;
 
   useEffect(() => {
     const subscription = alertApi
@@ -56,7 +64,7 @@ export function AlertDisplay(_props: {}) {
   };
 
   return (
-    <Snackbar open anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
+    <Snackbar open anchorOrigin={{ vertical, horizontal}}>
       <Alert
         action={
           <IconButton

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -33,12 +33,12 @@ import pluralize from 'pluralize';
 
 // TODO: improve on this and promote to a shared component for use by all apps.
 
-type Props = {
+export type AlertDisplayProps = {
   vertical?: 'top' | 'bottom';
   horizontal?: 'left' | 'center' | 'right';
 };
 
-export function AlertDisplay(props: Props) {
+export function AlertDisplay(props: AlertDisplayProps) {
   const [messages, setMessages] = useState<Array<AlertMessage>>([]);
   const alertApi = useApi(alertApiRef);
 

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.tsx
@@ -28,14 +28,15 @@ import pluralize from 'pluralize';
  * @public
  * @remarks
  *
- * Shown as SnackBar at the top of the page
+ * Shown as SnackBar at the center top of the page by default. Configurable with props.
  */
+
 // TODO: improve on this and promote to a shared component for use by all apps.
 
 type Props = {
   vertical?: 'top' | 'bottom';
   horizontal?: 'left' | 'center' | 'right';
-}
+};
 
 export function AlertDisplay(props: Props) {
   const [messages, setMessages] = useState<Array<AlertMessage>>([]);
@@ -64,7 +65,7 @@ export function AlertDisplay(props: Props) {
   };
 
   return (
-    <Snackbar open anchorOrigin={{ vertical, horizontal}}>
+    <Snackbar open anchorOrigin={{ vertical, horizontal }}>
       <Alert
         action={
           <IconButton

--- a/packages/core-components/src/components/AlertDisplay/index.ts
+++ b/packages/core-components/src/components/AlertDisplay/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { AlertDisplay } from './AlertDisplay';
+export * from './AlertDisplay';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added optional alignment props to AlertDisplay component in order to allow custom location for alerts from the AlertAPI.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
