### PR TITLE
Add an expiry time on server-to-server tokens

### DIFF
--- a/.changeset/olive-eggs-accept.md
+++ b/.changeset/olive-eggs-accept.md
@@ -1,0 +1,13 @@
+---
+'@backstage/backend-common': minor
+---
+
+**BREAKING**: Server-to-server authentication tokens issued from a
+`TokenManager` (specifically, `ServerTokenManager`) now has an expiry time set,
+for one hour in the future from when issued. This improves security.
+
+It was always the case that users of this interface were expected to call its
+`getToken()` method for every outgoing call and never hold on to any given token
+for reuse. But this now has become even more important advice to heed, and you
+should verify that you do not hold on to and reuse tokens such as these in your
+own code.

--- a/.changeset/olive-eggs-accept.md
+++ b/.changeset/olive-eggs-accept.md
@@ -1,10 +1,13 @@
 ---
-'@backstage/backend-common': minor
+'@backstage/backend-common': patch
 ---
 
-**BREAKING**: Server-to-server authentication tokens issued from a
+**DEPRECATION**: Server-to-server authentication tokens issued from a
 `TokenManager` (specifically, `ServerTokenManager`) now has an expiry time set,
-for one hour in the future from when issued. This improves security.
+for one hour in the future from when issued. This improves security. The ability
+to pass in and validate tokens that either have a missing `exp` claim, or an
+`exp` claim that expired in the past, is now deprecated. Trying to do so will
+lead to logged warnings, and in a future release will instead lead to errors.
 
 It was always the case that users of this interface were expected to call its
 `getToken()` method for every outgoing call and never hold on to any given token

--- a/packages/backend-common/api-report.md
+++ b/packages/backend-common/api-report.md
@@ -599,16 +599,18 @@ export class ServerTokenManager implements TokenManager {
   // (undocumented)
   static fromConfig(
     config: Config,
-    options: {
-      logger: Logger;
-    },
+    options: ServerTokenManagerOptions,
   ): ServerTokenManager;
   // (undocumented)
   getToken(): Promise<{
     token: string;
   }>;
-  // (undocumented)
   static noop(): TokenManager;
+}
+
+// @public
+export interface ServerTokenManagerOptions {
+  logger: Logger;
 }
 
 // @public
