### PR TITLE
enable custom headers for bitbucketserver integration

### DIFF
--- a/.changeset/clever-comics-type.md
+++ b/.changeset/clever-comics-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': minor
+---
+
+enable insertion of custom headers for Bitbucket Server requests

--- a/packages/integration/api-report.md
+++ b/packages/integration/api-report.md
@@ -150,6 +150,7 @@ export type BitbucketServerIntegrationConfig = {
   host: string;
   apiBaseUrl: string;
   token?: string;
+  headers?: Record<string, string>;
 };
 
 // @public

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -94,6 +94,11 @@ export interface Config {
        * @visibility frontend
        */
       apiBaseUrl?: string;
+      /**
+       * Custom request headers to Bitbucket Server provider.
+       * @visibility secret
+       */
+      headers?: Record<string, string>;
     }>;
 
     /** Integration configuration for Gerrit */

--- a/packages/integration/src/bitbucketServer/config.test.ts
+++ b/packages/integration/src/bitbucketServer/config.test.ts
@@ -61,12 +61,18 @@ describe('readBitbucketServerIntegrationConfig', () => {
         host: 'a.com',
         apiBaseUrl: 'https://a.com/api',
         token: 't',
+        headers: {
+          foo: 'bar',
+        },
       }),
     );
     expect(output).toEqual({
       host: 'a.com',
       apiBaseUrl: 'https://a.com/api',
       token: 't',
+      headers: {
+        foo: 'bar',
+      },
     });
   });
 
@@ -87,6 +93,21 @@ describe('readBitbucketServerIntegrationConfig', () => {
     expect(() =>
       readBitbucketServerIntegrationConfig(buildConfig({ ...valid, token: 7 })),
     ).toThrow(/token/);
+    expect(() =>
+      readBitbucketServerIntegrationConfig(
+        buildConfig({ ...valid, headers: 7 }),
+      ),
+    ).toThrow(/headers/);
+    expect(() =>
+      readBitbucketServerIntegrationConfig(
+        buildConfig({ ...valid, headers: 'foo' }),
+      ),
+    ).toThrow(/headers/);
+    expect(() =>
+      readBitbucketServerIntegrationConfig(
+        buildConfig({ ...valid, headers: true }),
+      ),
+    ).toThrow(/headers/);
   });
 
   it('works on the frontend', async () => {
@@ -119,6 +140,9 @@ describe('readBitbucketServerIntegrationConfigs', () => {
           host: 'a.com',
           apiBaseUrl: 'https://a.com/api',
           token: 't',
+          headers: {
+            foo: 'bar',
+          },
         },
       ]),
     );
@@ -126,6 +150,9 @@ describe('readBitbucketServerIntegrationConfigs', () => {
       host: 'a.com',
       apiBaseUrl: 'https://a.com/api',
       token: 't',
+      headers: {
+        foo: 'bar',
+      },
     });
   });
 

--- a/packages/integration/src/bitbucketServer/config.ts
+++ b/packages/integration/src/bitbucketServer/config.ts
@@ -46,6 +46,11 @@ export type BitbucketServerIntegrationConfig = {
    * If no token is specified, anonymous access is used.
    */
   token?: string;
+
+  /**
+   * Custom headers to use for request to a Bitbucket Server provider.
+   */
+  headers?: Record<string, string>;
 };
 
 /**
@@ -71,6 +76,19 @@ export function readBitbucketServerIntegrationConfig(
     apiBaseUrl = trimEnd(apiBaseUrl, '/');
   } else {
     apiBaseUrl = `https://${host}/rest/api/1.0`;
+  }
+
+  if (config.getOptionalConfig('headers')) {
+    const headers: Record<string, string> = {};
+    for (const itemKey of config.getConfig('headers').keys()) {
+      headers[`${itemKey}`] = config.getString(`headers.${itemKey}`);
+    }
+    return {
+      host,
+      apiBaseUrl,
+      token,
+      headers,
+    };
   }
 
   return {

--- a/packages/integration/src/bitbucketServer/core.test.ts
+++ b/packages/integration/src/bitbucketServer/core.test.ts
@@ -49,6 +49,32 @@ describe('bitbucketServer core', () => {
           .Authorization,
       ).toBeUndefined();
     });
+
+    it('inserts custom headers when needed', () => {
+      const withHeaders: BitbucketServerIntegrationConfig = {
+        host: '',
+        apiBaseUrl: '',
+        token: 'A',
+        headers: {
+          foo: 'bar',
+        },
+      };
+      const withoutHeaders: BitbucketServerIntegrationConfig = {
+        host: '',
+        apiBaseUrl: '',
+        token: 'A',
+      };
+      expect(
+        (getBitbucketServerRequestOptions(withHeaders).headers as any).foo,
+      ).toEqual('bar');
+      expect(
+        (getBitbucketServerRequestOptions(withHeaders).headers as any)
+          .Authorization,
+      ).toEqual('Bearer A');
+      expect(
+        (getBitbucketServerRequestOptions(withoutHeaders).headers as any).foo,
+      ).toBeUndefined();
+    });
   });
 
   describe('getBitbucketServerFileFetchUrl', () => {

--- a/packages/integration/src/bitbucketServer/core.ts
+++ b/packages/integration/src/bitbucketServer/core.ts
@@ -139,6 +139,12 @@ export function getBitbucketServerRequestOptions(
     headers.Authorization = `Bearer ${config.token}`;
   }
 
+  if (config.headers) {
+    for (const key of Object.keys(config.headers)) {
+      headers[`${key}`] = config.headers[`${key}`];
+    }
+  }
+
   return {
     headers,
   };


### PR DESCRIPTION
Custom headers can be added in app-config.yaml for the bitbucketserver integration.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
