### PR TITLE
Export the SortView frontend component from the Bazaar plugin for direct use

### DIFF
--- a/.changeset/empty-planes-destroy.md
+++ b/.changeset/empty-planes-destroy.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-bazaar': patch
+---
+
+Exported the SortView component from the Bazaar plugin for use directly

--- a/plugins/bazaar/api-report.md
+++ b/plugins/bazaar/api-report.md
@@ -28,5 +28,10 @@ export const bazaarPlugin: BackstagePlugin<
 // @public (undocumented)
 export const EntityBazaarInfoCard: () => JSX.Element | null;
 
+// Warning: (ae-missing-release-tag) "SortView" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export const SortView: () => JSX.Element;
+
 // (No @packageDocumentation comment for this package)
 ```

--- a/plugins/bazaar/src/index.ts
+++ b/plugins/bazaar/src/index.ts
@@ -16,3 +16,4 @@
 
 export { bazaarPlugin, BazaarPage } from './plugin';
 export { EntityBazaarInfoCard } from './components/EntityBazaarInfoCard';
+export { SortView } from './components/SortView';


### PR DESCRIPTION
Signed-off-by: Marcus Crane <marcus@utf9k.net>

## Hey, I just made a Pull Request!

In the same vein as [other changes mentioned in this RFC](https://github.com/backstage/backstage/issues/7926), this PR directly exports the `<SortView />` component from the Bazaar frontend plugin.

For context, it's the component that contains the contents of the "Home" tab.

I'm interested in embedding it within the Explore plugin (as a tab) to reduce the amount of sidebar items.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
