### PR TITLE
add Azure as a Kubernetes auth provider

### DIFF
--- a/.changeset/big-teachers-dress.md
+++ b/.changeset/big-teachers-dress.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+add Azure Identity auth provider

--- a/.changeset/big-teachers-dress.md
+++ b/.changeset/big-teachers-dress.md
@@ -1,6 +1,7 @@
 ---
 '@backstage/plugin-kubernetes': patch
 '@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-common': patch
 ---
 
 add Azure Identity auth provider and AKS dashboard formatter

--- a/.changeset/big-teachers-dress.md
+++ b/.changeset/big-teachers-dress.md
@@ -3,4 +3,4 @@
 '@backstage/plugin-kubernetes-backend': patch
 ---
 
-add Azure Identity auth provider
+add Azure Identity auth provider and AKS dashboard formatter

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -90,7 +90,8 @@ cluster. Valid values are:
 | `serviceAccount`       | This will use a Kubernetes [service account](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) to access the Kubernetes API. When this is used the `serviceAccountToken` field should also be set. |
 | `google`               | This will use a user's Google auth token from the [Google auth plugin](https://backstage.io/docs/auth/) to access the Kubernetes API.                                                                                             |
 | `aws`                  | This will use AWS credentials to access resources in EKS clusters                                                                                                                                                                 |
-| `googleServiceAccount` | This will use the Google Cloud service account credentials to access resources in clusters                                                                                                                                        |
+| `googleServiceAccount` | This will use the Google Cloud service account credentials to access resources in clusters  
+| `azure`                | This will use [Azure Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to access resources in clusters    |
 
 ##### `clusters.\*.skipTLSVerify`
 

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -90,8 +90,8 @@ cluster. Valid values are:
 | `serviceAccount`       | This will use a Kubernetes [service account](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) to access the Kubernetes API. When this is used the `serviceAccountToken` field should also be set. |
 | `google`               | This will use a user's Google auth token from the [Google auth plugin](https://backstage.io/docs/auth/) to access the Kubernetes API.                                                                                             |
 | `aws`                  | This will use AWS credentials to access resources in EKS clusters                                                                                                                                                                 |
-| `googleServiceAccount` | This will use the Google Cloud service account credentials to access resources in clusters  
-| `azure`                | This will use [Azure Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to access resources in clusters    |
+| `googleServiceAccount` | This will use the Google Cloud service account credentials to access resources in clusters                                                                                                                                        |
+| `azure`                | This will use [Azure Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to access resources in clusters                                                               |
 
 ##### `clusters.\*.skipTLSVerify`
 

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -24,6 +24,11 @@ export interface AWSClusterDetails extends ClusterDetails {
   externalId?: string;
 }
 
+// Warning: (ae-missing-release-tag) "AzureClusterDetails" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface AzureClusterDetails extends ClusterDetails {}
+
 // Warning: (ae-missing-release-tag) "ClusterDetails" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -35,6 +35,7 @@
     "clean": "backstage-cli package clean"
   },
   "dependencies": {
+    "@azure/identity": "^2.0.4",
     "@backstage/backend-common": "^0.13.3-next.0",
     "@backstage/catalog-model": "^1.0.1",
     "@backstage/config": "^1.0.0",

--- a/plugins/kubernetes-backend/schema.d.ts
+++ b/plugins/kubernetes-backend/schema.d.ts
@@ -52,7 +52,7 @@ export interface Config {
             /** @visibility secret  */
             serviceAccountToken?: string;
             /** @visibility frontend */
-            authProvider: 'aws' | 'google' | 'serviceAccount';
+            authProvider: 'aws' | 'google' | 'serviceAccount' | 'azure';
             /** @visibility frontend */
             skipTLSVerify?: boolean;
           }>;

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -61,6 +61,9 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
 
             return { assumeRole, externalId, ...clusterDetails };
           }
+          case 'azure': {
+            return clusterDetails;
+          }
           case 'serviceAccount': {
             return clusterDetails;
           }

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/AzureIdentityKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/AzureIdentityKubernetesAuthTranslator.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthTranslator } from './types';
+import { AzureClusterDetails } from '../types/types';
+import { DefaultAzureCredential } from '@azure/identity';
+
+const aksScope = "6dae42f8-4368-4678-94ff-3960e28e3630/.default" // This scope is the same for all Azure Managed Kubernetes
+
+export class AzureIdentityKubernetesAuthTranslator
+  implements KubernetesAuthTranslator
+{
+  async decorateClusterDetailsWithAuth(
+    clusterDetails: AzureClusterDetails,
+  ): Promise<AzureClusterDetails> {
+    const clusterDetailsWithAuthToken: AzureClusterDetails = Object.assign(
+      {},
+      clusterDetails,
+    );
+
+    const credentials = new DefaultAzureCredential();
+
+    // TODO: can we cache this? It's inneficiant to get a new token every time
+    const accessToken = await credentials.getToken(aksScope);
+    clusterDetailsWithAuthToken.serviceAccountToken = accessToken.token
+    return clusterDetailsWithAuthToken;
+  }
+}

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/AzureIdentityKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/AzureIdentityKubernetesAuthTranslator.ts
@@ -18,7 +18,7 @@ import { KubernetesAuthTranslator } from './types';
 import { AzureClusterDetails } from '../types/types';
 import { DefaultAzureCredential } from '@azure/identity';
 
-const aksScope = "6dae42f8-4368-4678-94ff-3960e28e3630/.default" // This scope is the same for all Azure Managed Kubernetes
+const aksScope = '6dae42f8-4368-4678-94ff-3960e28e3630/.default'; // This scope is the same for all Azure Managed Kubernetes
 
 export class AzureIdentityKubernetesAuthTranslator
   implements KubernetesAuthTranslator
@@ -35,7 +35,7 @@ export class AzureIdentityKubernetesAuthTranslator
 
     // TODO: can we cache this? It's inneficiant to get a new token every time
     const accessToken = await credentials.getToken(aksScope);
-    clusterDetailsWithAuthToken.serviceAccountToken = accessToken.token
+    clusterDetailsWithAuthToken.serviceAccountToken = accessToken.token;
     return clusterDetailsWithAuthToken;
   }
 }

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
@@ -19,6 +19,7 @@ import { GoogleKubernetesAuthTranslator } from './GoogleKubernetesAuthTranslator
 import { ServiceAccountKubernetesAuthTranslator } from './ServiceAccountKubernetesAuthTranslator';
 import { AwsIamKubernetesAuthTranslator } from './AwsIamKubernetesAuthTranslator';
 import { GoogleServiceAccountAuthTranslator } from './GoogleServiceAccountAuthProvider';
