### PR TITLE
[Search] Use batchSize of 1000 by default

### DIFF
--- a/.changeset/search-the-worst-of-you.md
+++ b/.changeset/search-the-worst-of-you.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-search-backend-node': patch
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+'@backstage/plugin-search-backend-module-pg': patch
+---
+
+Search Engines will now index documents in batches of 1000 instead of 100 (under the hood). This may result in your Backstage backend consuming slightly more memory during index runs, but should dramatically improve indexing performance for large document sets.

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngineIndexer.ts
@@ -53,7 +53,7 @@ export class ElasticSearchSearchEngineIndexer extends BatchSearchEngineIndexer {
   private bulkResult: Promise<any>;
 
   constructor(options: ElasticSearchSearchEngineIndexerOptions) {
-    super({ batchSize: 100 });
+    super({ batchSize: 1000 });
     this.logger = options.logger;
     this.startTimestamp = process.hrtime();
     this.type = options.type;

--- a/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngine.test.ts
+++ b/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngine.test.ts
@@ -136,7 +136,7 @@ describe('PgSearchEngine', () => {
       // Indexer instantiated with expected args.
       expect(PgSearchEngineIndexer).toHaveBeenCalledWith(
         expect.objectContaining({
-          batchSize: 100,
+          batchSize: 1000,
           type: 'my-type',
           databaseStore: database,
         }),

--- a/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngine.ts
+++ b/plugins/search-backend-module-pg/src/PgSearchEngine/PgSearchEngine.ts
@@ -78,7 +78,7 @@ export class PgSearchEngine implements SearchEngine {
 
   async getIndexer(type: string) {
     return new PgSearchEngineIndexer({
-      batchSize: 100,
+      batchSize: 1000,
       type,
       databaseStore: this.databaseStore,
     });

--- a/plugins/search-backend-node/src/engines/LunrSearchEngineIndexer.ts
+++ b/plugins/search-backend-node/src/engines/LunrSearchEngineIndexer.ts
@@ -27,7 +27,7 @@ export class LunrSearchEngineIndexer extends BatchSearchEngineIndexer {
   private docStore: Record<string, IndexableDocument> = {};
 
   constructor() {
-    super({ batchSize: 100 });
+    super({ batchSize: 1000 });
 
     this.builder = new lunr.Builder();
     this.builder.pipeline.add(lunr.trimmer, lunr.stopWordFilter, lunr.stemmer);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In testing the search indexing process, I found that larger document sets (e.g. hundreds of thousands of documents) could take an unexpectedly long amount of time to complete.  Making the batch size larger helps with this, with relatively small impact to memory consumption.

...Maybe we want to make this configurable in the future, but doing so is a little annoying to do in a backward compatible way at the moment because of how exposed the indexing classes are in all of the underlying packages.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
