### PR TITLE
Do not send last_activity_after timestamp to gitlab api when the cache is empty 

### DIFF
--- a/.changeset/long-spiders-wave.md
+++ b/.changeset/long-spiders-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+The `last_activity_after` timestamp is now being omitted when querying the GitLab API for the first time.

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
@@ -65,9 +65,9 @@ function setupFakeServer(
     rest.get(url, (req, res, ctx) => {
       // Send the request to the assertion to give the test an opportunity to inspect the parameters.
       if (assertion !== undefined) {
-        assertion(req)
+        assertion(req);
       }
-      
+
       if (req.headers.get('private-token') !== 'test-token') {
         return res(ctx.status(401), ctx.json({}));
       }
@@ -420,17 +420,24 @@ describe('GitlabDiscoveryProcessor', () => {
         ],
       };
       const processor = getProcessor();
-      setupFakeServer(PROJECTS_URL, request => {
-        switch (request.page) {
-          case 1:
-            return payload;
-          default:
-            throw new Error('Invalid request');
-        }
-      }, request => {
-        // We assert that the last activity timestamp is not being sent to the GitLab API as we expect the cache to be empty.
-        expect(request.url.searchParams.get('last_activity_after')).toBeNull()
-      });
+
+      setupFakeServer(
+        PROJECTS_URL,
+        request => {
+          switch (request.page) {
+            case 1:
+              return payload;
+            default:
+              throw new Error('Invalid request');
+          }
+        },
+        request => {
+          // We assert that the last activity timestamp is not being sent to the GitLab API as we expect the cache to be empty.
+          expect(
+            request.url.searchParams.get('last_activity_after'),
+          ).toBeNull();
+        },
+      );
 
       const result: any[] = [];
 
@@ -442,12 +449,18 @@ describe('GitlabDiscoveryProcessor', () => {
 
       // Second scan should have used the mocked Date to set the last scanned time to 2001
       // This should result in only the second repo being scanned, since that has a timestamp of 2002
-      setupFakeServer(PROJECTS_URL, _ => {
-        return payload;
-      }, request => {
-        // We assert that the last activity timestamp is being sent to the GitLab API since we expect it to be in the cache.
-        expect(request.url.searchParams.get('last_activity_after')).toMatch(SERVER_TIME)
-      });
+      setupFakeServer(
+        PROJECTS_URL,
+        _ => {
+          return payload;
+        },
+        request => {
+          // We assert that the last activity timestamp is being sent to the GitLab API since we expect it to be in the cache.
+          expect(request.url.searchParams.get('last_activity_after')).toMatch(
+            SERVER_TIME,
+          );
+        },
+      );
       const result2: any[] = [];
       await processor.readLocation(PROJECT_LOCATION, false, e => {
         result2.push(e);

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
@@ -17,7 +17,7 @@
 import { getVoidLogger } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import { LocationSpec } from '@backstage/plugin-catalog-backend';
-import { rest } from 'msw';
+import { rest, RestRequest } from 'msw';
 import { setupServer } from 'msw/node';
 import { GitLabDiscoveryProcessor, parseUrl } from './GitLabDiscoveryProcessor';
 import { GitLabProject } from './lib';
@@ -48,6 +48,7 @@ const GROUP_LOCATION_CUSTOM_BRANCH: LocationSpec = {
   type: 'gitlab-discovery',
   target: `${SERVER_URL}/group/subgroup/blob/test/catalog-info.yaml`,
 };
+const SERVER_TIME = '2001-01-01T12:34:56.000Z';
 
 function setupFakeServer(
   url: string,
@@ -58,9 +59,15 @@ function setupFakeServer(
     data: GitLabProject[];
     nextPage?: number;
   },
+  assertion?: (r: RestRequest) => any,
 ) {
   server.use(
     rest.get(url, (req, res, ctx) => {
+      // Send the request to the assertion to give the test an opportunity to inspect the parameters.
+      if (assertion !== undefined) {
+        assertion(req)
+      }
+      
       if (req.headers.get('private-token') !== 'test-token') {
         return res(ctx.status(401), ctx.json({}));
       }
@@ -145,7 +152,7 @@ describe('GitlabDiscoveryProcessor', () => {
   beforeAll(() => {
     server.listen();
     jest.useFakeTimers('modern');
-    jest.setSystemTime(new Date('2001-01-01T12:34:56Z'));
+    jest.setSystemTime(new Date(SERVER_TIME));
   });
   afterEach(() => server.resetHandlers());
   afterAll(() => {
@@ -394,33 +401,35 @@ describe('GitlabDiscoveryProcessor', () => {
     });
 
     it('uses the previous scan timestamp to filter', async () => {
+      const payload = {
+        data: [
+          {
+            id: 1,
+            archived: false,
+            default_branch: 'main',
+            last_activity_at: '2000-01-01T00:00:00Z',
+            web_url: 'https://gitlab.fake/1',
+          },
+          {
+            id: 2,
+            archived: false,
+            default_branch: 'main',
+            last_activity_at: '2002-01-01T00:00:00Z',
+            web_url: 'https://gitlab.fake/2',
+          },
+        ],
+      };
       const processor = getProcessor();
       setupFakeServer(PROJECTS_URL, request => {
         switch (request.page) {
           case 1:
-            return {
-              data: [
-                {
-                  id: 1,
-                  archived: false,
-                  default_branch: 'main',
-                  last_activity_at: '2000-01-01T00:00:00Z',
-                  web_url: 'https://gitlab.fake/1',
-                  path_with_namespace: '1',
-                },
-                {
-                  id: 2,
-                  archived: false,
-                  default_branch: 'main',
-                  last_activity_at: '2002-01-01T00:00:00Z',
-                  web_url: 'https://gitlab.fake/2',
-                  path_with_namespace: '2',
-                },
-              ],
-            };
+            return payload;
           default:
             throw new Error('Invalid request');
         }
+      }, request => {
+        // We assert that the last activity timestamp is not being sent to the GitLab API as we expect the cache to be empty.
+        expect(request.url.searchParams.get('last_activity_after')).toBeNull()
       });
 
       const result: any[] = [];
@@ -433,6 +442,12 @@ describe('GitlabDiscoveryProcessor', () => {
 
       // Second scan should have used the mocked Date to set the last scanned time to 2001
       // This should result in only the second repo being scanned, since that has a timestamp of 2002
+      setupFakeServer(PROJECTS_URL, _ => {
+        return payload;
+      }, request => {
+        // We assert that the last activity timestamp is being sent to the GitLab API since we expect it to be in the cache.
+        expect(request.url.searchParams.get('last_activity_after')).toMatch(SERVER_TIME)
+      });
       const result2: any[] = [];
       await processor.readLocation(PROJECT_LOCATION, false, e => {
         result2.push(e);

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
@@ -107,7 +107,7 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
       // We check for the existence of lastActivity and only set it if it's present to ensure
       // that the options doesn't include the key so that the API doesn't receive an empty query parameter.
       ...(lastActivity && { last_activity_after: lastActivity }),
-    }
+    };
 
     const projects = paginated(options => client.listProjects(options), opts);
 

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
@@ -100,19 +100,18 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
     const startTimestamp = Date.now();
     this.logger.debug(`Reading GitLab projects from ${location.target}`);
 
-
     const opts = {
       group,
       page: 1,
     } as {
-      group: string
-      page: number
-      last_activity_after: string | undefined
-    }
-  
-    const lastActivity = await this.cache.get(this.getCacheKey()) as string;
-    if (lastActivity !== "") {
-      opts.last_activity_after = lastActivity
+      group: string;
+      page: number;
+      last_activity_after: string | undefined;
+    };
+
+    const lastActivity = (await this.cache.get(this.getCacheKey())) as string;
+    if (lastActivity !== '') {
+      opts.last_activity_after = lastActivity;
     }
 
     const projects = paginated(options => client.listProjects(options), opts);

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
@@ -100,20 +100,13 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
     });
     this.logger.debug(`Reading GitLab projects from ${location.target}`);
 
+    const lastActivity = (await this.cache.get(this.getCacheKey())) as string;
     const opts = {
       group,
       page: 1,
-    } as {
-      group: string;
-      page: number;
-      last_activity_after: string | undefined;
-    };
-
-    const lastActivity = (await this.cache.get(this.getCacheKey())) as string;
-    // We check for the existence of lastActivity and only set it if it's present to ensure
-    // that the options doesn't include the key so that the API doesn't receive an empty query parameter.
-    if (lastActivity) {
-      opts.last_activity_after = lastActivity;
+      // We check for the existence of lastActivity and only set it if it's present to ensure
+      // that the options doesn't include the key so that the API doesn't receive an empty query parameter.
+      ...(lastActivity && { last_activity_after: lastActivity }),
     }
 
     const projects = paginated(options => client.listProjects(options), opts);

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
@@ -110,7 +110,7 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
     };
 
     const lastActivity = (await this.cache.get(this.getCacheKey())) as string;
-    if (lastActivity !== '') {
+    if (lastActivity) {
       opts.last_activity_after = lastActivity;
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
The `last_activity_after` timestamp was being sent as current time when the cache is empty. Now it should not be sent at all and as we assert in the test.

Fixes #10399

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
