### PR TITLE
cli: prevent imports of stories or tests

### DIFF
--- a/.changeset/funny-lamps-turn.md
+++ b/.changeset/funny-lamps-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Extended lint rule to prevents imports of stories or tests from production code.

--- a/packages/cli/config/eslint-factory.js
+++ b/packages/cli/config/eslint-factory.js
@@ -130,8 +130,14 @@ function createConfig(dir, extraConfig = {}) {
             ...(restrictedImports ?? []),
             ...(restrictedSrcImports ?? []),
           ],
-          // Avoid cross-package imports
-          patterns: ['**/../../**/*/src/**', '**/../../**/*/src'],
+          patterns: [
+            // Avoid cross-package imports
+            '**/../../**/*/src/**',
+            '**/../../**/*/src',
+            // Prevent imports of stories or tests
+            '*.stories*',
+            '*.test*',
+          ],
         },
       ],
 


### PR DESCRIPTION
This slipped through, let's start linting for it. Intentionally failing for now while awaiting a fix.