### PR TITLE
Added alternative text to profile picture (Settings)

### DIFF
--- a/.changeset/kind-cats-clap.md
+++ b/.changeset/kind-cats-clap.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-user-settings': minor
+'@backstage/plugin-user-settings': patch
 ---
 
 Added alternative text to profile picture

--- a/.changeset/kind-cats-clap.md
+++ b/.changeset/kind-cats-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': minor
+---
+
+Added alternative text to profile picture

--- a/plugins/user-settings/src/components/General/UserSettingsSignInAvatar.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsSignInAvatar.tsx
@@ -36,5 +36,11 @@ export const UserSettingsSignInAvatar = ({ size }: Props) => {
   const classes = useStyles(size ? { size } : { size: iconSize });
   const { profile } = useUserProfile();
 
-  return <Avatar src={profile.picture} className={classes.avatar} />;
+  return (
+    <Avatar
+      src={profile.picture}
+      className={classes.avatar}
+      alt="Profile picture"
+    />
+  );
 };


### PR DESCRIPTION
Work done: Added alternative text to profile picture (Settings).

![profile-picture-alt](https://user-images.githubusercontent.com/54085737/166228263-96bd5638-cc27-4301-a4ea-735eecde76e9.png)


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshot attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
