### PR TITLE
Add generic OIDC as a Kubernetes auth provider

### DIFF
--- a/.changeset/fluffy-sloths-deliver.md
+++ b/.changeset/fluffy-sloths-deliver.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-kubernetes': patch
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-common': patch
+---
+
+Add support for 'oidc' as authProvider for kubernetes authentication
+and adds optional 'oidcTokenProvider' config value. This will allow
+users to authenticate to kubernetes cluster using id tokens obtained
+from the configured auth provider in their backstage instance.

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -92,6 +92,8 @@ cluster. Valid values are:
 | `aws`                  | This will use AWS credentials to access resources in EKS clusters                                                                                                                                                                 |
 | `googleServiceAccount` | This will use the Google Cloud service account credentials to access resources in clusters                                                                                                                                        |
 | `azure`                | This will use [Azure Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to access resources in clusters                                                               |
+| `oidc`                    | This will use [Oidc Tokens](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens) to authenticate to the Kubernetes API. When this is used the `oidcTokenProvider`                       |
+| field should also be set. |
 
 ##### `clusters.\*.skipTLSVerify`
 
@@ -114,6 +116,33 @@ kubectl -n <NAMESPACE> get secret $(kubectl -n <NAMESPACE> get sa <SERVICE_ACCOU
 | jq -r '.data["token"]' \
 | base64 --decode
 ```
+
+##### `clusters.\*.oidcTokenProvider` (optional)
+
+This field is to be used when using the `oidc` auth provider. It will use the id tokens
+from a configured [backstage auth provider](https://backstage.io/docs/auth/) to
+authenticate to the cluster. The selected `oidcTokenProvider` needs to be properly
+configured under `auth` for this to work.
+
+```yaml
+kubernetes:
+  clusterLocatorMethods:
+    - type: 'config'
+      clusters:
+        - name: test-cluster
+          url: http://localhost:8080
+          authProvider: oidc
+          oidcTokenProvider: okta # This value needs to match a config under auth.providers
+auth:
+  providers:
+    okta:
+      development:
+        clientId: ${AUTH_OKTA_CLIENT_ID}
+        clientSecret: ${AUTH_OKTA_CLIENT_SECRET}
+        audience: ${AUTH_OKTA_AUDIENCE}
+```
+
+The following values are supported out-of-the-box by the frontend: `google`, `microsoft`, `okta`, `onelogin`.
 
 ##### `clusters.\*.dashboardUrl` (optional)
 

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -85,15 +85,14 @@ array. Users will see this value in the Software Catalog Kubernetes plugin.
 This determines how the Kubernetes client authenticates with the Kubernetes
 cluster. Valid values are:
 
-| Value                  | Description                                                                                                                                                                                                                       |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `serviceAccount`       | This will use a Kubernetes [service account](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) to access the Kubernetes API. When this is used the `serviceAccountToken` field should also be set. |
-| `google`               | This will use a user's Google auth token from the [Google auth plugin](https://backstage.io/docs/auth/) to access the Kubernetes API.                                                                                             |
-| `aws`                  | This will use AWS credentials to access resources in EKS clusters                                                                                                                                                                 |
-| `googleServiceAccount` | This will use the Google Cloud service account credentials to access resources in clusters                                                                                                                                        |
-| `azure`                | This will use [Azure Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to access resources in clusters                                                               |
-| `oidc`                    | This will use [Oidc Tokens](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens) to authenticate to the Kubernetes API. When this is used the `oidcTokenProvider`                       |
-| field should also be set. |
+| Value                  | Description                                                                                                                                                                                                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `serviceAccount`       | This will use a Kubernetes [service account](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/) to access the Kubernetes API. When this is used the `serviceAccountToken` field should also be set.     |
+| `google`               | This will use a user's Google auth token from the [Google auth plugin](https://backstage.io/docs/auth/) to access the Kubernetes API.                                                                                                 |
+| `aws`                  | This will use AWS credentials to access resources in EKS clusters                                                                                                                                                                     |
+| `googleServiceAccount` | This will use the Google Cloud service account credentials to access resources in clusters                                                                                                                                            |
+| `azure`                | This will use [Azure Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to access resources in clusters                                                                   |
+| `oidc`                 | This will use [Oidc Tokens](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens) to authenticate to the Kubernetes API. When this is used the `oidcTokenProvider` field should also be set. |
 
 ##### `clusters.\*.skipTLSVerify`
 

--- a/plugins/kubernetes-backend/api-report.md
+++ b/plugins/kubernetes-backend/api-report.md
@@ -41,6 +41,7 @@ export interface ClusterDetails {
   dashboardParameters?: JsonObject;
   dashboardUrl?: string;
   name: string;
+  oidcTokenProvider?: string | undefined;
   // (undocumented)
   serviceAccountToken?: string | undefined;
   skipMetricsLookup?: boolean;

--- a/plugins/kubernetes-backend/schema.d.ts
+++ b/plugins/kubernetes-backend/schema.d.ts
@@ -52,7 +52,12 @@ export interface Config {
             /** @visibility secret  */
             serviceAccountToken?: string;
             /** @visibility frontend */
-            authProvider: 'aws' | 'google' | 'serviceAccount' | 'azure' | 'oidc';
+            authProvider:
+              | 'aws'
+              | 'google'
+              | 'serviceAccount'
+              | 'azure'
+              | 'oidc';
             /** @visibility frontend */
             oidcTokenProvider?: string;
             /** @visibility frontend */

--- a/plugins/kubernetes-backend/schema.d.ts
+++ b/plugins/kubernetes-backend/schema.d.ts
@@ -52,7 +52,9 @@ export interface Config {
             /** @visibility secret  */
             serviceAccountToken?: string;
             /** @visibility frontend */
-            authProvider: 'aws' | 'google' | 'serviceAccount' | 'azure';
+            authProvider: 'aws' | 'google' | 'serviceAccount' | 'azure' | 'oidc';
+            /** @visibility frontend */
+            oidcTokenProvider?: string;
             /** @visibility frontend */
             skipTLSVerify?: boolean;
           }>;

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -64,6 +64,11 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
           case 'azure': {
             return clusterDetails;
           }
+          case 'oidc': {
+            const oidcTokenProvider = c.getString('oidcTokenProvider');
+
+            return { oidcTokenProvider, ...clusterDetails };
+          }
           case 'serviceAccount': {
             return clusterDetails;
           }

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.test.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.test.ts
@@ -19,6 +19,7 @@ import { GoogleKubernetesAuthTranslator } from './GoogleKubernetesAuthTranslator
 import { KubernetesAuthTranslatorGenerator } from './KubernetesAuthTranslatorGenerator';
 import { ServiceAccountKubernetesAuthTranslator } from './ServiceAccountKubernetesAuthTranslator';
 import { AwsIamKubernetesAuthTranslator } from './AwsIamKubernetesAuthTranslator';
+import { OidcKubernetesAuthTranslator } from './OidcKubernetesAuthTranslator';
 
 describe('getKubernetesAuthTranslatorInstance', () => {
   const sut = KubernetesAuthTranslatorGenerator;
@@ -41,6 +42,12 @@ describe('getKubernetesAuthTranslatorInstance', () => {
     expect(
       authTranslator instanceof ServiceAccountKubernetesAuthTranslator,
     ).toBe(true);
+  });
+
+  it('can return an auth translator for oidc auth', () => {
+    const authTranslator: KubernetesAuthTranslator =
+      sut.getKubernetesAuthTranslatorInstance('oidc');
+    expect(authTranslator instanceof OidcKubernetesAuthTranslator).toBe(true);
   });
 
   it('throws an error when asked for an auth translator for an unsupported auth type', () => {

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/KubernetesAuthTranslatorGenerator.ts
@@ -20,6 +20,7 @@ import { ServiceAccountKubernetesAuthTranslator } from './ServiceAccountKubernet
 import { AwsIamKubernetesAuthTranslator } from './AwsIamKubernetesAuthTranslator';
 import { GoogleServiceAccountAuthTranslator } from './GoogleServiceAccountAuthProvider';
 import { AzureIdentityKubernetesAuthTranslator } from './AzureIdentityKubernetesAuthTranslator';
+import { OidcKubernetesAuthTranslator } from './OidcKubernetesAuthTranslator';
 
 export class KubernetesAuthTranslatorGenerator {
   static getKubernetesAuthTranslatorInstance(
@@ -40,6 +41,9 @@ export class KubernetesAuthTranslatorGenerator {
       }
       case 'googleServiceAccount': {
         return new GoogleServiceAccountAuthTranslator();
+      }
+      case 'oidc': {
+        return new OidcKubernetesAuthTranslator();
       }
       default: {
         throw new Error(

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.test.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.test.ts
@@ -38,7 +38,7 @@ describe('OidcKubernetesAuthTranslator tests', () => {
         ...baseClusterDetails,
       },
       {
-        auth: { okta: 'fakeToken' },
+        oidc: { okta: 'fakeToken' },
         entity,
       },
     );
@@ -60,6 +60,6 @@ describe('OidcKubernetesAuthTranslator tests', () => {
         { oidcTokenProvider: 'okta', ...baseClusterDetails },
         { entity },
       ),
-    ).rejects.toThrow('Auth token not found under auth.okta in request body');
+    ).rejects.toThrow('Auth token not found under oidc.okta in request body');
   });
 });

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.test.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OidcKubernetesAuthTranslator } from './OidcKubernetesAuthTranslator';
+import { ClusterDetails } from '../types/types';
+import { Entity } from '@backstage/catalog-model';
+
+describe('OidcKubernetesAuthTranslator tests', () => {
+  const at = new OidcKubernetesAuthTranslator();
+  const entity: Entity = {
+    apiVersion: 'v1',
+    kind: 'service',
+    metadata: { name: 'test' },
+  };
+  const baseClusterDetails: ClusterDetails = {
+    name: 'test',
+    authProvider: 'oidc',
+    url: '',
+  };
+
+  it('returns cluster details with auth token', async () => {
+    const details = await at.decorateClusterDetailsWithAuth(
+      {
+        oidcTokenProvider: 'okta',
+        ...baseClusterDetails,
+      },
+      {
+        auth: { okta: 'fakeToken' },
+        entity,
+      },
+    );
+
+    expect(details.serviceAccountToken).toBe('fakeToken');
+  });
+
+  it('returns error when oidcTokenProvider is not configured', async () => {
+    await expect(
+      at.decorateClusterDetailsWithAuth(baseClusterDetails, { entity }),
+    ).rejects.toThrow(
+      'oidc authProvider requires a configured oidcTokenProvider',
+    );
+  });
+
+  it('returns error when token is not included in request body', async () => {
+    await expect(
+      at.decorateClusterDetailsWithAuth(
+        { oidcTokenProvider: 'okta', ...baseClusterDetails },
+        { entity },
+      ),
+    ).rejects.toThrow('Auth token not found under auth.okta in request body');
+  });
+});

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.test.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.test.ts
@@ -38,7 +38,9 @@ describe('OidcKubernetesAuthTranslator tests', () => {
         ...baseClusterDetails,
       },
       {
-        oidc: { okta: 'fakeToken' },
+        auth: {
+          oidc: { okta: 'fakeToken' },
+        },
         entity,
       },
     );

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.ts
@@ -36,13 +36,13 @@ export class OidcKubernetesAuthTranslator implements KubernetesAuthTranslator {
       );
     }
 
-    const authToken: string | undefined = requestBody.auth?.[oidcTokenProvider];
+    const authToken: string | undefined = requestBody.oidc?.[oidcTokenProvider];
 
     if (authToken) {
       clusterDetailsWithAuthToken.serviceAccountToken = authToken;
     } else {
       throw new Error(
-        `Auth token not found under auth.${oidcTokenProvider} in request body`,
+        `Auth token not found under oidc.${oidcTokenProvider} in request body`,
       );
     }
     return clusterDetailsWithAuthToken;

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthTranslator } from './types';
+import { ClusterDetails } from '../types/types';
+import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
+
+export class OidcKubernetesAuthTranslator implements KubernetesAuthTranslator {
+  async decorateClusterDetailsWithAuth(
+    clusterDetails: ClusterDetails,
+    requestBody: KubernetesRequestBody,
+  ): Promise<ClusterDetails> {
+    const clusterDetailsWithAuthToken: ClusterDetails = Object.assign(
+      {},
+      clusterDetails,
+    );
+
+    const { oidcTokenProvider } = clusterDetails;
+
+    if (!oidcTokenProvider || oidcTokenProvider === '') {
+      throw new Error(
+        `oidc authProvider requires a configured oidcTokenProvider`,
+      );
+    }
+
+    const authToken: string | undefined = requestBody.auth?.[oidcTokenProvider];
+
+    if (authToken) {
+      clusterDetailsWithAuthToken.serviceAccountToken = authToken;
+    } else {
+      throw new Error(
+        `Auth token not found under auth.${oidcTokenProvider} in request body`,
+      );
+    }
+    return clusterDetailsWithAuthToken;
+  }
+}

--- a/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.ts
+++ b/plugins/kubernetes-backend/src/kubernetes-auth-translator/OidcKubernetesAuthTranslator.ts
@@ -36,7 +36,8 @@ export class OidcKubernetesAuthTranslator implements KubernetesAuthTranslator {
       );
     }
 
-    const authToken: string | undefined = requestBody.oidc?.[oidcTokenProvider];
+    const authToken: string | undefined =
+      requestBody.auth?.oidc?.[oidcTokenProvider];
 
     if (authToken) {
       clusterDetailsWithAuthToken.serviceAccountToken = authToken;

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -246,6 +246,7 @@ export class KubernetesBuilder {
           name: cd.name,
           dashboardUrl: cd.dashboardUrl,
           authProvider: cd.authProvider,
+          oidcTokenProvider: cd.oidcTokenProvider,
         })),
       });
     });

--- a/plugins/kubernetes-backend/src/types/types.ts
+++ b/plugins/kubernetes-backend/src/types/types.ts
@@ -105,6 +105,10 @@ export interface ClusterDetails {
   url: string;
   authProvider: string;
   serviceAccountToken?: string | undefined;
+  /**
+   * oidc provider used to get id tokens to authenticate against kubernetes
+   */
+  oidcTokenProvider?: string | undefined;
   skipTLSVerify?: boolean;
   /**
    * Whether to skip the lookup to the metrics server to retrieve pod resource usage.

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -194,10 +194,14 @@ export interface KubernetesFetchError {
 export interface KubernetesRequestBody {
   // (undocumented)
   auth?: {
-    google?: string;
+    google: string;
   };
   // (undocumented)
   entity: Entity;
+  // (undocumented)
+  oidc?: {
+    [key: string]: string;
+  };
 }
 
 // Warning: (ae-missing-release-tag) "ObjectsByEntityResponse" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/kubernetes-common/api-report.md
+++ b/plugins/kubernetes-common/api-report.md
@@ -194,14 +194,13 @@ export interface KubernetesFetchError {
 export interface KubernetesRequestBody {
   // (undocumented)
   auth?: {
-    google: string;
+    google?: string;
+    oidc?: {
+      [key: string]: string;
+    };
   };
   // (undocumented)
   entity: Entity;
-  // (undocumented)
-  oidc?: {
-    [key: string]: string;
-  };
 }
 
 // Warning: (ae-missing-release-tag) "ObjectsByEntityResponse" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -30,7 +30,7 @@ import { Entity } from '@backstage/catalog-model';
 
 export interface KubernetesRequestBody {
   auth?: {
-    google?: string;
+    [key: string]: string;
   };
   entity: Entity;
 }

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -30,6 +30,9 @@ import { Entity } from '@backstage/catalog-model';
 
 export interface KubernetesRequestBody {
   auth?: {
+    google: string;
+  };
+  oidc?: {
     [key: string]: string;
   };
   entity: Entity;

--- a/plugins/kubernetes-common/src/types.ts
+++ b/plugins/kubernetes-common/src/types.ts
@@ -30,10 +30,10 @@ import { Entity } from '@backstage/catalog-model';
 
 export interface KubernetesRequestBody {
   auth?: {
-    google: string;
-  };
-  oidc?: {
-    [key: string]: string;
+    google?: string;
+    oidc?: {
+      [key: string]: string;
+    };
   };
   entity: Entity;
 }

--- a/plugins/kubernetes/api-report.md
+++ b/plugins/kubernetes/api-report.md
@@ -17,6 +17,7 @@ import type { JsonObject } from '@backstage/types';
 import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
 import { OAuthApi } from '@backstage/core-plugin-api';
 import { ObjectsByEntityResponse } from '@backstage/plugin-kubernetes-common';
+import { OpenIdConnectApi } from '@backstage/core-plugin-api';
 import { default as React_2 } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { V1ConfigMap } from '@kubernetes/client-node';
@@ -225,6 +226,7 @@ export interface KubernetesApi {
     {
       name: string;
       authProvider: string;
+      oidcTokenProvider?: string | undefined;
     }[]
   >;
   // (undocumented)
@@ -242,7 +244,12 @@ export const kubernetesApiRef: ApiRef<KubernetesApi>;
 //
 // @public (undocumented)
 export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
-  constructor(options: { googleAuthApi: OAuthApi });
+  constructor(options: {
+    googleAuthApi: OAuthApi;
+    oidcProviders?: {
+      [key: string]: OpenIdConnectApi;
+    };
+  });
   // (undocumented)
   decorateRequestBodyForAuth(
     authProvider: string,

--- a/plugins/kubernetes/src/api/types.ts
+++ b/plugins/kubernetes/src/api/types.ts
@@ -28,5 +28,11 @@ export interface KubernetesApi {
   getObjectsByEntity(
     requestBody: KubernetesRequestBody,
   ): Promise<ObjectsByEntityResponse>;
-  getClusters(): Promise<{ name: string; authProvider: string }[]>;
+  getClusters(): Promise<
+    {
+      name: string;
+      authProvider: string;
+      oidcTokenProvider?: string | undefined;
+    }[]
+  >;
 }

--- a/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
+++ b/plugins/kubernetes/src/hooks/useKubernetesObjects.ts
@@ -53,8 +53,16 @@ export const useKubernetesObjects = (
     }
 
     const authProviders: string[] = [
-      ...new Set(clusters.map(c => c.authProvider)),
+      ...new Set(
+        clusters.map(
+          c =>
+            `${c.authProvider}${
+              c.oidcTokenProvider ? `.${c.oidcTokenProvider}` : ''
+            }`,
+        ),
+      ),
     ];
+
     // For each auth type, invoke decorateRequestBodyForAuth on corresponding KubernetesAuthProvider
     let requestBody: KubernetesRequestBody = {
       entity,

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OAuthApi, OpenIdConnectApi } from '@backstage/core-plugin-api';
+import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
+import { KubernetesAuthProviders } from './KubernetesAuthProviders';
+
+class MockAuthApi implements OAuthApi, OpenIdConnectApi {
+  constructor(private readonly token: string) {}
+
+  getAccessToken = jest.fn(async () => {
+    return this.token;
+  });
+
+  getIdToken = jest.fn(async () => {
+    return this.token;
+  });
+}
+
+const requestBody: KubernetesRequestBody = {
+  entity: {
+    apiVersion: 'v1',
+    kind: 'service',
+    metadata: { name: 'test' },
+  },
+};
+
+describe('KubernetesAuthProviders tests', () => {
+  const kap = new KubernetesAuthProviders({
+    googleAuthApi: new MockAuthApi('googleToken'),
+    oidcProviders: {
+      okta: new MockAuthApi('oktaToken'),
+    },
+  });
+
+  it('adds token to request body for google authProvider', async () => {
+    const details = await kap.decorateRequestBodyForAuth('google', requestBody);
+
+    expect(details.auth?.google).toBe('googleToken');
+  });
+
+  it('adds token to request body for oidc authProvider', async () => {
+    const details = await kap.decorateRequestBodyForAuth(
+      'oidc.okta',
+      requestBody,
+    );
+
+    expect(details.oidc?.okta).toBe('oktaToken');
+  });
+
+  it('returns error for unknown authProvider', async () => {
+    await expect(
+      kap.decorateRequestBodyForAuth('unknown', requestBody),
+    ).rejects.toThrow(
+      'authProvider "unknown" has no KubernetesAuthProvider defined for it',
+    );
+  });
+
+  it('returns error for missconfigured oidc authProvider', async () => {
+    await expect(
+      kap.decorateRequestBodyForAuth('oidc.random', requestBody),
+    ).rejects.toThrow(
+      'KubernetesAuthProviders has no oidcProvider configured for oidc.random',
+    );
+  });
+});

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.test.ts
@@ -58,7 +58,7 @@ describe('KubernetesAuthProviders tests', () => {
       requestBody,
     );
 
-    expect(details.oidc?.okta).toBe('oktaToken');
+    expect(details.auth?.oidc?.okta).toBe('oktaToken');
   });
 
   it('returns error for unknown authProvider', async () => {

--- a/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/KubernetesAuthProviders.ts
@@ -19,9 +19,10 @@ import { KubernetesAuthProvider, KubernetesAuthProvidersApi } from './types';
 import { GoogleKubernetesAuthProvider } from './GoogleKubernetesAuthProvider';
 import { ServiceAccountKubernetesAuthProvider } from './ServiceAccountKubernetesAuthProvider';
 import { AwsKubernetesAuthProvider } from './AwsKubernetesAuthProvider';
-import { OAuthApi } from '@backstage/core-plugin-api';
+import { OAuthApi, OpenIdConnectApi } from '@backstage/core-plugin-api';
 import { GoogleServiceAccountAuthProvider } from './GoogleServiceAccountAuthProvider';
 import { AzureKubernetesAuthProvider } from './AzureKubernetesAuthProvider';
+import { OidcKubernetesAuthProvider } from './OidcKubernetesAuthProvider';
 
 export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
   private readonly kubernetesAuthProviderMap: Map<
@@ -29,7 +30,10 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
     KubernetesAuthProvider
   >;
 
-  constructor(options: { googleAuthApi: OAuthApi }) {
+  constructor(options: {
+    googleAuthApi: OAuthApi;
+    oidcProviders?: { [key: string]: OpenIdConnectApi };
+  }) {
     this.kubernetesAuthProviderMap = new Map<string, KubernetesAuthProvider>();
     this.kubernetesAuthProviderMap.set(
       'google',
@@ -48,6 +52,18 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
       'azure',
       new AzureKubernetesAuthProvider(),
     );
+
+    if (options.oidcProviders) {
+      Object.keys(options.oidcProviders).forEach(provider => {
+        this.kubernetesAuthProviderMap.set(
+          `oidc.${provider}`,
+          new OidcKubernetesAuthProvider(
+            provider,
+            options.oidcProviders![provider],
+          ),
+        );
+      });
+    }
   }
 
   async decorateRequestBodyForAuth(
@@ -59,6 +75,12 @@ export class KubernetesAuthProviders implements KubernetesAuthProvidersApi {
     if (kubernetesAuthProvider) {
       return await kubernetesAuthProvider.decorateRequestBodyForAuth(
         requestBody,
+      );
+    }
+
+    if (authProvider.startsWith('oidc.')) {
+      throw new Error(
+        `KubernetesAuthProviders has no oidcProvider configured for ${authProvider}`,
       );
     }
     throw new Error(

--- a/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubernetesAuthProvider } from './types';
+import { KubernetesRequestBody } from '@backstage/plugin-kubernetes-common';
+import { OpenIdConnectApi } from '@backstage/core-plugin-api';
+
+export class OidcKubernetesAuthProvider implements KubernetesAuthProvider {
+  providerName: string;
+  authProvider: OpenIdConnectApi;
+
+  constructor(providerName: string, authProvider: OpenIdConnectApi) {
+    this.providerName = providerName;
+    this.authProvider = authProvider;
+  }
+
+  async decorateRequestBodyForAuth(
+    requestBody: KubernetesRequestBody,
+  ): Promise<KubernetesRequestBody> {
+    const authToken: string = await this.authProvider.getIdToken();
+    if ('oidc' in requestBody) {
+      requestBody.oidc![this.providerName] = authToken;
+    } else {
+      requestBody.oidc = { [this.providerName]: authToken };
+    }
+    return requestBody;
+  }
+}

--- a/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
+++ b/plugins/kubernetes/src/kubernetes-auth-provider/OidcKubernetesAuthProvider.ts
@@ -31,11 +31,13 @@ export class OidcKubernetesAuthProvider implements KubernetesAuthProvider {
     requestBody: KubernetesRequestBody,
   ): Promise<KubernetesRequestBody> {
     const authToken: string = await this.authProvider.getIdToken();
-    if ('oidc' in requestBody) {
-      requestBody.oidc![this.providerName] = authToken;
+    const auth = { ...requestBody.auth };
+    if (auth.oidc) {
+      auth.oidc[this.providerName] = authToken;
     } else {
-      requestBody.oidc = { [this.providerName]: authToken };
+      auth.oidc = { [this.providerName]: authToken };
     }
+    requestBody.auth = auth;
     return requestBody;
   }
 }

--- a/plugins/kubernetes/src/plugin.ts
+++ b/plugins/kubernetes/src/plugin.ts
@@ -24,6 +24,9 @@ import {
   discoveryApiRef,
   identityApiRef,
   googleAuthApiRef,
+  microsoftAuthApiRef,
+  oktaAuthApiRef,
+  oneloginAuthApiRef,
   createRoutableExtension,
 } from '@backstage/core-plugin-api';
 
@@ -45,9 +48,26 @@ export const kubernetesPlugin = createPlugin({
     }),
     createApiFactory({
       api: kubernetesAuthProvidersApiRef,
-      deps: { googleAuthApi: googleAuthApiRef },
-      factory: ({ googleAuthApi }) => {
-        return new KubernetesAuthProviders({ googleAuthApi });
+      deps: {
+        googleAuthApi: googleAuthApiRef,
+        microsoftAuthApi: microsoftAuthApiRef,
+        oktaAuthApi: oktaAuthApiRef,
+        oneloginAuthApi: oneloginAuthApiRef,
+      },
+      factory: ({
+        googleAuthApi,
+        microsoftAuthApi,
+        oktaAuthApi,
+        oneloginAuthApi,
+      }) => {
+        const oidcProviders = {
+          google: googleAuthApi,
+          microsoft: microsoftAuthApi,
+          okta: oktaAuthApi,
+          onelogin: oneloginAuthApi,
+        };
+
+        return new KubernetesAuthProviders({ googleAuthApi, oidcProviders });
       },
     }),
   ],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds:

1. AuthProvider "oidc" for kubernetes clusters, with an extra config option called "oidcTokenProvider", to couple the kubernetes cluster with a configured backstage auth provider. This enables [kubernete's oidc authentication](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens)
2. A new KubernetesAuthProvider in the kubernetes frontend plugin to prop the user for the right credentials

Closes #10284

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
