### PR TITLE
fix(OwnershipCard): correctly link to owner filtered catalog respecting namespaces

### DIFF
--- a/.changeset/polite-planets-learn.md
+++ b/.changeset/polite-planets-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fix linking ownership card to catalog owner filter when namespaces are used

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -265,6 +265,10 @@ describe('OwnershipCard', () => {
           type: 'memberOf',
           targetRef: 'group:default/my-team',
         },
+        {
+          type: 'memberOf',
+          targetRef: 'group:custom/some-team',
+        },
       ],
     };
     const catalogApi: jest.Mocked<CatalogApi> = {
@@ -288,7 +292,7 @@ describe('OwnershipCard', () => {
 
     expect(getByText('OPENAPI').closest('a')).toHaveAttribute(
       'href',
-      '/create/?filters%5Bkind%5D=API&filters%5Btype%5D=openapi&filters%5Bowners%5D=the-user&filters%5Bowners%5D=my-team&filters%5Buser%5D=all',
+      '/create/?filters%5Bkind%5D=API&filters%5Btype%5D=openapi&filters%5Bowners%5D=user%3Athe-user&filters%5Bowners%5D=my-team&filters%5Bowners%5D=custom%2Fsome-team&filters%5Buser%5D=all',
     );
   });
 

--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
@@ -18,12 +18,14 @@ import {
   Entity,
   RELATION_MEMBER_OF,
   RELATION_PARENT_OF,
+  parseEntityRef,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import {
   CatalogApi,
   catalogApiRef,
   getEntityRelations,
+  humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
 import limiterFactory from 'p-limit';
 import { useApi } from '@backstage/core-plugin-api';
@@ -43,7 +45,9 @@ const getQueryParams = (
   selectedEntity: EntityTypeProps,
 ): string => {
   const { kind, type } = selectedEntity;
-  const owners = ownersEntityRef.map(owner => owner.split('/')[1]);
+  const owners = ownersEntityRef.map(owner =>
+    humanizeEntityRef(parseEntityRef(owner), { defaultKind: 'group' }),
+  );
   const filters = {
     kind,
     type,


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!

Addresses issue where ownership links weren't properly applying owner filters on the Catalog page when namespaces are used. This fix constructs owner refs there same way as the `EntityOwnerPicker` to ensure values will be consistent:
https://github.com/backstage/backstage/blob/13682ba03ce449b95e61a5fd08e757f2c0ba4112/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx#L93

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
