### PR TITLE
test-utils: add rerender support for renderInTestApp

### DIFF
--- a/.changeset/brave-starfishes-try.md
+++ b/.changeset/brave-starfishes-try.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': patch
+---
+
+Fixed `renderInTestApp` so that it is able to re-render the result without removing the app wrapping.

--- a/.changeset/hip-monkeys-hide.md
+++ b/.changeset/hip-monkeys-hide.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': minor
+---
+
+Added the options parameter to `renderWithEffects`, which if forwarded to the `render` function from `@testling-library/react`. Initially only the `wrapper` option is supported.

--- a/.changeset/six-buckets-tap.md
+++ b/.changeset/six-buckets-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/test-utils': minor
+---
+
+Added `createTestAppWrapper`, which returns a component that can be used as the `wrapper` option for `render` or `renderWithEffects`.

--- a/packages/test-utils/api-report.md
+++ b/packages/test-utils/api-report.md
@@ -27,6 +27,7 @@ import { Observable } from '@backstage/types';
 import { PermissionApi } from '@backstage/plugin-permission-react';
 import { ReactElement } from 'react';
 import { ReactNode } from 'react';
+import { RenderOptions } from '@testing-library/react';
 import { RenderResult } from '@testing-library/react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { StorageApi } from '@backstage/core-plugin-api';
@@ -39,6 +40,11 @@ export type AsyncLogCollector = () => Promise<void>;
 export type CollectedLogs<T extends LogFuncs> = {
   [key in T]: string[];
 };
+
+// @public
+export function createTestAppWrapper(
+  options?: TestAppOptions,
+): (props: { children: ReactNode }) => JSX.Element;
 
 // @public
 export type ErrorWithContext = {
@@ -187,7 +193,10 @@ export function renderInTestApp(
 ): Promise<RenderResult>;
 
 // @public
-export function renderWithEffects(nodes: ReactElement): Promise<RenderResult>;
+export function renderWithEffects(
+  nodes: ReactElement,
+  options?: Pick<RenderOptions, 'wrapper'>,
+): Promise<RenderResult>;
 
 // @public
 export function setupRequestMockHandlers(worker: {

--- a/packages/test-utils/src/testUtils/appWrappers.test.tsx
+++ b/packages/test-utils/src/testUtils/appWrappers.test.tsx
@@ -20,6 +20,7 @@ import {
   createSubRouteRef,
   errorApiRef,
   useApi,
+  useApp,
   useRouteRef,
 } from '@backstage/core-plugin-api';
 import { withLogCollector } from './logCollector';
@@ -171,5 +172,19 @@ describe('wrapInTestApp', () => {
     expect(root).toBeInTheDocument();
     expect(root.children.length).toBe(1);
     expect(root.children[0].textContent).toBe('foo');
+  });
+
+  it('should support rerenders', async () => {
+    const MyComponent = () => {
+      const app = useApp();
+      const { Progress } = app.getComponents();
+      return <Progress />;
+    };
+
+    const rendered = await renderInTestApp(<MyComponent />);
+    expect(rendered.getByTestId('progress')).toBeInTheDocument();
+
+    rendered.rerender(<MyComponent />);
+    expect(rendered.getByTestId('progress')).toBeInTheDocument();
   });
 });

--- a/packages/test-utils/src/testUtils/index.tsx
+++ b/packages/test-utils/src/testUtils/index.tsx
@@ -16,7 +16,11 @@
 
 export * from './apis';
 export { default as mockBreakpoint } from './mockBreakpoint';
-export { wrapInTestApp, renderInTestApp } from './appWrappers';
+export {
+  wrapInTestApp,
+  renderInTestApp,
+  createTestAppWrapper,
+} from './appWrappers';
 export type { TestAppOptions } from './appWrappers';
 export * from './msw';
 export * from './logCollector';

--- a/packages/test-utils/src/testUtils/testingLibrary.ts
+++ b/packages/test-utils/src/testUtils/testingLibrary.ts
@@ -15,7 +15,12 @@
  */
 
 import { ReactElement } from 'react';
-import { act, render, RenderResult } from '@testing-library/react';
+import {
+  act,
+  render,
+  RenderOptions,
+  RenderResult,
+} from '@testing-library/react';
 
 /**
  * @public
@@ -31,10 +36,11 @@ import { act, render, RenderResult } from '@testing-library/react';
  */
 export async function renderWithEffects(
   nodes: ReactElement,
+  options?: Pick<RenderOptions, 'wrapper'>,
 ): Promise<RenderResult> {
   let value: RenderResult;
   await act(async () => {
-    value = render(nodes);
+    value = render(nodes, options);
   });
   return value!;
 }

--- a/plugins/shortcuts/src/ShortcutItem.test.tsx
+++ b/plugins/shortcuts/src/ShortcutItem.test.tsx
@@ -19,11 +19,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { ShortcutItem } from './ShortcutItem';
 import { Shortcut } from './types';
 import { LocalStoredShortcuts } from './api';
-import {
-  MockStorageApi,
-  renderInTestApp,
-  wrapInTestApp,
-} from '@backstage/test-utils';
+import { MockStorageApi, renderInTestApp } from '@backstage/test-utils';
 import { SidebarContext } from '@backstage/core-components';
 
 describe('ShortcutItem', () => {
@@ -66,12 +62,12 @@ describe('ShortcutItem', () => {
     );
     expect(screen.getByText('On')).toBeInTheDocument();
 
-    rerender(wrapInTestApp(<ShortcutItem api={api} shortcut={shortcut2} />));
+    rerender(<ShortcutItem api={api} shortcut={shortcut2} />);
     await waitFor(() => {
       expect(screen.getByText('TT')).toBeInTheDocument();
     });
 
-    rerender(wrapInTestApp(<ShortcutItem api={api} shortcut={shortcut3} />));
+    rerender(<ShortcutItem api={api} shortcut={shortcut3} />);
     await waitFor(() => {
       expect(screen.getByText('MT')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enables the following:

```tsx
const rendered = await renderInTestApp(<MyComponent />);
...
rendered.rerender(<MyComponent />);
```

Currently the second call will remove the app wrapping and render the component alone instead. I'm considering that broken behavior so calling this a fix rather than a breaking change.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
