### PR TITLE
scaffolder-backend-module-rails: add allowedImageNames option

### DIFF
--- a/.changeset/fluffy-poems-sell.md
+++ b/.changeset/fluffy-poems-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-rails': minor
+---
+
+**BREAKING**: Added a new `allowedImageNames` option, which needs to list any image name for it to be allowed as `imageName` input.

--- a/plugins/scaffolder-backend-module-rails/README.md
+++ b/plugins/scaffolder-backend-module-rails/README.md
@@ -246,3 +246,16 @@ steps:
         system: ${{ parameters.system }}
         railsArguments: ${{ parameters.railsArguments }}
 ```
+
+You also need to configure the list of allowed images as part of the creating the action for the scaffolder backend:
+
+```typescript
+const actions = [
+  createFetchRailsAction({
+    integrations,
+    reader: env.reader,
+    containerRunner,
+    allowedImageNames: ['repository/rails:tag'],
+  }),
+];
+```

--- a/plugins/scaffolder-backend-module-rails/api-report.md
+++ b/plugins/scaffolder-backend-module-rails/api-report.md
@@ -14,6 +14,7 @@ export function createFetchRailsAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
   containerRunner: ContainerRunner;
+  allowedImageNames?: string[];
 }): TemplateAction<{
   url: string;
   targetPath?: string | undefined;

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.test.ts
@@ -86,6 +86,7 @@ describe('fetch:rails', () => {
     integrations,
     reader: mockReader,
     containerRunner,
+    allowedImageNames: ['foo/rails-custom-image'],
   });
 
   beforeEach(() => {
@@ -136,6 +137,35 @@ describe('fetch:rails', () => {
         imageName: 'foo/rails-custom-image',
       },
     });
+  });
+
+  it('should not allow unknown images', async () => {
+    await expect(
+      action.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          imageName: 'foo/bar',
+        },
+      }),
+    ).rejects.toThrow('Image foo/bar is not allowed');
+  });
+
+  it('should not allow any images', async () => {
+    const action2 = createFetchRailsAction({
+      integrations,
+      reader: mockReader,
+      containerRunner,
+    });
+    await expect(
+      action2.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          imageName: 'foo/rails-custom-image',
+        },
+      }),
+    ).rejects.toThrow('Image foo/rails-custom-image is not allowed');
   });
 
   it('should throw if the target directory is outside of the workspace path', async () => {

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/index.ts
@@ -41,6 +41,8 @@ export function createFetchRailsAction(options: {
   reader: UrlReader;
   integrations: ScmIntegrations;
   containerRunner: ContainerRunner;
+  /** A list of image names that are allowed to be passed as imageName input */
+  allowedImageNames?: string[];
 }) {
   const { reader, integrations, containerRunner } = options;
 
@@ -177,16 +179,16 @@ export function createFetchRailsAction(options: {
 
       const templateRunner = new RailsNewRunner({ containerRunner });
 
-      const values = {
-        ...ctx.input.values,
-        imageName: ctx.input.imageName,
-      };
+      const { imageName } = ctx.input;
+      if (imageName && !options.allowedImageNames?.includes(imageName)) {
+        throw new Error(`Image ${imageName} is not allowed`);
+      }
 
       // Will execute the template in ./template and put the result in ./result
       await templateRunner.run({
         workspacePath: workDir,
         logStream: ctx.logStream,
-        values,
+        values: { ...ctx.input.values, imageName },
       });
 
       // Finally move the template result into the task workspace

--- a/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/railsNewRunner.ts
+++ b/plugins/scaffolder-backend-module-rails/src/actions/fetch/rails/railsNewRunner.ts
@@ -74,6 +74,9 @@ export class RailsNewRunner {
         logStream,
       });
     } else {
+      if (!imageName) {
+        throw new Error('No imageName provided');
+      }
       const arrayExtraArguments = railsArgumentResolver(
         '/input',
         railsArguments as RailsRunOptions,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding a new option that is required for rails dockerfile execution. Any image that one wants to use now needs to be configured as part of the action setup.

CC @angeliski 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
