### PR TITLE
cli/create-github-app: prompt for read or write permissions during setup

### DIFF
--- a/.changeset/three-tips-hunt.md
+++ b/.changeset/three-tips-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Updated `create-github-app` command to prompt for read or write permissions to simplify setup.

--- a/packages/cli/src/commands/create-github-app/index.ts
+++ b/packages/cli/src/commands/create-github-app/index.ts
@@ -16,9 +16,8 @@
 
 import fs from 'fs-extra';
 import chalk from 'chalk';
-import inquirer, { Answers } from 'inquirer';
 import { stringify as stringifyYaml } from 'yaml';
-import inquirer, { Question } from 'inquirer';
+import inquirer, { Question, Answers } from 'inquirer';
 import { paths } from '../../lib/paths';
 import { GithubCreateAppServer } from './GithubCreateAppServer';
 import fetch from 'node-fetch';

--- a/packages/cli/src/commands/create-github-app/index.ts
+++ b/packages/cli/src/commands/create-github-app/index.ts
@@ -32,10 +32,7 @@ export default async (org: string) => {
       type: 'list',
       name: 'appType',
       message: chalk.blue('What will the app be used for [required]'),
-      choices: [
-        'Read and Write (needed by Software Templates)',
-        'Read only',
-      ],
+      choices: ['Read and Write (needed by Software Templates)', 'Read only'],
     },
   ]);
   const readWrite = answers.appType !== 'Read only';

--- a/packages/cli/src/commands/create-github-app/index.ts
+++ b/packages/cli/src/commands/create-github-app/index.ts
@@ -33,7 +33,7 @@ export default async (org: string) => {
       name: 'appType',
       message: chalk.blue('What will the app be used for [required]'),
       choices: [
-        'Read and Write(needed by the scaffolding to create new projects)',
+        'Read and Write (needed by Software Templates)',
         'Read only',
       ],
     },

--- a/packages/cli/src/commands/create-github-app/index.ts
+++ b/packages/cli/src/commands/create-github-app/index.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs-extra';
 import chalk from 'chalk';
+import inquirer, { Answers } from 'inquirer';
 import { stringify as stringifyYaml } from 'yaml';
 import inquirer, { Question } from 'inquirer';
 import { paths } from '../../lib/paths';
@@ -26,8 +27,23 @@ import openBrowser from 'react-dev-utils/openBrowser';
 // due to lacking support for creating apps from manifests.
 // https://docs.github.com/en/free-pro-team@latest/developers/apps/creating-a-github-app-from-a-manifest
 export default async (org: string) => {
+  const answers: Answers = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'appType',
+      message: chalk.blue('What will the app be used for [required]'),
+      choices: [
+        'Read and Write(needed by the scaffolding to create new projects)',
+        'Read only',
+      ],
+    },
+  ]);
+  const readWrite = answers.appType !== 'Read only';
   await verifyGithubOrg(org);
-  const { slug, name, ...config } = await GithubCreateAppServer.run({ org });
+  const { slug, name, ...config } = await GithubCreateAppServer.run({
+    org,
+    readWrite,
+  });
 
   const fileName = `github-app-${slug}-credentials.yaml`;
   const content = `# Name: ${name}\n${stringifyYaml(config)}`;


### PR DESCRIPTION
Updated `create-github-app` command to prompt for read or write permissions to simplify setup.
