### PR TITLE
Updated parseEntityTransformParams to handle keys with '.' in them

### DIFF
--- a/.changeset/shiny-apes-design.md
+++ b/.changeset/shiny-apes-design.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Updated entity query param transform to handle keys with '.' in them. This will allow for querying based of annotations such as 'backstage.io/orgin-location' for instance

--- a/plugins/catalog-backend/src/service/request/parseEntityTransformParams.test.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityTransformParams.test.ts
@@ -24,6 +24,9 @@ describe('parseEntityTransformParams', () => {
     metadata: {
       name: 'n',
       tags: ['t1', 't2'],
+      annotations: {
+        'test.com/url-like': 'ul1',
+      },
     },
     spec: {
       type: 't',
@@ -61,7 +64,24 @@ describe('parseEntityTransformParams', () => {
       parseEntityTransformParams({ fields: 'kind,metadata.name' })!(entity),
     ).toEqual({ kind: 'k', metadata: { name: 'n' } });
     expect(parseEntityTransformParams({ fields: 'metadata' })!(entity)).toEqual(
-      { metadata: { name: 'n', tags: ['t1', 't2'] } },
+      {
+        metadata: {
+          name: 'n',
+          tags: ['t1', 't2'],
+          annotations: { 'test.com/url-like': 'ul1' },
+        },
+      },
     );
+  });
+
+  it('supports dot notated feilds properly', () => {
+    expect(
+      parseEntityTransformParams({
+        fields: 'kind,metadata.annotations.test.com/url-like',
+      })!(entity),
+    ).toEqual({
+      kind: 'k',
+      metadata: { annotations: { 'test.com/url-like': 'ul1' } },
+    });
   });
 });

--- a/plugins/catalog-backend/src/service/request/parseEntityTransformParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityTransformParams.ts
@@ -20,6 +20,22 @@ import lodash from 'lodash';
 import { RecursivePartial } from '../../util/RecursivePartial';
 import { parseStringsParam } from './common';
 
+function getPathArray(input: Entity, field: string) {
+  const pathArray = [];
+  let currentPathPart = '';
+
+  for (const pathPart of field.split('.')) {
+    currentPathPart += pathPart;
+
+    if (lodash.has(input, pathArray.concat(currentPathPart))) {
+      pathArray.push(currentPathPart);
+      currentPathPart = '';
+    }
+  }
+
+  return pathArray;
+}
+
 export function parseEntityTransformParams(
   params: Record<string, unknown>,
 ): ((entity: Entity) => Entity) | undefined {
@@ -46,9 +62,11 @@ export function parseEntityTransformParams(
     const output: RecursivePartial<Entity> = {};
 
     for (const field of fields) {
-      const value = lodash.get(input, field);
+      const pathArray = getPathArray(input, field);
+
+      const value = lodash.get(input, pathArray);
       if (value !== undefined) {
-        lodash.set(output, field, value);
+        lodash.set(output, pathArray, value);
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Mark David Avery <mark@webark.cc>

## Hey, I just made a Pull Request!

When writing queries against the entity list, this will enable using keys with `.` in them. This includes annotations such as `backstage.io/source-location` and the like.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
