### PR TITLE
Exclude css from dts

### DIFF
--- a/.changeset/nine-geese-rest.md
+++ b/.changeset/nine-geese-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Changed Rollup configuration for TypeScript definition plugin to ignore css files.

--- a/packages/cli/src/lib/builder/config.ts
+++ b/packages/cli/src/lib/builder/config.ts
@@ -154,6 +154,7 @@ export async function makeRollupConfigs(
         file: resolvePath(distDir, 'index.d.ts'),
         format: 'es',
       },
+      external: [/\.css$/],
       onwarn,
       plugins: [dts()],
     });


### PR DESCRIPTION
## Motivation

I was upgrading the [graphql-voyager-plugin](https://github.com/shipshapecode/backstage-graphql-voyager) to latest version of backstage-cli. After the upgrade, I found that I couldn't build the package because DTS rollup plugin was not able to resolve `.css` files.

The problem is caused by `import './GraphQLVoyagerComponent.css'` statement which ends up in `.d.ts` files after `yarn tsc`. [The file looks like this](https://github.com/shipshapecode/backstage-graphql-voyager/blob/master/src/components/GraphQLVoyagerComponent/GraphQLVoyagerComponent.tsx#L11),

```ts
import 'graphql-voyager/dist/voyager.css';
import './GraphQLVoyagerComponent.css';
export declare const GraphQLVoyagerComponent: ({ endpoint, sdl, }: {
    endpoint?: string | undefined;
    sdl?: string | undefined;
}) => JSX.Element;
```

This is happening because DTS Rollup plugin is trying to import `.css` files that do not exist. 

## Approach

Treat `.css` files as external in DTS Rollup config so they do not get rolled up.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [-] Added or updated documentation
- [-] Tests for new functionality and regression tests for bug fixes
- [-] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
