### PR TITLE
Gerrit-catalog-plugin: Fix incorrect main entry

### DIFF
--- a/.changeset/loud-peaches-warn.md
+++ b/.changeset/loud-peaches-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gerrit': patch
+---
+
+Fix incorrect main path in `publishConfig`

--- a/plugins/catalog-backend-module-gerrit/package.json
+++ b/plugins/catalog-backend-module-gerrit/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.esm.js",
+    "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
   "backstage": {


### PR DESCRIPTION
Signed-off-by: Niklas Aronsson <niklasar@axis.com>

## Hey, I just made a Pull Request!

Plugin can not be loaded due to incorrect "main" path in the "publishConfig".

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
