### PR TITLE
gh actions: Automatically merge lock file dependency bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,6 @@
 {
   labels: ['dependencies'],
-  extends: [
-    'config:base',
-    ':disableDependencyDashboard',
-    ':gitSignOff',
-    ':automergePatch',
-  ],
+  extends: ['config:base', ':disableDependencyDashboard', ':gitSignOff'],
   rangeStrategy: 'update-lockfile',
   // @elastic/elasticsearch is ignored due to licensing issues. See #10992
   ignoreDeps: ['@elastic/elasticsearch'],

--- a/.github/workflows/automate_merge_renovate_prs.yaml
+++ b/.github/workflows/automate_merge_renovate_prs.yaml
@@ -54,7 +54,7 @@ jobs:
 
             const date = new Date();
             if (date.getDay() === 2) {
-              console.log("Skipping auto approve because Tuesday is release day");
+              console.log("Skipping auto merge because Tuesday is release day");
               return;
             }
 

--- a/.github/workflows/automate_merge_renovate_prs.yaml
+++ b/.github/workflows/automate_merge_renovate_prs.yaml
@@ -1,0 +1,85 @@
+name: Automate Merge Renovate PRs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/10 * * * *'
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const owner = "backstage";
+            const repo = "backstage";
+            const query = `{
+              repository(name: "backstage", owner: "backstage") {
+                pullRequests(labels: ["dependencies"], last: 10, states: [OPEN]) {
+                  nodes {
+                    title
+                    author {
+                      login
+                    }
+                    number
+                    mergeable
+                    files(first: 1) {
+                      nodes {
+                        path
+                      }
+                    }
+                    changedFiles
+                    commits(last: 1) {
+                      nodes {
+                        commit {
+                          statusCheckRollup {
+                            state 
+                          }
+                        }
+                      }
+                    }
+                    reviewDecision
+                    reviews(first: 10) {
+                      nodes {
+                        author {
+                          login
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }`;
+
+            const date = new Date();
+            if (date.getDay() === 2) {
+              console.log("Skipping auto approve because Tuesday is release day");
+              return;
+            }
+
+            const r = await github.graphql(query);
+            const mergable = r.repository.pullRequests.nodes.filter(
+              (pr) =>
+                pr.author.login === "renovate" &&
+                pr.mergeable === "MERGEABLE" &&
+                pr.changedFiles === 1 &&
+                pr.files.nodes[0].path.split("/").slice(-1)[0] === "yarn.lock" &&
+                pr.commits.nodes[0].commit.statusCheckRollup.state === "SUCCESS" &&
+                pr.reviewDecision === "APPROVED"
+            );
+
+            if (mergable.length === 0) {
+              console.log("no mergable PRs");
+              return;
+            }
+
+            for (const pr of mergable) {
+              console.log(`Merging #${pr.number} - ${pr.title}`);
+              await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number: pr.number,
+              });
+              await new Promise((r) => setTimeout(r, 2000));
+            }

--- a/.github/workflows/automate_merge_renovate_prs.yaml
+++ b/.github/workflows/automate_merge_renovate_prs.yaml
@@ -15,7 +15,7 @@ jobs:
             const owner = "backstage";
             const repo = "backstage";
             const query = `{
-              repository(name: "backstage", owner: "backstage") {
+              repository(owner: "backstage", name: "backstage") {
                 pullRequests(labels: ["dependencies"], last: 10, states: [OPEN]) {
                   nodes {
                     title


### PR DESCRIPTION
Replace the automerge functionality in renovate with our own implementation.

Will merge when
- it's not release day
- renovate is author
- last commit is passing build
- approved
- mergeable
- only one file has changed
- file is yarn.lock
 