### PR TITLE
feat: rename use to adopt

### DIFF
--- a/.changeset/cyan-boxes-double.md
+++ b/.changeset/cyan-boxes-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tech-radar': patch
+---
+
+Rename `use` to `adopt`, to reflect Zalando Tech Radar regarding quadrants and add link to Zalando explanation.

--- a/plugins/tech-radar/src/components/RadarPage.tsx
+++ b/plugins/tech-radar/src/components/RadarPage.tsx
@@ -20,6 +20,7 @@ import {
   Header,
   Page,
   SupportButton,
+  Link,
 } from '@backstage/core-components';
 import { Grid, Input, makeStyles } from '@material-ui/core';
 import React from 'react';
@@ -74,9 +75,16 @@ export function RadarPage(props: TechRadarPageProps) {
             onChange={e => setSearchText(e.target.value)}
           />
           <SupportButton>
-            This is used for visualizing the official guidelines of different
-            areas of software development such as languages, frameworks,
-            infrastructure and processes.
+            <p>
+              This is used for visualizing the official guidelines of different
+              areas of software development such as languages, frameworks,
+              infrastructure and processes. You can find an explanation for the
+              radar at{' '}
+              <Link to="https://opensource.zalando.com/tech-radar/">
+                Zalando Tech Radar
+              </Link>
+              .
+            </p>
           </SupportButton>
         </ContentHeader>
         <Grid container spacing={3} direction="row">

--- a/plugins/tech-radar/src/sample.ts
+++ b/plugins/tech-radar/src/sample.ts
@@ -23,7 +23,7 @@ import {
 } from './api';
 
 const rings = new Array<RadarRing>();
-rings.push({ id: 'use', name: 'USE', color: '#93c47d' });
+rings.push({ id: 'adopt', name: 'ADOPT', color: '#93c47d' });
 rings.push({ id: 'trial', name: 'TRIAL', color: '#93d2c2' });
 rings.push({ id: 'assess', name: 'ASSESS', color: '#fbdb84' });
 rings.push({ id: 'hold', name: 'HOLD', color: '#efafa9' });
@@ -39,7 +39,7 @@ entries.push({
   timeline: [
     {
       moved: 0,
-      ringId: 'use',
+      ringId: 'adopt',
       date: new Date('2020-08-06'),
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
@@ -57,7 +57,7 @@ entries.push({
   timeline: [
     {
       moved: -1,
-      ringId: 'use',
+      ringId: 'adopt',
       date: new Date('2020-08-06'),
       description:
         'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat',
@@ -75,7 +75,7 @@ entries.push({
   timeline: [
     {
       moved: 1,
-      ringId: 'use',
+      ringId: 'adopt',
       date: new Date('2020-08-06'),
       description:
         'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur',
@@ -91,7 +91,7 @@ entries.push({
   timeline: [
     {
       moved: 0,
-      ringId: 'use',
+      ringId: 'adopt',
       date: new Date('2020-08-06'),
     },
   ],
@@ -105,7 +105,7 @@ entries.push({
   timeline: [
     {
       moved: 0,
-      ringId: 'use',
+      ringId: 'adopt',
       date: new Date('2020-08-06'),
     },
   ],
@@ -133,7 +133,7 @@ entries.push({
   timeline: [
     {
       moved: 0,
-      ringId: 'use',
+      ringId: 'adopt',
       date: new Date('2020-08-06'),
     },
   ],
@@ -159,7 +159,7 @@ entries.push({
 entries.push({
   timeline: [
     {
-      ringId: 'use',
+      ringId: 'adopt',
       date: new Date('2020-08-06'),
       description: 'long description',
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Rename `use` to `adopt`, to reflect Zalando Tech Radar regarding quadrants and add link to Zalando explanation.

The change will look like this for the support button
<img width="1558" alt="tech-radar" src="https://user-images.githubusercontent.com/1021324/166070361-c68c3ca2-532a-490c-a1f4-10606edfa872.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
