### PR TITLE
Aria label for support button

### DIFF
--- a/.changeset/nine-actors-fly.md
+++ b/.changeset/nine-actors-fly.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Add an aria-label to the support button to improve accesibility for screen readers
+Add an aria-label to the support button to improve accessibility for screen readers

--- a/.changeset/nine-actors-fly.md
+++ b/.changeset/nine-actors-fly.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add an aria-label to the support button to improve accesibility for screen readers

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -116,6 +116,7 @@ export function SupportButton(props: SupportButtonProps) {
         ) : (
           <Button
             data-testid="support-button"
+            aria-label="support-button"
             color="primary"
             onClick={onClickHandler}
             startIcon={<HelpIcon />}

--- a/packages/core-components/src/components/SupportButton/SupportButton.tsx
+++ b/packages/core-components/src/components/SupportButton/SupportButton.tsx
@@ -116,7 +116,7 @@ export function SupportButton(props: SupportButtonProps) {
         ) : (
           <Button
             data-testid="support-button"
-            aria-label="support-button"
+            aria-label="support"
             color="primary"
             onClick={onClickHandler}
             startIcon={<HelpIcon />}


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Addresses a small part of https://github.com/backstage/backstage/issues/7124
This adds an aria-label for the support button, to increase the accessibility for screen readers by adding a description of what the button is. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
