### PR TITLE
fix(tasks): set next run time relative to now

### DIFF
--- a/.changeset/tricky-phones-sing.md
+++ b/.changeset/tricky-phones-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-tasks': patch
+---
+
+Correctly set next run time for tasks

--- a/packages/backend-tasks/src/tasks/TaskWorker.ts
+++ b/packages/backend-tasks/src/tasks/TaskWorker.ts
@@ -283,8 +283,13 @@ export class TaskWorker {
         })}`,
       );
       nextRun = this.knex.client.config.client.includes('sqlite3')
-        ? this.knex.raw('datetime(next_run_start_at, ?)', [`+${dt} seconds`])
-        : this.knex.raw(`next_run_start_at + interval '${dt} seconds'`);
+        ? this.knex.raw(
+            `max(datetime(next_run_start_at, ?), datetime('now'))`,
+            [`+${dt} seconds`],
+          )
+        : this.knex.raw(
+            `greatest(next_run_start_at + interval '${dt} seconds', now())`,
+          );
     }
 
     const rows = await this.knex<DbTasksRow>(DB_TASKS_TABLE)


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

## Hey, I just made a Pull Request!
Discovered this issue when doing local dev:

1. Start backend with backend-tasks registered
2. Stop your instance and restart it later eg. the next day
3. Registered tasks will repeatedly re-run as many times as the number of scheduled intervals between when you stopped your instance and when you restarted

Issue: Tasks are being scheduled to next run from last scheduled run + interval eg. last run at 12:00 + every 5 min = next run at 12:05 so what ends up happening:

1. If you restart your instance at 2:00, task will run since 2:00 > 12:05, schedule next run at 12:05 (last scheduled run) + 5min (interval) = 12:10
2. Run again since 2:xx > 12:10, schedule next at 12:15
3. Run again since 2:xx > 12:15, schedule next at 12:20
4. ... Rinse & repeat until next run > 2:xx ...

 This fixes the scheduling to ensure the next run is scheduled = now + interval (like the existing log statement claims to do 😄 )

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
