### PR TITLE
Add search() implementation to googleGcs reader

### DIFF
--- a/.changeset/backend-common-twist-your-ankle.md
+++ b/.changeset/backend-common-twist-your-ankle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-common': patch
+---
+
+Implemented the `UrlReader.search()` method for Google Cloud Storage. Due to limitations in the underlying storage API, only prefix-based searches are supported right now (for example, `https://storage.cloud.google.com/your-bucket/some-path/*`).


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Makes it possible to, for example...

```ts
reader.search('https://storage.cloud.google.com/bucket/path/file-prefix-*');
```

And match objects like `path/file-prefix-20220429.ndjson`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
