### PR TITLE
Fix invalid aria- attribute

### DIFF
--- a/.changeset/odd-apples-smash.md
+++ b/.changeset/odd-apples-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Lighthouse was reporting this button as having invalid aria- values, as the popover doesn't exist until clicked. This adds additional labels to the button to make it valid aria

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -109,9 +109,12 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
         aria-label="more"
         aria-controls="long-menu"
         aria-haspopup="true"
+        aria-expanded={!!anchorEl}
+        role="button"
         onClick={onOpen}
         data-testid="menu-button"
         className={classes.button}
+        id="long-menu"
       >
         <MoreVert />
       </IconButton>
@@ -121,6 +124,7 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
         anchorEl={anchorEl}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        aria-labelledby="long-menu"
       >
         <MenuList>
           {extraItems}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Addresses some of #7124

<img width="644" alt="Screen Shot 2022-04-28 at 4 08 57 pm" src="https://user-images.githubusercontent.com/41275089/166402648-10e90221-741d-47f9-b518-eb57f7dc030d.png">

Lighthouse reports that this button has invalid `aria-` values, as the popover doesn't exist until the button has been clicked. I followed the guidelines here https://techservicesillinois.github.io/accessibility/examples/popover.html to add additional values to address this 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
