### PR TITLE
Fix oauth dialog accessibility

### DIFF
--- a/.changeset/seven-panthers-pump.md
+++ b/.changeset/seven-panthers-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Add ARIA landmark( <main>), & label and a heading to OAuthRequestDialog. Removed nested interactive control (button).

--- a/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
+++ b/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
@@ -59,7 +59,7 @@ const LoginRequestListItem = ({ request, busy, setBusy }: RowProps) => {
   const IconComponent = request.provider.icon;
 
   return (
-    <ListItem button disabled={busy} classes={{ root: classes.root }}>
+    <ListItem disabled={busy} classes={{ root: classes.root }}>
       <ListItemAvatar>
         <IconComponent fontSize="large" />
       </ListItemAvatar>

--- a/packages/core-components/src/components/OAuthRequestDialog/OAuthRequestDialog.tsx
+++ b/packages/core-components/src/components/OAuthRequestDialog/OAuthRequestDialog.tsx
@@ -25,6 +25,7 @@ import React, { useMemo, useState } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 import LoginRequestListItem from './LoginRequestListItem';
 import { useApi, oauthRequestApiRef } from '@backstage/core-plugin-api';
+import Typography from '@material-ui/core/Typography';
 
 export type OAuthRequestDialogClassKey =
   | 'dialog'
@@ -39,6 +40,9 @@ const useStyles = makeStyles<Theme>(
     },
     title: {
       minWidth: 0,
+    },
+    titleHeading: {
+      fontSize: theme.typography.h6.fontSize,
     },
     contentList: {
       padding: 0,
@@ -69,23 +73,31 @@ export function OAuthRequestDialog(_props: {}) {
       fullWidth
       maxWidth="xs"
       classes={{ paper: classes.dialog }}
+      aria-labelledby="oauth-req-dialog-title"
     >
-      <DialogTitle classes={{ root: classes.title }}>
-        Login Required
-      </DialogTitle>
+      <main>
+        <DialogTitle
+          classes={{ root: classes.title }}
+          id="oauth-req-dialog-title"
+        >
+          <Typography className={classes.titleHeading} variant="h1">
+            Login Required
+          </Typography>
+        </DialogTitle>
 
-      <DialogContent dividers classes={{ root: classes.contentList }}>
-        <List>
-          {requests.map(request => (
-            <LoginRequestListItem
-              key={request.provider.title}
-              request={request}
-              busy={busy}
-              setBusy={setBusy}
-            />
-          ))}
-        </List>
-      </DialogContent>
+        <DialogContent dividers classes={{ root: classes.contentList }}>
+          <List>
+            {requests.map(request => (
+              <LoginRequestListItem
+                key={request.provider.title}
+                request={request}
+                busy={busy}
+                setBusy={setBusy}
+              />
+            ))}
+          </List>
+        </DialogContent>
+      </main>
 
       <DialogActions classes={{ root: classes.actionButtons }}>
         <Button onClick={handleRejectAll}>Reject All</Button>


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Addressed some ARIA issues from #7124 related to the `OAuthRequestDialog` component.  

Screenshot from browser scan:
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/2686352/166521706-6716b17e-cf91-425a-878b-d2052dfb27c6.png">


These changes address the Serious and Moderate issues:

### Serious
* `<ul>` and `<ol>` must only directly contain `<li>`, `<script>` or `<template>` elements
* Interactive controls must not be nested
* ARIA dialog and alertdialog nodes should have an accessible name

### Moderate
* Document should have one main landmark
* Page should contain a level-one heading

Several of these issues have been solved by disabling the `button` attribute of `ListItem`.  This is the most impactful as it changes each item so that only the embedded `Button` component is clickable focus-able.  Other changes are less impactful.   

Screenshot of post-change scan:
<img width="1183" alt="image" src="https://user-images.githubusercontent.com/2686352/166521398-95d7d7c6-dc86-4ff0-ade4-de4a44bdc8b8.png">


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
