### PR TITLE
fix(frontend): Fixed overflow bug of name and email on EntitiyMembersListCard component

### DIFF
--- a/.changeset/dirty-ducks-suffer.md
+++ b/.changeset/dirty-ducks-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fixed overflow bug of name and email on EntitiyMembersListCard component which can occur on specific 'screen width' + ’character length' combinations

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -59,6 +59,17 @@ const useStyles = makeStyles((theme: Theme) =>
       flex: '1',
       minWidth: '0px',
     },
+    email: {
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+      display: 'inline-block',
+      maxWidth: '100%',
+      '&:hover': {
+        overflow: 'visible',
+        whiteSpace: 'normal',
+      },
+    },
   }),
 );
 
@@ -88,7 +99,13 @@ const MemberComponent = (props: { member: UserEntity }) => {
               top: '-2rem',
             }}
           />
-          <Box pt={2} textAlign="center">
+          <Box
+            pt={2}
+            sx={{
+              maxWidth: '100%',
+            }}
+            textAlign="center"
+          >
             <Typography variant="h5">
               <Link
                 to={generatePath(
@@ -100,7 +117,9 @@ const MemberComponent = (props: { member: UserEntity }) => {
               </Link>
             </Typography>
             {profile?.email && (
-              <Link to={`mailto:${profile.email}`}>{profile.email}</Link>
+              <Link className={classes.email} to={`mailto:${profile.email}`}>
+                {profile.email}
+              </Link>
             )}
             {description && (
               <Typography variant="subtitle2">{description}</Typography>


### PR DESCRIPTION
closes https://github.com/backstage/backstage/issues/11340

The fix is to replace email overflow by either showing email with ellipsis or showing full wrapping email on mouse over

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

https://user-images.githubusercontent.com/7813706/166936540-85c801d3-e55e-49f1-8261-a53cde0797aa.mov