@@ -669,10 +671,8 @@ export interface StatusCheckHandlerOptions {
 
 // @public
 export interface TokenManager {
-  // (undocumented)
-  authenticate: (token: string) => Promise<void>;
-  // (undocumented)
-  getToken: () => Promise<{
+  authenticate(token: string): Promise<void>;
+  getToken(): Promise<{
     token: string;
   }>;
 }

--- a/packages/backend-common/src/tokens/ServerTokenManager.test.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.test.ts
@@ -171,6 +171,7 @@ describe('ServerTokenManager', () => {
 
     it('should throw for expired tokens, and re-issue new ones', async () => {
       jest.useFakeTimers();
+      const warn = jest.spyOn(logger, 'warn');
 
       const tokenManager = ServerTokenManager.fromConfig(configWithSecret, {
         logger,
@@ -178,12 +179,14 @@ describe('ServerTokenManager', () => {
 
       const { token: token1 } = await tokenManager.getToken();
       await expect(tokenManager.authenticate(token1)).resolves.not.toThrow();
+      expect(warn.mock.calls.length).toBe(0);
 
       // Right before the reissue timeout, it still returns the same token
       jest.advanceTimersByTime(9 * 60 * 1000);
       const { token: token1Again } = await tokenManager.getToken();
       expect(token1).toEqual(token1Again);
       await expect(tokenManager.authenticate(token1)).resolves.not.toThrow();
+      expect(warn.mock.calls.length).toBe(0);
 
       // Right after the reissue timeout, the old ones are still valid but returning a new token
       jest.advanceTimersByTime(2 * 60 * 1000);
@@ -191,15 +194,15 @@ describe('ServerTokenManager', () => {
       expect(token1).not.toEqual(token2);
       await expect(tokenManager.authenticate(token1)).resolves.not.toThrow();
       await expect(tokenManager.authenticate(token2)).resolves.not.toThrow();
+      expect(warn.mock.calls.length).toBe(0);
 
-      // After expiry of the first one, the newest one is still valid
+      // After expiry of the first one, it gets warnings but the newest one is still valid
       jest.advanceTimersByTime(52 * 60 * 1000);
-      await expect(
-        tokenManager.authenticate(token1),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        '"Invalid server token: JWTExpired: \\"exp\\" claim timestamp check failed"',
-      );
+      await expect(tokenManager.authenticate(token1)).resolves.not.toThrow();
       await expect(tokenManager.authenticate(token2)).resolves.not.toThrow();
+      expect(warn.mock.calls[0][0]).toMatchInlineSnapshot(
+        '"#### DEPRECATION WARNING: #### Server-to-server token had an expired exp claim, support for this has been deprecated and will result in errors in a future release"',
+      );
     });
   });
 

--- a/packages/backend-common/src/tokens/ServerTokenManager.test.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.test.ts
@@ -179,21 +179,21 @@ describe('ServerTokenManager', () => {
       const { token: token1 } = await tokenManager.getToken();
       await expect(tokenManager.authenticate(token1)).resolves.not.toThrow();
 
-      // Less than ten minutes before expiry, it still returns the same token
-      jest.advanceTimersByTime(49 * 60 * 1000);
+      // Right before the reissue timeout, it still returns the same token
+      jest.advanceTimersByTime(9 * 60 * 1000);
       const { token: token1Again } = await tokenManager.getToken();
       expect(token1).toEqual(token1Again);
       await expect(tokenManager.authenticate(token1)).resolves.not.toThrow();
 
-      // Right before the expiry, the old ones are still valid but returning a new token
-      jest.advanceTimersByTime(10 * 60 * 1000);
+      // Right after the reissue timeout, the old ones are still valid but returning a new token
+      jest.advanceTimersByTime(2 * 60 * 1000);
       const { token: token2 } = await tokenManager.getToken();
       expect(token1).not.toEqual(token2);
       await expect(tokenManager.authenticate(token1)).resolves.not.toThrow();
       await expect(tokenManager.authenticate(token2)).resolves.not.toThrow();
 
-      // After expiry, the newest one is still valid
-      jest.advanceTimersByTime(2 * 60 * 1000);
+      // After expiry of the first one, the newest one is still valid
+      jest.advanceTimersByTime(52 * 60 * 1000);
       await expect(
         tokenManager.authenticate(token1),
       ).rejects.toThrowErrorMatchingInlineSnapshot(

--- a/packages/backend-common/src/tokens/ServerTokenManager.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.ts
@@ -64,6 +64,8 @@ export class ServerTokenManager implements TokenManager {
   private signingKey: Uint8Array;
   private privateKeyPromise: Promise<void> | undefined;
   private currentTokenPromise: Promise<{ token: string }> | undefined;
+  private warnedForMissingExpClaim = false;
+  private warnedForExpiredExpClaim = false;
 
   /**
    * Creates a token manager that issues static dummy tokens and never fails
@@ -179,17 +181,40 @@ export class ServerTokenManager implements TokenManager {
 
     for (const key of this.verificationKeys) {
       try {
-        const result = await jwtVerify(token, key);
-        if (result.protectedHeader.alg !== TOKEN_ALG) {
-          throw new NotAllowedError(
-            `Illegal alg "${result.protectedHeader.alg}"`,
-          );
+        const {
+          protectedHeader: { alg },
+          payload: { sub, exp },
+        } = await jwtVerify(token, key, {
+          // TODO(freben): Holding on to tokens and reusing them is deprecated; remove this tolerance in a future release
+          clockTolerance: 3e9,
+        });
+
+        if (alg !== TOKEN_ALG) {
+          throw new NotAllowedError(`Illegal alg "${alg}"`);
         }
-        if (result.payload.sub !== TOKEN_SUB) {
-          throw new NotAllowedError(`Illegal sub "${result.payload.sub}"`);
+
+        if (sub !== TOKEN_SUB) {
+          throw new NotAllowedError(`Illegal sub "${sub}"`);
         }
-        // TODO(freben): Reject missing payload.exp in the future as well
-        // The jose library does NOT throw if exp is not set in the token, but DOES throw if exp is set and expired
+
+        // TODO(freben): Passing in tokens without an exp is deprecated; change this warning to an error in a future release
+        if (typeof exp !== 'number') {
+          if (!this.warnedForMissingExpClaim) {
+            this.warnedForMissingExpClaim = true;
+            this.options.logger.warn(
+              `#### DEPRECATION WARNING: #### Server-to-server token had no exp claim, support for this has been deprecated and will result in errors in a future release`,
+            );
+          }
+        }
+        // TODO(freben): Holding on to tokens and reusing them is deprecated; remove this tolerance in a future release
+        else if (exp * 1000 < Date.now()) {
+          if (!this.warnedForExpiredExpClaim) {
+            this.warnedForExpiredExpClaim = true;
+            this.options.logger.warn(
+              `#### DEPRECATION WARNING: #### Server-to-server token had an expired exp claim, support for this has been deprecated and will result in errors in a future release`,
+            );
+          }
+        }
         return;
       } catch (e) {
         // Catch the verify exception and continue

--- a/packages/backend-common/src/tokens/ServerTokenManager.ts
+++ b/packages/backend-common/src/tokens/ServerTokenManager.ts
@@ -23,7 +23,8 @@ import { TokenManager } from './types';
 
 const TOKEN_ALG = 'HS256';
 const TOKEN_SUB = 'backstage-server';
-const TOKEN_EXPIRY = Duration.fromObject({ hours: 1 });
+const TOKEN_EXPIRY_AFTER = Duration.fromObject({ hours: 1 });
+const TOKEN_REISSUE_AFTER = Duration.fromObject({ minutes: 10 });
 
 /**
  * A token manager that issues static dummy tokens and never fails
@@ -151,7 +152,9 @@ export class ServerTokenManager implements TokenManager {
       const jwt = await new SignJWT({})
         .setProtectedHeader({ alg: TOKEN_ALG })
         .setSubject(TOKEN_SUB)
-        .setExpirationTime(DateTime.now().plus(TOKEN_EXPIRY).toUnixInteger())
+        .setExpirationTime(
+          DateTime.now().plus(TOKEN_EXPIRY_AFTER).toUnixInteger(),
+        )
         .sign(this.signingKey);
       return { token: jwt };
     });
@@ -162,7 +165,7 @@ export class ServerTokenManager implements TokenManager {
       .then(() => {
         setTimeout(() => {
           this.currentTokenPromise = undefined;
-        }, TOKEN_EXPIRY.minus({ minutes: 5 }).toMillis());
+        }, TOKEN_REISSUE_AFTER.toMillis());
       })
       .catch(() => {
         this.currentTokenPromise = undefined;

--- a/packages/backend-common/src/tokens/index.ts
+++ b/packages/backend-common/src/tokens/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { ServerTokenManager } from './ServerTokenManager';
+export type { ServerTokenManagerOptions } from './ServerTokenManager';
 export type { TokenManager } from './types';

--- a/packages/backend-common/src/tokens/types.ts
+++ b/packages/backend-common/src/tokens/types.ts
@@ -20,6 +20,20 @@
  * @public
  */
 export interface TokenManager {
-  getToken: () => Promise<{ token: string }>;
-  authenticate: (token: string) => Promise<void>;
+  /**
+   * Fetches a valid token.
+   *
+   * @remarks
+   *
+   * Tokens are valid for roughly one hour; the actual deadline is set in the
+   * payload `exp` claim. Never hold on to tokens for reuse; always ask for a
+   * new one for each outgoing request. This ensures that you always get a
+   * valid, fresh one.
+   */
+  getToken(): Promise<{ token: string }>;
+
+  /**
+   * Validates a given token.
+   */
+  authenticate(token: string): Promise<void>;
 }


### PR DESCRIPTION
`ServerTokenManagerOptions` may seem excessive - it's there because I started out adding like issuer and expiry in there, but backtracked. I don't mind having it though for consistency and when we maybe expand on it later.