### PR TITLE
Fix link "bugs" in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ No one likes bugs. Report bugs as an issue [here](https://github.com/backstage/b
 
 ### Fix bugs or build new features
 
-Look through the GitHub issues for [bugs](https://github.com/backstage/backstage/labels/bugs), [good first issues](https://github.com/backstage/backstage/labels/good%20first%20issue) or [help wanted](https://github.com/backstage/backstage/labels/help%20wanted).
+Look through the GitHub issues for [bugs](https://github.com/backstage/backstage/labels/bug), [good first issues](https://github.com/backstage/backstage/labels/good%20first%20issue) or [help wanted](https://github.com/backstage/backstage/labels/help%20wanted).
 
 ### Build a plugin
 


### PR DESCRIPTION
The link used to point to [GitHub label "bugs"](https://github.com/backstage/backstage/labels/bugs) which doesn't exist. The [correct label is "bug"](https://github.com/backstage/backstage/labels/bug).

Signed-off-by: Chris Nitsas <nitsas.chris@gmail.com>

## Hey, I just made a Pull Request!

As mentioned above, the link used to point to [GitHub label "bugs"](https://github.com/backstage/backstage/labels/bugs) which doesn't exist. The [correct label is "bug"](https://github.com/backstage/backstage/labels/bug). 🙂

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