+import { AzureIdentityKubernetesAuthTranslator } from './AzureIdentityKubernetesAuthTranslator';
 
 export class KubernetesAuthTranslatorGenerator {
   static getKubernetesAuthTranslatorInstance(
@@ -30,6 +31,9 @@ export class KubernetesAuthTranslatorGenerator {
       }
       case 'aws': {
         return new AwsIamKubernetesAuthTranslator();
+      }
+      case 'azure': {
+        return new AzureIdentityKubernetesAuthTranslator();
       }
       case 'serviceAccount': {
         return new ServiceAccountKubernetesAuthTranslator();

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -147,6 +147,7 @@ export interface ClusterDetails {
 }
 
 export interface GKEClusterDetails extends ClusterDetails {}
+export interface AzureClusterDetails extends ClusterDetails {}
 export interface ServiceAccountClusterDetails extends ClusterDetails {}
 export interface AWSClusterDetails extends ClusterDetails {
   assumeRole?: string;

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -18,7 +18,7 @@ import { V1Service } from '@kubernetes/client-node';
 // Warning: (ae-missing-release-tag) "AuthProviderType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type AuthProviderType = 'google' | 'serviceAccount' | 'aws';
+export type AuthProviderType = 'google' | 'serviceAccount' | 'aws' | 'azure';
 
 // Warning: (ae-missing-release-tag) "ClientContainerStatus" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -84,7 +84,7 @@ export interface ObjectsByEntityResponse {
   items: ClusterObjects[];
 }
 
-export type AuthProviderType = 'google' | 'serviceAccount' | 'aws';
+export type AuthProviderType = 'google' | 'serviceAccount' | 'aws' | 'azure';
 
 export type FetchResponse =
   | PodFetchResponse

--- a/plugins/kubernetes/src/kubernetes-auth-provider/AzureKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/AzureKubernetesAuthProvider.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthProvider } from './types';
+import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
+
+export class AzureKubernetesAuthProvider implements KubernetesAuthProvider {
+  async decorateRequestBodyForAuth(
+    requestBody: KubernetesRequestBody,
+  ): Promise<KubernetesRequestBody> {
+    // No-op, with aws auth, server's Azire credentials are used for access
+    return requestBody;
+  }
+}

--- a/plugins/kubernetes/src/kubernetes-auth-provider/AzureKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/AzureKubernetesAuthProvider.ts
@@ -21,7 +21,7 @@ export class AzureKubernetesAuthProvider implements KubernetesAuthProvider {
   async decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody> {
-    // No-op, with aws auth, server's Azire credentials are used for access
+    // No-op, with aws auth, server's Azure credentials are used for access
     return requestBody;
   }
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/AzureKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/AzureKubernetesAuthProvider.ts
@@ -21,7 +21,7 @@ export class AzureKubernetesAuthProvider implements KubernetesAuthProvider {
   async decorateRequestBodyForAuth(
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody> {
-    // No-op, with aws auth, server's Azure credentials are used for access
+    // No-op, with azure auth, server's Azure credentials are used for access
     return requestBody;
   }
 }

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -44,7 +44,10 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
       new GoogleServiceAccountAuthProvider(),
     );
     this.kubernetesAuthProviderMap.set('aws', new AwsKubernetesAuthProvider());
-    this.kubernetesAuthProviderMap.set('azure', new AzureKubernetesAuthProvider());
+    this.kubernetesAuthProviderMap.set(
+      'azure',
+      new AzureKubernetesAuthProvider(),
+    );
   }
 
   async decorateRequestBodyForAuth(

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -21,6 +21,7 @@ import { ServiceAccountKubernetesAuthProvider } from './ServiceAccountKubernetes
 import { AwsKubernetesAuthProvider } from './AwsKubernetesAuthProvider';
 import { OAuthApi } from '@backstage/core-plugin-api';
 import { GoogleServiceAccountAuthProvider } from './GoogleServiceAccountAuthProvider';
+import { AzureKubernetesAuthProvider } from './AzureKubernetesAuthProvider';
 
 export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
   private readonly kubernetesAuthProviderMap: Map<
@@ -43,6 +44,7 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
       new GoogleServiceAccountAuthProvider(),
     );
     this.kubernetesAuthProviderMap.set('aws', new AwsKubernetesAuthProvider());
+    this.kubernetesAuthProviderMap.set('azure', new AzureKubernetesAuthProvider());
   }
 
   async decorateRequestBodyForAuth(

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/aks.test.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/aks.test.ts
@@ -16,10 +16,9 @@
 import { aksFormatter } from './aks';
 
 describe('clusterLinks - AKS formatter', () => {
-  it('should return an url on the workloads when there is a namespace only', () => {
+  it('should provide a dashboardParameters in the options', () => {
     expect(() =>
       aksFormatter({
-        dashboardUrl: new URL('https://k8s.foo.com'),
         object: {
           metadata: {
             name: 'foobar',
@@ -28,6 +27,90 @@ describe('clusterLinks - AKS formatter', () => {
         },
         kind: 'Deployment',
       }),
-    ).toThrowError('AKS formatter is not yet implemented. Please, contribute!');
+    ).toThrowError('AKS dashboard requires a dashboardParameters option');
+  });
+  it('should provide a subscriptionId in the dashboardParameters options', () => {
+    expect(() =>
+      aksFormatter({
+        dashboardParameters: {
+          resourceGroup: 'rg-1',
+          clusterName: 'cluster-1',
+        },
+        object: {
+          metadata: {
+            name: 'foobar',
+            namespace: 'bar',
+          },
+        },
+        kind: 'Deployment',
+      }),
+    ).toThrowError(
+      'AKS dashboard requires a "subscriptionId" of type string in the dashboardParameters option',
+    );
+  });
+  it('should provide a resourceGroup in the dashboardParameters options', () => {
+    expect(() =>
+      aksFormatter({
+        dashboardParameters: {
+          subscriptionId: '1234-GUID-5678',
+          clusterName: 'cluster-1',
+        },
+        object: {
+          metadata: {
+            name: 'foobar',
+            namespace: 'bar',
+          },
+        },
+        kind: 'Deployment',
+      }),
+    ).toThrowError(
+      'AKS dashboard requires a "resourceGroup" of type string in the dashboardParameters option',
+    );
+  });
+  it('should provide a clusterName in the dashboardParameters options', () => {
+    expect(() =>
+      aksFormatter({
+        dashboardParameters: {
+          subscriptionId: '1234-GUID-5678',
+          resourceGroup: 'us-east1-c',
+        },
+        object: {
+          metadata: {
+            name: 'foobar',
+            namespace: 'bar',
+          },
+        },
+        kind: 'Deployment',
+      }),
+    ).toThrowError(
+      'AKS dashboard requires a "clusterName" of type string in the dashboardParameters option',
+    );
+  });
+  it('should return an url on the cluster with object details', () => {
+    const url = aksFormatter({
+      dashboardParameters: {
+        subscriptionId: '1234-GUID-5678',
+        resourceGroup: 'rg-1',
+        clusterName: 'cluster-1',
+      },
+      object: {
+        metadata: {
+          name: 'my-deployment',
+          namespace: 'my-namespace',
+          uid: '111-GUID-222',
+        },
+        spec: {
+          selector: {
+            matchLabels: {
+              app: 'foo',
+            },
+          },
+        },
+      },
+      kind: 'Deployment',
+    });
+    expect(url.href).toBe(
+      'https://portal.azure.com/#blade/Microsoft_Azure_ContainerService/AksK8ResourceMenuBlade/overview-Deployment/aksClusterId/%2Fsubscriptions%2F1234-GUID-5678%2FresourceGroups%2Frg-1%2Fproviders%2FMicrosoft.ContainerService%2FmanagedClusters%2Fcluster-1/resource/%7B%22kind%22%3A%22Deployment%22%2C%22metadata%22%3A%7B%22name%22%3A%22my-deployment%22%2C%22namespace%22%3A%22my-namespace%22%2C%22uid%22%3A%22111-GUID-222%22%7D%2C%22spec%22%3A%7B%22selector%22%3A%7B%22matchLabels%22%3A%7B%22app%22%3A%22foo%22%7D%7D%7D%7D',
+    );
   });
 });

--- a/plugins/kubernetes/src/utils/clusterLinks/formatters/aks.ts
+++ b/plugins/kubernetes/src/utils/clusterLinks/formatters/aks.ts
@@ -15,6 +15,39 @@
  */
 import { ClusterLinksFormatterOptions } from '../../../types/types';
 
-export function aksFormatter(_options: ClusterLinksFormatterOptions): URL {
-  throw new Error('AKS formatter is not yet implemented. Please, contribute!');
+const basePath =
+  'https://portal.azure.com/#blade/Microsoft_Azure_ContainerService/AksK8ResourceMenuBlade/overview-Deployment/aksClusterId';
+
+const requiredParams = ['subscriptionId', 'resourceGroup', 'clusterName'];
+
+export function aksFormatter(options: ClusterLinksFormatterOptions): URL {
+  if (!options.dashboardParameters) {
+    throw new Error('AKS dashboard requires a dashboardParameters option');
+  }
+  const args = options.dashboardParameters;
+  for (const param of requiredParams) {
+    if (typeof args[param] !== 'string') {
+      throw new Error(
+        `AKS dashboard requires a "${param}" of type string in the dashboardParameters option`,
+      );
+    }
+  }
+
+  const path = `/subscriptions/${args.subscriptionId}/resourceGroups/${args.resourceGroup}/providers/Microsoft.ContainerService/managedClusters/${args.clusterName}`;
+
+  const { name, namespace, uid } = options.object.metadata;
+  const { selector } = options.object.spec;
+  const params = {
+    kind: options.kind,
+    metadata: { name, namespace, uid },
+    spec: {
+      selector,
+    },
+  };
+
+  return new URL(
+    `${basePath}/${encodeURIComponent(path)}/resource/${encodeURIComponent(
+      JSON.stringify(params),
+    )}`,
+  );
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds:

1. Azure Identity as a K8s auth provider. For more: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
2. AKS dashboard formatter

This is how the config would look like:

```
        - url: https://my-cluster-aks-53f23f22.privatelink.eastus.azmk8s.io
          name: My AKS Cluster
          authProvider: 'azure'
          skipTLSVerify: true
          dashboardApp: aks #optional
          dashboardParameters: #optional
            subscriptionId: MY-SUB-GUID
            resourceGroup: MY-RG-NAME
            clusterName: my-cluster-aks
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
