### PR TITLE
Associate labels to select component

### DIFF
--- a/.changeset/beige-glasses-swim.md
+++ b/.changeset/beige-glasses-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Enabled select component to be enabled by keyboard

--- a/packages/core-components/src/components/Select/Select.tsx
+++ b/packages/core-components/src/components/Select/Select.tsx
@@ -19,6 +19,7 @@ import Chip from '@material-ui/core/Chip';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import FormControl from '@material-ui/core/FormControl';
 import InputBase from '@material-ui/core/InputBase';
+import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import {
@@ -78,6 +79,16 @@ const useStyles = makeStyles(
         maxWidth: 300,
       },
       label: {
+        transform: 'initial',
+        fontWeight: 'bold',
+        fontSize: 14,
+        fontFamily: theme.typography.fontFamily,
+        color: theme.palette.text.primary,
+        '&.Mui-focused': {
+          color: theme.palette.text.primary,
+        },
+      },
+      formLabel: {
         transform: 'initial',
         fontWeight: 'bold',
         fontSize: 14,
@@ -184,9 +195,10 @@ export function SelectComponent(props: SelectProps) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="button">{label}</Typography>
+      {/* <Typography variant="button">{label}</Typography> */}
       <ClickAwayListener onClickAway={handleClickAway}>
         <FormControl className={classes.formControl}>
+          <InputLabel className={classes.formLabel}>{label}</InputLabel>
           <Select
             value={value}
             native={native}
@@ -198,6 +210,8 @@ export function SelectComponent(props: SelectProps) {
             onClick={handleClick}
             open={isOpen}
             input={<BootstrapInput />}
+            label={label}
+            tabIndex={0}
             renderValue={s =>
               multiple && (value as any[]).length !== 0 ? (
                 <div className={classes.chips}>


### PR DESCRIPTION
- Solved label not being connected to correspondent `Select` component #11253 

- Fixed `Select` component not accessible through keyboard #11289 

<img width="1458" alt="select-component-accessiblity" src="https://user-images.githubusercontent.com/54085737/166917208-c02b3c5e-02f3-48ac-b3b7-55a99eae2ce8.png">


#### :heavy_check_mark: Checklist

- [ x] A changeset describing the change and affected packages. 
- [x] Screenshots attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
