### PR TITLE
cli: fix next test coverage configuration

### DIFF
--- a/.changeset/early-lemons-add.md
+++ b/.changeset/early-lemons-add.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Fixed coverage configuration when using `BACKSTAGE_NEXT_TESTS`.

--- a/packages/cli/config/jest.js
+++ b/packages/cli/config/jest.js
@@ -123,7 +123,7 @@ async function getProjectConfig(targetPath, displayName) {
     ...(displayName && { displayName }),
     rootDir: path.resolve(targetPath, 'src'),
     coverageDirectory: path.resolve(targetPath, 'coverage'),
-    coverageProvider: envOptions.nextTests ? undefined : 'v8',
+    coverageProvider: envOptions.nextTests ? 'babel' : 'v8',
     collectCoverageFrom: ['**/*.{js,jsx,ts,tsx,mjs,cjs}', '!**/*.d.ts'],
     moduleNameMapper: {
       '\\.(css|less|scss|sss|styl)$': require.resolve('jest-css-modules'),


### PR DESCRIPTION
Turns out `undefined` does not mean "use default", it's something closer to "maybe coverage"

![image](https://user-images.githubusercontent.com/4984472/166109793-361ce0d7-f7b0-449b-8a84-f8cbc0c3c6c4.png)
