### PR TITLE
gh actions: Auto approve renovate lock file changes

### DIFF
--- a/.github/workflows/sync_approve_renovate_pr.yaml
+++ b/.github/workflows/sync_approve_renovate_pr.yaml
@@ -24,11 +24,6 @@ jobs:
               return;
             }
 
-            if (context.payload.pull_request.changed_files !== 1) {
-              console.log('Skipping approval because multiple files are changed in this PR');
-              return;
-            }
-
             const r = await octokit.rest.pulls.listFiles({
               owner,
               repo,

--- a/.github/workflows/sync_approve_renovate_pr.yaml
+++ b/.github/workflows/sync_approve_renovate_pr.yaml
@@ -29,7 +29,7 @@ jobs:
               repo,
               pull_number: context.issue.number,
             });
-            
+
             if (r.data.every((f) => f.filename.endsWith("yarn.lock"))) {
               console.log('skipping approval since some files are not yarn.lock');
               return;

--- a/.github/workflows/sync_approve_renovate_pr.yaml
+++ b/.github/workflows/sync_approve_renovate_pr.yaml
@@ -1,0 +1,42 @@
+name: Approve renovate lock file changes
+on:
+  pull_request_target:
+    paths:
+      - '.github/workflows/sync_renovate-changesets.yml'
+      - '**/yarn.lock'
+
+jobs:
+  generate-changeset:
+    runs-on: ubuntu-latest
+    if: github.actor == 'renovate[bot]' && github.repository == 'backstage/backstage'
+    steps:
+      - name: Approve
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+          script: |
+            const owner = 'backstage';
+            const repo = 'backstage';
+
+            if (context.payload.pull_request.changed_files !== 1) {
+              console.log('Skipping approval because multiple files are changed in this PR');
+              return;
+            }
+
+            const r = await octokit.rest.pulls.listFiles({
+              owner,
+              repo,
+              pull_number: context.issue.number,
+            });
+            
+            if (r.data.every((f) => f.filename.endsWith("yarn.lock"))) {
+              console.log('skipping approval since some files are not yarn.lock');
+              return;
+            }
+
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number: context.issue.number,
+              event: 'APPROVE'
+            })

--- a/.github/workflows/sync_approve_renovate_pr.yaml
+++ b/.github/workflows/sync_approve_renovate_pr.yaml
@@ -30,7 +30,7 @@ jobs:
               pull_number: context.issue.number,
             });
 
-            if (r.data.every((f) => f.filename.endsWith("yarn.lock"))) {
+            if (r.data.every((f) => f.filename.split('/').slice(-1)[0] === 'yarn.lock')) {
               console.log('skipping approval since some files are not yarn.lock');
               return;
             }

--- a/.github/workflows/sync_approve_renovate_pr.yaml
+++ b/.github/workflows/sync_approve_renovate_pr.yaml
@@ -18,6 +18,12 @@ jobs:
             const owner = 'backstage';
             const repo = 'backstage';
 
+            const date = new Date();
+            if (date.getDay() === 2) {
+              console.log('Skipping auto approve because Tuesday is release day');
+              return;
+            }
+
             if (context.payload.pull_request.changed_files !== 1) {
               console.log('Skipping approval because multiple files are changed in this PR');
               return;


### PR DESCRIPTION
Adds new actions workflow that automatically approve renovate PRs for yarn.lock changes.
The code can potentially be tweaks if we feel like automatically approving patch bumps. 