### PR TITLE
Make Menu items on filters accessible through keyboard

### DIFF
--- a/.changeset/witty-lions-reply.md
+++ b/.changeset/witty-lions-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Make Menu item on filters accessible through keyboard

--- a/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/UserListPicker.tsx
@@ -253,6 +253,7 @@ export const UserListPicker = (props: UserListPickerProps) => {
                   className={classes.menuItem}
                   disabled={filterCounts[item.id] === 0}
                   data-testid={`user-picker-${item.id}`}
+                  tabIndex={0}
                 >
                   {item.icon && (
                     <ListItemIcon className={classes.listIcon}>


### PR DESCRIPTION
Signed-off-by: Hamza El Aoutar <elaoutarhamza@gmail.com>

## Hey, I just made a Pull Request which fixes [11172](https://github.com/backstage/backstage/issues/11172)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I added `tabindex=0` to menu items on filters


https://user-images.githubusercontent.com/12495892/166121764-76c9e243-579c-4329-baf8-ff78a237dec7.mov


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
